### PR TITLE
feat(practice): integrate rosclaw_practice SeekDB bridge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ ros2 = [
     "trajectory-msgs",
     "control-msgs",
 ]
+practice = [
+    "rosclaw-practice @ git+https://github.com/ros-claw/rosclaw-practice.git@bfb4ac7",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",

--- a/src/rosclaw/practice/seekdb_bridge.py
+++ b/src/rosclaw/practice/seekdb_bridge.py
@@ -1,0 +1,89 @@
+"""Bridge from ROSClaw core PraxisEvent to rosclaw_practice SeekDB committer.
+
+This module lets the main ROSClaw runtime persist its native
+`rosclaw.core.types.PraxisEvent` records to SeekDB using the well-tested
+`rosclaw_practice` package.  It is an optional integration: importing it
+requires ``rosclaw-practice`` to be installed (``pip install rosclaw[practice]``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rosclaw.core.types import PraxisEvent as RosclawPraxisEvent
+
+try:
+    from rosclaw_practice.committer import ExperienceCommitter
+    from rosclaw_practice.schemas import (
+        CognitiveContext,
+        DataPointers,
+        PhysicalFeedback,
+        PraxisEvent as PracticePraxisEvent,
+    )
+except ImportError as exc:  # pragma: no cover - exercised by optional-deps tests
+    raise ImportError(
+        "rosclaw-practice is required for SeekDB integration. "
+        "Install it with: pip install rosclaw[practice]"
+    ) from exc
+
+
+class SeekDBBridge:
+    """Commits ROSClaw ``PraxisEvent`` records to SeekDB via ``rosclaw_practice``."""
+
+    def __init__(
+        self,
+        seekdb_url: str = "http://localhost:2881",
+        fallback_dir: str = "/data/rosclaw/fallback",
+    ) -> None:
+        """Initialize the bridge.
+
+        :param seekdb_url: Base URL of the SeekDB instance.
+        :param fallback_dir: Directory for offline JSON fallback files.
+        """
+        self._committer = ExperienceCommitter(
+            seekdb_url=seekdb_url,
+            fallback_dir=fallback_dir,
+        )
+
+    def commit(self, event: RosclawPraxisEvent) -> None:
+        """Send *event* to SeekDB, falling back to local JSON on failure.
+
+        This method is synchronous because ``ExperienceCommitter`` performs a
+        blocking HTTP request.  Use :meth:`commit_async` from async code to avoid
+        blocking the event loop.
+        """
+        practice_event = self._convert(event)
+        self._committer.save_to_seekdb(practice_event.model_dump())
+
+    async def commit_async(self, event: RosclawPraxisEvent) -> None:
+        """Async wrapper around :meth:`commit`."""
+        await asyncio.to_thread(self.commit, event)
+
+    def _convert(self, event: RosclawPraxisEvent) -> PracticePraxisEvent:
+        """Convert a ROSClaw ``PraxisEvent`` to a ``rosclaw_practice`` event."""
+        return PracticePraxisEvent(
+            practice_id=event.event_id,
+            timestamp=_to_iso_utc(event.timestamp),
+            robot_id=event.robot_id,
+            cognitive_context=CognitiveContext(
+                semantic_intent=event.agent_instruction,
+                llm_cot="\n".join(event.cot_trace),
+            ),
+            physical_feedback=PhysicalFeedback(
+                status=event.event_type.upper(),
+                reward=float(event.metadata.get("reward", 0.0)),
+                error_log=event.error_details or "",
+            ),
+            data_pointers=DataPointers(
+                mcap_path=event.mcap_path or "",
+            ),
+        )
+
+
+def _to_iso_utc(timestamp: float) -> str:
+    """Format a Unix timestamp as an ISO 8601 UTC string."""
+    dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/practice/test_seekdb_bridge.py
+++ b/tests/practice/test_seekdb_bridge.py
@@ -1,0 +1,128 @@
+"""Tests for the ROSClaw -> rosclaw_practice SeekDB bridge."""
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+pytest.importorskip("rosclaw_practice")
+
+from rosclaw.core.types import PraxisEvent, RobotState
+from rosclaw.practice.seekdb_bridge import SeekDBBridge
+
+
+@pytest.fixture
+def robot_state():
+    return RobotState(
+        timestamp=1.0,
+        joint_positions=np.array([0.1, 0.2, 0.3]),
+        joint_velocities=np.array([0.0, 0.0, 0.0]),
+        joint_torques=np.array([0.0, 0.0, 0.0]),
+        joint_names=["j1", "j2", "j3"],
+    )
+
+
+@pytest.fixture
+def praxis_event(robot_state):
+    return PraxisEvent(
+        event_id="evt_123",
+        event_type="success",
+        timestamp=1718875200.0,
+        robot_id="ur5e_lab_01",
+        agent_instruction="抓取红色水杯",
+        cot_trace=["检测目标", "规划路径", "执行抓取"],
+        initial_state=robot_state,
+        final_state=robot_state,
+        trajectory=[[0.1, 0.2], [0.2, 0.3]],
+        mcap_path="/data/rosclaw/mcap/evt_123/evt_123.mcap",
+        error_details=None,
+        duration_sec=1.5,
+        metadata={"reward": 1.0},
+    )
+
+
+class TestSeekDBBridge:
+    def test_convert_maps_fields(self, praxis_event):
+        bridge = SeekDBBridge()
+        converted = bridge._convert(praxis_event)
+
+        assert converted.practice_id == "evt_123"
+        assert converted.timestamp == "2024-06-20T09:20:00Z"
+        assert converted.robot_id == "ur5e_lab_01"
+        assert converted.cognitive_context.semantic_intent == "抓取红色水杯"
+        assert converted.cognitive_context.llm_cot == "检测目标\n规划路径\n执行抓取"
+        assert converted.physical_feedback.status == "SUCCESS"
+        assert converted.physical_feedback.reward == 1.0
+        assert converted.physical_feedback.error_log == ""
+        assert converted.data_pointers.mcap_path == "/data/rosclaw/mcap/evt_123/evt_123.mcap"
+
+    def test_convert_default_reward_and_empty_mcap(self, robot_state):
+        event = PraxisEvent(
+            event_id="evt_456",
+            event_type="failure",
+            timestamp=0.0,
+            robot_id="ur5e_lab_02",
+            agent_instruction="插入U盘",
+            cot_trace=[],
+            initial_state=robot_state,
+            final_state=None,
+            trajectory=[],
+            mcap_path=None,
+            error_details="gripper fault",
+            duration_sec=0.0,
+            metadata={},
+        )
+        bridge = SeekDBBridge()
+        converted = bridge._convert(event)
+
+        assert converted.physical_feedback.status == "FAILURE"
+        assert converted.physical_feedback.reward == 0.0
+        assert converted.physical_feedback.error_log == "gripper fault"
+        assert converted.data_pointers.mcap_path == ""
+
+    def test_commit_posts_to_seekdb(self, praxis_event):
+        bridge = SeekDBBridge()
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            bridge.commit(praxis_event)
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs["json"]["table"] == "praxis_events"
+        assert call_kwargs["json"]["data"]["practice_id"] == "evt_123"
+        assert call_kwargs["timeout"] == 2.0
+
+    def test_commit_fallback_on_failure(self, praxis_event):
+        fallback_dir = tempfile.mkdtemp()
+        bridge = SeekDBBridge(fallback_dir=fallback_dir)
+
+        with patch("requests.post", side_effect=ConnectionError(" SeekDB offline")):
+            bridge.commit(praxis_event)
+
+        fallback_files = [f for f in os.listdir(fallback_dir) if f.endswith(".json")]
+        assert len(fallback_files) == 1
+
+        with open(os.path.join(fallback_dir, fallback_files[0]), encoding="utf-8") as f:
+            saved = json.load(f)
+
+        assert saved["practice_id"] == "evt_123"
+        assert saved["physical_feedback"]["status"] == "SUCCESS"
+
+        os.remove(os.path.join(fallback_dir, fallback_files[0]))
+        os.rmdir(fallback_dir)
+
+    @pytest.mark.asyncio
+    async def test_commit_async(self, praxis_event):
+        bridge = SeekDBBridge()
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            await bridge.commit_async(praxis_event)
+
+        mock_post.assert_called_once()


### PR DESCRIPTION
Closing as superseded by #9, which includes the same SeekDB bridge plus additional MCP schema/adapter hardening.