### PR TITLE
fix(pyproject): remove duplicate [tool.hatch.metadata] block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,6 @@ Repository = "https://github.com/ros-claw/rosclaw"
 Documentation = "https://docs.rosclaw.io"
 "Bug Tracker" = "https://github.com/ros-claw/rosclaw/issues"
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/rosclaw"]
 


### PR DESCRIPTION
The merged `pyproject.toml` contained two `[[tool.hatch.metadata]]` sections with `allow-direct-references`, causing `tomllib` to fail when installing the package from source.

This change removes the duplicate block so `pip install -e .` works again.