### PR TITLE
fix(ci): add pytest-cov to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ practice = [
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
     "mypy>=1.5.0",
     "rank-bm25>=0.2",

--- a/tests/body/test_update_state_from_ros.py
+++ b/tests/body/test_update_state_from_ros.py
@@ -51,13 +51,15 @@ def test_update_state_from_ros(linked_body):
         "node_count": 1,
     }
 
-    with patch("rosclaw.body.cli.introspect_ros", return_value=(snapshot, runtime_state)):
-        with patch.object(sys, "argv", [
+    with (
+        patch("rosclaw.body.cli.introspect_ros", return_value=(snapshot, runtime_state)),
+        patch.object(sys, "argv", [
             "rosclaw", "body", "update-state",
             "--from-ros",
             "--reason", "live ROS 2 introspection",
-        ]):
-            assert rosclaw_main() == 0
+        ]),
+    ):
+        assert rosclaw_main() == 0
 
     resolver = BodyResolver()
     body_yaml = resolver.get_current_body_yaml()
@@ -67,13 +69,15 @@ def test_update_state_from_ros(linked_body):
 
 
 def test_update_state_from_ros_failure(linked_body):
-    with patch("rosclaw.body.cli.introspect_ros", side_effect=RosIntrospectionError("no bridge")):
-        with patch.object(sys, "argv", [
+    with (
+        patch("rosclaw.body.cli.introspect_ros", side_effect=RosIntrospectionError("no bridge")),
+        patch.object(sys, "argv", [
             "rosclaw", "body", "update-state",
             "--from-ros",
             "--reason", "live ROS 2 introspection",
-        ]):
-            assert rosclaw_main() == 1
+        ]),
+    ):
+        assert rosclaw_main() == 1
 
 
 def test_update_state_from_ros_changes_hash(linked_body):
@@ -83,12 +87,14 @@ def test_update_state_from_ros_changes_hash(linked_body):
     resolver = BodyResolver()
     old_hash = resolver.get_effective_body_hash()
 
-    with patch("rosclaw.body.cli.introspect_ros", return_value=(snapshot, runtime_state)):
-        with patch.object(sys, "argv", [
+    with (
+        patch("rosclaw.body.cli.introspect_ros", return_value=(snapshot, runtime_state)),
+        patch.object(sys, "argv", [
             "rosclaw", "body", "update-state",
             "--from-ros",
             "--reason", "live ROS 2 introspection",
-        ]):
-            assert rosclaw_main() == 0
+        ]),
+    ):
+        assert rosclaw_main() == 0
 
     assert resolver.get_effective_body_hash() != old_hash


### PR DESCRIPTION
The CI test job runs pytest with `--cov=src/rosclaw --cov-report=xml`, but `pytest-cov` was not declared in the `dev` extra. This caused the Test (3.11) and Test (3.12) jobs to fail with exit code 4 while the same command passed locally where pytest-cov was already installed.\n\nChanges:\n- Add `pytest-cov>=4.0.0` to `project.optional-dependencies.dev` in `pyproject.toml`.\n\nVerification:\n- `pytest tests/agent tests/mcp tests/security tests/practice -v --cov=src/rosclaw --cov-report=xml` now passes locally (155 passed, 1 skipped).\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)