### PR TITLE
feat(sense): wire body-sense snapshots into recorder, memory, and recovery hints

### DIFF
--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -252,6 +252,8 @@ class Runtime(LifecycleMixin):
                     embodied_memory=self.config.embodied_memory,
                 )
                 self._modules.append(self._memory)
+                if self._sense is not None:
+                    self._memory.set_sense_runtime(self._sense)
                 em_label = "+EmbodiedMemory" if self.config.embodied_memory else "SeekDB-only"
                 logger.info(f"Experience Grounding (Memory) initialized [{em_label}]")
             except ImportError as e:
@@ -416,6 +418,7 @@ class Runtime(LifecycleMixin):
                     event_bus=self.event_bus,
                     seekdb_client=seekdb,
                     skill_registry=getattr(self._skill_manager, "registry", None) if self._skill_manager else None,
+                    sense_runtime=self._sense,
                 )
                 self._modules.append(self._auto)
                 logger.info("Self-Evolution Control Plane (Auto) initialized")
@@ -484,6 +487,7 @@ class Runtime(LifecycleMixin):
             seekdb_client=seekdb,
             knowledge_interface=self._knowledge,
             event_bus=self.event_bus,
+            sense_runtime=self._sense,
         )
         self._run_async(engine.initialize())
         self._run_async(engine.seed_defaults())

--- a/src/rosclaw/how/engine.py
+++ b/src/rosclaw/how/engine.py
@@ -632,6 +632,8 @@ class HeuristicEngine:
         hint = await coro
         if hint and self._event_bus is not None:
             event_payload = re.format_for_eventbus(hint, request_id=payload.get("request_id", payload.get("episode_id", "")))
+            event_payload["body_readiness"] = context.get("body_readiness")
+            event_payload["body_block_reasons"] = context.get("body_block_reasons")
             from rosclaw.core.event_bus import Event, EventPriority
             self._event_bus.publish(Event(
                 topic="rosclaw.how.recovery_hint.generated",

--- a/src/rosclaw/memory/interface.py
+++ b/src/rosclaw/memory/interface.py
@@ -233,7 +233,7 @@ class MemoryInterface(LifecycleMixin):
                 or "unnamed_task"  # noqa: W503
             )
         self.store_experience(
-            event_id=payload.get("event_id", payload.get("episode_id", "")),
+            event_id=str(payload.get("event_id") or payload.get("episode_id") or ""),
             event_type=payload.get("event_type", "unknown"),
             instruction=instruction,
             duration_sec=payload.get("duration_sec", 0.0),

--- a/src/rosclaw/practice/episode_recorder.py
+++ b/src/rosclaw/practice/episode_recorder.py
@@ -214,12 +214,18 @@ class EpisodeRecorder(LifecycleMixin):
             buf.agent_request = payload["agent_request"]
         elif "parameters" in payload:
             buf.agent_request = {"skill_name": payload.get("skill_name"), "parameters": payload.get("parameters")}
-        buf.trajectory.append({
+        start_entry = {
             "phase": "start",
             "timestamp": time.time(),
             "skill_name": payload.get("skill_name"),
             "parameters": payload.get("parameters"),
-        })
+        }
+        if self._practice_adapter is not None:
+            try:
+                start_entry = self._practice_adapter.apply(start_entry)
+            except Exception:
+                logger.warning("PracticeWriterAdapter failed for start entry", exc_info=True)
+        buf.trajectory.append(start_entry)
         buf.last_event_at = time.time()
 
     def _on_skill_complete(self, event: Event) -> None:
@@ -460,6 +466,14 @@ class EpisodeRecorder(LifecycleMixin):
                 "error_details": praxis_event.error_details,
             },
         }
+        # Capture final body-sense snapshot if available
+        if self._practice_adapter is not None:
+            try:
+                end_context = self._practice_adapter.apply({"phase": "end"})
+                metadata["body_sense_end"] = end_context.get("body_sense_end")
+            except Exception:
+                logger.warning("PracticeWriterAdapter failed for end snapshot", exc_info=True)
+
         with open(episode_dir / "metadata.json", "w", encoding="utf-8") as f:
             json.dump(metadata, f, indent=2, default=str)
 

--- a/src/rosclaw/sense/adapters/how_context.py
+++ b/src/rosclaw/sense/adapters/how_context.py
@@ -26,8 +26,14 @@ class HowContextAdapter(SenseAdapterBase):
 
         readiness = sense.get("readiness", {})
         item = readiness.get("capabilities", {}).get(task, {})
+        status = item.get("status", "unknown")
         reasons = list(item.get("reasons", []))
-        block_reasons = [f"{task}: {r}" for r in reasons] if reasons else [f"{task}: not ready"]
+        if status == "ready":
+            block_reasons: list[str] = []
+        elif reasons:
+            block_reasons = [f"{task}: {r}" for r in reasons]
+        else:
+            block_reasons = [f"{task}: not ready"]
 
         return {
             **context,

--- a/tests/test_episode_recorder.py
+++ b/tests/test_episode_recorder.py
@@ -331,3 +331,86 @@ class TestStubTopics:
             meta = json.load(f)
         assert meta["status"] == "success"
         assert meta["reward"] == 0.9
+
+
+class TestEpisodeRecorderBodySense:
+    @pytest.fixture
+    def sense_runtime_kick_not_ready(self):
+        from rosclaw.sense.config import SenseConfig
+        from rosclaw.sense.runtime import SenseRuntime
+        bus = EventBus()
+        cfg = SenseConfig(
+            robot_id="g1_lab_01",
+            collector="mock",
+            update_hz=0.0,
+            extra={"scenario": "kick_not_ready"},
+        )
+        runtime = SenseRuntime(cfg, event_bus=bus, robot_id="g1_lab_01")
+        runtime.initialize()
+        runtime.tick()
+        yield runtime
+        runtime.stop()
+
+    @pytest.fixture
+    def recorder_with_sense(self, bus, temp_artifact_dir, sense_runtime_kick_not_ready):
+        r = EpisodeRecorder(
+            "test_bot",
+            bus,
+            artifact_base_dir=temp_artifact_dir,
+            sense_runtime=sense_runtime_kick_not_ready,
+        )
+        r.initialize()
+        yield r
+        r.stop()
+
+    def test_skill_start_captures_body_sense_start(self, recorder_with_sense, temp_artifact_dir):
+        recorder_with_sense._event_bus.publish(Event(
+            topic="skill.execution.start",
+            payload={"skill_name": "kick_ball", "correlation_id": "ep_sense_001"},
+        ))
+        recorder_with_sense._event_bus.publish(Event(
+            topic="praxis.completed",
+            payload={"practice_id": "ep_sense_001", "outcome": {"reward": 1.0}},
+        ))
+        traj_path = os.path.join(temp_artifact_dir, "episodes", "ep_sense_001", "trajectory.jsonl")
+        with open(traj_path) as f:
+            entries = [json.loads(line) for line in f]
+        start_entry = entries[0]
+        assert "body_sense_start" in start_entry
+        assert start_entry["body_sense_start"]["overall_status"] == "not_ready"
+
+    def test_finalize_captures_body_sense_end(self, recorder_with_sense, temp_artifact_dir):
+        recorder_with_sense._event_bus.publish(Event(
+            topic="skill.execution.start",
+            payload={"skill_name": "kick_ball", "correlation_id": "ep_sense_002"},
+        ))
+        recorder_with_sense._event_bus.publish(Event(
+            topic="praxis.completed",
+            payload={"practice_id": "ep_sense_002", "outcome": {"reward": 1.0}},
+        ))
+        meta_path = os.path.join(temp_artifact_dir, "episodes", "ep_sense_002", "metadata.json")
+        with open(meta_path) as f:
+            meta = json.load(f)
+        assert "body_sense_end" in meta
+        assert meta["body_sense_end"]["overall_status"] == "not_ready"
+
+    def test_recorder_without_sense_does_not_add_body_sense(self, bus, temp_artifact_dir):
+        r = EpisodeRecorder("test_bot", bus, artifact_base_dir=temp_artifact_dir)
+        r.initialize()
+        r._event_bus.publish(Event(
+            topic="skill.execution.start",
+            payload={"skill_name": "kick_ball", "correlation_id": "ep_sense_003"},
+        ))
+        r._event_bus.publish(Event(
+            topic="praxis.completed",
+            payload={"practice_id": "ep_sense_003", "outcome": {"reward": 1.0}},
+        ))
+        traj_path = os.path.join(temp_artifact_dir, "episodes", "ep_sense_003", "trajectory.jsonl")
+        with open(traj_path) as f:
+            entries = [json.loads(line) for line in f]
+        assert "body_sense_start" not in entries[0]
+        meta_path = os.path.join(temp_artifact_dir, "episodes", "ep_sense_003", "metadata.json")
+        with open(meta_path) as f:
+            meta = json.load(f)
+        assert "body_sense_end" not in meta
+        r.stop()

--- a/tests/test_heuristic_integration.py
+++ b/tests/test_heuristic_integration.py
@@ -664,3 +664,118 @@ class TestHowEndToEndRecovery:
         assert fallback is not None
         assert fallback["source"] == "knowledge_analogy"
         assert "charging station" in fallback["action"]
+
+
+class TestHeuristicEngineBodySense:
+    """Tests for body-aware recovery hint enrichment via HowContextAdapter."""
+
+    @pytest.fixture
+    def sense_runtime_kick_not_ready(self):
+        from rosclaw.core.event_bus import EventBus
+        from rosclaw.sense.config import SenseConfig
+        from rosclaw.sense.runtime import SenseRuntime
+
+        bus = EventBus()
+        cfg = SenseConfig(
+            robot_id="g1_lab_01",
+            collector="mock",
+            update_hz=0.0,
+            extra={"scenario": "kick_not_ready"},
+        )
+        runtime = SenseRuntime(cfg, event_bus=bus, robot_id="g1_lab_01")
+        runtime.initialize()
+        runtime.tick()
+        yield runtime
+        runtime.stop()
+
+    @pytest.fixture
+    def engine_with_sense(self, sense_runtime_kick_not_ready):
+        client = SeekDBMemoryClient()
+        client.connect()
+        engine = HeuristicEngine(
+            seekdb_client=client,
+            sense_runtime=sense_runtime_kick_not_ready,
+        )
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_generate_recovery_hint_includes_body_readiness(self, engine_with_sense):
+        await engine_with_sense.seed_defaults()
+        hint = await engine_with_sense.generate_recovery_hint(
+            "joint limit exceeded",
+            context={"task": "kick_ball"},
+        )
+        assert hint is not None
+        assert "body_readiness" in hint
+        assert "body_block_reasons" in hint
+        reasons = hint["body_block_reasons"] or []
+        assert any("kick_ball" in r for r in reasons)
+        assert any("temperature" in r.lower() for r in reasons)
+
+    @pytest.mark.asyncio
+    async def test_generate_recovery_hint_ready_state_no_blocks(self):
+        from rosclaw.core.event_bus import EventBus
+        from rosclaw.sense.config import SenseConfig
+        from rosclaw.sense.runtime import SenseRuntime
+
+        bus = EventBus()
+        cfg = SenseConfig(
+            robot_id="g1_lab_01",
+            collector="mock",
+            update_hz=0.0,
+            extra={"scenario": "normal"},
+        )
+        runtime = SenseRuntime(cfg, event_bus=bus, robot_id="g1_lab_01")
+        runtime.initialize()
+        runtime.tick()
+
+        client = SeekDBMemoryClient()
+        client.connect()
+        engine = HeuristicEngine(seekdb_client=client, sense_runtime=runtime)
+        await engine.seed_defaults()
+        hint = await engine.generate_recovery_hint(
+            "joint limit exceeded",
+            context={"task": "observe_scene"},
+        )
+        assert hint is not None
+        assert hint.get("body_block_reasons") in (None, [])
+        assert hint["body_readiness"]["overall_status"] == "ready"
+        runtime.stop()
+
+    @pytest.mark.asyncio
+    async def test_on_failure_event_enriches_context(self, sense_runtime_kick_not_ready):
+        from rosclaw.core.event_bus import EventBus
+
+        client = SeekDBMemoryClient()
+        client.connect()
+        bus = EventBus()
+        engine = HeuristicEngine(
+            seekdb_client=client,
+            event_bus=bus,
+            sense_runtime=sense_runtime_kick_not_ready,
+        )
+        await engine.initialize()
+        await engine.seed_defaults()
+
+        captured = []
+        bus.subscribe("rosclaw.how.recovery_hint.generated", lambda e: captured.append(e.payload))
+
+        class FakeEvent:
+            payload = {
+                "error_log": "joint limit exceeded",
+                "request_id": "req_sense_001",
+                "task": "kick_ball",
+            }
+
+        engine._on_failure_sync_wrapper(FakeEvent())
+        # Give fire_and_forget a moment to run
+        import asyncio
+        await asyncio.sleep(0.05)
+
+        assert len(captured) == 1
+        payload = captured[0]
+        assert payload["failure_type"] == "joint limit exceeded"
+        assert "body_readiness" in payload
+        assert "body_block_reasons" in payload
+        assert payload["body_readiness"]["overall_status"] == "not_ready"
+        assert any("kick_ball" in r for r in payload["body_block_reasons"])

--- a/tests/test_memory_body_sense.py
+++ b/tests/test_memory_body_sense.py
@@ -1,0 +1,136 @@
+"""Tests for MemoryInterface body-conditioned failure writing (Phase 7)."""
+
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.memory.interface import MemoryInterface
+from rosclaw.memory.seekdb_client import SeekDBMemoryClient
+from rosclaw.memory.types import FailureMemory
+from rosclaw.sense.config import SenseConfig
+from rosclaw.sense.runtime import SenseRuntime
+
+
+@pytest.fixture
+def sense_runtime_kick_not_ready():
+    bus = EventBus()
+    cfg = SenseConfig(
+        robot_id="g1_lab_01",
+        collector="mock",
+        update_hz=0.0,
+        extra={"scenario": "kick_not_ready"},
+    )
+    runtime = SenseRuntime(cfg, event_bus=bus, robot_id="g1_lab_01")
+    runtime.initialize()
+    runtime.tick()
+    yield runtime
+    runtime.stop()
+
+
+@pytest.fixture
+def memory_with_sense(sense_runtime_kick_not_ready):
+    client = SeekDBMemoryClient()
+    client.connect()
+    memory = MemoryInterface(
+        robot_id="g1_lab_01",
+        event_bus=EventBus(),
+        seekdb_client=client,
+    )
+    memory.set_sense_runtime(sense_runtime_kick_not_ready)
+    return memory
+
+
+class TestMemoryBodyConditionFailure:
+    def test_set_sense_runtime_initializes_adapter(self, memory_with_sense):
+        assert memory_with_sense._memory_writer_adapter is not None
+
+    def test_write_failure_memory_enriches_with_body_sense(self, memory_with_sense):
+        failure = FailureMemory(
+            failure_id="fail_001",
+            robot_id="g1_lab_01",
+            episode_id="ep_001",
+            task_id="kick_ball",
+            failure_type="body_sense_blocked",
+            root_cause="joint overheating",
+            recovery_hint="cooldown",
+        )
+        record_id = memory_with_sense.write_failure_memory(failure)
+        assert record_id
+
+        stored = memory_with_sense.seekdb_client.query(
+            "failures", filters={"id": record_id}, limit=1
+        )
+        assert len(stored) == 1
+        assert stored[0].get("body_condition_failure") is True
+        assert "body_sense_evidence" in stored[0]
+        evidence = stored[0]["body_sense_evidence"]
+        assert evidence["overall_status"] == "not_ready"
+
+    def test_write_failure_memory_dict_enriched(self, memory_with_sense):
+        record = {
+            "id": "fail_002",
+            "failure_type": "blocked",
+            "root_cause": "overheat",
+        }
+        record_id = memory_with_sense.write_failure_memory(record)
+        stored = memory_with_sense.seekdb_client.query(
+            "failures", filters={"id": record_id}, limit=1
+        )
+        assert stored[0].get("body_condition_failure") is True
+        assert "body_sense_evidence" in stored[0]
+
+    def test_firewall_blocked_handler_writes_body_condition(self, sense_runtime_kick_not_ready):
+        client = SeekDBMemoryClient()
+        client.connect()
+        bus = EventBus()
+        memory = MemoryInterface(robot_id="g1_lab_01", event_bus=bus, seekdb_client=client)
+        memory.set_sense_runtime(sense_runtime_kick_not_ready)
+        memory._do_initialize()
+
+        bus.publish(Event(
+            topic="firewall.action_blocked",
+            payload={
+                "episode_id": "ep_fire_001",
+                "reason": "joint limit",
+            },
+            source="test",
+        ))
+
+        stored = client.query("failures", filters={"id": "ep_fire_001"}, limit=1)
+        assert len(stored) == 1
+        assert stored[0].get("body_condition_failure") is True
+        assert stored[0].get("body_sense_evidence", {}).get("overall_status") == "not_ready"
+
+    def test_ready_state_does_not_flag_body_condition(self):
+        bus = EventBus()
+        cfg = SenseConfig(robot_id="g1_lab_01", collector="mock", update_hz=0.0, extra={"scenario": "normal"})
+        runtime = SenseRuntime(cfg, event_bus=bus, robot_id="g1_lab_01")
+        runtime.initialize()
+        runtime.tick()
+
+        client = SeekDBMemoryClient()
+        client.connect()
+        memory = MemoryInterface(robot_id="g1_lab_01", event_bus=EventBus(), seekdb_client=client)
+        memory.set_sense_runtime(runtime)
+
+        record_id = memory.write_failure_memory({
+            "id": "fail_ready",
+            "failure_type": "other",
+            "root_cause": "unknown",
+        })
+        stored = client.query("failures", filters={"id": record_id}, limit=1)
+        assert stored[0].get("body_condition_failure") is False
+        runtime.stop()
+
+    def test_no_sense_runtime_leaves_record_unchanged(self):
+        client = SeekDBMemoryClient()
+        client.connect()
+        memory = MemoryInterface(robot_id="g1_lab_01", event_bus=EventBus(), seekdb_client=client)
+        record_id = memory.write_failure_memory({
+            "id": "fail_no_sense",
+            "failure_type": "other",
+        })
+        stored = client.query("failures", filters={"id": record_id}, limit=1)
+        assert "body_condition_failure" not in stored[0]
+        assert "body_sense_evidence" not in stored[0]

--- a/tests/test_sandbox_adapter.py
+++ b/tests/test_sandbox_adapter.py
@@ -1,7 +1,8 @@
 """Tests for SandboxRuntimeAdapter."""
 
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from rosclaw.core.event_bus import EventBus
 from rosclaw.sandbox.runtime_adapter import SandboxRuntimeAdapter

--- a/tests/test_sandbox_adapter.py
+++ b/tests/test_sandbox_adapter.py
@@ -1,9 +1,12 @@
 """Tests for SandboxRuntimeAdapter."""
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from rosclaw.core.event_bus import EventBus
 from rosclaw.sandbox.runtime_adapter import SandboxRuntimeAdapter
+from rosclaw.sense.config import SenseConfig
+from rosclaw.sense.runtime import SenseRuntime
 
 
 class TestSandboxRuntimeAdapterLifecycle:
@@ -240,3 +243,98 @@ class TestSandboxRuntimeAdapterProperties:
         health = adapter.health()
         assert health["status"] == "unavailable"
         assert health["session_id"] is None
+
+
+class TestSandboxRuntimeAdapterSenseAware:
+    @pytest.fixture
+    def sense_runtime(self):
+        bus = EventBus()
+        cfg = SenseConfig(
+            robot_id="g1_lab_01",
+            collector="mock",
+            update_hz=0.0,
+            extra={"scenario": "kick_not_ready"},
+        )
+        runtime = SenseRuntime(cfg, event_bus=bus, robot_id="g1_lab_01")
+        runtime.initialize()
+        runtime.tick()
+        yield runtime
+        runtime.stop()
+
+    def _make_adapter(self, sense_runtime=None):
+        bus = EventBus()
+        config = {"engine": "mujoco", "world_id": "empty", "robot_id": "test_bot"}
+        runtime_wrapper = type("FakeRuntime", (), {"sense": sense_runtime})() if sense_runtime else None
+        adapter = SandboxRuntimeAdapter(config, event_bus=bus, runtime=runtime_wrapper)
+        adapter._sandbox_service = MagicMock()
+        return adapter
+
+    def test_validate_injects_body_sense_snapshot(self, sense_runtime):
+        adapter = self._make_adapter(sense_runtime)
+        captured_action = {}
+
+        with patch("rosclaw.sandbox.firewall.gate.FirewallGate") as mock_gate:
+            instance = mock_gate.return_value
+            decision = MagicMock()
+            decision.is_allowed = True
+            decision.risk_score = 0.1
+            decision.reason = "safe"
+            decision.predicted_collision = False
+            decision.violated_constraints = []
+            decision.replay_id = None
+            instance.check.return_value = decision
+
+            def capture_check(action):
+                captured_action.update(action)
+                return decision
+
+            instance.check.side_effect = capture_check
+            adapter.validate_trajectory([[0.0, 0.0, 0.0]])
+
+        assert "body_sense_snapshot" in captured_action
+        assert captured_action["body_sense_snapshot"]["overall_status"] == "not_ready"
+
+    def test_validate_without_runtime_does_not_inject_snapshot(self):
+        adapter = self._make_adapter(None)
+        captured_action = {}
+
+        with patch("rosclaw.sandbox.firewall.gate.FirewallGate") as mock_gate:
+            instance = mock_gate.return_value
+            decision = MagicMock()
+            decision.is_allowed = True
+            decision.risk_score = 0.1
+            decision.reason = "safe"
+            decision.predicted_collision = False
+            decision.violated_constraints = []
+            decision.replay_id = None
+
+            def capture_check(action):
+                captured_action.update(action)
+                return decision
+
+            instance.check.side_effect = capture_check
+            adapter.validate_trajectory([[0.0, 0.0, 0.0]])
+
+        assert "body_sense_snapshot" not in captured_action
+
+    def test_validate_adapter_failure_falls_back(self, sense_runtime, caplog):
+        import logging
+        adapter = self._make_adapter(sense_runtime)
+        adapter._sandbox_context_adapter = MagicMock()
+        adapter._sandbox_context_adapter.apply.side_effect = RuntimeError("adapter broken")
+
+        with patch("rosclaw.sandbox.firewall.gate.FirewallGate") as mock_gate:
+            instance = mock_gate.return_value
+            decision = MagicMock()
+            decision.is_allowed = True
+            decision.risk_score = 0.0
+            decision.reason = "safe"
+            decision.predicted_collision = False
+            decision.violated_constraints = []
+            decision.replay_id = None
+            instance.check.return_value = decision
+            with caplog.at_level(logging.WARNING, logger="rosclaw.sandbox.runtime_adapter"):
+                result = adapter.validate_trajectory([[0.0, 0.0, 0.0]])
+
+        assert result["is_safe"] is True
+        assert "without body sense" in caplog.text or "adapter broken" in caplog.text


### PR DESCRIPTION
## Summary
- `EpisodeRecorder` captures body-sense start/end snapshots when a `SenseRuntime` is available.
- `MemoryInterface` accepts `SenseRuntime` via `set_sense_runtime()` and enriches failure/experience records with body evidence.
- `HeuristicEngine` / `HowContextAdapter` include body readiness and block reasons in recovery hints.
- `Runtime` wires `sense_runtime` into Memory, Auto, and HeuristicEngine modules.
- Fixes `HowContextAdapter` to treat `readiness.status=ready` as no block reasons.
- Adds focused tests for episode recorder, memory, heuristic recovery, and sandbox adapter.

## Test plan
- [x] `python3 -m ruff check src tests`
- [x] `python3 -m mypy --config-file .github/mypy-ci.ini src/rosclaw/core/runtime.py src/rosclaw/practice/episode_recorder.py src/rosclaw/how/engine.py src/rosclaw/sense/adapters/how_context.py src/rosclaw/memory/interface.py`
- [x] `python3 -m pytest tests/test_episode_recorder.py tests/test_heuristic_integration.py tests/test_memory_body_sense.py -q`
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)