### PR TITLE
fix(sense): complete Phase 7 wiring and stabilize tests

### DIFF
--- a/examples/sense/g1_mock_demo.py
+++ b/examples/sense/g1_mock_demo.py
@@ -30,7 +30,7 @@ def main() -> None:
         collector = MockCollector(robot_id="g1_lab_01", scenario=scenario)
         state = collector.collect()
 
-        fatigue = fatigue_estimator.estimate(state, previous_state=None, dt=1.0)
+        fatigue = fatigue_estimator.estimate(state, prev_state=None, dt=1.0)
         risk_summary, _ = risk_estimator.evaluate(
             state, fatigue_risk=fatigue["fatigue_risk"]
         )

--- a/src/rosclaw/sense/interface.py
+++ b/src/rosclaw/sense/interface.py
@@ -49,9 +49,21 @@ class SenseInterface:
         """Return a fresh BodySense snapshot."""
         return self._runtime.tick()
 
+    def tick(self) -> BodySense:
+        """Alias for :meth:`get_body_sense` used by sense-aware adapters."""
+        return self._runtime.tick()
+
     def get_body_state(self) -> BodyState:
         """Return the latest raw BodyState."""
         return self._runtime.get_latest_state() or self._runtime._collector.collect()
+
+    def get_latest_state(self) -> BodyState | None:
+        """Alias for :meth:`get_body_state`."""
+        return self.get_body_state()
+
+    def get_latest_sense(self) -> BodySense | None:
+        """Return the latest cached BodySense without forcing a tick."""
+        return self._runtime.get_latest_sense()
 
     def get_readiness(
         self,

--- a/src/rosclaw/sense/schemas.py
+++ b/src/rosclaw/sense/schemas.py
@@ -198,6 +198,15 @@ class FailedRequirement:
     severity: str = "medium"
     reason: str = ""
 
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "current": self.current,
+            "required": self.required,
+            "severity": self.severity,
+            "reason": self.reason,
+        }
+
 
 @dataclass
 class ReadinessItem:

--- a/src/rosclaw/skill_manager/executor.py
+++ b/src/rosclaw/skill_manager/executor.py
@@ -107,6 +107,7 @@ class SkillExecutor(LifecycleMixin):
                 "reason": "blocked_by_body_sense",
                 "message": sense_check["reason"],
                 "failed_requirements": sense_check.get("failed_requirements", []),
+                **({"body_sense_check": bsc} if (bsc := sense_check.get("body_sense_check")) else {}),
             }
 
         self._current_skill = skill_name
@@ -124,7 +125,13 @@ class SkillExecutor(LifecycleMixin):
         ))
 
         # Execute handler if available
-        result: dict[str, Any] = {"status": "executed", "skill": skill_name}
+        result: dict[str, Any] = {
+            "status": "executed",
+            "skill": skill_name,
+        }
+        bsc = sense_check.get("body_sense_check")
+        if bsc is not None:
+            result["body_sense_check"] = bsc
         t0 = time.time()
         if skill.handler is not None:
             try:

--- a/tests/mcp/test_e2e.py
+++ b/tests/mcp/test_e2e.py
@@ -31,7 +31,7 @@ def _server_env() -> dict[str, str]:
     return env
 
 
-async def _wait_for_port(host: str, port: int, timeout: float = 10.0) -> None:
+async def _wait_for_port(host: str, port: int, timeout: float = 30.0) -> None:
     deadline = asyncio.get_event_loop().time() + timeout
     while asyncio.get_event_loop().time() < deadline:
         try:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -413,7 +413,13 @@ class TestDashboardServerBroadcast:
         server.register_client(client)
 
         await server.start()
-        await asyncio.sleep(0.12)
+        # Yield once so the broadcast task starts before we begin polling.
+        await asyncio.sleep(0)
+        # Wait for at least two snapshots to be broadcast, with a generous
+        # deadline so the test stays green under heavy parallel load.
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while client.send_text.await_count < 2 and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
         await server.stop()
 
         assert client.send_text.await_count >= 2

--- a/tests/test_skill_manager.py
+++ b/tests/test_skill_manager.py
@@ -6,6 +6,7 @@ import pytest
 from pytest import MonkeyPatch
 
 from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.sense.interface import SenseInterface
 from rosclaw.skill_manager.executor import SkillExecutor
 from rosclaw.skill_manager.loader import SkillLoader
 from rosclaw.skill_manager.registry import SkillEntry, SkillRegistry
@@ -413,5 +414,101 @@ class TestSkillExecutorBodyCheck:
         result = executor.execute("body_test_skill")
         assert result["status"] == "blocked"
         assert "unknown" in result.get("message", "").lower()
+        executor.stop()
+        reg.stop()
+
+
+class TestSkillExecutorBodySense:
+    @pytest.fixture
+    def sense_interface_kick_not_ready(self):
+        iface = SenseInterface(
+            robot_id="g1_lab_01",
+            collector="mock",
+            scenario="kick_not_ready",
+        )
+        iface.initialize()
+        yield iface
+        iface.stop()
+
+    @pytest.fixture
+    def sense_interface_normal(self):
+        iface = SenseInterface(
+            robot_id="g1_lab_01",
+            collector="mock",
+            scenario="normal",
+        )
+        iface.initialize()
+        yield iface
+        iface.stop()
+
+    def test_skill_blocked_when_body_not_ready(self, sense_interface_kick_not_ready):
+        bus = EventBus()
+        reg = SkillRegistry()
+        reg.initialize()
+        executor = SkillExecutor(bus, reg, sense_interface=sense_interface_kick_not_ready)
+        executor.initialize()
+
+        blocked_events = []
+        bus.subscribe("rosclaw.sense.capability.blocked", lambda e: blocked_events.append(e.payload))
+
+        reg.register(SkillEntry(
+            name="kick_ball",
+            description="Kick the ball",
+            skill_type="programmed",
+            metadata={"requires_body_sense": {"battery_percent_min": 40.0}},
+        ))
+
+        result = executor.execute("kick_ball")
+        assert result["status"] == "blocked"
+        assert result["reason"] == "blocked_by_body_sense"
+        assert "body_sense_check" in result
+        assert result["body_sense_check"]["status"] == "not_ready"
+        assert len(blocked_events) == 1
+        assert blocked_events[0]["capability"] == "kick_ball"
+
+        executor.stop()
+        reg.stop()
+
+    def test_skill_allowed_when_body_ready(self, sense_interface_normal):
+        bus = EventBus()
+        reg = SkillRegistry()
+        reg.initialize()
+        executor = SkillExecutor(bus, reg, sense_interface=sense_interface_normal)
+        executor.initialize()
+
+        reg.register(SkillEntry(
+            name="observe_scene",
+            description="Observe the scene",
+            skill_type="programmed",
+            metadata={"requires_body_sense": {"camera_fps_min": 10.0}},
+        ))
+
+        result = executor.execute("observe_scene")
+        assert result["status"] in ("success", "dispatched")
+        assert "body_sense_check" in result
+        assert result["body_sense_check"]["status"] == "ready"
+
+        executor.stop()
+        reg.stop()
+
+    def test_skill_requires_body_sense_fails_closed_without_interface(self):
+        bus = EventBus()
+        reg = SkillRegistry()
+        reg.initialize()
+        executor = SkillExecutor(bus, reg, sense_interface=None)
+        executor.initialize()
+
+        reg.register(SkillEntry(
+            name="kick_ball",
+            description="Kick the ball",
+            skill_type="programmed",
+            metadata={"requires_body_sense": {"battery_percent_min": 40.0}},
+        ))
+
+        result = executor.execute("kick_ball")
+        assert result["status"] == "blocked"
+        assert "Sense module is not available" in result["message"]
+        assert "body_sense_check" not in result
+
         executor.stop()
         reg.stop()

--- a/tests/unit/auto/test_engine.py
+++ b/tests/unit/auto/test_engine.py
@@ -1,9 +1,46 @@
 """Integration tests for AutoEngine."""
 import tempfile
 
+import pytest
+
 from rosclaw.auto.config import AutoConfig
 from rosclaw.auto.engine import AutoEngine
 from rosclaw.auto.storage import LocalStore
+from rosclaw.core.event_bus import EventBus
+from rosclaw.sense.config import SenseConfig
+from rosclaw.sense.runtime import SenseRuntime
+
+
+@pytest.fixture
+def sense_runtime_kick_not_ready():
+    bus = EventBus()
+    cfg = SenseConfig(
+        robot_id="g1_lab_01",
+        collector="mock",
+        update_hz=0.0,
+        extra={"scenario": "kick_not_ready"},
+    )
+    runtime = SenseRuntime(cfg, event_bus=bus, robot_id="g1_lab_01")
+    runtime.initialize()
+    runtime.tick()
+    yield runtime
+    runtime.stop()
+
+
+@pytest.fixture
+def sense_runtime_normal():
+    bus = EventBus()
+    cfg = SenseConfig(
+        robot_id="g1_lab_01",
+        collector="mock",
+        update_hz=0.0,
+        extra={"scenario": "normal"},
+    )
+    runtime = SenseRuntime(cfg, event_bus=bus, robot_id="g1_lab_01")
+    runtime.initialize()
+    runtime.tick()
+    yield runtime
+    runtime.stop()
 
 
 def test_full_workflow():
@@ -56,3 +93,43 @@ def test_full_workflow():
         # 9. Run dry-run evolution
         report2 = engine.run(task.id, rounds=2, dry_run=True)
         assert report2.proposals_created >= 1
+
+
+class TestAutoEngineBodySense:
+    def test_create_failure_case_with_body_condition(self, sense_runtime_kick_not_ready):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = AutoConfig(local_store_path=tmp)
+            engine = AutoEngine(config, sense_runtime=sense_runtime_kick_not_ready)
+
+            fc = engine.create_failure_case(
+                "evt_sense_001", "task_001", "kick_ball",
+                phase="swing", failure_mode="overheat",
+            )
+            assert fc.evidence.get("body_condition_failure") is True
+            assert "body_sense_snapshot" in fc.evidence
+            assert fc.evidence["body_sense_snapshot"]["overall_status"] == "not_ready"
+
+    def test_create_failure_case_ready_state_not_flagged(self, sense_runtime_normal):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = AutoConfig(local_store_path=tmp)
+            engine = AutoEngine(config, sense_runtime=sense_runtime_normal)
+
+            fc = engine.create_failure_case(
+                "evt_sense_002", "task_002", "observe_scene",
+                phase="perceive", failure_mode="target_lost",
+            )
+            assert fc.evidence.get("body_condition_failure") is False
+            assert "body_sense_snapshot" in fc.evidence
+
+    def test_create_failure_case_without_sense_runtime(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = AutoConfig(local_store_path=tmp)
+            engine = AutoEngine(config)
+
+            fc = engine.create_failure_case(
+                "evt_sense_003", "task_003", "pick_v1",
+                phase="grasp", failure_mode="missed_grasp",
+                evidence={"custom": True},
+            )
+            assert "body_condition_failure" not in fc.evidence
+            assert fc.evidence.get("custom") is True


### PR DESCRIPTION
Completes the remaining Phase 7 work for `rosclaw.sense`:

- Fixes `SenseInterface` adapter aliases so body-sense checks flow through the skill executor.
- Adds `FailedRequirement.to_dict()` and propagates `body_sense_check` in allowed/blocked results.
- Adds unit tests for `SkillExecutor` body-sense gating and `AutoEngine` body-conditioned failure writing.
- Fixes `examples/sense/g1_mock_demo.py` to match the current `FatigueEstimator` API.
- Hardens flaky MCP HTTP smoke and dashboard broadcast tests.

Verification:
- Targeted sense-related tests: 154 passed.
- E2E smoke: `rosclaw sense now --mock kick_not_ready --json` returns `not_ready` with `kick_ball` blocked.
- Full suite: 3105 passed; the single unrelated failure/error were environmental (port-binding timeout / tmp disk space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)