### PR TITLE
docs: align GitHub homepage with ROSClaw Physical AI runtime positioning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,15 +1,15 @@
-# ROSClaw 1.0 Architecture
+# ROSClaw Architecture
 
 ## Mission
 
-**The Open Infrastructure for Physical Intelligence**
+**Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents**
 
-Grounding AI into the Physical World.
+Ground AI agents into robot bodies. Validate every action. Learn from every trace. Evolve every skill.
 
 ## Engineering Identity
 
 ```text
-ROSClaw 1.0 =
+ROSClaw =
   Physical Runtime
   + Capability Provider
   + Sandbox Safety Gate
@@ -20,6 +20,7 @@ ROSClaw 1.0 =
   + Self-Evolution Control Plane
   + Skill Registry
   + Darwin Evaluation
+  + Physical-AI Asset Hub
 ```
 
 ## Engineering Iron Rules
@@ -38,8 +39,86 @@ ROSClaw 1.0 =
 12. **Auto owns self-evolution orchestration.**
 13. **Darwin owns evaluation pressure.**
 14. **Skill Registry owns promoted capabilities.**
+15. **Hub owns asset discovery and distribution; Runtime owns asset execution.**
 
-> **Auto 可以提出改变，但不能独自批准改变。Sandbox、Darwin、Promotion Gate 和 Human Approval 共同决定改变是否进入真实世界。**
+> **Auto can propose changes, but cannot approve them alone. Sandbox, Darwin, the promotion gate, and human approval together decide whether a change reaches the real world.**
+
+## Runtime Principles
+
+- **EventBus-only communication**: All modules communicate exclusively through the EventBus. No direct module-to-module calls. This ensures complete decoupling and enables any agent to connect without hardware-specific knowledge.
+- **Embodiment-first**: Every physical action is grounded through robot embodiment, capability schemas, safety limits, and runtime context.
+- **Sandbox-before-reality**: No model output reaches a real robot without passing through simulation-based validation.
+- **Practice-as-fact**: Execution traces are first-class evidence for failure analysis, memory recall, and skill evolution.
+- **Human-in-the-loop for safety**: Code patches, safety configuration changes, and skill promotion to real hardware require explicit human approval.
+
+## System Overview
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│           External Cognitive Brains                          │
+│     OpenClaw / Claude / GPT / Qwen / Custom Agents           │
+└───────────────────────────┬──────────────────────────────────┘
+                            │ MCP / SDK / AgentContext
+                            ▼
+┌──────────────────────────────────────────────────────────────┐
+│           ROSClaw Runtime                                    │
+│  AgentContext │ TaskContext │ SkillContext │ Trace           │
+└───────────────────────────┬──────────────────────────────────┘
+                            │
+        ┌───────────────────┼───────────────────┐
+        ▼                   ▼                   ▼
+┌───────────────┐   ┌───────────────┐   ┌───────────────┐
+│   Provider    │   │   Sandbox     │   │    Darwin     │
+│  Capability   │   │  e-URDF /     │   │  Benchmark /  │
+│   Router      │   │  MuJoCo /     │   │  Regression / │
+│               │   │  Firewall     │   │  Evaluation   │
+└───────┬───────┘   └───────┬───────┘   └───────────────┘
+        │                   │
+        └───────────┬───────┘
+                    ▼
+┌──────────────────────────────────────────────────────────────┐
+│           Physical World / Simulator                         │
+│        UR5e / G1 / Go2 / RealSense / IoT / MuJoCo            │
+└───────────────────────────┬──────────────────────────────────┘
+                            │
+                            ▼
+┌──────────────────────────────────────────────────────────────┐
+│           Practice Capture                                   │
+│   Unified Timeline / MCAP / JSONL / Video / Events           │
+└───────────────────────────┬──────────────────────────────────┘
+                            │
+                            ▼
+┌──────────────────────────────────────────────────────────────┐
+│           SeekDB Knowledge Plane                             │
+│  Robot │ Skill │ Provider │ Episode │ Failure │ Evidence    │
+└───────────────┬────────────────────────────┬─────────────────┘
+                │                            │
+                ▼                            ▼
+┌───────────────────────┐      ┌───────────────────────────────┐
+│     Memory            │      │         Know                  │
+│  Spatiotemporal       │      │  Physical-AI Knowledge        │
+│  Failure / Success    │      │  Compiler                     │
+│  Pattern / Causal     │      │  TaskCard / Pattern / Evidence│
+└───────────┬───────────┘      └───────────────┬───────────────┘
+            │                                  │
+            └──────────────┬───────────────────┘
+                           │
+                           ▼
+            ┌──────────────────────────────┐
+            │      How  ←→  Auto           │
+            │  Runtime Intervention        │
+            │  Self-Evolution Control      │
+            │  Proposal / Patch / Champion │
+            └──────────────┬───────────────┘
+                           │
+                           ▼
+                 ┌─────────────────┐
+                 │  Skill Registry │
+                 │  Versioned /    │
+                 │  Champion /     │
+                 │  Rollback-safe  │
+                 └─────────────────┘
+```
 
 ## Module Boundaries
 
@@ -57,22 +136,23 @@ ROSClaw 1.0 =
 | Darwin | Multi-seed benchmark, stress scenario, regression | Approve patches, override safety |
 | Skill Registry | Version, lineage, champion, rollback | Execute skills, validate safety |
 | Dashboard | Observability, evolution trace, lineage viz | Mutate state, bypass gates |
+| Hub | Asset discovery, validation, distribution | Execute assets, bypass runtime gates |
 
 ## Execution Loop
 
 ```text
 1. Agent receives task
-2. agent-runtime constructs AgentContext
-3. provider routes capabilities
-4. provider outputs structured results
-5. sandbox enters firewall mode
-6. sandbox decides ALLOW/BLOCK/MODIFY/REQUIRE_CONFIRMATION
-7. runtime executes on physical robot
-8. practice captures execution trace
-9. critic judges success/failure
-10. memory writes experience
-11. how decides intervention
-12. auto decides self-evolution
+2. Runtime constructs AgentContext
+3. Provider routes capabilities
+4. Provider outputs structured results
+5. Sandbox enters firewall mode
+6. Sandbox decides ALLOW / BLOCK / MODIFY / REQUIRE_HUMAN_CONFIRMATION
+7. Runtime executes on physical robot or simulator
+8. Practice captures execution trace
+9. Critic judges success/failure
+10. Memory writes experience
+11. How decides intervention
+12. Auto decides self-evolution
 ```
 
 ## Self-Evolution Loop
@@ -92,18 +172,27 @@ PraxisFailedEvent
   → How / Know / Memory Evidence Update
 ```
 
-## SeekDB Collections
+A skill is not overwritten blindly. It is **versioned, evaluated, promoted, and rollback-safe**:
 
 ```text
-robots, providers, skills, skill_versions, tasks, runs, episodes
-praxis_events, failures, memory_nodes, memory_edges
-knowledge_patterns, task_cards, embodiment_cards, verifier_cards
-interventions, evidence_traces
-auto_proposals, auto_patches, auto_experiments, auto_results
-champions, dead_ends, darwin_benchmarks, artifacts
+pick_cube@v1.0.0  baseline_champion
+    ↓
+pick_cube@candidate_0001  sandbox_passed
+    ↓
+pick_cube@v1.1.0  sim_champion
+    ↓
+pick_cube@v1.1.0  sandbox_champion
+    ↓
+pick_cube@v1.1.0  real_candidate
+    ↓
+pick_cube@v1.1.0  real_champion
 ```
 
-## Core Events
+## Event Bus
+
+All modules publish and subscribe through a unified EventBus. Topics are namespaced by module and trace correlation.
+
+### Core Events
 
 ```text
 TaskSubmittedEvent
@@ -128,7 +217,7 @@ DarwinBenchmarkCompletedEvent
 HumanApprovalRequiredEvent
 ```
 
-## Event Envelope
+### Event Envelope
 
 ```json
 {
@@ -144,3 +233,273 @@ HumanApprovalRequiredEvent
   "payload": {}
 }
 ```
+
+## Agent Context
+
+The AgentContext carries everything an MCP-compatible agent needs to interact with ROSClaw without knowing hardware details:
+
+- Task description and history
+- Connected robot body profile
+- Available capabilities and providers
+- Sandbox decisions and constraints
+- Memory recall results
+- Safety level and approval status
+
+## Embodiment Context
+
+ROSClaw treats robot embodiment as a first-class system primitive. An e-URDF profile defines:
+
+- Robot structure
+- Joints, links, sensors, actuators
+- Safety envelopes
+- Tool frames
+- Workspace limits
+- Capabilities
+- Simulation assets
+- Benchmark metadata
+
+This allows the same skill to be adapted, validated, and transferred across different robot bodies.
+
+## Capability Provider
+
+The Provider layer turns heterogeneous models and algorithms into routable physical capabilities:
+
+- LLM for planning and reasoning
+- VLM for visual grounding
+- VLA for vision-language-action proposals
+- VLN for navigation
+- World model for scene understanding
+- Skill policy for execution
+- Critic for success/failure judgment
+- Embedding for semantic memory retrieval
+
+Providers produce structured outputs, not raw motor commands.
+
+## Sandbox / Firewall
+
+The Sandbox module provides simulation-first validation. Its firewall mode can block risky actions before they reach hardware.
+
+Possible decisions:
+
+```text
+ALLOW
+BLOCK
+MODIFY
+REQUIRE_HUMAN_CONFIRMATION
+```
+
+Example result:
+
+```json
+{
+  "decision": "BLOCK",
+  "risk_score": 0.92,
+  "reason": "Predicted collision between wrist_link and table",
+  "violated_constraints": ["collision", "workspace_boundary"],
+  "replay_id": "sandbox://replays/firewall_00042"
+}
+```
+
+## Practice Timeline
+
+Practice captures a unified physical timeline including:
+
+- Robot state snapshots
+- Sensor data
+- Action traces
+- Provider traces
+- Sandbox decisions
+- Skill execution metadata
+- Critic results
+- MCAP / JSONL artifacts
+- Replay files
+- Failure reports
+
+## Memory Schema
+
+SeekDB collections:
+
+```text
+robots, providers, skills, skill_versions, tasks, runs, episodes
+praxis_events, failures, memory_nodes, memory_edges
+knowledge_patterns, task_cards, embodiment_cards, verifier_cards
+interventions, evidence_traces
+auto_proposals, auto_patches, auto_experiments, auto_results
+champions, dead_ends, darwin_benchmarks, artifacts
+```
+
+## How Intervention
+
+`rosclaw-how` acts as a runtime reflex layer. When an agent is stuck, unsafe, invalid-heavy, or regressing, it provides minimal, evidence-backed interventions such as:
+
+- Safety constraints
+- Feasibility repair
+- Stabilizing hints
+- Next experiment suggestions
+- Recovery instructions
+
+## Know TaskCard
+
+`rosclaw-know` compiles unstructured engineering knowledge into structured TaskCards:
+
+- Papers and documentation
+- Code and logs
+- Trajectories and benchmark traces
+- Failures and causal evidence
+
+## Auto Evolution
+
+`rosclaw-auto` turns repeated failures into structured improvement cycles:
+
+```text
+FailureCase
+    ↓
+Diagnosis
+    ↓
+Hypothesis
+    ↓
+Proposal
+    ↓
+Patch
+    ↓
+Sandbox Experiment
+    ↓
+Darwin Evaluation
+    ↓
+Champion / DeadEnd
+```
+
+## Darwin Evaluation
+
+`rosclaw-darwin` provides the evaluation pressure that gates skill promotion:
+
+- Multi-seed validation
+- Stress scenarios
+- Regression tests
+- Safety event tracking
+- Success-rate thresholds
+
+Promotion gates:
+
+| Gate | Check |
+|------|-------|
+| Success Improvement | Candidate success rate > baseline + threshold |
+| Safety Regression | No increase in collision or safety events |
+| Multi-Seed Validation | Passes on seeds [0, 1, 2, ...] |
+| Sandbox Clearance | Firewall decision == ALLOW |
+| Regression Suite | No degradation on existing tasks |
+| Human Approval | Required for code patches and safety config |
+
+## Hub Asset Lifecycle
+
+Physical-AI assets flow through the Hub with explicit lifecycle states:
+
+```text
+Create
+  → Validate
+  → Sign
+  → Publish
+  → Sync
+  → Install
+  → Activate
+  → Evaluate
+  → Update / Rollback
+  → Uninstall
+```
+
+Asset types:
+
+| Type | Description |
+|---|---|
+| `skill` | Task policy, recovery logic, skill graph, parameters, evaluation metadata |
+| `provider` | LLM / VLM / VLA / VLN / world model / critic / embedding / robotics algorithm |
+| `hardware_mcp` | MCP-compatible robot, sensor, or device interface |
+| `digital_twin` | Simulation world, robot asset, replay scene, validation environment |
+| `e_urdf` | Robot embodiment profile and safety envelope |
+| `cognitive_wiki` | TaskCard, failure taxonomy, constraints, evidence, and repair knowledge |
+
+## Safety Boundary
+
+The safety pipeline:
+
+```text
+Agent Intent
+  ↓
+Provider Schema
+  ↓
+Embodiment Constraints
+  ↓
+Sandbox Validation
+  ↓
+Runtime Guard
+  ↓
+Robot Controller
+```
+
+Hard rules:
+
+- VLA outputs are proposals, not raw motor commands.
+- World models are previews, not safety proofs.
+- MCP is an agent tool interface, not a real-time control bus.
+- Auto-generated skills must pass sandbox validation before execution.
+- Code patches require human review before production use.
+- Safety configuration changes require explicit approval.
+- Every promoted skill must be versioned and rollback-safe.
+
+See [docs/SAFETY.md](docs/SAFETY.md) for the complete safety model.
+
+## Deployment Modes
+
+| Mode | Description | Cloud Key Required |
+|---|---|---|
+| **Simulation-only (offline)** | Local runtime, local assets, local traces. No real robot. | No |
+| **Simulation-to-Reality** | Firewall-enabled; all real-robot actions validated in sandbox first. | Optional |
+| **Production** | All gates active, human approval required for patches and promotion. | Yes |
+
+## Data Flow
+
+```text
+Agent → Runtime → EventBus
+              ├── Provider → Sandbox → Robot/Simulator → Practice → Memory
+              ├── How ←→ Auto ←→ Darwin → Skill Registry
+              └── Dashboard ←→ Hub
+```
+
+## Repository Structure
+
+```text
+rosclaw/
+├── src/rosclaw/              # Core runtime, schemas, CLI, MCP gateway
+│   ├── core/                 # Runtime, EventBus, lifecycle
+│   ├── schemas/              # Unified canonical dataclasses
+│   ├── provider/             # Capability provider layer
+│   ├── sandbox/              # MuJoCo simulation & firewall
+│   ├── practice/             # Timeline capture & MCAP
+│   ├── memory/               # Spatiotemporal memory
+│   ├── how/                  # Runtime intervention
+│   ├── know/                 # Knowledge compiler
+│   ├── auto/                 # Self-evolution control plane
+│   ├── darwin/               # Benchmark & evaluation arena
+│   ├── forge/                # Asset compiler
+│   ├── dashboard/            # Observability & WebSocket
+│   └── mcp/                  # MCP server implementation
+├── e-urdf-zoo/               # Physical DNA registry
+├── docs/                     # Architecture, RFCs, usage guides
+├── examples/                 # Robot and simulation examples
+├── tests/                    # Unit, integration, E2E, safety tests
+├── benchmarks/               # Benchmark and evaluation tasks
+├── scripts/                  # Install and utility scripts
+├── rosclaw.yaml              # Default runtime config
+├── ARCHITECTURE.md           # This file
+├── QUICKSTART.md             # Quick start guide
+└── INSTALL.md                # Installation details
+```
+
+## References
+
+- [Quick Start](QUICKSTART.md)
+- [Installation](INSTALL.md)
+- [Safety Model](docs/SAFETY.md)
+- [Physical-AI Assets](docs/ASSETS.md)
+- [CLI Reference](docs/CLI.md)
+- [Hub](docs/hub/README.md)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,12 @@
-# ROSClaw v1.0 Installation Guide
+# ROSClaw Installation Guide
+
+For a guided first experience, see [QUICKSTART.md](QUICKSTART.md). This guide covers installation methods, platform-specific requirements, and troubleshooting.
+
+---
 
 ## Recommended User Install
 
-The fastest way to get ROSClaw is the official bootstrapper. It installs the CLI, creates a minimal workspace, and runs a bootstrap health check. No robot is moved, no cloud account is created, and no telemetry is sent unless you explicitly opt in later.
+The official bootstrapper installs the CLI, creates a minimal workspace, and runs a bootstrap health check. No robot is moved, no cloud account is created, and no telemetry is sent unless you explicitly opt in later.
 
 ```bash
 curl -sSL https://rosclaw.io/get | bash
@@ -139,6 +143,20 @@ WSL is supported. The bootstrapper detects WSL and warns if you try to install u
 
 ---
 
+## Configuration
+
+After `rosclaw firstboot`, the main config lives at `~/.rosclaw/config/rosclaw.yaml`. For a complete example, see [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md).
+
+To inspect or edit the config:
+
+```bash
+rosclaw config show
+rosclaw config path
+rosclaw config edit
+```
+
+---
+
 ## Verify Installation
 
 ```bash
@@ -146,6 +164,24 @@ rosclaw --version
 rosclaw doctor --bootstrap
 rosclaw doctor --full --json
 ```
+
+---
+
+## Uninstall
+
+To remove the CLI and optionally the workspace:
+
+```bash
+rosclaw uninstall --purge
+```
+
+To keep workspace data:
+
+```bash
+rosclaw uninstall --keep-data
+```
+
+---
 
 ## Troubleshooting
 
@@ -156,3 +192,15 @@ rosclaw doctor --full --json
 | PEP 668 externally-managed environment | The bootstrapper will use a private venv automatically |
 | `rosclaw doctor` reports missing modules | Run `pip install -e .` from the repo root |
 | MuJoCo rendering fails | `sudo apt install libglfw3 libglew2.2` |
+| ROS 2 import errors | Source `/opt/ros/humble/setup.bash` before running ROS 2 features |
+| Permission denied during firstboot | Ensure `~/.rosclaw` is writable by your user |
+
+---
+
+## Next Steps
+
+- [Quick Start](QUICKSTART.md)
+- [Architecture](ARCHITECTURE.md)
+- [First Boot Details](docs/FIRSTBOOT.md)
+- [CLI Reference](docs/CLI.md)
+- [Safety Model](docs/SAFETY.md)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,80 +1,259 @@
-# ROSClaw v1.0 Quick Start
+# ROSClaw Quick Start
 
-## 1. Install
+This guide gets you running with ROSClaw in about 15 minutes. Choose the path that matches your goal:
+
+- [Path A: Local Simulation Only](#path-a-local-simulation-only) — no robot required
+- [Path B: Agent Integration](#path-b-agent-integration) — connect Claude Code or another MCP agent
+- [Path C: Robot Body Setup](#path-c-robot-body-setup) — configure a real or simulated robot body
+- [Path D: Developer Setup](#path-d-developer-setup) — modify ROSClaw itself
+
+---
+
+## Path A: Local Simulation Only
+
+The fastest way to see ROSClaw in action.
+
+### 1. Install
 
 ```bash
 curl -sSL https://rosclaw.io/get | bash
 ```
 
-This installs the `rosclaw` CLI and prepares a minimal workspace at `~/.rosclaw`.
+This installs the `rosclaw` CLI and creates a minimal workspace at `~/.rosclaw`.
 
-## 2. First Boot
-
-```bash
-rosclaw firstboot
-```
-
-Follow the interactive wizard to choose your profile, robot, safety level, and MCP setup.
-
-For headless/CI environments:
+### 2. First Boot
 
 ```bash
 rosclaw firstboot --yes --profile offline --no-telemetry
 ```
 
-## 3. Verify
+For an interactive setup, run `rosclaw firstboot` without flags.
+
+### 3. Check Health
 
 ```bash
-rosclaw --version
 rosclaw doctor
 ```
 
-Structured doctor report:
+Expected: all core modules report `HEALTHY` or a clear message if optional dependencies are missing.
 
-```bash
-rosclaw doctor --full --json
-```
-
-## 4. List Robots
-
-```bash
-rosclaw robot list
-```
-
-## 5. Run a Simulation Demo
+### 4. Run a Sandbox Demo
 
 ```bash
 rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach
 ```
 
-## 6. Inspect Configuration
+Expected output: a simulated episode result with status, steps, duration, and artifact URI.
+
+### 5. Open Dashboard
 
 ```bash
-rosclaw config show
+rosclaw dashboard --open
+```
+
+Visit `http://localhost:8765` to view runtime health, traces, and registered skills.
+
+### Common Failures
+
+| Issue | Solution |
+|---|---|
+| `rosclaw: command not found` | Add `export PATH="$HOME/.rosclaw/bin:$PATH"` to your shell profile |
+| `MuJoCo not installed` | Install with `pip install mujoco>=3.0.0` |
+| Python version error | Use Python 3.11+ |
+
+### Next Steps
+
+- Read [ARCHITECTURE.md](ARCHITECTURE.md) for the system design.
+- Explore `rosclaw sandbox --help` for more simulation options.
+- See [docs/SAFETY.md](docs/SAFETY.md) before running on real hardware.
+
+---
+
+## Path B: Agent Integration
+
+Connect ROSClaw to Claude Code or any MCP-compatible agent.
+
+### 1. Initialize ROSClaw
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot --yes --profile offline --no-telemetry
+```
+
+### 2. Initialize Claude Code
+
+```bash
+rosclaw agent init claude-code
+```
+
+This generates `.mcp.json`, `CLAUDE.md`, `ROSCLAW.md`, and `.claude/settings.json` in the current directory.
+
+### 3. Inspect MCP Config
+
+```bash
 rosclaw config path
-rosclaw profile current
+# ~/.rosclaw/config/rosclaw.yaml
 ```
 
-## 7. Start the MCP Hub (optional)
+The MCP server config is written to `~/.rosclaw/config/mcp.json` by default.
 
-If you use Claude Code or another MCP-compatible agent, the MCP config was written to:
+### 4. Validate Agent Tools
 
-```text
-~/.rosclaw/config/mcp.json
+```bash
+rosclaw agent test claude-code
 ```
 
-Point your agent at this file to expose ROSClaw physical tools.
+### 5. Start the MCP Server
 
-## Developer Quick Start
+```bash
+rosclaw mcp serve --transport stdio --robot-id sim_ur5e
+```
+
+Then point your MCP client at this command.
+
+### Common Failures
+
+| Issue | Solution |
+|---|---|
+| Agent cannot see tools | Verify `~/.rosclaw/config/mcp.json` is referenced by the agent |
+| `rosclaw agent test` fails | Run `rosclaw doctor` and check that the sandbox module is healthy |
+
+### Next Steps
+
+- Read [docs/MCP_USAGE.md](docs/MCP_USAGE.md).
+- Try the tabletop grasp demo through the agent interface.
+- See [docs/SAFETY.md](docs/SAFETY.md) for agent safety rules.
+
+---
+
+## Path C: Robot Body Setup
+
+Configure a robot body using an e-URDF profile.
+
+### 1. Install and First Boot
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot --yes --profile offline --no-telemetry
+```
+
+### 2. List Available Robot Profiles
+
+```bash
+rosclaw robot list
+```
+
+### 3. Initialize a Body
+
+```bash
+rosclaw body init --robot unitree-g1
+```
+
+### 4. Link an e-URDF Profile
+
+```bash
+rosclaw body link-eurdf unitree-g1
+```
+
+### 5. Inspect the Body
+
+```bash
+rosclaw body inspect --skills --safety
+```
+
+### 6. Validate in Sandbox
+
+```bash
+rosclaw sandbox run --robot sim_g1 --world tabletop --task stand_balance
+```
+
+### Common Failures
+
+| Issue | Solution |
+|---|---|
+| `Robot profile not found` | Check `e-urdf-zoo/<robot>/robot.eurdf.yaml` exists |
+| `No body linked` | Run `rosclaw body link-eurdf <profile>` first |
+| Sandbox validation fails | Inspect `rosclaw body inspect --safety` for constraint violations |
+
+### Next Steps
+
+- Read [e-urdf-zoo/](e-urdf-zoo/) for available robot profiles.
+- See [docs/BODYSENSE_SCHEMA.md](docs/BODYSENSE_SCHEMA.md) for body sense data.
+- Calibrate the body with `rosclaw body calibration update --file calib.yaml`.
+
+---
+
+## Path D: Developer Setup
+
+Work on ROSClaw itself.
+
+### 1. Clone
 
 ```bash
 git clone https://github.com/ros-claw/rosclaw.git
 cd rosclaw
+```
+
+### 2. Setup
+
+```bash
 make setup
 ```
 
+This creates a virtual environment, installs dependencies, and bootstraps a local workspace.
+
+### 3. Test
+
+```bash
+make test
+```
+
+Or run pytest directly:
+
+```bash
+PYTHONPATH=src pytest tests -q
+```
+
+### 4. First Boot in Dev Mode
+
+```bash
+rosclaw firstboot --dev --workspace .rosclaw --profile offline --no-telemetry --yes
+rosclaw doctor --full
+```
+
+### Common Failures
+
+| Issue | Solution |
+|---|---|
+| `make setup` fails | Ensure Python 3.11+ and `pip` are available |
+| Import errors | Activate the venv created by `make setup` |
+| Tests fail in ROS 2 areas | Source `/opt/ros/humble/setup.bash` before running tests |
+
+### Next Steps
+
+- Read [CONTRIBUTING.md](CONTRIBUTING.md).
+- Explore `src/rosclaw/` modules.
+- Run integration tests with `make integration`.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|---|---|
+| `rosclaw: command not found` | Add `export PATH="$HOME/.rosclaw/bin:$PATH"` to your shell profile |
+| Python version error | Install Python 3.11+ or use `uv` |
+| PEP 668 externally-managed environment | The bootstrapper uses a private venv automatically |
+| `rosclaw doctor` reports missing modules | Run `pip install -e .` from the repo root |
+| MuJoCo rendering fails | `sudo apt install libglfw3 libglew2.2` |
+
+---
+
 ## Next Steps
 
-- Read [ARCHITECTURE.md](ARCHITECTURE.md) for the 14 Engineering Iron Rules.
-- Explore `rosclaw sandbox --help` for simulation options.
-- Check `rosclaw doctor --full` for optional capability gaps.
+- [Architecture](ARCHITECTURE.md)
+- [CLI Reference](docs/CLI.md)
+- [Safety Model](docs/SAFETY.md)
+- [Physical-AI Assets](docs/ASSETS.md)
+- [First Boot Details](docs/FIRSTBOOT.md)
+- [Hub](docs/hub/README.md)

--- a/README.md
+++ b/README.md
@@ -2,385 +2,164 @@
 
 # ROSClaw
 
-**The Open Infrastructure for Physical Intelligence**
+### Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents
 
-*Grounding AI Agents into the Physical World.*
+**Ground AI agents into robot bodies. Validate every action. Learn from every trace. Evolve every skill.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python)](https://www.python.org/)
 [![ROS 2](https://img.shields.io/badge/ROS_2-Humble_|_Jazzy-FF3E00?logo=ros)](https://docs.ros.org/)
 [![Simulation](https://img.shields.io/badge/Simulation-MuJoCo_|_Isaac--Sim-black?logo=mujoco)](https://mujoco.org/)
 [![MCP](https://img.shields.io/badge/Protocol-MCP_Ready-8A2BE2)](https://modelcontextprotocol.io/)
-[![Status](https://img.shields.io/badge/Release-v1.0-purple)](https://github.com/ros-claw/rosclaw/releases)
+[![Status](https://img.shields.io/badge/status-active%20development-orange)](https://github.com/ros-claw/rosclaw)
+[![Contact](https://img.shields.io/badge/contact-ai%40rosclaw.io-blue)](mailto:ai@rosclaw.io)
 
-[English](README.md) • [中文](README.zh.md) • [Architecture](#architecture) • [Quick Start](#-quick-start) • [Docs](docs/)
-
-<br/>
-
-> **Teach Once. Embody Anywhere. Evolve Continuously.**
+[English](README.md) • [中文](README.zh.md) • [Quick Start](QUICKSTART.md) • [Architecture](ARCHITECTURE.md) • [Docs](docs/) • [Contact](mailto:ai@rosclaw.io)
 
 </div>
 
 ---
 
+ROSClaw is an open runtime infrastructure layer for **Physical AI** and **embodied agents**.
+
+It connects AI agents, robot embodiments, sandbox safety, capability providers, praxis capture, physical memory, runtime intervention, and benchmark-driven skill evolution into one coherent operating layer.
+
+> From agent intent → validated action → physical trace → memory → intervention → evolved skill.
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot
+```
+
+---
+
 ## What is ROSClaw?
 
-ROSClaw is **not** another chatbot framework. It is **not** a thin LLM-to-ROS wrapper. It is **not** a collection of random robotics tools.
+ROSClaw is **not** a chatbot framework.  
+It is **not** a thin LLM-to-ROS wrapper.  
+It is **not** just another robotics toolkit.
 
-ROSClaw is an **open infrastructure layer for Physical Intelligence**: a runtime that connects AI agents, robot embodiments, simulation sandboxes, skill systems, multimodal providers, physical memory, and self-evolution loops into one coherent operating layer.
+ROSClaw provides the missing runtime layer between AI agents and the physical world:
 
-It is designed for the next generation of embodied agents that must not only reason, but also **act safely, remember physically, recover from failure, and improve over time**.
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│           External Cognitive Brains                          │
-│     OpenClaw / Claude / GPT / Qwen / Custom Agents           │
-└───────────────────────────┬──────────────────────────────────┘
-                            │ MCP / SDK / AgentContext
-                            ▼
-┌──────────────────────────────────────────────────────────────┐
-│           ROSClaw Runtime                                    │
-│  AgentContext │ TaskContext │ SkillContext │ Trace           │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-        ┌───────────────────┼───────────────────┐
-        ▼                   ▼                   ▼
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│   Provider    │   │   Sandbox     │   │    Darwin     │
-│  Capability   │   │  e-URDF /     │   │  Benchmark /  │
-│   Router      │   │  MuJoCo /     │   │  Regression / │
-│               │   │  Firewall     │   │  Evaluation   │
-└───────┬───────┘   └───────┬───────┘   └───────────────┘
-        │                   │
-        └───────────┬───────┘
-                    ▼
-┌──────────────────────────────────────────────────────────────┐
-│           Physical World / Simulator                         │
-│        UR5e / G1 / Go2 / RealSense / IoT / MuJoCo            │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────┐
-│           Practice Capture                                   │
-│   Unified Timeline / MCAP / JSONL / Video / Events           │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────┐
-│           SeekDB Knowledge Plane                             │
-│  Robot │ Skill │ Provider │ Episode │ Failure │ Evidence    │
-└───────────────┬────────────────────────────┬─────────────────┘
-                │                            │
-                ▼                            ▼
-┌───────────────────────┐      ┌───────────────────────────────┐
-│     Memory            │      │         Know                  │
-│  Spatiotemporal       │      │  Physical-AI Knowledge        │
-│  Failure / Success    │      │  Compiler                     │
-│  Pattern / Causal     │      │  TaskCard / Pattern / Evidence│
-└───────────┬───────────┘      └───────────────┬───────────────┘
-            │                                  │
-            └──────────────┬───────────────────┘
-                           │
-                           ▼
-            ┌──────────────────────────────┐
-            │      How  ←→  Auto           │
-            │  Runtime Intervention        │
-            │  Self-Evolution Control      │
-            │  Proposal / Patch / Champion │
-            └──────────────┬───────────────┘
-                           │
-                           ▼
-                 ┌─────────────────┐
-                 │  Skill Registry │
-                 │  Versioned /    │
-                 │  Champion /     │
-                 │  Rollback-safe  │
-                 └─────────────────┘
-```
+- **Embodiment grounding** — describe robot bodies, sensors, actuators, constraints, safety limits, and capabilities through e-URDF.
+- **Sandbox-before-reality safety** — validate physical actions in digital twins before they reach real hardware.
+- **Capability routing** — connect LLMs, VLMs, VLAs, VLNs, world models, classical robotics algorithms, skill policies, critics, and embeddings as routable physical capabilities.
+- **Praxis capture** — record physical execution traces, robot states, sensor streams, model decisions, sandbox decisions, failures, and recoveries.
+- **Physical memory** — store spatiotemporal experience, success patterns, failure evidence, and reusable physical knowledge.
+- **Runtime intervention** — inject minimal, evidence-backed corrections when an agent is stuck, unsafe, or regressing.
+- **Self-evolving skills** — evaluate, patch, benchmark, promote, and roll back skills through a closed evolution loop.
 
 ---
 
-## Why ROSClaw?
+## Why Physical AI Needs Runtime Infrastructure
 
-Large language models can plan, write code, and reason over symbols. But physical intelligence requires more than tokens.
+Large models can plan, reason, and generate code. But physical intelligence requires more than tokens.
 
-A physical agent must understand:
+An embodied agent must know:
 
-- What body it has;
-- What sensors and actuators it owns;
-- What actions are safe;
-- What happened during execution;
-- Why a skill failed;
-- How to recover;
-- How to improve the skill without breaking safety.
+- what body it has;
+- what sensors and actuators it owns;
+- what actions are safe;
+- what happened during execution;
+- why a skill failed;
+- how to recover;
+- how to improve without breaking safety.
 
-ROSClaw provides the missing infrastructure between high-level AI agents and the physical world.
+ROSClaw turns these requirements into a unified runtime.
 
 ---
 
-## Core Principle
+## The ROSClaw Closed Loop
 
-> **Every physical action should be grounded, validated, recorded, remembered, and improved.**
-
-The full closed loop:
-
-```
-Physical Task
-    ↓
+```text
 Agent Intent
-    ↓
-Capability Provider
-    ↓
-Sandbox / Firewall Validation
-    ↓
-Runtime Execution
-    ↓
+  ↓
+Embodiment Context
+  ↓
+Capability Routing
+  ↓
+Sandbox Validation
+  ↓
+Physical Execution
+  ↓
 Praxis Capture
-    ↓
-Spatiotemporal Memory
-    ↓
-Runtime Intervention (How)
-    ↓
-Knowledge Compilation (Know)
-    ↓
+  ↓
+Physical Memory
+  ↓
+Runtime Intervention
+  ↓
+Knowledge Compilation
+  ↓
 Auto Evolution
-    ↓
-Champion Skill
-    ↓
-Safer Physical Task
-```
-
----
-
-## Architecture
-
-```mermaid
-graph TD
-    subgraph Agents[Any MCP-Compatible Agent]
-        CC[Claude Code]
-        OC[OpenClaw]
-        AC[AutoGen / Custom]
-    end
-
-    subgraph Runtime[ROSClaw Runtime]
-        MCP[MCP Hub]
-        EB[Event Bus]
-        FW[Digital Twin Firewall]
-        TM[Unified Timeline]
-        MEM[Spatiotemporal Memory]
-        SK[Skill Manager]
-        HO[How Intervention]
-        AU[Auto Evolution]
-        DW[Darwin Evaluator]
-    end
-
-    subgraph Infra[Infrastructure]
-        EURDF[e-URDF Zoo]
-        SKDB[SeekDB Knowledge Plane]
-    end
-
-    subgraph HW[Hardware Layer]
-        G1[Unitree G1]
-        UR5[UR5e Arm]
-        GO[Go2]
-        Other[Your Robot]
-    end
-
-    CC & OC & AC <-->|MCP| MCP
-    MCP <-->|Events| EB
-    EB <-->|Validate| FW
-    EB <-->|Record| TM
-    EB <-->|Store| MEM
-    EB <-->|Execute| SK
-    EB <-->|Intervene| HO
-    EB <-->|Evolve| AU
-    EB <-->|Evaluate| DW
-    FW <-->|Model| EURDF
-    MEM <-->|Persist| SKDB
-    SK -->|Dispatch| HW
-    AU -->|Promote| SK
-    DW -->|Report| AU
-```
-
-**Key Insight**: All modules communicate exclusively through the EventBus. No direct module-to-module calls. This ensures complete decoupling and enables any agent to connect without hardware-specific knowledge.
-
----
-
-## Key Modules
-
-| Module | Role |
-|--------|------|
-| `rosclaw-runtime` | The lifecycle manager for the whole system. Owns configuration, plugins, health checks, event routing, and runtime orchestration. |
-| `e-urdf-zoo` | The Physical DNA Registry. Defines robot embodiment, kinematics, dynamics, sensors, safety limits, capabilities, and simulation assets. |
-| `rosclaw-provider` | The capability provider layer. Turns LLMs, VLMs, VLAs, VLNs, world models, skill policies, critics, and embeddings into routable physical capabilities. |
-| `rosclaw-sandbox` | The physical simulation, validation, replay, and safety layer. Its `firewall` mode validates actions before execution. |
-| `rosclaw-practice` | The praxis capture engine. Records unified physical timelines with sensorimotor traces, model decisions, tool calls, events, MCAP, and replay artifacts. |
-| `rosclaw-memory` | The spatiotemporal memory system. Stores physical failures, success patterns, scene memory, trajectory memory, and causal experience graphs. |
-| `rosclaw-how` | The runtime intervention controller. Injects minimal, evidence-backed guidance when an agent is stuck, unsafe, or regressing. |
-| `rosclaw-know` | The physical-AI knowledge compiler. Turns papers, code, logs, trajectories, benchmark traces, and failures into structured engineering knowledge. |
-| `rosclaw-auto` | The self-evolution control plane. Generates proposals, patches skills, runs experiments, evaluates candidates, promotes champions, and records dead ends. |
-| `rosclaw-darwin` | The evaluation and evolution arena. Provides benchmark pressure, multi-seed validation, regression tests, and skill evaluation. |
-| `rosclaw-forge` | The embodied asset compiler. Turns SDKs, ROS 2 interfaces, docs, and e-URDF profiles into MCP servers, skills, provider manifests, and asset bundles. |
-| `rosclaw-dashboard` | The observability layer for runtime health, traces, sandbox replay, memory, interventions, and skill evolution. |
-
----
-
-## What Makes ROSClaw Different?
-
-### 1. Physical Grounding, Not Just Tool Calling
-
-ROSClaw does not expose raw robot APIs directly to an LLM. Every action is grounded through robot embodiment, capability schemas, safety limits, and runtime context.
-
-```
-Token Intent → Capability Request → Safety Validation → Physical Execution
-```
-
-### 2. e-URDF as Physical DNA
-
-ROSClaw treats robot embodiment as a first-class system primitive. An e-URDF profile defines:
-
-- Robot structure;
-- Joints, links, sensors, actuators;
-- Safety envelopes;
-- Tool frames;
-- Workspace limits;
-- Capabilities;
-- Simulation assets;
-- Benchmark metadata.
-
-This allows the same skill to be adapted, validated, and transferred across different robot bodies.
-
-### 3. Sandbox Before Reality
-
-The `rosclaw-sandbox` module provides a simulation-first validation layer. Its firewall mode can block risky actions before they reach hardware.
-
-Possible decisions:
-
-```
-ALLOW
-BLOCK
-MODIFY
-REQUIRE_HUMAN_CONFIRMATION
-```
-
-Example result:
-
-```json
-{
-  "decision": "BLOCK",
-  "risk_score": 0.92,
-  "reason": "Predicted collision between wrist_link and table",
-  "violated_constraints": ["collision", "workspace_boundary"],
-  "replay_id": "sandbox://replays/firewall_00042"
-}
-```
-
-### 4. Practice Capture
-
-ROSClaw records physical execution as structured praxis, not just logs. A single run can include:
-
-- Robot state;
-- Sensor snapshots;
-- Action trace;
-- Provider trace;
-- Sandbox decision;
-- Skill execution;
-- Critic result;
-- MCAP;
-- Replay;
-- Failure report.
-
-### 5. Runtime Intervention
-
-`rosclaw-how` acts as a runtime reflex layer. When an agent is stuck, unsafe, invalid-heavy, or regressing, it can provide minimal, evidence-backed interventions such as:
-
-- Safety constraints;
-- Feasibility repair;
-- Stabilizing hints;
-- Next experiment suggestions;
-- Recovery instructions.
-
-### 6. Self-Evolution
-
-`rosclaw-auto` turns repeated failures into structured improvement cycles:
-
-```
-FailureCase
-    ↓
-Diagnosis
-    ↓
-Hypothesis
-    ↓
-Proposal
-    ↓
-Patch
-    ↓
-Sandbox Experiment
-    ↓
+  ↓
 Darwin Evaluation
-    ↓
-Champion / DeadEnd
+  ↓
+Champion Skill
+  ↓
+Safer Next Execution
 ```
 
-A skill is not overwritten blindly. It is **versioned, evaluated, promoted, and rollback-safe**.
+Core principle:
 
-Skill promotion pipeline:
-
-```
-pick_cube@v1.0.0  baseline_champion
-    ↓
-pick_cube@candidate_0001  sandbox_passed
-    ↓
-pick_cube@v1.1.0  sim_champion
-    ↓
-pick_cube@v1.1.0  sandbox_champion
-    ↓
-pick_cube@v1.1.0  real_candidate
-    ↓
-pick_cube@v1.1.0  real_champion
-```
+> **Every physical action should be grounded, validated, recorded, remembered, repaired, and improved.**
 
 ---
 
 ## Quick Start
 
-### 1. Install the ROSClaw CLI
+### 1. Install
 
 ```bash
 curl -sSL https://rosclaw.io/get | bash
 ```
 
-This installs the `rosclaw` command and creates a minimal workspace at `~/.rosclaw`.  
-It does **not** start any runtime, connect to robots, or upload data.
-
-### 2. Run First Boot
+### 2. First boot
 
 ```bash
 rosclaw firstboot
 ```
 
-Follow the interactive wizard (or use `rosclaw firstboot --yes` for CI/servers).  
-This generates your local runtime profile, MCP config, and telemetry preferences.
-
-### 3. Check Health
+### 3. Check health
 
 ```bash
 rosclaw doctor
 ```
 
-For structured output:
-
-```bash
-rosclaw doctor --full --json
-```
-
-### 4. Run a Local Simulation Demo
+### 4. Run a sandbox demo
 
 ```bash
 rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach
 ```
 
-### Developer Install
+### 5. Open dashboard
+
+```bash
+rosclaw dashboard --open
+```
+
+For detailed setup, see [QUICKSTART.md](QUICKSTART.md).
+
+---
+
+## First Boot Flow
+
+`rosclaw firstboot` initializes a local Physical-AI runtime workspace:
+
+1. Creates `~/.rosclaw`
+2. Generates default runtime configuration
+3. Checks Python, Docker, GPU, ROS 2, and simulation dependencies
+4. Initializes local-only mode by default
+5. Optionally configures LLM / VLM / VLA providers
+6. Optionally initializes an embodiment profile
+7. Optionally connects Claude Code or another MCP-compatible agent
+8. Runs a local sandbox smoke test
+9. Prints the next recommended command
+
+See [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md) for details.
+
+---
+
+## Developer Install
 
 Prefer to hack on ROSClaw itself?
 
@@ -388,9 +167,109 @@ Prefer to hack on ROSClaw itself?
 git clone https://github.com/ros-claw/rosclaw.git
 cd rosclaw
 make setup
+make test
 ```
 
-See [INSTALL.md](INSTALL.md) for detailed installation options.
+See [INSTALL.md](INSTALL.md) for detailed development setup.
+
+---
+
+## CLI Map
+
+| Goal | Command | Status |
+|---|---|---|
+| Initialize ROSClaw | `rosclaw firstboot` | Stable |
+| Check environment health | `rosclaw doctor` | Stable |
+| Initialize an agent workspace | `rosclaw agent init claude-code` | Stable |
+| Initialize a robot body profile | `rosclaw body init --robot unitree-g1` | Stable |
+| Link an e-URDF profile | `rosclaw body link-eurdf unitree-g1` | Stable |
+| Configure model providers | `rosclaw provider init` | Planned |
+| Route a capability request | `rosclaw provider route --capability vision_language_action` | Planned |
+| Run sandbox validation | `rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach` | Stable |
+| Start praxis capture | `rosclaw practice start --sources dds,ros2,camera,agent,provider,sandbox,runtime` | Planned |
+| Query physical memory | `rosclaw memory query "last failed grasp near red cup"` | Stable |
+| Ask for runtime repair | `rosclaw how advise --task g1_kick_ball --failure torso_pitch_overshoot` | Planned |
+| Compile task knowledge | `rosclaw know compile --task g1_kick_ball` | Stable |
+| Run evolution experiments | `rosclaw auto run --suite tabletop_grasp` | Planned |
+| Evaluate skill candidates | `rosclaw darwin eval --skill pick_cube` | Research |
+| Open dashboard | `rosclaw dashboard --open` | Stable |
+| Search assets | `rosclaw hub search g1` | Stable |
+| Install an asset | `rosclaw hub install <asset>` | Planned |
+
+Some commands are **Planned** or **Research** depending on module status. See [docs/CLI.md](docs/CLI.md).
+
+---
+
+## Core Runtime Modules
+
+### Embodiment Layer
+
+| Module | Role |
+|---|---|
+| `e-urdf-zoo` | Physical DNA registry for robot embodiment, safety limits, capabilities, and simulation metadata |
+| Body / Embodiment Runtime | Local robot instance state, calibration, maintenance, and embodiment context |
+
+### Runtime & Safety Layer
+
+| Module | Role |
+|---|---|
+| `rosclaw-runtime` | Lifecycle, configuration, plugins, event routing, and orchestration |
+| `rosclaw-sandbox` | Simulation-first validation, replay, and sandbox-before-reality safety |
+| `rosclaw-provider` | Capability routing across models, policies, robotics algorithms, and tools |
+
+### Practice & Memory Layer
+
+| Module | Role |
+|---|---|
+| `rosclaw-practice` | Physical timeline capture: robot state, sensors, actions, tool calls, sandbox decisions, failures |
+| `rosclaw-memory` | Spatiotemporal physical memory, failure evidence, success patterns, and reusable experience |
+| SeekDB Knowledge Plane | Structured storage for robot, skill, provider, episode, failure, and evidence records |
+
+### Intervention & Knowledge Layer
+
+| Module | Role |
+|---|---|
+| `rosclaw-how` | Runtime intervention: minimal evidence-backed repair suggestions |
+| `rosclaw-know` | Knowledge compiler: papers, docs, traces, failures, constraints, and task cards |
+
+### Evolution & Evaluation Layer
+
+| Module | Role |
+|---|---|
+| `rosclaw-auto` | Self-evolution control plane: proposals, patches, experiments, champions, dead ends |
+| `rosclaw-darwin` | Benchmark pressure, multi-seed validation, regression testing, and skill promotion gates |
+
+### Developer & Observability Layer
+
+| Module | Role |
+|---|---|
+| `rosclaw-dashboard` | Physical trace viewer, runtime observability, sandbox replay, memory, and evolution dashboard |
+| `rosclaw-hub` | Physical-AI asset distribution and lifecycle management |
+| `rosclaw-forge` | Asset compiler for SDKs, ROS interfaces, provider manifests, MCP servers, and skill bundles |
+
+---
+
+## Hub & Assets
+
+ROSClaw Hub is a **Physical-AI Asset Hub** for skills, providers, hardware MCP servers, digital twins, e-URDF profiles, and cognitive wikis.
+
+- **Skills** — reusable embodied task policies, recovery strategies, and skill graphs.
+- **Providers** — LLM, VLM, VLA, VLN, world model, critic, embedding, and classical robotics providers.
+- **Hardware MCP servers** — agent-facing interfaces for robot bodies, sensors, tools, and lab devices.
+- **Digital twins** — simulation worlds, robot assets, validation scenes, and replay environments.
+- **e-URDF profiles** — robot embodiment definitions, safety envelopes, capabilities, and simulation metadata.
+- **Cognitive wikis** — task cards, failure taxonomies, constraints, evidence, and engineering knowledge.
+
+```bash
+rosclaw hub login --registry https://hub.rosclaw.io --token $TOKEN
+rosclaw hub sync
+rosclaw hub search g1
+rosclaw hub validate ./assets/manifest.yaml
+```
+
+Local-only usage does not require a ROSClaw Cloud key. Cloud sync, private assets, and team-managed registries may require authentication.
+
+See [docs/hub/README.md](docs/hub/README.md) and [docs/ASSETS.md](docs/ASSETS.md).
 
 ---
 
@@ -411,412 +290,176 @@ What happens:
 6. Runtime executes safe action
 7. Practice records the full physical timeline
 8. Critic evaluates success or failure
-9. Memory stores the result
-10. How generates recovery guidance if needed
-11. Auto proposes a skill improvement after repeated failures
-12. Darwin evaluates the candidate skill
-13. A champion skill is promoted if it passes all gates
+9. How generates recovery guidance if needed
+10. Auto proposes a skill improvement after repeated failures
+11. Darwin evaluates the candidate skill
+12. A champion skill is promoted if it passes all gates
 ```
 
 ---
 
 ## Safety Model
 
-ROSClaw follows a strict safety boundary:
+ROSClaw follows one strict rule:
 
 > **No model output should directly control a robot.**
 
-All physical execution must pass through:
+Every physical action must pass through:
 
-```
+```text
+Agent Intent
+  ↓
 Provider Schema
-    ↓
-e-URDF Constraints
-    ↓
-Sandbox / Firewall
-    ↓
+  ↓
+Embodiment Constraints
+  ↓
+Sandbox Validation
+  ↓
 Runtime Guard
-    ↓
+  ↓
 Robot Controller
 ```
 
 Hard rules:
 
 - VLA outputs are **proposals**, not raw motor commands.
-- World models are **neural previews**, not safety proofs.
+- World models are **previews**, not safety proofs.
 - MCP is an **agent tool interface**, not a real-time control bus.
 - Auto-generated skills must pass **sandbox validation** before execution.
-- Code patches require **human approval** before production use.
-- Safety configuration patches require **human approval**.
-- Every champion skill must be **rollback-safe**.
+- Code patches require **human review** before production use.
+- Safety configuration changes require **explicit approval**.
+- Every promoted skill must be **versioned and rollback-safe**.
+
+See [docs/SAFETY.md](docs/SAFETY.md) for the full safety model.
 
 ---
 
-## Skill Evolution
+## Architecture
 
-ROSClaw treats skills as versioned physical assets with full lineage tracking.
-
-Promotion is gated by six evaluation gates:
-
-| Gate | Check |
-|------|-------|
-| Success Improvement | Candidate success rate > baseline + threshold |
-| Safety Regression | No increase in collision or safety events |
-| Multi-Seed Validation | Passes on seeds [0, 1, 2, ...] |
-| Sandbox Clearance | Firewall decision == ALLOW |
-| Regression Suite | No degradation on existing tasks |
-| Human Approval | Required for code patches and safety config |
-
-Example CLI:
-
-```bash
-# Initialize an auto task (required before running)
-./rosclaw auto init --task pick_cube --skill reach --type skill_tuning
-
-# Run auto evolution experiment
-./rosclaw auto run --task pick_cube --rounds 50
-
-# Check evolution status
-./rosclaw auto status
-
-# List current champions
-./rosclaw skill champions list
-
-# Show skill lineage
-./rosclaw skill lineage pick_cube
-
-# Rollback if needed
-./rosclaw skill rollback pick_cube --to v1.0.0
+```mermaid
+flowchart TD
+    A[AI Agent Intent] --> B[Embodiment Context<br/>e-URDF / body.yaml]
+    B --> C[Capability Routing<br/>Provider]
+    C --> D[Sandbox Validation]
+    D -->|ALLOW / MODIFY| E[Runtime Execution]
+    D -->|BLOCK| H[How Intervention]
+    E --> F[Praxis Capture]
+    F --> G[Physical Memory]
+    G --> H[Runtime Intervention]
+    H --> I[Know Compilation]
+    I --> J[Auto Evolution]
+    J --> K[Darwin Evaluation]
+    K --> L[Champion Skill]
+    L --> A
 ```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full system design.
 
 ---
 
-## SDK-to-MCP / Asset Forge
+## Supported Integrations
 
-ROSClaw includes an embodied asset compiler:
+ROSClaw is designed to integrate with:
 
-```
-SDK / ROS 2 Interfaces / Docs / e-URDF
-        ↓
-rosclaw-forge
-        ↓
-MCP Server + Skill Manifest + Provider Manifest + Tests + ClawHub Metadata
-```
+- ROS 2 and robot middleware
+- MCP-compatible agents
+- Claude Code and custom agent runtimes
+- LLM / VLM / VLA / VLN providers
+- OpenAI-compatible model endpoints
+- MuJoCo and other local simulation backends
+- Digital twin and replay environments
+- RLDS / LeRobot-style data export pipelines
+- MCAP / Parquet / JSONL trace formats
 
-Example:
-
-```bash
-./rosclaw forge sdk-to-mcp \
-  --name unitree_go2 \
-  --sdk-docs ./docs/unitree_go2_sdk.md \
-  --output ./generated/unitree_go2_bundle
-```
-
-Validate generated assets:
-
-```bash
-./rosclaw forge validate ./generated/unitree_go2_bundle
-```
-
-Install to staging:
-
-```bash
-./rosclaw forge install ./generated/unitree_go2_bundle --staging
-```
+Integration status varies by module. See [docs/CLI.md](docs/CLI.md) and [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 
-## Repository Structure
+## Documentation
 
-```text
-rosclaw/
-├── src/rosclaw/              # Core runtime, schemas, CLI, MCP gateway
-│   ├── core/                 # Runtime, EventBus, lifecycle
-│   ├── schemas/              # Unified canonical dataclasses
-│   ├── provider/             # Capability provider layer
-│   ├── sandbox/              # MuJoCo simulation & firewall
-│   ├── practice/             # Timeline capture & MCAP
-│   ├── memory/               # Spatiotemporal memory
-│   ├── how/                  # Runtime intervention
-│   ├── know/                 # Knowledge compiler
-│   ├── auto/                 # Self-evolution control plane
-│   ├── darwin/               # Benchmark & evaluation arena
-│   ├── forge/                # Asset compiler
-│   ├── dashboard/            # Observability & WebSocket
-│   └── mcp/                  # MCP server implementation
-├── e-urdf-zoo/               # Physical DNA registry
-├── docs/                     # Architecture, RFCs, usage guides
-├── examples/                 # Robot and simulation examples
-├── tutorials/                # Step-by-step tutorials
-├── tests/                    # Unit, integration, E2E, safety tests
-├── benchmarks/               # Benchmark and evaluation tasks
-├── acceptance/               # Release acceptance tests
-├── scripts/                  # Install and utility scripts
-├── rosclaw.yaml              # Default runtime config
-├── docker-compose.yml        # Optional local services
-├── ARCHITECTURE.md           # 14 Engineering Iron Rules
-├── QUICKSTART.md             # Quick start guide
-└── INSTALL.md                # Installation details
-```
-
----
-
-## Configuration
-
-Example `rosclaw.yaml` generated by `rosclaw firstboot --profile offline`:
-
-```yaml
-schema_version: '1.0'
-generated_by: rosclaw firstboot
-workspace:
-  home: ~/.rosclaw
-  profile: offline
-  mode: local
-  install_channel: stable
-  auto_update: false
-
-runtime:
-  enabled: true
-  robot_id: sim_ur5e
-  safety_level: strict
-  log_level: INFO
-
-event_bus:
-  backend: local
-
-sandbox:
-  enabled: true
-  backend: mujoco
-  firewall_mode: true
-  require_sim_before_real: true
-  default_world: tabletop
-
-provider:
-  enabled: true
-  mode: local
-  manifests_dir: ~/.rosclaw/providers/manifests
-
-practice:
-  enabled: true
-  auto_record: true
-  output_dir: ~/.rosclaw/artifacts/episodes
-  formats:
-    jsonl: true
-    mcap: false
-    video: false
-
-memory:
-  enabled: true
-  backend: local
-  path: ~/.rosclaw/data/memory
-  write_failures: true
-  write_successes: true
-
-how:
-  enabled: true
-  evidence_trace_enabled: true
-  cooldown_window: 3
-
-know:
-  enabled: true
-  asset_dir: ~/.rosclaw/data/seekdb
-
-auto:
-  enabled: false
-  require_human_approval: true
-  allow_code_patch: false
-  trigger_failure_threshold: 3
-
-darwin:
-  enabled: false
-  seeds: [0, 1, 2]
-  episodes: 50
-
-mcp:
-  enabled: true
-  config_path: ~/.rosclaw/config/mcp.json
-  server_command: rosclaw-mcp
-
-cloud:
-  enabled: false
-  sync:
-    configs: false
-    logs: false
-    artifacts: false
-    memory: false
-    anonymous_usage: false
-
-telemetry:
-  enabled: false
-  anonymous_install_ping: false
-
-security:
-  never_execute_robot_without_confirmation: true
-  require_firewall_for_real_robot: true
-  secrets_backend: env
-```
-
-Cloud, telemetry, auto-evolution, and Darwin benchmarking are **disabled by default**.
-Enable them explicitly with `rosclaw profile use cloud` or by editing `rosclaw.yaml`.
+- [Quick Start](QUICKSTART.md)
+- [Installation](INSTALL.md)
+- [First Boot](docs/FIRSTBOOT.md)
+- [Architecture](ARCHITECTURE.md)
+- [CLI Reference](docs/CLI.md)
+- [Safety Model](docs/SAFETY.md)
+- [Physical-AI Assets](docs/ASSETS.md)
+- [Hub](docs/hub/README.md)
+- [Contributing](CONTRIBUTING.md)
 
 ---
 
 ## Roadmap
 
-### ROSClaw v1.0 (Current)
+### Current
 
-- [x] Runtime and plugin architecture
-- [x] e-URDF physical embodiment registry
-- [x] MCP-compatible agent runtime
-- [x] Capability provider layer
-- [x] MuJoCo sandbox and firewall mode
-- [x] Practice timeline capture (MCAP / JSONL)
-- [x] SeekDB-backed spatiotemporal memory
-- [x] How runtime intervention (v1.5)
-- [x] Know physical-AI knowledge compiler
-- [x] Auto self-evolution control plane
-- [x] Darwin benchmark & evaluation arena
-- [x] Skill Registry with champion/lineage/rollback
-- [x] Forge SDK-to-MCP asset compiler
-- [x] Dashboard observability (WebSocket + HTTP API)
-- [x] End-to-end physical intelligence demos
-- [x] Unified schema package (`rosclaw.schemas`)
-- [x] ARCHITECTURE.md — 14 Engineering Iron Rules
+- Local runtime workspace
+- e-URDF based embodiment profiles
+- Sandbox validation
+- Capability provider routing
+- Practice trace capture
+- Hub asset validation and local registry workflows
+- Dashboard and replay foundations
+- Test suite and benchmark scaffolding
 
-### Next
+### In Progress
 
-- [ ] Isaac Sim backend
-- [ ] Multi-robot collaborative sandbox
-- [ ] Advanced DDS reflex handshake
-- [ ] LeRobot / RLDS dataset export
-- [ ] OpenVLA and Cosmos provider integration
-- [ ] Darwin benchmark leaderboard
-- [ ] ClawHub skill and provider marketplace
-- [ ] Real-world long-horizon inspection demos
+- First Boot productization
+- Hardware MCP auto-install flow
+- Physical memory closed-loop evaluation
+- How runtime intervention integration
+- Provider container lifecycle
+- Dashboard physical trace viewer
+- Darwin benchmark-driven skill promotion
 
----
+### Research
 
-## Use Cases
-
-### Robotics Research
-
-- Embodied agent evaluation
-- Skill learning and refinement
-- Simulation-to-real validation
-- Multi-modal robot memory
-- Benchmark-driven evolution
-
-### Industrial Robotics
-
-- Robot skill packaging and versioning
-- Safe LLM-to-robot execution
-- Digital twin pre-validation
-- Inspection and manipulation workflows
-- Failure replay and root-cause analysis
-
-### Agent Infrastructure
-
-- MCP-compatible physical tools
-- Capability routing and abstraction
-- Agent safety guardrails
-- Runtime intervention
-- Self-improving skill systems
-
----
-
-## Development
-
-Run tests:
-
-```bash
-PYTHONPATH=src python3 -m pytest tests -v
-```
-
-Run end-to-end pipeline:
-
-```bash
-PYTHONPATH=src python3 -m pytest tests/test_e2e_full_pipeline.py -v
-```
-
-Run architecture checks:
-
-```bash
-./rosclaw doctor --ros2
-```
+- Cross-embodiment skill transfer
+- VLA / VLN / world model provider orchestration
+- Long-horizon physical memory
+- Self-evolving embodied skills
+- Sim-to-real promotion gates
+- Multi-agent physical collaboration
 
 ---
 
 ## Contributing
 
-ROSClaw welcomes contributors building the open infrastructure for Physical Intelligence.
+We welcome contributions in:
 
-Good first contribution areas:
+- Robot embodiment profiles
+- e-URDF assets
+- Hardware MCP servers
+- Capability providers
+- Sandbox worlds
+- Benchmark tasks
+- Physical memory evaluators
+- Runtime intervention policies
+- Skill evolution pipelines
+- Documentation and tutorials
 
-- e-URDF profiles for new robots;
-- MCP servers for robot SDKs;
-- Capability providers for perception, action, navigation, and verification;
-- Sandbox tasks and worlds;
-- Skill packages;
-- Benchmark tasks;
-- Documentation and tutorials.
-
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a pull request.
-
----
-
-## Safety Notice
-
-ROSClaw is research infrastructure for physical AI and embodied agents.
-
-Always test in simulation before running on real hardware. Use emergency stop systems, workspace boundaries, safety-rated controllers, and human supervision when deploying to physical robots.
-
-**ROSClaw does not replace certified industrial safety systems.**
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 
-## Citation
+## Contact
 
-If you use ROSClaw in your research, please consider citing:
+Interested in ROSClaw, Physical AI infrastructure, embodied agents, robot safety, physical memory, runtime intervention, or self-evolving skills?
 
-```bibtex
-@software{rosclaw2026,
-  title  = {ROSClaw: Open Infrastructure for Physical Intelligence},
-  author = {ROSClaw Contributors},
-  year   = {2026},
-  url    = {https://github.com/ros-claw/rosclaw}
-}
-```
+Contact: [**ai@rosclaw.io**](mailto:ai@rosclaw.io)
 
-If you use the Genesis simulator with ROSClaw, please also cite:
-
-```bibtex
-@article{genesis2026,
-  title   = {Genesis: A Generative Physics Engine for General Purpose Robotics},
-  author  = {Genesis Authors},
-  journal = {arXiv preprint},
-  year    = {2026},
-  url     = {https://arxiv.org/abs/2604.04664}
-}
-```
+We welcome research collaborations, robot platform integrations, provider integrations, benchmark contributions, and industrial Physical-AI use cases.
 
 ---
 
 ## License
 
-This project is released under the MIT License. See [LICENSE](LICENSE).
-
----
-
-## Links
-
-- **Website**: [https://www.rosclaw.io/](https://www.rosclaw.io/)
-- **GitHub**: [https://github.com/ros-claw/rosclaw](https://github.com/ros-claw/rosclaw)
-- **Documentation**: [docs/](docs/)
-- **Quick Start**: [QUICKSTART.md](QUICKSTART.md)
-- **Architecture**: [ARCHITECTURE.md](ARCHITECTURE.md)
+MIT License.
 
 ---
 
 <div align="center">
-  <b>ROSClaw — Grounding AI into the Physical World.</b>
+
+**ROSClaw — Self-Evolving Runtime Infrastructure for Physical AI.**
+
 </div>

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,489 +2,280 @@
 
 # ROSClaw
 
-**面向物理 AI 的开放基础设施**
+### 面向物理 AI 与具身 Agent 的自进化运行时基础设施
 
-*让 AI Agent 真正进入物理世界。*
+**让 AI Agent 进入机器人身体，让每一次物理行动都可验证、可记忆、可修复、可进化。**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python)](https://www.python.org/)
 [![ROS 2](https://img.shields.io/badge/ROS_2-Humble_|_Jazzy-FF3E00?logo=ros)](https://docs.ros.org/)
 [![Simulation](https://img.shields.io/badge/Simulation-MuJoCo_|_Isaac--Sim-black?logo=mujoco)](https://mujoco.org/)
 [![MCP](https://img.shields.io/badge/Protocol-MCP_Ready-8A2BE2)](https://modelcontextprotocol.io/)
-[![Status](https://img.shields.io/badge/Release-v1.0-purple)](https://github.com/ros-claw/rosclaw/releases)
+[![Status](https://img.shields.io/badge/status-active%20development-orange)](https://github.com/ros-claw/rosclaw)
+[![Contact](https://img.shields.io/badge/contact-ai%40rosclaw.io-blue)](mailto:ai@rosclaw.io)
 
-[English](README.md) • **中文** • [架构](#架构) • [快速开始](#-快速开始) • [文档](docs/)
-
-<br/>
-
-> **教导一次，任意实体运行。共享技能，持续进化。**
+[English](README.md) • **中文** • [快速开始](QUICKSTART.md) • [架构说明](ARCHITECTURE.md) • [文档](docs/) • [联系](mailto:ai@rosclaw.io)
 
 </div>
 
 ---
 
+ROSClaw 是一个面向 **物理 AI** 与 **具身 Agent** 的开源运行时基础设施。
+
+它不是普通聊天机器人框架，不是简单的 LLM-to-ROS 封装，也不是单一仿真器或机器人工具集。
+
+ROSClaw 试图补上 AI Agent 与真实机器人之间缺失的运行时层：本体建模、安全沙盒、能力路由、实践数据采集、物理记忆、运行时干预和技能进化。
+
+> 从 Agent 意图 → 安全验证动作 → 物理执行轨迹 → 记忆沉淀 → 失败修复 → 技能进化。
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot
+```
+
+---
+
 ## ROSClaw 是什么？
 
-ROSClaw **不是**另一个聊天机器人框架，**不是**简单的"大模型调用 ROS"工具，**不是**一堆零散的机器人工具集合。
+ROSClaw **不是**另一个聊天机器人框架。  
+**不是**简单的"大模型调用 ROS"工具。  
+**不是**一堆零散的机器人工具集合。
 
-ROSClaw 是一套面向 **物理 AI / 具身智能** 的开放基础设施。它把 AI Agent、机器人本体、仿真沙盒、技能系统、多模态模型、物理记忆和自进化闭环连接到一起，形成统一的运行时层。
+ROSClaw 是 AI Agent 与物理世界之间的缺失运行时层：
 
-它是为下一代具身智能体设计的——这些智能体不仅要会推理，还要能 **安全行动、记住经验、失败恢复、持续进化**。
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│                    外部认知大脑                              │
-│        OpenClaw / Claude / GPT / Qwen / 自定义 Agent          │
-└───────────────────────────┬──────────────────────────────────┘
-                            │ MCP / SDK / AgentContext
-                            ▼
-┌──────────────────────────────────────────────────────────────┐
-│                    ROSClaw Runtime                           │
-│  AgentContext │ TaskContext │ SkillContext │ Trace           │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-        ┌───────────────────┼───────────────────┐
-        ▼                   ▼                   ▼
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│   Provider    │   │   Sandbox     │   │    Darwin     │
-│   能力路由     │   │  e-URDF /     │   │  Benchmark /  │
-│               │   │  MuJoCo /     │   │  回归测试 /   │
-│               │   │  防火墙       │   │  技能评估     │
-└───────┬───────┘   └───────┬───────┘   └───────────────┘
-        │                   │
-        └───────────┬───────┘
-                    ▼
-┌──────────────────────────────────────────────────────────────┐
-│                    物理世界 / 仿真世界                        │
-│             UR5e / G1 / Go2 / RealSense / IoT / MuJoCo       │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────┐
-│                    Practice 实践捕获                          │
-│        统一时空轴 / MCAP / JSONL / 视频 / 事件                │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────┐
-│                    SeekDB Knowledge Plane                    │
-│  机器人 / 技能 / Provider / Episode / 失败案例 / 证据链        │
-└───────────────┬────────────────────────────┬─────────────────┘
-                │                            │
-                ▼                            ▼
-┌───────────────────────┐      ┌───────────────────────────────┐
-│       Memory          │      │          Know                 │
-│     时空记忆          │      │     物理 AI 知识编译器         │
-│  失败 / 成功模式      │      │  TaskCard / Pattern / Evidence│
-│  因果图谱             │      │                               │
-└───────────┬───────────┘      └───────────────┬───────────────┘
-            │                                  │
-            └──────────────┬───────────────────┘
-                           │
-                           ▼
-            ┌──────────────────────────────┐
-            │      How  ←→  Auto           │
-            │     运行时干预                │
-            │     自进化控制平面            │
-            │  Proposal / Patch / Champion │
-            └──────────────┬───────────────┘
-                           │
-                           ▼
-                 ┌─────────────────┐
-                 │   Skill Registry│
-                 │   版本化 /      │
-                 │   Champion /    │
-                 │   可回滚        │
-                 └─────────────────┘
-```
+- **本体建模（e-URDF）** — 用 e-URDF 描述机器人身体、传感器、执行器、约束、安全限制与能力。
+- **安全沙盒验证** — 真实执行前，先在数字孪生中验证物理动作的安全性。
+- **能力路由（Provider）** — 把 LLM、VLM、VLA、VLN、世界模型、经典机器人算法、Skill、Critic、Embedding 统一封装成可调用的物理能力。
+- **实践数据采集（Practice）** — 记录机器人状态、传感器流、动作、工具调用、沙盒决策、失败与恢复过程。
+- **物理记忆（Memory）** — 沉淀时空经验、成功模式、失败证据和可复用的物理知识。
+- **运行时干预（How）** — 当 Agent 卡住、失败、危险或退化时，提供最小必要的恢复建议。
+- **技能进化（Auto / Darwin）** — 通过闭环评估、补丁、Benchmark 和晋升，让 Skill 持续进化并支持回滚。
 
 ---
 
 ## 为什么需要 ROSClaw？
 
-今天的大模型已经很会推理、写代码、规划任务，但它们本质上还活在"文字和 Token 世界"里。
+大模型可以规划、推理、写代码，但物理智能需要更多东西。
 
-如果让一个大模型直接控制机器人，会遇到很多问题：
+一个真正进入物理世界的 Agent 必须知道：
 
-- 它不知道机器人身体的真实限制；
-- 它不知道机械臂能转多少度；
-- 它不知道某个动作会不会撞到桌子；
-- 它不知道上一次抓取为什么失败；
-- 它不知道失败之后该如何恢复；
-- 它也不知道如何把失败经验变成新的技能。
+- 自己控制的是什么身体；
+- 有哪些传感器和执行器；
+- 哪些动作安全，哪些动作危险；
+- 执行过程中发生了什么；
+- 技能为什么失败；
+- 下次如何恢复；
+- 如何在不破坏安全边界的前提下持续进化。
 
-**物理世界不是聊天窗口。**
-
-物理世界有重力、摩擦、碰撞、延迟、传感噪声、力矩限制、关节限制和安全边界。
-
-ROSClaw 要做的，就是把大模型的"认知能力"真正接到物理世界中。
+ROSClaw 把这些能力组织成一个统一的物理 AI 运行时。
 
 ---
 
-## 核心理念
+## 核心闭环
 
-> **每一次物理行动，都应该被约束、被验证、被记录、被记住，并最终变成更好的技能。**
-
-完整闭环：
-
-```
-物理任务
-    ↓
+```text
 Agent 意图
-    ↓
-能力 Provider
-    ↓
-沙盒 / 防火墙验证
-    ↓
-真实执行
-    ↓
-实践数据捕获
-    ↓
-时空记忆沉淀
-    ↓
-运行时干预 (How)
-    ↓
-知识编译 (Know)
-    ↓
-自动进化 (Auto)
-    ↓
-Champion Skill
-    ↓
-更安全、更可靠的下一次执行
-```
-
----
-
-## 系统架构
-
-```mermaid
-graph TD
-    subgraph Agents[任何 MCP 兼容 Agent]
-        CC[Claude Code]
-        OC[OpenClaw]
-        AC[AutoGen / 自定义]
-    end
-
-    subgraph Runtime[ROSClaw 运行时]
-        MCP[MCP Hub]
-        EB[事件总线]
-        FW[数字孪生防火墙]
-        TM[统一时空轴]
-        MEM[时空记忆系统]
-        SK[技能管理器]
-        HO[How 干预]
-        AU[Auto 进化]
-        DW[Darwin 评测]
-    end
-
-    subgraph Infra[基础设施]
-        EURDF[e-URDF Zoo]
-        SKDB[SeekDB 知识平面]
-    end
-
-    subgraph HW[硬件层]
-        G1[宇树 G1]
-        UR5[UR5e 机械臂]
-        GO[Go2]
-        Other[你的机器人]
-    end
-
-    CC & OC & AC <-->|MCP| MCP
-    MCP <-->|事件| EB
-    EB <-->|验证| FW
-    EB <-->|记录| TM
-    EB <-->|存储| MEM
-    EB <-->|执行| SK
-    EB <-->|干预| HO
-    EB <-->|进化| AU
-    EB <-->|评测| DW
-    FW <-->|模型| EURDF
-    MEM <-->|持久化| SKDB
-    SK -->|调度| HW
-    AU -->|晋升| SK
-    DW -->|报告| AU
-```
-
-**关键洞察**：所有模块仅通过事件总线通信，禁止直接模块间调用。这确保了解耦，并使任何 Agent 无需硬件特定知识即可连接。
-
----
-
-## 核心模块
-
-| 模块 | 作用 |
-|------|------|
-| `rosclaw-runtime` | ROSClaw 的运行时内核，负责配置、插件、生命周期、健康检查、事件总线和模块编排。 |
-| `e-urdf-zoo` | 机器人的"物理基因库"，定义机器人结构、关节、传感器、执行器、安全边界、能力和仿真资产。 |
-| `rosclaw-provider` | 具身能力接入层，把 LLM、VLM、VLA、VLN、世界模型、Skill、Critic、Embedding 等统一封装成可调用能力。 |
-| `rosclaw-sandbox` | 物理沙盒与安全验证层，负责仿真、预演、回放和动作防火墙。 |
-| `rosclaw-practice` | 实践捕获系统，记录机器人执行过程中的传感器、动作、模型决策、工具调用、失败原因和回放数据。 |
-| `rosclaw-memory` | 时空记忆系统，沉淀机器人过去经历、失败案例、成功模式、场景记忆和技能经验。 |
-| `rosclaw-how` | 运行时干预控制器，当 Agent 卡住、失败、危险或退化时，提供最小必要的恢复建议。 |
-| `rosclaw-know` | 物理 AI 知识编译器，把论文、代码、日志、轨迹和失败案例编译成可检索、可验证的工程知识。 |
-| `rosclaw-auto` | 自进化控制平面，负责生成改进方案、修改候选技能、组织实验、评估结果、晋升 Champion Skill。 |
-| `rosclaw-darwin` | 进化评测竞技场，用于 benchmark、压力测试、技能对比、回归测试和进化速度评估。 |
-| `rosclaw-forge` | 具身资产编译器，可以把 SDK、ROS 2 接口、文档和 e-URDF 转换成 MCP Server、Skill、Provider Manifest 等资产。 |
-| `rosclaw-dashboard` | 可视化观测平台，用于查看运行状态、任务链路、沙盒回放、记忆、干预、进化过程和技能版本。 |
-
----
-
-## ROSClaw 有什么不同？
-
-### 1. 不是简单 Tool Calling，而是物理接地
-
-普通 Agent 调工具，很多时候只是调用 API。但机器人不是普通 API。
-
-机器人动作必须考虑：关节限制、力矩限制、工作空间、碰撞风险、速度和加速度、传感器状态、当前环境、人机安全。
-
-ROSClaw 会把大模型的意图先转换成结构化能力请求，再经过安全验证和执行控制。
-
-```
-Token 意图 → 能力请求 → 安全验证 → 物理执行
-```
-
-### 2. e-URDF：机器人本体是第一等公民
-
-ROSClaw 把机器人本体视为系统最重要的基础资产。一个 e-URDF 不只是传统 URDF，而是包含：
-
-- 机器人结构；
-- 关节、连杆、传感器、执行器；
-- 安全边界；
-- 语义部位；
-- 工具坐标系；
-- 工作空间；
-- 运动能力；
-- 仿真模型；
-- benchmark 配置。
-
-这让 Agent 不只是知道"我要抓杯子"，还知道"我这具身体能不能安全地抓杯子"。
-
-### 3. 先沙盒，后真实世界
-
-ROSClaw 不鼓励大模型直接控制真实机器人。在真实执行前，动作可以先进入 `rosclaw-sandbox` 做物理预演和安全检查。
-
-可能返回：
-
-```
-ALLOW：允许执行
-BLOCK：阻止执行
-MODIFY：建议修改后执行
-REQUIRE_HUMAN_CONFIRMATION：需要人类确认
-```
-
-示例：
-
-```json
-{
-  "decision": "BLOCK",
-  "risk_score": 0.92,
-  "reason": "预测 wrist_link 会与桌面发生碰撞",
-  "violated_constraints": ["collision", "workspace_boundary"],
-  "replay_id": "sandbox://replays/firewall_00042"
-}
-```
-
-### 4. Practice：物理世界的"行车记录仪"
-
-机器人执行失败时，普通系统可能只留下一行日志：
-
-```
-grasp failed
-```
-
-但 ROSClaw 会记录完整实践过程：Agent 想做什么、Provider 调用了什么能力、Sandbox 是否拦截、Runtime 执行了什么、传感器看到了什么、关节和力矩发生了什么、Critic 判断是否成功、失败发生在哪个阶段、后续是否生成了恢复建议。
-
-这些会被保存为：MCAP、JSONL、视频、replay、failure report、PraxisEvent。
-
-### 5. Memory：机器人记得自己经历过什么
-
-ROSClaw 的 Memory 不只是聊天记录。它是机器人自己的时空记忆系统。它可以回答：
-
-```
-刚才为什么抓取失败？
-上一次类似失败是怎么解决的？
-这个机器人在哪些场景下容易碰撞？
-哪个版本的 skill 成功率最高？
-某个按钮上次是如何被按下的？
-```
-
-### 6. How：Agent 卡住时的运行时反射弧
-
-当 Agent 一直失败、分数不涨、动作危险或陷入无效尝试时，`rosclaw-how` 会提供最小必要的干预。例如：
-
-```
-当前失败可能是接近高度过低导致的。
-下一次只调整 pre_grasp_height，不要同时修改所有参数。
-建议增加 3cm 预抓取高度，并降低接近速度。
-预期信号：碰撞率下降，抓取成功率上升。
-```
-
-How 不是代替 Agent，而是像"反射弧"一样，在关键时刻给它一点提示。
-
-### 7. Auto：让技能越练越好
-
-`rosclaw-auto` 会把重复失败变成自动改进流程：
-
-```
-失败案例
-    ↓
-诊断
-    ↓
-假设
-    ↓
-改进提案
-    ↓
-技能补丁
-    ↓
-沙盒实验
-    ↓
+  ↓
+机器人本体上下文
+  ↓
+能力路由
+  ↓
+安全沙盒验证
+  ↓
+物理执行
+  ↓
+实践数据采集
+  ↓
+物理记忆
+  ↓
+运行时干预
+  ↓
+知识编译
+  ↓
+自动进化
+  ↓
 Darwin 评测
-    ↓
-Champion 晋升 / DeadEnd 记录
+  ↓
+冠军技能
+  ↓
+更安全的下一次执行
 ```
 
-ROSClaw 不会直接覆盖原技能，而是做版本管理：
+核心原则：
 
-```
-pick_cube@v1.0.0  baseline_champion
-    ↓
-pick_cube@candidate_0001  sandbox_passed
-    ↓
-pick_cube@v1.1.0  sim_champion
-    ↓
-pick_cube@v1.1.0  sandbox_champion
-    ↓
-pick_cube@v1.1.0  real_candidate
-    ↓
-pick_cube@v1.1.0  real_champion
-```
-
-每个 Champion Skill 都可以回滚。
+> **每一次物理行动都应该被本体约束、被沙盒验证、被完整记录、被记忆沉淀、被运行时修复，并最终推动技能进化。**
 
 ---
 
 ## 快速开始
 
-### 1. 克隆项目
+### 1. 安装
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+```
+
+### 2. First Boot
+
+```bash
+rosclaw firstboot
+```
+
+### 3. 环境检查
+
+```bash
+rosclaw doctor
+```
+
+### 4. 运行本地沙盒 Demo
+
+```bash
+rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach
+```
+
+### 5. 打开 Dashboard
+
+```bash
+rosclaw dashboard --open
+```
+
+详细说明见 [QUICKSTART.md](QUICKSTART.md)。
+
+---
+
+## First Boot 开箱流程
+
+`rosclaw firstboot` 会初始化本地物理 AI 运行时工作区：
+
+1. 创建 `~/.rosclaw`
+2. 生成默认运行时配置
+3. 检查 Python、Docker、GPU、ROS 2、仿真依赖
+4. 默认进入 local-only 模式
+5. 可选配置 LLM / VLM / VLA Provider
+6. 可选初始化机器人本体
+7. 可选接入 Claude Code 或其他 MCP-compatible Agent
+8. 运行本地 sandbox smoke test
+9. 给出下一步推荐命令
+
+详见 [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md)。
+
+---
+
+## 开发者安装
+
+如果你要参与 ROSClaw 本身开发：
 
 ```bash
 git clone https://github.com/ros-claw/rosclaw.git
 cd rosclaw
-```
-
-### 2. 安装
-
-```bash
-bash scripts/install.sh
-```
-
-或者开发模式安装：
-
-```bash
-pip install -e .
+make setup
+make test
 ```
 
 详细说明见 [INSTALL.md](INSTALL.md)。
 
-### 3. 检查系统状态
+---
 
-```bash
-./rosclaw doctor
-```
+## CLI 速查
 
-期望输出：
+| 目标 | 命令 | 状态 |
+|---|---|---|
+| 初始化 ROSClaw | `rosclaw firstboot` | Stable |
+| 检查环境健康 | `rosclaw doctor` | Stable |
+| 初始化 Agent 工作区 | `rosclaw agent init claude-code` | Stable |
+| 初始化机器人本体 | `rosclaw body init --robot unitree-g1` | Stable |
+| 链接 e-URDF 本体 | `rosclaw body link-eurdf unitree-g1` | Stable |
+| 配置模型 Provider | `rosclaw provider init` | Planned |
+| 路由能力请求 | `rosclaw provider route --capability vision_language_action` | Planned |
+| 运行沙盒验证 | `rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach` | Stable |
+| 启动实践数据采集 | `rosclaw practice start --sources dds,ros2,camera,agent,provider,sandbox,runtime` | Planned |
+| 查询物理记忆 | `rosclaw memory query "last failed grasp near red cup"` | Stable |
+| 请求运行时修复 | `rosclaw how advise --task g1_kick_ball --failure torso_pitch_overshoot` | Planned |
+| 编译任务知识 | `rosclaw know compile --task g1_kick_ball` | Stable |
+| 运行进化实验 | `rosclaw auto run --suite tabletop_grasp` | Planned |
+| 评估候选 Skill | `rosclaw darwin eval --skill pick_cube` | Research |
+| 打开 Dashboard | `rosclaw dashboard --open` | Stable |
+| 搜索资产 | `rosclaw hub search g1` | Stable |
+| 安装资产 | `rosclaw hub install <asset>` | Planned |
 
-```text
-runtime:     HEALTHY
-event_bus:   HEALTHY
-seekdb:      HEALTHY
-provider:    HEALTHY
-sandbox:     HEALTHY
-practice:    HEALTHY
-memory:      HEALTHY
-how:         HEALTHY
-auto:        HEALTHY
-darwin:      HEALTHY
-dashboard:   HEALTHY
-```
-
-### 4. 启动 ROSClaw Runtime
-
-```bash
-./rosclaw start
-```
-
-或者通过代码启动：
-
-```python
-from rosclaw.core import Runtime, RuntimeConfig
-
-config = RuntimeConfig(
-    robot_id="ur5e",
-    robot_zoo_path="./e-urdf-zoo",
-    default_eurdf_robot="ur5e",
-    enable_firewall=True,
-    enable_memory=True,
-    enable_practice=True,
-    enable_how=True,
-    enable_auto=True,
-    enable_darwin=True,
-)
-
-runtime = Runtime(config)
-runtime.initialize()
-runtime.start()
-```
-
-### 5. 查看机器人资产
-
-```bash
-./rosclaw robot list
-./rosclaw robot inspect ur5e
-```
-
-### 6. 运行沙盒验证
-
-```bash
-./rosclaw sandbox validate ur5e
-./rosclaw sandbox run --robot ur5e --world tabletop --task reach
-```
-
-### 7. 运行防火墙检查
-
-```bash
-./rosclaw firewall check \
-  --robot ur5e \
-  --world tabletop \
-  --action examples/actions/unsafe_reach.json
-```
-
-### 8. 连接 MCP Agent
-
-ROSClaw 可以作为 MCP Server 暴露给支持 MCP 的 Agent，例如 Claude Code、OpenClaw 或其他 Agent Runtime。
-
-示例配置：
-
-```json
-{
-  "mcpServers": {
-    "rosclaw": {
-      "command": "python3",
-      "args": ["-m", "rosclaw.mcp.minimal_server"],
-      "env": {
-        "PYTHONPATH": "src"
-      }
-    }
-  }
-}
-```
-
-连接后，Agent 可以调用 ROSClaw 提供的工具，例如：观察场景、定位物体、执行技能、查询记忆、请求安全验证、触发沙盒回放、生成或验证 MCP 资产。
+部分命令处于 **Planned** 或 **Research** 状态。详见 [docs/CLI.md](docs/CLI.md)。
 
 ---
 
-## 一个完整例子：桌面抓取
+## 核心运行时模块
 
-运行：
+### 本体层
+
+| 模块 | 作用 |
+|---|---|
+| `e-urdf-zoo` | 机器人物理基因库：结构、关节、传感器、安全限制、能力、仿真元数据 |
+| Body / Embodiment Runtime | 本地机器人实例状态、标定、维护与本体上下文 |
+
+### 运行时与安全层
+
+| 模块 | 作用 |
+|---|---|
+| `rosclaw-runtime` | 生命周期、配置、插件、事件路由与模块编排 |
+| `rosclaw-sandbox` | 仿真优先验证、回放与"先沙盒后真实"安全边界 |
+| `rosclaw-provider` | 跨模型、策略、机器人算法与工具的能力路由 |
+
+### 实践与记忆层
+
+| 模块 | 作用 |
+|---|---|
+| `rosclaw-practice` | 物理时间轴捕获：机器人状态、传感器、动作、工具调用、沙盒决策、失败 |
+| `rosclaw-memory` | 时空物理记忆、失败证据、成功模式与可复用经验 |
+| SeekDB Knowledge Plane | 机器人、Skill、Provider、Episode、失败与证据记录的结构化存储 |
+
+### 干预与知识层
+
+| 模块 | 作用 |
+|---|---|
+| `rosclaw-how` | 运行时干预：基于证据的最小修复建议 |
+| `rosclaw-know` | 知识编译器：论文、文档、轨迹、失败、约束与任务卡片 |
+
+### 进化与评测层
+
+| 模块 | 作用 |
+|---|---|
+| `rosclaw-auto` | 自进化控制平面：提案、补丁、实验、冠军、死胡同 |
+| `rosclaw-darwin` | Benchmark 压力、多随机种子验证、回归测试与技能晋升门控 |
+
+### 开发者与可观测层
+
+| 模块 | 作用 |
+|---|---|
+| `rosclaw-dashboard` | 物理轨迹查看器、运行时可观测、沙盒回放、记忆与进化面板 |
+| `rosclaw-hub` | 物理 AI 资产分发与生命周期管理 |
+| `rosclaw-forge` | 资产编译器：SDK、ROS 接口、Provider 清单、MCP Server、Skill Bundle |
+
+---
+
+## Hub 与资产
+
+ROSClaw Hub 是**物理 AI 资产中心**，用于管理 Skill、Provider、Hardware MCP Server、Digital Twin、e-URDF Profile 与 Cognitive Wiki。
+
+- **Skills** — 可复用的具身任务策略、恢复策略与技能图。
+- **Providers** — LLM、VLM、VLA、VLN、世界模型、Critic、Embedding 与经典机器人算法。
+- **Hardware MCP servers** — 面向 Agent 的机器人本体、传感器、工具与实验设备接口。
+- **Digital twins** — 仿真世界、机器人资产、验证场景与回放环境。
+- **e-URDF profiles** — 机器人本体定义、安全包络、能力与仿真元数据。
+- **Cognitive wikis** — 任务卡片、失败分类、约束、证据与工程知识。
+
+```bash
+rosclaw hub login --registry https://hub.rosclaw.io --token $TOKEN
+rosclaw hub sync
+rosclaw hub search g1
+rosclaw hub validate ./assets/manifest.yaml
+```
+
+Local-only 模式不需要 ROSClaw Cloud key。Cloud sync、私有资产与团队托管注册表可能需要认证。
+
+详见 [docs/hub/README.md](docs/hub/README.md) 与 [docs/ASSETS.md](docs/ASSETS.md)。
+
+---
+
+## 完整示例：桌面抓取
 
 ```bash
 ./rosclaw demo tabletop-grasp --robot-id ur5e
@@ -494,43 +285,44 @@ ROSClaw 可以作为 MCP Server 暴露给支持 MCP 的 Agent，例如 Claude Co
 
 ```text
 1. Agent 接收任务："拿起红色杯子"
-2. Provider 调用视觉能力定位杯子
+2. Provider 调用感知与技能能力
 3. Memory 检索类似抓取经验
 4. Skill Provider 生成抓取方案
 5. Sandbox 预演动作并检查碰撞
 6. Runtime 控制机器人执行
 7. Practice 记录完整执行过程
 8. Critic 判断是否成功
-9. Memory 写入成功或失败经验
-10. How 在失败时给出恢复建议
-11. Auto 在重复失败后生成技能改进方案
-12. Darwin 评估候选技能
-13. 通过后晋升为 Champion Skill
+9. How 在失败时给出恢复建议
+10. Auto 在重复失败后生成技能改进方案
+11. Darwin 评估候选技能
+12. 通过后晋升为 Champion Skill
 ```
 
 ---
 
-## 安全原则
+## 安全边界
 
-ROSClaw 的核心安全原则：
+ROSClaw 坚持一个底线：
 
-> **任何模型输出，都不能直接裸控机器人。**
+> **任何模型输出都不应该直接控制机器人。**
 
-所有真实执行都必须经过：
+所有物理动作必须经过：
 
-```
+```text
+Agent 意图
+  ↓
 Provider Schema
-    ↓
-e-URDF 物理约束
-    ↓
-Sandbox / Firewall
-    ↓
+  ↓
+本体约束
+  ↓
+Sandbox 验证
+  ↓
 Runtime Guard
-    ↓
-Robot Controller
+  ↓
+机器人控制器
 ```
 
-安全规则：
+基本规则：
 
 - VLA 输出只是动作建议，不是电机命令；
 - 世界模型只是神经预演，不是安全证明；
@@ -538,330 +330,137 @@ Robot Controller
 - 自动生成的 Skill 必须经过沙盒验证；
 - 代码补丁进入生产环境前必须人工审批；
 - 安全配置变更必须人工审批；
-- 每个 Champion Skill 必须支持回滚；
-- 真机部署必须配合急停、限位、安全区域和人工监督。
+- 每个 Champion Skill 必须支持回滚。
+
+详见 [docs/SAFETY.md](docs/SAFETY.md)。
 
 ---
 
-## Skill 如何进化？
+## 系统架构
 
-ROSClaw 把 Skill 当成可版本化、可测试、可晋升、可回滚的物理资产。
-
-一次失败不会直接修改技能。系统会先生成候选版本，通过六道评估门控才会晋升：
-
-| 门控 | 检查内容 |
-|------|---------|
-| 成功率提升 | 候选版本成功率 > 基线 + 阈值 |
-| 安全回归 | 碰撞率和安全事件不增加 |
-| 多随机种子验证 | 在种子 [0, 1, 2, ...] 上均通过 |
-| 沙盒放行 | Firewall 决策为 ALLOW |
-| 回归测试 | 现有任务无退化 |
-| 人工确认 | 代码补丁和安全配置变更需人工审批 |
-
-查看技能演化：
-
-```bash
-# 初始化自进化任务（运行前必需）
-./rosclaw auto init --task pick_cube --skill reach --type skill_tuning
-
-# 运行自进化实验
-./rosclaw auto run --task pick_cube --rounds 50
-
-# 查看进化状态
-./rosclaw auto status
-
-# 列出当前 Champion
-./rosclaw skill champions list
-
-# 查看技能谱系
-./rosclaw skill lineage pick_cube
-
-# 回滚到安全版本
-./rosclaw skill rollback pick_cube --to v1.0.0
+```mermaid
+flowchart TD
+    A[AI Agent 意图] --> B[本体上下文<br/>e-URDF / body.yaml]
+    B --> C[能力路由<br/>Provider]
+    C --> D[沙盒验证]
+    D -->|ALLOW / MODIFY| E[运行时执行]
+    D -->|BLOCK| H[How 干预]
+    E --> F[Practice 捕获]
+    F --> G[物理记忆]
+    G --> H[运行时干预]
+    H --> I[Know 编译]
+    I --> J[Auto 进化]
+    J --> K[Darwin 评测]
+    K --> L[冠军技能]
+    L --> A
 ```
+
+详见 [ARCHITECTURE.md](ARCHITECTURE.md)。
 
 ---
 
-## SDK-to-MCP / Asset Forge
+## 支持的集成
 
-ROSClaw 内置具身资产编译器 `rosclaw-forge`。
+ROSClaw 支持与以下系统集成：
 
-它可以把：SDK 文档、ROS 2 接口、机器人说明、e-URDF 约束
+- ROS 2 与机器人中间件
+- MCP-compatible Agent
+- Claude Code 与自定义 Agent Runtime
+- LLM / VLM / VLA / VLN Provider
+- OpenAI-compatible 模型端点
+- MuJoCo 等本地仿真后端
+- 数字孪生与回放环境
+- RLDS / LeRobot 风格数据导出
+- MCAP / Parquet / JSONL 轨迹格式
 
-转换成：MCP Server、Skill Manifest、Provider Manifest、测试文件、ClawHub 元数据
-
-示例：
-
-```bash
-./rosclaw forge sdk-to-mcp \
-  --name unitree_go2 \
-  --sdk-docs ./docs/unitree_go2_sdk.md \
-  --output ./generated/unitree_go2_bundle
-```
-
-验证生成结果：
-
-```bash
-./rosclaw forge validate ./generated/unitree_go2_bundle
-```
-
-安装到 staging 环境：
-
-```bash
-./rosclaw forge install ./generated/unitree_go2_bundle --staging
-```
-
-注意：自动生成的资产默认不会直接进入真实机器人执行链路，必须先经过验证和审批。
+各模块集成状态不同，详见 [docs/CLI.md](docs/CLI.md) 与 [ARCHITECTURE.md](ARCHITECTURE.md)。
 
 ---
 
-## 项目目录
+## 文档
 
-```text
-rosclaw/
-├── src/rosclaw/              # 核心 Runtime、Schema、CLI、MCP Gateway
-│   ├── core/                 # 运行时、EventBus、生命周期
-│   ├── schemas/              # 统一规范数据类
-│   ├── provider/             # 能力接入层
-│   ├── sandbox/              # MuJoCo 仿真与防火墙
-│   ├── practice/             # 时空轴捕获与 MCAP
-│   ├── memory/               # 时空记忆系统
-│   ├── how/                  # 运行时干预
-│   ├── know/                 # 知识编译器
-│   ├── auto/                 # 自进化控制平面
-│   ├── darwin/               # Benchmark 与评测竞技场
-│   ├── forge/                # 资产编译器
-│   ├── dashboard/            # 可观测平台与 WebSocket
-│   └── mcp/                  # MCP Server 实现
-├── e-urdf-zoo/               # 机器人物理基因库
-├── docs/                     # 架构、RFC、使用文档
-├── examples/                 # 示例任务和机器人 Demo
-├── tutorials/                # 教程
-├── tests/                    # 单元测试、集成测试、端到端测试、安全测试
-├── benchmarks/               # Benchmark 和评测任务
-├── acceptance/               # 发布验收测试
-├── scripts/                  # 安装脚本和工具脚本
-├── rosclaw.yaml              # 默认运行配置
-├── docker-compose.yml        # 本地服务编排
-├── ARCHITECTURE.md           # 14 条工程铁律
-├── QUICKSTART.md             # 快速开始
-└── INSTALL.md                # 安装说明
-```
-
----
-
-## 配置示例
-
-`rosclaw.yaml` 示例：
-
-```yaml
-runtime:
-  robot_id: ur5e
-  safety_level: strict
-
-event_bus:
-  backend: local
-
-knowledge_plane:
-  backend: seekdb
-  path: .rosclaw/seekdb
-
-object_store:
-  backend: local
-  path: .rosclaw/artifacts
-
-sandbox:
-  enabled: true
-  backend: mujoco
-  firewall_mode: true
-
-provider:
-  enabled: true
-
-practice:
-  enabled: true
-  mcap: true
-
-memory:
-  enabled: true
-
-how:
-  enabled: true
-  cooldown_window: 3
-  evidence_trace_enabled: true
-
-auto:
-  enabled: true
-  allow_code_patch: false
-  require_human_approval: true
-  trigger_failure_threshold: 3
-
-darwin:
-  enabled: true
-  seeds: [0, 1, 2]
-  episodes: 50
-  metrics: [success_rate, collision_rate, completion_time]
-```
+- [快速开始](QUICKSTART.md)
+- [安装说明](INSTALL.md)
+- [First Boot](docs/FIRSTBOOT.md)
+- [架构说明](ARCHITECTURE.md)
+- [CLI 参考](docs/CLI.md)
+- [安全模型](docs/SAFETY.md)
+- [物理 AI 资产](docs/ASSETS.md)
+- [Hub](docs/hub/README.md)
+- [贡献指南](CONTRIBUTING.md)
 
 ---
 
 ## 路线图
 
-### ROSClaw v1.0（当前版本）
+### 当前
 
-- [x] Runtime 插件架构
-- [x] e-URDF 机器人本体注册
-- [x] MCP 兼容 Agent Runtime
-- [x] 能力 Provider 层
-- [x] MuJoCo Sandbox 和 Firewall Mode
-- [x] Practice 统一时空轴捕获（MCAP / JSONL）
-- [x] SeekDB 时空记忆系统
-- [x] How 运行时干预（v1.5）
-- [x] Know 物理 AI 知识编译
-- [x] Auto 自进化控制平面
-- [x] Darwin Benchmark 与评测竞技场
-- [x] Skill Registry 支持 champion/谱系/回滚
-- [x] Forge SDK-to-MCP 资产编译
-- [x] Dashboard 可观测平台（WebSocket + HTTP API）
-- [x] 端到端物理智能 Demo
-- [x] 统一 Schema 包（`rosclaw.schemas`）
-- [x] ARCHITECTURE.md — 14 条工程铁律
+- 本地运行时工作区
+- 基于 e-URDF 的本体建模
+- 沙盒验证
+- 能力 Provider 路由
+- Practice 轨迹捕获
+- Hub 资产验证与本地注册表工作流
+- Dashboard 与回放基础
+- 测试套件与 Benchmark 脚手架
 
-### 后续计划
+### 进行中
 
-- [ ] Isaac Sim 后端
-- [ ] 多机器人协作沙盒
-- [ ] DDS 反射握手
-- [ ] LeRobot / RLDS 数据导出
-- [ ] OpenVLA 和 Cosmos Provider
-- [ ] Darwin Benchmark 排行榜
-- [ ] ClawHub Skill / Provider 市场
-- [ ] 长周期真实巡检 Demo
+- First Boot 产品化
+- Hardware MCP 自动安装流程
+- 物理记忆闭环评估
+- How 运行时干预集成
+- Provider 容器生命周期
+- Dashboard 物理轨迹查看器
+- Darwin 评测驱动的技能晋升
 
----
+### 研究
 
-## 使用场景
-
-### 机器人研究
-
-- 具身 Agent 评测；
-- 技能学习与技能优化；
-- 仿真到真实迁移；
-- 机器人长期记忆；
-- 自进化实验闭环。
-
-### 工业机器人
-
-- 机器人 Skill 封装与版本管理；
-- LLM 安全控制机器人；
-- 数字孪生预演；
-- 巡检、抓取、按钮、阀门等处置任务；
-- 失败回放和根因分析。
-
-### Agent 基础设施
-
-- MCP 物理工具；
-- 具身能力路由；
-- Agent 安全边界；
-- 运行时干预；
-- 自我改进 Skill 系统。
-
----
-
-## 开发
-
-运行测试：
-
-```bash
-PYTHONPATH=src pytest tests -v
-```
-
-运行端到端测试：
-
-```bash
-PYTHONPATH=src pytest tests/test_e2e_full_pipeline.py -v
-```
-
-运行架构检查：
-
-```bash
-./rosclaw doctor --ros2
-```
+- 跨本体技能迁移
+- VLA / VLN / 世界模型 Provider 编排
+- 长周期物理记忆
+- 自进化具身技能
+- Sim-to-real 晋升门控
+- 多 Agent 物理协作
 
 ---
 
 ## 参与贡献
 
-欢迎一起建设 Physical AI 的开放基础设施。
+欢迎贡献：
 
-适合贡献的方向包括：
+- 新机器人 e-URDF
+- Hardware MCP Server
+- Capability Provider
+- 沙盒场景与世界
+- Benchmark 任务
+- 物理记忆评估器
+- 运行时干预策略
+- 技能进化流水线
+- 文档与教程
 
-- 新机器人 e-URDF；
-- 新机器人 MCP Server；
-- 新感知 / 操作 / 导航 Provider；
-- 新 Skill；
-- 新 Sandbox 任务和场景；
-- 新 Benchmark；
-- Dashboard 可视化；
-- 文档和教程。
-
-提交 PR 前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
-
----
-
-## 安全声明
-
-ROSClaw 是面向物理 AI 和具身智能的研究与工程基础设施。
-
-在真实机器人上运行前，请务必先在仿真环境中测试。真实部署时，请使用急停、安全围栏、限位、速度限制、安全控制器和人工监督。
-
-**ROSClaw 不能替代经过认证的工业安全系统。**
+详见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ---
 
-## 引用
+## 联系我们
 
-如果你在研究中使用 ROSClaw，可以引用：
+如果你对 ROSClaw、物理 AI 基础设施、具身 Agent、机器人安全运行时、物理记忆、自进化技能系统感兴趣，欢迎联系：
 
-```bibtex
-@software{rosclaw2026,
-  title  = {ROSClaw: Open Infrastructure for Physical Intelligence},
-  author = {ROSClaw Contributors},
-  year   = {2026},
-  url    = {https://github.com/ros-claw/rosclaw}
-}
-```
+[**ai@rosclaw.io**](mailto:ai@rosclaw.io)
 
-如果你在使用 Genesis 仿真器配合 ROSClaw，也请引用：
-
-```bibtex
-@article{genesis2026,
-  title   = {Genesis: A Generative Physics Engine for General Purpose Robotics},
-  author  = {Genesis Authors},
-  journal = {arXiv preprint},
-  year    = {2026},
-  url     = {https://arxiv.org/abs/2604.04664}
-}
-```
+我们欢迎科研合作、机器人平台适配、Provider 接入、Benchmark / 评测任务贡献，以及工业物理 AI 场景合作。
 
 ---
 
-## License
+## 许可证
 
-本项目采用 MIT License，详见 [LICENSE](LICENSE)。
-
----
-
-## Links
-
-- **Website**: [https://www.rosclaw.io/](https://www.rosclaw.io/)
-- **GitHub**: [https://github.com/ros-claw/rosclaw](https://github.com/ros-claw/rosclaw)
-- **文档**: [docs/](docs/)
-- **快速开始**: [QUICKSTART.md](QUICKSTART.md)
-- **架构规范**: [ARCHITECTURE.md](ARCHITECTURE.md)
+MIT License.
 
 ---
 
 <div align="center">
-  <b>ROSClaw — 让 AI 真正进入物理世界。</b>
+
+**ROSClaw — 面向物理 AI 的自进化运行时基础设施。**
+
 </div>

--- a/docs/ASSETS.md
+++ b/docs/ASSETS.md
@@ -1,0 +1,154 @@
+# ROSClaw Physical-AI Assets
+
+## What is the Physical-AI Asset Hub?
+
+ROSClaw Hub is a **Physical-AI Asset Hub** for skills, providers, hardware MCP servers, digital twins, e-URDF profiles, and cognitive wikis. It supports local-only usage, cloud-synced registries, and team-managed private registries.
+
+The Hub is **not** only a Skill Market and **not** only an MCP package manager. It is a unified registry for all assets that an embodied agent needs to operate, validate, and evolve safely.
+
+---
+
+## Asset Types
+
+| Type | Description |
+|---|---|
+| `skill` | Task policy, recovery logic, skill graph, parameters, evaluation metadata |
+| `provider` | LLM / VLM / VLA / VLN / world model / critic / embedding / robotics algorithm |
+| `hardware_mcp` | MCP-compatible robot, sensor, or device interface |
+| `digital_twin` | Simulation world, robot asset, replay scene, validation environment |
+| `e_urdf` | Robot embodiment profile and safety envelope |
+| `cognitive_wiki` | TaskCard, failure taxonomy, constraints, evidence, and repair knowledge |
+
+---
+
+## Asset Lifecycle
+
+```text
+Create
+  → Validate
+  → Sign
+  → Publish
+  → Sync
+  → Install
+  → Activate
+  → Evaluate
+  → Update / Rollback
+  → Uninstall
+```
+
+- **Create** — author the asset or generate it with `rosclaw-forge`.
+- **Validate** — run `rosclaw hub validate` against the manifest schema.
+- **Sign** — optional cryptographic signature for provenance.
+- **Publish** — upload to a registry.
+- **Sync** — download the catalog index with `rosclaw hub sync`.
+- **Install** — stage the asset in `~/.rosclaw/hub/`.
+- **Activate** — register the asset with the runtime.
+- **Evaluate** — run benchmarks and sandbox tests.
+- **Update / Rollback** — versioned replacement or revert.
+- **Uninstall** — remove the asset from the workspace.
+
+---
+
+## Local-only Assets
+
+Local assets can be created, validated, and used without a ROSClaw Cloud key:
+
+```bash
+rosclaw hub validate ./my_skill/manifest.yaml
+rosclaw hub verify ./my_skill/
+```
+
+Local-only mode is the default after `rosclaw firstboot --profile offline`.
+
+---
+
+## Cloud-synced Assets
+
+Cloud sync, private team assets, and organization-managed registries may require authentication:
+
+```bash
+rosclaw hub login --registry https://hub.rosclaw.io --token $ROSCLAW_HUB_TOKEN
+rosclaw hub sync
+rosclaw hub search pick_cube --type skill
+```
+
+Cloud sync is opt-in. Telemetry and artifact upload are disabled by default.
+
+---
+
+## Asset Reference URI
+
+ROSClaw uses a `rosclaw://` URI scheme for assets:
+
+```text
+rosclaw://hub/<registry>/<asset-type>/<namespace>/<name>@<version>
+```
+
+Example:
+
+```text
+rosclaw://hub/rosclaw.io/hardware_mcp/rosclaw/unitree-g1@1.0.0
+```
+
+---
+
+## Forge Workflow
+
+`rosclaw-forge` compiles SDKs, ROS 2 interfaces, docs, and e-URDF profiles into distributable assets:
+
+```text
+SDK / ROS 2 Interfaces / Docs / e-URDF
+        ↓
+  rosclaw-forge
+        ↓
+MCP Server + Skill Manifest + Provider Manifest + Tests + Hub Metadata
+```
+
+Example:
+
+```bash
+rosclaw forge sdk-to-mcp \
+  --name unitree_go2 \
+  --sdk-docs ./docs/unitree_go2_sdk.md \
+  --output ./generated/unitree_go2_bundle
+
+rosclaw forge validate ./generated/unitree_go2_bundle
+rosclaw forge install ./generated/unitree_go2_bundle --staging
+```
+
+---
+
+## Hub CLI
+
+Currently available Hub commands:
+
+```bash
+rosclaw hub search g1
+rosclaw hub validate ./manifest.yaml
+rosclaw hub verify ./asset_dir
+rosclaw hub policy check ./asset_dir
+rosclaw hub sync
+rosclaw hub login --registry https://hub.rosclaw.io --token $TOKEN
+rosclaw hub whoami
+rosclaw hub logout
+```
+
+Planned commands:
+
+```bash
+rosclaw hub install rosclaw://hub/rosclaw.io/skill/rosclaw/pick_cube@1.0.0
+rosclaw hub list --installed
+```
+
+---
+
+## Team-managed Registries
+
+Organizations can run private registries with custom policies:
+
+- Require signed manifests
+- Restrict real-robot assets
+- Enforce license acceptance
+- Gate skill promotion by team role
+
+Use `rosclaw hub policy check` to validate an asset against local policy before activation.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,315 @@
+# ROSClaw CLI
+
+This reference documents the `rosclaw` command-line interface.
+
+## Status Labels
+
+| Label | Meaning |
+|---|---|
+| **Stable** | Implemented and tested. Safe for primary workflows. |
+| **Experimental** | Implemented but API may change. Use with caution. |
+| **Planned** | Documented design, not yet implemented. |
+| **Research** | Research-facing workflow; may not ship in v1.x. |
+
+Use `rosclaw --help` and `rosclaw <command> --help` to see the current help text.
+
+---
+
+## Core
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw firstboot` | Stable | Initialize local Physical-AI runtime workspace |
+| `rosclaw doctor` | Stable | Run health diagnosis |
+| `rosclaw --version` | Stable | Show version |
+| `rosclaw init [DIR]` | Stable | Initialize a ROSClaw workspace |
+| `rosclaw run` / `rosclaw start` | Stable | Start the ROSClaw runtime |
+| `rosclaw stop` | Stable | Stop the ROSClaw runtime |
+| `rosclaw restart` | Stable | Restart the ROSClaw runtime |
+| `rosclaw status` | Stable | Show runtime status |
+| `rosclaw logs` | Stable | Show runtime logs |
+| `rosclaw uninstall` | Stable | Uninstall ROSClaw |
+
+---
+
+## Agent
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw agent init claude-code` | Stable | Generate MCP and agent context files |
+| `rosclaw agent doctor claude-code` | Stable | Diagnose Claude Code integration |
+| `rosclaw agent test claude-code` | Stable | Validate generated agent files |
+
+---
+
+## Body
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw body init --robot unitree-g1` | Stable | Initialize a new body instance from an e-URDF profile |
+| `rosclaw body create --robot unitree-g1 --name g1_01` | Stable | Create a body instance |
+| `rosclaw body link-eurdf unitree-g1` | Stable | Link current body to an e-URDF profile |
+| `rosclaw body inspect` | Stable | Inspect current body state |
+| `rosclaw body show` | Stable | Show body summary |
+| `rosclaw body state` | Stable | Print unified body state |
+| `rosclaw body query "question"` | Stable | Ask a question about the body |
+| `rosclaw body validate` | Stable | Validate body workspace |
+| `rosclaw body render` | Stable | Re-render EMBODIMENT.md and summaries |
+| `rosclaw body switch <body_id>` | Stable | Switch active body |
+| `rosclaw body remove <body_id>` | Stable | Remove a body instance |
+| `rosclaw body history` | Stable | List body snapshots |
+| `rosclaw body diff` | Stable | Compare body states |
+| `rosclaw body update-state` | Stable | Update body instance state |
+| `rosclaw body note "message"` | Stable | Add a maintenance/incident note |
+| `rosclaw body calibration update --file calib.yaml` | Stable | Update calibration |
+| `rosclaw body fault add --component X --severity high --summary "..."` | Stable | Add a known fault |
+| `rosclaw body maintenance add --component X --summary "..."` | Stable | Add a maintenance event |
+| `rosclaw body retrofit add` | Stable | Record a hardware retrofit |
+| `rosclaw body capability enable/disable/degrade <cap_id>` | Stable | Manage capabilities |
+| `rosclaw body export dest.zip` | Stable | Export body directory as archive |
+
+---
+
+## Provider
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw provider list` | Stable | List registered providers |
+| `rosclaw provider invoke <provider_id> <input>` | Stable | Invoke a provider capability |
+| `rosclaw provider init` | Planned | Initialize a provider configuration |
+| `rosclaw provider route --capability vision_language_action` | Planned | Route a capability request |
+
+---
+
+## Sandbox
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach` | Stable | Run a sandbox episode |
+| `rosclaw sandbox validate <robot_id>` | Stable | Validate a robot in sandbox |
+| `rosclaw sandbox check --robot <robot> --action <action>` | Stable | Check action safety |
+| `rosclaw sandbox replay <episode_id>` | Stable | Replay a sandbox episode |
+| `rosclaw sandbox list-worlds` | Stable | List available sandbox worlds |
+
+---
+
+## Practice
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw practice list` | Stable | List recorded episodes |
+| `rosclaw practice show <episode_id>` | Stable | Show episode details |
+| `rosclaw practice replay <episode_id>` | Stable | Replay episode trace |
+| `rosclaw practice export <episode_id> --format json` | Stable | Export episode metadata |
+| `rosclaw practice start --sources ...` | Planned | Start continuous praxis capture |
+
+---
+
+## Memory
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw memory query "last failed grasp near red cup"` | Stable | Query memory for similar experiences |
+| `rosclaw memory explain` | Stable | Explain the most recent failure |
+| `rosclaw memory status` | Stable | Show memory module status |
+
+---
+
+## How
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw how explain <episode_id>` | Stable | Explain a failure episode |
+| `rosclaw how recover <episode_id>` | Stable | Generate a recovery plan |
+| `rosclaw how advise --task ... --failure ...` | Planned | Ask for runtime repair advice |
+
+---
+
+## Know
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw know compile --task g1_kick_ball` | Stable | Compile a task into a TaskCard |
+| `rosclaw know search "symptom"` | Stable | Search knowledge base |
+| `rosclaw know robot <robot_id>` | Stable | Show robot safety limits and simulation profile |
+| `rosclaw know recommend --task "pick and place"` | Stable | Recommend robots for a task |
+| `rosclaw know validate --taskcard file.yaml` | Stable | Validate a TaskCard YAML file |
+| `rosclaw know eval-taskcard --taskcard gen.yaml --gold gold.yaml` | Stable | Evaluate a TaskCard against a gold fixture |
+| `rosclaw know export-hooks --taskcard file.yaml --out ./hooks` | Stable | Export hooks from a TaskCard |
+
+---
+
+## Auto
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw auto init --task pick_cube --skill reach` | Stable | Initialize an auto task |
+| `rosclaw auto run --task pick_cube --rounds 50` | Stable | Run auto evolution |
+| `rosclaw auto status --task pick_cube` | Stable | Show auto status |
+| `rosclaw auto champion --task pick_cube` | Stable | Show current champion |
+| `rosclaw auto deadends --task pick_cube` | Stable | List dead ends |
+| `rosclaw auto report --task pick_cube` | Stable | Generate evolution report |
+| `rosclaw auto run --suite tabletop_grasp` | Planned | Run an evolution suite |
+
+---
+
+## Darwin
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw darwin eval --skill pick_cube` | Research | Evaluate skill candidates under benchmark pressure |
+
+`rosclaw-darwin` currently operates as a subcomponent of the Auto evolution pipeline. A standalone `darwin` CLI is on the research roadmap.
+
+---
+
+## Skill
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw skill list` | Stable | List available skills |
+| `rosclaw skill invoke <skill_id> <input>` | Stable | Invoke a skill |
+| `rosclaw skill check <skill_id>` | Stable | Check skill compatibility against current body |
+| `rosclaw skill champions list` | Stable | List current champions |
+| `rosclaw skill lineage <skill_id>` | Stable | Show skill lineage |
+| `rosclaw skill rollback <skill_id> --to v1.0.0` | Stable | Rollback skill to version |
+
+---
+
+## Hub
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw hub search g1` | Stable | Search the local catalog index |
+| `rosclaw hub login --registry https://hub.rosclaw.io --token $TOKEN` | Stable | Authenticate with a Hub registry |
+| `rosclaw hub whoami` | Stable | Show active Hub identity |
+| `rosclaw hub logout` | Stable | Forget stored credentials |
+| `rosclaw hub sync` | Stable | Sync the local catalog index |
+| `rosclaw hub validate ./manifest.yaml` | Stable | Validate an asset manifest |
+| `rosclaw hub verify ./asset_dir` | Stable | Verify asset integrity |
+| `rosclaw hub policy check ./asset_dir` | Stable | Check asset against local policy |
+| `rosclaw hub ref parse rosclaw://...` | Stable | Parse a rosclaw URI |
+| `rosclaw hub schema export` | Stable | Export manifest JSON Schema |
+| `rosclaw hub install <asset>` | Planned | Install an asset |
+| `rosclaw hub list --installed` | Planned | List installed assets |
+
+---
+
+## Dashboard
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw dashboard --open` | Stable | Start dashboard web server |
+| `rosclaw dashboard` | Stable | Show dashboard status summary |
+
+---
+
+## Forge
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw forge sdk-to-mcp --name unitree_go2 --output ./out` | Stable | Convert SDK doc to MCP bundle |
+| `rosclaw forge validate ./bundle` | Stable | Validate a Forge bundle |
+| `rosclaw forge install ./bundle --staging` | Stable | Install a bundle to staging |
+
+---
+
+## Robot Registry
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw robot list` | Stable | List available robots |
+| `rosclaw robot install <robot_id>` | Stable | Install/register a robot |
+| `rosclaw robot inspect <robot_id>` | Stable | Show robot profile |
+| `rosclaw robot validate <robot_id>` | Stable | Validate e-URDF completeness |
+
+---
+
+## Config / Profile
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw config show` | Stable | Show current config |
+| `rosclaw config path` | Stable | Show config file path |
+| `rosclaw config validate` | Stable | Validate config schema |
+| `rosclaw config edit` | Stable | Open config in editor |
+| `rosclaw profile list` | Stable | List profiles |
+| `rosclaw profile current` | Stable | Show active profile |
+| `rosclaw profile use offline` | Stable | Activate a profile |
+
+---
+
+## Runtime
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw runtime backends` | Stable | List available runtime backends |
+
+---
+
+## Firewall
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw firewall check --robot <robot> --action <action>` | Stable | Check action safety |
+
+---
+
+## Events
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw events tail` | Stable | Tail EventBus events |
+| `rosclaw events publish <topic>` | Stable | Publish an event |
+| `rosclaw events list` | Stable | List published events |
+
+---
+
+## MCP
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw mcp serve --transport stdio` | Stable | Start the P0 MCP server |
+| `rosclaw mcp install` | Stable | Install a hardware MCP server |
+| `rosclaw mcp list` | Stable | List hardware MCP servers |
+| `rosclaw mcp health` | Stable | Check hardware MCP health |
+
+---
+
+## Sense
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw sense now` | Stable | Get current BodySense snapshot |
+| `rosclaw sense state` | Stable | Show detailed BodyState |
+| `rosclaw sense readiness --task "walk"` | Stable | Show body readiness |
+| `rosclaw sense watch` | Stable | Watch body sense stream |
+| `rosclaw sense events` | Stable | Show recent body events |
+| `rosclaw sense explain --task "walk"` | Stable | Explain task block |
+
+---
+
+## Demo
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw demo tabletop-grasp --robot-id ur5e` | Experimental | Tabletop grasp demo |
+| `rosclaw demo mobile-pid --robot-id turtlebot` | Experimental | Mobile base PID control demo |
+
+---
+
+## ROS Connector
+
+| Command | Status | Description |
+|---|---|---|
+| `rosclaw ros discover` | Stable | Discover ROS capabilities |
+| `rosclaw ros ping` | Stable | Ping ROS bridge |
+| `rosclaw ros list-capabilities` | Stable | List ROS capabilities |
+| `rosclaw ros emergency-stop` | Stable | Emergency stop |
+
+---
+
+## Notes
+
+- Commands marked **Planned** are documented for roadmap transparency but do not yet have implementations. Use `rosclaw --help` to confirm what is available in your installed version.
+- Commands marked **Research** are part of active research and may change significantly or be removed.

--- a/docs/FIRSTBOOT.md
+++ b/docs/FIRSTBOOT.md
@@ -1,0 +1,196 @@
+# First Boot
+
+`rosclaw firstboot` initializes a local Physical-AI runtime workspace. It is the recommended first command after installing the CLI.
+
+---
+
+## Overview
+
+First boot creates the workspace, generates a default configuration, checks dependencies, and optionally sets up providers, a robot body, and an MCP-compatible agent.
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot
+```
+
+For CI or headless environments:
+
+```bash
+rosclaw firstboot --yes --profile offline --no-telemetry
+```
+
+---
+
+## What firstboot creates
+
+```text
+~/.rosclaw/
+  config/
+    rosclaw.yaml
+    mcp.json
+    profiles/
+  secrets/
+  bodies/
+  providers/
+  hub/
+  artifacts/
+    episodes/
+  data/
+    memory/
+    seekdb/
+  logs/
+```
+
+Key files:
+
+| Path | Purpose |
+|---|---|
+| `~/.rosclaw/config/rosclaw.yaml` | Main runtime configuration |
+| `~/.rosclaw/config/mcp.json` | MCP server config for agents |
+| `~/.rosclaw/secrets/` | API keys and tokens (not synced to cloud by default) |
+| `~/.rosclaw/bodies/` | Robot body instances |
+| `~/.rosclaw/providers/` | Provider manifests |
+| `~/.rosclaw/hub/` | Local asset cache |
+| `~/.rosclaw/artifacts/episodes/` | Practice episode traces |
+
+---
+
+## Modes
+
+| Mode | Cloud key required | Description |
+|---|---|---|
+| `offline` / `local-only` | No | Local runtime, local assets, local traces. Default. |
+| `cloud-sync` | Yes | Sync assets and metadata with ROSClaw Cloud. |
+| `hybrid` / `team-managed` | Yes | Organization-managed assets and policies. |
+
+In local-only mode, no telemetry is sent and no cloud account is required.
+
+---
+
+## Provider keys
+
+After first boot, configure provider keys as needed:
+
+```bash
+rosclaw secrets set OPENAI_API_KEY
+rosclaw secrets set ANTHROPIC_API_KEY
+rosclaw secrets set QWEN_API_KEY
+rosclaw secrets set ROSCLAW_API_KEY
+```
+
+Secrets are stored in `~/.rosclaw/secrets/` and are not uploaded unless cloud sync is explicitly enabled.
+
+---
+
+## Agent setup
+
+To connect Claude Code or another MCP-compatible agent:
+
+```bash
+rosclaw agent init claude-code
+```
+
+This generates:
+
+- `.mcp.json`
+- `CLAUDE.md`
+- `ROSCLAW.md`
+- `.claude/settings.json`
+- `.rosclaw/agent/context.snapshot.json`
+
+Point the agent at `~/.rosclaw/config/mcp.json` or the generated `.mcp.json`.
+
+---
+
+## Body setup
+
+To initialize a robot body:
+
+```bash
+rosclaw body init --robot unitree-g1
+rosclaw body link-eurdf unitree-g1
+rosclaw body inspect
+```
+
+For a local simulation body:
+
+```bash
+rosclaw body init --robot sim_ur5e
+rosclaw body link-eurdf ur5e
+rosclaw body inspect --safety --skills
+```
+
+---
+
+## Validation
+
+After first boot, run the doctor to verify the workspace:
+
+```bash
+rosclaw doctor --full
+```
+
+Run a sandbox smoke test:
+
+```bash
+rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach
+```
+
+---
+
+## Non-interactive options
+
+| Flag | Meaning |
+|---|---|
+| `--yes` | Accept defaults without prompting |
+| `--profile offline` | Use offline/local-only mode |
+| `--no-telemetry` | Disable anonymous telemetry |
+| `--workspace PATH` | Use a custom workspace path |
+| `--robot ROBOT` | Pre-select a robot profile |
+| `--safety strict` | Set safety level |
+| `--enable-sandbox` / `--disable-sandbox` | Control sandbox module |
+| `--enable-mcp` / `--disable-mcp` | Control MCP config generation |
+| `--dev` | Developer mode |
+| `--force` | Re-run even if already initialized |
+| `--dry-run` | Show what would be done without writing |
+
+---
+
+## Re-running firstboot
+
+To regenerate the workspace config:
+
+```bash
+rosclaw firstboot --force
+```
+
+To re-run in dry-run mode:
+
+```bash
+rosclaw firstboot --dry-run
+```
+
+---
+
+## Cleaning up
+
+To remove the workspace while keeping the CLI:
+
+```bash
+rm -rf ~/.rosclaw
+```
+
+To uninstall completely:
+
+```bash
+rosclaw uninstall --purge
+```
+
+---
+
+## Next Steps
+
+- [Quick Start](../QUICKSTART.md)
+- [Installation](../INSTALL.md)
+- [CLI Reference](CLI.md)
+- [Safety Model](SAFETY.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,61 +6,59 @@ Welcome to the ROSClaw documentation index. This directory contains all project 
 
 | Category | Documents |
 |----------|-----------|
-| [Architecture](#architecture) | Design decisions, reviews, audits |
-| [API](#api) | API reference, improvements, end-to-end findings |
-| [Development](#development) | Collaboration framework, contributing, benchmarks |
-| [Security](#security) | Security audits, gap analysis |
-| [Planning](#planning) | Roadmaps, sprints, release checklist |
-| [Testing](#testing) | Test reports, verification, deep user tests |
+| [User Guides](#user-guides) | Getting started, CLI, safety, assets |
+| [Architecture](#architecture) | System design, engineering rules, events |
+| [Integration](#integration) | ROS, MCP, OpenClaw, robot SDKs |
+| [Reference](#reference) | API, event topics, schemas |
+| [Specialized Topics](#specialized-topics) | Sense, benchmarks, audits |
+| [Contributing](#contributing) | How to contribute |
+
+---
+
+## User Guides
+
+- **[../QUICKSTART.md](../QUICKSTART.md)** — Four-path quick start: simulation, agent, robot body, developer
+- **[../INSTALL.md](../INSTALL.md)** — Installation methods, platform notes, troubleshooting
+- **[FIRSTBOOT.md](FIRSTBOOT.md)** — What `rosclaw firstboot` creates and how to configure it
+- **[CLI.md](CLI.md)** — Complete CLI reference with Stable / Experimental / Planned / Research labels
+- **[SAFETY.md](SAFETY.md)** — Safety boundary, hard rules, and deployment checklist
+- **[ASSETS.md](ASSETS.md)** — Physical-AI Asset Hub: skills, providers, digital twins, e-URDF, cognitive wikis
+- **[hub/README.md](hub/README.md)** — Hub asset discovery, validation, and lifecycle
 
 ---
 
 ## Architecture
 
-- **[ARCHITECTURE_REVIEW.md](ARCHITECTURE_REVIEW.md)** — P0/P1 architecture review findings and recommendations
-- **[ARCHITECTURE_AUDIT.md](ARCHITECTURE_AUDIT.md)** — Full architecture audit report
-- **[ROLE_SWAP_REVIEW.md](ROLE_SWAP_REVIEW.md)** — Cross-team architecture role-swap review (score: 7.4/10)
-- **[CODE_REVIEW.md](CODE_REVIEW.md)** — Code review findings and action items
-- **[GAP_ANALYSIS.md](GAP_ANALYSIS.md)** — Identified gaps between design and implementation
-
-## API
-
-- **[API_REFERENCE.md](API_REFERENCE.md)** — Complete public API reference for ROSClaw v1.0
-- **[API_IMPROVEMENTS.md](API_IMPROVEMENTS.md)** — Planned API enhancements for v1.1
-- **[E2E_TEST_FINDINGS.md](E2E_TEST_FINDINGS.md)** — End-to-end test results and discovered issues
-
-## Development
-
-- **[COLLABORATION_FRAMEWORK.md](COLLABORATION_FRAMEWORK.md)** — Multi-agent collaboration framework specification
-- **[COLLABORATION_LOG.md](COLLABORATION_LOG.md)** — Sprint-by-sprint collaboration log
-- **[BENCHMARK.md](BENCHMARK.md)** — Performance benchmarks (EventBus, SeekDB, SkillRegistry, FirewallValidator)
-- **[OPENCLAW_INTEGRATION.md](OPENCLAW_INTEGRATION.md)** — OpenClaw integration guide
-
-## Security
-
-- **[SECURITY_AUDIT.md](SECURITY_AUDIT.md)** — Security audit from stress test review
-- **[GAP_ANALYSIS.md](GAP_ANALYSIS.md)** — Security and functionality gap analysis
-
-## Planning
-
-- **[ROADMAP_v1.1.md](ROADMAP_v1.1.md)** — v1.1 roadmap and planned features
-- **[RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md)** — Pre-release verification checklist
-- **[DESIGN_SPRINT3_5.md](DESIGN_SPRINT3_5.md)** — Sprint 3-5 design documentation
-- **[SPRINT3_5_IMPLEMENTATION_REVIEW.md](SPRINT3_5_IMPLEMENTATION_REVIEW.md)** — Sprint 3-5 implementation review
-
-## Testing
-
-- **[DEEP_USER_TEST.md](DEEP_USER_TEST.md)** — Deep user experience test report
-- **[FINAL_ACCEPTANCE.md](FINAL_ACCEPTANCE.md)** — Final acceptance criteria and results (9.2/10)
-- **[FINAL_VERIFICATION.md](FINAL_VERIFICATION.md)** — Final verification checklist
-- **[ROS_INTEGRATION_TESTING.md](ROS_INTEGRATION_TESTING.md)** — Cross-project ROS 1 / ROS 2 integration test matrix
+- **[../ARCHITECTURE.md](../ARCHITECTURE.md)** — System architecture, engineering iron rules, execution loops, and deployment modes
+- **[EVENT_TOPICS.md](EVENT_TOPICS.md)** — EventBus topic definitions
+- **[BODYSENSE_SCHEMA.md](BODYSENSE_SCHEMA.md)** — BodySense schema specification
 
 ---
 
-## Design Assets
+## Integration
 
-- **[design/](design/)** — Architecture diagrams and visual assets
-- **[logos/](logos/)** — ROSClaw branding and logos
+- **[MCP_USAGE.md](MCP_USAGE.md)** — MCP (Model Context Protocol) usage guide
+- **[OPENCLAW_INTEGRATION.md](OPENCLAW_INTEGRATION.md)** — OpenClaw integration guide
+- **[ROS_CONNECTOR.md](ROS_CONNECTOR.md)** — ROS connector documentation
+- **[ROS_INTEGRATION_TESTING.md](ROS_INTEGRATION_TESTING.md)** — Cross-project ROS 1 / ROS 2 integration test matrix
+- **[INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md)** — General integration guide
+- **[unitree_go2_sdk.md](unitree_go2_sdk.md)** — Unitree Go2 SDK integration
+
+---
+
+## Reference
+
+- **[API_REFERENCE.md](API_REFERENCE.md)** — Complete public API reference for ROSClaw v1.0
+- **[SENSE.md](SENSE.md)** — Sense system documentation
+- **[G1_SENSE_DEMO.md](G1_SENSE_DEMO.md)** — G1 Sense demo documentation
+
+---
+
+## Specialized Topics
+
+- **[BENCHMARK.md](BENCHMARK.md)** — Performance benchmarks (EventBus, SeekDB, SkillRegistry, FirewallValidator)
+- **[AUDIT_REPORT_v1.0_POST_RELEASE.md](AUDIT_REPORT_v1.0_POST_RELEASE.md)** — Post-release architecture audit
+- **[issues/rosclaw-how-match-gaps.md](issues/rosclaw-how-match-gaps.md)** — Gap analysis issue note
 
 ---
 

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -1,0 +1,138 @@
+# ROSClaw Safety Model
+
+## Core Rule
+
+> **No model output should directly control a robot.**
+
+ROSClaw is research infrastructure for physical AI and embodied agents. It reduces risk through validation, replay, and runtime guards. It does not guarantee absolute safety and does not replace certified industrial safety systems.
+
+---
+
+## Safety Pipeline
+
+Every physical action must pass through:
+
+```text
+Agent Intent
+  ↓
+Provider Schema
+  ↓
+Embodiment Constraints
+  ↓
+Sandbox Validation
+  ↓
+Runtime Guard
+  ↓
+Robot Controller
+```
+
+Each layer narrows what is allowed:
+
+1. **Provider Schema** — the capability request must match a registered, typed schema.
+2. **Embodiment Constraints** — the action must respect e-URDF limits: joint ranges, workspace, velocity, force.
+3. **Sandbox Validation** — the action is simulated and checked for collisions, instability, and policy violations.
+4. **Runtime Guard** — runtime monitors enforce rate limits, emergency stop, and approval gates.
+5. **Robot Controller** — the certified controller receives the final, validated command.
+
+---
+
+## Sandbox Decisions
+
+The Sandbox firewall can return one of four decisions:
+
+| Decision | Meaning |
+|---|---|
+| `ALLOW` | Action passed validation; may proceed to runtime guard. |
+| `MODIFY` | Action passed after adjusting parameters to stay within constraints. |
+| `BLOCK` | Action violates safety constraints and must not execute. |
+| `REQUIRE_HUMAN_CONFIRMATION` | Action is borderline; requires explicit operator approval. |
+
+Example blocked action:
+
+```json
+{
+  "decision": "BLOCK",
+  "risk_score": 0.92,
+  "reason": "Predicted collision between wrist_link and table",
+  "violated_constraints": ["collision", "workspace_boundary"],
+  "replay_id": "sandbox://replays/firewall_00042"
+}
+```
+
+---
+
+## Hard Rules
+
+- **VLA outputs are proposals, not raw motor commands.** A vision-language-action model may suggest a target pose or trajectory; the runtime decides whether and how to execute it.
+- **World models are previews, not safety proofs.** Neural simulators predict outcomes but cannot certify safety.
+- **MCP is an agent tool interface, not a real-time control bus.** Tool calls are request/response, not hard real-time loops.
+- **Auto-generated skills must pass sandbox validation before execution.** No generated code runs on a real robot without validation.
+- **Code patches require human review before production use.** Auto may propose patches; humans must approve them.
+- **Safety configuration changes require explicit approval.** Changes to safety limits, workspace, or firewalls must be reviewed.
+- **Every promoted skill must be versioned and rollback-safe.** Champion skills can be reverted to a previous known-good version.
+
+---
+
+## Human Approval Gates
+
+The following actions require explicit human approval in production mode:
+
+- First execution on real hardware
+- Safety configuration changes
+- Code patches from Auto evolution
+- Skill promotion from simulation to real robot
+- Installation of unknown or unverified assets
+- Capability degradation or enable after fault
+
+---
+
+## What ROSClaw Does Not Guarantee
+
+ROSClaw is designed to **reduce risk** and **increase observability**, not to eliminate all hazards:
+
+- It does not guarantee zero collision.
+- It does not guarantee perfect sensor perception.
+- It does not replace certified industrial safety systems.
+- It does not remove the need for human supervision during real-robot deployment.
+
+Operators remain responsible for emergency stops, workspace boundaries, safety-rated controllers, and risk assessment.
+
+---
+
+## Recommended Deployment Practice
+
+Before running on a real robot:
+
+1. Start in local simulation.
+2. Validate in a digital twin that matches the real robot.
+3. Use low-speed hardware tests with a human operator present.
+4. Enable emergency stop and verify it works.
+5. Record all traces with Practice.
+6. Promote skills gradually: sim → sandbox → low-speed real → full-speed real.
+7. Review Auto-proposed patches before applying them.
+8. Keep safety configuration under version control.
+
+---
+
+## Emergency Procedures
+
+- Use `rosclaw ros emergency-stop` to halt motion immediately.
+- Maintain a physical emergency stop near the robot.
+- Test e-stop behavior in simulation before real deployment.
+- Document recovery steps after an e-stop event.
+
+---
+
+## Failure Evidence
+
+When a safety event occurs, ROSClaw captures:
+
+- The original agent intent
+- The provider output
+- Sandbox decision and risk score
+- Embodiment constraints that were checked
+- Runtime guard logs
+- Sensor data and robot state at the time
+- Replay artifact ID
+
+This evidence supports root-cause analysis and skill improvement without requiring the failure to be reproduced.

--- a/docs/hub/README.md
+++ b/docs/hub/README.md
@@ -1,0 +1,126 @@
+# ROSClaw Hub
+
+ROSClaw Hub is a **Physical-AI Asset Hub** for skills, providers, hardware MCP servers, digital twins, e-URDF profiles, and cognitive wikis.
+
+It is **not** only a Skill Market and **not** only an MCP package manager. It is a unified registry for all assets that an embodied agent needs to operate, validate, and evolve safely.
+
+---
+
+## Asset Types
+
+| Type | Description |
+|---|---|
+| **Skills** | Reusable embodied task policies, recovery strategies, and skill graphs. |
+| **Providers** | LLM, VLM, VLA, VLN, world model, critic, embedding, and classical robotics providers. |
+| **Hardware MCP servers** | Agent-facing interfaces for robot bodies, sensors, tools, and lab devices. |
+| **Digital twins** | Simulation worlds, robot assets, validation scenes, and replay environments. |
+| **e-URDF profiles** | Robot embodiment definitions, safety envelopes, capabilities, and simulation metadata. |
+| **Cognitive wikis** | Task cards, failure taxonomies, constraints, evidence, and engineering knowledge. |
+
+---
+
+## Usage Modes
+
+| Mode | Cloud key required | Description |
+|---|---|---|
+| **Local-only** | No | Use local assets without any cloud connection. Default after `rosclaw firstboot --profile offline`. |
+| **Cloud-sync** | Yes | Sync asset catalog and selected metadata with ROSClaw Cloud. |
+| **Team-managed** | Yes | Use organization-managed assets, policies, and registries. |
+
+Local-only mode does not require a `ROSCLAW_API_KEY`.
+
+---
+
+## Available CLI Commands
+
+### Search
+
+```bash
+rosclaw hub search g1
+rosclaw hub search pick_cube --type skill
+rosclaw hub search --robot ur5e --compatible
+```
+
+### Authentication
+
+```bash
+rosclaw hub login --registry https://hub.rosclaw.io --token $ROSCLAW_HUB_TOKEN
+rosclaw hub whoami
+rosclaw hub logout
+```
+
+### Catalog Sync
+
+```bash
+rosclaw hub sync
+rosclaw hub sync --clear
+```
+
+### Validation and Verification
+
+```bash
+rosclaw hub validate ./manifest.yaml
+rosclaw hub verify ./asset_dir
+rosclaw hub policy check ./asset_dir --accept-license
+```
+
+### Reference Parsing
+
+```bash
+rosclaw hub ref parse rosclaw://hub/rosclaw.io/skill/rosclaw/pick_cube@1.0.0
+rosclaw hub schema export --output schema.json
+```
+
+---
+
+## Asset Lifecycle
+
+```text
+Create
+  → Validate
+  → Sign
+  → Publish
+  → Sync
+  → Install
+  → Activate
+  → Evaluate
+  → Update / Rollback
+  → Uninstall
+```
+
+Use `rosclaw-forge` to create assets from SDKs, ROS 2 interfaces, docs, and e-URDF profiles.
+
+---
+
+## Asset URI Scheme
+
+```text
+rosclaw://hub/<registry>/<asset-type>/<namespace>/<name>@<version>
+```
+
+Example:
+
+```text
+rosclaw://hub/rosclaw.io/hardware_mcp/rosclaw/unitree-g1@1.0.0
+```
+
+---
+
+## Planned Commands
+
+The following commands are on the roadmap but not yet implemented:
+
+```bash
+rosclaw hub install rosclaw://hub/rosclaw.io/skill/rosclaw/pick_cube@1.0.0
+rosclaw hub list --installed
+```
+
+Until then, install assets manually by downloading and validating them locally.
+
+---
+
+## See Also
+
+- [Physical-AI Assets](../ASSETS.md)
+- [CLI Reference](../CLI.md)
+- [Forge Workflow](../../README.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "hatchling.build"
 [project]
 name = "rosclaw"
 version = "1.0.1"
-description = "The Universal Operating System for Software-Defined Embodied AI"
+description = "Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
-    {name = "ROSClaw Team", email = "team@rosclaw.io"},
+    {name = "ROSClaw Team", email = "ai@rosclaw.io"},
 ]
-keywords = ["robotics", "ros2", "mcp", "llm", "embodied-ai", "mujoco"]
+keywords = ["robotics", "ros2", "mcp", "llm", "embodied-ai", "physical-ai", "mujoco", "runtime", "eurdf"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -78,6 +78,7 @@ Homepage = "https://rosclaw.io"
 Repository = "https://github.com/ros-claw/rosclaw"
 Documentation = "https://docs.rosclaw.io"
 "Bug Tracker" = "https://github.com/ros-claw/rosclaw/issues"
+"Contact" = "mailto:ai@rosclaw.io"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rosclaw"]

--- a/src/rosclaw/__init__.py
+++ b/src/rosclaw/__init__.py
@@ -1,7 +1,9 @@
 """
-ROSClaw - The Universal Operating System for Software-Defined Embodied AI.
+ROSClaw - Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents.
 
-This package provides production-ready middleware for connecting LLMs to physical robots.
+This package provides an open runtime infrastructure layer for connecting AI agents
+to physical robots through embodiment grounding, sandbox safety, capability routing,
+praxis capture, physical memory, runtime intervention, and skill evolution.
 
 Architecture:
     Agent Runtime (LLM/MCP)

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -2787,7 +2787,7 @@ def cmd_restart(args: argparse.Namespace) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="rosclaw",
-        description="ROSClaw - Universal OS for Software-Defined Embodied AI",
+        description="ROSClaw - Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents",
     )
     parser.add_argument(
         "--version",


### PR DESCRIPTION
This PR updates ROSClaw's public GitHub presentation to align with the product narrative on rosclaw.io while preserving GitHub's developer-first workflow.

## Key Changes

- Repositions ROSClaw as self-evolving runtime infrastructure for Physical AI and embodied agents.
- Unifies installation around `curl -sSL https://rosclaw.io/get | bash` and `rosclaw firstboot`.
- Separates user quick start from developer install.
- Clarifies the ROSClaw closed loop: intent → validation → execution → trace → memory → intervention → evolution.
- Defines Hub as a Physical-AI Asset Hub instead of only MCP Hub or Skill Market.
- Adds stronger safety model language and links to docs/SAFETY.md.
- Adds contact entry: ai@rosclaw.io.
- Removes or avoids unverified marketing claims.

## Files Changed

- `README.md` / `README.zh.md`: repositioned landing pages
- `QUICKSTART.md`: four-path quick start
- `INSTALL.md`: dependency and troubleshooting reference
- `ARCHITECTURE.md`: expanded system design
- `docs/CLI.md`: new CLI reference with status labels
- `docs/SAFETY.md`: new safety model document
- `docs/ASSETS.md`: new Physical-AI Asset Hub guide
- `docs/FIRSTBOOT.md`: new firstboot guide
- `docs/hub/README.md`: new Hub documentation
- `docs/README.md`: updated documentation index
- `pyproject.toml`: updated description, keywords, and URLs
- `src/rosclaw/__init__.py` / `src/rosclaw/cli.py`: updated description strings

## Test Plan

- [x] Banned marketing phrase scan passed
- [x] Internal markdown links resolve
- [x] README line count within target (465 / 466 lines)
- [x] CLI Planned commands not mislabeled as Stable
- [x] `rosclaw --help` imports and displays updated description
- [ ] Full pytest suite after installing `rosclaw_auto` dependency
- [ ] Markdown lint check in CI

## Verification Commands

```bash
# Banned phrase scan
for phrase in "Universal OS" "Teach Once" "production-ready MCP server in seconds" "Zero-code hardware integration"; do
  grep -Rin "$phrase" README.md README.zh.md docs/ || echo "OK: $phrase not found"
done

# Link check
python3 scripts/check_links.py
```

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)