### PR TITLE
docs: align GitHub homepage with ROSClaw Physical AI runtime positioning (v2)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,9 +2,9 @@
 
 ## Mission
 
-**The Open Infrastructure for Physical Intelligence**
+**Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents**
 
-Grounding AI into the Physical World.
+Ground AI agents into robot bodies. Validate every action. Learn from every trace. Evolve every skill.
 
 ## Engineering Identity
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,6 @@
-# ROSClaw v1.0 Installation Guide
+# ROSClaw Installation Guide
+
+For the fastest path, see [QUICKSTART.md](QUICKSTART.md).
 
 ## Recommended User Install
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,73 +1,139 @@
-# ROSClaw v1.0 Quick Start
+# ROSClaw Quick Start
 
-## 1. Install
+Choose the path that matches your goal. Each path starts from the same one-line install and then diverges.
 
 ```bash
 curl -sSL https://rosclaw.io/get | bash
-```
-
-This installs the `rosclaw` CLI and prepares a minimal workspace at `~/.rosclaw`.
-
-## 2. First Boot
-
-```bash
 rosclaw firstboot
 ```
 
-Follow the interactive wizard to choose your profile, robot, safety level, and MCP setup.
+---
 
-For headless/CI environments:
+## Path A: Local Simulation Only
 
-```bash
-rosclaw firstboot --yes --profile offline --no-telemetry
-```
-
-## 3. Verify
+No robot required. Verify the install and run a MuJoCo demo in minutes.
 
 ```bash
+# 1. Verify
 rosclaw --version
 rosclaw doctor
-```
 
-Structured doctor report:
-
-```bash
-rosclaw doctor --full --json
-```
-
-## 4. List Robots
-
-```bash
+# 2. List available robots
 rosclaw robot list
-```
 
-## 5. Run a Simulation Demo
-
-```bash
+# 3. Run a tabletop reach demo
 rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach
-```
 
-## 6. Inspect Configuration
-
-```bash
+# 4. Inspect configuration
 rosclaw config show
-rosclaw config path
 rosclaw profile current
 ```
 
-## 7. Start the MCP Hub (optional)
+Expected: the sandbox prints scene info, runs the task, and exits cleanly.
 
-If you use Claude Code or another MCP-compatible agent, the MCP config was written to:
+Common failures:
 
-```text
-~/.rosclaw/config/mcp.json
+- `rosclaw: command not found` — add `export PATH="$HOME/.rosclaw/bin:$PATH"` to your shell profile.
+- MuJoCo rendering fails on Linux — install `libglfw3` and `libglew2.2`.
+
+Next: read [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md) and [docs/SAFETY.md](docs/SAFETY.md).
+
+---
+
+## Path B: Agent Integration
+
+Connect ROSClaw to Claude Code or any MCP-compatible agent.
+
+```bash
+# 1. Generate an MCP config for Claude Code
+rosclaw agent init claude-code
+
+# 2. Review the generated config
+rosclaw agent doctor
+
+# 3. Start the MCP server manually (optional)
+rosclaw mcp serve --transport stdio
 ```
 
-Point your agent at this file to expose ROSClaw physical tools.
+The MCP config is written to `~/.rosclaw/config/mcp.json`. Point your agent at this file to expose read-only / simulation / emergency tools.
+
+Expected: `rosclaw agent doctor` reports the config path and tool count.
+
+Common failures:
+
+- `mcp.json` missing — re-run `rosclaw firstboot --enable-mcp`.
+- Agent cannot connect — check transport type (`stdio`, `http`, or `sse`).
+
+Next: read [docs/hub/README.md](docs/hub/README.md) to install skills for the agent.
+
+---
+
+## Path C: Robot Body Setup
+
+Link a real or custom robot body so the runtime knows its physical limits.
+
+```bash
+# 1. Initialize a body profile
+rosclaw body init --robot unitree-g1
+
+# 2. Link an e-URDF model
+rosclaw body link-eurdf --body unitree-g1 --eurdf e-urdf-zoo/unitree-g1/main.yaml
+
+# 3. Inspect the effective body model
+rosclaw body inspect
+
+# 4. Check skill compatibility
+rosclaw skill check --task pick_cube
+```
+
+Expected: `rosclaw body inspect` shows the compiled body manual, joints, and limits.
+
+Common failures:
+
+- Body not found — run `rosclaw body init` first.
+- e-URDF link fails — verify the e-URDF path and schema.
+
+Next: read [docs/body/EMBODIMENT_FORMAT.md](docs/body/EMBODIMENT_FORMAT.md).
+
+---
+
+## Path D: Developer Setup
+
+Clone the repo and run the test suite.
+
+```bash
+git clone https://github.com/ros-claw/rosclaw.git
+cd rosclaw
+make setup
+PYTHONPATH=src pytest tests -q
+```
+
+`make setup` is equivalent to:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install --upgrade pip wheel setuptools
+python3 -m pip install -e ".[dev]"
+rosclaw firstboot --dev --workspace .rosclaw --profile offline --no-telemetry --yes
+rosclaw doctor --full
+```
+
+Expected: all tests pass and `rosclaw doctor --full` is green.
+
+Common failures:
+
+- Python version error — install Python 3.11+ or use `uv`.
+- PEP 668 error — the bootstrapper falls back to a private venv automatically.
+- Doctor reports missing modules — run `pip install -e .` from the repo root.
+
+Next: read [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
 
 ## Hub Quick Start
 
-Discover, install, and publish physical-AI assets through the ROSClaw Hub.
+Discover, validate, and publish physical-AI assets through the ROSClaw Hub.
 
 ```bash
 # Validate a local asset
@@ -81,26 +147,33 @@ rosclaw hub login --registry http://localhost:8787 --token fake-valid-token --in
 rosclaw hub sync
 rosclaw hub search g1
 
-# Install and uninstall an asset
+# Install, list, and uninstall an asset
 rosclaw hub install rosclaw://hardware_mcp/rosclaw/unitree-g1@1.0.0 --yes
 rosclaw hub list --installed
 rosclaw hub uninstall rosclaw://hardware_mcp/rosclaw/unitree-g1@1.0.0 --yes
 ```
 
-See [docs/hub/README.md](docs/hub/README.md) for the full Hub documentation.
+See [docs/hub/README.md](docs/hub/README.md) for the full Hub documentation and [docs/ASSETS.md](docs/ASSETS.md) for asset definitions.
 
-## Developer Quick Start
+---
 
-```bash
-git clone https://github.com/ros-claw/rosclaw.git
-cd rosclaw
-make setup
-```
+## Troubleshooting
+
+| Symptom | Cause | Solution |
+|---------|-------|----------|
+| `rosclaw: command not found` | PATH not updated | Add `export PATH="$HOME/.rosclaw/bin:$PATH"` to shell profile |
+| `Python >= 3.11 is required` | Old Python | Install Python 3.11+ or `uv` |
+| PEP 668 error | Externally-managed environment | Bootstrapper falls back to private venv automatically |
+| Doctor reports missing modules | Dev install incomplete | Run `pip install -e .` from repo root |
+| MuJoCo rendering fails | Missing graphics libs | `sudo apt install libglfw3 libglew2.2` |
+| Firstboot refuses to overwrite | Existing workspace | Use `--force` or backup and remove workspace |
+
+---
 
 ## Next Steps
 
 - Read [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md) for the complete bootstrap and first boot reference.
-- Read [ARCHITECTURE.md](ARCHITECTURE.md) for the 14 Engineering Iron Rules.
+- Read [ARCHITECTURE.md](ARCHITECTURE.md) for the runtime architecture.
 - Explore `rosclaw sandbox --help` for simulation options.
 - Check `rosclaw doctor --full` for optional capability gaps.
 - Browse [docs/hub/](docs/hub/) for the asset distribution workflow.

--- a/README.md
+++ b/README.md
@@ -2,22 +2,25 @@
 
 # ROSClaw
 
-**The Open Infrastructure for Physical Intelligence**
+### Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents
 
-*Grounding AI Agents into the Physical World.*
+**Ground AI agents into robot bodies. Validate every action. Learn from every trace. Evolve every skill.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python)](https://www.python.org/)
 [![ROS 2](https://img.shields.io/badge/ROS_2-Humble_|_Jazzy-FF3E00?logo=ros)](https://docs.ros.org/)
 [![Simulation](https://img.shields.io/badge/Simulation-MuJoCo_|_Isaac--Sim-black?logo=mujoco)](https://mujoco.org/)
-[![MCP](https://img.shields.io/badge/Protocol-MCP_Ready-8A2BE2)](https://modelcontextprotocol.io/)
+[![MCP](https://img.shields.io/badge/Protocol-MCP-8A2BE2)](https://modelcontextprotocol.io/)
 [![Status](https://img.shields.io/badge/Release-v1.0-purple)](https://github.com/ros-claw/rosclaw/releases)
 
-[English](README.md) • [中文](README.zh.md) • [Architecture](#architecture) • [Quick Start](#-quick-start) • [Docs](docs/)
+[Website](https://rosclaw.io) • [Quick Start](QUICKSTART.md) • [Architecture](ARCHITECTURE.md) • [Docs](docs/) • [Contact](mailto:ai@rosclaw.io)
 
 <br/>
 
-> **Teach Once. Embody Anywhere. Evolve Continuously.**
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot
+```
 
 </div>
 
@@ -25,16 +28,14 @@
 
 ## What is ROSClaw?
 
-ROSClaw is **not** another chatbot framework. It is **not** a thin LLM-to-ROS wrapper. It is **not** a collection of random robotics tools.
+ROSClaw is **not** another chatbot framework. It is **not** a thin LLM-to-ROS wrapper. It is **not** a collection of unrelated robotics scripts.
 
-ROSClaw is an **open infrastructure layer for Physical Intelligence**: a runtime that connects AI agents, robot embodiments, simulation sandboxes, skill systems, multimodal providers, physical memory, and self-evolution loops into one coherent operating layer.
-
-It is designed for the next generation of embodied agents that must not only reason, but also **act safely, remember physically, recover from failure, and improve over time**.
+ROSClaw is a **runtime infrastructure layer for Physical AI**: it connects AI agents, robot embodiments, simulation sandboxes, capability providers, physical memory, and self-evolution loops into one coherent operating layer. It is designed for embodied agents that must reason, act safely, remember what happened, recover from failure, and improve over time.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │           External Cognitive Brains                          │
-│     OpenClaw / Claude / GPT / Qwen / Custom Agents           │
+│     Claude / GPT / Qwen / OpenClaw / Custom Agents           │
 └───────────────────────────┬──────────────────────────────────┘
                             │ MCP / SDK / AgentContext
                             ▼
@@ -67,7 +68,7 @@ It is designed for the next generation of embodied agents that must not only rea
                             │
                             ▼
 ┌──────────────────────────────────────────────────────────────┐
-│           SeekDB Knowledge Plane                             │
+│           Knowledge Plane                                    │
 │  Robot │ Skill │ Provider │ Episode │ Failure │ Evidence    │
 └───────────────┬────────────────────────────┬─────────────────┘
                 │                            │
@@ -100,11 +101,11 @@ It is designed for the next generation of embodied agents that must not only rea
 
 ---
 
-## Why ROSClaw?
+## Why Physical AI Needs Runtime Infrastructure
 
 Large language models can plan, write code, and reason over symbols. But physical intelligence requires more than tokens.
 
-A physical agent must understand:
+A physical agent must know:
 
 - What body it has;
 - What sensors and actuators it owns;
@@ -114,15 +115,13 @@ A physical agent must understand:
 - How to recover;
 - How to improve the skill without breaking safety.
 
-ROSClaw provides the missing infrastructure between high-level AI agents and the physical world.
+Physical worlds have gravity, friction, collision, latency, sensor noise, torque limits, joint limits, and safety boundaries. ROSClaw provides the missing infrastructure between high-level AI agents and the physical world.
 
 ---
 
-## Core Principle
+## The ROSClaw Closed Loop
 
 > **Every physical action should be grounded, validated, recorded, remembered, and improved.**
-
-The full closed loop:
 
 ```
 Physical Task
@@ -135,7 +134,7 @@ Sandbox / Firewall Validation
     ↓
 Runtime Execution
     ↓
-Praxis Capture
+Practice Capture
     ↓
 Spatiotemporal Memory
     ↓
@@ -150,6 +149,189 @@ Champion Skill
 Safer Physical Task
 ```
 
+Auto may propose changes, but it cannot approve them alone. Sandbox validation, Darwin evaluation, the promotion gate, and human approval together decide whether a change reaches the real world.
+
+---
+
+## Quick Start
+
+Install the CLI and run the interactive first-boot wizard:
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot
+rosclaw doctor
+rosclaw status
+```
+
+Run a local simulation demo without any hardware:
+
+```bash
+rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach
+```
+
+For headless or CI environments:
+
+```bash
+rosclaw firstboot --yes --profile offline --no-telemetry
+```
+
+See [QUICKSTART.md](QUICKSTART.md) for four guided paths: local simulation, agent integration, robot body setup, and developer setup.
+
+---
+
+## First Boot Flow
+
+`rosclaw firstboot` turns the bootstrap install into a working local runtime:
+
+1. Detects platform and Python version.
+2. Creates the workspace skeleton at `~/.rosclaw`.
+3. Writes `rosclaw.yaml` with chosen profile.
+4. Generates `mcp.json` if MCP is enabled.
+5. Creates telemetry preferences (default disabled).
+6. Records install metadata in `state/install.json`.
+7. Runs `rosclaw doctor --bootstrap`.
+8. Prints next-step instructions.
+9. Leaves the system read-only and robot-safe until you opt in.
+
+Read [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md) for the complete guide.
+
+---
+
+## Developer Install
+
+To hack on ROSClaw itself:
+
+```bash
+git clone https://github.com/ros-claw/rosclaw.git
+cd rosclaw
+make setup
+PYTHONPATH=src pytest tests -q
+```
+
+`make setup` creates a local venv, installs the package in editable mode, and runs `rosclaw firstboot` in dev mode.
+
+---
+
+## CLI Map
+
+| Goal | Command | Status |
+|------|---------|--------|
+| Install CLI | `curl -sSL https://rosclaw.io/get \| bash` | Stable |
+| First boot | `rosclaw firstboot` | Stable |
+| Health check | `rosclaw doctor` | Stable |
+| List robots | `rosclaw robot list` | Stable |
+| Run simulation | `rosclaw sandbox run --robot sim_ur5e ...` | Stable |
+| Configure agent | `rosclaw agent init claude-code` | Stable |
+| Start MCP server | `rosclaw mcp serve` | Stable |
+| Validate hub asset | `rosclaw hub validate <manifest.yaml>` | Stable |
+| Search hub | `rosclaw hub search <term>` | Stable |
+| Install hub asset | `rosclaw hub install <uri>` | Stable |
+| List installed assets | `rosclaw hub list --installed` | Stable |
+| Uninstall hub asset | `rosclaw hub uninstall <uri>` | Stable |
+| Initialize provider | `rosclaw provider init` | Planned |
+| Route capability | `rosclaw provider route --capability <name>` | Planned |
+| Start practice | `rosclaw practice start --sources <sources>` | Planned |
+| Advise on failure | `rosclaw how advise --task <id> --failure <id>` | Planned |
+| Run auto suite | `rosclaw auto run --suite <suite>` | Planned |
+| Evaluate with Darwin | `rosclaw darwin eval --skill <id>` | Research |
+
+See [docs/CLI.md](docs/CLI.md) for the full command reference with status labels.
+
+---
+
+## Core Runtime Modules
+
+| Module | Responsibility |
+|--------|----------------|
+| **Runtime** | Lifecycle, config, plugin registration, dependency injection. |
+| **EventBus** | Module communication, topic routing, trace correlation. |
+| **Provider** | Capability routing, schema enforcement, safety boundary. |
+| **Sandbox** | Safety validation, firewall, MuJoCo pre-play. |
+| **Practice** | Timeline, MCAP, JSONL, execution records. |
+| **Memory** | Experience graph, failure/success patterns, recall. |
+| **Know** | TaskCard, Pattern, EvidenceTrace, failure taxonomy. |
+| **How** | Runtime intervention, injection_id, evidence. |
+| **Auto** | Proposal, patch, experiment, champion, dead-end tracking. |
+| **Darwin** | Multi-seed benchmark, stress scenario, regression. |
+| **Skill Registry** | Version, lineage, champion, rollback. |
+| **Dashboard** | Observability, evolution trace, lineage visualization. |
+
+---
+
+## Hub & Assets
+
+The ROSClaw Hub is a **Physical-AI Asset Hub** for skills, providers, hardware MCP servers, digital twins, and cognitive wikis. Assets can be kept entirely local or synced with a registry.
+
+Supported asset types:
+
+- `skill` — reusable physical-AI skill
+- `provider` — runtime capability provider
+- `hardware_mcp` — MCP server that wraps real hardware
+- `digital_twin` — simulation asset / e-URDF twin
+- `cognitive_wiki` — structured operational knowledge
+
+Validate a local asset, search the hub, and publish your own:
+
+```bash
+rosclaw hub validate tests/fixtures/hub_assets/hardware_mcp_valid/manifest.yaml
+rosclaw hub search g1
+rosclaw hub publish --dry-run
+```
+
+See [docs/ASSETS.md](docs/ASSETS.md) and [docs/hub/README.md](docs/hub/README.md).
+
+---
+
+## Example Workflow: Desktop Pick-and-Place
+
+A complete closed-loop example:
+
+```
+Agent: "Pick the red cube from the table and place it in the bin."
+  ↓
+Provider selects the pick-and-place skill for the current body.
+  ↓
+Sandbox validates the trajectory against the e-URDF and safety limits.
+  ↓
+Runtime dispatches the validated trajectory.
+  ↓
+Practice records the episode: video, state, events, outcome.
+  ↓
+Memory indexes the experience for similar future tasks.
+  ↓
+How intervenes if the grasp fails and requests a retry pattern.
+  ↓
+Know compiles a TaskCard: "red cube, glossy surface, parallel jaw grip."
+  ↓
+Auto proposes a grip-force patch.
+  ↓
+Darwin evaluates the patch across 100 simulated seeds.
+  ↓
+Promotion gate moves the patch to champion if it improves success rate.
+```
+
+---
+
+## Safety Model
+
+ROSClaw's core safety rule:
+
+> **No model output should directly control a robot.**
+
+Every physical action passes through a validation pipeline:
+
+1. Provider produces a structured action proposal.
+2. Sandbox / Firewall checks it against the effective body model and safety policy.
+3. The decision is one of `ALLOW`, `MODIFY`, `BLOCK`, or `REQUIRE_HUMAN_CONFIRMATION`.
+4. Execution is recorded by Practice.
+5. Memory and Know retain evidence for later audit.
+6. How and Auto may propose improvements, but only the promotion gate can change the active skill.
+
+ROSClaw is research infrastructure. It does not replace certified industrial safety systems. Always test in simulation first, keep emergency stops engaged, and use human supervision.
+
+Read [docs/SAFETY.md](docs/SAFETY.md) for the full safety model.
+
 ---
 
 ## Architecture
@@ -159,7 +341,7 @@ graph TD
     subgraph Agents[Any MCP-Compatible Agent]
         CC[Claude Code]
         OC[OpenClaw]
-        AC[AutoGen / Custom]
+        AC[Custom Agents]
     end
 
     subgraph Runtime[ROSClaw Runtime]
@@ -176,7 +358,7 @@ graph TD
 
     subgraph Infra[Infrastructure]
         EURDF[e-URDF Zoo]
-        SKDB[SeekDB Knowledge Plane]
+        SKDB[Knowledge Plane]
     end
 
     subgraph HW[Hardware Layer]
@@ -198,686 +380,65 @@ graph TD
     FW <-->|Model| EURDF
     MEM <-->|Persist| SKDB
     SK -->|Dispatch| HW
-    AU -->|Promote| SK
-    DW -->|Report| AU
 ```
 
-**Key Insight**: All modules communicate exclusively through the EventBus. No direct module-to-module calls. This ensures complete decoupling and enables any agent to connect without hardware-specific knowledge.
+Read [ARCHITECTURE.md](ARCHITECTURE.md) for the 14 Engineering Iron Rules and detailed module boundaries.
 
 ---
 
-## Key Modules
+## Supported Integrations
 
-| Module | Role |
-|--------|------|
-| `rosclaw-runtime` | The lifecycle manager for the whole system. Owns configuration, plugins, health checks, event routing, and runtime orchestration. |
-| `e-urdf-zoo` | The Physical DNA Registry. Defines robot embodiment, kinematics, dynamics, sensors, safety limits, capabilities, and simulation assets. |
-| `rosclaw-provider` | The capability provider layer. Turns LLMs, VLMs, VLAs, VLNs, world models, skill policies, critics, and embeddings into routable physical capabilities. |
-| `rosclaw-sandbox` | The physical simulation, validation, replay, and safety layer. Its `firewall` mode validates actions before execution. |
-| `rosclaw-practice` | The praxis capture engine. Records unified physical timelines with sensorimotor traces, model decisions, tool calls, events, MCAP, and replay artifacts. |
-| `rosclaw-memory` | The spatiotemporal memory system. Stores physical failures, success patterns, scene memory, trajectory memory, and causal experience graphs. |
-| `rosclaw-how` | The runtime intervention controller. Injects minimal, evidence-backed guidance when an agent is stuck, unsafe, or regressing. |
-| `rosclaw-know` | The physical-AI knowledge compiler. Turns papers, code, logs, trajectories, benchmark traces, and failures into structured engineering knowledge. |
-| `rosclaw-auto` | The self-evolution control plane. Generates proposals, patches skills, runs experiments, evaluates candidates, promotes champions, and records dead ends. |
-| `rosclaw-darwin` | The evaluation and evolution arena. Provides benchmark pressure, multi-seed validation, regression tests, and skill evaluation. |
-| `rosclaw-forge` | The embodied asset compiler. Turns SDKs, ROS 2 interfaces, docs, and e-URDF profiles into MCP servers, skills, provider manifests, and asset bundles. |
-| `rosclaw-hub` | Asset distribution layer: validate, publish, sync, install, update, and uninstall skills, providers, hardware MCP servers, digital twins, and cognitive wikis. |
-| `rosclaw-dashboard` | The observability layer for runtime health, traces, sandbox replay, memory, interventions, and skill evolution. |
+| Category | Technologies |
+|----------|--------------|
+| **Agents** | Claude Code, OpenClaw, any MCP-compatible client |
+| **Simulation** | MuJoCo, Isaac Sim |
+| **Robots** | Unitree G1 / Go2, UR5e, TurtleBot3, custom e-URDF |
+| **ROS** | ROS 2 Humble / Jazzy via MCP drivers |
+| **Models** | OpenAI, DeepSeek, Qwen, local providers via capability routing |
+| **Memory** | SeekDB / local experience graph |
 
 ---
 
-## What Makes ROSClaw Different?
-
-### 1. Physical Grounding, Not Just Tool Calling
-
-ROSClaw does not expose raw robot APIs directly to an LLM. Every action is grounded through robot embodiment, capability schemas, safety limits, and runtime context.
-
-```
-Token Intent → Capability Request → Safety Validation → Physical Execution
-```
-
-### 2. e-URDF as Physical DNA
-
-ROSClaw treats robot embodiment as a first-class system primitive. An e-URDF profile defines:
-
-- Robot structure;
-- Joints, links, sensors, actuators;
-- Safety envelopes;
-- Tool frames;
-- Workspace limits;
-- Capabilities;
-- Simulation assets;
-- Benchmark metadata.
-
-This allows the same skill to be adapted, validated, and transferred across different robot bodies.
-
-### 3. Sandbox Before Reality
-
-The `rosclaw-sandbox` module provides a simulation-first validation layer. Its firewall mode can block risky actions before they reach hardware.
-
-Possible decisions:
-
-```
-ALLOW
-BLOCK
-MODIFY
-REQUIRE_HUMAN_CONFIRMATION
-```
-
-Example result:
-
-```json
-{
-  "decision": "BLOCK",
-  "risk_score": 0.92,
-  "reason": "Predicted collision between wrist_link and table",
-  "violated_constraints": ["collision", "workspace_boundary"],
-  "replay_id": "sandbox://replays/firewall_00042"
-}
-```
-
-### 4. Practice Capture
-
-ROSClaw records physical execution as structured praxis, not just logs. A single run can include:
-
-- Robot state;
-- Sensor snapshots;
-- Action trace;
-- Provider trace;
-- Sandbox decision;
-- Skill execution;
-- Critic result;
-- MCAP;
-- Replay;
-- Failure report.
-
-### 5. Runtime Intervention
-
-`rosclaw-how` acts as a runtime reflex layer. When an agent is stuck, unsafe, invalid-heavy, or regressing, it can provide minimal, evidence-backed interventions such as:
-
-- Safety constraints;
-- Feasibility repair;
-- Stabilizing hints;
-- Next experiment suggestions;
-- Recovery instructions.
-
-### 6. Self-Evolution
-
-`rosclaw-auto` turns repeated failures into structured improvement cycles:
-
-```
-FailureCase
-    ↓
-Diagnosis
-    ↓
-Hypothesis
-    ↓
-Proposal
-    ↓
-Patch
-    ↓
-Sandbox Experiment
-    ↓
-Darwin Evaluation
-    ↓
-Champion / DeadEnd
-```
-
-A skill is not overwritten blindly. It is **versioned, evaluated, promoted, and rollback-safe**.
-
-Skill promotion pipeline:
-
-```
-pick_cube@v1.0.0  baseline_champion
-    ↓
-pick_cube@candidate_0001  sandbox_passed
-    ↓
-pick_cube@v1.1.0  sim_champion
-    ↓
-pick_cube@v1.1.0  sandbox_champion
-    ↓
-pick_cube@v1.1.0  real_candidate
-    ↓
-pick_cube@v1.1.0  real_champion
-```
-
----
-
-## Quick Start
-
-### 1. Install the ROSClaw CLI
-
-```bash
-curl -sSL https://rosclaw.io/get | bash
-```
-
-This installs the `rosclaw` command and creates a minimal workspace at `~/.rosclaw`.  
-It does **not** start any runtime, connect to robots, or upload data.
-
-### 2. Run First Boot
-
-```bash
-rosclaw firstboot
-```
-
-Follow the interactive wizard (or use `rosclaw firstboot --yes` for CI/servers).  
-This generates your local runtime profile, MCP config, and telemetry preferences.
-
-### 3. Check Health
-
-```bash
-rosclaw doctor
-```
-
-For structured output:
-
-```bash
-rosclaw doctor --full --json
-```
-
-### 4. Run a Local Simulation Demo
-
-```bash
-rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach
-```
-
-## Hub Quick Start
-
-The ROSClaw Hub discovers, validates, installs, and publishes physical-AI
-assets from a registry.
-
-### Validate a local asset
-
-```bash
-rosclaw hub validate tests/fixtures/hub_assets/hardware_mcp_valid/manifest.yaml
-```
-
-### Connect to a registry
-
-```bash
-python -m tests.fixtures.fake_registry.server --port 8787 &
-rosclaw hub login --registry http://localhost:8787 --token fake-valid-token --insecure-local
-```
-
-### Sync and search the catalog
-
-```bash
-rosclaw hub sync
-rosclaw hub search g1
-```
-
-### Install and manage an asset
-
-```bash
-rosclaw hub install rosclaw://hardware_mcp/rosclaw/unitree-g1@1.0.0 --yes
-rosclaw hub list --installed
-rosclaw hub uninstall rosclaw://hardware_mcp/rosclaw/unitree-g1@1.0.0 --yes
-```
-
-See the full Hub docs in [docs/hub/README.md](docs/hub/README.md).
-
-### Developer Install
-
-Prefer to hack on ROSClaw itself?
-
-```bash
-git clone https://github.com/ros-claw/rosclaw.git
-cd rosclaw
-make setup
-```
-
-See [INSTALL.md](INSTALL.md) for detailed installation options and [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md) for the full first boot guide.
-
----
-
-## Example: A Full Physical Intelligence Loop
-
-```bash
-./rosclaw demo tabletop-grasp --robot-id ur5e
-```
-
-What happens:
-
-```text
-1. Agent receives task: "pick up the red cup"
-2. Provider routes to perception and skill capabilities
-3. Memory retrieves similar grasping experience
-4. Skill provider generates grasp plan
-5. Sandbox validates candidate motion
-6. Runtime executes safe action
-7. Practice records the full physical timeline
-8. Critic evaluates success or failure
-9. Memory stores the result
-10. How generates recovery guidance if needed
-11. Auto proposes a skill improvement after repeated failures
-12. Darwin evaluates the candidate skill
-13. A champion skill is promoted if it passes all gates
-```
-
----
-
-## Safety Model
-
-ROSClaw follows a strict safety boundary:
-
-> **No model output should directly control a robot.**
-
-All physical execution must pass through:
-
-```
-Provider Schema
-    ↓
-e-URDF Constraints
-    ↓
-Sandbox / Firewall
-    ↓
-Runtime Guard
-    ↓
-Robot Controller
-```
-
-Hard rules:
-
-- VLA outputs are **proposals**, not raw motor commands.
-- World models are **neural previews**, not safety proofs.
-- MCP is an **agent tool interface**, not a real-time control bus.
-- Auto-generated skills must pass **sandbox validation** before execution.
-- Code patches require **human approval** before production use.
-- Safety configuration patches require **human approval**.
-- Every champion skill must be **rollback-safe**.
-
----
-
-## Skill Evolution
-
-ROSClaw treats skills as versioned physical assets with full lineage tracking.
-
-Promotion is gated by six evaluation gates:
-
-| Gate | Check |
-|------|-------|
-| Success Improvement | Candidate success rate > baseline + threshold |
-| Safety Regression | No increase in collision or safety events |
-| Multi-Seed Validation | Passes on seeds [0, 1, 2, ...] |
-| Sandbox Clearance | Firewall decision == ALLOW |
-| Regression Suite | No degradation on existing tasks |
-| Human Approval | Required for code patches and safety config |
-
-Example CLI:
-
-```bash
-# Initialize an auto task (required before running)
-./rosclaw auto init --task pick_cube --skill reach --type skill_tuning
-
-# Run auto evolution experiment
-./rosclaw auto run --task pick_cube --rounds 50
-
-# Check evolution status
-./rosclaw auto status
-
-# List current champions
-./rosclaw skill champions list
-
-# Show skill lineage
-./rosclaw skill lineage pick_cube
-
-# Rollback if needed
-./rosclaw skill rollback pick_cube --to v1.0.0
-```
-
----
-
-## SDK-to-MCP / Asset Forge
-
-ROSClaw includes an embodied asset compiler:
-
-```
-SDK / ROS 2 Interfaces / Docs / e-URDF
-        ↓
-rosclaw-forge
-        ↓
-MCP Server + Skill Manifest + Provider Manifest + Tests + ClawHub Metadata
-```
-
-Example:
-
-```bash
-./rosclaw forge sdk-to-mcp \
-  --name unitree_go2 \
-  --sdk-docs ./docs/unitree_go2_sdk.md \
-  --output ./generated/unitree_go2_bundle
-```
-
-Validate generated assets:
-
-```bash
-./rosclaw forge validate ./generated/unitree_go2_bundle
-```
-
-Install to staging:
-
-```bash
-./rosclaw forge install ./generated/unitree_go2_bundle --staging
-```
-
----
-
-## Hardware MCP Onboarding
-
-ROSClaw can auto-install hardware MCP servers from declarative manifests and keep
-them healthy.
-
-```bash
-# Preview installation
-./rosclaw mcp install unitree-g1 --dry-run --offline
-
-# Install
-./rosclaw mcp install unitree-g1 --offline
-
-# List available/installed servers
-./rosclaw mcp list --offline
-
-# Health-check
-./rosclaw mcp health unitree-g1
-```
-
-See [`docs/HARDWARE_MCP_ONBOARDING.md`](docs/HARDWARE_MCP_ONBOARDING.md) for the
-full lifecycle, state files, and troubleshooting.
-
----
-
-## Repository Structure
-
-```text
-rosclaw/
-├── src/rosclaw/              # Core runtime, schemas, CLI, MCP gateway
-│   ├── core/                 # Runtime, EventBus, lifecycle
-│   ├── schemas/              # Unified canonical dataclasses
-│   ├── provider/             # Capability provider layer
-│   ├── sandbox/              # MuJoCo simulation & firewall
-│   ├── practice/             # Timeline capture & MCAP
-│   ├── memory/               # Spatiotemporal memory
-│   ├── how/                  # Runtime intervention
-│   ├── know/                 # Knowledge compiler
-│   ├── auto/                 # Self-evolution control plane
-│   ├── darwin/               # Benchmark & evaluation arena
-│   ├── forge/                # Asset compiler
-│   ├── hub/                  # Asset distribution, registry, lifecycle
-│   ├── dashboard/            # Observability & WebSocket
-│   └── mcp/                  # MCP server implementation
-├── e-urdf-zoo/               # Physical DNA registry
-├── docs/                     # Architecture, RFCs, usage guides
-├── examples/                 # Robot and simulation examples
-├── tutorials/                # Step-by-step tutorials
-├── tests/                    # Unit, integration, E2E, safety tests
-├── benchmarks/               # Benchmark and evaluation tasks
-├── acceptance/               # Release acceptance tests
-├── scripts/                  # Install and utility scripts
-├── rosclaw.yaml              # Default runtime config
-├── docker-compose.yml        # Optional local services
-├── ARCHITECTURE.md           # 14 Engineering Iron Rules
-├── QUICKSTART.md             # Quick start guide
-└── INSTALL.md                # Installation details
-```
-
----
-
-## Configuration
-
-Example `rosclaw.yaml` generated by `rosclaw firstboot --profile offline`:
-
-```yaml
-schema_version: '1.0'
-generated_by: rosclaw firstboot
-workspace:
-  home: ~/.rosclaw
-  profile: offline
-  mode: local
-  install_channel: stable
-  auto_update: false
-
-runtime:
-  enabled: true
-  robot_id: sim_ur5e
-  safety_level: strict
-  log_level: INFO
-
-event_bus:
-  backend: local
-
-sandbox:
-  enabled: true
-  backend: mujoco
-  firewall_mode: true
-  require_sim_before_real: true
-  default_world: tabletop
-
-provider:
-  enabled: true
-  mode: local
-  manifests_dir: ~/.rosclaw/providers/manifests
-
-practice:
-  enabled: true
-  auto_record: true
-  output_dir: ~/.rosclaw/artifacts/episodes
-  formats:
-    jsonl: true
-    mcap: false
-    video: false
-
-memory:
-  enabled: true
-  backend: local
-  path: ~/.rosclaw/data/memory
-  write_failures: true
-  write_successes: true
-
-how:
-  enabled: true
-  evidence_trace_enabled: true
-  cooldown_window: 3
-
-know:
-  enabled: true
-  asset_dir: ~/.rosclaw/data/seekdb
-
-auto:
-  enabled: false
-  require_human_approval: true
-  allow_code_patch: false
-  trigger_failure_threshold: 3
-
-darwin:
-  enabled: false
-  seeds: [0, 1, 2]
-  episodes: 50
-
-mcp:
-  enabled: true
-  config_path: ~/.rosclaw/config/mcp.json
-  server_command: rosclaw-mcp
-
-cloud:
-  enabled: false
-  sync:
-    configs: false
-    logs: false
-    artifacts: false
-    memory: false
-    anonymous_usage: false
-
-telemetry:
-  enabled: false
-  anonymous_install_ping: false
-
-security:
-  never_execute_robot_without_confirmation: true
-  require_firewall_for_real_robot: true
-  secrets_backend: env
-```
-
-Cloud, telemetry, auto-evolution, and Darwin benchmarking are **disabled by default**.
-Enable them explicitly with `rosclaw profile use cloud` or by editing `rosclaw.yaml`.
+## Documentation
+
+- [QUICKSTART.md](QUICKSTART.md) — 5-minute quick start.
+- [INSTALL.md](INSTALL.md) — Detailed installation and troubleshooting.
+- [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md) — Bootstrap and first boot reference.
+- [docs/CLI.md](docs/CLI.md) — CLI command reference.
+- [docs/SAFETY.md](docs/SAFETY.md) — Safety model and deployment rules.
+- [docs/ASSETS.md](docs/ASSETS.md) — Physical-AI Asset Hub.
+- [docs/hub/README.md](docs/hub/README.md) — Hub workflows.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — Runtime architecture.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Development standards.
 
 ---
 
 ## Roadmap
 
-### ROSClaw v1.0 (Current)
-
-- [x] Runtime and plugin architecture
-- [x] e-URDF physical embodiment registry
-- [x] MCP-compatible agent runtime
-- [x] Capability provider layer
-- [x] MuJoCo sandbox and firewall mode
-- [x] Practice timeline capture (MCAP / JSONL)
-- [x] SeekDB-backed spatiotemporal memory
-- [x] How runtime intervention (v1.5)
-- [x] Know physical-AI knowledge compiler
-- [x] Auto self-evolution control plane
-- [x] Darwin benchmark & evaluation arena
-- [x] Skill Registry with champion/lineage/rollback
-- [x] Forge SDK-to-MCP asset compiler
-- [x] Dashboard observability (WebSocket + HTTP API)
-- [x] End-to-end physical intelligence demos
-- [x] Unified schema package (`rosclaw.schemas`)
-- [x] ARCHITECTURE.md — 14 Engineering Iron Rules
-
-### Next
-
-- [ ] Isaac Sim backend
-- [ ] Multi-robot collaborative sandbox
-- [ ] Advanced DDS reflex handshake
-- [ ] LeRobot / RLDS dataset export
-- [ ] OpenVLA and Cosmos provider integration
-- [ ] Darwin benchmark leaderboard
-- [ ] ClawHub skill and provider marketplace
-- [ ] Real-world long-horizon inspection demos
-
----
-
-## Use Cases
-
-### Robotics Research
-
-- Embodied agent evaluation
-- Skill learning and refinement
-- Simulation-to-real validation
-- Multi-modal robot memory
-- Benchmark-driven evolution
-
-### Industrial Robotics
-
-- Robot skill packaging and versioning
-- Safe LLM-to-robot execution
-- Digital twin pre-validation
-- Inspection and manipulation workflows
-- Failure replay and root-cause analysis
-
-### Agent Infrastructure
-
-- MCP-compatible physical tools
-- Capability routing and abstraction
-- Agent safety guardrails
-- Runtime intervention
-- Self-improving skill systems
-
----
-
-## Development
-
-Run tests:
-
-```bash
-PYTHONPATH=src python3 -m pytest tests -v
-```
-
-Run end-to-end pipeline:
-
-```bash
-PYTHONPATH=src python3 -m pytest tests/test_e2e_full_pipeline.py -v
-```
-
-Run architecture checks:
-
-```bash
-./rosclaw doctor --ros2
-```
+| Phase | Focus |
+|-------|-------|
+| **Current (v1.0)** | Runtime, EventBus, Sandbox, Practice, Memory, How, MCP server, first boot, Hub validation/search. |
+| **In Progress** | Provider routing, skill execution on real bodies, auto evolution workflow, Darwin evaluation. |
+| **Research** | Multi-agent fleet coordination, continuous self-evolution in production, cross-robot skill transfer. |
 
 ---
 
 ## Contributing
 
-ROSClaw welcomes contributors building the open infrastructure for Physical Intelligence.
-
-Good first contribution areas:
-
-- e-URDF profiles for new robots;
-- MCP servers for robot SDKs;
-- Capability providers for perception, action, navigation, and verification;
-- Sandbox tasks and worlds;
-- Skill packages;
-- Benchmark tasks;
-- Documentation and tutorials.
-
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a pull request.
+We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for standards, PR process, and code style.
 
 ---
 
-## Safety Notice
+## Contact
 
-ROSClaw is research infrastructure for physical AI and embodied agents.
+Questions, partnerships, and security reports:
 
-Always test in simulation before running on real hardware. Use emergency stop systems, workspace boundaries, safety-rated controllers, and human supervision when deploying to physical robots.
-
-**ROSClaw does not replace certified industrial safety systems.**
-
----
-
-## Citation
-
-If you use ROSClaw in your research, please consider citing:
-
-```bibtex
-@software{rosclaw2026,
-  title  = {ROSClaw: Open Infrastructure for Physical Intelligence},
-  author = {ROSClaw Contributors},
-  year   = {2026},
-  url    = {https://github.com/ros-claw/rosclaw}
-}
-```
-
-If you use the Genesis simulator with ROSClaw, please also cite:
-
-```bibtex
-@article{genesis2026,
-  title   = {Genesis: A Generative Physics Engine for General Purpose Robotics},
-  author  = {Genesis Authors},
-  journal = {arXiv preprint},
-  year    = {2026},
-  url     = {https://arxiv.org/abs/2604.04664}
-}
-```
+- Email: [ai@rosclaw.io](mailto:ai@rosclaw.io)
+- Issues: [GitHub Issues](https://github.com/ros-claw/rosclaw/issues)
+- Discussions: [GitHub Discussions](https://github.com/ros-claw/rosclaw/discussions)
 
 ---
 
 ## License
 
-This project is released under the MIT License. See [LICENSE](LICENSE).
-
----
-
-## Links
-
-- **Website**: [https://www.rosclaw.io/](https://www.rosclaw.io/)
-- **GitHub**: [https://github.com/ros-claw/rosclaw](https://github.com/ros-claw/rosclaw)
-- **Documentation**: [docs/](docs/)
-- **Quick Start**: [QUICKSTART.md](QUICKSTART.md)
-- **Architecture**: [ARCHITECTURE.md](ARCHITECTURE.md)
-
----
-
-<div align="center">
-  <b>ROSClaw — Grounding AI into the Physical World.</b>
-</div>
+[MIT](LICENSE)

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,22 +2,25 @@
 
 # ROSClaw
 
-**面向物理 AI 的开放基础设施**
+### 面向物理 AI 与具身 Agent 的自进化运行时基础设施
 
-*让 AI Agent 真正进入物理世界。*
+**让 AI Agent 进入机器人身体，让每一次物理行动都可验证、可记忆、可修复、可进化。**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python)](https://www.python.org/)
 [![ROS 2](https://img.shields.io/badge/ROS_2-Humble_|_Jazzy-FF3E00?logo=ros)](https://docs.ros.org/)
 [![Simulation](https://img.shields.io/badge/Simulation-MuJoCo_|_Isaac--Sim-black?logo=mujoco)](https://mujoco.org/)
-[![MCP](https://img.shields.io/badge/Protocol-MCP_Ready-8A2BE2)](https://modelcontextprotocol.io/)
+[![MCP](https://img.shields.io/badge/Protocol-MCP-8A2BE2)](https://modelcontextprotocol.io/)
 [![Status](https://img.shields.io/badge/Release-v1.0-purple)](https://github.com/ros-claw/rosclaw/releases)
 
-[English](README.md) • **中文** • [架构](#架构) • [快速开始](#-快速开始) • [文档](docs/)
+[English](README.md) • **中文** • [架构](ARCHITECTURE.md) • [快速开始](QUICKSTART.md) • [文档](docs/)
 
 <br/>
 
-> **教导一次，任意实体运行。共享技能，持续进化。**
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot
+```
 
 </div>
 
@@ -25,82 +28,13 @@
 
 ## ROSClaw 是什么？
 
-ROSClaw **不是**另一个聊天机器人框架，**不是**简单的"大模型调用 ROS"工具，**不是**一堆零散的机器人工具集合。
+ROSClaw **不是**另一个聊天机器人框架，**不是**简单的"大模型调用 ROS"工具，**不是**一堆零散的机器人脚本集合。
 
-ROSClaw 是一套面向 **物理 AI / 具身智能** 的开放基础设施。它把 AI Agent、机器人本体、仿真沙盒、技能系统、多模态模型、物理记忆和自进化闭环连接到一起，形成统一的运行时层。
-
-它是为下一代具身智能体设计的——这些智能体不仅要会推理，还要能 **安全行动、记住经验、失败恢复、持续进化**。
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│                    外部认知大脑                              │
-│        OpenClaw / Claude / GPT / Qwen / 自定义 Agent          │
-└───────────────────────────┬──────────────────────────────────┘
-                            │ MCP / SDK / AgentContext
-                            ▼
-┌──────────────────────────────────────────────────────────────┐
-│                    ROSClaw Runtime                           │
-│  AgentContext │ TaskContext │ SkillContext │ Trace           │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-        ┌───────────────────┼───────────────────┐
-        ▼                   ▼                   ▼
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│   Provider    │   │   Sandbox     │   │    Darwin     │
-│   能力路由     │   │  e-URDF /     │   │  Benchmark /  │
-│               │   │  MuJoCo /     │   │  回归测试 /   │
-│               │   │  防火墙       │   │  技能评估     │
-└───────┬───────┘   └───────┬───────┘   └───────────────┘
-        │                   │
-        └───────────┬───────┘
-                    ▼
-┌──────────────────────────────────────────────────────────────┐
-│                    物理世界 / 仿真世界                        │
-│             UR5e / G1 / Go2 / RealSense / IoT / MuJoCo       │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────┐
-│                    Practice 实践捕获                          │
-│        统一时空轴 / MCAP / JSONL / 视频 / 事件                │
-└───────────────────────────┬──────────────────────────────────┘
-                            │
-                            ▼
-┌──────────────────────────────────────────────────────────────┐
-│                    SeekDB Knowledge Plane                    │
-│  机器人 / 技能 / Provider / Episode / 失败案例 / 证据链        │
-└───────────────┬────────────────────────────┬─────────────────┘
-                │                            │
-                ▼                            ▼
-┌───────────────────────┐      ┌───────────────────────────────┐
-│       Memory          │      │          Know                 │
-│     时空记忆          │      │     物理 AI 知识编译器         │
-│  失败 / 成功模式      │      │  TaskCard / Pattern / Evidence│
-│  因果图谱             │      │                               │
-└───────────┬───────────┘      └───────────────┬───────────────┘
-            │                                  │
-            └──────────────┬───────────────────┘
-                           │
-                           ▼
-            ┌──────────────────────────────┐
-            │      How  ←→  Auto           │
-            │     运行时干预                │
-            │     自进化控制平面            │
-            │  Proposal / Patch / Champion │
-            └──────────────┬───────────────┘
-                           │
-                           ▼
-                 ┌─────────────────┐
-                 │   Skill Registry│
-                 │   版本化 /      │
-                 │   Champion /    │
-                 │   可回滚        │
-                 └─────────────────┘
-```
+ROSClaw 是一套**面向物理 AI 的运行时基础设施层**：它把 AI Agent、机器人本体、仿真沙盒、能力 Provider、物理记忆和自进化闭环连接到一起，形成统一的运行时层。它是为下一代具身智能体设计的——这些智能体不仅要会推理，还要能**安全行动、记住经验、失败恢复、持续进化**。
 
 ---
 
-## 为什么需要 ROSClaw？
+## 为什么物理 AI 需要运行时基础设施？
 
 今天的大模型已经很会推理、写代码、规划任务，但它们本质上还活在"文字和 Token 世界"里。
 
@@ -113,19 +47,13 @@ ROSClaw 是一套面向 **物理 AI / 具身智能** 的开放基础设施。它
 - 它不知道失败之后该如何恢复；
 - 它也不知道如何把失败经验变成新的技能。
 
-**物理世界不是聊天窗口。**
-
-物理世界有重力、摩擦、碰撞、延迟、传感噪声、力矩限制、关节限制和安全边界。
-
-ROSClaw 要做的，就是把大模型的"认知能力"真正接到物理世界中。
+**物理世界不是聊天窗口。**物理世界有重力、摩擦、碰撞、延迟、传感噪声、力矩限制、关节限制和安全边界。ROSClaw 要做的，就是把大模型的"认知能力"真正接到物理世界中。
 
 ---
 
-## 核心理念
+## ROSClaw 的闭环
 
 > **每一次物理行动，都应该被约束、被验证、被记录、被记住，并最终变成更好的技能。**
-
-完整闭环：
 
 ```
 物理任务
@@ -153,6 +81,189 @@ Champion Skill
 更安全、更可靠的下一次执行
 ```
 
+Auto 可以提出改变，但不能独自批准改变。沙盒验证、Darwin 评测、晋升门和人类确认共同决定改变是否能进入真实世界。
+
+---
+
+## 快速开始
+
+安装 CLI 并运行交互式首次启动向导：
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot
+rosclaw doctor
+rosclaw status
+```
+
+无需硬件即可运行本地仿真演示：
+
+```bash
+rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach
+```
+
+无头或 CI 环境：
+
+```bash
+rosclaw firstboot --yes --profile offline --no-telemetry
+```
+
+查看 [QUICKSTART.md](QUICKSTART.md) 获取四条路径的详细指南：本地仿真、Agent 集成、机器人本体设置和开发者设置。
+
+---
+
+## First Boot 流程
+
+`rosclaw firstboot` 会把一次性的安装变成可用的本地运行时：
+
+1. 检测平台与 Python 版本。
+2. 在 `~/.rosclaw` 创建工作区骨架。
+3. 写入根据所选 profile 生成的 `rosclaw.yaml`。
+4. 如果启用 MCP，生成 `mcp.json`。
+5. 创建遥测偏好配置（默认关闭）。
+6. 在 `state/install.json` 记录安装元数据。
+7. 运行 `rosclaw doctor --bootstrap`。
+8. 打印下一步操作提示。
+9. 在明确选择加入之前，保持只读、不连接真实机器人。
+
+完整说明见 [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md)。
+
+---
+
+## 开发者安装
+
+如果你想修改 ROSClaw 本身：
+
+```bash
+git clone https://github.com/ros-claw/rosclaw.git
+cd rosclaw
+make setup
+PYTHONPATH=src pytest tests -q
+```
+
+`make setup` 会创建本地 venv、以可编辑模式安装包，并以 dev 模式运行 `rosclaw firstboot`。
+
+---
+
+## CLI 速查表
+
+| 目标 | 命令 | 状态 |
+|------|------|------|
+| 安装 CLI | `curl -sSL https://rosclaw.io/get \| bash` | Stable |
+| 首次启动 | `rosclaw firstboot` | Stable |
+| 健康检查 | `rosclaw doctor` | Stable |
+| 列出机器人 | `rosclaw robot list` | Stable |
+| 运行仿真 | `rosclaw sandbox run --robot sim_ur5e ...` | Stable |
+| 配置 Agent | `rosclaw agent init claude-code` | Stable |
+| 启动 MCP 服务 | `rosclaw mcp serve` | Stable |
+| 验证 Hub 资产 | `rosclaw hub validate <manifest.yaml>` | Stable |
+| 搜索 Hub | `rosclaw hub search <term>` | Stable |
+| 安装 Hub 资产 | `rosclaw hub install <uri>` | Stable |
+| 列出已安装资产 | `rosclaw hub list --installed` | Stable |
+| 卸载 Hub 资产 | `rosclaw hub uninstall <uri>` | Stable |
+| 初始化 Provider | `rosclaw provider init` | Planned |
+| 路由能力 | `rosclaw provider route --capability <name>` | Planned |
+| 开始 Practice | `rosclaw practice start --sources <sources>` | Planned |
+| 故障建议 | `rosclaw how advise --task <id> --failure <id>` | Planned |
+| 运行 Auto 套件 | `rosclaw auto run --suite <suite>` | Planned |
+| Darwin 评测 | `rosclaw darwin eval --skill <id>` | Research |
+
+完整命令参考见 [docs/CLI.md](docs/CLI.md)。
+
+---
+
+## 核心运行时模块
+
+| 模块 | 职责 |
+|------|------|
+| **Runtime** | 生命周期、配置、插件注册、依赖注入。 |
+| **EventBus** | 模块通信、主题路由、Trace 关联。 |
+| **Provider** | 能力路由、Schema 约束、安全边界。 |
+| **Sandbox** | 安全验证、防火墙、MuJoCo 预演。 |
+| **Practice** | 时间线、MCAP、JSONL、执行记录。 |
+| **Memory** | 经验图谱、失败/成功模式、召回。 |
+| **Know** | TaskCard、Pattern、EvidenceTrace、故障分类。 |
+| **How** | 运行时干预、injection_id、证据。 |
+| **Auto** | 提案、补丁、实验、Champion、DeadEnd 跟踪。 |
+| **Darwin** | 多种子基准测试、压力场景、回归。 |
+| **Skill Registry** | 版本、血缘、Champion、回滚。 |
+| **Dashboard** | 可观测性、进化轨迹、血缘可视化。 |
+
+---
+
+## Hub 与资产
+
+ROSClaw Hub 是一个**物理 AI 资产中心**，用于管理技能、Provider、硬件 MCP 服务器、数字孪生和认知 Wiki。资产可以完全本地化，也可以与注册表同步。
+
+支持的资产类型：
+
+- `skill` — 可复用的物理 AI 技能
+- `provider` — 运行时能力 Provider
+- `hardware_mcp` — 封装真实硬件的 MCP 服务器
+- `digital_twin` — 仿真资产 / e-URDF 孪生
+- `cognitive_wiki` — 结构化运维知识
+
+验证本地资产、搜索 Hub、发布资产：
+
+```bash
+rosclaw hub validate tests/fixtures/hub_assets/hardware_mcp_valid/manifest.yaml
+rosclaw hub search g1
+rosclaw hub publish --dry-run
+```
+
+详见 [docs/ASSETS.md](docs/ASSETS.md) 和 [docs/hub/README.md](docs/hub/README.md)。
+
+---
+
+## 示例工作流：桌面抓取
+
+一个完整的闭环示例：
+
+```
+Agent: "把桌上的红色方块捡起来放到盒子里。"
+  ↓
+Provider 为当前本体选择抓取技能。
+  ↓
+Sandbox 根据 e-URDF 和安全限制验证轨迹。
+  ↓
+Runtime 分发通过验证的轨迹。
+  ↓
+Practice 记录 Episode：视频、状态、事件、结果。
+  ↓
+Memory 索引经验，供未来相似任务调用。
+  ↓
+How 在抓取失败时介入，请求重试模式。
+  ↓
+Know 编译 TaskCard："红色方块、光滑表面、平行夹爪"。
+  ↓
+Auto 提出夹持力补丁。
+  ↓
+Darwin 在 100 个仿真种子上评测补丁。
+  ↓
+晋升门将补丁提升为 Champion，前提是成功率提高。
+```
+
+---
+
+## 安全模型
+
+ROSClaw 的核心安全规则：
+
+> **任何模型输出都不应该直接控制机器人。**
+
+每一个物理动作都要经过验证流水线：
+
+1. Provider 生成结构化的动作提案。
+2. Sandbox / Firewall 根据有效本体模型和安全策略检查。
+3. 决策结果为 `ALLOW`、`MODIFY`、`BLOCK` 或 `REQUIRE_HUMAN_CONFIRMATION`。
+4. Practice 记录执行过程。
+5. Memory 和 Know 保留证据供后续审计。
+6. How 和 Auto 可以提出改进，但只有晋升门能改变当前生效的技能。
+
+ROSClaw 是研究基础设施，不能替代经过认证的工业安全系统。务必先在仿真中测试，保持急停系统可用，并在人类监督下运行。
+
+完整安全模型见 [docs/SAFETY.md](docs/SAFETY.md)。
+
 ---
 
 ## 系统架构
@@ -162,7 +273,7 @@ graph TD
     subgraph Agents[任何 MCP 兼容 Agent]
         CC[Claude Code]
         OC[OpenClaw]
-        AC[AutoGen / 自定义]
+        AC[自定义 Agent]
     end
 
     subgraph Runtime[ROSClaw 运行时]
@@ -179,7 +290,7 @@ graph TD
 
     subgraph Infra[基础设施]
         EURDF[e-URDF Zoo]
-        SKDB[SeekDB 知识平面]
+        SKDB[知识平面]
     end
 
     subgraph HW[硬件层]
@@ -200,666 +311,66 @@ graph TD
     EB <-->|评测| DW
     FW <-->|模型| EURDF
     MEM <-->|持久化| SKDB
-    SK -->|调度| HW
-    AU -->|晋升| SK
-    DW -->|报告| AU
+    SK -->|分发| HW
 ```
 
-**关键洞察**：所有模块仅通过事件总线通信，禁止直接模块间调用。这确保了解耦，并使任何 Agent 无需硬件特定知识即可连接。
+架构的 14 条工程铁律和详细模块边界见 [ARCHITECTURE.md](ARCHITECTURE.md)。
 
 ---
 
-## 核心模块
+## 支持的集成
 
-| 模块 | 作用 |
+| 类别 | 技术 |
 |------|------|
-| `rosclaw-runtime` | ROSClaw 的运行时内核，负责配置、插件、生命周期、健康检查、事件总线和模块编排。 |
-| `e-urdf-zoo` | 机器人的"物理基因库"，定义机器人结构、关节、传感器、执行器、安全边界、能力和仿真资产。 |
-| `rosclaw-provider` | 具身能力接入层，把 LLM、VLM、VLA、VLN、世界模型、Skill、Critic、Embedding 等统一封装成可调用能力。 |
-| `rosclaw-sandbox` | 物理沙盒与安全验证层，负责仿真、预演、回放和动作防火墙。 |
-| `rosclaw-practice` | 实践捕获系统，记录机器人执行过程中的传感器、动作、模型决策、工具调用、失败原因和回放数据。 |
-| `rosclaw-memory` | 时空记忆系统，沉淀机器人过去经历、失败案例、成功模式、场景记忆和技能经验。 |
-| `rosclaw-how` | 运行时干预控制器，当 Agent 卡住、失败、危险或退化时，提供最小必要的恢复建议。 |
-| `rosclaw-know` | 物理 AI 知识编译器，把论文、代码、日志、轨迹和失败案例编译成可检索、可验证的工程知识。 |
-| `rosclaw-auto` | 自进化控制平面，负责生成改进方案、修改候选技能、组织实验、评估结果、晋升 Champion Skill。 |
-| `rosclaw-darwin` | 进化评测竞技场，用于 benchmark、压力测试、技能对比、回归测试和进化速度评估。 |
-| `rosclaw-forge` | 具身资产编译器，可以把 SDK、ROS 2 接口、文档和 e-URDF 转换成 MCP Server、Skill、Provider Manifest 等资产。 |
-| `rosclaw-dashboard` | 可视化观测平台，用于查看运行状态、任务链路、沙盒回放、记忆、干预、进化过程和技能版本。 |
+| **Agent** | Claude Code、OpenClaw、任何 MCP 兼容客户端 |
+| **仿真** | MuJoCo、Isaac Sim |
+| **机器人** | Unitree G1 / Go2、UR5e、TurtleBot3、自定义 e-URDF |
+| **ROS** | ROS 2 Humble / Jazzy，通过 MCP 驱动 |
+| **模型** | OpenAI、DeepSeek、Qwen，通过能力路由接入本地/私有模型 |
+| **记忆** | SeekDB / 本地经验图谱 |
 
 ---
 
-## ROSClaw 有什么不同？
-
-### 1. 不是简单 Tool Calling，而是物理接地
-
-普通 Agent 调工具，很多时候只是调用 API。但机器人不是普通 API。
-
-机器人动作必须考虑：关节限制、力矩限制、工作空间、碰撞风险、速度和加速度、传感器状态、当前环境、人机安全。
-
-ROSClaw 会把大模型的意图先转换成结构化能力请求，再经过安全验证和执行控制。
-
-```
-Token 意图 → 能力请求 → 安全验证 → 物理执行
-```
-
-### 2. e-URDF：机器人本体是第一等公民
-
-ROSClaw 把机器人本体视为系统最重要的基础资产。一个 e-URDF 不只是传统 URDF，而是包含：
-
-- 机器人结构；
-- 关节、连杆、传感器、执行器；
-- 安全边界；
-- 语义部位；
-- 工具坐标系；
-- 工作空间；
-- 运动能力；
-- 仿真模型；
-- benchmark 配置。
-
-这让 Agent 不只是知道"我要抓杯子"，还知道"我这具身体能不能安全地抓杯子"。
-
-### 3. 先沙盒，后真实世界
-
-ROSClaw 不鼓励大模型直接控制真实机器人。在真实执行前，动作可以先进入 `rosclaw-sandbox` 做物理预演和安全检查。
-
-可能返回：
-
-```
-ALLOW：允许执行
-BLOCK：阻止执行
-MODIFY：建议修改后执行
-REQUIRE_HUMAN_CONFIRMATION：需要人类确认
-```
-
-示例：
-
-```json
-{
-  "decision": "BLOCK",
-  "risk_score": 0.92,
-  "reason": "预测 wrist_link 会与桌面发生碰撞",
-  "violated_constraints": ["collision", "workspace_boundary"],
-  "replay_id": "sandbox://replays/firewall_00042"
-}
-```
-
-### 4. Practice：物理世界的"行车记录仪"
-
-机器人执行失败时，普通系统可能只留下一行日志：
-
-```
-grasp failed
-```
-
-但 ROSClaw 会记录完整实践过程：Agent 想做什么、Provider 调用了什么能力、Sandbox 是否拦截、Runtime 执行了什么、传感器看到了什么、关节和力矩发生了什么、Critic 判断是否成功、失败发生在哪个阶段、后续是否生成了恢复建议。
-
-这些会被保存为：MCAP、JSONL、视频、replay、failure report、PraxisEvent。
-
-### 5. Memory：机器人记得自己经历过什么
-
-ROSClaw 的 Memory 不只是聊天记录。它是机器人自己的时空记忆系统。它可以回答：
-
-```
-刚才为什么抓取失败？
-上一次类似失败是怎么解决的？
-这个机器人在哪些场景下容易碰撞？
-哪个版本的 skill 成功率最高？
-某个按钮上次是如何被按下的？
-```
-
-### 6. How：Agent 卡住时的运行时反射弧
-
-当 Agent 一直失败、分数不涨、动作危险或陷入无效尝试时，`rosclaw-how` 会提供最小必要的干预。例如：
-
-```
-当前失败可能是接近高度过低导致的。
-下一次只调整 pre_grasp_height，不要同时修改所有参数。
-建议增加 3cm 预抓取高度，并降低接近速度。
-预期信号：碰撞率下降，抓取成功率上升。
-```
-
-How 不是代替 Agent，而是像"反射弧"一样，在关键时刻给它一点提示。
-
-### 7. Auto：让技能越练越好
-
-`rosclaw-auto` 会把重复失败变成自动改进流程：
-
-```
-失败案例
-    ↓
-诊断
-    ↓
-假设
-    ↓
-改进提案
-    ↓
-技能补丁
-    ↓
-沙盒实验
-    ↓
-Darwin 评测
-    ↓
-Champion 晋升 / DeadEnd 记录
-```
-
-ROSClaw 不会直接覆盖原技能，而是做版本管理：
-
-```
-pick_cube@v1.0.0  baseline_champion
-    ↓
-pick_cube@candidate_0001  sandbox_passed
-    ↓
-pick_cube@v1.1.0  sim_champion
-    ↓
-pick_cube@v1.1.0  sandbox_champion
-    ↓
-pick_cube@v1.1.0  real_candidate
-    ↓
-pick_cube@v1.1.0  real_champion
-```
-
-每个 Champion Skill 都可以回滚。
-
----
-
-## 快速开始
-
-### 1. 安装 ROSClaw CLI
-
-```bash
-curl -sSL https://rosclaw.io/get | bash
-```
-
-这只会安装 `rosclaw` 命令，并在 `~/.rosclaw` 创建最小工作区。  
-不会启动任何运行时、连接机器人或上传数据。
-
-### 2. 运行 First Boot
-
-```bash
-rosclaw firstboot
-```
-
-按交互式向导操作（或在 CI/服务器上使用 `rosclaw firstboot --yes`）。  
-这会生成本地运行时配置、MCP 配置和 telemetry 偏好。
-
-### 3. 检查系统健康
-
-```bash
-rosclaw doctor
-```
-
-结构化输出：
-
-```bash
-rosclaw doctor --full --json
-```
-
-### 4. 运行本地仿真 Demo
-
-```bash
-rosclaw sandbox run --robot sim_ur5e --world tabletop --task reach
-```
-
-### 开发者安装
-
-想直接修改 ROSClaw 源码？
-
-```bash
-git clone https://github.com/ros-claw/rosclaw.git
-cd rosclaw
-make setup
-```
-
-详细说明见 [INSTALL.md](INSTALL.md)。
-
----
-
-### 连接 MCP Agent
-
-ROSClaw 可以作为 MCP Server 暴露给支持 MCP 的 Agent，例如 Claude Code、OpenClaw 或其他 Agent Runtime。
-
-`rosclaw firstboot` 会在 `~/.rosclaw/config/mcp.json` 生成如下配置：
-
-```json
-{
-  "mcpServers": {
-    "rosclaw": {
-      "command": "rosclaw-mcp",
-      "args": []
-    }
-  }
-}
-```
-
-连接后，Agent 可以调用 ROSClaw 提供的工具，例如：观察场景、定位物体、执行技能、查询记忆、请求安全验证、触发沙盒回放、生成或验证 MCP 资产。
-
----
-
-## 一个完整例子：桌面抓取
-
-运行：
-
-```bash
-./rosclaw demo tabletop-grasp --robot-id ur5e
-```
-
-系统会执行：
-
-```text
-1. Agent 接收任务："拿起红色杯子"
-2. Provider 调用视觉能力定位杯子
-3. Memory 检索类似抓取经验
-4. Skill Provider 生成抓取方案
-5. Sandbox 预演动作并检查碰撞
-6. Runtime 控制机器人执行
-7. Practice 记录完整执行过程
-8. Critic 判断是否成功
-9. Memory 写入成功或失败经验
-10. How 在失败时给出恢复建议
-11. Auto 在重复失败后生成技能改进方案
-12. Darwin 评估候选技能
-13. 通过后晋升为 Champion Skill
-```
-
----
-
-## 安全原则
-
-ROSClaw 的核心安全原则：
-
-> **任何模型输出，都不能直接裸控机器人。**
-
-所有真实执行都必须经过：
-
-```
-Provider Schema
-    ↓
-e-URDF 物理约束
-    ↓
-Sandbox / Firewall
-    ↓
-Runtime Guard
-    ↓
-Robot Controller
-```
-
-安全规则：
-
-- VLA 输出只是动作建议，不是电机命令；
-- 世界模型只是神经预演，不是安全证明；
-- MCP 是 Agent 工具接口，不是实时控制总线；
-- 自动生成的 Skill 必须经过沙盒验证；
-- 代码补丁进入生产环境前必须人工审批；
-- 安全配置变更必须人工审批；
-- 每个 Champion Skill 必须支持回滚；
-- 真机部署必须配合急停、限位、安全区域和人工监督。
-
----
-
-## Skill 如何进化？
-
-ROSClaw 把 Skill 当成可版本化、可测试、可晋升、可回滚的物理资产。
-
-一次失败不会直接修改技能。系统会先生成候选版本，通过六道评估门控才会晋升：
-
-| 门控 | 检查内容 |
-|------|---------|
-| 成功率提升 | 候选版本成功率 > 基线 + 阈值 |
-| 安全回归 | 碰撞率和安全事件不增加 |
-| 多随机种子验证 | 在种子 [0, 1, 2, ...] 上均通过 |
-| 沙盒放行 | Firewall 决策为 ALLOW |
-| 回归测试 | 现有任务无退化 |
-| 人工确认 | 代码补丁和安全配置变更需人工审批 |
-
-查看技能演化：
-
-```bash
-# 初始化自进化任务（运行前必需）
-./rosclaw auto init --task pick_cube --skill reach --type skill_tuning
-
-# 运行自进化实验
-./rosclaw auto run --task pick_cube --rounds 50
-
-# 查看进化状态
-./rosclaw auto status
-
-# 列出当前 Champion
-./rosclaw skill champions list
-
-# 查看技能谱系
-./rosclaw skill lineage pick_cube
-
-# 回滚到安全版本
-./rosclaw skill rollback pick_cube --to v1.0.0
-```
-
----
-
-## SDK-to-MCP / Asset Forge
-
-ROSClaw 内置具身资产编译器 `rosclaw-forge`。
-
-它可以把：SDK 文档、ROS 2 接口、机器人说明、e-URDF 约束
-
-转换成：MCP Server、Skill Manifest、Provider Manifest、测试文件、ClawHub 元数据
-
-示例：
-
-```bash
-./rosclaw forge sdk-to-mcp \
-  --name unitree_go2 \
-  --sdk-docs ./docs/unitree_go2_sdk.md \
-  --output ./generated/unitree_go2_bundle
-```
-
-验证生成结果：
-
-```bash
-./rosclaw forge validate ./generated/unitree_go2_bundle
-```
-
-安装到 staging 环境：
-
-```bash
-./rosclaw forge install ./generated/unitree_go2_bundle --staging
-```
-
-注意：自动生成的资产默认不会直接进入真实机器人执行链路，必须先经过验证和审批。
-
----
-
-## 项目目录
-
-```text
-rosclaw/
-├── src/rosclaw/              # 核心 Runtime、Schema、CLI、MCP Gateway
-│   ├── core/                 # 运行时、EventBus、生命周期
-│   ├── schemas/              # 统一规范数据类
-│   ├── provider/             # 能力接入层
-│   ├── sandbox/              # MuJoCo 仿真与防火墙
-│   ├── practice/             # 时空轴捕获与 MCAP
-│   ├── memory/               # 时空记忆系统
-│   ├── how/                  # 运行时干预
-│   ├── know/                 # 知识编译器
-│   ├── auto/                 # 自进化控制平面
-│   ├── darwin/               # Benchmark 与评测竞技场
-│   ├── forge/                # 资产编译器
-│   ├── dashboard/            # 可观测平台与 WebSocket
-│   └── mcp/                  # MCP Server 实现
-├── e-urdf-zoo/               # 机器人物理基因库
-├── docs/                     # 架构、RFC、使用文档
-├── examples/                 # 示例任务和机器人 Demo
-├── tutorials/                # 教程
-├── tests/                    # 单元测试、集成测试、端到端测试、安全测试
-├── benchmarks/               # Benchmark 和评测任务
-├── acceptance/               # 发布验收测试
-├── scripts/                  # 安装脚本和工具脚本
-├── rosclaw.yaml              # 默认运行配置
-├── docker-compose.yml        # 本地服务编排
-├── ARCHITECTURE.md           # 14 条工程铁律
-├── QUICKSTART.md             # 快速开始
-└── INSTALL.md                # 安装说明
-```
-
----
-
-## 配置示例
-
-`rosclaw firstboot --profile offline` 生成的 `rosclaw.yaml` 示例：
-
-```yaml
-schema_version: '1.0'
-generated_by: rosclaw firstboot
-workspace:
-  home: ~/.rosclaw
-  profile: offline
-  mode: local
-  install_channel: stable
-  auto_update: false
-
-runtime:
-  enabled: true
-  robot_id: sim_ur5e
-  safety_level: strict
-  log_level: INFO
-
-event_bus:
-  backend: local
-
-sandbox:
-  enabled: true
-  backend: mujoco
-  firewall_mode: true
-  require_sim_before_real: true
-  default_world: tabletop
-
-provider:
-  enabled: true
-  mode: local
-  manifests_dir: ~/.rosclaw/providers/manifests
-
-practice:
-  enabled: true
-  auto_record: true
-  output_dir: ~/.rosclaw/artifacts/episodes
-  formats:
-    jsonl: true
-    mcap: false
-    video: false
-
-memory:
-  enabled: true
-  backend: local
-  path: ~/.rosclaw/data/memory
-  write_failures: true
-  write_successes: true
-
-how:
-  enabled: true
-  evidence_trace_enabled: true
-  cooldown_window: 3
-
-know:
-  enabled: true
-  asset_dir: ~/.rosclaw/data/seekdb
-
-auto:
-  enabled: false
-  require_human_approval: true
-  allow_code_patch: false
-  trigger_failure_threshold: 3
-
-darwin:
-  enabled: false
-  seeds: [0, 1, 2]
-  episodes: 50
-
-mcp:
-  enabled: true
-  config_path: ~/.rosclaw/config/mcp.json
-  server_command: rosclaw-mcp
-
-cloud:
-  enabled: false
-  sync:
-    configs: false
-    logs: false
-    artifacts: false
-    memory: false
-    anonymous_usage: false
-
-telemetry:
-  enabled: false
-  anonymous_install_ping: false
-
-security:
-  never_execute_robot_without_confirmation: true
-  require_firewall_for_real_robot: true
-  secrets_backend: env
-```
-
-Cloud、telemetry、auto-evolution 和 Darwin benchmark 默认均**关闭**。  
-可通过 `rosclaw profile use cloud` 或手动编辑 `rosclaw.yaml` 显式开启。
+## 文档
+
+- [QUICKSTART.md](QUICKSTART.md) — 5 分钟快速开始。
+- [INSTALL.md](INSTALL.md) — 详细安装与故障排查。
+- [docs/FIRSTBOOT.md](docs/FIRSTBOOT.md) — 安装与首次启动完整参考。
+- [docs/CLI.md](docs/CLI.md) — CLI 命令参考。
+- [docs/SAFETY.md](docs/SAFETY.md) — 安全模型与部署规则。
+- [docs/ASSETS.md](docs/ASSETS.md) — 物理 AI 资产中心。
+- [docs/hub/README.md](docs/hub/README.md) — Hub 工作流。
+- [ARCHITECTURE.md](ARCHITECTURE.md) — 运行时架构。
+- [CONTRIBUTING.md](CONTRIBUTING.md) — 开发规范。
 
 ---
 
 ## 路线图
 
-### ROSClaw v1.0（当前版本）
-
-- [x] Runtime 插件架构
-- [x] e-URDF 机器人本体注册
-- [x] MCP 兼容 Agent Runtime
-- [x] 能力 Provider 层
-- [x] MuJoCo Sandbox 和 Firewall Mode
-- [x] Practice 统一时空轴捕获（MCAP / JSONL）
-- [x] SeekDB 时空记忆系统
-- [x] How 运行时干预（v1.5）
-- [x] Know 物理 AI 知识编译
-- [x] Auto 自进化控制平面
-- [x] Darwin Benchmark 与评测竞技场
-- [x] Skill Registry 支持 champion/谱系/回滚
-- [x] Forge SDK-to-MCP 资产编译
-- [x] Dashboard 可观测平台（WebSocket + HTTP API）
-- [x] 端到端物理智能 Demo
-- [x] 统一 Schema 包（`rosclaw.schemas`）
-- [x] ARCHITECTURE.md — 14 条工程铁律
-
-### 后续计划
-
-- [ ] Isaac Sim 后端
-- [ ] 多机器人协作沙盒
-- [ ] DDS 反射握手
-- [ ] LeRobot / RLDS 数据导出
-- [ ] OpenVLA 和 Cosmos Provider
-- [ ] Darwin Benchmark 排行榜
-- [ ] ClawHub Skill / Provider 市场
-- [ ] 长周期真实巡检 Demo
+| 阶段 | 重点 |
+|------|------|
+| **当前 (v1.0)** | Runtime、EventBus、Sandbox、Practice、Memory、How、MCP 服务、first boot、Hub 验证/搜索。 |
+| **进行中** | Provider 路由、真实本体上的技能执行、自动进化工作流、Darwin 评测。 |
+| **研究** | 多 Agent 集群协作、生产环境持续自进化、跨机器人技能迁移。 |
 
 ---
 
-## 使用场景
+## 贡献
 
-### 机器人研究
-
-- 具身 Agent 评测；
-- 技能学习与技能优化；
-- 仿真到真实迁移；
-- 机器人长期记忆；
-- 自进化实验闭环。
-
-### 工业机器人
-
-- 机器人 Skill 封装与版本管理；
-- LLM 安全控制机器人；
-- 数字孪生预演；
-- 巡检、抓取、按钮、阀门等处置任务；
-- 失败回放和根因分析。
-
-### Agent 基础设施
-
-- MCP 物理工具；
-- 具身能力路由；
-- Agent 安全边界；
-- 运行时干预；
-- 自我改进 Skill 系统。
+欢迎贡献。开发规范、PR 流程和代码风格见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ---
 
-## 开发
+## 联系方式
 
-运行测试：
+问题、合作与安全报告：
 
-```bash
-PYTHONPATH=src python3 -m pytest tests -v
-```
-
-运行端到端测试：
-
-```bash
-PYTHONPATH=src python3 -m pytest tests/test_e2e_full_pipeline.py -v
-```
-
-运行架构检查：
-
-```bash
-./rosclaw doctor --ros2
-```
+- 邮箱：[ai@rosclaw.io](mailto:ai@rosclaw.io)
+- Issues：[GitHub Issues](https://github.com/ros-claw/rosclaw/issues)
+- Discussions：[GitHub Discussions](https://github.com/ros-claw/rosclaw/discussions)
 
 ---
 
-## 参与贡献
+## 许可证
 
-欢迎一起建设 Physical AI 的开放基础设施。
-
-适合贡献的方向包括：
-
-- 新机器人 e-URDF；
-- 新机器人 MCP Server；
-- 新感知 / 操作 / 导航 Provider；
-- 新 Skill；
-- 新 Sandbox 任务和场景；
-- 新 Benchmark；
-- Dashboard 可视化；
-- 文档和教程。
-
-提交 PR 前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
-
----
-
-## 安全声明
-
-ROSClaw 是面向物理 AI 和具身智能的研究与工程基础设施。
-
-在真实机器人上运行前，请务必先在仿真环境中测试。真实部署时，请使用急停、安全围栏、限位、速度限制、安全控制器和人工监督。
-
-**ROSClaw 不能替代经过认证的工业安全系统。**
-
----
-
-## 引用
-
-如果你在研究中使用 ROSClaw，可以引用：
-
-```bibtex
-@software{rosclaw2026,
-  title  = {ROSClaw: Open Infrastructure for Physical Intelligence},
-  author = {ROSClaw Contributors},
-  year   = {2026},
-  url    = {https://github.com/ros-claw/rosclaw}
-}
-```
-
-如果你在使用 Genesis 仿真器配合 ROSClaw，也请引用：
-
-```bibtex
-@article{genesis2026,
-  title   = {Genesis: A Generative Physics Engine for General Purpose Robotics},
-  author  = {Genesis Authors},
-  journal = {arXiv preprint},
-  year    = {2026},
-  url     = {https://arxiv.org/abs/2604.04664}
-}
-```
-
----
-
-## License
-
-本项目采用 MIT License，详见 [LICENSE](LICENSE)。
-
----
-
-## Links
-
-- **Website**: [https://www.rosclaw.io/](https://www.rosclaw.io/)
-- **GitHub**: [https://github.com/ros-claw/rosclaw](https://github.com/ros-claw/rosclaw)
-- **文档**: [docs/](docs/)
-- **快速开始**: [QUICKSTART.md](QUICKSTART.md)
-- **架构规范**: [ARCHITECTURE.md](ARCHITECTURE.md)
-
----
-
-<div align="center">
-  <b>ROSClaw — 让 AI 真正进入物理世界。</b>
-</div>
+[MIT](LICENSE)

--- a/docs/ASSETS.md
+++ b/docs/ASSETS.md
@@ -1,0 +1,186 @@
+# ROSClaw Physical-AI Asset Hub
+
+The ROSClaw Hub is a **Physical-AI Asset Hub**: a registry-aware system for discovering, validating, distributing, and versioning assets that connect AI agents to the physical world.
+
+---
+
+## What is a Physical-AI Asset?
+
+A Physical-AI asset is any versioned, self-describing package that:
+
+- Declares what physical capabilities it requires.
+- Declares what physical capabilities it provides.
+- Carries a manifest with identity, provenance, license, and verification policy.
+- Can be validated against the ROSClaw manifest schema.
+- Can be installed into a local workspace or synced from a registry.
+
+Assets are not generic files. They are typed, validated, and runtime-aware.
+
+---
+
+## Asset Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `skill` | Reusable physical-AI skill | `pick_cube`, `open_door` |
+| `provider` | Runtime capability provider | vision provider, LLM router |
+| `hardware_mcp` | MCP server that wraps real hardware | Unitree G1 MCP, UR5e MCP |
+| `digital_twin` | Simulation asset / e-URDF twin | MuJoCo scene, Isaac Sim asset |
+| `e_urdf` | Extended URDF model with capabilities | `unitree-g1@1.0.0` |
+| `cognitive_wiki` | Structured operational knowledge | maintenance procedures, safety notes |
+
+---
+
+## Asset Lifecycle
+
+```
+Author
+    ↓
+Write manifest.yaml + payload
+    ↓
+rosclaw hub validate   (local schema check)
+    ↓
+rosclaw hub publish --dry-run   (bundle + sign simulation)
+    ↓
+Upload to registry
+    ↓
+Registry verification + policy check
+    ↓
+rosclaw hub sync   (consumer fetches index)
+    ↓
+rosclaw hub search / info   (consumer discovers)
+    ↓
+rosclaw hub install   (consumer installs locally)  [Planned]
+    ↓
+Runtime loads asset and checks body compatibility
+    ↓
+Sandbox validates every use
+    ↓
+Practice records evidence
+    ↓
+Auto / Darwin may propose updates
+```
+
+---
+
+## Asset Identity
+
+Assets are identified by URIs of the form:
+
+```text
+rosclaw://{type}/{namespace}/{name}@{version}
+```
+
+Examples:
+
+```text
+rosclaw://skill/rosclaw/pick_cube@1.2.0
+rosclaw://hardware_mcp/rosclaw/unitree-g1@1.0.0
+rosclaw://digital_twin/rosclaw/tabletop@0.4.1
+```
+
+Identity rules:
+
+- `type` must be one of the supported asset types.
+- `namespace` identifies the publisher or organization.
+- `name` is kebab-case and unique within `{type}/{namespace}`.
+- `version` follows [SemVer](https://semver.org/).
+
+---
+
+## Manifest Schema
+
+Every asset contains a `manifest.yaml` with at least:
+
+```yaml
+apiVersion: hub.rosclaw.io/v1
+kind: Asset
+metadata:
+  id: rosclaw://hardware_mcp/rosclaw/unitree-g1@1.0.0
+  name: unitree-g1
+  namespace: rosclaw
+  version: 1.0.0
+spec:
+  type: hardware_mcp
+  description: MCP server for Unitree G1 humanoid
+  requires:
+    capabilities:
+      - name: ros2-control
+      - name: humanoid-locomotion
+  provides:
+    capabilities:
+      - name: walk
+      - name: stand
+  license: MIT
+  verification:
+    signed: false
+    checksums:
+      sha256: abc123...
+```
+
+See [docs/hub/asset_manifest.md](hub/asset_manifest.md) for the full schema.
+
+---
+
+## Local-Only Assets
+
+You can use assets without any registry:
+
+```bash
+# Validate a local manifest
+rosclaw hub validate ./my_skill/manifest.yaml
+
+# Use it in a sandbox run
+rosclaw sandbox run --skill ./my_skill --robot sim_ur5e
+```
+
+Local-only assets are useful for:
+
+- Air-gapped robots.
+- Proprietary skills that must not leave the lab.
+- Development and debugging.
+
+---
+
+## Cloud-Synced Assets
+
+To discover and sync assets from a registry:
+
+```bash
+rosclaw hub login --registry https://hub.rosclaw.io --token $ROSCLAW_HUB_TOKEN
+rosclaw hub sync
+rosclaw hub search pick
+rosclaw hub info rosclaw://skill/rosclaw/pick_cube@1.2.0
+rosclaw hub install rosclaw://skill/rosclaw/pick_cube@1.2.0
+rosclaw hub list --installed
+rosclaw hub uninstall rosclaw://skill/rosclaw/pick_cube@1.2.0
+```
+
+---
+
+## Verification and Trust
+
+Before an asset is loaded by the runtime:
+
+1. The manifest schema is validated.
+2. Checksums are verified against the payload.
+3. The license and permission policy are checked.
+4. Required capabilities are matched against the effective body model.
+5. The Sandbox validates every skill execution.
+
+Currently, signing uses placeholder material and must be replaced before production. See [docs/hub/security.md](hub/security.md).
+
+---
+
+## CLI Reference
+
+See [docs/CLI.md](CLI.md) for the full list of `rosclaw hub` commands and their status.
+
+---
+
+## See Also
+
+- [docs/hub/README.md](hub/README.md) — Hub workflows and registry setup.
+- [docs/hub/asset_manifest.md](hub/asset_manifest.md) — Full manifest schema.
+- [docs/SAFETY.md](SAFETY.md) — Safety model.
+- [QUICKSTART.md](../QUICKSTART.md) — Quick start.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,188 @@
+# ROSClaw CLI Reference
+
+This document lists ROSClaw CLI commands and their implementation status.
+
+## Status Labels
+
+- **Stable** — implemented and tested; API is unlikely to change in patch releases.
+- **Experimental** — implemented, but the interface may change.
+- **Planned** — documented design, not yet implemented.
+- **Research** — exploration-stage workflow; may not exist as a CLI command yet.
+
+---
+
+## Lifecycle & Workspace
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw --version` | Stable | Show version |
+| `rosclaw firstboot` | Stable | Interactive first-boot wizard |
+| `rosclaw firstboot --yes` | Stable | Non-interactive first boot |
+| `rosclaw doctor` | Stable | Health diagnosis |
+| `rosclaw doctor --full` | Stable | Complete check |
+| `rosclaw doctor --fix` | Stable | Repair safe local issues only |
+| `rosclaw status` | Stable | Runtime status |
+| `rosclaw config show` | Stable | Show effective config |
+| `rosclaw config path` | Stable | Show config file path |
+| `rosclaw profile current` | Stable | Show active profile |
+
+---
+
+## Runtime
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw run` | Stable | Start the ROSClaw runtime |
+| `rosclaw start` | Stable | Alias for `run` |
+| `rosclaw stop` | Stable | Stop the runtime |
+| `rosclaw logs` | Stable | Show runtime logs |
+
+---
+
+## Simulation
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw sandbox run --robot <id> --world <id> --task <id>` | Stable | Run a MuJoCo simulation |
+| `rosclaw robot list` | Stable | List available robots |
+| `rosclaw robot inspect <id>` | Stable | Show complete robot profile |
+| `rosclaw robot validate <id>` | Stable | Validate e-URDF completeness |
+
+---
+
+## Agent & MCP
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw agent init claude-code` | Stable | Generate MCP config for Claude Code |
+| `rosclaw agent test claude-code` | Stable | Test the agent integration |
+| `rosclaw agent doctor` | Stable | Validate agent/MCP setup |
+| `rosclaw mcp serve` | Stable | Start the ROSClaw MCP server |
+| `rosclaw mcp serve --transport http --port 9000` | Stable | HTTP transport |
+| `rosclaw mcp onboard` | Stable | Hardware MCP onboarding flow |
+
+---
+
+## Body / Embodiment
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw body init --robot <id>` | Stable | Initialize a body profile |
+| `rosclaw body inspect` | Stable | Show effective body model |
+| `rosclaw body list` | Stable | List registered bodies |
+| `rosclaw body switch <id>` | Stable | Change active body |
+| `rosclaw body link-eurdf --body <id> --eurdf <path>` | Stable | Link an e-URDF model |
+| `rosclaw body history` | Stable | Show body snapshot history |
+| `rosclaw skill check --task <id>` | Stable | Check skill compatibility |
+| `rosclaw skill fleet-check --task <id>` | Stable | Fleet-wide compatibility |
+
+---
+
+## Hub
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw hub validate <manifest.yaml>` | Stable | Validate a local asset manifest |
+| `rosclaw hub login --registry <url> --token <token>` | Stable | Log in to a registry |
+| `rosclaw hub sync` | Stable | Sync registry metadata |
+| `rosclaw hub search <term>` | Stable | Search available assets |
+| `rosclaw hub info <uri>` | Stable | Show asset details |
+| `rosclaw hub publish --dry-run` | Stable | Validate before publishing |
+| `rosclaw hub policy` | Stable | Show license/permission policy |
+| `rosclaw hub install <uri>` | Stable | Install an asset locally |
+| `rosclaw hub list --installed` | Stable | List installed assets |
+| `rosclaw hub uninstall <uri>` | Stable | Remove an installed asset |
+| `rosclaw hub update <uri>` | Stable | Update an installed asset from a local directory |
+
+---
+
+## Provider
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw provider list` | Stable | List registered providers |
+| `rosclaw provider invoke <capability> [--input ...]` | Stable | Invoke a provider capability |
+| `rosclaw provider init` | Planned | Initialize a provider skeleton |
+| `rosclaw provider route --capability <name>` | Planned | Route a capability request |
+| `rosclaw provider test <id>` | Planned | Test a provider endpoint |
+
+---
+
+## Practice
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw practice list` | Stable | List recorded episodes |
+| `rosclaw practice show <id>` | Stable | Show episode details |
+| `rosclaw practice replay <id>` | Stable | Replay episode trace |
+| `rosclaw practice export <id> --format json` | Stable | Export episode metadata |
+| `rosclaw practice start --sources <sources>` | Planned | Start a practice recording session |
+
+---
+
+## Memory
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw memory query <query>` | Stable | Query spatiotemporal memory |
+| `rosclaw memory near --robot <id> --time <ts>` | Stable | Find experiences near a robot/time |
+| `rosclaw memory graph --episode <id>` | Stable | Show memory subgraph |
+
+---
+
+## How / Know / Auto / Darwin
+
+| Command | Status | Description |
+|---------|--------|-------------|
+| `rosclaw how explain --task <id>` | Stable | Explain a failure or decision |
+| `rosclaw how recover --task <id>` | Stable | Recommend recovery actions |
+| `rosclaw how advise --task <id> --failure <id>` | Planned | Advise on a failure |
+| `rosclaw how inject --proposal <id>` | Planned | Inject a runtime intervention |
+| `rosclaw know compile --episode <id>` | Planned | Compile episode into a TaskCard |
+| `rosclaw know search --task <id>` | Planned | Search compiled knowledge |
+| `rosclaw auto run --task <id>` | Experimental | Run auto evolution for a task |
+| `rosclaw auto status` | Stable | Show evolution status |
+| `rosclaw auto champion --patch <id>` | Experimental | Promote a patch to champion |
+| `rosclaw auto deadends` | Experimental | List dead-end experiments |
+| `rosclaw auto run --suite <suite>` | Planned | Run a named auto-evolution suite |
+| `rosclaw darwin eval --skill <id>` | Research | Evaluate a skill with Darwin |
+| `rosclaw darwin benchmark --skill <id>` | Research | Run multi-seed benchmark |
+
+---
+
+## Exit Codes
+
+Many ROSClaw commands use the following exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | General error |
+| `2` | Invalid usage |
+| `10` | Python >= 3.11 missing |
+| `11` | Unsupported platform |
+| `20` | Package install failed |
+| `21` | PEP 668 externally-managed environment |
+| `30` | Workspace permission denied |
+| `40` | Existing install conflict |
+
+---
+
+## JSON Output
+
+Commands that support `--json` emit structured output for scripting:
+
+```bash
+rosclaw doctor --full --json
+rosclaw firstboot --yes --json
+rosclaw profile current --json
+```
+
+---
+
+## See Also
+
+- [QUICKSTART.md](../QUICKSTART.md) — 5-minute quick start.
+- [INSTALL.md](../INSTALL.md) — Installation and troubleshooting.
+- [docs/SAFETY.md](SAFETY.md) — Safety model.
+- [docs/ASSETS.md](ASSETS.md) — Physical-AI Asset Hub.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,17 +6,27 @@ Welcome to the ROSClaw documentation index. This directory contains all project 
 
 | Category | Documents |
 |----------|-----------|
+| [User Guides](#user-guides) | Quick start, install, first boot, CLI, safety, assets |
 | [Installation & First Boot](#installation--first-boot) | Bootstrap, first boot, verification, troubleshooting |
 | [Architecture](#architecture) | Design decisions, reviews, audits |
-| [Body / Embodiment](#body--embodiment) | e-URDF, body formats, embodiment testing |
+| [Body / Embodiment](#body--embodiment) | e-URDF, body formats, registry, routing |
 | [Practice](#practice) | Practice recording and SeekDB persistence |
-| [API](#api) | API reference, improvements, end-to-end findings |
+| [API & Integration](#api--integration) | API reference, MCP, ROS, OpenClaw |
 | [Development](#development) | Collaboration framework, contributing, benchmarks |
-| [Security](#security) | Security audits, gap analysis |
 | [Planning](#planning) | Roadmaps, sprints, release checklist |
-| [Testing](#testing) | Test reports, verification, deep user tests |
-| [Practice](#practice) | SeekDB / `rosclaw_practice` integration |
-| [Body module](#body-module) | Multi-body registry and routing |
+| [Testing](#testing) | Test reports, verification, ROS integration |
+
+---
+
+## User Guides
+
+- **[QUICKSTART.md](../QUICKSTART.md)** — 5-minute quick start with four paths.
+- **[INSTALL.md](../INSTALL.md)** — Detailed installation options and troubleshooting.
+- **[FIRSTBOOT.md](FIRSTBOOT.md)** — Bootstrap and first boot reference.
+- **[CLI.md](CLI.md)** — CLI command reference with Stable / Experimental / Planned / Research labels.
+- **[SAFETY.md](SAFETY.md)** — Safety model, hard rules, and deployment checklist.
+- **[ASSETS.md](ASSETS.md)** — Physical-AI Asset Hub and asset lifecycle.
+- **[hub/README.md](hub/README.md)** — Hub workflows and registry setup.
 
 ---
 
@@ -26,11 +36,24 @@ Welcome to the ROSClaw documentation index. This directory contains all project 
 
 ---
 
+## Architecture
+
+- **[ARCHITECTURE.md](../ARCHITECTURE.md)** — Runtime architecture and 14 Engineering Iron Rules.
+- **[AUDIT_REPORT_v1.0_POST_RELEASE.md](AUDIT_REPORT_v1.0_POST_RELEASE.md)** — Post-release audit report.
+
+---
+
 ## Body / Embodiment
 
 - **[body/EMBODIMENT_FORMAT.md](body/EMBODIMENT_FORMAT.md)** — e-URDF / `body.yaml` / `EMBODIMENT.md` three-layer format.
 - **[body/TESTING.md](body/TESTING.md)** — Body subsystem testing guide.
 - **[body/MIGRATION.md](body/MIGRATION.md)** — Migration notes for body and embodiment changes.
+- **[body/BODY_REGISTRY.md](body/BODY_REGISTRY.md)** — Multi-body registry, `list`/`create`/`switch`/`remove`, and `--body` routing.
+- **[body/BODY_HISTORY_EXPORT.md](body/BODY_HISTORY_EXPORT.md)** — Body snapshots, `history`, `export`, and restoration workflow.
+- **[body/SKILL_COMPATIBILITY.md](body/SKILL_COMPATIBILITY.md)** — Skill compatibility statuses and enforcement.
+- **[body/FLEET_OPERATIONS.md](body/FLEET_OPERATIONS.md)** — Fleet-wide compatibility aggregation and fleet CLI commands.
+- **[body/URI_SCHEME.md](body/URI_SCHEME.md)** — Stable `rosclaw://` references to body and e-URDF resources.
+- **[BODYSENSE_SCHEMA.md](BODYSENSE_SCHEMA.md)** — Body sense schema reference.
 
 ---
 
@@ -40,69 +63,43 @@ Welcome to the ROSClaw documentation index. This directory contains all project 
 
 ---
 
-## Architecture
+## API & Integration
 
-- **[ARCHITECTURE_REVIEW.md](ARCHITECTURE_REVIEW.md)** — P0/P1 architecture review findings and recommendations
-- **[ARCHITECTURE_AUDIT.md](ARCHITECTURE_AUDIT.md)** — Full architecture audit report
-- **[ROLE_SWAP_REVIEW.md](ROLE_SWAP_REVIEW.md)** — Cross-team architecture role-swap review (score: 7.4/10)
-- **[CODE_REVIEW.md](CODE_REVIEW.md)** — Code review findings and action items
-- **[GAP_ANALYSIS.md](GAP_ANALYSIS.md)** — Identified gaps between design and implementation
-
-## API
-
-- **[API_REFERENCE.md](API_REFERENCE.md)** — Complete public API reference for ROSClaw v1.0
-- **[API_IMPROVEMENTS.md](API_IMPROVEMENTS.md)** — Planned API enhancements for v1.1
-- **[E2E_TEST_FINDINGS.md](E2E_TEST_FINDINGS.md)** — End-to-end test results and discovered issues
-- **[MCP_USAGE.md](MCP_USAGE.md)** — Chinese-language guide to using MCP with ROSClaw
-- **[HARDWARE_MCP_ONBOARDING.md](HARDWARE_MCP_ONBOARDING.md)** — Auto-install, bind, and health-check hardware MCP servers
-
-## Development
-
-- **[COLLABORATION_FRAMEWORK.md](COLLABORATION_FRAMEWORK.md)** — Multi-agent collaboration framework specification
-- **[COLLABORATION_LOG.md](COLLABORATION_LOG.md)** — Sprint-by-sprint collaboration log
-- **[BENCHMARK.md](BENCHMARK.md)** — Performance benchmarks (EventBus, SeekDB, SkillRegistry, FirewallValidator)
-- **[OPENCLAW_INTEGRATION.md](OPENCLAW_INTEGRATION.md)** — OpenClaw integration guide
-
-## Security
-
-- **[SECURITY_AUDIT.md](SECURITY_AUDIT.md)** — Security audit from stress test review
-- **[GAP_ANALYSIS.md](GAP_ANALYSIS.md)** — Security and functionality gap analysis
-
-## Planning
-
-- **[ROADMAP_v1.1.md](ROADMAP_v1.1.md)** — v1.1 roadmap and planned features
-- **[RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md)** — Pre-release verification checklist
-- **[DESIGN_SPRINT3_5.md](DESIGN_SPRINT3_5.md)** — Sprint 3-5 design documentation
-- **[SPRINT3_5_IMPLEMENTATION_REVIEW.md](SPRINT3_5_IMPLEMENTATION_REVIEW.md)** — Sprint 3-5 implementation review
-
-## Testing
-
-- **[DEEP_USER_TEST.md](DEEP_USER_TEST.md)** — Deep user experience test report
-- **[FINAL_ACCEPTANCE.md](FINAL_ACCEPTANCE.md)** — Final acceptance criteria and results (9.2/10)
-- **[FINAL_VERIFICATION.md](FINAL_VERIFICATION.md)** — Final verification checklist
-- **[ROS_INTEGRATION_TESTING.md](ROS_INTEGRATION_TESTING.md)** — Cross-project ROS 1 / ROS 2 integration test matrix
-
-## Body module
-
-- **[body/BODY_REGISTRY.md](body/BODY_REGISTRY.md)** — Multi-body registry, `list`/`create`/`switch`/`remove`, and `--body` routing
-- **[body/BODY_HISTORY_EXPORT.md](body/BODY_HISTORY_EXPORT.md)** — Body snapshots, `history`, `export`, and restoration workflow
-- **[body/SKILL_COMPATIBILITY.md](body/SKILL_COMPATIBILITY.md)** — Skill compatibility statuses and enforcement
-- **[body/FLEET_OPERATIONS.md](body/FLEET_OPERATIONS.md)** — Fleet-wide compatibility aggregation and fleet CLI commands
-- **[body/URI_SCHEME.md](body/URI_SCHEME.md)** — Stable `rosclaw://` references to body and e-URDF resources
-
-## Practice
-
-- **[practice/SEEKDB_INTEGRATION.md](practice/SEEKDB_INTEGRATION.md)** — Persisting physical episodes to SeekDB via `rosclaw_practice`
+- **[API_REFERENCE.md](API_REFERENCE.md)** — Complete public API reference for ROSClaw v1.0.
+- **[MCP_USAGE.md](MCP_USAGE.md)** — Chinese-language guide to using MCP with ROSClaw.
+- **[HARDWARE_MCP_ONBOARDING.md](HARDWARE_MCP_ONBOARDING.md)** — Auto-install, bind, and health-check hardware MCP servers.
+- **[P0_AGENT_INTEGRATION.md](P0_AGENT_INTEGRATION.md)** — P0 agent integration guide.
+- **[OPENCLAW_INTEGRATION.md](OPENCLAW_INTEGRATION.md)** — OpenClaw integration guide.
+- **[ROS_CONNECTOR.md](ROS_CONNECTOR.md)** — ROS connector documentation.
+- **[ROS_INTEGRATION_TESTING.md](ROS_INTEGRATION_TESTING.md)** — Cross-project ROS 1 / ROS 2 integration test matrix.
+- **[SENSE.md](SENSE.md)** — Sense subsystem documentation.
+- **[EVENT_TOPICS.md](EVENT_TOPICS.md)** — Event topic reference.
 
 ---
 
-## Design Assets
+## Development
 
-- **[design/](design/)** — Architecture diagrams and visual assets
-- **[logos/](logos/)** — ROSClaw branding and logos
+- **[BENCHMARK.md](BENCHMARK.md)** — Performance benchmarks (EventBus, SeekDB, SkillRegistry, FirewallValidator).
+- **[INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md)** — Integration guide.
+- **[G1_SENSE_DEMO.md](G1_SENSE_DEMO.md)** — Unitree G1 sense demo.
+
+---
+
+## Planning
+
+- **[../ROSCLAW.md](../ROSCLAW.md)** — Project whitepaper (Chinese).
+- **[../CHANGELOG.md](../CHANGELOG.md)** — Release changelog.
+
+---
+
+## Testing
+
+- **[ROS_INTEGRATION_TESTING.md](ROS_INTEGRATION_TESTING.md)** — Cross-project ROS 1 / ROS 2 integration test matrix.
 
 ---
 
 ## Contributing
 
 See [../CONTRIBUTING.md](../CONTRIBUTING.md) for development standards, PR process, and code style guidelines.
+
+See [../CLAUDE.md](../CLAUDE.md) for Claude Code onboarding notes.

--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -1,0 +1,114 @@
+# ROSClaw Safety Model
+
+ROSClaw is research infrastructure for Physical AI. It adds validation, memory, and governance between AI agents and physical robots, but it does **not** replace certified industrial safety systems.
+
+---
+
+## Core Rule
+
+> **No model output should directly control a robot.**
+
+Every physical action must be:
+
+1. Proposed in a structured, inspectable form.
+2. Validated against the effective body model and safety policy.
+3. Either allowed, modified, blocked, or escalated to a human.
+4. Recorded for audit and learning.
+
+---
+
+## Safety Pipeline
+
+```
+Agent Intent
+    ↓
+Provider produces structured action proposal
+    ↓
+Sandbox / Firewall validation
+    ↓
+Decision: ALLOW / MODIFY / BLOCK / REQUIRE_HUMAN_CONFIRMATION
+    ↓
+Runtime execution (if allowed)
+    ↓
+Practice captures execution trace
+    ↓
+Memory and Know retain evidence
+    ↓
+How / Auto may propose improvements
+    ↓
+Promotion gate decides whether to update active skills
+```
+
+---
+
+## Sandbox Decisions
+
+The Sandbox evaluates every action against:
+
+- The effective body model (joint limits, torque limits, collision geometry).
+- The active safety level (`strict`, `moderate`, or `relaxed`).
+- The declared skill manifest and capability requirements.
+- Historical failure patterns from Memory.
+
+Possible decisions:
+
+| Decision | Meaning |
+|----------|---------|
+| `ALLOW` | Proceed as proposed. |
+| `MODIFY` | Proceed with a bounded correction (e.g., clamped velocity). |
+| `BLOCK` | Refuse execution and log the reason. |
+| `REQUIRE_HUMAN_CONFIRMATION` | Pause and wait for operator approval. |
+
+---
+
+## Human Approval Gates
+
+The following actions require explicit human confirmation by default:
+
+- Switching from simulation to a real-robot body for the first time.
+- Running an unverified skill on hardware.
+- Applying a skill patch promoted by Auto before Darwin evaluation.
+- Disabling the sandbox or lowering the safety level.
+- Executing an emergency-stop override.
+
+---
+
+## What ROSClaw Does Not Guarantee
+
+- ROSClaw cannot prove that a physical action is safe in all possible worlds.
+- ROSClaw does not replace functional safety hardware (e.g., physical e-stops, light curtains, force limits).
+- ROSClaw does not certify robots or skills for regulatory compliance.
+- ROSClaw cannot prevent misuse if the operator disables gates or feeds malicious configuration.
+
+---
+
+## Recommended Deployment Practice
+
+1. **Always start in simulation.** Use `rosclaw sandbox run` before any hardware command.
+2. **Keep emergency stops engaged.** Human supervision is required for real-robot operation.
+3. **Use `strict` safety level for new bodies.** Relax only after extensive validation.
+4. **Run `rosclaw doctor --full` before each session.** Verify workspace, config, and body model.
+5. **Review the effective body model.** Run `rosclaw body inspect` and confirm limits.
+6. **Test skills in sandbox first.** Use `rosclaw skill check` before hardware dispatch.
+7. **Inspect practice records.** Review episodes with `rosclaw practice show` and `rosclaw practice replay`.
+8. **Audit promoted skills.** Never promote an Auto patch before Darwin evaluation.
+9. **Disable cloud features by default.** Use `--profile offline` unless cloud sync is required.
+10. **Report security issues privately.** Email [ai@rosclaw.io](mailto:ai@rosclaw.io).
+
+---
+
+## Fail-Closed Defaults
+
+- If the effective body model is missing or invalid, skill execution is blocked.
+- If the Sandbox cannot reach a decision, it defaults to `BLOCK`.
+- If the Skill Registry cannot verify a skill manifest, execution is blocked.
+- If the active body changes without confirmation, real-robot execution is paused.
+
+---
+
+## See Also
+
+- [QUICKSTART.md](../QUICKSTART.md) — Quick start.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — Architecture and module boundaries.
+- [docs/CLI.md](CLI.md) — CLI command reference.
+- [docs/FIRSTBOOT.md](FIRSTBOOT.md) — First boot safety defaults.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "hatchling.build"
 [project]
 name = "rosclaw"
 version = "1.0.1"
-description = "The Universal Operating System for Software-Defined Embodied AI"
+description = "Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
-    {name = "ROSClaw Team", email = "team@rosclaw.io"},
+    {name = "ROSClaw Team", email = "ai@rosclaw.io"},
 ]
-keywords = ["robotics", "ros2", "mcp", "llm", "embodied-ai", "mujoco"]
+keywords = ["robotics", "ros2", "mcp", "llm", "embodied-ai", "physical-ai", "mujoco", "runtime", "eurdf"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -80,6 +80,7 @@ Homepage = "https://rosclaw.io"
 Repository = "https://github.com/ros-claw/rosclaw"
 Documentation = "https://docs.rosclaw.io"
 "Bug Tracker" = "https://github.com/ros-claw/rosclaw/issues"
+"Contact" = "mailto:ai@rosclaw.io"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rosclaw"]

--- a/src/rosclaw/__init__.py
+++ b/src/rosclaw/__init__.py
@@ -1,7 +1,9 @@
 """
-ROSClaw - The Universal Operating System for Software-Defined Embodied AI.
+ROSClaw - Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents.
 
-This package provides production-ready middleware for connecting LLMs to physical robots.
+This package provides an open runtime infrastructure layer for connecting AI agents
+to physical robots through embodiment grounding, sandbox safety, capability routing,
+praxis capture, physical memory, runtime intervention, and skill evolution.
 
 Architecture:
     Agent Runtime (LLM/MCP)

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -2865,7 +2865,7 @@ def cmd_restart(args: argparse.Namespace) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="rosclaw",
-        description="ROSClaw - Universal OS for Software-Defined Embodied AI",
+        description="ROSClaw - Self-Evolving Runtime Infrastructure for Physical AI & Embodied Agents",
     )
     parser.add_argument(
         "--version",


### PR DESCRIPTION
Re-applies the GitHub homepage optimization on top of the latest main after the original PR (#23) became unmergeable.

### Changes
- README.md / README.zh.md: new positioning, removed outdated slogans, unified install path
- QUICKSTART.md: four-path structure (simulation, agent integration, body setup, developer setup)
- INSTALL.md / ARCHITECTURE.md: updated positioning and links
- docs/CLI.md: command reference with Stable/Experimental/Planned/Research labels
- docs/SAFETY.md: safety model and deployment checklist
- docs/ASSETS.md: Physical-AI Asset Hub definition and lifecycle
- docs/README.md: updated index with new guides
- pyproject.toml, src/rosclaw/__init__.py, src/rosclaw/cli.py: description/keyword/contact alignment

### Verification
- Banned phrase scan: clean
- Internal markdown links: all resolve
- README line count: 444 lines
- CLI status labels: hub install/list/uninstall marked Stable (implemented on main)
