### PR TITLE
docs: fix broken links and inaccurate CLI status labels from review

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -49,7 +49,7 @@ Connect ROSClaw to Claude Code or any MCP-compatible agent.
 rosclaw agent init claude-code
 
 # 2. Review the generated config
-rosclaw agent doctor
+rosclaw agent doctor claude-code
 
 # 3. Start the MCP server manually (optional)
 rosclaw mcp serve --transport stdio
@@ -57,7 +57,7 @@ rosclaw mcp serve --transport stdio
 
 The MCP config is written to `~/.rosclaw/config/mcp.json`. Point your agent at this file to expose read-only / simulation / emergency tools.
 
-Expected: `rosclaw agent doctor` reports the config path and tool count.
+Expected: `rosclaw agent doctor claude-code` reports the config path and tool count.
 
 Common failures:
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ PYTHONPATH=src pytest tests -q
 | Route capability | `rosclaw provider route --capability <name>` | Planned |
 | Start practice | `rosclaw practice start --sources <sources>` | Planned |
 | Advise on failure | `rosclaw how advise --task <id> --failure <id>` | Planned |
-| Run auto suite | `rosclaw auto run --suite <suite>` | Planned |
+| Run auto evolution | `rosclaw auto run --task <id>` | Experimental |
 | Evaluate with Darwin | `rosclaw darwin eval --skill <id>` | Research |
 
 See [docs/CLI.md](docs/CLI.md) for the full command reference with status labels.

--- a/README.zh.md
+++ b/README.zh.md
@@ -165,7 +165,7 @@ PYTHONPATH=src pytest tests -q
 | 路由能力 | `rosclaw provider route --capability <name>` | Planned |
 | 开始 Practice | `rosclaw practice start --sources <sources>` | Planned |
 | 故障建议 | `rosclaw how advise --task <id> --failure <id>` | Planned |
-| 运行 Auto 套件 | `rosclaw auto run --suite <suite>` | Planned |
+| 运行 Auto 进化 | `rosclaw auto run --task <id>` | Experimental |
 | Darwin 评测 | `rosclaw darwin eval --skill <id>` | Research |
 
 完整命令参考见 [docs/CLI.md](docs/CLI.md)。

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -56,10 +56,10 @@ This document lists ROSClaw CLI commands and their implementation status.
 |---------|--------|-------------|
 | `rosclaw agent init claude-code` | Stable | Generate MCP config for Claude Code |
 | `rosclaw agent test claude-code` | Stable | Test the agent integration |
-| `rosclaw agent doctor` | Stable | Validate agent/MCP setup |
+| `rosclaw agent doctor claude-code` | Stable | Validate agent/MCP setup |
 | `rosclaw mcp serve` | Stable | Start the ROSClaw MCP server |
 | `rosclaw mcp serve --transport http --port 9000` | Stable | HTTP transport |
-| `rosclaw mcp onboard` | Stable | Hardware MCP onboarding flow |
+| `rosclaw mcp install <package>` | Stable | Install a hardware MCP server |
 
 ---
 
@@ -73,8 +73,8 @@ This document lists ROSClaw CLI commands and their implementation status.
 | `rosclaw body switch <id>` | Stable | Change active body |
 | `rosclaw body link-eurdf --body <id> --eurdf <path>` | Stable | Link an e-URDF model |
 | `rosclaw body history` | Stable | Show body snapshot history |
-| `rosclaw skill check --task <id>` | Stable | Check skill compatibility |
-| `rosclaw skill fleet-check --task <id>` | Stable | Fleet-wide compatibility |
+| `rosclaw skill check --task <id>` | Stable | Check skill compatibility for the current body |
+| `rosclaw body fleet-compat --task <id>` | Stable | Fleet-wide skill compatibility |
 
 ---
 
@@ -86,13 +86,13 @@ This document lists ROSClaw CLI commands and their implementation status.
 | `rosclaw hub login --registry <url> --token <token>` | Stable | Log in to a registry |
 | `rosclaw hub sync` | Stable | Sync registry metadata |
 | `rosclaw hub search <term>` | Stable | Search available assets |
-| `rosclaw hub info <uri>` | Stable | Show asset details |
+| `rosclaw hub verify <uri>` | Stable | Verify an asset bundle |
 | `rosclaw hub publish --dry-run` | Stable | Validate before publishing |
-| `rosclaw hub policy` | Stable | Show license/permission policy |
+| `rosclaw hub policy check <asset_dir>` | Stable | Check license/permission policy |
 | `rosclaw hub install <uri>` | Stable | Install an asset locally |
 | `rosclaw hub list --installed` | Stable | List installed assets |
 | `rosclaw hub uninstall <uri>` | Stable | Remove an installed asset |
-| `rosclaw hub update <uri>` | Stable | Update an installed asset from a local directory |
+| `rosclaw hub update <uri> <asset_dir>` | Stable | Update an installed asset from a local directory |
 
 ---
 


### PR DESCRIPTION
Post-merge review fixes for #24.

### Fixes
- `docs/README.md`: corrected `BODYSENSE_SCHEMA.md` link path
- `docs/CLI.md`: fixed command signatures and status labels
  - `rosclaw agent doctor` → `rosclaw agent doctor claude-code`
  - `rosclaw mcp onboard` → `rosclaw mcp install <package>`
  - removed non-existent `rosclaw hub info <uri>`
  - `rosclaw hub policy` → `rosclaw hub policy check <asset_dir>`
  - `rosclaw hub update <uri>` → `rosclaw hub update <uri> <asset_dir>`
  - `rosclaw skill fleet-check` → `rosclaw body fleet-compat --task <id>`
- `README.md` / `README.zh.md`: updated CLI Map auto run entry to `--task` Experimental
- `QUICKSTART.md`: fixed `rosclaw agent doctor` → `rosclaw agent doctor claude-code`