### PR TITLE
docs: use absolute workspace path for state/install.json references

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ See [QUICKSTART.md](QUICKSTART.md) for four guided paths: local simulation, agen
 3. Writes `rosclaw.yaml` with chosen profile.
 4. Generates `mcp.json` if MCP is enabled.
 5. Creates telemetry preferences (default disabled).
-6. Records install metadata in `state/install.json`.
+6. Records install metadata in `~/.rosclaw/state/install.json`.
 7. Runs `rosclaw doctor --bootstrap`.
 8. Prints next-step instructions.
 9. Leaves the system read-only and robot-safe until you opt in.

--- a/README.zh.md
+++ b/README.zh.md
@@ -121,7 +121,7 @@ rosclaw firstboot --yes --profile offline --no-telemetry
 3. 写入根据所选 profile 生成的 `rosclaw.yaml`。
 4. 如果启用 MCP，生成 `mcp.json`。
 5. 创建遥测偏好配置（默认关闭）。
-6. 在 `state/install.json` 记录安装元数据。
+6. 在 `~/.rosclaw/state/install.json` 记录安装元数据。
 7. 运行 `rosclaw doctor --bootstrap`。
 8. 打印下一步操作提示。
 9. 在明确选择加入之前，保持只读、不连接真实机器人。


### PR DESCRIPTION
Fixes `tests/test_docs_assets.py` regression introduced by the README rewrite in #24.

The test treats backtick references ending in `.json` as project-relative file paths. `state/install.json` is a runtime workspace file (`~/.rosclaw/state/install.json`), not a repo file, so this change uses the absolute home path to skip the existence check.