### PR TITLE
feat(dashboard): add firstboot page wizard and preview API

### DIFF
--- a/docs/help/rosclaw-firstboot-dashboard-help.md
+++ b/docs/help/rosclaw-firstboot-dashboard-help.md
@@ -1,0 +1,109 @@
+# ROSClaw Dashboard First Boot 页面开发求助清单
+
+> 生成时间：2026-06-22
+> 当前分支：`verify-main`（基于 `origin/main` 准备 rebase）
+> 上游 `origin/main` HEAD：`7e2dda4f`
+> 参考计划：`/home/ubuntu/.claude/plans/lazy-puzzling-dawn.md`
+
+---
+
+## 1. 本次完成的工作
+
+实现了 **Dashboard firstboot page**（First Boot Phase 3 子项），为本地 dashboard 提供可视化的首次配置向导。
+
+### 1.1 新增/修改文件
+
+| 文件 | 说明 |
+|------|------|
+| `src/rosclaw/dashboard/firstboot.py` | 新增：First Boot 状态读取、配置预览、CLI 命令生成、HTML 向导页面 |
+| `src/rosclaw/dashboard/server.py` | 修改：`DashboardServer.get_firstboot_state()` 委托给新 helper |
+| `src/rosclaw/dashboard/web_server.py` | 修改：新增 `/api/firstboot`、`/api/firstboot/preview`、`/firstboot` 路由 |
+| `tests/dashboard/test_firstboot_page.py` | 新增：API 与页面测试 |
+
+### 1.2 功能说明
+
+- `/firstboot`：单页 HTML 向导，展示当前 First Boot 状态、可交互选择 profile/robot/safety/模块、实时生成 `rosclaw firstboot --yes ...` 命令。
+- `/api/firstboot`：返回当前安装/工作区/配置状态，供页面刷新使用。
+- `/api/firstboot/preview`：接收用户选择，返回配置预览和可复制命令；**只生成命令，不在服务端执行 firstboot**，符合安全契约。
+
+### 1.3 验证结果
+
+| 检查项 | 结果 |
+|--------|------|
+| `ruff check .` | ✅ 通过 |
+| `PYTHONPATH=src python3 -m pytest tests/dashboard/test_firstboot_page.py tests/dashboard/test_body_page.py -v` | ✅ 10 passed |
+| `PYTHONPATH=src python3 -m pytest tests -q --tb=short` | ✅ 3123 passed, 5 skipped |
+| `python3 scripts/integration_test.py` | ✅ 通过 |
+| `ROSCLAW_DEV_SOURCE=1 bash scripts/acceptance_firstboot.sh` | ✅ 通过 |
+
+---
+
+## 2. 当前状态
+
+- `verify-main` 分支在本地保存了上述改动，但尚未 rebase 到最新的 `origin/main`。
+- `origin/main` 自上次验证以来新增了 3 个 docs 提交（`706058f0`、`6a7cd599`、`7e2dda4f`），与本次 dashboard 改动无冲突。
+- 下一步：**rebase 到 `origin/main` → 推送到 `feat/dashboard-firstboot-page` → 创建 PR**。
+
+---
+
+## 3. 已提交/已合并的 First Boot 相关 PR
+
+| PR | 状态 | 说明 |
+|----|------|------|
+| #13 Body docs + fail-closed executor + firstboot | ✅ 已合并 | Phase 1/2 核心 |
+| #17 MCP CLI tests / onboarding docs | ✅ 已合并 | 验证时 main HEAD |
+| #20 P0 agent docs refresh | ✅ 已合并 | 文档 managed blocks |
+| #21? / #22? Phase 7 sense wiring | ✅ 已合并 | body-sense 别名、skill executor gating |
+
+本次新增改动尚未提交 PR。
+
+---
+
+## 4. Phase 3 剩余开发项（更新后）
+
+- [x] **Dashboard firstboot page** — 已实现，待 PR 合并。
+- [ ] **Homebrew tap**：需要单独仓库 `ros-claw/homebrew-tap`。
+- [ ] **签名 release artifacts**：需要 GPG/代码签名密钥决策。
+- [ ] **Offline wheel bundle**：可本地实现，建议作为下一个子项。
+- [ ] **Cloud login**：需要后端 API 规范与 OAuth client。
+
+---
+
+## 5. 需要的外部支持 / 资源
+
+| 需求 | 说明 |
+|------|------|
+| **PR 评审与合并** | 需要维护者 review `feat/dashboard-firstboot-page` PR。 |
+| **macOS / Windows (WSL) 测试环境** | 当前仅在 Linux 验证 dashboard 页面。 |
+| **Homebrew tap 仓库** | 需创建 `ros-claw/homebrew-tap`。 |
+| **代码签名 / GPG 密钥** | Phase 3 签名 release 需要持有者决策。 |
+| **Cloud login API 规范** | 若后续实现 cloud firstboot，需要后端接口。 |
+
+---
+
+## 6. 困惑 / 待确认的问题
+
+1. **help 文档是否随 PR 一起提交？**
+   本文件放在 `docs/help/` 下，用户此前要求“名字要包含你的工作关键词，放到 docs 目录下的help目录下”。是否应在 PR 中提交？还是仅作为本地辅助文件？
+
+2. **是否继续 Phase 3 的 offline wheel bundle？**
+   Dashboard 页面合入后，Phase 3 中“无需外部依赖”的子项只剩下 offline wheel bundle。是否立即开始？
+
+3. **过时分支如何清理？**
+   本地和远程存在大量已合并分支（`feat/body-docs-and-fail-closed`、`feat/body-p2-postmerge-verify`、`feat/p0-claude-code-agent-*` 等）。是否可以批量删除？
+
+4. **是否需要打 tag / release？**
+   First Boot P0 已完整合入 `main`，Dashboard 页面是 P1 增强。是否要在 Dashboard PR 合并后发布版本？
+
+---
+
+## 7. 下一步建议
+
+1. **rebase + push PR**：`git rebase origin/main`，切到 `feat/dashboard-firstboot-page`，`git push -u origin`，创建 PR。
+2. **等待 review 并修复反馈**。
+3. **Dashboard PR 合并后**：建议启动 offline wheel bundle，继续推进 Phase 3。
+4. **分支清理**：在 PR 合并后统一删除已合并分支。
+
+---
+
+*本清单为本地辅助文档，用于跟踪当前模块开发状态与待确认事项。*

--- a/docs/help/rosclaw-firstboot-dashboard-help.md
+++ b/docs/help/rosclaw-firstboot-dashboard-help.md
@@ -64,7 +64,7 @@
 - [x] **Dashboard firstboot page** — 已实现，待 PR 合并。
 - [ ] **Homebrew tap**：需要单独仓库 `ros-claw/homebrew-tap`。
 - [ ] **签名 release artifacts**：需要 GPG/代码签名密钥决策。
-- [ ] **Offline wheel bundle**：可本地实现，建议作为下一个子项。
+- [ ] ~~**Offline wheel bundle**~~ — **已决定不做**。
 - [ ] **Cloud login**：需要后端 API 规范与 OAuth client。
 
 ---
@@ -86,8 +86,12 @@
 1. **help 文档是否随 PR 一起提交？**
    本文件放在 `docs/help/` 下，用户此前要求“名字要包含你的工作关键词，放到 docs 目录下的help目录下”。是否应在 PR 中提交？还是仅作为本地辅助文件？
 
-2. **是否继续 Phase 3 的 offline wheel bundle？**
-   Dashboard 页面合入后，Phase 3 中“无需外部依赖”的子项只剩下 offline wheel bundle。是否立即开始？
+2. **是否继续 Phase 3 的下一项？**
+   用户已明确 offline wheel bundle 不做。Phase 3 剩余项均需要外部资源：
+   - Homebrew tap（需要仓库）
+   - 签名 release artifacts（需要密钥）
+   - Cloud login（需要 API 规范）
+   请确认优先启动哪一项，或等资源到位后再继续。
 
 3. **过时分支如何清理？**
    本地和远程存在大量已合并分支（`feat/body-docs-and-fail-closed`、`feat/body-p2-postmerge-verify`、`feat/p0-claude-code-agent-*` 等）。是否可以批量删除？
@@ -101,7 +105,7 @@
 
 1. **rebase + push PR**：`git rebase origin/main`，切到 `feat/dashboard-firstboot-page`，`git push -u origin`，创建 PR。
 2. **等待 review 并修复反馈**。
-3. **Dashboard PR 合并后**：建议启动 offline wheel bundle，继续推进 Phase 3。
+3. **Dashboard PR 合并后**：Phase 3 剩余项均依赖外部资源，建议先确认优先级与可用资源，再启动下一项。
 4. **分支清理**：在 PR 合并后统一删除已合并分支。
 
 ---

--- a/src/rosclaw/dashboard/firstboot.py
+++ b/src/rosclaw/dashboard/firstboot.py
@@ -1,0 +1,280 @@
+"""Dashboard firstboot page helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from rosclaw.firstboot.workspace import is_workspace_initialized, load_install_state, resolve_home
+
+
+def get_firstboot_state(home: Path | str | None = None) -> dict[str, Any]:
+    """Return current First Boot state for the dashboard.
+
+    Reads install metadata and configuration file presence from the workspace.
+    """
+    home_path = Path(home) if home else resolve_home()
+    state: dict[str, Any] = {
+        "home": str(home_path),
+        "workspace_exists": False,
+        "initialized": False,
+        "install_state": None,
+        "rosclaw_yaml_exists": False,
+        "mcp_json_exists": False,
+        "telemetry_yaml_exists": False,
+        "steps": {},
+    }
+
+    try:
+        state["workspace_exists"] = home_path.exists()
+        state["initialized"] = is_workspace_initialized(home_path)
+        state["install_state"] = load_install_state(home_path)
+        state["rosclaw_yaml_exists"] = (home_path / "config" / "rosclaw.yaml").exists()
+        state["mcp_json_exists"] = (home_path / "config" / "mcp.json").exists()
+        state["telemetry_yaml_exists"] = (home_path / "config" / "telemetry.yaml").exists()
+    except Exception as exc:  # noqa: BLE001
+        state["error"] = str(exc)
+
+    install = state["install_state"] or {}
+    state["steps"] = {
+        "bootstrap": bool(install.get("installed_at")),
+        "workspace": state["initialized"],
+        "config": state["rosclaw_yaml_exists"],
+        "mcp": state["mcp_json_exists"],
+        "telemetry": state["telemetry_yaml_exists"],
+        "firstboot": bool(install.get("firstboot_completed")),
+        "doctor": install.get("last_doctor_status") == "ready",
+    }
+
+    return state
+
+
+def build_firstboot_command(choices: dict[str, Any]) -> str:
+    """Build the equivalent non-interactive `rosclaw firstboot` CLI command."""
+    cmd = ["rosclaw", "firstboot", "--yes"]
+
+    profile = choices.get("profile", "offline")
+    cmd.extend(["--profile", profile])
+
+    robot = choices.get("robot", "sim_ur5e")
+    cmd.extend(["--robot", robot])
+
+    safety = choices.get("safety", "strict")
+    cmd.extend(["--safety", safety])
+
+    if choices.get("telemetry", False):
+        cmd.append("--telemetry")
+    else:
+        cmd.append("--no-telemetry")
+
+    if choices.get("mcp", True):
+        cmd.append("--enable-mcp")
+    else:
+        cmd.append("--disable-mcp")
+
+    if choices.get("sandbox", True):
+        cmd.append("--enable-sandbox")
+    else:
+        cmd.append("--disable-sandbox")
+
+    if choices.get("ros2", False):
+        cmd.append("--enable-ros2")
+    if choices.get("memory", False):
+        cmd.append("--enable-memory")
+    if choices.get("practice", False):
+        cmd.append("--enable-practice")
+    if choices.get("auto", False):
+        cmd.append("--enable-auto")
+
+    return " ".join(cmd)
+
+
+def preview_firstboot_config(choices: dict[str, Any]) -> dict[str, Any]:
+    """Return a human-readable preview of the configuration implied by choices."""
+    return {
+        "profile": choices.get("profile", "offline"),
+        "robot": choices.get("robot", "sim_ur5e"),
+        "safety": choices.get("safety", "strict"),
+        "telemetry": bool(choices.get("telemetry", False)),
+        "mcp": bool(choices.get("mcp", True)),
+        "sandbox": bool(choices.get("sandbox", True)),
+        "use_cases": {
+            "ros2": bool(choices.get("ros2", False)),
+            "memory": bool(choices.get("memory", False)),
+            "practice": bool(choices.get("practice", False)),
+            "auto": bool(choices.get("auto", False)),
+        },
+    }
+
+
+FIRSTBOOT_PAGE_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ROSClaw First Boot</title>
+  <style>
+    :root { --bg: #0f172a; --card: #1e293b; --text: #e2e8f0; --muted: #94a3b8; --accent: #38bdf8; --ok: #22c55e; --warn: #f59e0b; --danger: #ef4444; }
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 0; padding: 2rem; background: var(--bg); color: var(--text); line-height: 1.5; }
+    h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+    h2 { font-size: 1.25rem; margin-top: 0; }
+    .subtitle { color: var(--muted); margin-bottom: 1.5rem; }
+    .card { background: var(--card); border-radius: 0.5rem; padding: 1.25rem; margin: 1rem 0; }
+    .muted { color: var(--muted); }
+    .status { font-weight: bold; }
+    .status.ok { color: var(--ok); }
+    .status.pending { color: var(--warn); }
+    .status.error { color: var(--danger); }
+    ul.steps { list-style: none; padding: 0; }
+    ul.steps li { display: flex; justify-content: space-between; padding: 0.4rem 0; border-bottom: 1px solid #334155; }
+    ul.steps li:last-child { border-bottom: none; }
+    label { display: block; margin: 0.75rem 0 0.25rem; color: var(--muted); }
+    select, input[type="text"] { width: 100%; padding: 0.5rem; border-radius: 0.25rem; border: 1px solid #475569; background: #0f172a; color: var(--text); box-sizing: border-box; }
+    .checks { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.5rem; margin-top: 0.5rem; }
+    .checks label { display: flex; align-items: center; gap: 0.5rem; margin: 0; color: var(--text); cursor: pointer; }
+    .checks input { accent-color: var(--accent); }
+    code { display: block; background: #0f172a; padding: 0.75rem; border-radius: 0.25rem; overflow-x: auto; white-space: pre-wrap; word-break: break-all; }
+    .actions { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1rem; }
+    button { background: var(--accent); color: #0f172a; border: none; padding: 0.5rem 1rem; border-radius: 0.25rem; cursor: pointer; font-weight: bold; }
+    button:hover { opacity: 0.9; }
+    button.secondary { background: #334155; color: var(--text); }
+    .notice { border-left: 4px solid var(--accent); padding-left: 0.75rem; color: var(--muted); }
+  </style>
+</head>
+<body>
+  <h1>ROSClaw First Boot</h1>
+  <div class="subtitle">Visual setup wizard — no robot will be moved.</div>
+
+  <div class="card">
+    <h2>Current Status</h2>
+    <div id="status">Loading...</div>
+    <ul class="steps" id="steps"></ul>
+    <div class="actions">
+      <button onclick="refreshStatus()">Refresh Status</button>
+      <button class="secondary" onclick="window.open('/body', '_blank')">Body Dashboard</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Configure</h2>
+    <form id="firstboot-form">
+      <label for="profile">Operating profile</label>
+      <select id="profile" name="profile">
+        <option value="offline" selected>Offline (default, no cloud)</option>
+        <option value="hybrid">Hybrid</option>
+        <option value="cloud">Cloud</option>
+      </select>
+
+      <label for="robot">Default robot</label>
+      <select id="robot" name="robot">
+        <option value="sim_ur5e" selected>sim_ur5e</option>
+        <option value="turtlebot">turtlebot</option>
+        <option value="unitree_go2">unitree_go2</option>
+        <option value="unitree_g1">unitree_g1</option>
+      </select>
+
+      <label for="safety">Safety level</label>
+      <select id="safety" name="safety">
+        <option value="strict" selected>strict</option>
+        <option value="moderate">moderate</option>
+        <option value="relaxed">relaxed</option>
+      </select>
+
+      <label>Modules</label>
+      <div class="checks">
+        <label><input type="checkbox" id="sandbox" name="sandbox" checked> Sandbox</label>
+        <label><input type="checkbox" id="mcp" name="mcp" checked> MCP / Claude Code</label>
+        <label><input type="checkbox" id="ros2" name="ros2"> ROS 2</label>
+        <label><input type="checkbox" id="memory" name="memory"> Memory</label>
+        <label><input type="checkbox" id="practice" name="practice"> Practice</label>
+        <label><input type="checkbox" id="auto" name="auto"> Auto evolution</label>
+        <label><input type="checkbox" id="telemetry" name="telemetry"> Anonymous telemetry</label>
+      </div>
+    </form>
+  </div>
+
+  <div class="card">
+    <h2>Run in Terminal</h2>
+    <p class="muted">Copy this command and run it in your terminal to apply the configuration.</p>
+    <code id="command">rosclaw firstboot --yes --profile offline --robot sim_ur5e --safety strict --no-telemetry --enable-mcp --enable-sandbox</code>
+    <div class="actions">
+      <button onclick="copyCommand()">Copy Command</button>
+    </div>
+    <p class="notice" style="margin-top: 1rem;">
+      The dashboard wizard is read-only for safety. After running the command, click <strong>Refresh Status</strong> to see the updated state.
+    </p>
+  </div>
+
+  <script>
+    function statusClass(done) {
+      return done ? 'ok' : 'pending';
+    }
+
+    async function refreshStatus() {
+      try {
+        const res = await fetch('/api/firstboot');
+        const data = await res.json();
+        const install = data.install_state || {};
+        const completed = install.firstboot_completed;
+        document.getElementById('status').innerHTML =
+          `<div>Workspace: <strong>${data.home}</strong></div>` +
+          `<div>Initialized: <span class="status ${statusClass(data.initialized)}">${data.initialized ? 'yes' : 'no'}</span></div>` +
+          `<div>Firstboot completed: <span class="status ${statusClass(completed)}">${completed ? 'yes' : 'no'}</span></div>` +
+          `<div class="muted">Install version: ${install.installer_version || 'unknown'} · Channel: ${install.install_channel || 'unknown'}</div>`;
+
+        const steps = data.steps || {};
+        const list = document.getElementById('steps');
+        list.innerHTML = Object.entries(steps).map(([key, done]) =>
+          `<li><span>${key}</span><span class="status ${statusClass(done)}">${done ? 'done' : 'pending'}</span></li>`
+        ).join('');
+      } catch (err) {
+        document.getElementById('status').innerHTML = `<span class="status error">Error: ${err.message}</span>`;
+      }
+    }
+
+    async function updatePreview() {
+      const choices = {
+        profile: document.getElementById('profile').value,
+        robot: document.getElementById('robot').value,
+        safety: document.getElementById('safety').value,
+        sandbox: document.getElementById('sandbox').checked,
+        mcp: document.getElementById('mcp').checked,
+        ros2: document.getElementById('ros2').checked,
+        memory: document.getElementById('memory').checked,
+        practice: document.getElementById('practice').checked,
+        auto: document.getElementById('auto').checked,
+        telemetry: document.getElementById('telemetry').checked,
+      };
+      try {
+        const res = await fetch('/api/firstboot/preview', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(choices),
+        });
+        const data = await res.json();
+        document.getElementById('command').textContent = data.command || '';
+      } catch (err) {
+        document.getElementById('command').textContent = `Error generating preview: ${err.message}`;
+      }
+    }
+
+    async function copyCommand() {
+      const text = document.getElementById('command').textContent;
+      try {
+        await navigator.clipboard.writeText(text);
+        const btn = document.querySelector('button[onclick="copyCommand()"]');
+        const old = btn.textContent;
+        btn.textContent = 'Copied!';
+        setTimeout(() => btn.textContent = old, 1500);
+      } catch (err) {
+        alert('Copy failed: ' + err.message);
+      }
+    }
+
+    document.getElementById('firstboot-form').addEventListener('change', updatePreview);
+    refreshStatus();
+    updatePreview();
+  </script>
+</body>
+</html>
+"""

--- a/src/rosclaw/dashboard/server.py
+++ b/src/rosclaw/dashboard/server.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from rosclaw.core.event_topics import EventTopics
 
+from .firstboot import get_firstboot_state
 from .metrics import DashboardMetrics
 
 
@@ -200,6 +201,11 @@ class DashboardServer:
             "current_body": current_body,
             "compatibility": compatibility,
         }
+
+    def get_firstboot_state(self, workspace: Path | str | None = None) -> dict[str, Any]:
+        """Return First Boot state for the dashboard wizard."""
+        ws = Path(workspace) if workspace else None
+        return get_firstboot_state(ws)
 
 
     # ── Auto Evolution API ──

--- a/src/rosclaw/dashboard/web_server.py
+++ b/src/rosclaw/dashboard/web_server.py
@@ -6,8 +6,9 @@ import asyncio
 import json
 from typing import Any
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 
+from .firstboot import FIRSTBOOT_PAGE_HTML, build_firstboot_command, preview_firstboot_config
 from .metrics import DashboardMetrics
 from .server import DashboardServer
 
@@ -136,6 +137,28 @@ class DashboardWebServer:
         async def body_page() -> Any:
             from fastapi.responses import HTMLResponse
             return HTMLResponse(_BODY_PAGE_HTML)
+
+        @self.app.get("/api/firstboot")
+        async def api_firstboot() -> dict[str, Any]:
+            return self.server.get_firstboot_state()
+
+        @self.app.post("/api/firstboot/preview")
+        async def firstboot_preview(request: Request) -> dict[str, Any]:
+            try:
+                choices = await request.json()
+                if not isinstance(choices, dict):
+                    raise HTTPException(status_code=400, detail="Expected JSON object")
+            except json.JSONDecodeError as exc:
+                raise HTTPException(status_code=400, detail=f"Invalid JSON: {exc}") from exc
+            return {
+                "preview": preview_firstboot_config(choices),
+                "command": build_firstboot_command(choices),
+            }
+
+        @self.app.get("/firstboot")
+        async def firstboot_page() -> Any:
+            from fastapi.responses import HTMLResponse
+            return HTMLResponse(FIRSTBOOT_PAGE_HTML)
 
         @self.app.get("/events/counts")
         async def event_counts() -> dict[str, int]:

--- a/tests/dashboard/test_firstboot_page.py
+++ b/tests/dashboard/test_firstboot_page.py
@@ -1,0 +1,110 @@
+"""Tests for dashboard firstboot page and API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rosclaw.dashboard.web_server import DashboardWebServer
+
+
+@pytest.fixture(autouse=True)
+def isolated_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+@pytest.fixture
+def client() -> TestClient:
+    server = DashboardWebServer()
+    return TestClient(server.app)
+
+
+def test_api_firstboot_returns_state(client: TestClient) -> None:
+    response = client.get("/api/firstboot")
+    assert response.status_code == 200
+    data = response.json()
+    assert "home" in data
+    assert data["initialized"] is False
+    assert data["install_state"] is None
+    assert "steps" in data
+    assert data["steps"]["bootstrap"] is False
+
+
+def test_firstboot_page_returns_html(client: TestClient) -> None:
+    response = client.get("/firstboot")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    text = response.text
+    assert "ROSClaw First Boot" in text
+    assert "rosclaw firstboot" in text
+
+
+def test_firstboot_preview_default_command(client: TestClient) -> None:
+    response = client.post("/api/firstboot/preview", json={})
+    assert response.status_code == 200
+    data = response.json()
+    command = data["command"]
+    assert command.startswith("rosclaw firstboot --yes")
+    assert "--profile offline" in command
+    assert "--robot sim_ur5e" in command
+    assert "--safety strict" in command
+    assert "--no-telemetry" in command
+    assert "--enable-mcp" in command
+    assert "--enable-sandbox" in command
+
+    preview = data["preview"]
+    assert preview["profile"] == "offline"
+    assert preview["robot"] == "sim_ur5e"
+    assert preview["telemetry"] is False
+
+
+def test_firstboot_preview_custom_command(client: TestClient) -> None:
+    choices = {
+        "profile": "cloud",
+        "robot": "unitree_g1",
+        "safety": "moderate",
+        "telemetry": True,
+        "mcp": False,
+        "sandbox": False,
+        "ros2": True,
+        "memory": True,
+    }
+    response = client.post("/api/firstboot/preview", json=choices)
+    assert response.status_code == 200
+    data = response.json()
+    command = data["command"]
+    assert "--profile cloud" in command
+    assert "--robot unitree_g1" in command
+    assert "--safety moderate" in command
+    assert "--telemetry" in command
+    assert "--disable-mcp" in command
+    assert "--disable-sandbox" in command
+    assert "--enable-ros2" in command
+    assert "--enable-memory" in command
+    assert "--no-telemetry" not in command
+
+    preview = data["preview"]
+    assert preview["telemetry"] is True
+    assert preview["mcp"] is False
+    assert preview["use_cases"]["ros2"] is True
+
+
+def test_firstboot_preview_rejects_non_object(client: TestClient) -> None:
+    response = client.post("/api/firstboot/preview", content=b"\"not-an-object\"")
+    assert response.status_code == 400
+
+
+def test_api_firstboot_with_initialized_workspace(client: TestClient) -> None:
+    from rosclaw.firstboot.workspace import ensure_minimal_workspace
+
+    home = Path.home() / ".rosclaw"
+    ensure_minimal_workspace(home)
+
+    response = client.get("/api/firstboot")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["initialized"] is True
+    assert data["workspace_exists"] is True
+    assert data["steps"]["bootstrap"] is True


### PR DESCRIPTION
## Summary

Implements the **Dashboard firstboot page** from First Boot Phase 3.

- Adds `src/rosclaw/dashboard/firstboot.py` with helpers to read First Boot state, preview configuration, and build a safe copy-pasteable `rosclaw firstboot --yes ...` command.
- Wires new routes into the dashboard web server:
  - `GET /api/firstboot` — current install/workspace/config state
  - `POST /api/firstboot/preview` — configuration preview + CLI command
  - `GET /firstboot` — visual setup wizard HTML page
- The wizard is read-only for safety: it generates the CLI command but never executes firstboot server-side.
- Adds `tests/dashboard/test_firstboot_page.py` covering default/custom choices, invalid input, and initialized workspace.

## Verification

- `ruff check .` ✅
- Focused dashboard tests: 10 passed ✅
- Full test suite: 3123 passed, 5 skipped ✅
- `python3 scripts/integration_test.py` ✅
- `ROSCLAW_DEV_SOURCE=1 bash scripts/acceptance_firstboot.sh` ✅

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)