### PR TITLE
docs(readme): center hero install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 
 <br/>
 
-```bash
-curl -sSL https://rosclaw.io/get | bash
-rosclaw firstboot
-```
+<p align="center">
+  <code>curl -sSL https://rosclaw.io/get | bash</code><br/>
+  <code>rosclaw firstboot</code>
+</p>
 
 </div>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,10 +17,10 @@
 
 <br/>
 
-```bash
-curl -sSL https://rosclaw.io/get | bash
-rosclaw firstboot
-```
+<p align="center">
+  <code>curl -sSL https://rosclaw.io/get | bash</code><br/>
+  <code>rosclaw firstboot</code>
+</p>
 
 </div>
 


### PR DESCRIPTION
Centers the `curl` and `rosclaw firstboot` commands in the README hero section so they align with the centered title, badges, and navigation links.

Replaces the markdown code block (which renders left-aligned as a block element) with centered inline `<code>` spans.