### PR TITLE
docs(readme): restore fenced code block for install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,12 @@
 
 [Website](https://rosclaw.io) · [Quick Start](QUICKSTART.md) · [Architecture](ARCHITECTURE.md) · [Docs](docs/) · [Contact](mailto:ai@rosclaw.io)
 
-<br/>
-
-<p align="center">
-  <code>curl -sSL https://rosclaw.io/get | bash</code><br/>
-  <code>rosclaw firstboot</code>
-</p>
-
 </div>
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot
+```
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,14 +15,12 @@
 
 [English](README.md) • **中文** • [架构](ARCHITECTURE.md) • [快速开始](QUICKSTART.md) • [文档](docs/)
 
-<br/>
-
-<p align="center">
-  <code>curl -sSL https://rosclaw.io/get | bash</code><br/>
-  <code>rosclaw firstboot</code>
-</p>
-
 </div>
+
+```bash
+curl -sSL https://rosclaw.io/get | bash
+rosclaw firstboot
+```
 
 ---
 


### PR DESCRIPTION
Restores the standard fenced code block for the hero install commands so GitHub shows the copy button.

The previous inline-code approach centered the commands but lost the copy button and looked worse. This change places the code block just below the centered hero div.