### PR TITLE
feat(practice): Physical Data Flywheel P0 skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "rosclaw-know>=1.0.2",
     "rosclaw-how>=1.0.2",
     "pydantic>=2.0.0",
+    "requests>=2.25.0",
     "semver>=3.0.0",
     "filelock>=3.0.0",
 ]

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -1267,7 +1267,7 @@ def cmd_practice_init(args: argparse.Namespace) -> int:
     (config_root / "robots" / robot_id).mkdir(parents=True, exist_ok=True)
 
     config_path = config_root / "config.yaml"
-    content = f"""# rosclaw-practice global configuration
+    content = """# rosclaw-practice global configuration
 data_root: /data/rosclaw/practice
 seekdb:
   enabled: false

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -25,6 +25,7 @@ import argparse
 import contextlib
 import json
 import os
+import shutil
 import sys
 import time
 from pathlib import Path
@@ -43,6 +44,11 @@ from rosclaw.firstboot.workspace import resolve_home
 from rosclaw.hub.cli import add_hub_subparser, dispatch_hub_command
 from rosclaw.mcp.onboarding.cli import add_mcp_subparser
 from rosclaw.mcp.server import serve as _mcp_serve
+from rosclaw.practice.config import PracticeConfig, SourceConfig
+from rosclaw.practice.coordinator import PracticeCoordinator
+from rosclaw.practice.storage.catalog import PracticeCatalog
+from rosclaw.practice.storage.fallback_sync import FallbackSync
+from rosclaw.practice.storage.layout import PracticeLayout
 from rosclaw.sense.cli import (
     cmd_sense_events,
     cmd_sense_explain,
@@ -1182,7 +1188,29 @@ def cmd_practice_replay(args: argparse.Namespace) -> int:
 
 
 def cmd_practice_export(args: argparse.Namespace) -> int:
-    """Export episode metadata."""
+    """Export episode metadata or practice events JSONL."""
+    if args.format == "jsonl":
+        practice_id = args.practice_id or args.episode_id
+        layout = PracticeLayout(args.data_root)
+        jsonl_path = layout.events_jsonl_path(practice_id)
+        if not jsonl_path.exists():
+            # Fall back to catalog lookup
+            catalog = PracticeCatalog(layout.catalog_db_path)
+            record = catalog.get_practice(practice_id)
+            if record and record.get("events_jsonl_path"):
+                jsonl_path = Path(record["events_jsonl_path"])
+        if not jsonl_path.exists():
+            print(f"[ROSClaw] Practice '{practice_id}' events not found.", file=sys.stderr)
+            return 1
+        out_path = args.output
+        if out_path:
+            shutil.copyfile(jsonl_path, out_path)
+            print(f"[ROSClaw] Exported JSONL to {out_path}")
+        else:
+            with open(jsonl_path, encoding="utf-8") as f:
+                sys.stdout.write(f.read())
+        return 0
+
     from rosclaw.practice.episode_recorder import EpisodeRecorder
 
     recorder = EpisodeRecorder("cli", event_bus=None, artifact_base_dir=str(_practice_artifacts_dir()))
@@ -1201,9 +1229,211 @@ def cmd_practice_export(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_duration(value: str | None) -> float | None:
+    """Parse a human-readable duration into seconds."""
+    if value is None:
+        return None
+    value = value.strip()
+    if value.endswith("ms"):
+        seconds = float(value[:-2]) / 1000.0
+    elif value.endswith("s"):
+        seconds = float(value[:-1])
+    elif value.endswith("m"):
+        seconds = float(value[:-1]) * 60.0
+    elif value.endswith("h"):
+        seconds = float(value[:-1]) * 3600.0
+    else:
+        seconds = float(value)
+    if seconds <= 0:
+        raise ValueError(f"duration must be positive, got {value}")
+    return seconds
+
+
+def _parse_sources(value: str | None) -> SourceConfig:
+    sources = SourceConfig()
+    if not value:
+        return sources
+    for name in [p.strip() for p in value.split(",") if p.strip()]:
+        if hasattr(sources, name):
+            setattr(sources, name, True)
+    return sources
+
+
+def cmd_practice_init(args: argparse.Namespace) -> int:
+    """Initialize rosclaw-practice configuration for a robot."""
+    config_root = Path.home() / ".rosclaw" / "practice"
+    robot_id = args.robot
+    config_root.mkdir(parents=True, exist_ok=True)
+    (config_root / "robots" / robot_id).mkdir(parents=True, exist_ok=True)
+
+    config_path = config_root / "config.yaml"
+    content = f"""# rosclaw-practice global configuration
+data_root: /data/rosclaw/practice
+seekdb:
+  enabled: false
+  url: ""
+  fallback_dir: /data/rosclaw/practice/fallback
+"""
+    config_path.write_text(content, encoding="utf-8")
+
+    robot_config = config_root / "robots" / robot_id / "robot.yaml"
+    robot_config.write_text(
+        f"robot_id: {robot_id}\nrobot_type: unknown\n",
+        encoding="utf-8",
+    )
+    print(f"[rosclaw-practice] Initialized for robot '{robot_id}'")
+    print(f"  config: {config_path}")
+    print(f"  robot:  {robot_config}")
+    return 0
+
+
+def cmd_practice_start(args: argparse.Namespace) -> int:
+    """Start a practice session using PracticeCoordinator."""
+    import signal
+
+    seekdb_enabled = args.seekdb
+    seekdb_url = os.environ.get("ROSCLAW_SEEKDB_URL", "http://localhost:2881")
+    fallback_dir = os.environ.get("ROSCLAW_SEEKDB_FALLBACK_DIR", "/data/rosclaw/practice/fallback")
+
+    try:
+        duration_sec = _parse_duration(args.duration)
+    except ValueError as exc:
+        print(f"[rosclaw-practice] Invalid duration: {exc}", file=sys.stderr)
+        return 1
+
+    config = PracticeConfig(
+        robot_id=args.robot,
+        robot_type=args.robot_type,
+        task_id=args.task,
+        task_name=args.task,
+        skill_id=args.skill,
+        data_root=args.data_root,
+        sources=_parse_sources(args.sources),
+        mock=args.mock,
+        duration_sec=duration_sec,
+        publish_to_event_bus=True,
+    )
+    config.seekdb.enabled = seekdb_enabled
+    config.seekdb.url = seekdb_url if seekdb_enabled else None
+    config.seekdb.fallback_dir = fallback_dir
+
+    coordinator = PracticeCoordinator(config)
+    coordinator.initialize()
+
+    recorder = None
+    if seekdb_enabled:
+        try:
+            from rosclaw.practice.episode_recorder import EpisodeRecorder
+            from rosclaw.practice.seekdb_bridge import SeekDBBridge
+
+            bridge = SeekDBBridge(seekdb_url=seekdb_url, fallback_dir=fallback_dir)
+            recorder = EpisodeRecorder(
+                robot_id=args.robot,
+                event_bus=coordinator.event_bus,
+                seekdb_bridge=bridge,
+            )
+            recorder.initialize()
+        except Exception as exc:
+            print(f"[rosclaw-practice] SeekDB recorder unavailable: {exc}", file=sys.stderr)
+
+    coordinator.start()
+
+    practice_id = coordinator.session.practice_id if coordinator.session else "unknown"
+    pid_file = Path.home() / ".rosclaw" / "practice" / "coordinator.pid"
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(f"{os.getpid()}\n{practice_id}\n", encoding="utf-8")
+
+    print(f"[rosclaw-practice] Started session {practice_id}")
+
+    stop_requested = False
+
+    def _handle_signal(signum, frame):
+        nonlocal stop_requested
+        stop_requested = True
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    try:
+        if config.duration_sec:
+            deadline = time.time() + config.duration_sec
+            while not stop_requested and time.time() < deadline:
+                time.sleep(0.1)
+        else:
+            while not stop_requested:
+                time.sleep(0.1)
+    finally:
+        coordinator.stop()
+        if recorder is not None:
+            recorder.stop()
+        if pid_file.exists():
+            pid_file.unlink()
+
+    summary = coordinator.summary
+    if summary:
+        print(f"[rosclaw-practice] Stopped {summary.practice_id}")
+        print(f"  events:   {summary.event_count}")
+        print(f"  duration: {summary.duration_ms:.1f} ms")
+        print(f"  outcome:  {summary.outcome}")
+        print(f"  artifacts: {summary.artifact_dir}")
+    return 0
+
+
+def cmd_practice_stop(args: argparse.Namespace) -> int:
+    """Stop the running practice coordinator."""
+    import os
+    import signal
+
+    pid_file = Path.home() / ".rosclaw" / "practice" / "coordinator.pid"
+    if not pid_file.exists():
+        print("[rosclaw-practice] No running coordinator found.", file=sys.stderr)
+        return 1
+
+    lines = pid_file.read_text(encoding="utf-8").strip().splitlines()
+    try:
+        pid = int(lines[0])
+        running_practice_id = lines[1] if len(lines) > 1 else None
+    except (ValueError, IndexError):
+        print("[rosclaw-practice] Invalid PID file.", file=sys.stderr)
+        return 1
+
+    requested_id = getattr(args, "practice_id", None)
+    if requested_id and running_practice_id and requested_id != running_practice_id:
+        print(
+            f"[rosclaw-practice] Running session is {running_practice_id}, not {requested_id}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+        print(f"[rosclaw-practice] Sent stop signal to coordinator (PID {pid}).")
+    except ProcessLookupError:
+        print(f"[rosclaw-practice] Coordinator PID {pid} not found.", file=sys.stderr)
+        pid_file.unlink()
+        return 1
+    return 0
+
+
+def cmd_practice_sync_fallback(args: argparse.Namespace) -> int:
+    """Re-submit fallback JSON files to SeekDB."""
+    seekdb_url = args.seekdb_url or os.environ.get("ROSCLAW_SEEKDB_URL", "http://localhost:2881")
+    fallback_dir = args.fallback_dir or os.environ.get(
+        "ROSCLAW_SEEKDB_FALLBACK_DIR", "/data/rosclaw/practice/fallback"
+    )
+    sync = FallbackSync(seekdb_url=seekdb_url, fallback_dir=fallback_dir)
+    summary = sync.sync()
+    print(f"[rosclaw-practice] Fallback sync: attempted={summary['attempted']} "
+          f"success={summary['success']} failed={summary['failed']}")
+    for err in summary["errors"]:
+        print(f"  ERROR: {err}", file=sys.stderr)
+    return 0 if summary["failed"] == 0 else 1
+
+
+# Keep original export available; add jsonl support below.
+
 def cmd_provider_invoke(args: argparse.Namespace) -> int:
     """Invoke a provider capability."""
-
     provider_id = args.provider_id
     input_data = args.input
 
@@ -3154,16 +3384,42 @@ def main() -> int:
 
     practice_subparsers.add_parser("list", help="List recorded episodes")
 
-    practice_show_parser = practice_subparsers.add_parser("show", help="Show episode details")
-    practice_show_parser.add_argument("episode_id", help="Episode identifier (e.g., ep_0001)")
+    practice_init_parser = practice_subparsers.add_parser("init", help="Initialize practice configuration")
+    practice_init_parser.add_argument("--robot", required=True, help="Robot identifier")
+
+    practice_start_parser = practice_subparsers.add_parser("start", help="Start a practice session")
+    practice_start_parser.add_argument("--robot", required=True, help="Robot identifier")
+    practice_start_parser.add_argument("--robot-type", default=None, help="Robot type")
+    practice_start_parser.add_argument("--task", default=None, help="Task name / task_id")
+    practice_start_parser.add_argument("--skill", default=None, help="Skill identifier")
+    practice_start_parser.add_argument(
+        "--sources", default="agent,runtime", help="Comma-separated source list (e.g. agent,runtime,dds)"
+    )
+    practice_start_parser.add_argument("--mock", action="store_true", help="Use mock adapters")
+    practice_start_parser.add_argument("--duration", default=None, help="Duration like 5s, 2m, 1h")
+    practice_start_parser.add_argument("--seekdb", action="store_true", help="Enable SeekDB commit")
+    practice_start_parser.add_argument("--data-root", default="/data/rosclaw/practice", help="Practice data root")
+
+    practice_stop_parser = practice_subparsers.add_parser("stop", help="Stop the running practice coordinator")
+    practice_stop_parser.add_argument("--practice-id", default=None, help="Practice session identifier")
+
+    practice_sync_parser = practice_subparsers.add_parser("sync-fallback", help="Sync fallback JSON files to SeekDB")
+    practice_sync_parser.add_argument("--seekdb-url", default=None, help="SeekDB base URL")
+    practice_sync_parser.add_argument("--fallback-dir", default=None, help="Fallback directory")
+
+    practice_show_parser = practice_subparsers.add_parser("show", help="Show episode/practice details")
+    practice_show_parser.add_argument("episode_id", help="Episode or practice identifier")
     practice_show_parser.add_argument("--json", action="store_true", help="Output as JSON")
 
     practice_replay_parser = practice_subparsers.add_parser("replay", help="Replay episode trace")
     practice_replay_parser.add_argument("episode_id", help="Episode identifier")
 
-    practice_export_parser = practice_subparsers.add_parser("export", help="Export episode metadata")
-    practice_export_parser.add_argument("episode_id", help="Episode identifier")
-    practice_export_parser.add_argument("--format", choices=["json"], default="json", help="Export format")
+    practice_export_parser = practice_subparsers.add_parser("export", help="Export episode metadata or practice events")
+    practice_export_parser.add_argument("episode_id", help="Episode or practice identifier")
+    practice_export_parser.add_argument("--practice-id", default=None, help="Practice identifier (for jsonl)")
+    practice_export_parser.add_argument("--format", choices=["json", "jsonl"], default="json", help="Export format")
+    practice_export_parser.add_argument("--output", default=None, help="Output file (default stdout)")
+    practice_export_parser.add_argument("--data-root", default="/data/rosclaw/practice", help="Practice data root")
 
     # know subcommand
     know_parser = subparsers.add_parser("know", help="Knowledge base queries")
@@ -3438,6 +3694,14 @@ def main() -> int:
     elif args.command == "practice":
         if args.practice_command == "list":
             return cmd_practice_list(args)
+        elif args.practice_command == "init":
+            return cmd_practice_init(args)
+        elif args.practice_command == "start":
+            return cmd_practice_start(args)
+        elif args.practice_command == "stop":
+            return cmd_practice_stop(args)
+        elif args.practice_command == "sync-fallback":
+            return cmd_practice_sync_fallback(args)
         elif args.practice_command == "show":
             return cmd_practice_show(args)
         elif args.practice_command == "replay":

--- a/src/rosclaw/practice/__init__.py
+++ b/src/rosclaw/practice/__init__.py
@@ -1,12 +1,24 @@
 """
-ROSClaw Practice - Timeline Grounding Engine
+ROSClaw Practice - Physical Data Flywheel Runtime
 
 MCAP-based black box recording and replay.
 Captures robot execution traces for analysis and learning.
 """
 
+from rosclaw.practice.config import PracticeConfig, PracticeSession, PracticeSummary
+from rosclaw.practice.coordinator import PracticeCoordinator
 from rosclaw.practice.episode_recorder import EpisodeRecorder
 from rosclaw.practice.recorder import PracticeRecorder
 from rosclaw.practice.timeline import TimelineChannel, TimelineEntry, UnifiedTimeline
 
-__all__ = ["PracticeRecorder", "UnifiedTimeline", "TimelineChannel", "TimelineEntry", "EpisodeRecorder"]
+__all__ = [
+    "PracticeConfig",
+    "PracticeCoordinator",
+    "PracticeRecorder",
+    "PracticeSession",
+    "PracticeSummary",
+    "UnifiedTimeline",
+    "TimelineChannel",
+    "TimelineEntry",
+    "EpisodeRecorder",
+]

--- a/src/rosclaw/practice/adapters/__init__.py
+++ b/src/rosclaw/practice/adapters/__init__.py
@@ -1,0 +1,14 @@
+"""Practice source adapters package."""
+
+from rosclaw.practice.adapters.base import SourceAdapter, SourceHealth
+from rosclaw.practice.adapters.mock_agent_adapter import MockAgentAdapter
+from rosclaw.practice.adapters.mock_runtime_adapter import MockRuntimeAdapter
+from rosclaw.practice.adapters.sense_adapter import SenseAdapter
+
+__all__ = [
+    "SourceAdapter",
+    "SourceHealth",
+    "MockAgentAdapter",
+    "MockRuntimeAdapter",
+    "SenseAdapter",
+]

--- a/src/rosclaw/practice/adapters/base.py
+++ b/src/rosclaw/practice/adapters/base.py
@@ -1,0 +1,48 @@
+"""SourceAdapter protocol for practice data sources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Protocol
+
+from rosclaw.practice.schemas import PracticeEventEnvelope
+
+
+@dataclass
+class SourceHealth:
+    """Health status reported by a source adapter."""
+
+    source: str
+    healthy: bool
+    message: str = ""
+    dropped_frames: int = 0
+
+
+class SourceAdapter(Protocol):
+    """Protocol for a practice data source."""
+
+    source_name: str
+
+    def start(self, session: Any) -> None:
+        """Called when the practice session starts."""
+        ...
+
+    def stop(self) -> None:
+        """Called when the practice session stops."""
+        ...
+
+    def health(self) -> SourceHealth:
+        """Return current health status."""
+        ...
+
+    def poll(self) -> Iterable[PracticeEventEnvelope]:
+        """Return zero or more events since the last poll.
+
+        Implementations may alternatively use ``on_event`` callbacks for
+        push-based sources.
+        """
+        ...
+
+    def on_event(self, callback: Callable[[PracticeEventEnvelope], None]) -> None:
+        """Optional callback registration for push-based sources."""
+        ...

--- a/src/rosclaw/practice/adapters/base.py
+++ b/src/rosclaw/practice/adapters/base.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Protocol
+from typing import Any, Protocol
 
 from rosclaw.practice.schemas import PracticeEventEnvelope
 

--- a/src/rosclaw/practice/adapters/mock_agent_adapter.py
+++ b/src/rosclaw/practice/adapters/mock_agent_adapter.py
@@ -1,0 +1,103 @@
+"""Mock agent adapter for testing the practice runtime without a real agent."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from rosclaw.practice.adapters.base import SourceAdapter, SourceHealth
+from rosclaw.practice.schemas import (
+    AgentPlanPayload,
+    PracticeEventEnvelope,
+    ToolCallPayload,
+)
+
+
+class MockAgentAdapter(SourceAdapter):
+    """Generates synthetic agent trace events."""
+
+    source_name = "agent"
+
+    def __init__(self, robot_id: str, task: str = "mock task"):
+        self._robot_id = robot_id
+        self._task = task
+        self._practice_id: str | None = None
+        self._step = 0
+        self._running = False
+
+    def start(self, session: Any) -> None:
+        self._practice_id = getattr(session, "practice_id", None)
+        self._running = True
+        self._step = 0
+
+    def stop(self) -> None:
+        self._running = False
+
+    def health(self) -> SourceHealth:
+        return SourceHealth(source=self.source_name, healthy=True)
+
+    def poll(self) -> Iterable[PracticeEventEnvelope]:
+        if not self._running or self._practice_id is None:
+            return
+
+        self._step += 1
+        if self._step == 1:
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="agent",
+                event_type="agent.task_received",
+                payload={"task": self._task},
+            )
+        elif self._step == 2:
+            plan = AgentPlanPayload(
+                task=self._task,
+                plan_id=f"plan_{self._practice_id}",
+                planner="mock_agent",
+                plan_steps=[
+                    {"step": 1, "name": "perceive"},
+                    {"step": 2, "name": "plan"},
+                    {"step": 3, "name": "act"},
+                ],
+                decision_summary="Mock plan generated for testing.",
+            )
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="agent",
+                event_type="agent.plan_created",
+                payload=plan.model_dump(),
+            )
+        elif self._step == 3:
+            tool = ToolCallPayload(
+                tool_call_id=f"tc_{self._practice_id}",
+                tool_name="mock_grasp",
+                arguments={"object": "cup"},
+                status="started",
+            )
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="agent",
+                event_type="agent.tool_call_started",
+                payload=tool.model_dump(),
+            )
+        elif self._step == 4:
+            tool = ToolCallPayload(
+                tool_call_id=f"tc_{self._practice_id}",
+                tool_name="mock_grasp",
+                arguments={"object": "cup"},
+                result_summary={"success": True},
+                status="success",
+                latency_ms=12.0,
+            )
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="agent",
+                event_type="agent.tool_call_finished",
+                payload=tool.model_dump(),
+            )
+
+    def on_event(self, callback: Any) -> None:
+        pass

--- a/src/rosclaw/practice/adapters/mock_runtime_adapter.py
+++ b/src/rosclaw/practice/adapters/mock_runtime_adapter.py
@@ -1,0 +1,82 @@
+"""Mock runtime adapter for testing the practice runtime without real robots."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from time import monotonic_ns
+from typing import Any
+
+from rosclaw.practice.adapters.base import SourceAdapter, SourceHealth
+from rosclaw.practice.schemas import ExecutedActionPayload, PracticeEventEnvelope
+
+
+class MockRuntimeAdapter(SourceAdapter):
+    """Generates synthetic runtime/action events."""
+
+    source_name = "runtime"
+
+    def __init__(self, robot_id: str):
+        self._robot_id = robot_id
+        self._practice_id: str | None = None
+        self._step = 0
+        self._running = False
+        self._action_id = ""
+
+    def start(self, session: Any) -> None:
+        self._practice_id = getattr(session, "practice_id", None)
+        self._running = True
+        self._step = 0
+        self._action_id = f"action_{self._practice_id}"
+
+    def stop(self) -> None:
+        self._running = False
+
+    def health(self) -> SourceHealth:
+        return SourceHealth(source=self.source_name, healthy=True)
+
+    def poll(self) -> Iterable[PracticeEventEnvelope]:
+        if not self._running or self._practice_id is None:
+            return
+
+        self._step += 1
+        if self._step == 1:
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="runtime",
+                event_type="runtime.action_proposed",
+                payload={
+                    "action_id": self._action_id,
+                    "action_type": "mock_move",
+                    "command": {"target": [0.5, 0.0, 0.2]},
+                },
+            )
+        elif self._step == 2:
+            start_ns = monotonic_ns()
+            action = ExecutedActionPayload(
+                action_id=self._action_id,
+                action_type="mock_move",
+                command={"target": [0.5, 0.0, 0.2]},
+                controller="mock",
+                start_time_ns=start_ns,
+                status="completed",
+                reward=0.8,
+            )
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="runtime",
+                event_type="runtime.action_executed",
+                payload=action.model_dump(),
+            )
+        elif self._step == 3:
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="runtime",
+                event_type="runtime.reward_observed",
+                payload={"action_id": self._action_id, "reward": 0.8},
+            )
+
+    def on_event(self, callback: Any) -> None:
+        pass

--- a/src/rosclaw/practice/adapters/sense_adapter.py
+++ b/src/rosclaw/practice/adapters/sense_adapter.py
@@ -1,0 +1,117 @@
+"""Sense adapter: turn BodyState snapshots into practice events."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from time import monotonic_ns
+from typing import Any
+
+from rosclaw.practice.adapters.base import SourceAdapter, SourceHealth
+from rosclaw.practice.schemas import (
+    FootContactPayload,
+    IMUPayload,
+    JointStatePayload,
+    PracticeEventEnvelope,
+)
+
+
+class SenseAdapter(SourceAdapter):
+    """Bridge from SenseRuntime/MockCollector to practice events."""
+
+    source_name = "dds"
+
+    def __init__(self, robot_id: str, sense_runtime: Any | None = None, scenario: str = "normal"):
+        self._robot_id = robot_id
+        self._sense_runtime = sense_runtime
+        self._scenario = scenario
+        self._practice_id: str | None = None
+        self._running = False
+        self._collector: Any | None = None
+
+    def start(self, session: Any) -> None:
+        self._practice_id = getattr(session, "practice_id", None)
+        self._running = True
+        if self._sense_runtime is None:
+            from rosclaw.sense.collectors.mock_collector import MockCollector
+            self._collector = MockCollector(robot_id=self._robot_id, scenario=self._scenario)
+        else:
+            self._collector = getattr(self._sense_runtime, "collector", None)
+
+    def stop(self) -> None:
+        self._running = False
+
+    def health(self) -> SourceHealth:
+        return SourceHealth(source=self.source_name, healthy=True)
+
+    def poll(self) -> Iterable[PracticeEventEnvelope]:
+        if not self._running or self._practice_id is None or self._collector is None:
+            return
+
+        try:
+            body_state = self._collector.collect()
+        except Exception as e:
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="dds",
+                event_type="dds.collect_error",
+                payload={"error": str(e)},
+            )
+            return
+
+        ts_ns = monotonic_ns()
+        joints = body_state.joints
+        if joints:
+            names = list(joints.keys())
+            payload = JointStatePayload(
+                joint_names=names,
+                position=[j.position_rad or 0.0 for j in joints.values()],
+                velocity=[j.velocity_rad_s or 0.0 for j in joints.values()],
+                effort=[j.torque_nm or 0.0 for j in joints.values()],
+                temperature=[j.temperature_c or 0.0 for j in joints.values()],
+            )
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="dds",
+                event_type="dds.joint_state",
+                timestamp_ns=ts_ns,
+                payload=payload.model_dump(),
+            )
+
+        imu = body_state.imu
+        if imu and imu.angular_velocity:
+            payload = IMUPayload(
+                angular_velocity_xyz=imu.angular_velocity or [0.0, 0.0, 0.0],
+                linear_acceleration_xyz=[0.0, 0.0, 9.81],
+            )
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="dds",
+                event_type="dds.imu",
+                timestamp_ns=ts_ns,
+                payload=payload.model_dump(),
+            )
+
+        contact = body_state.contact
+        if contact:
+            left = contact.get("left_foot")
+            right = contact.get("right_foot")
+            payload = FootContactPayload(
+                left_contact=bool(left.contact) if left else False,
+                right_contact=bool(right.contact) if right else False,
+                left_force_n=left.confidence if left else None,
+                right_force_n=right.confidence if right else None,
+            )
+            yield PracticeEventEnvelope(
+                practice_id=self._practice_id,
+                robot_id=self._robot_id,
+                source="dds",
+                event_type="dds.foot_contact",
+                timestamp_ns=ts_ns,
+                payload=payload.model_dump(),
+            )
+
+    def on_event(self, callback: Any) -> None:
+        pass

--- a/src/rosclaw/practice/config.py
+++ b/src/rosclaw/practice/config.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-
 DEFAULT_DATA_ROOT = "/data/rosclaw/practice"
 DEFAULT_FALLBACK_DIR = "/data/rosclaw/practice/fallback"
 DEFAULT_INDEX_DIR = "/data/rosclaw/practice/indexes"

--- a/src/rosclaw/practice/config.py
+++ b/src/rosclaw/practice/config.py
@@ -1,0 +1,136 @@
+"""Configuration and session objects for rosclaw-practice."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_DATA_ROOT = "/data/rosclaw/practice"
+DEFAULT_FALLBACK_DIR = "/data/rosclaw/practice/fallback"
+DEFAULT_INDEX_DIR = "/data/rosclaw/practice/indexes"
+DEFAULT_CONFIG_ROOT = Path.home() / ".rosclaw" / "practice"
+
+
+@dataclass
+class RecorderConfig:
+    """Writer settings for a practice session."""
+
+    jsonl_enabled: bool = True
+    jsonl_rotate_mb: float = 512.0
+
+    mcap_enabled: bool = False
+    mcap_compression: str = "zstd"
+    mcap_chunk_size_bytes: int = 4 * 1024 * 1024
+
+    frames_enabled: bool = False
+    rgb_format: str = "jpg"
+    depth_format: str = "png16"
+
+
+@dataclass
+class SeekDBConfig:
+    """SeekDB integration settings."""
+
+    enabled: bool = False
+    url: str | None = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_SEEKDB_URL")
+    )
+    fallback_dir: str = field(
+        default_factory=lambda: os.environ.get(
+            "ROSCLAW_SEEKDB_FALLBACK_DIR", DEFAULT_FALLBACK_DIR
+        )
+    )
+    table: str = "praxis_events"
+    timeout_sec: float = 2.0
+
+
+@dataclass
+class SourceConfig:
+    """Which data sources to record."""
+
+    dds: bool = False
+    ros2: bool = False
+    camera: bool = False
+    agent: bool = True
+    provider: bool = False
+    sandbox: bool = False
+    runtime: bool = True
+    human: bool = False
+
+
+@dataclass
+class PracticeConfig:
+    """Top-level configuration for a PracticeCoordinator."""
+
+    robot_id: str = "default_robot"
+    robot_type: str | None = None
+    task_id: str | None = None
+    task_name: str | None = None
+    skill_id: str | None = None
+    session_name: str | None = None
+
+    data_root: str = DEFAULT_DATA_ROOT
+    config_root: Path = field(default_factory=lambda: DEFAULT_CONFIG_ROOT)
+    sources: SourceConfig = field(default_factory=SourceConfig)
+    recorder: RecorderConfig = field(default_factory=RecorderConfig)
+    seekdb: SeekDBConfig = field(default_factory=SeekDBConfig)
+
+    # Runtime knobs
+    mock: bool = False
+    duration_sec: float | None = None
+    publish_to_event_bus: bool = True
+
+    # Optional pre-built objects (used by Runtime and tests)
+    event_bus: Any | None = None
+    seekdb_bridge: Any | None = None
+
+    @property
+    def data_root_path(self) -> Path:
+        return Path(self.data_root)
+
+    @property
+    def sessions_dir(self) -> Path:
+        return self.data_root_path / "sessions"
+
+    @property
+    def indexes_dir(self) -> Path:
+        return self.data_root_path / "indexes"
+
+    @property
+    def fallback_dir(self) -> Path:
+        return Path(self.seekdb.fallback_dir)
+
+
+@dataclass
+class PracticeSession:
+    """Live practice session handle."""
+
+    practice_id: str
+    robot_id: str
+    task_id: str | None
+    task_name: str | None
+    skill_id: str | None
+    session_dir: Path
+    start_time_ns: int
+    start_time_utc: str
+    session_id: str | None = None
+    tags: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PracticeSummary:
+    """Result returned when a practice session stops."""
+
+    practice_id: str
+    robot_id: str
+    outcome: str = "UNKNOWN"
+    reward: float | None = None
+    duration_ms: float | None = None
+    event_count: int = 0
+    artifact_dir: Path | None = None
+    seekdb_committed: bool | None = None
+    failure_labels: list[str] = field(default_factory=list)

--- a/src/rosclaw/practice/coordinator.py
+++ b/src/rosclaw/practice/coordinator.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from collections.abc import Iterable
-from typing import Any
 
 from rosclaw.core.event_bus import Event, EventBus
 from rosclaw.core.lifecycle import LifecycleMixin

--- a/src/rosclaw/practice/coordinator.py
+++ b/src/rosclaw/practice/coordinator.py
@@ -1,0 +1,349 @@
+"""PracticeCoordinator - Physical Data Flywheel Runtime core."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Iterable
+from typing import Any
+
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.core.lifecycle import LifecycleMixin
+from rosclaw.practice.adapters.base import SourceAdapter
+from rosclaw.practice.adapters.mock_agent_adapter import MockAgentAdapter
+from rosclaw.practice.adapters.mock_runtime_adapter import MockRuntimeAdapter
+from rosclaw.practice.adapters.sense_adapter import SenseAdapter
+from rosclaw.practice.config import PracticeConfig, PracticeSession, PracticeSummary
+from rosclaw.practice.schemas import PracticeEventEnvelope
+from rosclaw.practice.storage.catalog import PracticeCatalog
+from rosclaw.practice.storage.layout import PracticeLayout, generate_practice_id
+from rosclaw.practice.writers.jsonl_writer import JsonlWriter
+
+logger = logging.getLogger("rosclaw.practice.coordinator")
+
+
+class PracticeCoordinator(LifecycleMixin):
+    """Coordinates a practice session: adapters, writers, catalog, SeekDB."""
+
+    def __init__(self, config: PracticeConfig | None = None):
+        super().__init__()
+        self.config = config or PracticeConfig()
+        self.layout = PracticeLayout(self.config.data_root)
+        self.catalog = PracticeCatalog(self.layout.catalog_db_path)
+        self._event_bus = self.config.event_bus or EventBus()
+        self._adapters: list[SourceAdapter] = []
+        self._writer: JsonlWriter | None = None
+        self._session: PracticeSession | None = None
+        self._summary: PracticeSummary | None = None
+        self._poll_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._poll_hz = 10.0
+        self._event_count = 0
+        self._lock = threading.RLock()
+
+    @property
+    def event_bus(self) -> EventBus:
+        """Public access to the coordinator's event bus for subscribers."""
+        return self._event_bus
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _do_initialize(self) -> None:
+        self.layout.ensure_directories()
+        self._build_adapters()
+
+    def _do_start(self) -> None:
+        self._start_session()
+
+    def _do_stop(self) -> None:
+        self._stop_session()
+
+    # ------------------------------------------------------------------
+    # Adapter setup
+    # ------------------------------------------------------------------
+
+    def _build_adapters(self) -> None:
+        sources = self.config.sources
+        if self.config.mock:
+            if sources.agent:
+                self._adapters.append(
+                    MockAgentAdapter(self.config.robot_id, task=self.config.task_name or "mock task")
+                )
+            if sources.runtime:
+                self._adapters.append(MockRuntimeAdapter(self.config.robot_id))
+            if sources.dds:
+                self._adapters.append(
+                    SenseAdapter(
+                        self.config.robot_id,
+                        sense_runtime=getattr(self.config, "sense_runtime", None),
+                        scenario="normal",
+                    )
+                )
+            return
+
+        # Non-mock P0: only DDS via SenseRuntime if available
+        if sources.dds:
+            self._adapters.append(
+                SenseAdapter(
+                    self.config.robot_id,
+                    sense_runtime=getattr(self.config, "sense_runtime", None),
+                    scenario="normal",
+                )
+            )
+
+    def register_adapter(self, adapter: SourceAdapter) -> None:
+        self._adapters.append(adapter)
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def _start_session(self) -> None:
+        practice_id = generate_practice_id()
+        session_dir = self.layout.create_session_dirs(practice_id)
+        start_ns = time.monotonic_ns()
+        from datetime import UTC, datetime
+
+        start_utc = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        self._session = PracticeSession(
+            practice_id=practice_id,
+            robot_id=self.config.robot_id,
+            task_id=self.config.task_id,
+            task_name=self.config.task_name,
+            skill_id=self.config.skill_id,
+            session_dir=session_dir,
+            start_time_ns=start_ns,
+            start_time_utc=start_utc,
+        )
+        self._writer = JsonlWriter(
+            self.layout.events_jsonl_path(practice_id),
+            rotate_mb=self.config.recorder.jsonl_rotate_mb if self.config.recorder.jsonl_rotate_mb > 0 else None,
+        )
+        self._event_count = 0
+        self._summary = None
+
+        self.catalog.insert_practice(
+            {
+                "practice_id": practice_id,
+                "robot_id": self.config.robot_id,
+                "robot_type": self.config.robot_type,
+                "task_id": self.config.task_id,
+                "task_name": self.config.task_name,
+                "skill_id": self.config.skill_id,
+                "start_time": start_utc,
+                "manifest_path": str(self.layout.manifest_path(practice_id)),
+                "events_jsonl_path": str(self.layout.events_jsonl_path(practice_id)),
+                "outcome": "running",
+            }
+        )
+
+        self.layout.write_manifest(
+            self._session,
+            sources=self._sources_dict(),
+            seekdb_enabled=bool(self.config.seekdb.url),
+        )
+
+        for adapter in self._adapters:
+            try:
+                adapter.start(self._session)
+            except Exception as e:
+                logger.error("Failed to start adapter %s: %s", adapter.source_name, e)
+
+        if self.config.publish_to_event_bus:
+            self._event_bus.publish(
+                Event(
+                    topic="practice.session_started",
+                    payload={
+                        "practice_id": practice_id,
+                        "robot_id": self.config.robot_id,
+                        "task_id": self.config.task_id,
+                        "task_name": self.config.task_name,
+                        "skill_id": self.config.skill_id,
+                        "session_dir": str(session_dir),
+                        "semantic_intent": self.config.task_name or "",
+                    },
+                    source="practice_coordinator",
+                )
+            )
+
+        self._stop_event.clear()
+        self._poll_thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._poll_thread.start()
+
+        logger.info("Practice session started: %s", practice_id)
+
+    def _stop_session(self) -> None:
+        self._stop_event.set()
+        if self._poll_thread is not None:
+            self._poll_thread.join(timeout=2.0)
+
+        for adapter in self._adapters:
+            try:
+                adapter.stop()
+            except Exception as e:
+                logger.error("Failed to stop adapter %s: %s", adapter.source_name, e)
+
+        duration_ms: float | None = None
+        if self._session is not None:
+            duration_ms = (time.monotonic_ns() - self._session.start_time_ns) / 1_000_000.0
+
+        outcome = "SUCCESS"
+        reward = 0.0
+        failure_labels: list[str] = []
+
+        self._summary = PracticeSummary(
+            practice_id=self._session.practice_id if self._session else "unknown",
+            robot_id=self.config.robot_id,
+            outcome=outcome,
+            reward=reward,
+            duration_ms=duration_ms,
+            event_count=self._event_count,
+            artifact_dir=self._session.session_dir if self._session else None,
+            failure_labels=failure_labels,
+        )
+
+        self.catalog.update_practice(
+            self._session.practice_id if self._session else "unknown",
+            {
+                "end_time": _utc_now_iso(),
+                "duration_ms": duration_ms,
+                "outcome": outcome,
+                "reward": reward,
+            },
+        )
+
+        if self._writer is not None:
+            self._writer.close()
+            self._writer = None
+
+        if self._session is not None:
+            self.layout.write_manifest(
+                self._session,
+                summary=self._summary,
+                sources=self._sources_dict(),
+                seekdb_enabled=bool(self.config.seekdb.url),
+            )
+
+        if self.config.publish_to_event_bus and self._session is not None:
+            self._event_bus.publish(
+                Event(
+                    topic="practice.session_finished",
+                    payload={
+                        "practice_id": self._session.practice_id,
+                        "robot_id": self.config.robot_id,
+                        "outcome": outcome,
+                        "reward": reward,
+                        "duration_ms": duration_ms,
+                        "event_count": self._event_count,
+                    },
+                    source="practice_coordinator",
+                )
+            )
+
+        logger.info("Practice session stopped: %s", self._session.practice_id if self._session else "unknown")
+
+    # ------------------------------------------------------------------
+    # Event loop
+    # ------------------------------------------------------------------
+
+    def _poll_loop(self) -> None:
+        interval = 1.0 / self._poll_hz
+        while not self._stop_event.is_set():
+            self.tick()
+            time.sleep(interval)
+
+    def tick(self) -> None:
+        """Poll all adapters once and emit captured events."""
+        if self._session is None:
+            return
+        for adapter in self._adapters:
+            try:
+                for event in adapter.poll():
+                    self._emit(event)
+            except Exception as e:
+                logger.error("Adapter %s poll failed: %s", adapter.source_name, e)
+
+    def emit_event(self, event: PracticeEventEnvelope) -> None:
+        """Public entry for external callers to inject events."""
+        self._emit(event)
+
+    def _emit(self, event: PracticeEventEnvelope) -> None:
+        with self._lock:
+            self._event_count += 1
+            event.sequence_id = self._event_count
+
+        # Local JSONL
+        if self._writer is not None:
+            try:
+                self._writer.write(event.model_dump(mode="json"))
+            except Exception as e:
+                logger.error("Failed to write event to JSONL: %s", e)
+
+        # Local catalog
+        try:
+            self.catalog.insert_event(
+                {
+                    "event_id": event.event_id,
+                    "practice_id": event.practice_id,
+                    "source": event.source,
+                    "event_type": event.event_type,
+                    "timestamp_ns": event.timestamp_ns,
+                    "timestamp_utc": event.timestamp_utc,
+                    "action_id": event.action_id,
+                    "task_id": event.task_id,
+                    "skill_id": event.skill_id,
+                    "payload_ref": json.dumps(event.payload_ref) if event.payload_ref else None,
+                    "tags": ",".join(event.tags),
+                }
+            )
+        except Exception as e:
+            logger.error("Failed to insert event into catalog: %s", e)
+
+        # EventBus
+        if self.config.publish_to_event_bus:
+            try:
+                self._event_bus.publish(
+                    Event(
+                        topic="practice.event",
+                        payload=event.model_dump(mode="json"),
+                        source=f"practice_coordinator:{event.source}",
+                    )
+                )
+            except Exception as e:
+                logger.error("Failed to publish practice.event: %s", e)
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    def _sources_dict(self) -> dict[str, bool]:
+        return {
+            "dds": self.config.sources.dds,
+            "ros2": self.config.sources.ros2,
+            "camera": self.config.sources.camera,
+            "agent": self.config.sources.agent,
+            "provider": self.config.sources.provider,
+            "sandbox": self.config.sources.sandbox,
+            "runtime": self.config.sources.runtime,
+            "human": self.config.sources.human,
+        }
+
+    @property
+    def session(self) -> PracticeSession | None:
+        return self._session
+
+    @property
+    def summary(self) -> PracticeSummary | None:
+        return self._summary
+
+
+import json  # noqa: E402
+
+
+def _utc_now_iso() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")

--- a/src/rosclaw/practice/episode_recorder.py
+++ b/src/rosclaw/practice/episode_recorder.py
@@ -145,6 +145,8 @@ class EpisodeRecorder(LifecycleMixin):
             "safety.violation": self._on_safety_violation,
             "agent.command": self._on_agent_command,
             "agent.response": self._on_agent_response,
+            "practice.session_started": self._on_practice_session_started,
+            "practice.session_finished": self._on_practice_session_finished,
             # Future topics — no-op stubs
             "rosclaw.provider.inference.completed": self._on_provider_inference,
             "rosclaw.critic.success.detected": self._on_critic_success,
@@ -338,6 +340,33 @@ class EpisodeRecorder(LifecycleMixin):
             "request_id": payload.get("request_id"),
         })
         buf.last_event_at = time.time()
+
+    def _on_practice_session_started(self, event: Event) -> None:
+        """Capture PracticeCoordinator session start."""
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        episode_id = self._extract_episode_id(payload)
+        buf = self._get_or_create_buffer(episode_id)
+        buf.received_events.add("practice.session_started")
+        buf.robot_id = payload.get("robot_id", self._robot_id)
+        buf.semantic_intent = payload.get("semantic_intent") or payload.get("task_name") or buf.semantic_intent
+        buf.initial_state = payload.get("initial_state", buf.initial_state)
+        buf.last_event_at = time.time()
+
+    def _on_practice_session_finished(self, event: Event) -> None:
+        """Capture PracticeCoordinator session end and finalize."""
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        episode_id = self._extract_episode_id(payload)
+        buf = self._get_or_create_buffer(episode_id)
+        buf.received_events.add("practice.session_finished")
+        buf.robot_id = payload.get("robot_id", buf.robot_id)
+        outcome = payload.get("outcome", "UNKNOWN")
+        buf.praxis_status = outcome.lower()
+        buf.praxis_reward = payload.get("reward", 0.0)
+        duration_ms = payload.get("duration_ms")
+        if duration_ms is not None:
+            buf.duration_sec = duration_ms / 1000.0
+        buf.last_event_at = time.time()
+        self._finalize_episode(episode_id)
 
     # ------------------------------------------------------------------
     # Event handlers — stub topics (future sprints)
@@ -554,24 +583,25 @@ class EpisodeRecorder(LifecycleMixin):
                 logger.error(f"SeekDB commit failed for {episode_id}: {e}")
 
         # Publish enriched praxis.recorded
-        self._event_bus.publish(Event(
-            topic="praxis.recorded",
-            payload={
-                "event_id": praxis_event.event_id,
-                "event_type": praxis_event.event_type,
-                "robot_id": praxis_event.robot_id,
-                "instruction": praxis_event.agent_instruction,
-                "duration_sec": praxis_event.duration_sec,
-                "outcome": status,
-                "trajectory_waypoints": len(buf.trajectory),
-                "cot_steps": len(praxis_event.cot_trace),
-                "artifact_dir": str(episode_dir),
-                "artifact_uri": f"rosclaw://artifacts/episodes/{episode_id}",
-                "episode_metadata": metadata,
-            },
-            source="episode_recorder",
-            priority=EventPriority.NORMAL,
-        ))
+        if self._event_bus is not None:
+            self._event_bus.publish(Event(
+                topic="praxis.recorded",
+                payload={
+                    "event_id": praxis_event.event_id,
+                    "event_type": praxis_event.event_type,
+                    "robot_id": praxis_event.robot_id,
+                    "instruction": praxis_event.agent_instruction,
+                    "duration_sec": praxis_event.duration_sec,
+                    "outcome": status,
+                    "trajectory_waypoints": len(buf.trajectory),
+                    "cot_steps": len(praxis_event.cot_trace),
+                    "artifact_dir": str(episode_dir),
+                    "artifact_uri": f"rosclaw://artifacts/episodes/{episode_id}",
+                    "episode_metadata": metadata,
+                },
+                source="episode_recorder",
+                priority=EventPriority.NORMAL,
+            ))
 
         print(f"[EpisodeRecorder] Finalized {episode_id}: status={status}, "
               f"reward={reward}, events={len(buf.received_events)}, "

--- a/src/rosclaw/practice/schemas.py
+++ b/src/rosclaw/practice/schemas.py
@@ -1,0 +1,218 @@
+"""Practice data schemas for the Physical Data Flywheel Runtime.
+
+This module defines the canonical event envelope and payload models used by
+`rosclaw-practice`. All JSONL/MCAP/SeekDB events share the same envelope so
+that downstream tools can query, replay, and export practices without
+source-specific parsing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+
+SCHEMA_VERSION = "practice.event.v1"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _now_ns() -> int:
+    return int(datetime.now(UTC).timestamp() * 1_000_000_000)
+
+
+class PracticeEventEnvelope(BaseModel):
+    """Unified envelope for every event captured by rosclaw-practice.
+
+    Large or binary payloads should be written to files and referenced via
+    ``payload_ref``; only small serializable metadata belongs in ``payload``.
+    """
+
+    schema_version: str = SCHEMA_VERSION
+
+    practice_id: str
+    session_id: str | None = None
+    robot_id: str
+
+    source: Literal[
+        "dds",
+        "ros2",
+        "camera",
+        "agent",
+        "provider",
+        "sandbox",
+        "runtime",
+        "human",
+        "system",
+    ]
+    event_type: str
+
+    timestamp_ns: int = Field(default_factory=_now_ns)
+    timestamp_utc: str = Field(default_factory=_utc_now_iso)
+    source_timestamp_ns: int | None = None
+    sequence_id: int | None = None
+
+    trace_id: str | None = None
+    parent_event_id: str | None = None
+    event_id: str = Field(default_factory=lambda: str(uuid4()))
+
+    frame_id: str | None = None
+    task_id: str | None = None
+    skill_id: str | None = None
+    action_id: str | None = None
+
+    payload: dict[str, Any] = Field(default_factory=dict)
+    payload_ref: dict[str, str] = Field(default_factory=dict)
+
+    quality: dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Payload models for individual sources (P0 mock + forward-compatible)
+# ---------------------------------------------------------------------------
+
+
+class JointStatePayload(BaseModel):
+    joint_names: list[str]
+    position: list[float]
+    velocity: list[float] | None = None
+    effort: list[float] | None = None
+    temperature: list[float] | None = None
+    control_mode: list[str] | None = None
+
+
+class IMUPayload(BaseModel):
+    orientation_xyzw: list[float] | None = None
+    angular_velocity_xyz: list[float]
+    linear_acceleration_xyz: list[float]
+    covariance: dict[str, list[float]] | None = None
+
+
+class FootContactPayload(BaseModel):
+    left_contact: bool
+    right_contact: bool
+    left_force_n: float | None = None
+    right_force_n: float | None = None
+    contact_confidence: float | None = None
+
+
+class OdometryPayload(BaseModel):
+    frame_id: str
+    child_frame_id: str
+    position_xyz: list[float]
+    orientation_xyzw: list[float]
+    linear_velocity_xyz: list[float] | None = None
+    angular_velocity_xyz: list[float] | None = None
+
+
+class RGBDFramePayload(BaseModel):
+    camera_id: str
+    width: int
+    height: int
+    rgb_encoding: str
+    depth_encoding: str
+    rgb_ref: str
+    depth_ref: str | None = None
+    camera_info_ref: str | None = None
+    intrinsics: list[float] | None = None
+    extrinsics_ref: str | None = None
+    dropped_frame_count: int | None = None
+
+
+class AgentPlanPayload(BaseModel):
+    task: str
+    plan_id: str
+    planner: str
+    plan_steps: list[dict[str, Any]]
+    constraints: list[str] = Field(default_factory=list)
+    referenced_memory_ids: list[str] = Field(default_factory=list)
+    referenced_taskcards: list[str] = Field(default_factory=list)
+    decision_summary: str | None = None
+
+
+class ToolCallPayload(BaseModel):
+    tool_call_id: str
+    tool_name: str
+    arguments: dict[str, Any]
+    result_summary: dict[str, Any] | None = None
+    status: Literal["started", "success", "failed"]
+    latency_ms: float | None = None
+    error: str | None = None
+
+
+class ProviderOutputPayload(BaseModel):
+    provider_id: str
+    provider_type: str
+    model: str | None = None
+    route_reason: str | None = None
+    input_summary: dict[str, Any] | None = None
+    output_summary: dict[str, Any] | None = None
+    latency_ms: float
+    token_usage: dict[str, int] | None = None
+    confidence: float | None = None
+    status: Literal["success", "failed", "fallback"]
+
+
+class SandboxDecisionPayload(BaseModel):
+    decision_id: str
+    action_id: str
+    requested_action: dict[str, Any]
+    decision: Literal["ALLOW", "MODIFY", "BLOCK"]
+    modified_action: dict[str, Any] | None = None
+    risk_score: float
+    rules_triggered: list[str]
+    simulation_ref: str | None = None
+    reason: str
+    policy_version: str
+    latency_ms: float
+
+
+class ExecutedActionPayload(BaseModel):
+    action_id: str
+    action_type: str
+    command: dict[str, Any]
+    controller: str
+    start_time_ns: int
+    end_time_ns: int | None = None
+    status: Literal["started", "completed", "failed", "blocked"]
+    pre_state_ref: str | None = None
+    post_state_ref: str | None = None
+    reward: float | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+
+class FailureLabelPayload(BaseModel):
+    failure_id: str
+    failure_type: str
+    severity: Literal["low", "medium", "high", "critical"]
+    source: Literal["auto", "human", "sandbox", "runtime", "critic"]
+    related_action_id: str | None = None
+    related_event_ids: list[str] = Field(default_factory=list)
+    description: str
+    evidence_refs: list[str] = Field(default_factory=list)
+    suggested_fix: dict[str, Any] | None = None
+
+
+class HumanFeedbackPayload(BaseModel):
+    feedback_id: str
+    feedback_type: Literal[
+        "thumbs_up",
+        "thumbs_down",
+        "correction",
+        "label",
+        "takeover",
+        "success_confirm",
+        "safety_concern",
+    ]
+    rating: int | None = None
+    text: str | None = None
+    related_event_ids: list[str] = Field(default_factory=list)
+    related_action_id: str | None = None
+    operator_id: str | None = None

--- a/src/rosclaw/practice/schemas.py
+++ b/src/rosclaw/practice/schemas.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
-
 SCHEMA_VERSION = "practice.event.v1"
 
 

--- a/src/rosclaw/practice/storage/__init__.py
+++ b/src/rosclaw/practice/storage/__init__.py
@@ -1,0 +1,7 @@
+"""Practice storage package."""
+
+from rosclaw.practice.storage.catalog import PracticeCatalog
+from rosclaw.practice.storage.fallback_sync import FallbackSync
+from rosclaw.practice.storage.layout import PracticeLayout
+
+__all__ = ["PracticeCatalog", "FallbackSync", "PracticeLayout"]

--- a/src/rosclaw/practice/storage/catalog.py
+++ b/src/rosclaw/practice/storage/catalog.py
@@ -1,0 +1,186 @@
+"""Local SQLite catalog for practice sessions, events, and artifacts."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("rosclaw.practice.storage.catalog")
+
+
+class PracticeCatalog:
+    """SQLite-backed index of practices, events, and artifacts."""
+
+    _SCHEMA = """
+    CREATE TABLE IF NOT EXISTS practices (
+        practice_id TEXT PRIMARY KEY,
+        session_id TEXT,
+        robot_id TEXT,
+        robot_type TEXT,
+        task_id TEXT,
+        task_name TEXT,
+        skill_id TEXT,
+        start_time TEXT,
+        end_time TEXT,
+        duration_ms REAL,
+        outcome TEXT,
+        reward REAL,
+        manifest_path TEXT,
+        events_jsonl_path TEXT,
+        replay_path TEXT,
+        failure_report_path TEXT,
+        seekdb_committed INTEGER
+    );
+
+    CREATE TABLE IF NOT EXISTS events (
+        event_id TEXT PRIMARY KEY,
+        practice_id TEXT,
+        source TEXT,
+        event_type TEXT,
+        timestamp_ns INTEGER,
+        timestamp_utc TEXT,
+        action_id TEXT,
+        task_id TEXT,
+        skill_id TEXT,
+        payload_ref TEXT,
+        tags TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS failures (
+        failure_id TEXT PRIMARY KEY,
+        practice_id TEXT,
+        failure_type TEXT,
+        severity TEXT,
+        source TEXT,
+        related_action_id TEXT,
+        description TEXT,
+        timestamp_ns INTEGER
+    );
+
+    CREATE TABLE IF NOT EXISTS artifacts (
+        artifact_id TEXT PRIMARY KEY,
+        practice_id TEXT,
+        artifact_type TEXT,
+        path TEXT,
+        checksum TEXT,
+        size_bytes INTEGER,
+        created_at TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_practices_robot ON practices(robot_id);
+    CREATE INDEX IF NOT EXISTS idx_practices_task ON practices(task_id);
+    CREATE INDEX IF NOT EXISTS idx_practices_outcome ON practices(outcome);
+    CREATE INDEX IF NOT EXISTS idx_events_practice ON events(practice_id);
+    CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);
+    """
+
+    def __init__(self, db_path: Path | str):
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        with self._lock:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.executescript(self._SCHEMA)
+            self._conn.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def insert_practice(self, record: dict[str, Any]) -> None:
+        cols = ", ".join(record.keys())
+        placeholders = ", ".join("?" for _ in record)
+        values = list(record.values())
+        with self._lock:
+            self._conn.execute(
+                f"INSERT OR REPLACE INTO practices ({cols}) VALUES ({placeholders})",
+                values,
+            )
+            self._conn.commit()
+
+    def insert_event(self, record: dict[str, Any]) -> None:
+        cols = ", ".join(record.keys())
+        placeholders = ", ".join("?" for _ in record)
+        values = list(record.values())
+        with self._lock:
+            self._conn.execute(
+                f"INSERT OR REPLACE INTO events ({cols}) VALUES ({placeholders})",
+                values,
+            )
+            self._conn.commit()
+
+    def update_practice(
+        self,
+        practice_id: str,
+        updates: dict[str, Any],
+    ) -> bool:
+        if not updates:
+            return False
+        set_clause = ", ".join(f"{k} = ?" for k in updates)
+        values = list(updates.values()) + [practice_id]
+        with self._lock:
+            cursor = self._conn.execute(
+                f"UPDATE practices SET {set_clause} WHERE practice_id = ?",
+                values,
+            )
+            self._conn.commit()
+        return cursor.rowcount > 0
+
+    def get_practice(self, practice_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM practices WHERE practice_id = ?",
+                (practice_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def list_practices(
+        self,
+        robot_id: str | None = None,
+        task_id: str | None = None,
+        outcome: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        where: list[str] = []
+        params: list[Any] = []
+        if robot_id:
+            where.append("robot_id = ?")
+            params.append(robot_id)
+        if task_id:
+            where.append("task_id = ?")
+            params.append(task_id)
+        if outcome:
+            where.append("outcome = ?")
+            params.append(outcome)
+        sql = "SELECT * FROM practices"
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY start_time DESC LIMIT ?"
+        params.append(limit)
+        with self._lock:
+            rows = self._conn.execute(sql, params).fetchall()
+        return [dict(row) for row in rows]
+
+    def count_events(self, practice_id: str) -> int:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT COUNT(*) FROM events WHERE practice_id = ?",
+                (practice_id,),
+            ).fetchone()
+        return row[0] if row else 0
+
+    def __enter__(self) -> PracticeCatalog:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/src/rosclaw/practice/storage/catalog.py
+++ b/src/rosclaw/practice/storage/catalog.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import sqlite3
 import threading
-import time
 from pathlib import Path
 from typing import Any
 

--- a/src/rosclaw/practice/storage/fallback_sync.py
+++ b/src/rosclaw/practice/storage/fallback_sync.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import shutil
 from pathlib import Path
 from typing import Any

--- a/src/rosclaw/practice/storage/fallback_sync.py
+++ b/src/rosclaw/practice/storage/fallback_sync.py
@@ -1,0 +1,74 @@
+"""Sync offline fallback JSON files back to SeekDB.
+
+Scans the fallback directory for previously-failed PraxisEvent JSON files,
+POSTs them to SeekDB, and moves successfully-uploaded files to an archive
+subdirectory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import requests
+
+logger = logging.getLogger("rosclaw.practice.storage.fallback_sync")
+
+
+class FallbackSync:
+    """Re-submit fallback JSON files to SeekDB."""
+
+    def __init__(
+        self,
+        seekdb_url: str = "http://localhost:2881",
+        fallback_dir: Path | str = "/data/rosclaw/practice/fallback",
+        table: str = "praxis_events",
+        timeout_sec: float = 2.0,
+    ):
+        self._seekdb_url = seekdb_url.rstrip("/")
+        self._endpoint = f"{self._seekdb_url}/api/v1/insert"
+        self._fallback_dir = Path(fallback_dir)
+        self._table = table
+        self._timeout = timeout_sec
+        self._archived_dir = self._fallback_dir / "archived"
+
+    def sync(self) -> dict[str, Any]:
+        """Return summary with attempted/success/failed counts."""
+        self._fallback_dir.mkdir(parents=True, exist_ok=True)
+        self._archived_dir.mkdir(parents=True, exist_ok=True)
+
+        summary = {"attempted": 0, "success": 0, "failed": 0, "errors": []}
+        files = sorted(self._fallback_dir.glob("*.json"))
+        for path in files:
+            summary["attempted"] += 1
+            try:
+                with open(path, encoding="utf-8") as f:
+                    event_data = json.load(f)
+                response = requests.post(
+                    self._endpoint,
+                    json={"table": self._table, "data": event_data},
+                    timeout=self._timeout,
+                )
+                response.raise_for_status()
+                target = self._archived_dir / path.name
+                suffix = 1
+                stem = path.stem
+                ext = path.suffix
+                while target.exists():
+                    target = self._archived_dir / f"{stem}.{suffix:03d}{ext}"
+                    suffix += 1
+                shutil.move(str(path), str(target))
+                summary["success"] += 1
+            except Exception as e:
+                summary["failed"] += 1
+                summary["errors"].append(f"{path.name}: {e}")
+                logger.error("Failed to sync fallback %s: %s", path, e)
+        return summary
+
+    def list_pending(self) -> list[Path]:
+        self._fallback_dir.mkdir(parents=True, exist_ok=True)
+        return sorted(self._fallback_dir.glob("*.json"))

--- a/src/rosclaw/practice/storage/layout.py
+++ b/src/rosclaw/practice/storage/layout.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import time
 from pathlib import Path
 from typing import Any
 

--- a/src/rosclaw/practice/storage/layout.py
+++ b/src/rosclaw/practice/storage/layout.py
@@ -1,0 +1,154 @@
+"""Filesystem layout and manifest helpers for rosclaw-practice."""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from rosclaw.practice.config import PracticeSession, PracticeSummary
+
+logger = logging.getLogger("rosclaw.practice.storage.layout")
+
+
+class PracticeLayout:
+    """Manages directory layout for a practice data root."""
+
+    def __init__(self, data_root: Path | str):
+        self._data_root = Path(data_root)
+
+    @property
+    def data_root(self) -> Path:
+        return self._data_root
+
+    @property
+    def sessions_dir(self) -> Path:
+        return self._data_root / "sessions"
+
+    @property
+    def indexes_dir(self) -> Path:
+        return self._data_root / "indexes"
+
+    @property
+    def fallback_dir(self) -> Path:
+        return self._data_root / "fallback"
+
+    @property
+    def catalog_db_path(self) -> Path:
+        return self.indexes_dir / "practice_catalog.sqlite"
+
+    def ensure_directories(self) -> None:
+        for sub in (
+            "sessions",
+            "fallback",
+            "fallback/archived",
+            "indexes",
+            "datasets/rlds",
+            "datasets/lerobot",
+        ):
+            (self._data_root / sub).mkdir(parents=True, exist_ok=True)
+
+    def session_dir(self, practice_id: str) -> Path:
+        return self.sessions_dir / practice_id
+
+    def raw_dir(self, practice_id: str) -> Path:
+        return self.session_dir(practice_id) / "raw"
+
+    def index_dir(self, practice_id: str) -> Path:
+        return self.session_dir(practice_id) / "index"
+
+    def reports_dir(self, practice_id: str) -> Path:
+        return self.session_dir(practice_id) / "reports"
+
+    def events_jsonl_path(self, practice_id: str) -> Path:
+        return self.raw_dir(practice_id) / "events.jsonl"
+
+    def manifest_path(self, practice_id: str) -> Path:
+        return self.session_dir(practice_id) / "manifest.yaml"
+
+    def create_session_dirs(self, practice_id: str) -> Path:
+        session = self.session_dir(practice_id)
+        for sub in ("raw", "frames/rgb", "frames/depth", "derived", "exports", "replay", "reports", "index"):
+            (session / sub).mkdir(parents=True, exist_ok=True)
+        return session
+
+    def write_manifest(
+        self,
+        session: PracticeSession,
+        summary: PracticeSummary | None = None,
+        sources: dict[str, bool] | None = None,
+        seekdb_enabled: bool = False,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        manifest: dict[str, Any] = {
+            "schema_version": "practice.manifest.v1",
+            "practice_id": session.practice_id,
+            "session_id": session.session_id,
+            "robot_id": session.robot_id,
+            "robot_type": None,
+            "task": {
+                "task_id": session.task_id,
+                "task_name": session.task_name,
+                "skill_id": session.skill_id,
+            },
+            "start_time": session.start_time_utc,
+            "end_time": None,
+            "duration_ms": None,
+            "sources": sources or {},
+            "artifacts": {
+                "events_jsonl": str(self.events_jsonl_path(session.practice_id)),
+            },
+            "seekdb": {
+                "enabled": seekdb_enabled,
+                "committed": None,
+                "table": "praxis_events",
+            },
+            "status": {
+                "outcome": "running",
+                "failure_labels": [],
+                "reward": None,
+            },
+        }
+        if extra:
+            manifest.update(extra)
+        if summary is not None:
+            manifest["end_time"] = _utc_now_iso()
+            manifest["duration_ms"] = summary.duration_ms
+            manifest["status"]["outcome"] = summary.outcome
+            manifest["status"]["reward"] = summary.reward
+            manifest["status"]["failure_labels"] = summary.failure_labels
+            manifest["seekdb"]["committed"] = summary.seekdb_committed
+        path = self.manifest_path(session.practice_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(manifest, f, sort_keys=False, allow_unicode=True)
+
+    def read_manifest(self, practice_id: str) -> dict[str, Any] | None:
+        path = self.manifest_path(practice_id)
+        if not path.exists():
+            return None
+        try:
+            with open(path, encoding="utf-8") as f:
+                return yaml.safe_load(f)
+        except Exception as e:
+            logger.warning("Failed to read manifest %s: %s", path, e)
+            return None
+
+
+def _utc_now_iso() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def generate_practice_id() -> str:
+    """Generate a unique practice id: prac_<utc_time>_<short_hash>."""
+    from datetime import UTC, datetime
+    from uuid import uuid4
+
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    short_hash = uuid4().hex[:6]
+    return f"prac_{ts}_{short_hash}"

--- a/src/rosclaw/practice/writers/__init__.py
+++ b/src/rosclaw/practice/writers/__init__.py
@@ -1,0 +1,5 @@
+"""Practice writers package."""
+
+from rosclaw.practice.writers.jsonl_writer import JsonlWriter
+
+__all__ = ["JsonlWriter"]

--- a/src/rosclaw/practice/writers/jsonl_writer.py
+++ b/src/rosclaw/practice/writers/jsonl_writer.py
@@ -1,0 +1,105 @@
+"""JSONL writer for practice events.
+
+Appends ``PracticeEventEnvelope`` records as one JSON object per line.
+Supports optional rotation by file size and atomic-ish writes via a temporary
+file rename.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("rosclaw.practice.jsonl_writer")
+
+
+class JsonlWriter:
+    """Append-only JSONL writer with optional size-based rotation."""
+
+    def __init__(
+        self,
+        path: Path | str,
+        rotate_mb: float | None = None,
+    ):
+        self._path = Path(path)
+        self._rotate_bytes = int(rotate_mb * 1024 * 1024) if rotate_mb else None
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._file = None
+        self._open()
+
+    def _open(self) -> None:
+        self._file = open(self._path, "a", encoding="utf-8")
+
+    def write(self, record: dict[str, Any]) -> None:
+        """Serialize *record* to one JSON line and append."""
+        try:
+            line = json.dumps(record, ensure_ascii=False, default=str)
+        except (TypeError, ValueError) as e:
+            logger.error("Failed to serialize JSONL record: %s", e)
+            return
+
+        with self._lock:
+            self._file.write(line + "\n")
+            self._file.flush()
+
+            if self._rotate_bytes and self._path.stat().st_size >= self._rotate_bytes:
+                self._rotate()
+
+    def _rotate(self) -> None:
+        self._file.close()
+        suffix = 1
+        while True:
+            rotated = self._path.with_suffix(f".jsonl.{suffix:03d}")
+            if not rotated.exists():
+                self._path.rename(rotated)
+                break
+            suffix += 1
+        self._open()
+
+    def flush(self) -> None:
+        with self._lock:
+            if self._file is not None:
+                self._file.flush()
+                os.fsync(self._file.fileno())
+
+    def close(self) -> None:
+        with self._lock:
+            if self._file is not None:
+                self.flush()
+                self._file.close()
+                self._file = None
+
+    def write_atomic(self, record: dict[str, Any]) -> None:
+        """Write a single record atomically using a temp file + rename.
+
+        Useful for small metadata files where rotation is not needed.
+        """
+        line = json.dumps(record, ensure_ascii=False, default=str)
+        fd, tmp = tempfile.mkstemp(
+            dir=self._path.parent,
+            prefix=self._path.name + ".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(line + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, self._path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def __enter__(self) -> JsonlWriter:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/src/rosclaw/practice/writers/jsonl_writer.py
+++ b/src/rosclaw/practice/writers/jsonl_writer.py
@@ -7,6 +7,7 @@ file rename.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -34,7 +35,7 @@ class JsonlWriter:
         self._open()
 
     def _open(self) -> None:
-        self._file = open(self._path, "a", encoding="utf-8")
+        self._file = open(self._path, "a", encoding="utf-8")  # noqa: SIM115
 
     def write(self, record: dict[str, Any]) -> None:
         """Serialize *record* to one JSON line and append."""
@@ -92,10 +93,8 @@ class JsonlWriter:
                 os.fsync(f.fileno())
             os.replace(tmp, self._path)
         except Exception:
-            try:
+            with contextlib.suppress(OSError):
                 os.unlink(tmp)
-            except OSError:
-                pass
             raise
 
     def __enter__(self) -> JsonlWriter:

--- a/tests/practice/test_catalog.py
+++ b/tests/practice/test_catalog.py
@@ -1,0 +1,89 @@
+"""Tests for PracticeCatalog."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from rosclaw.practice.storage.catalog import PracticeCatalog
+
+
+def test_insert_and_get_practice():
+    with tempfile.TemporaryDirectory() as tmp:
+        db = PracticeCatalog(Path(tmp) / "catalog.sqlite")
+        db.insert_practice({
+            "practice_id": "prac_001",
+            "robot_id": "r1",
+            "robot_type": "humanoid",
+            "task_id": "t1",
+            "task_name": "walk",
+            "skill_id": "s1",
+            "start_time": "2024-01-01T00:00:00Z",
+            "manifest_path": "/tmp/manifest.yaml",
+            "events_jsonl_path": "/tmp/events.jsonl",
+            "outcome": "running",
+        })
+        record = db.get_practice("prac_001")
+        assert record is not None
+        assert record["robot_id"] == "r1"
+        assert record["task_name"] == "walk"
+        db.close()
+
+
+def test_update_practice():
+    with tempfile.TemporaryDirectory() as tmp:
+        db = PracticeCatalog(Path(tmp) / "catalog.sqlite")
+        db.insert_practice({
+            "practice_id": "prac_002",
+            "robot_id": "r1",
+            "start_time": "2024-01-01T00:00:00Z",
+            "outcome": "running",
+        })
+        ok = db.update_practice("prac_002", {"outcome": "SUCCESS", "reward": 0.8})
+        assert ok is True
+        record = db.get_practice("prac_002")
+        assert record["outcome"] == "SUCCESS"
+        assert record["reward"] == 0.8
+        db.close()
+
+
+def test_list_practices_filters():
+    with tempfile.TemporaryDirectory() as tmp:
+        db = PracticeCatalog(Path(tmp) / "catalog.sqlite")
+        for i, robot in enumerate(["r1", "r1", "r2"]):
+            db.insert_practice({
+                "practice_id": f"prac_{i}",
+                "robot_id": robot,
+                "task_id": "t1",
+                "start_time": f"2024-01-0{i+1}T00:00:00Z",
+                "outcome": "SUCCESS",
+            })
+        results = db.list_practices(robot_id="r1")
+        assert len(results) == 2
+        results = db.list_practices(outcome="SUCCESS", limit=2)
+        assert len(results) == 2
+        db.close()
+
+
+def test_insert_event():
+    with tempfile.TemporaryDirectory() as tmp:
+        db = PracticeCatalog(Path(tmp) / "catalog.sqlite")
+        db.insert_practice({
+            "practice_id": "prac_003",
+            "robot_id": "r1",
+            "start_time": "2024-01-01T00:00:00Z",
+            "outcome": "running",
+        })
+        db.insert_event({
+            "event_id": "evt_1",
+            "practice_id": "prac_003",
+            "source": "agent",
+            "event_type": "agent.task_received",
+            "timestamp_ns": 123,
+            "timestamp_utc": "2024-01-01T00:00:00Z",
+            "tags": "",
+        })
+        with db._lock:
+            rows = db._conn.execute("SELECT * FROM events WHERE practice_id = ?", ("prac_003",)).fetchall()
+        assert len(rows) == 1
+        db.close()

--- a/tests/practice/test_coordinator.py
+++ b/tests/practice/test_coordinator.py
@@ -1,0 +1,94 @@
+"""Tests for PracticeCoordinator."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+from pathlib import Path
+
+from rosclaw.core.event_bus import EventBus
+from rosclaw.practice.config import PracticeConfig, SourceConfig
+from rosclaw.practice.coordinator import PracticeCoordinator
+
+
+def test_coordinator_mock_session_writes_manifest_and_jsonl():
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = PracticeConfig(
+            robot_id="test_bot",
+            task_name="pick cup",
+            data_root=tmp,
+            sources=SourceConfig(agent=True, runtime=True),
+            mock=True,
+            publish_to_event_bus=False,
+        )
+        coord = PracticeCoordinator(cfg)
+        coord.initialize()
+        coord.start()
+        time.sleep(0.4)
+        coord.stop()
+
+        summary = coord.summary
+        assert summary is not None
+        assert summary.outcome == "SUCCESS"
+        assert summary.event_count >= 7
+
+        session_dir = Path(tmp) / "sessions" / summary.practice_id
+        assert (session_dir / "manifest.yaml").exists()
+        assert (session_dir / "raw" / "events.jsonl").exists()
+
+        events_jsonl = session_dir / "raw" / "events.jsonl"
+        lines = events_jsonl.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == summary.event_count
+        first = json.loads(lines[0])
+        assert first["schema_version"] == "practice.event.v1"
+        assert first["practice_id"] == summary.practice_id
+
+
+def test_coordinator_publishes_session_events_on_event_bus():
+    with tempfile.TemporaryDirectory() as tmp:
+        bus = EventBus()
+        received = []
+        bus.subscribe("practice.session_started", lambda e: received.append(("started", e.payload)))
+        bus.subscribe("practice.session_finished", lambda e: received.append(("finished", e.payload)))
+
+        cfg = PracticeConfig(
+            robot_id="test_bot",
+            task_name="pick cup",
+            data_root=tmp,
+            sources=SourceConfig(agent=True),
+            mock=True,
+            event_bus=bus,
+        )
+        coord = PracticeCoordinator(cfg)
+        coord.initialize()
+        coord.start()
+        time.sleep(0.2)
+        coord.stop()
+
+        assert any(t == "started" for t, _ in received)
+        assert any(t == "finished" for t, _ in received)
+
+
+def test_coordinator_catalog_indexed():
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = PracticeConfig(
+            robot_id="test_bot",
+            task_name="pick cup",
+            data_root=tmp,
+            sources=SourceConfig(agent=True),
+            mock=True,
+            publish_to_event_bus=False,
+        )
+        coord = PracticeCoordinator(cfg)
+        coord.initialize()
+        coord.start()
+        time.sleep(0.2)
+        coord.stop()
+
+        record = coord.catalog.get_practice(coord.summary.practice_id)
+        assert record is not None
+        assert record["outcome"] == "SUCCESS"
+        # event_count is tracked in the summary, not the practices table
+        assert coord.summary.event_count > 0
+        assert coord.catalog.count_events(coord.summary.practice_id) == coord.summary.event_count

--- a/tests/practice/test_episode_recorder_practice.py
+++ b/tests/practice/test_episode_recorder_practice.py
@@ -1,0 +1,49 @@
+"""Tests for EpisodeRecorder integration with PracticeCoordinator sessions."""
+
+from __future__ import annotations
+
+import tempfile
+import time
+
+from rosclaw.core.event_bus import EventBus
+from rosclaw.practice.config import PracticeConfig, SourceConfig
+from rosclaw.practice.coordinator import PracticeCoordinator
+from rosclaw.practice.episode_recorder import EpisodeRecorder
+
+
+class _FakeSeekDBBridge:
+    def __init__(self):
+        self.events = []
+
+    def commit(self, event):
+        self.events.append(event)
+
+
+def test_episode_recorder_finalizes_on_practice_session_finished():
+    bus = EventBus()
+    bridge = _FakeSeekDBBridge()
+    recorder = EpisodeRecorder("test_bot", event_bus=bus, seekdb_bridge=bridge)
+    recorder.initialize()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = PracticeConfig(
+            robot_id="test_bot",
+            task_name="pick cup",
+            data_root=tmp,
+            sources=SourceConfig(agent=True),
+            mock=True,
+            event_bus=bus,
+        )
+        coord = PracticeCoordinator(cfg)
+        coord.initialize()
+        coord.start()
+        time.sleep(0.3)
+        coord.stop()
+        recorder.stop()
+
+    assert len(bridge.events) == 1
+    event = bridge.events[0]
+    assert event.event_id == coord.summary.practice_id
+    assert event.event_type == "success"
+    assert event.robot_id == "test_bot"
+    assert event.agent_instruction == "pick cup"

--- a/tests/practice/test_fallback_sync.py
+++ b/tests/practice/test_fallback_sync.py
@@ -1,0 +1,52 @@
+"""Tests for FallbackSync."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from rosclaw.practice.storage.fallback_sync import FallbackSync
+
+
+def test_sync_success_moves_to_archive():
+    with tempfile.TemporaryDirectory() as tmp:
+        fallback = Path(tmp)
+        payload = {"practice_id": "prac_001"}
+        (fallback / "prac_001.json").write_text(json.dumps(payload), encoding="utf-8")
+
+        with patch("rosclaw.practice.storage.fallback_sync.requests.post") as mock_post:
+            mock_post.return_value.raise_for_status = lambda: None
+            sync = FallbackSync(seekdb_url="http://localhost:2881", fallback_dir=fallback)
+            summary = sync.sync()
+
+        assert summary["attempted"] == 1
+        assert summary["success"] == 1
+        assert summary["failed"] == 0
+        assert not (fallback / "prac_001.json").exists()
+        assert (fallback / "archived" / "prac_001.json").exists()
+
+
+def test_sync_failure_keeps_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        fallback = Path(tmp)
+        (fallback / "prac_002.json").write_text(json.dumps({"practice_id": "prac_002"}), encoding="utf-8")
+
+        with patch("rosclaw.practice.storage.fallback_sync.requests.post") as mock_post:
+            mock_post.return_value.raise_for_status.side_effect = Exception("boom")
+            sync = FallbackSync(seekdb_url="http://localhost:2881", fallback_dir=fallback)
+            summary = sync.sync()
+
+        assert summary["attempted"] == 1
+        assert summary["success"] == 0
+        assert summary["failed"] == 1
+        assert (fallback / "prac_002.json").exists()
+
+
+def test_list_pending():
+    with tempfile.TemporaryDirectory() as tmp:
+        fallback = Path(tmp)
+        (fallback / "a.json").write_text("{}", encoding="utf-8")
+        sync = FallbackSync(fallback_dir=fallback)
+        assert len(sync.list_pending()) == 1

--- a/tests/practice/test_jsonl_writer.py
+++ b/tests/practice/test_jsonl_writer.py
@@ -1,0 +1,70 @@
+"""Tests for JsonlWriter."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from rosclaw.practice.writers.jsonl_writer import JsonlWriter
+
+
+def test_write_creates_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "events.jsonl"
+        writer = JsonlWriter(path)
+        writer.write({"event": 1})
+        writer.close()
+        assert path.exists()
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["event"] == 1
+
+
+def test_multiple_records():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "events.jsonl"
+        with JsonlWriter(path) as writer:
+            for i in range(3):
+                writer.write({"i": i})
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 3
+        assert [json.loads(line)["i"] for line in lines] == [0, 1, 2]
+
+
+def test_bad_record_written_as_string():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "events.jsonl"
+        writer = JsonlWriter(path)
+        writer.write({"ok": True})
+        writer.write(object())  # type: ignore[arg-type]
+        writer.write({"ok": False})
+        writer.close()
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 3
+        assert json.loads(lines[0])["ok"] is True
+        assert json.loads(lines[2])["ok"] is False
+        # middle line is the string representation of the object
+        assert "object object" in lines[1]
+
+
+def test_rotation():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "events.jsonl"
+        writer = JsonlWriter(path, rotate_mb=0.001)  # ~1KB
+        for i in range(100):
+            writer.write({"payload": "x" * 100})
+        writer.close()
+        assert path.exists()
+        rotated = list(Path(tmp).glob("events.jsonl.*"))
+        assert len(rotated) >= 1
+
+
+def test_write_atomic():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "meta.jsonl"
+        writer = JsonlWriter(path)
+        writer.write_atomic({"meta": True})
+        writer.close()
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert json.loads(lines[0])["meta"] is True

--- a/tests/practice/test_jsonl_writer.py
+++ b/tests/practice/test_jsonl_writer.py
@@ -52,7 +52,7 @@ def test_rotation():
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "events.jsonl"
         writer = JsonlWriter(path, rotate_mb=0.001)  # ~1KB
-        for i in range(100):
+        for _ in range(100):
             writer.write({"payload": "x" * 100})
         writer.close()
         assert path.exists()

--- a/tests/practice/test_mock_adapters.py
+++ b/tests/practice/test_mock_adapters.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from rosclaw.practice.adapters.mock_agent_adapter import MockAgentAdapter
 from rosclaw.practice.adapters.mock_runtime_adapter import MockRuntimeAdapter
-from rosclaw.practice.config import PracticeSession
 
 
 class _FakeSession:

--- a/tests/practice/test_mock_adapters.py
+++ b/tests/practice/test_mock_adapters.py
@@ -1,0 +1,48 @@
+"""Tests for mock source adapters."""
+
+from __future__ import annotations
+
+from rosclaw.practice.adapters.mock_agent_adapter import MockAgentAdapter
+from rosclaw.practice.adapters.mock_runtime_adapter import MockRuntimeAdapter
+from rosclaw.practice.config import PracticeSession
+
+
+class _FakeSession:
+    practice_id = "prac_test"
+
+
+def test_mock_agent_adapter_generates_trace():
+    adapter = MockAgentAdapter("r1", task="pick cup")
+    adapter.start(_FakeSession())
+    events = []
+    for _ in range(5):
+        events.extend(adapter.poll())
+    adapter.stop()
+
+    types = [e.event_type for e in events]
+    assert "agent.task_received" in types
+    assert "agent.plan_created" in types
+    assert "agent.tool_call_started" in types
+    assert "agent.tool_call_finished" in types
+    assert all(e.practice_id == "prac_test" for e in events)
+
+
+def test_mock_runtime_adapter_generates_actions():
+    adapter = MockRuntimeAdapter("r1")
+    adapter.start(_FakeSession())
+    events = []
+    for _ in range(4):
+        events.extend(adapter.poll())
+    adapter.stop()
+
+    types = [e.event_type for e in events]
+    assert "runtime.action_proposed" in types
+    assert "runtime.action_executed" in types
+    assert "runtime.reward_observed" in types
+
+
+def test_adapter_health():
+    adapter = MockAgentAdapter("r1")
+    health = adapter.health()
+    assert health.source == "agent"
+    assert health.healthy is True

--- a/tests/practice/test_schemas.py
+++ b/tests/practice/test_schemas.py
@@ -1,0 +1,107 @@
+"""Tests for rosclaw.practice schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from rosclaw.practice.schemas import (
+    AgentPlanPayload,
+    ExecutedActionPayload,
+    FootContactPayload,
+    HumanFeedbackPayload,
+    IMUPayload,
+    JointStatePayload,
+    PracticeEventEnvelope,
+    ToolCallPayload,
+)
+
+
+def test_envelope_defaults():
+    env = PracticeEventEnvelope(
+        practice_id="prac_001",
+        robot_id="r1",
+        source="agent",
+        event_type="agent.task_received",
+    )
+    assert env.schema_version == "practice.event.v1"
+    assert env.timestamp_ns is not None
+    assert env.timestamp_utc is not None
+    assert env.event_id
+
+
+def test_envelope_payload_roundtrip():
+    payload = AgentPlanPayload(
+        task="pick cup",
+        plan_id="plan_1",
+        planner="mock",
+        plan_steps=[{"step": 1, "name": "perceive"}],
+    )
+    env = PracticeEventEnvelope(
+        practice_id="prac_001",
+        robot_id="r1",
+        source="agent",
+        event_type="agent.plan_created",
+        payload=payload.model_dump(),
+    )
+    data = env.model_dump(mode="json")
+    assert data["payload"]["task"] == "pick cup"
+    restored = PracticeEventEnvelope.model_validate(data)
+    assert restored.payload["task"] == "pick cup"
+
+
+def test_envelope_source_must_be_valid():
+    with pytest.raises(ValidationError):
+        PracticeEventEnvelope(
+            practice_id="prac_001",
+            robot_id="r1",
+            source="not_a_source",  # type: ignore[arg-type]
+            event_type="x",
+        )
+
+
+def test_joint_state_payload_validation():
+    p = JointStatePayload(
+        joint_names=["j1", "j2"],
+        position=[0.1, 0.2],
+        velocity=[0.0, 0.0],
+    )
+    assert p.joint_names == ["j1", "j2"]
+
+
+def test_imu_payload_requires_angular_and_linear():
+    with pytest.raises(ValidationError):
+        IMUPayload(angular_velocity_xyz=[0.0, 0.0, 0.0])  # missing linear_acceleration
+
+
+def test_foot_contact_payload():
+    p = FootContactPayload(left_contact=True, right_contact=False)
+    assert p.left_contact is True
+
+
+def test_tool_call_payload_status():
+    p = ToolCallPayload(
+        tool_call_id="tc1",
+        tool_name="grasp",
+        arguments={"object": "cup"},
+        status="started",
+    )
+    assert p.status == "started"
+
+
+def test_executed_action_payload_status():
+    p = ExecutedActionPayload(
+        action_id="a1",
+        action_type="move",
+        command={"target": [0.0, 0.0]},
+        controller="mock",
+        start_time_ns=123,
+        status="completed",
+        reward=0.8,
+    )
+    assert p.reward == 0.8
+
+
+def test_human_feedback_payload():
+    p = HumanFeedbackPayload(feedback_id="f1", feedback_type="thumbs_up", rating=5)
+    assert p.rating == 5

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,6 +261,67 @@ class TestPracticeCommands:
         captured = capsys.readouterr()
         assert "not found" in captured.out or code == 1
 
+    def test_practice_init(self, monkeypatch, tmp_path):
+        from rosclaw.cli import main
+        monkeypatch.setenv("HOME", str(tmp_path))
+        sys.argv = ["rosclaw", "practice", "init", "--robot", "test_bot"]
+        assert main() == 0
+        assert (tmp_path / ".rosclaw" / "practice" / "config.yaml").exists()
+
+    def test_practice_start_mock(self, monkeypatch, tmp_path, capsys):
+        from rosclaw.cli import main
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        data_root = tmp_path / "practice_data"
+        sys.argv = [
+            "rosclaw", "practice", "start",
+            "--robot", "test_bot",
+            "--task", "mock_task",
+            "--sources", "agent,runtime",
+            "--mock",
+            "--duration", "500ms",
+            "--data-root", str(data_root),
+        ]
+        assert main() == 0
+        captured = capsys.readouterr()
+        assert "Started session" in captured.out
+        assert "Stopped" in captured.out
+
+    def test_practice_export_jsonl(self, monkeypatch, tmp_path, capsys):
+        from rosclaw.cli import main
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        data_root = tmp_path / "practice_data"
+        sys.argv = [
+            "rosclaw", "practice", "start",
+            "--robot", "test_bot",
+            "--task", "mock_task",
+            "--sources", "agent",
+            "--mock",
+            "--duration", "300ms",
+            "--data-root", str(data_root),
+        ]
+        assert main() == 0
+        # Find the practice id from data root
+        sessions = [d for d in (data_root / "sessions").iterdir() if d.is_dir()]
+        assert sessions
+        practice_id = sessions[0].name
+        sys.argv = [
+            "rosclaw", "practice", "export",
+            practice_id,
+            "--format", "jsonl",
+            "--data-root", str(data_root),
+        ]
+        capsys.readouterr()  # clear output from start command
+        assert main() == 0
+        captured = capsys.readouterr()
+        lines = [line for line in captured.out.splitlines() if line.strip()]
+        assert len(lines) > 0
+        import json
+        assert json.loads(lines[0])["schema_version"] == "practice.event.v1"
+
 
 class TestDashboard:
     def test_dashboard(self, capsys):


### PR DESCRIPTION
## Summary
- Introduces `PracticeCoordinator` to manage practice session lifecycle (init / start / stop) and emit canonical `PracticeEventEnvelope` events.
- Adds layered local storage: `sessions/<practice_id>/raw/events.jsonl`, `manifest.yaml`, and `indexes/practice_catalog.sqlite`.
- Implements mock source adapters (`agent`, `runtime`, `sense`) for Sprint 1 offline development.
- Reuses existing `EpisodeRecorder` + `SeekDBBridge` to commit the final `PraxisEvent` when SeekDB is enabled.
- Extends CLI with `rosclaw practice init/start/stop/sync-fallback` and `--format jsonl` export.

## Test plan
- [x] `pytest tests/practice -q` passes
- [x] `pytest tests/test_cli.py tests/test_readme_commands.py -q` passes
- [x] Full suite: `pytest tests/ -q --timeout=180` → 3146 passed, 3 skipped, 23 deselected
- [x] Branch rebased on `main`; no `rosclaw.skill.cli` dependency introduced

## Scope notes
- Real DDS/ROS2/Camera adapters are intentionally left as interface placeholders for future sprints.
- MCAP writing remains a placeholder; this PR focuses on JSONL event persistence and catalog indexing.