### PR TITLE
fix(practice): persist robot_type in manifest

### DIFF
--- a/src/rosclaw/practice/config.py
+++ b/src/rosclaw/practice/config.py
@@ -115,6 +115,7 @@ class PracticeSession:
     session_dir: Path
     start_time_ns: int
     start_time_utc: str
+    robot_type: str | None = None
     session_id: str | None = None
     tags: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/src/rosclaw/practice/coordinator.py
+++ b/src/rosclaw/practice/coordinator.py
@@ -109,6 +109,7 @@ class PracticeCoordinator(LifecycleMixin):
         self._session = PracticeSession(
             practice_id=practice_id,
             robot_id=self.config.robot_id,
+            robot_type=self.config.robot_type,
             task_id=self.config.task_id,
             task_name=self.config.task_name,
             skill_id=self.config.skill_id,

--- a/src/rosclaw/practice/storage/layout.py
+++ b/src/rosclaw/practice/storage/layout.py
@@ -87,7 +87,7 @@ class PracticeLayout:
             "practice_id": session.practice_id,
             "session_id": session.session_id,
             "robot_id": session.robot_id,
-            "robot_type": None,
+            "robot_type": session.robot_type,
             "task": {
                 "task_id": session.task_id,
                 "task_name": session.task_name,


### PR DESCRIPTION
## Summary
`--robot-type` passed to `rosclaw practice start` was being ignored in the generated `manifest.yaml` because `PracticeSession` did not carry the field and `write_manifest` hard-coded `robot_type: null`.

## Changes
- Add `robot_type` to `PracticeSession`.
- Pass `config.robot_type` when creating the session in `PracticeCoordinator`.
- Write `session.robot_type` into the manifest instead of `None`.

## Verification
- `rosclaw practice start --robot-type humanoid ...` now produces `robot_type: humanoid` in `manifest.yaml`.
- `pytest tests/practice tests/test_cli.py tests/test_readme_commands.py -q` → 96 passed.
- `pytest tests/ -q --timeout=180` → 3167 passed, 3 skipped, 23 deselected.
- `ruff check src tests --select E,F,I,N,W,UP,B,C4,SIM --ignore E501` passes.