### PR TITLE
fix(cli): dispatch skill hub subcommands via args.func

### DIFF
--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -3607,6 +3607,8 @@ def main() -> int:
             provider_parser.print_help()
             return 1
     elif args.command == "skill":
+        if getattr(args, "func", None):
+            return args.func(args)
         if args.skill_command == "list":
             return cmd_skill_list(args)
         elif args.skill_command == "check":


### PR DESCRIPTION
## Problem

PR #33 merged the Skill Hub lifecycle commands, but the top-level `rosclaw skill` dispatch branch in `src/rosclaw/cli.py` only handled the legacy subcommands (`list`, `check`, `invoke`, `champions`, `lineage`, `rollback`). The new hub subcommands (`init`, `validate`, `mine`, `eval`, `promote`, `package`, `verify-package`, `upload`) register handlers via `parser.set_defaults(func=...)`, so they fell through to the help output and exited with code 1.

## Fix

Add an early `args.func` dispatch check in the `skill` command branch, matching the pattern already used for `agent` and `mcp` commands.

## Verification

After this fix, the full Skill Hub end-to-end sequence passes on `main`:

\`\`\`bash
rosclaw skill init g1_kick_ball --robot unitree_g1 --category manipulation
rosclaw skill validate g1_kick_ball
rosclaw skill mine --from tests/skill/fixtures/practice_sessions --task g1_kick_ball --output g1_kick_ball
rosclaw skill eval g1_kick_ball --candidate candidate_0001 --mode replay
rosclaw skill promote g1_kick_ball@candidate_0001 --to-version 0.1.0
rosclaw skill package g1_kick_ball --output dist/
rosclaw skill verify-package dist/g1_kick_ball-0.1.0.tar.gz
ROSCLAW_ADMIN_API_KEY=test rosclaw skill upload g1_kick_ball --visibility private --dry-run
rosclaw skill rollback g1_kick_ball --to-version 0.1.0
\`\`\`

Test results:
- \`pytest tests/skill -q\` → **21 passed**
- \`pytest tests/test_cli.py -q\` → **39 passed** (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
