### PR TITLE
fix(ros): add websocket-client dep, sync skill CLI docs, speed up ROS2 discovery

### DIFF
--- a/docs/CLI_COMMANDS.md
+++ b/docs/CLI_COMMANDS.md
@@ -31,7 +31,7 @@
 | `how` | How recovery commands | `rosclaw how [-h] {explain,recover} ...` |
 | `provider` | Provider commands | `rosclaw provider [-h] {list,invoke} ...` |
 | `auto` | Auto self-evolution commands | `rosclaw auto [-h] {init,run,status,champion,deadends,report} ...` |
-| `skill` | Skill commands | `rosclaw skill [-h] {init,validate,mine,eval,promote,package,verify-package,upload} ...` |
+| `skill` | Skill commands | `rosclaw skill [-h] {list,check,invoke,champions,lineage,rollback,init,validate,mine,eval,promote,package,verify-package,upload} ...` |
 | `sandbox` | Sandbox commands | `rosclaw sandbox [-h] {list-worlds,validate,run,replay,check} ...` |
 | `runtime` | Runtime backend commands | `rosclaw runtime [-h] {backends} ...` |
 | `firewall` | Firewall safety checks | `rosclaw firewall [-h] {check} ...` |
@@ -96,6 +96,12 @@
 
 | Command | Description | Usage |
 |---------|-------------|-------|
+| `skill list` | List available skills | `rosclaw skill list [-h]` |
+| `skill check` | Check skill availability and body compatibility | `rosclaw skill check [-h] [--all] [--json] [skill_id]` |
+| `skill invoke` | Invoke a skill | `rosclaw skill invoke [-h] [--trace-id TRACE_ID] skill_id input` |
+| `skill champions` | Skill champion management | `rosclaw skill champions [-h] {list} ...` |
+| `skill lineage` | Show skill lineage | `rosclaw skill lineage [-h] skill_id` |
+| `skill rollback` | Rollback skill to version | `rosclaw skill rollback [-h] --to TO skill_id` |
 | `skill init` | Initialize a new skill package from a template | `rosclaw skill init [-h] [--robot ROBOT] [--category CATEGORY] [--namespace NAMESPACE] [--template TEMPLATE] [--output OUTPUT] [--force] name` |
 | `skill validate` | Validate a skill package against the ROSClaw Skill Hub schema | `rosclaw skill validate [-h] [--name NAME] [--workspace WORKSPACE] [--json] [skill_dir]` |
 | `skill mine` | Mine a candidate skill from a source artifact | `rosclaw skill mine [-h] --from SOURCE --task TASK [--robot ROBOT] [--output OUTPUT] [--candidate CANDIDATE] [--json]` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",
     "websockets>=12.0",
+    "websocket-client>=1.0.0",
     "openai>=1.0.0",
     "rosclaw-know>=1.0.2",
     "rosclaw-how>=1.0.2",

--- a/src/rosclaw/connectors/ros/discovery/graph.py
+++ b/src/rosclaw/connectors/ros/discovery/graph.py
@@ -327,7 +327,16 @@ class RosGraphDiscovery:
     def get_service_type(self, service: str) -> str:
         if service in self._service_types:
             return self._service_types[service]
-        result = self._call_rosapi("service_type", {"service": service})
+        # ROS2's /rosapi/service_type can stall for several seconds per service
+        # when the type is not cached. Use a tight timeout; the retry path in
+        # RosbridgeTransport still yields a fast empty response for unknown
+        # services and a quick correct response for known ones.
+        timeout = 0.5 if self._profile.version == RosVersion.ROS2 else None
+        result = self._transport.call_service(
+            self._profile.service("service_type"),
+            {"service": service},
+            timeout_sec=timeout,
+        )
         if result.ok:
             values = _extract_values(result.data)
             raw = values.get("type", "")
@@ -436,7 +445,14 @@ class RosGraphDiscovery:
         return values.get("subscribers") or []
 
     def _get_service_providers(self, service: str) -> list[str]:
-        result = self._call_rosapi("service_node", {"service": service})
+        # ROS2's /rosapi/service_node can stall when the providing node is not
+        # immediately discoverable. Use a tight timeout and fall back to empty.
+        timeout = 0.5 if self._profile.version == RosVersion.ROS2 else None
+        result = self._transport.call_service(
+            self._profile.service("service_node"),
+            {"service": service},
+            timeout_sec=timeout,
+        )
         if not result.ok:
             return []
         values = _extract_values(result.data)


### PR DESCRIPTION
This PR addresses three issues found while validating the ROS 2 Docker integration test stack:

1. **Missing runtime dependency**: `rosbridge` transport imports `websocket`, but `websocket-client` was not declared in `pyproject.toml`. Fresh installs failed with `websocket-client is required for rosbridge transport`.
2. **Out-of-sync skill CLI docs**: `docs/CLI_COMMANDS.md` only listed the new Skill Hub lifecycle commands, while `rosclaw skill --help` also exposes the legacy `list/check/invoke/champions/lineage/rollback` commands.
3. **ROS2 discovery was extremely slow**: `RosGraphDiscovery.discover()` called `/rosapi/service_type` and `/rosapi/service_node` for every service with the default timeout. On the live ROS2 turtlesim container each unknown service stalled for ~3s, making `discover()` take ~300s and the integration tests take 10+ minutes. Using a tight 0.5s timeout on ROS2 lets the transport retry/fast-fail and reduces full discovery to ~2.5s.

### Verification

- `ruff check src tests --select E,F,I,N,W,UP,B,C4,SIM --ignore E501` ✅
- `pytest tests --ignore=tests/unit/auto -q` → **3035 passed, 6 skipped** ✅
- `scripts/acceptance_firstboot.sh` → **READY_WITH_WARNINGS** ✅
- `pytest -o addopts= -m integration tests/connectors/ros/test_turtlesim_integration.py -v` → **6 passed in ~12.5s** ✅ (down from ~632s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
