### PR TITLE
feat(feedback): ROSClaw v1.0 Feedback & Telemetry module

### DIFF
--- a/docs/help/rosclaw-firstboot-dashboard-help.md
+++ b/docs/help/rosclaw-firstboot-dashboard-help.md
@@ -1,38 +1,47 @@
-# ROSClaw Dashboard First Boot 页面开发求助清单
+# ROSClaw First Boot 产品化开发求助清单
 
-> 生成时间：2026-06-22
-> 当前分支：`verify-main`（基于 `origin/main` 准备 rebase）
-> 上游 `origin/main` HEAD：`7e2dda4f`
+> 生成时间：2026-06-24
+> 当前分支：`feat/feedback-telemetry-v1`
+> 上游 `origin/main` HEAD：基于 PR #28 合并后的 main
 > 参考计划：`/home/ubuntu/.claude/plans/lazy-puzzling-dawn.md`
 
 ---
 
 ## 1. 本次完成的工作
 
-实现了 **Dashboard firstboot page**（First Boot Phase 3 子项），为本地 dashboard 提供可视化的首次配置向导。
+在 PR #28（Dashboard firstboot page）已合并到 `main` 的基础上，继续实现 **Feedback / Telemetry v1** 模块，为 ROSClaw 提供可审计、可撤销的产品遥测与反馈上传能力。
 
 ### 1.1 新增/修改文件
 
 | 文件 | 说明 |
 |------|------|
-| `src/rosclaw/dashboard/firstboot.py` | 新增：First Boot 状态读取、配置预览、CLI 命令生成、HTML 向导页面 |
-| `src/rosclaw/dashboard/server.py` | 修改：`DashboardServer.get_firstboot_state()` 委托给新 helper |
-| `src/rosclaw/dashboard/web_server.py` | 修改：新增 `/api/firstboot`、`/api/firstboot/preview`、`/firstboot` 路由 |
-| `tests/dashboard/test_firstboot_page.py` | 新增：API 与页面测试 |
+| `src/rosclaw/feedback/` | 新增：遥测/反馈核心包（config、consent、installation、store、telemetry_client、upload、redactor、cli） |
+| `src/rosclaw/firstboot/telemetry.py` | 重写：使用 `TelemetryConfig` / `FeedbackConfig` 生成 telemetry.yaml / feedback.yaml |
+| `src/rosclaw/firstboot/wizard.py` | 修改：交互/非交互流程中增加 telemetry/diagnostics/rich-feedback 选项，并记录 `firstboot_completed` 事件 |
+| `src/rosclaw/firstboot/workspace.py` | 修改：初始化 workspace 时创建 feedback / telemetry 目录 |
+| `src/rosclaw/cli.py` | 修改：dispatch 接入 `telemetry_command_hook`，新增 `feedback` 子命令，firstboot 新增 `--diagnostics` / `--no-diagnostics` / `--rich-feedback` / `--no-rich-feedback` |
+| `src/rosclaw/dashboard/firstboot.py` | 修改：dashboard 向导增加 diagnostics / rich-feedback 选项，默认 telemetry 关闭（offline 默认） |
+| `tests/feedback/` | 新增：反馈/遥测单元测试 |
+| `tests/test_firstboot.py` | 修改：补充 diagnostics / rich-feedback 参数 |
+| `tests/dashboard/test_firstboot_page.py` | 修改：补充 dashboard 默认命令断言 |
+| `supabase/migrations/004_telemetry_feedback_schema.sql` | 新增：后端遥测/反馈事件表 |
 
 ### 1.2 功能说明
 
-- `/firstboot`：单页 HTML 向导，展示当前 First Boot 状态、可交互选择 profile/robot/safety/模块、实时生成 `rosclaw firstboot --yes ...` 命令。
-- `/api/firstboot`：返回当前安装/工作区/配置状态，供页面刷新使用。
-- `/api/firstboot/preview`：接收用户选择，返回配置预览和可复制命令；**只生成命令，不在服务端执行 firstboot**，符合安全契约。
+- `rosclaw firstboot --yes --profile offline --no-telemetry --no-diagnostics --no-rich-feedback`：非交互式首次配置，offline 默认关闭遥测与反馈上传。
+- `rosclaw feedback telemetry {on|off|status|ping|reset-id}`：用户可随时启用/禁用/测试/轮换匿名安装 ID。
+- `rosclaw feedback consent --diagnostics/--rich-feedback/--revoke-all`：管理诊断摘要与富媒体反馈上传同意。
+- `rosclaw feedback export --redact` / `rosclaw feedback upload --redact`：本地导出或手动上传经过 redaction 的反馈包。
+- Telemetry 事件本地先写入文件，上传为 fire-and-forget；失败不影响本地使用。
+- 所有上传均包含 redaction：不发送 hostname、username、local_path、prompt、log、mcap、api_key、robot_serial 等敏感字段。
 
 ### 1.3 验证结果
 
 | 检查项 | 结果 |
 |--------|------|
 | `ruff check .` | ✅ 通过 |
-| `PYTHONPATH=src python3 -m pytest tests/dashboard/test_firstboot_page.py tests/dashboard/test_body_page.py -v` | ✅ 10 passed |
-| `PYTHONPATH=src python3 -m pytest tests -q --tb=short` | ✅ 3123 passed, 5 skipped |
+| `PYTHONPATH=src python3 -m pytest tests -q --tb=short` | ✅ 3203 passed, 3 skipped |
+| `PYTHONPATH=src python3 -m pytest tests/dashboard/test_firstboot_page.py tests/feedback tests/test_firstboot.py -q` | ✅ 通过 |
 | `python3 scripts/integration_test.py` | ✅ 通过 |
 | `ROSCLAW_DEV_SOURCE=1 bash scripts/acceptance_firstboot.sh` | ✅ 通过 |
 
@@ -40,9 +49,9 @@
 
 ## 2. 当前状态
 
-- `verify-main` 分支在本地保存了上述改动，但尚未 rebase 到最新的 `origin/main`。
-- `origin/main` 自上次验证以来新增了 3 个 docs 提交（`706058f0`、`6a7cd599`、`7e2dda4f`），与本次 dashboard 改动无冲突。
-- 下一步：**rebase 到 `origin/main` → 推送到 `feat/dashboard-firstboot-page` → 创建 PR**。
+- PR #28 已确认合并（`state: MERGED`，合并时间 2026-06-22）。
+- Feedback / Telemetry v1 已在本分支实现并验证，**待提交 PR**。
+- 本地改动包括已合并 PR #28 的 dashboard 页面与新增 feedback 模块，将以 `feat/feedback-telemetry-v1` 分支推送。
 
 ---
 
@@ -53,15 +62,17 @@
 | #13 Body docs + fail-closed executor + firstboot | ✅ 已合并 | Phase 1/2 核心 |
 | #17 MCP CLI tests / onboarding docs | ✅ 已合并 | 验证时 main HEAD |
 | #20 P0 agent docs refresh | ✅ 已合并 | 文档 managed blocks |
-| #21? / #22? Phase 7 sense wiring | ✅ 已合并 | body-sense 别名、skill executor gating |
+| #22 Phase 7 sense wiring | ✅ 已合并 | body-sense 别名、skill executor gating |
+| #28 Dashboard firstboot page | ✅ 已合并 | First Boot Phase 3 首个子项 |
 
-本次新增改动尚未提交 PR。
+本次新增改动（Feedback / Telemetry v1）尚未提交 PR。
 
 ---
 
 ## 4. Phase 3 剩余开发项（更新后）
 
-- [x] **Dashboard firstboot page** — 已实现，待 PR 合并。
+- [x] **Dashboard firstboot page** — 已合并（PR #28）。
+- [ ] **Feedback / Telemetry v1** — 已实现，待 PR 合并。
 - [ ] **Homebrew tap**：需要单独仓库 `ros-claw/homebrew-tap`。
 - [ ] **签名 release artifacts**：需要 GPG/代码签名密钥决策。
 - [ ] ~~**Offline wheel bundle**~~ — **已决定不做**。
@@ -73,8 +84,8 @@
 
 | 需求 | 说明 |
 |------|------|
-| **PR 评审与合并** | 需要维护者 review `feat/dashboard-firstboot-page` PR。 |
-| **macOS / Windows (WSL) 测试环境** | 当前仅在 Linux 验证 dashboard 页面。 |
+| **PR 评审与合并** | 需要维护者 review `feat/feedback-telemetry-v1` PR。 |
+| **macOS / Windows (WSL) 测试环境** | 当前仅在 Linux 验证。 |
 | **Homebrew tap 仓库** | 需创建 `ros-claw/homebrew-tap`。 |
 | **代码签名 / GPG 密钥** | Phase 3 签名 release 需要持有者决策。 |
 | **Cloud login API 规范** | 若后续实现 cloud firstboot，需要后端接口。 |
@@ -94,18 +105,18 @@
    请确认优先启动哪一项，或等资源到位后再继续。
 
 3. **过时分支如何清理？**
-   本地和远程存在大量已合并分支（`feat/body-docs-and-fail-closed`、`feat/body-p2-postmerge-verify`、`feat/p0-claude-code-agent-*` 等）。是否可以批量删除？
+   本地和远程存在大量已合并分支。是否可以批量删除？
 
 4. **是否需要打 tag / release？**
-   First Boot P0 已完整合入 `main`，Dashboard 页面是 P1 增强。是否要在 Dashboard PR 合并后发布版本？
+   Feedback / Telemetry v1 是 P1 增强。是否要在 PR 合并后发布版本？
 
 ---
 
 ## 7. 下一步建议
 
-1. **rebase + push PR**：`git rebase origin/main`，切到 `feat/dashboard-firstboot-page`，`git push -u origin`，创建 PR。
+1. **提交并推送 PR**：当前分支 `feat/feedback-telemetry-v1`，已验证 lint + 全量测试 + acceptance，建议 `git push -u origin feat/feedback-telemetry-v1` 并创建 PR。
 2. **等待 review 并修复反馈**。
-3. **Dashboard PR 合并后**：Phase 3 剩余项均依赖外部资源，建议先确认优先级与可用资源，再启动下一项。
+3. **PR 合并后**：Phase 3 剩余项均依赖外部资源，建议先确认优先级与可用资源，再启动下一项。
 4. **分支清理**：在 PR 合并后统一删除已合并分支。
 
 ---

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -39,6 +39,8 @@ from rosclaw.body.registry import BodyRegistryManager
 from rosclaw.body.resolver import BodyResolver
 from rosclaw.connectors.ros.cli import add_ros_subparser, cmd_doctor_ros, dispatch_ros_command
 from rosclaw.core.event_bus import Event, EventPriority
+from rosclaw.feedback.cli import add_feedback_subparser, dispatch_feedback_command
+from rosclaw.feedback.hooks import telemetry_command_hook
 from rosclaw.firstboot.wizard import run_firstboot
 from rosclaw.firstboot.workspace import resolve_home
 from rosclaw.hub.cli import add_hub_subparser, dispatch_hub_command
@@ -3182,6 +3184,10 @@ def main() -> int:
     firstboot_parser.add_argument("--enable-auto", action="store_true", help="Enable auto evolution")
     firstboot_parser.add_argument("--telemetry", action="store_true", help="Enable anonymous telemetry")
     firstboot_parser.add_argument("--no-telemetry", action="store_true", help="Disable anonymous telemetry")
+    firstboot_parser.add_argument("--diagnostics", action="store_true", help="Allow redacted diagnostic upload")
+    firstboot_parser.add_argument("--no-diagnostics", action="store_true", help="Disallow redacted diagnostic upload")
+    firstboot_parser.add_argument("--rich-feedback", action="store_true", help="Allow manual rich feedback upload")
+    firstboot_parser.add_argument("--no-rich-feedback", action="store_true", help="Disallow manual rich feedback upload")
     firstboot_parser.add_argument("--dev", action="store_true", help="Developer mode")
     firstboot_parser.add_argument("--force", action="store_true", help="Re-run even if already initialized")
     firstboot_parser.add_argument("--dry-run", action="store_true", help="Show what would be done without writing")
@@ -3548,243 +3554,249 @@ def main() -> int:
     # Hardware MCP onboarding subcommands (install/list/health)
     add_mcp_subparser(mcp_subparsers)
 
-    args = parser.parse_args()
+    # feedback and telemetry
+    add_feedback_subparser(subparsers)
 
-    if args.command == "init":
-        return cmd_init(args)
-    elif args.command in ("run", "start"):
-        return cmd_run(args)
-    elif args.command == "status":
-        return cmd_status(args)
-    elif args.command == "dashboard":
-        return cmd_dashboard(args)
-    elif args.command == "doctor":
-        if getattr(args, "ros", False):
-            return cmd_doctor_ros(args)
-        return cmd_doctor(args)
-    elif args.command == "firstboot":
-        return cmd_firstboot(args)
-    elif args.command == "config":
-        if getattr(args, "config_command", None):
-            return cmd_config(args)
-        config_parser.print_help()
-        return 1
-    elif args.command == "profile":
-        if getattr(args, "profile_command", None):
-            return cmd_profile(args)
-        profile_parser.print_help()
-        return 1
-    elif args.command == "uninstall":
-        return cmd_uninstall(args)
-    elif args.command == "ros":
-        return dispatch_ros_command(args)
-    elif args.command == "body":
-        return dispatch_body_command(args)
-    elif args.command == "logs":
-        return cmd_logs(args)
-    elif args.command == "robot":
-        if args.robot_command == "list":
-            return cmd_robot_list(args)
-        elif args.robot_command == "install":
-            return cmd_robot_install(args)
-        elif args.robot_command == "inspect":
-            return cmd_robot_inspect(args)
-        elif args.robot_command == "validate":
-            return cmd_robot_validate(args)
-        else:
-            robot_parser.print_help()
+    args = parser.parse_args()
+    with telemetry_command_hook(args):
+
+        if args.command == "init":
+            return cmd_init(args)
+        elif args.command in ("run", "start"):
+            return cmd_run(args)
+        elif args.command == "status":
+            return cmd_status(args)
+        elif args.command == "dashboard":
+            return cmd_dashboard(args)
+        elif args.command == "doctor":
+            if getattr(args, "ros", False):
+                return cmd_doctor_ros(args)
+            return cmd_doctor(args)
+        elif args.command == "firstboot":
+            return cmd_firstboot(args)
+        elif args.command == "config":
+            if getattr(args, "config_command", None):
+                return cmd_config(args)
+            config_parser.print_help()
             return 1
-    elif args.command == "provider":
-        if args.provider_command == "list":
-            return cmd_provider_list(args)
-        elif args.provider_command == "invoke":
-            return cmd_provider_invoke(args)
-        else:
-            provider_parser.print_help()
+        elif args.command == "profile":
+            if getattr(args, "profile_command", None):
+                return cmd_profile(args)
+            profile_parser.print_help()
             return 1
-    elif args.command == "skill":
-        if getattr(args, "func", None):
-            return args.func(args)
-        if args.skill_command == "list":
-            return cmd_skill_list(args)
-        elif args.skill_command == "check":
-            return cmd_skill_check(args)
-        elif args.skill_command == "invoke":
-            return cmd_skill_invoke(args)
-        elif args.skill_command == "champions":
-            if args.skill_champions_command == "list":
-                return cmd_skill_champions_list(args)
+        elif args.command == "uninstall":
+            return cmd_uninstall(args)
+        elif args.command == "ros":
+            return dispatch_ros_command(args)
+        elif args.command == "body":
+            return dispatch_body_command(args)
+        elif args.command == "logs":
+            return cmd_logs(args)
+        elif args.command == "robot":
+            if args.robot_command == "list":
+                return cmd_robot_list(args)
+            elif args.robot_command == "install":
+                return cmd_robot_install(args)
+            elif args.robot_command == "inspect":
+                return cmd_robot_inspect(args)
+            elif args.robot_command == "validate":
+                return cmd_robot_validate(args)
             else:
-                skill_champions_parser.print_help()
+                robot_parser.print_help()
                 return 1
-        elif args.skill_command == "lineage":
-            return cmd_skill_lineage(args)
-        elif args.skill_command == "rollback":
-            return cmd_skill_rollback(args)
-        else:
-            skill_parser.print_help()
+        elif args.command == "provider":
+            if args.provider_command == "list":
+                return cmd_provider_list(args)
+            elif args.provider_command == "invoke":
+                return cmd_provider_invoke(args)
+            else:
+                provider_parser.print_help()
+                return 1
+        elif args.command == "skill":
+            if getattr(args, "func", None):
+                return args.func(args)
+            if args.skill_command == "list":
+                return cmd_skill_list(args)
+            elif args.skill_command == "check":
+                return cmd_skill_check(args)
+            elif args.skill_command == "invoke":
+                return cmd_skill_invoke(args)
+            elif args.skill_command == "champions":
+                if args.skill_champions_command == "list":
+                    return cmd_skill_champions_list(args)
+                else:
+                    skill_champions_parser.print_help()
+                    return 1
+            elif args.skill_command == "lineage":
+                return cmd_skill_lineage(args)
+            elif args.skill_command == "rollback":
+                return cmd_skill_rollback(args)
+            else:
+                skill_parser.print_help()
+                return 1
+        elif args.command == "how":
+            if args.how_command == "explain":
+                return cmd_how_explain(args)
+            elif args.how_command == "recover":
+                return cmd_how_recover(args)
+            else:
+                how_parser.print_help()
+                return 1
+        elif args.command == "auto":
+            if args.auto_command == "init":
+                return cmd_auto_init(args)
+            elif args.auto_command == "run":
+                return cmd_auto_run(args)
+            elif args.auto_command == "status":
+                return cmd_auto_status(args)
+            elif args.auto_command == "champion":
+                return cmd_auto_champion(args)
+            elif args.auto_command == "deadends":
+                return cmd_auto_deadends(args)
+            elif args.auto_command == "report":
+                return cmd_auto_report(args)
+            else:
+                auto_parser.print_help()
+                return 1
+        elif args.command == "sandbox":
+            if args.sandbox_command == "list-worlds":
+                return cmd_sandbox_list_worlds(args)
+            elif args.sandbox_command == "validate":
+                return cmd_sandbox_validate(args)
+            elif args.sandbox_command == "run":
+                return cmd_sandbox_run(args)
+            elif args.sandbox_command == "replay":
+                return cmd_sandbox_replay(args)
+            elif args.sandbox_command == "check":
+                return cmd_sandbox_check(args)
+            else:
+                sandbox_parser.print_help()
+                return 1
+        elif args.command == "firewall":
+            if args.firewall_command == "check":
+                return cmd_firewall_check(args)
+            else:
+                firewall_parser.print_help()
+                return 1
+        elif args.command == "forge":
+            if args.forge_command == "validate":
+                return cmd_forge_validate(args)
+            elif args.forge_command == "install":
+                return cmd_forge_install(args)
+            elif args.forge_command == "sdk-to-mcp":
+                return cmd_forge_sdk_to_mcp(args)
+            else:
+                forge_parser.print_help()
+                return 1
+        elif args.command == "memory":
+            if args.memory_command == "status":
+                return cmd_memory_status(args)
+            elif args.memory_command == "query":
+                return cmd_memory_query(args)
+            elif args.memory_command == "explain":
+                return cmd_memory_explain(args)
+            else:
+                memory_parser.print_help()
+                return 1
+        elif args.command == "events":
+            if getattr(args, "events_command", None) == "publish":
+                return cmd_events_publish(args)
+            elif getattr(args, "events_command", None) == "list":
+                return cmd_events_list(args)
+            elif getattr(args, "events_command", None) == "tail" or not args.events_command:
+                return cmd_events_tail(args)
+            else:
+                events_parser.print_help()
+                return 1
+        elif args.command == "runtime":
+            if args.runtime_command == "backends":
+                return cmd_runtime_backends(args)
+            else:
+                runtime_parser.print_help()
+                return 1
+        elif args.command == "stop":
+            return cmd_stop(args)
+        elif args.command == "restart":
+            return cmd_restart(args)
+        elif args.command == "practice":
+            if args.practice_command == "list":
+                return cmd_practice_list(args)
+            elif args.practice_command == "init":
+                return cmd_practice_init(args)
+            elif args.practice_command == "start":
+                return cmd_practice_start(args)
+            elif args.practice_command == "stop":
+                return cmd_practice_stop(args)
+            elif args.practice_command == "sync-fallback":
+                return cmd_practice_sync_fallback(args)
+            elif args.practice_command == "show":
+                return cmd_practice_show(args)
+            elif args.practice_command == "replay":
+                return cmd_practice_replay(args)
+            elif args.practice_command == "export":
+                return cmd_practice_export(args)
+            else:
+                practice_parser.print_help()
+                return 1
+        elif args.command == "know":
+            if args.know_command == "search":
+                return cmd_know_search(args)
+            elif args.know_command == "robot":
+                return cmd_know_robot(args)
+            elif args.know_command == "recommend":
+                return cmd_know_recommend(args)
+            else:
+                know_parser.print_help()
+                return 1
+        elif args.command == "sense":
+            if args.sense_command == "now":
+                return cmd_sense_now(args)
+            elif args.sense_command == "state":
+                return cmd_sense_state(args)
+            elif args.sense_command == "readiness":
+                return cmd_sense_readiness(args)
+            elif args.sense_command == "watch":
+                return cmd_sense_watch(args)
+            elif args.sense_command == "events":
+                return cmd_sense_events(args)
+            elif args.sense_command == "explain":
+                return cmd_sense_explain(args)
+            else:
+                sense_parser.print_help()
+                return 1
+        elif args.command == "demo":
+            if args.demo_command == "mobile-pid":
+                return cmd_demo_mobile_pid(args)
+            elif args.demo_command == "tabletop-grasp":
+                return cmd_demo_tabletop_grasp(args)
+            else:
+                demo_parser.print_help()
+                return 1
+        elif args.command == "hub":
+            return dispatch_hub_command(args)
+        elif args.command == "agent":
+            if getattr(args, "func", None):
+                return args.func(args)
+            agent_parser.print_help()
             return 1
-    elif args.command == "how":
-        if args.how_command == "explain":
-            return cmd_how_explain(args)
-        elif args.how_command == "recover":
-            return cmd_how_recover(args)
-        else:
-            how_parser.print_help()
+        elif args.command == "mcp":
+            if getattr(args, "func", None):
+                return args.func(args)
+            mcp_parser.print_help()
             return 1
-    elif args.command == "auto":
-        if args.auto_command == "init":
-            return cmd_auto_init(args)
-        elif args.auto_command == "run":
-            return cmd_auto_run(args)
-        elif args.auto_command == "status":
-            return cmd_auto_status(args)
-        elif args.auto_command == "champion":
-            return cmd_auto_champion(args)
-        elif args.auto_command == "deadends":
-            return cmd_auto_deadends(args)
-        elif args.auto_command == "report":
-            return cmd_auto_report(args)
+        elif args.command == "fleet":
+            if args.fleet_command == "status":
+                return cmd_fleet_status(args)
+            elif args.fleet_command == "stop":
+                return cmd_fleet_stop(args)
+            else:
+                fleet_parser.print_help()
+                return 1
+        elif args.command == "feedback":
+            return dispatch_feedback_command(args)
         else:
-            auto_parser.print_help()
+            parser.print_help()
             return 1
-    elif args.command == "sandbox":
-        if args.sandbox_command == "list-worlds":
-            return cmd_sandbox_list_worlds(args)
-        elif args.sandbox_command == "validate":
-            return cmd_sandbox_validate(args)
-        elif args.sandbox_command == "run":
-            return cmd_sandbox_run(args)
-        elif args.sandbox_command == "replay":
-            return cmd_sandbox_replay(args)
-        elif args.sandbox_command == "check":
-            return cmd_sandbox_check(args)
-        else:
-            sandbox_parser.print_help()
-            return 1
-    elif args.command == "firewall":
-        if args.firewall_command == "check":
-            return cmd_firewall_check(args)
-        else:
-            firewall_parser.print_help()
-            return 1
-    elif args.command == "forge":
-        if args.forge_command == "validate":
-            return cmd_forge_validate(args)
-        elif args.forge_command == "install":
-            return cmd_forge_install(args)
-        elif args.forge_command == "sdk-to-mcp":
-            return cmd_forge_sdk_to_mcp(args)
-        else:
-            forge_parser.print_help()
-            return 1
-    elif args.command == "memory":
-        if args.memory_command == "status":
-            return cmd_memory_status(args)
-        elif args.memory_command == "query":
-            return cmd_memory_query(args)
-        elif args.memory_command == "explain":
-            return cmd_memory_explain(args)
-        else:
-            memory_parser.print_help()
-            return 1
-    elif args.command == "events":
-        if getattr(args, "events_command", None) == "publish":
-            return cmd_events_publish(args)
-        elif getattr(args, "events_command", None) == "list":
-            return cmd_events_list(args)
-        elif getattr(args, "events_command", None) == "tail" or not args.events_command:
-            return cmd_events_tail(args)
-        else:
-            events_parser.print_help()
-            return 1
-    elif args.command == "runtime":
-        if args.runtime_command == "backends":
-            return cmd_runtime_backends(args)
-        else:
-            runtime_parser.print_help()
-            return 1
-    elif args.command == "stop":
-        return cmd_stop(args)
-    elif args.command == "restart":
-        return cmd_restart(args)
-    elif args.command == "practice":
-        if args.practice_command == "list":
-            return cmd_practice_list(args)
-        elif args.practice_command == "init":
-            return cmd_practice_init(args)
-        elif args.practice_command == "start":
-            return cmd_practice_start(args)
-        elif args.practice_command == "stop":
-            return cmd_practice_stop(args)
-        elif args.practice_command == "sync-fallback":
-            return cmd_practice_sync_fallback(args)
-        elif args.practice_command == "show":
-            return cmd_practice_show(args)
-        elif args.practice_command == "replay":
-            return cmd_practice_replay(args)
-        elif args.practice_command == "export":
-            return cmd_practice_export(args)
-        else:
-            practice_parser.print_help()
-            return 1
-    elif args.command == "know":
-        if args.know_command == "search":
-            return cmd_know_search(args)
-        elif args.know_command == "robot":
-            return cmd_know_robot(args)
-        elif args.know_command == "recommend":
-            return cmd_know_recommend(args)
-        else:
-            know_parser.print_help()
-            return 1
-    elif args.command == "sense":
-        if args.sense_command == "now":
-            return cmd_sense_now(args)
-        elif args.sense_command == "state":
-            return cmd_sense_state(args)
-        elif args.sense_command == "readiness":
-            return cmd_sense_readiness(args)
-        elif args.sense_command == "watch":
-            return cmd_sense_watch(args)
-        elif args.sense_command == "events":
-            return cmd_sense_events(args)
-        elif args.sense_command == "explain":
-            return cmd_sense_explain(args)
-        else:
-            sense_parser.print_help()
-            return 1
-    elif args.command == "demo":
-        if args.demo_command == "mobile-pid":
-            return cmd_demo_mobile_pid(args)
-        elif args.demo_command == "tabletop-grasp":
-            return cmd_demo_tabletop_grasp(args)
-        else:
-            demo_parser.print_help()
-            return 1
-    elif args.command == "hub":
-        return dispatch_hub_command(args)
-    elif args.command == "agent":
-        if getattr(args, "func", None):
-            return args.func(args)
-        agent_parser.print_help()
-        return 1
-    elif args.command == "mcp":
-        if getattr(args, "func", None):
-            return args.func(args)
-        mcp_parser.print_help()
-        return 1
-    elif args.command == "fleet":
-        if args.fleet_command == "status":
-            return cmd_fleet_status(args)
-        elif args.fleet_command == "stop":
-            return cmd_fleet_stop(args)
-        else:
-            fleet_parser.print_help()
-            return 1
-    else:
-        parser.print_help()
-        return 1
 
 
 if __name__ == "__main__":

--- a/src/rosclaw/dashboard/firstboot.py
+++ b/src/rosclaw/dashboard/firstboot.py
@@ -22,6 +22,8 @@ def get_firstboot_state(home: Path | str | None = None) -> dict[str, Any]:
         "rosclaw_yaml_exists": False,
         "mcp_json_exists": False,
         "telemetry_yaml_exists": False,
+        "feedback_yaml_exists": False,
+        "installation_json_exists": False,
         "steps": {},
     }
 
@@ -32,6 +34,8 @@ def get_firstboot_state(home: Path | str | None = None) -> dict[str, Any]:
         state["rosclaw_yaml_exists"] = (home_path / "config" / "rosclaw.yaml").exists()
         state["mcp_json_exists"] = (home_path / "config" / "mcp.json").exists()
         state["telemetry_yaml_exists"] = (home_path / "config" / "telemetry.yaml").exists()
+        state["feedback_yaml_exists"] = (home_path / "config" / "feedback.yaml").exists()
+        state["installation_json_exists"] = (home_path / "config" / "installation.json").exists()
     except Exception as exc:  # noqa: BLE001
         state["error"] = str(exc)
 
@@ -42,6 +46,8 @@ def get_firstboot_state(home: Path | str | None = None) -> dict[str, Any]:
         "config": state["rosclaw_yaml_exists"],
         "mcp": state["mcp_json_exists"],
         "telemetry": state["telemetry_yaml_exists"],
+        "feedback": state["feedback_yaml_exists"],
+        "installation": state["installation_json_exists"],
         "firstboot": bool(install.get("firstboot_completed")),
         "doctor": install.get("last_doctor_status") == "ready",
     }
@@ -66,6 +72,16 @@ def build_firstboot_command(choices: dict[str, Any]) -> str:
         cmd.append("--telemetry")
     else:
         cmd.append("--no-telemetry")
+
+    if choices.get("diagnostics", False):
+        cmd.append("--diagnostics")
+    else:
+        cmd.append("--no-diagnostics")
+
+    if choices.get("rich_feedback", False):
+        cmd.append("--rich-feedback")
+    else:
+        cmd.append("--no-rich-feedback")
 
     if choices.get("mcp", True):
         cmd.append("--enable-mcp")
@@ -96,6 +112,8 @@ def preview_firstboot_config(choices: dict[str, Any]) -> dict[str, Any]:
         "robot": choices.get("robot", "sim_ur5e"),
         "safety": choices.get("safety", "strict"),
         "telemetry": bool(choices.get("telemetry", False)),
+        "diagnostics": bool(choices.get("diagnostics", False)),
+        "rich_feedback": bool(choices.get("rich_feedback", False)),
         "mcp": bool(choices.get("mcp", True)),
         "sandbox": bool(choices.get("sandbox", True)),
         "use_cases": {
@@ -196,7 +214,7 @@ FIRSTBOOT_PAGE_HTML = """<!DOCTYPE html>
   <div class="card">
     <h2>Run in Terminal</h2>
     <p class="muted">Copy this command and run it in your terminal to apply the configuration.</p>
-    <code id="command">rosclaw firstboot --yes --profile offline --robot sim_ur5e --safety strict --no-telemetry --enable-mcp --enable-sandbox</code>
+    <code id="command">rosclaw firstboot --yes --profile offline --robot sim_ur5e --safety strict --no-telemetry --no-diagnostics --no-rich-feedback --enable-mcp --enable-sandbox</code>
     <div class="actions">
       <button onclick="copyCommand()">Copy Command</button>
     </div>

--- a/src/rosclaw/feedback/__init__.py
+++ b/src/rosclaw/feedback/__init__.py
@@ -1,0 +1,20 @@
+"""ROSClaw Feedback & Telemetry package."""
+
+from __future__ import annotations
+
+from rosclaw.feedback.config import FeedbackConfig, TelemetryConfig
+from rosclaw.feedback.directories import ensure_feedback_dirs
+from rosclaw.feedback.installation import Installation, InstallationManager
+from rosclaw.feedback.store import append_event, count_events, directory_size_mb, read_events
+
+__all__ = [
+    "FeedbackConfig",
+    "TelemetryConfig",
+    "ensure_feedback_dirs",
+    "Installation",
+    "InstallationManager",
+    "append_event",
+    "count_events",
+    "directory_size_mb",
+    "read_events",
+]

--- a/src/rosclaw/feedback/cli.py
+++ b/src/rosclaw/feedback/cli.py
@@ -1,0 +1,287 @@
+"""Feedback and telemetry CLI commands."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from rosclaw.firstboot.workspace import resolve_home
+
+from .config import TelemetryConfig
+from .consent import ConsentManager
+from .export import FeedbackExporter
+from .installation import InstallationManager
+from .store import count_events, directory_size_mb, event_file_for_date
+from .telemetry_client import TelemetryClient
+from .upload import FeedbackUploader
+
+
+def add_feedback_subparser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[name-defined]
+    """Register the `rosclaw feedback` command tree."""
+    feedback_parser = subparsers.add_parser(
+        "feedback",
+        help="Feedback, telemetry, and privacy controls",
+    )
+    feedback_subparsers = feedback_parser.add_subparsers(dest="feedback_command")
+
+    # status
+    status_parser = feedback_subparsers.add_parser(
+        "status", help="Show feedback and telemetry status"
+    )
+    status_parser.add_argument("--workspace", default=None, help="ROSClaw workspace path")
+
+    # telemetry
+    telemetry_parser = feedback_subparsers.add_parser(
+        "telemetry", help="Manage product telemetry"
+    )
+    telemetry_parser.add_argument("--workspace", default=None, help="ROSClaw workspace path")
+    telemetry_subparsers = telemetry_parser.add_subparsers(dest="telemetry_command")
+
+    for name, help_text in [
+        ("status", "Show telemetry status"),
+        ("on", "Enable product telemetry"),
+        ("off", "Disable product telemetry"),
+        ("ping", "Send a test telemetry ping"),
+        ("reset-id", "Rotate the anonymous installation ID"),
+    ]:
+        p = telemetry_subparsers.add_parser(name, help=help_text)
+        p.add_argument("--workspace", default=None, help="ROSClaw workspace path")
+
+    # consent
+    consent_parser = feedback_subparsers.add_parser(
+        "consent", help="Manage upload consent"
+    )
+    consent_parser.add_argument("--workspace", default=None, help="ROSClaw workspace path")
+    consent_parser.add_argument("--diagnostics", action="store_true", help="Enable diagnostic upload consent")
+    consent_parser.add_argument("--rich-feedback", action="store_true", help="Enable rich feedback upload consent")
+    consent_parser.add_argument("--revoke-diagnostics", action="store_true", help="Revoke diagnostic upload consent")
+    consent_parser.add_argument("--revoke-all", action="store_true", help="Revoke all upload consent")
+    consent_parser.add_argument("--show", action="store_true", help="Show current consent")
+
+    # export
+    export_parser = feedback_subparsers.add_parser(
+        "export", help="Export local feedback events to a bundle"
+    )
+    export_parser.add_argument("--workspace", default=None, help="ROSClaw workspace path")
+    export_parser.add_argument("--days", type=int, default=30, help="Number of days to include")
+    export_parser.add_argument("--redact", action="store_true", help="Redact sensitive fields")
+    export_parser.add_argument("--output", default=None, help="Output tar.gz path")
+
+    # upload
+    upload_parser = feedback_subparsers.add_parser(
+        "upload", help="Upload a redacted feedback bundle"
+    )
+    upload_parser.add_argument("--workspace", default=None, help="ROSClaw workspace path")
+    upload_parser.add_argument("--redact", action="store_true", required=True, help="Redact before upload")
+    upload_parser.add_argument("--days", type=int, default=30, help="Number of days to include")
+    upload_parser.add_argument("--dry-run", action="store_true", help="Prepare bundle without uploading")
+    upload_parser.add_argument("--include-media", action="store_true", help="Include local media files")
+
+
+def dispatch_feedback_command(args: argparse.Namespace) -> int:
+    """Dispatch to the appropriate feedback subcommand."""
+    command = getattr(args, "feedback_command", None)
+    if command == "status":
+        return cmd_feedback_status(args)
+    if command == "telemetry":
+        return cmd_feedback_telemetry(args)
+    if command == "consent":
+        return cmd_feedback_consent(args)
+    if command == "export":
+        return cmd_feedback_export(args)
+    if command == "upload":
+        return cmd_feedback_upload(args)
+
+    print("Usage: rosclaw feedback {status|telemetry|consent|export|upload}")
+    return 1
+
+
+def cmd_feedback_status(args: argparse.Namespace) -> int:
+    home = resolve_home(getattr(args, "workspace", None))
+    install_mgr = InstallationManager(home)
+    telemetry_cfg = TelemetryConfig.load(home)
+    consent = ConsentManager(home).show()
+
+    anonymous_id = install_mgr.get_anonymous_installation_id()
+    telemetry_enabled = bool(
+        telemetry_cfg.mode.get("enabled", True)
+        and telemetry_cfg.mode.get("product_telemetry", True)
+    )
+
+    telemetry_count = count_events(event_file_for_date(home, "telemetry"))
+    feedback_count = count_events(event_file_for_date(home, "feedback"))
+    crash_count = len(list((home / "feedback" / "crashes").glob("crash_*.json")))
+    local_size = directory_size_mb(home / "telemetry") + directory_size_mb(home / "feedback")
+
+    print("ROSClaw Feedback & Telemetry Status\n")
+    print("Product Telemetry:")
+    print(f"  enabled: {telemetry_enabled}")
+    print(f"  heartbeat: {telemetry_cfg.product_telemetry.get('heartbeat', True)}")
+    last_hb = _last_heartbeat(home)
+    print(f"  last_heartbeat: {last_hb or 'never'}")
+    print(f"  anonymous_installation_id: {anonymous_id or 'not initialized'}\n")
+
+    print("Diagnostics:")
+    print(f"  enabled: {consent.diagnostics}")
+    print(f"  upload: {consent.diagnostics}")
+    print("  redact: True\n")
+
+    print("Rich Feedback:")
+    print("  manual_upload_only: True")
+    print("  raw_prompt_upload: False")
+    print(f"  raw_media_upload: {consent.rich_feedback and False}")
+    print("  raw_mcap_upload: False\n")
+
+    print("Local Store:")
+    print(f"  telemetry_events: {telemetry_count}")
+    print(f"  feedback_events: {feedback_count}")
+    print(f"  crashes: {crash_count}")
+    print(f"  local_size: {local_size} MB\n")
+
+    print("Commands:")
+    print("  disable telemetry:")
+    print("    rosclaw feedback telemetry off\n")
+    print("  export local feedback:")
+    print("    rosclaw feedback export --days 7\n")
+    print("  upload redacted feedback:")
+    print("    rosclaw feedback upload --redact")
+    return 0
+
+
+def cmd_feedback_telemetry(args: argparse.Namespace) -> int:
+    home = resolve_home(getattr(args, "workspace", None))
+    subcommand = getattr(args, "telemetry_command", "status")
+    install_mgr = InstallationManager(home)
+
+    if subcommand == "status":
+        cfg = TelemetryConfig.load(home)
+        enabled = bool(cfg.mode.get("enabled", True) and cfg.mode.get("product_telemetry", True))
+        print(f"Product telemetry is {'enabled' if enabled else 'disabled'}.")
+        return 0
+
+    if subcommand == "on":
+        cfg = TelemetryConfig.load(home)
+        cfg.mode["enabled"] = True
+        cfg.mode["product_telemetry"] = True
+        cfg.product_telemetry["enabled"] = True
+        cfg.save(home)
+        install_mgr.set_telemetry_enabled(True)
+        print("Product telemetry is now enabled.")
+        return 0
+
+    if subcommand == "off":
+        cfg = TelemetryConfig.load(home)
+        cfg.mode["enabled"] = False
+        cfg.mode["product_telemetry"] = False
+        cfg.product_telemetry["enabled"] = False
+        cfg.save(home)
+        install_mgr.set_telemetry_enabled(False)
+        print("Product telemetry is now disabled.")
+        print("\nROSClaw will no longer send:")
+        print("- heartbeat")
+        print("- command usage")
+        print("- module usage")
+        print("- version distribution events")
+        print("\nLocal feedback storage is unchanged.")
+        return 0
+
+    if subcommand == "ping":
+        result = TelemetryClient(home).ping()
+        if result.get("ok"):
+            print("Telemetry ping succeeded.")
+            print(f"endpoint: {TelemetryConfig.load(home).upload.get('endpoint')}")
+            print(f"request_id: {result.get('request_id', 'n/a')}")
+            return 0
+        print("Telemetry ping failed, but ROSClaw will continue to work locally.")
+        print(f"reason: {result.get('error', 'unknown')}")
+        return 0
+
+    if subcommand == "reset-id":
+        install_mgr.reset_installation_id()
+        new_anon = install_mgr.get_anonymous_installation_id()
+        print("Installation ID rotated.")
+        print(f"New anonymous installation ID: {new_anon}")
+        return 0
+
+    print("Usage: rosclaw feedback telemetry {status|on|off|ping|reset-id}")
+    return 1
+
+
+def cmd_feedback_consent(args: argparse.Namespace) -> int:
+    home = resolve_home(getattr(args, "workspace", None))
+    mgr = ConsentManager(home)
+
+    if args.revoke_all:
+        state = mgr.revoke_all()
+    elif args.revoke_diagnostics:
+        state = mgr.set_diagnostics(False)
+    elif args.diagnostics:
+        state = mgr.set_diagnostics(True)
+    elif args.rich_feedback:
+        state = mgr.set_rich_feedback(True)
+    else:
+        state = mgr.show()
+
+    if getattr(args, "show", False) or not any([
+        args.diagnostics, args.rich_feedback, args.revoke_diagnostics, args.revoke_all
+    ]):
+        print("ROSClaw Feedback Consent\n")
+        print(f"Product telemetry: {'enabled' if state.product_telemetry else 'disabled'}")
+        print(f"Diagnostics upload: {'enabled' if state.diagnostics else 'disabled'}")
+        print(f"Rich feedback upload: {'enabled' if state.rich_feedback else 'disabled'}")
+        print(f"Updated at: {state.updated_at}")
+        return 0
+
+    print("Consent updated.")
+    print(f"Diagnostics: {'enabled' if state.diagnostics else 'disabled'}")
+    print(f"Rich feedback: {'enabled' if state.rich_feedback else 'disabled'}")
+    return 0
+
+
+def cmd_feedback_export(args: argparse.Namespace) -> int:
+    home = resolve_home(getattr(args, "workspace", None))
+    output = FeedbackExporter(home).export(
+        days=args.days,
+        redact=args.redact,
+        output_path=args.output,
+    )
+    print(f"Exported feedback bundle to: {output}")
+    return 0
+
+
+def cmd_feedback_upload(args: argparse.Namespace) -> int:
+    home = resolve_home(getattr(args, "workspace", None))
+    result = FeedbackUploader(home).upload(
+        redact=args.redact,
+        days=args.days,
+        dry_run=args.dry_run,
+        include_media=args.include_media,
+    )
+    if not result.get("ok"):
+        print(f"Upload failed: {result.get('error')}")
+        if result.get("message"):
+            print(result["message"])
+        return 1
+
+    if result.get("dry_run"):
+        print(f"Dry-run prepared bundle: {result.get('bundle_path')}")
+        return 0
+
+    print("Feedback upload accepted.")
+    if result.get("request_id"):
+        print(f"request_id: {result['request_id']}")
+    return 0
+
+
+def _last_heartbeat(home: Path) -> str | None:
+    path = home / "telemetry" / "heartbeat" / "last_heartbeat.json"
+    if not path.exists():
+        return None
+    try:
+        data = __import__("json").loads(path.read_text(encoding="utf-8"))
+        return data.get("timestamp")
+    except Exception:
+        return None
+
+
+__all__ = ["add_feedback_subparser", "dispatch_feedback_command"]

--- a/src/rosclaw/feedback/config.py
+++ b/src/rosclaw/feedback/config.py
@@ -1,0 +1,275 @@
+"""Telemetry and feedback configuration dataclasses with YAML persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class TelemetryConfig:
+    """Product telemetry configuration matching rosclaw_feedback_v1.md."""
+
+    version: str = "1"
+    mode: dict[str, Any] = field(default_factory=dict)
+    identity: dict[str, Any] = field(default_factory=dict)
+    product_telemetry: dict[str, Any] = field(default_factory=dict)
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+    rich_feedback: dict[str, Any] = field(default_factory=dict)
+    upload: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._apply_defaults()
+
+    def _apply_defaults(self) -> None:
+        self.mode = self._merge(self.mode, {
+            "enabled": True,
+            "product_telemetry": True,
+            "diagnostics_upload": False,
+            "rich_feedback_upload": False,
+        })
+        self.identity = self._merge(self.identity, {
+            "use_anonymous_installation_id": True,
+            "include_hostname": False,
+            "include_username": False,
+            "include_ip_field": False,
+            "include_robot_serial": False,
+            "rotate_installation_id": False,
+        })
+        self.product_telemetry = self._merge(self.product_telemetry, {
+            "enabled": True,
+            "opt_out": True,
+            "heartbeat": True,
+            "heartbeat_interval_hours": 24,
+            "send_on_install": True,
+            "send_on_firstboot": True,
+            "send_on_version_check": True,
+            "send_command_usage": True,
+            "send_module_usage": True,
+            "send_error_summary": True,
+            "send_duration_bucket": True,
+        })
+        self.diagnostics = self._merge(self.diagnostics, {
+            "enabled": False,
+            "require_consent": True,
+            "redact": True,
+            "collect_crash_summary": True,
+            "collect_failure_stats": True,
+            "collect_sandbox_blocks": True,
+            "collect_provider_performance": True,
+            "include_stacktrace": False,
+            "include_logs": False,
+        })
+        self.rich_feedback = self._merge(self.rich_feedback, {
+            "enabled": False,
+            "require_manual_upload": True,
+            "require_redact": True,
+            "raw_prompt_upload": False,
+            "raw_media_upload": False,
+            "raw_mcap_upload": False,
+            "raw_trace_upload": False,
+        })
+        self.upload = self._merge(self.upload, {
+            "endpoint": "https://www.rosclaw.io/api/telemetry/event",
+            "heartbeat_endpoint": "https://www.rosclaw.io/api/telemetry/heartbeat",
+            "timeout_seconds": 3,
+            "max_retries": 1,
+            "fail_silently": True,
+            "max_events_per_batch": 50,
+        })
+
+    @staticmethod
+    def _merge(existing: dict[str, Any], defaults: dict[str, Any]) -> dict[str, Any]:
+        result = dict(existing)
+        for key, value in defaults.items():
+            if key not in result:
+                result[key] = value
+            elif isinstance(value, dict) and isinstance(result.get(key), dict):
+                result[key] = TelemetryConfig._merge(result[key], value)
+        return result
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "mode": self.mode,
+            "identity": self.identity,
+            "product_telemetry": self.product_telemetry,
+            "diagnostics": self.diagnostics,
+            "rich_feedback": self.rich_feedback,
+            "upload": self.upload,
+        }
+
+    def save(self, home: Path) -> Path:
+        path = home / "config" / "telemetry.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            yaml.safe_dump(self.to_dict(), default_flow_style=False, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        return path
+
+    @classmethod
+    def load(cls, home: Path) -> TelemetryConfig:
+        path = home / "config" / "telemetry.yaml"
+        if not path.exists():
+            return cls()
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except (yaml.YAMLError, OSError):
+            return cls()
+        return cls(
+            version=data.get("version", "1"),
+            mode=data.get("mode", {}),
+            identity=data.get("identity", {}),
+            product_telemetry=data.get("product_telemetry", {}),
+            diagnostics=data.get("diagnostics", {}),
+            rich_feedback=data.get("rich_feedback", {}),
+            upload=data.get("upload", {}),
+        )
+
+
+@dataclass
+class FeedbackConfig:
+    """Local feedback and rich bundle configuration."""
+
+    version: str = "1"
+    mode: dict[str, Any] = field(default_factory=dict)
+    retention: dict[str, Any] = field(default_factory=dict)
+    collect: dict[str, Any] = field(default_factory=dict)
+    redaction: dict[str, Any] = field(default_factory=dict)
+    upload: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._apply_defaults()
+
+    def _apply_defaults(self) -> None:
+        self.mode = self._merge(self.mode, {
+            "enabled": True,
+            "local_store": True,
+            "upload": False,
+            "redact": True,
+        })
+        self.retention = self._merge(self.retention, {
+            "local_days": 30,
+            "max_local_size_mb": 512,
+            "uploaded_metadata_days": 180,
+            "uploaded_attachments_days": 30,
+        })
+        self.collect = self._merge(self.collect, {
+            "failure_stats": {"enabled": True, "local_only": True},
+            "skill_performance": {"enabled": True, "local_only": True},
+            "crash_reports": {"enabled": True, "local_only": True, "include_stacktrace": False},
+            "human_feedback": {"enabled": True, "local_only": True},
+            "sandbox_blocks": {"enabled": True, "local_only": True},
+            "provider_performance": {"enabled": True, "local_only": True},
+            "prompts": {"enabled": False, "local_only": True},
+            "media": {"enabled": False, "local_only": True},
+            "mcap": {"enabled": False, "local_only": True},
+        })
+        self.redaction = self._merge(self.redaction, {
+            "text": {
+                "enabled": True,
+                "replace_emails": True,
+                "replace_phone_numbers": True,
+                "replace_ips": True,
+                "replace_urls": True,
+                "replace_file_paths": True,
+                "replace_tokens": True,
+                "replace_usernames": True,
+            },
+            "prompts": {
+                "enabled": True,
+                "mode": "summary_and_hash",
+                "keep_full_prompt": False,
+            },
+            "media": {
+                "enabled": True,
+                "face_blur": True,
+                "person_blur": True,
+                "qr_blur": True,
+                "screen_blur": True,
+                "downsample_fps": 1,
+                "max_seconds": 15,
+            },
+            "mcap": {
+                "enabled": True,
+                "allow_topics": [
+                    "/joint_states",
+                    "/imu",
+                    "/odom",
+                    "/sandbox/decision",
+                    "/rosclaw/runtime/event",
+                    "/rosclaw/provider/perf",
+                    "/rosclaw/skill/outcome",
+                ],
+                "deny_topics": [
+                    "/camera",
+                    "/rgb",
+                    "/depth",
+                    "/audio",
+                    "/microphone",
+                    "/pointcloud",
+                ],
+            },
+        })
+        self.upload = self._merge(self.upload, {
+            "endpoint": "https://www.rosclaw.io/api/feedback/upload",
+            "timeout_seconds": 10,
+            "max_retries": 1,
+            "fail_silently": True,
+            "require_redact": True,
+            "max_bundle_mb": 25,
+        })
+
+    @staticmethod
+    def _merge(existing: dict[str, Any], defaults: dict[str, Any]) -> dict[str, Any]:
+        result = dict(existing)
+        for key, value in defaults.items():
+            if key not in result:
+                result[key] = value
+            elif isinstance(value, dict) and isinstance(result.get(key), dict):
+                result[key] = FeedbackConfig._merge(result[key], value)
+        return result
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "mode": self.mode,
+            "retention": self.retention,
+            "collect": self.collect,
+            "redaction": self.redaction,
+            "upload": self.upload,
+        }
+
+    def save(self, home: Path) -> Path:
+        path = home / "config" / "feedback.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            yaml.safe_dump(self.to_dict(), default_flow_style=False, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        return path
+
+    @classmethod
+    def load(cls, home: Path) -> FeedbackConfig:
+        path = home / "config" / "feedback.yaml"
+        if not path.exists():
+            return cls()
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except (yaml.YAMLError, OSError):
+            return cls()
+        return cls(
+            version=data.get("version", "1"),
+            mode=data.get("mode", {}),
+            retention=data.get("retention", {}),
+            collect=data.get("collect", {}),
+            redaction=data.get("redaction", {}),
+            upload=data.get("upload", {}),
+        )
+
+
+__all__ = ["TelemetryConfig", "FeedbackConfig"]

--- a/src/rosclaw/feedback/consent.py
+++ b/src/rosclaw/feedback/consent.py
@@ -1,0 +1,98 @@
+"""User consent management for diagnostics and rich feedback."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .installation import InstallationManager
+from .store import append_event
+
+
+@dataclass
+class ConsentState:
+    """Aggregated consent state."""
+
+    product_telemetry: bool
+    diagnostics: bool
+    rich_feedback: bool
+    updated_at: str
+
+
+class ConsentManager:
+    """Read and write user consent for diagnostic/rich feedback upload."""
+
+    def __init__(self, home: Path) -> None:
+        self.home = Path(home)
+        self.path = self.home / "feedback" / "consent" / "consent.json"
+        self.audit_path = self.home / "feedback" / "consent" / "audit.jsonl"
+        self.installation = InstallationManager(home)
+
+    def ensure(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def show(self) -> ConsentState:
+        install = self.installation.get_installation()
+        if install is None:
+            install = self.installation.ensure_installation()
+        consent = self._load_consent()
+        return ConsentState(
+            product_telemetry=install.telemetry_enabled,
+            diagnostics=consent.get("diagnostics", install.diagnostics_enabled),
+            rich_feedback=consent.get("rich_feedback", install.rich_feedback_enabled),
+            updated_at=consent.get("updated_at", install.created_at),
+        )
+
+    def set_diagnostics(self, enabled: bool) -> ConsentState:
+        self.ensure()
+        consent = self._load_consent()
+        consent["diagnostics"] = enabled
+        consent["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        self.path.write_text(json.dumps(consent, indent=2, ensure_ascii=False), encoding="utf-8")
+        self.installation.set_diagnostics_enabled(enabled)
+        self._audit("set_diagnostics", {"enabled": enabled})
+        return self.show()
+
+    def set_rich_feedback(self, enabled: bool) -> ConsentState:
+        self.ensure()
+        consent = self._load_consent()
+        consent["rich_feedback"] = enabled
+        consent["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        self.path.write_text(json.dumps(consent, indent=2, ensure_ascii=False), encoding="utf-8")
+        self.installation.set_rich_feedback_enabled(enabled)
+        self._audit("set_rich_feedback", {"enabled": enabled})
+        return self.show()
+
+    def revoke_all(self) -> ConsentState:
+        self.ensure()
+        consent = {
+            "diagnostics": False,
+            "rich_feedback": False,
+            "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        }
+        self.path.write_text(json.dumps(consent, indent=2, ensure_ascii=False), encoding="utf-8")
+        self.installation.set_diagnostics_enabled(False)
+        self.installation.set_rich_feedback_enabled(False)
+        self._audit("revoke_all", {})
+        return self.show()
+
+    def _load_consent(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {}
+        try:
+            return json.loads(self.path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _audit(self, action: str, details: dict[str, Any]) -> None:
+        append_event(
+            self.audit_path,
+            {
+                "action": action,
+                "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+                "details": details,
+            },
+        )

--- a/src/rosclaw/feedback/directories.py
+++ b/src/rosclaw/feedback/directories.py
@@ -1,0 +1,28 @@
+"""Feedback and telemetry directory layout helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TELEMETRY_DIRS = [
+    "events",
+    "heartbeat",
+    "uploads",
+]
+
+FEEDBACK_DIRS = [
+    "events",
+    "crashes",
+    "bundles",
+    "redacted",
+    "media/local_only",
+    "consent",
+]
+
+
+def ensure_feedback_dirs(home: Path) -> None:
+    """Create the telemetry and feedback directory trees under `home`."""
+    for rel in TELEMETRY_DIRS:
+        (home / "telemetry" / rel).mkdir(parents=True, exist_ok=True)
+    for rel in FEEDBACK_DIRS:
+        (home / "feedback" / rel).mkdir(parents=True, exist_ok=True)

--- a/src/rosclaw/feedback/export.py
+++ b/src/rosclaw/feedback/export.py
@@ -1,0 +1,110 @@
+"""Export local telemetry/feedback events into a redacted bundle."""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .config import FeedbackConfig
+from .redactor.text_redactor import TextRedactor
+from .store import directory_size_mb, event_file_for_date, read_events
+
+
+class FeedbackExporter:
+    """Export recent telemetry and feedback events to a local bundle."""
+
+    def __init__(self, home: Path) -> None:
+        self.home = Path(home)
+        self.feedback_config = FeedbackConfig.load(home)
+        self.text_redactor = TextRedactor(
+            enabled=self.feedback_config.redaction.get("text", {}).get("enabled", True),
+        )
+
+    def export(
+        self,
+        *,
+        days: int = 30,
+        redact: bool = False,
+        output_path: Path | str | None = None,
+    ) -> Path:
+        """Collect events and write a gzipped tar archive."""
+        output_path = Path(output_path) if output_path else self._default_output_path()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        telemetry_records = self._collect_events("telemetry", days, redact)
+        feedback_records = self._collect_events("feedback", days, redact)
+
+        with tarfile.open(output_path, "w:gz") as tar:
+            self._add_jsonl(tar, telemetry_records, "telemetry.jsonl")
+            self._add_jsonl(tar, feedback_records, "feedback.jsonl")
+            manifest = {
+                "schema_version": "rosclaw.feedback.export.v1",
+                "exported_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+                "days": days,
+                "redacted": redact,
+                "telemetry_event_count": len(telemetry_records),
+                "feedback_event_count": len(feedback_records),
+                "local_size_mb": directory_size_mb(self.home / "telemetry")
+                + directory_size_mb(self.home / "feedback"),
+            }
+            self._add_json(tar, manifest, "manifest.json")
+
+        return output_path
+
+    def _collect_events(
+        self,
+        kind: str,
+        days: int,
+        redact: bool,
+    ) -> list[dict[str, Any]]:
+        records: list[dict[str, Any]] = []
+        today = datetime.now(UTC).date()
+        for offset in range(days + 1):
+            date = datetime.fromordinal(today.toordinal() - offset).replace(tzinfo=UTC)
+            path = event_file_for_date(self.home, kind, date=date)
+            for record in read_events(path):
+                if redact:
+                    record = self._redact_record(record)
+                records.append(record)
+        return records
+
+    def _redact_record(self, record: dict[str, Any]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in record.items():
+            if isinstance(value, str):
+                result[key] = self.text_redactor.redact(value)
+            elif isinstance(value, dict):
+                result[key] = self._redact_record(value)
+            elif isinstance(value, list):
+                result[key] = [
+                    self.text_redactor.redact(v) if isinstance(v, str) else v
+                    for v in value
+                ]
+            else:
+                result[key] = value
+        return result
+
+    @staticmethod
+    def _add_jsonl(tar: tarfile.TarFile, records: list[dict[str, Any]], name: str) -> None:
+        if not records:
+            return
+        text = "".join(json.dumps(r, ensure_ascii=False, default=str) + "\n" for r in records)
+        encoded = text.encode("utf-8")
+        info = tarfile.TarInfo(name=name)
+        info.size = len(encoded)
+        tar.addfile(info, io.BytesIO(encoded))
+
+    @staticmethod
+    def _add_json(tar: tarfile.TarFile, data: dict[str, Any], name: str) -> None:
+        encoded = json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
+        info = tarfile.TarInfo(name=name)
+        info.size = len(encoded)
+        tar.addfile(info, io.BytesIO(encoded))
+
+    def _default_output_path(self) -> Path:
+        ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        return self.home / "feedback" / "bundles" / f"feedback_export_{ts}.tar.gz"

--- a/src/rosclaw/feedback/hooks.py
+++ b/src/rosclaw/feedback/hooks.py
@@ -1,0 +1,36 @@
+"""CLI dispatch hook for command telemetry."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+from rosclaw.firstboot.workspace import resolve_home
+
+from .telemetry_client import TelemetryClient
+
+
+@contextmanager
+def telemetry_command_hook(args: Any) -> Generator[None, None, None]:
+    """Wrap CLI command dispatch and record a privacy-safe command_completed event.
+
+    Telemetry failures are swallowed so they can never block a user command.
+    """
+    start = time.monotonic()
+    error: BaseException | None = None
+    try:
+        yield
+    except BaseException as exc:
+        error = exc
+        raise
+    finally:
+        try:
+            home = resolve_home(getattr(args, "workspace", None))
+            if home.exists():
+                duration_ms = int((time.monotonic() - start) * 1000)
+                status = "failure" if error is not None else "success"
+                TelemetryClient(home).record_command(args, status, duration_ms, error=error)
+        except Exception:
+            pass

--- a/src/rosclaw/feedback/installation.py
+++ b/src/rosclaw/feedback/installation.py
@@ -1,0 +1,172 @@
+"""Installation identity: UUID, anonymous ID derivation, consent persistence."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .store import append_event
+
+
+@dataclass
+class Installation:
+    """In-memory representation of installation.json."""
+
+    installation_id: str
+    created_at: str
+    install_channel: str
+    telemetry_enabled: bool
+    diagnostics_enabled: bool
+    rich_feedback_enabled: bool
+    schema_version: str = "rosclaw.installation.v1"
+
+
+class InstallationManager:
+    """Manage the local installation identity and consent flags."""
+
+    def __init__(self, home: Path) -> None:
+        self.home = Path(home)
+        self.path = self.home / "config" / "installation.json"
+        self.salt_path = self.home / "telemetry" / "local_salt"
+        self.audit_path = self.home / "feedback" / "consent" / "audit.jsonl"
+
+    def ensure_installation(
+        self,
+        install_channel: str = "stable",
+        telemetry_enabled: bool = True,
+        diagnostics_enabled: bool = False,
+        rich_feedback_enabled: bool = False,
+    ) -> Installation:
+        """Create or update installation.json and salt."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.salt_path.parent.mkdir(parents=True, exist_ok=True)
+        self.audit_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = self._load_raw()
+        if not data.get("installation_id"):
+            data["installation_id"] = str(uuid.uuid4())
+            data["created_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        if not self.salt_path.exists():
+            self.salt_path.write_text(
+                uuid.uuid4().hex + uuid.uuid4().hex,
+                encoding="utf-8",
+            )
+
+        data["schema_version"] = "rosclaw.installation.v1"
+        data["install_channel"] = install_channel
+        data["telemetry_enabled"] = telemetry_enabled
+        data["diagnostics_enabled"] = diagnostics_enabled
+        data["rich_feedback_enabled"] = rich_feedback_enabled
+        data["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        self._audit("ensure_installation", {
+            "telemetry_enabled": telemetry_enabled,
+            "diagnostics_enabled": diagnostics_enabled,
+            "rich_feedback_enabled": rich_feedback_enabled,
+        })
+        return self._to_installation(data)
+
+    def get_installation(self) -> Installation | None:
+        data = self._load_raw()
+        if not data.get("installation_id"):
+            return None
+        return self._to_installation(data)
+
+    def get_anonymous_installation_id(self) -> str | None:
+        """Return a stable anonymous ID: rci_ + HMAC_SHA256(installation_id, salt)[0:32]."""
+        data = self._load_raw()
+        install_id = data.get("installation_id")
+        if not install_id or not self.salt_path.exists():
+            return None
+        salt = self.salt_path.read_text(encoding="utf-8").strip()
+        digest = hmac.new(
+            salt.encode("utf-8"),
+            install_id.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return f"rci_{digest[:32]}"
+
+    def set_telemetry_enabled(self, enabled: bool) -> None:
+        data = self._load_raw()
+        if not data.get("installation_id"):
+            self.ensure_installation(telemetry_enabled=enabled)
+            return
+        data["telemetry_enabled"] = enabled
+        data["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        self._audit("set_telemetry_enabled", {"enabled": enabled})
+
+    def set_diagnostics_enabled(self, enabled: bool) -> None:
+        data = self._load_raw()
+        if not data.get("installation_id"):
+            self.ensure_installation(diagnostics_enabled=enabled)
+            return
+        data["diagnostics_enabled"] = enabled
+        data["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        self._audit("set_diagnostics_enabled", {"enabled": enabled})
+
+    def set_rich_feedback_enabled(self, enabled: bool) -> None:
+        data = self._load_raw()
+        if not data.get("installation_id"):
+            self.ensure_installation(rich_feedback_enabled=enabled)
+            return
+        data["rich_feedback_enabled"] = enabled
+        data["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        self._audit("set_rich_feedback_enabled", {"enabled": enabled})
+
+    def reset_installation_id(self) -> Installation:
+        """Rotate installation ID and salt; old telemetry is no longer associable."""
+        new_id = str(uuid.uuid4())
+        new_salt = uuid.uuid4().hex + uuid.uuid4().hex
+        self.salt_path.write_text(new_salt, encoding="utf-8")
+        data = {
+            "schema_version": "rosclaw.installation.v1",
+            "installation_id": new_id,
+            "created_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "install_channel": self._load_raw().get("install_channel", "stable"),
+            "telemetry_enabled": self._load_raw().get("telemetry_enabled", True),
+            "diagnostics_enabled": self._load_raw().get("diagnostics_enabled", False),
+            "rich_feedback_enabled": self._load_raw().get("rich_feedback_enabled", False),
+        }
+        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        self._audit("reset_installation_id", {"new_installation_id_prefix": new_id[:8]})
+        return self._to_installation(data)
+
+    def _load_raw(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {}
+        try:
+            return json.loads(self.path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _to_installation(self, data: dict[str, Any]) -> Installation:
+        return Installation(
+            installation_id=data["installation_id"],
+            created_at=data.get("created_at", ""),
+            install_channel=data.get("install_channel", "stable"),
+            telemetry_enabled=data.get("telemetry_enabled", True),
+            diagnostics_enabled=data.get("diagnostics_enabled", False),
+            rich_feedback_enabled=data.get("rich_feedback_enabled", False),
+            schema_version=data.get("schema_version", "rosclaw.installation.v1"),
+        )
+
+    def _audit(self, action: str, details: dict[str, Any]) -> None:
+        append_event(
+            self.audit_path,
+            {
+                "action": action,
+                "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+                "details": details,
+            },
+        )

--- a/src/rosclaw/feedback/redactor/__init__.py
+++ b/src/rosclaw/feedback/redactor/__init__.py
@@ -1,0 +1,15 @@
+"""Feedback redaction package."""
+
+from __future__ import annotations
+
+from rosclaw.feedback.redactor.mcap_redactor import McapRedactor
+from rosclaw.feedback.redactor.prompt_redactor import PromptRedactor
+from rosclaw.feedback.redactor.secret_scanner import SecretScanner
+from rosclaw.feedback.redactor.text_redactor import TextRedactor
+
+__all__ = [
+    "McapRedactor",
+    "PromptRedactor",
+    "SecretScanner",
+    "TextRedactor",
+]

--- a/src/rosclaw/feedback/redactor/mcap_redactor.py
+++ b/src/rosclaw/feedback/redactor/mcap_redactor.py
@@ -1,0 +1,49 @@
+"""MCAP topic allowlist/denylist redactor."""
+
+from __future__ import annotations
+
+
+class McapRedactor:
+    """Filter MCAP/rosbag topics according to the configured allow/deny lists."""
+
+    DEFAULT_ALLOW_TOPICS = frozenset([
+        "/joint_states",
+        "/imu",
+        "/odom",
+        "/sandbox/decision",
+        "/rosclaw/runtime/event",
+        "/rosclaw/provider/perf",
+        "/rosclaw/skill/outcome",
+    ])
+
+    DEFAULT_DENY_TOPICS = frozenset([
+        "/camera",
+        "/rgb",
+        "/depth",
+        "/audio",
+        "/microphone",
+        "/pointcloud",
+    ])
+
+    def __init__(
+        self,
+        allow_topics: set[str] | None = None,
+        deny_topics: set[str] | None = None,
+    ) -> None:
+        self.allow_topics = set(allow_topics or self.DEFAULT_ALLOW_TOPICS)
+        self.deny_topics = set(deny_topics or self.DEFAULT_DENY_TOPICS)
+
+    def filter_topics(self, topics: list[str]) -> list[str]:
+        """Return topics allowed for upload."""
+        result = []
+        for topic in topics:
+            if any(topic.startswith(deny) for deny in self.deny_topics):
+                continue
+            if any(topic.startswith(allow) for allow in self.allow_topics):
+                result.append(topic)
+        return result
+
+    def is_allowed(self, topic: str) -> bool:
+        if any(topic.startswith(deny) for deny in self.deny_topics):
+            return False
+        return any(topic.startswith(allow) for allow in self.allow_topics)

--- a/src/rosclaw/feedback/redactor/prompt_redactor.py
+++ b/src/rosclaw/feedback/redactor/prompt_redactor.py
@@ -1,0 +1,78 @@
+"""Prompt abstraction: keep only summary/hash metadata, never raw text."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+
+class PromptRedactor:
+    """Convert a raw prompt into a privacy-safe summary."""
+
+    LENGTH_BUCKETS = [
+        (0, "empty"),
+        (100, "short"),
+        (1000, "medium"),
+        (5000, "long"),
+        (20000, "very_long"),
+    ]
+
+    def redact(self, prompt: str | None) -> dict[str, object]:
+        if not prompt:
+            return {
+                "prompt_hash": None,
+                "prompt_length_bucket": "empty",
+                "language": "unknown",
+                "intent_summary": None,
+                "tool_names": [],
+                "safety_tags": [],
+            }
+
+        text = str(prompt)
+        length = len(text)
+        bucket = "very_long"
+        for limit, name in self.LENGTH_BUCKETS:
+            if length <= limit:
+                bucket = name
+                break
+
+        return {
+            "prompt_hash": hashlib.sha256(text.encode("utf-8")).hexdigest()[:16],
+            "prompt_length_bucket": bucket,
+            "language": self._detect_language(text),
+            "intent_summary": self._intent_summary(text),
+            "tool_names": self._extract_tool_names(text),
+            "safety_tags": self._extract_safety_tags(text),
+        }
+
+    @staticmethod
+    def _detect_language(text: str) -> str:
+        # Very rough heuristic for telemetry only.
+        if re.search(r"[\u4e00-\u9fff]", text):
+            return "zh"
+        if re.search(r"[\u3040-\u309f\u30a0-\u30ff]", text):
+            return "ja"
+        return "en"
+
+    @staticmethod
+    def _intent_summary(text: str) -> str | None:
+        lowered = text.lower()
+        intents = []
+        for keyword in ("move", "grasp", "navigate", "stop", "run", "start", "doctor", "status"):
+            if keyword in lowered:
+                intents.append(keyword)
+        return ",".join(intents) if intents else None
+
+    @staticmethod
+    def _extract_tool_names(text: str) -> list[str]:
+        return sorted(set(re.findall(r"`([\w_]+)`", text)))
+
+    @staticmethod
+    def _extract_safety_tags(text: str) -> list[str]:
+        tags = []
+        lowered = text.lower()
+        if any(w in lowered for w in ("emergency", "stop", "halt")):
+            tags.append("safety")
+        if any(w in lowered for w in ("real robot", "execute", "motion")):
+            tags.append("motion")
+        return tags

--- a/src/rosclaw/feedback/redactor/secret_scanner.py
+++ b/src/rosclaw/feedback/redactor/secret_scanner.py
@@ -1,0 +1,27 @@
+"""Detect likely secrets in text before upload."""
+
+from __future__ import annotations
+
+import re
+
+
+class SecretScanner:
+    """Quick heuristic scan for API keys and tokens."""
+
+    PATTERNS = {
+        "anthropic_key": re.compile(r"sk-ant-[\w-]{32,}", re.IGNORECASE),
+        "openai_key": re.compile(r"sk-[\w-]{32,}", re.IGNORECASE),
+        "aws_key": re.compile(r"AKIA[\w]{16}", re.IGNORECASE),
+        "jwt": re.compile(r"\beyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*\b"),
+        "generic_secret": re.compile("(?:api[_-]?key|secret|token|password)\\s*[:=]\\s*['\"]?[\\w-]{16,}['\"]?", re.IGNORECASE),
+    }
+
+    def find_secrets(self, text: str) -> list[dict[str, str]]:
+        results = []
+        for name, pattern in self.PATTERNS.items():
+            for match in pattern.finditer(text):
+                results.append({"type": name, "position": str(match.start())})
+        return results
+
+    def has_secrets(self, text: str) -> bool:
+        return bool(self.find_secrets(text))

--- a/src/rosclaw/feedback/redactor/text_redactor.py
+++ b/src/rosclaw/feedback/redactor/text_redactor.py
@@ -1,0 +1,34 @@
+"""Regex-based text redactor for PII, secrets, paths, and robot serials."""
+
+from __future__ import annotations
+
+import re
+
+
+class TextRedactor:
+    """Redact sensitive substrings from free text."""
+
+    PATTERNS = {
+        "email": (re.compile(r"[\w.-]+@[\w.-]+\.[\w]{2,}"), "[REDACTED_EMAIL]"),
+        "url": (re.compile(r"https?://[^\s'\"<>]+"), "[REDACTED_URL]"),
+        "jwt": (re.compile(r"\beyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*\b"), "[REDACTED_TOKEN]"),
+        "api_key": (re.compile(r"\b(?:api[_-]?key|token|secret|password|passwd|pwd)\s*[:=]\s*['\"]?[\w-]{8,}['\"]?", re.IGNORECASE), "[REDACTED_SECRET]"),
+        "phone": (re.compile(r"(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?){2}\d{4}"), "[REDACTED_PHONE]"),
+        "ipv4": (re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"), "[REDACTED_IP]"),
+        "ipv6": (re.compile(r"\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b"), "[REDACTED_IP]"),
+        "path": (re.compile(r"(?:^|\s)([\w.-]+)?(/(?:[^\s\":;|<>]*))+"), "[REDACTED_PATH]"),
+        "username": (re.compile(r"\b(?:user|username)\s*[:=]\s*\S+", re.IGNORECASE), "[REDACTED_USERNAME]"),
+        "hostname": (re.compile(r"\b(?:host|hostname)\s*[:=]\s*\S+", re.IGNORECASE), "[REDACTED_HOSTNAME]"),
+        "robot_serial": (re.compile(r"\b(?:serial|sn)\s*[:=]\s*[A-Za-z0-9-]{6,}", re.IGNORECASE), "[REDACTED_SERIAL]"),
+    }
+
+    def __init__(self, enabled: bool = True) -> None:
+        self.enabled = enabled
+
+    def redact(self, text: str | None) -> str:
+        if not text or not self.enabled:
+            return text or ""
+        result = text
+        for _name, (pattern, replacement) in self.PATTERNS.items():
+            result = pattern.sub(replacement, result)
+        return result

--- a/src/rosclaw/feedback/store.py
+++ b/src/rosclaw/feedback/store.py
@@ -1,0 +1,92 @@
+"""Local JSONL event storage helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+def append_event(path: Path, record: dict[str, Any]) -> None:
+    """Append a single JSON object as a line to `path`."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, ensure_ascii=False, default=str) + "\n"
+    with path.open("a", encoding="utf-8") as f:
+        f.write(line)
+
+
+def read_events(
+    path: Path,
+    *,
+    limit: int | None = None,
+    days: int | None = None,
+) -> list[dict[str, Any]]:
+    """Read events from a JSONL file, optionally limited or filtered by age."""
+    path = Path(path)
+    if not path.exists():
+        return []
+
+    cutoff = None
+    if days is not None:
+        cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat().replace("+00:00", "Z")
+
+    results: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if cutoff is not None:
+                    ts = record.get("created_at", "")
+                    if isinstance(ts, str) and ts < cutoff:
+                        continue
+                results.append(record)
+                if limit is not None and len(results) >= limit:
+                    break
+    except OSError:
+        return []
+    return results
+
+
+def count_events(path: Path) -> int:
+    """Count non-empty lines in a JSONL file."""
+    path = Path(path)
+    if not path.exists():
+        return 0
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return sum(1 for line in f if line.strip())
+    except OSError:
+        return 0
+
+
+def directory_size_mb(path: Path) -> float:
+    """Return total size of all files under `path` in megabytes."""
+    path = Path(path)
+    if not path.exists():
+        return 0.0
+    total = 0
+    try:
+        for item in path.rglob("*"):
+            if item.is_file():
+                total += item.stat().st_size
+    except OSError:
+        pass
+    return round(total / (1024 * 1024), 2)
+
+
+def event_file_for_date(
+    home: Path,
+    kind: str,
+    date: datetime | None = None,
+) -> Path:
+    """Return the JSONL path for telemetry or feedback events on a given date."""
+    date = date or datetime.now(UTC)
+    return home / kind / "events" / f"{date.date().isoformat()}.jsonl"

--- a/src/rosclaw/feedback/telemetry_client.py
+++ b/src/rosclaw/feedback/telemetry_client.py
@@ -1,0 +1,333 @@
+"""Telemetry client: local spooling, bucketing, and fire-and-forget upload."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import platform
+import sys
+import threading
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from rosclaw import __version__ as rosclaw_version
+
+from .config import TelemetryConfig
+from .installation import InstallationManager
+from .store import append_event, event_file_for_date
+
+ALLOWED_EVENT_TYPES = frozenset([
+    "install_started",
+    "install_completed",
+    "firstboot_started",
+    "firstboot_completed",
+    "doctor_started",
+    "doctor_completed",
+    "command_completed",
+    "module_enabled",
+    "provider_installed",
+    "provider_served",
+    "hub_asset_installed",
+    "dashboard_opened",
+    "practice_started",
+    "heartbeat",
+    "telemetry_ping",
+])
+
+FORBIDDEN_FIELDS = frozenset([
+    "hostname",
+    "username",
+    "ip",
+    "local_path",
+    "cwd",
+    "full_command",
+    "full_args",
+    "prompt",
+    "system_prompt",
+    "tool_arguments",
+    "provider_response",
+    "stacktrace",
+    "log",
+    "video",
+    "image",
+    "audio",
+    "mcap",
+    "trace",
+    "api_key",
+    "secret",
+    "robot_serial",
+])
+
+ERROR_CLASS_BUCKETS = frozenset([
+    "ImportError",
+    "ConfigError",
+    "DockerUnavailable",
+    "ROSNotFound",
+    "ProviderTimeout",
+    "PermissionDenied",
+    "NetworkError",
+    "ValidationError",
+    "RuntimeError",
+])
+
+
+class TelemetryClient:
+    """Record, bucket, and optionally upload product telemetry events."""
+
+    def __init__(self, home: Path) -> None:
+        self.home = Path(home)
+        self.config = TelemetryConfig.load(home)
+        self.installation = InstallationManager(home)
+
+    def record_event(
+        self,
+        event_type: str,
+        command_name: str | None = None,
+        command_status: str | None = None,
+        module_name: str | None = None,
+        payload: dict[str, Any] | None = None,
+        error: BaseException | None = None,
+    ) -> dict[str, Any] | None:
+        """Record a telemetry event locally and upload if allowed."""
+        if not self._is_enabled_for_event_type(event_type):
+            return None
+
+        event = self._build_event(
+            event_type=event_type,
+            command_name=command_name,
+            command_status=command_status,
+            module_name=module_name,
+            payload=payload,
+            error=error,
+        )
+        if event is None:
+            return None
+
+        path = event_file_for_date(self.home, "telemetry")
+        append_event(path, event)
+
+        if self._should_upload():
+            self._upload_async(event)
+        return event
+
+    def record_command(
+        self,
+        args: Any,
+        status: str,
+        duration_ms: int,
+        error: BaseException | None = None,
+    ) -> dict[str, Any] | None:
+        """Record a command_completed event from CLI dispatch."""
+        command_name = self._command_name(args)
+        module_name = getattr(args, "command", None)
+        return self.record_event(
+            event_type="command_completed",
+            command_name=command_name,
+            command_status=status,
+            module_name=module_name,
+            payload={"duration_ms": duration_ms},
+            error=error,
+        )
+
+    def heartbeat_if_due(self) -> dict[str, Any] | None:
+        """Send a heartbeat event if the configured interval has elapsed."""
+        if not self._should_upload():
+            return None
+
+        last_path = self.home / "telemetry" / "heartbeat" / "last_heartbeat.json"
+        interval_hours = self.config.product_telemetry.get("heartbeat_interval_hours", 24)
+        now = datetime.now(UTC)
+        if last_path.exists():
+            try:
+                last = json.loads(last_path.read_text(encoding="utf-8"))
+                last_ts = last.get("timestamp", "")
+                if last_ts:
+                    last_dt = datetime.fromisoformat(last_ts.replace("Z", "+00:00"))
+                    if (now - last_dt) < timedelta(hours=interval_hours):
+                        return None
+            except (json.JSONDecodeError, ValueError, OSError):
+                pass
+
+        event = self._build_event("heartbeat")
+        if event is None:
+            return None
+
+        path = event_file_for_date(self.home, "telemetry")
+        append_event(path, event)
+
+        response = self._upload_sync(
+            self.config.upload.get("heartbeat_endpoint") or self.config.upload.get("endpoint"),
+            event,
+        )
+        try:
+            last_path.parent.mkdir(parents=True, exist_ok=True)
+            last_path.write_text(
+                json.dumps({"timestamp": event["created_at"]}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+        return response
+
+    def ping(self) -> dict[str, Any]:
+        """Send a telemetry_ping event synchronously and return server response."""
+        event = self._build_event("telemetry_ping")
+        if event is None:
+            return {"ok": False, "error": "no_installation"}
+        response = self._upload_sync(self.config.upload.get("endpoint"), event)
+        return response or {"ok": False, "error": "upload_failed"}
+
+    def _build_event(
+        self,
+        event_type: str,
+        command_name: str | None = None,
+        command_status: str | None = None,
+        module_name: str | None = None,
+        payload: dict[str, Any] | None = None,
+        error: BaseException | None = None,
+    ) -> dict[str, Any] | None:
+        anonymous_id = self.installation.get_anonymous_installation_id()
+        if anonymous_id is None and event_type != "install_started":
+            # Events before installation exists are best-effort only.
+            pass
+
+        install = self.installation.get_installation()
+        install_channel = install.install_channel if install else "unknown"
+
+        event: dict[str, Any] = {
+            "schema_version": "rosclaw.telemetry.event.v1",
+            "event_type": event_type,
+            "anonymous_installation_id": anonymous_id,
+            "created_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "rosclaw_version": rosclaw_version,
+            "cli_version": rosclaw_version,
+            "os_family": platform.system().lower() or "unknown",
+            "arch": platform.machine().lower() or "unknown",
+            "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+            "install_channel": install_channel,
+            "deployment_mode": "local",
+        }
+
+        if anonymous_id is None:
+            event["anonymous_installation_id"] = None
+
+        if command_name is not None:
+            event["command_name"] = command_name
+        if command_status is not None:
+            event["command_status"] = command_status
+        if module_name is not None:
+            event["module_name"] = module_name
+
+        payload = dict(payload or {})
+        if error is not None:
+            event["error_class_bucket"] = error_class_bucket(error)
+            payload["error_class"] = error_class_bucket(error)
+
+        if "duration_ms" in payload:
+            event["duration_bucket"] = duration_bucket(payload.pop("duration_ms"))
+
+        if payload:
+            event["payload"] = payload
+
+        event = self._scrub(event)
+        return event
+
+    def _should_upload(self) -> bool:
+        mode = self.config.mode
+        return bool(mode.get("enabled", True) and mode.get("product_telemetry", True))
+
+    def _is_enabled_for_event_type(self, event_type: str) -> bool:
+        if event_type not in ALLOWED_EVENT_TYPES:
+            return False
+        if event_type in ("telemetry_ping", "heartbeat"):
+            return True
+        return self._should_upload()
+
+    def _upload_async(self, event: dict[str, Any]) -> None:
+        """Fire-and-forget upload in a background thread."""
+        def _upload() -> None:
+            with contextlib.suppress(Exception):
+                self._upload_sync(self.config.upload.get("endpoint"), event)
+
+        thread = threading.Thread(target=_upload, daemon=True)
+        thread.start()
+
+    def _upload_sync(self, endpoint: str | None, event: dict[str, Any]) -> dict[str, Any] | None:
+        if not endpoint:
+            return None
+        timeout = self.config.upload.get("timeout_seconds", 3)
+        body = json.dumps(event, ensure_ascii=False).encode("utf-8")
+        request = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": f"rosclaw/{rosclaw_version}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = response.read().decode("utf-8")
+                if raw:
+                    return json.loads(raw)
+                return {"ok": True}
+        except urllib.error.HTTPError as exc:
+            return {"ok": False, "error": "http_error", "status": exc.code}
+        except urllib.error.URLError as exc:
+            return {"ok": False, "error": "url_error", "reason": str(exc.reason)}
+        except TimeoutError:
+            return {"ok": False, "error": "timeout"}
+        except Exception:
+            return {"ok": False, "error": "unknown"}
+
+    def _scrub(self, event: dict[str, Any]) -> dict[str, Any]:
+        """Remove forbidden fields from the event and payload recursively."""
+        def scrub_value(value: Any) -> Any:
+            if isinstance(value, dict):
+                return {k: scrub_value(v) for k, v in value.items() if k not in FORBIDDEN_FIELDS}
+            if isinstance(value, list):
+                return [scrub_value(v) for v in value]
+            return value
+
+        return scrub_value(event)
+
+    @staticmethod
+    def _command_name(args: Any) -> str | None:
+        command = getattr(args, "command", None)
+        if not command:
+            return None
+        return str(command)
+
+
+from datetime import timedelta  # noqa: E402
+
+
+def duration_bucket(duration_ms: int) -> str:
+    """Map a duration in milliseconds to a privacy-safe bucket."""
+    if duration_ms < 100:
+        return "<100ms"
+    if duration_ms < 1000:
+        return "100ms-1s"
+    if duration_ms < 5000:
+        return "1s-5s"
+    if duration_ms < 30000:
+        return "5s-30s"
+    if duration_ms < 300000:
+        return "30s-5m"
+    return ">5m"
+
+
+def error_class_bucket(error: BaseException | None) -> str | None:
+    """Classify an exception into a privacy-safe error bucket."""
+    if error is None:
+        return None
+    name = type(error).__name__
+    if name == "ValueError":
+        return "ValidationError"
+    if name in ERROR_CLASS_BUCKETS:
+        return name
+    return "Unknown"

--- a/src/rosclaw/feedback/upload.py
+++ b/src/rosclaw/feedback/upload.py
@@ -1,0 +1,107 @@
+"""Manual rich feedback bundle upload with mandatory redaction."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from rosclaw import __version__ as rosclaw_version
+
+from .config import FeedbackConfig
+from .export import FeedbackExporter
+from .installation import InstallationManager
+from .store import directory_size_mb
+
+
+class FeedbackUploader:
+    """Build and upload a redacted feedback bundle."""
+
+    def __init__(self, home: Path) -> None:
+        self.home = Path(home)
+        self.config = FeedbackConfig.load(home)
+        self.installation = InstallationManager(home)
+
+    def upload(
+        self,
+        *,
+        redact: bool,
+        days: int = 30,
+        dry_run: bool = False,
+        include_media: bool = False,
+    ) -> dict[str, Any]:
+        """Upload a feedback bundle; redaction is mandatory."""
+        if not redact:
+            return {
+                "ok": False,
+                "error": "redaction_required",
+                "message": "Feedback upload requires --redact. Use `rosclaw feedback upload --redact`.",
+            }
+
+        anonymous_id = self.installation.get_anonymous_installation_id()
+        if anonymous_id is None:
+            return {"ok": False, "error": "no_installation"}
+
+        media_dir = self.home / "feedback" / "media" / "local_only"
+        media_files = list(media_dir.glob("*")) if include_media and media_dir.exists() else []
+
+        exporter = FeedbackExporter(self.home)
+        bundle_path = exporter.export(days=days, redact=True)
+        size_mb = directory_size_mb(self.home / "feedback" / "bundles")
+        max_mb = self.config.upload.get("max_bundle_mb", 25)
+        if size_mb > max_mb:
+            return {"ok": False, "error": "bundle_too_large", "size_mb": size_mb, "max_mb": max_mb}
+
+        if dry_run:
+            return {
+                "ok": True,
+                "dry_run": True,
+                "bundle_path": str(bundle_path),
+                "anonymous_installation_id": anonymous_id,
+                "media_files": [str(p.name) for p in media_files],
+            }
+
+        endpoint = self.config.upload.get("endpoint")
+        if not endpoint:
+            return {"ok": False, "error": "no_upload_endpoint"}
+
+        payload = {
+            "schema_version": "rosclaw.feedback.upload.v1",
+            "anonymous_installation_id": anonymous_id,
+            "client_version": rosclaw_version,
+            "redacted": True,
+            "bundle_path": str(bundle_path),
+            "media_count": len(media_files),
+            "days": days,
+        }
+        response = self._post(endpoint, payload)
+        return response or {"ok": False, "error": "upload_failed"}
+
+    def _post(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+        timeout = self.config.upload.get("timeout_seconds", 10)
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        request = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": f"rosclaw/{rosclaw_version}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = response.read().decode("utf-8")
+                if raw:
+                    return json.loads(raw)
+                return {"ok": True}
+        except urllib.error.HTTPError as exc:
+            return {"ok": False, "error": "http_error", "status": exc.code}
+        except urllib.error.URLError as exc:
+            return {"ok": False, "error": "url_error", "reason": str(exc.reason)}
+        except TimeoutError:
+            return {"ok": False, "error": "timeout"}
+        except Exception:
+            return {"ok": False, "error": "unknown"}

--- a/src/rosclaw/firstboot/config.py
+++ b/src/rosclaw/firstboot/config.py
@@ -176,8 +176,8 @@ class FirstbootConfig:
         self.telemetry = merge_config(
             self.telemetry,
             {
-                "enabled": False,
-                "anonymous_install_ping": False,
+                "enabled": True,
+                "anonymous_install_ping": True,
                 "install_id": None,
                 "user_agent": None,
             },
@@ -196,7 +196,6 @@ class FirstbootConfig:
         """Overlay profile-specific defaults without overwriting existing keys."""
         if profile == "offline":
             self.cloud["enabled"] = False
-            self.telemetry["enabled"] = False
             self.provider["mode"] = "local"
             self.memory["backend"] = "local"
         elif profile == "cloud":

--- a/src/rosclaw/firstboot/telemetry.py
+++ b/src/rosclaw/firstboot/telemetry.py
@@ -1,4 +1,4 @@
-"""Telemetry configuration generation for ROSClaw First Boot."""
+"""Telemetry and feedback configuration generation for ROSClaw First Boot."""
 
 from __future__ import annotations
 
@@ -6,78 +6,41 @@ from pathlib import Path
 
 import yaml
 
+from rosclaw.feedback.config import FeedbackConfig, TelemetryConfig
 
-def generate_telemetry_yaml(home: Path, enabled: bool = False) -> Path:
-    """Generate telemetry.yaml with everything disabled by default."""
+
+def generate_telemetry_yaml(home: Path, enabled: bool = True) -> Path:
+    """Generate telemetry.yaml with the full v1 product telemetry spec."""
+    config = TelemetryConfig()
+    config.mode["enabled"] = True
+    config.mode["product_telemetry"] = enabled
+    config.mode["diagnostics_upload"] = False
+    config.mode["rich_feedback_upload"] = False
+    config.product_telemetry["enabled"] = enabled
+    config.product_telemetry["opt_out"] = True
+    config.diagnostics["enabled"] = False
+    config.rich_feedback["enabled"] = False
+    return config.save(home)
+
+
+def generate_feedback_yaml(home: Path) -> Path:
+    """Generate feedback.yaml with the full v1 local feedback spec."""
+    return FeedbackConfig().save(home)
+
+
+def load_telemetry_yaml(home: Path) -> dict:
+    """Load telemetry.yaml if present, returning an empty dict on error."""
     path = home / "config" / "telemetry.yaml"
-    config = {
-        "schema_version": "1.0",
-        "telemetry": {
-            "enabled": enabled,
-            "anonymous_install_ping": enabled,
-            "anonymous_doctor_ping": False,
-            "endpoint": "https://api.rosclaw.io/v1/telemetry",
-        },
-        "privacy": {
-            "send_install_id": True,
-            "send_os": True,
-            "send_arch": True,
-            "send_python_version": True,
-            "send_error_code": True,
-            "send_hostname": False,
-            "send_username": False,
-            "send_ip": False,
-            "send_workspace_path": False,
-            "send_logs": False,
-        },
-    }
-    path.write_text(
-        yaml.safe_dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True),
-        encoding="utf-8",
-    )
-    return path
+    if not path.exists():
+        return {}
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (yaml.YAMLError, OSError):
+        return {}
 
 
-def build_install_ping_payload(
-    install_state: dict,
-    status: str = "success",
-    error_code: str | None = None,
-    duration_ms: int | None = None,
-) -> dict:
-    """Build an anonymous install ping payload.
-
-    This only includes non-identifying fields: hashed install_id, platform,
-    Python version, install backend/channel, and result status.
-    """
-    import hashlib
-
-    install_id = install_state.get("install_id", "")
-    install_id_hash = hashlib.sha256(install_id.encode("utf-8")).hexdigest()
-    platform = install_state.get("platform", {})
-    python = install_state.get("python", {})
-
-    return {
-        "event": "install_completed",
-        "schema_version": "1.0",
-        "anonymous": True,
-        "install_id_hash": f"sha256:{install_id_hash}",
-        "timestamp": install_state.get("installed_at"),
-        "rosclaw_version": install_state.get("rosclaw_version", "unknown"),
-        "installer_version": install_state.get("installer_version", "1.0.0"),
-        "platform": {
-            "os": platform.get("os"),
-            "arch": platform.get("arch"),
-            "is_wsl": platform.get("is_wsl", False),
-        },
-        "python": {
-            "major": python.get("version", "").split(".")[0] if python.get("version") else None,
-            "minor": python.get("version", "").split(".")[1] if python.get("version") else None,
-        },
-        "install_backend": install_state.get("install_backend"),
-        "install_channel": install_state.get("install_channel"),
-        "result": {
-            "status": status,
-            "error_code": error_code,
-            "duration_ms": duration_ms,
-        },
-    }
+def is_product_telemetry_enabled(home: Path) -> bool:
+    """Return whether product telemetry is currently enabled."""
+    cfg = load_telemetry_yaml(home)
+    mode = cfg.get("mode", {})
+    return bool(mode.get("enabled", True) and mode.get("product_telemetry", True))

--- a/src/rosclaw/firstboot/wizard.py
+++ b/src/rosclaw/firstboot/wizard.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from rosclaw.feedback.directories import ensure_feedback_dirs
+from rosclaw.feedback.installation import InstallationManager
+from rosclaw.feedback.telemetry_client import TelemetryClient
+
 from .config import FirstbootConfig, generate_rosclaw_yaml
 from .doctor import FirstbootDoctor
 from .mcp import generate_mcp_config
-from .telemetry import generate_telemetry_yaml
+from .telemetry import generate_feedback_yaml, generate_telemetry_yaml
 from .workspace import (
     init_workspace,
     is_workspace_initialized,
@@ -187,11 +192,48 @@ def _interactive_safety() -> str:
 
 def _interactive_telemetry() -> bool:
     print(
-        "\nHelp improve ROSClaw by sending anonymous install diagnostics?\n"
-        "This sends: OS, architecture, Python version, ROSClaw version, install result.\n"
-        "This does NOT send: username, hostname, logs, workspace path, robot data, memory, code."
+        "\nHelp improve ROSClaw?\n\n"
+        "ROSClaw can send lightweight anonymous product telemetry:\n"
+        "  • install success\n"
+        "  • firstboot completion\n"
+        "  • version\n"
+        "  • OS / Python / ROS environment\n"
+        "  • command success/failure summary\n"
+        "  • module usage\n"
+        "  • daily active heartbeat\n\n"
+        "Never sent by default:\n"
+        "  • prompts\n"
+        "  • logs\n"
+        "  • camera/video/audio\n"
+        "  • local file paths\n"
+        "  • API keys\n"
+        "  • robot serial numbers\n"
+        "  • MCAP/raw traces\n\n"
+        "You can disable this anytime:\n"
+        "  rosclaw feedback telemetry off"
     )
-    return ask_yes_no("Enable anonymous diagnostics", False)
+    return ask_yes_no("Enable lightweight product telemetry", True)
+
+
+def _interactive_diagnostics() -> bool:
+    print(
+        "\nAllow ROSClaw to upload redacted diagnostic summaries when errors occur?\n"
+        "This may include:\n"
+        "  • crash type\n"
+        "  • failure type\n"
+        "  • sandbox block reason\n"
+        "  • provider latency bucket\n\n"
+        "This does NOT include full stacktraces, prompts, logs, or paths."
+    )
+    return ask_yes_no("Enable redacted diagnostics", False)
+
+
+def _interactive_rich_feedback() -> bool:
+    print(
+        "\nRich feedback bundles (logs, media, MCAP) are only uploaded manually.\n"
+        "Keep manual-only mode enabled for maximum privacy."
+    )
+    return ask_yes_no("Enable manual rich feedback upload", False)
 
 
 def _print_summary(
@@ -200,18 +242,22 @@ def _print_summary(
     robot: str,
     safety: str,
     telemetry_enabled: bool,
+    diagnostics_enabled: bool,
+    rich_feedback_enabled: bool,
     enable_mcp: bool,
     use_cases: dict[str, bool],
 ) -> None:
     print("\n" + "=" * 62)
     print(" First Boot Summary")
     print("=" * 62)
-    print(f"Workspace:    {home}")
-    print(f"Profile:      {profile}")
-    print(f"Robot:        {robot}")
-    print(f"Safety:       {safety}")
-    print(f"Telemetry:    {'enabled' if telemetry_enabled else 'disabled'}")
-    print(f"MCP config:   {'enabled' if enable_mcp else 'disabled'}")
+    print(f"Workspace:       {home}")
+    print(f"Profile:         {profile}")
+    print(f"Robot:           {robot}")
+    print(f"Safety:          {safety}")
+    print(f"Telemetry:       {'enabled' if telemetry_enabled else 'disabled'}")
+    print(f"Diagnostics:     {'enabled' if diagnostics_enabled else 'disabled'}")
+    print(f"Rich feedback:   {'enabled' if rich_feedback_enabled else 'disabled'}")
+    print(f"MCP config:      {'enabled' if enable_mcp else 'disabled'}")
     print("Use cases:")
     for key, val in use_cases.items():
         print(f"  • {key}: {'yes' if val else 'no'}")
@@ -244,6 +290,8 @@ def run_firstboot_interactive(args: argparse.Namespace) -> int:
         enable_mcp = ask_yes_no("Generate MCP config sample", True)
 
     telemetry_enabled = _interactive_telemetry()
+    diagnostics_enabled = _interactive_diagnostics()
+    rich_feedback_enabled = _interactive_rich_feedback()
 
     _print_summary(
         home=home,
@@ -251,6 +299,8 @@ def run_firstboot_interactive(args: argparse.Namespace) -> int:
         robot=robot,
         safety=safety,
         telemetry_enabled=telemetry_enabled,
+        diagnostics_enabled=diagnostics_enabled,
+        rich_feedback_enabled=rich_feedback_enabled,
         enable_mcp=enable_mcp,
         use_cases=use_cases,
     )
@@ -270,6 +320,8 @@ def run_firstboot_interactive(args: argparse.Namespace) -> int:
         robot=robot,
         safety=safety,
         telemetry_enabled=telemetry_enabled,
+        diagnostics_enabled=diagnostics_enabled,
+        rich_feedback_enabled=rich_feedback_enabled,
         enable_mcp=enable_mcp,
         use_cases=use_cases,
         force=args.force,
@@ -291,7 +343,9 @@ def run_firstboot_noninteractive(args: argparse.Namespace) -> int:
     robot = getattr(args, "robot", "sim_ur5e")
     safety = getattr(args, "safety", "strict")
 
-    telemetry_enabled = args.telemetry and not args.no_telemetry
+    telemetry_enabled = not args.no_telemetry if getattr(args, "no_telemetry", False) else True
+    diagnostics_enabled = getattr(args, "diagnostics", False) and not getattr(args, "no_diagnostics", False)
+    rich_feedback_enabled = getattr(args, "rich_feedback", False) and not getattr(args, "no_rich_feedback", False)
     enable_mcp = not args.disable_mcp if getattr(args, "disable_mcp", False) else True
 
     use_cases = {
@@ -310,6 +364,8 @@ def run_firstboot_noninteractive(args: argparse.Namespace) -> int:
         robot=robot,
         safety=safety,
         telemetry_enabled=telemetry_enabled,
+        diagnostics_enabled=diagnostics_enabled,
+        rich_feedback_enabled=rich_feedback_enabled,
         enable_mcp=enable_mcp,
         use_cases=use_cases,
         force=args.force,
@@ -329,6 +385,8 @@ def _write_firstboot(
     robot: str,
     safety: str,
     telemetry_enabled: bool,
+    diagnostics_enabled: bool,
+    rich_feedback_enabled: bool,
     enable_mcp: bool,
     use_cases: dict[str, bool],
     force: bool,
@@ -339,6 +397,7 @@ def _write_firstboot(
     _ = dev  # reserved for future dev-mode path handling
 
     init_workspace(home, force=force)
+    ensure_feedback_dirs(home)
 
     config = FirstbootConfig(
         workspace={"home": str(home), "profile": profile},
@@ -364,10 +423,12 @@ def _write_firstboot(
 
     generate_rosclaw_yaml(home, config)
     generate_telemetry_yaml(home, telemetry_enabled)
+    generate_feedback_yaml(home)
     if enable_mcp:
         generate_mcp_config(home)
 
     install_state = load_install_state(home) or {}
+    install_channel = install_state.get("install_channel", "stable")
     install_state["firstboot_completed"] = True
     install_state["firstboot_profile"] = profile
     install_state["firstboot_robot"] = robot
@@ -375,8 +436,28 @@ def _write_firstboot(
     install_state["firstboot_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
     save_install_state(home, install_state)
 
+    InstallationManager(home).ensure_installation(
+        install_channel=install_channel,
+        telemetry_enabled=telemetry_enabled,
+        diagnostics_enabled=diagnostics_enabled,
+        rich_feedback_enabled=rich_feedback_enabled,
+    )
+
     doctor = FirstbootDoctor(home)
     result = doctor.run_full(fix=False, json_output=json_output)
+
+    if telemetry_enabled and not json_output:
+        with contextlib.suppress(Exception):
+            TelemetryClient(home).record_event(
+                event_type="firstboot_completed",
+                payload={
+                    "profile": profile,
+                    "robot": robot,
+                    "safety": safety,
+                    "doctor_status": result.status.value.lower(),
+                    "enabled_modules": [k for k, v in use_cases.items() if v],
+                },
+            )
 
     if not json_output:
         _print_success(home, profile, result.status.value, result.checks)

--- a/src/rosclaw/firstboot/workspace.py
+++ b/src/rosclaw/firstboot/workspace.py
@@ -10,10 +10,11 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from rosclaw.feedback.directories import ensure_feedback_dirs
+
 DEFAULT_DIRS = [
     "config/profiles",
     "logs",
-    "events",
     "cache/wheels",
     "cache/downloads",
     "cache/doctor",
@@ -32,6 +33,15 @@ DEFAULT_DIRS = [
     "providers/manifests",
     "robots/installed",
     "state/locks",
+    "telemetry/events",
+    "telemetry/heartbeat",
+    "telemetry/uploads",
+    "feedback/events",
+    "feedback/crashes",
+    "feedback/bundles",
+    "feedback/redacted",
+    "feedback/media/local_only",
+    "feedback/consent",
     "tmp",
 ]
 
@@ -84,6 +94,8 @@ def init_workspace(home: Path, force: bool = False) -> dict:
 
     for rel in DEFAULT_DIRS:
         (home / rel).mkdir(parents=True, exist_ok=True)
+
+    ensure_feedback_dirs(home)
 
     install_id_path = home / "state" / "install_id"
     if not install_id_path.exists() or force:
@@ -153,6 +165,8 @@ def ensure_minimal_workspace(home: Path, platform: PlatformInfo | None = None) -
     home.mkdir(parents=True, exist_ok=True)
     for rel in ("config", "logs", "cache", "state"):
         (home / rel).mkdir(parents=True, exist_ok=True)
+
+    ensure_feedback_dirs(home)
 
     install_id_path = home / "state" / "install_id"
     if not install_id_path.exists():

--- a/supabase/migrations/004_telemetry_feedback_schema.sql
+++ b/supabase/migrations/004_telemetry_feedback_schema.sql
@@ -1,0 +1,239 @@
+-- ROSClaw v1.0 Feedback & Telemetry schema
+-- Create all tables, indexes, and RLS policies for product telemetry and rich feedback.
+
+-- -------------------------------------------------
+-- telemetry_installations
+-- -------------------------------------------------
+create table if not exists public.telemetry_installations (
+  id uuid default gen_random_uuid() primary key,
+  anonymous_installation_id text unique not null,
+  first_seen_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now(),
+  first_rosclaw_version text,
+  latest_rosclaw_version text,
+  os_family text,
+  arch text,
+  python_major_minor text,
+  install_channel text,
+  deployment_mode text,
+  telemetry_status text not null default 'enabled'
+);
+
+create index if not exists idx_telemetry_installations_last_seen
+  on public.telemetry_installations(last_seen_at);
+
+create index if not exists idx_telemetry_installations_version
+  on public.telemetry_installations(latest_rosclaw_version);
+
+create index if not exists idx_telemetry_installations_os
+  on public.telemetry_installations(os_family);
+
+-- -------------------------------------------------
+-- telemetry_events
+-- -------------------------------------------------
+create table if not exists public.telemetry_events (
+  id uuid default gen_random_uuid() primary key,
+  anonymous_installation_id text not null,
+  schema_version text not null,
+  event_type text not null,
+  command_name text,
+  command_status text,
+  module_name text,
+  rosclaw_version text,
+  cli_version text,
+  os_family text,
+  arch text,
+  python_major_minor text,
+  install_channel text,
+  deployment_mode text,
+  duration_bucket text,
+  error_class_bucket text,
+  created_at timestamptz not null,
+  received_at timestamptz not null default now(),
+  payload jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_telemetry_events_installation
+  on public.telemetry_events(anonymous_installation_id);
+
+create index if not exists idx_telemetry_events_type
+  on public.telemetry_events(event_type);
+
+create index if not exists idx_telemetry_events_command
+  on public.telemetry_events(command_name);
+
+create index if not exists idx_telemetry_events_module
+  on public.telemetry_events(module_name);
+
+create index if not exists idx_telemetry_events_received_at
+  on public.telemetry_events(received_at);
+
+-- -------------------------------------------------
+-- telemetry_daily_aggregates
+-- -------------------------------------------------
+create table if not exists public.telemetry_daily_aggregates (
+  id uuid default gen_random_uuid() primary key,
+  day date not null,
+  metric_name text not null,
+  dimension jsonb not null default '{}'::jsonb,
+  value numeric not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(day, metric_name, dimension)
+);
+
+create index if not exists idx_telemetry_daily_metric
+  on public.telemetry_daily_aggregates(metric_name);
+
+create index if not exists idx_telemetry_daily_day
+  on public.telemetry_daily_aggregates(day);
+
+-- -------------------------------------------------
+-- feedback_batches
+-- -------------------------------------------------
+create table if not exists public.feedback_batches (
+  id uuid default gen_random_uuid() primary key,
+  anonymous_installation_id text not null,
+  schema_version text not null,
+  event_count integer not null default 0,
+  attachment_count integer not null default 0,
+  redacted boolean not null default true,
+  client_version text,
+  created_at timestamptz not null default now(),
+  received_at timestamptz not null default now(),
+  status text not null default 'received',
+  privacy_level text not null default 'L0',
+  redaction_report jsonb not null default '{}'::jsonb
+);
+
+-- -------------------------------------------------
+-- feedback_events
+-- -------------------------------------------------
+create table if not exists public.feedback_events (
+  id uuid default gen_random_uuid() primary key,
+  batch_id uuid references public.feedback_batches(id) on delete cascade,
+  event_id text not null,
+  anonymous_installation_id text not null,
+  schema_version text not null,
+  category text not null,
+  module text not null,
+  severity text not null default 'info',
+  rosclaw_version text,
+  robot_type text,
+  skill_id text,
+  task_id text,
+  provider_type text,
+  created_at timestamptz not null,
+  received_at timestamptz not null default now(),
+  privacy_level text not null default 'L0',
+  redacted boolean not null default true,
+  payload jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_feedback_events_batch
+  on public.feedback_events(batch_id);
+
+create index if not exists idx_feedback_events_anon_id
+  on public.feedback_events(anonymous_installation_id);
+
+-- -------------------------------------------------
+-- feedback_attachments
+-- -------------------------------------------------
+create table if not exists public.feedback_attachments (
+  id uuid default gen_random_uuid() primary key,
+  batch_id uuid references public.feedback_batches(id) on delete cascade,
+  anonymous_installation_id text not null,
+  storage_bucket text not null,
+  storage_path text not null,
+  file_name text not null,
+  mime_type text not null,
+  size_bytes bigint not null,
+  sha256 text not null,
+  redacted boolean not null default true,
+  attachment_type text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_feedback_attachments_batch
+  on public.feedback_attachments(batch_id);
+
+-- -------------------------------------------------
+-- feedback_delete_requests
+-- -------------------------------------------------
+create table if not exists public.feedback_delete_requests (
+  id uuid default gen_random_uuid() primary key,
+  anonymous_installation_id text not null,
+  status text not null default 'pending',
+  reason text,
+  created_at timestamptz not null default now(),
+  completed_at timestamptz
+);
+
+create index if not exists idx_feedback_delete_requests_anon_id
+  on public.feedback_delete_requests(anonymous_installation_id);
+
+-- -------------------------------------------------
+-- Row Level Security
+-- -------------------------------------------------
+alter table public.telemetry_installations enable row level security;
+alter table public.telemetry_events enable row level security;
+alter table public.telemetry_daily_aggregates enable row level security;
+alter table public.feedback_batches enable row level security;
+alter table public.feedback_events enable row level security;
+alter table public.feedback_attachments enable row level security;
+alter table public.feedback_delete_requests enable row level security;
+
+-- Service-role-only policies: direct client access is disabled.
+-- Server-side API routes use the Supabase service role key.
+
+create policy "service_role_only_telemetry_installations"
+  on public.telemetry_installations
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+create policy "service_role_only_telemetry_events"
+  on public.telemetry_events
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+create policy "service_role_only_telemetry_daily_aggregates"
+  on public.telemetry_daily_aggregates
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+create policy "service_role_only_feedback_batches"
+  on public.feedback_batches
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+create policy "service_role_only_feedback_events"
+  on public.feedback_events
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+create policy "service_role_only_feedback_attachments"
+  on public.feedback_attachments
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+create policy "service_role_only_feedback_delete_requests"
+  on public.feedback_delete_requests
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+-- Note: anon/authenticated roles have no access by design.
+-- Admin dashboard reads through server-side API routes with service_role.

--- a/tests/dashboard/test_firstboot_page.py
+++ b/tests/dashboard/test_firstboot_page.py
@@ -51,6 +51,8 @@ def test_firstboot_preview_default_command(client: TestClient) -> None:
     assert "--robot sim_ur5e" in command
     assert "--safety strict" in command
     assert "--no-telemetry" in command
+    assert "--no-diagnostics" in command
+    assert "--no-rich-feedback" in command
     assert "--enable-mcp" in command
     assert "--enable-sandbox" in command
 
@@ -58,6 +60,8 @@ def test_firstboot_preview_default_command(client: TestClient) -> None:
     assert preview["profile"] == "offline"
     assert preview["robot"] == "sim_ur5e"
     assert preview["telemetry"] is False
+    assert preview["diagnostics"] is False
+    assert preview["rich_feedback"] is False
 
 
 def test_firstboot_preview_custom_command(client: TestClient) -> None:

--- a/tests/feedback/__init__.py
+++ b/tests/feedback/__init__.py
@@ -1,0 +1,1 @@
+"""Feedback and telemetry tests."""

--- a/tests/feedback/test_consent.py
+++ b/tests/feedback/test_consent.py
@@ -1,0 +1,51 @@
+"""Tests for ConsentManager and CLI."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from rosclaw.feedback.cli import cmd_feedback_consent
+from rosclaw.feedback.consent import ConsentManager
+
+
+class TestConsentManager:
+    def test_show_defaults(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        state = ConsentManager(home).show()
+        assert state.product_telemetry is True
+        assert state.diagnostics is False
+        assert state.rich_feedback is False
+
+    def test_set_diagnostics(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        mgr = ConsentManager(home)
+        state = mgr.set_diagnostics(True)
+        assert state.diagnostics is True
+        assert (home / "config" / "installation.json").exists()
+
+    def test_revoke_all(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        mgr = ConsentManager(home)
+        mgr.set_diagnostics(True)
+        mgr.set_rich_feedback(True)
+        state = mgr.revoke_all()
+        assert state.diagnostics is False
+        assert state.rich_feedback is False
+
+
+class TestConsentCLI:
+    def test_consent_show(self, tmp_path: Path, capsys) -> None:
+        home = tmp_path / ".rosclaw"
+        args = argparse.Namespace(
+            workspace=str(home),
+            diagnostics=False,
+            rich_feedback=False,
+            revoke_diagnostics=False,
+            revoke_all=False,
+            show=True,
+        )
+        code = cmd_feedback_consent(args)
+        captured = capsys.readouterr()
+        assert code == 0
+        assert "Product telemetry:" in captured.out

--- a/tests/feedback/test_export.py
+++ b/tests/feedback/test_export.py
@@ -1,0 +1,46 @@
+"""Tests for FeedbackExporter."""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+from rosclaw.feedback.export import FeedbackExporter
+from rosclaw.feedback.installation import InstallationManager
+from rosclaw.feedback.store import append_event
+from rosclaw.feedback.telemetry_client import TelemetryClient
+
+
+class TestFeedbackExporter:
+    def test_export_creates_tar_gz(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        client = TelemetryClient(home)
+        client.record_event("command_completed", command_name="status", command_status="success")
+
+        output = FeedbackExporter(home).export(days=7, redact=False)
+
+        assert output.exists()
+        assert output.suffix == ".gz"
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+            assert "telemetry.jsonl" in names
+            assert "manifest.json" in names
+
+    def test_export_redacts(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        append_event(
+            home / "telemetry" / "events" / f"{datetime.now(UTC).date().isoformat()}.jsonl",
+            {"event_type": "test", "message": "email me at foo@example.com"},
+        )
+
+        output = FeedbackExporter(home).export(days=7, redact=True)
+
+        with tarfile.open(output, "r:gz") as tar:
+            member = tar.extractfile("telemetry.jsonl")
+            lines = member.read().decode("utf-8").strip().split("\n")
+            record = json.loads(lines[0])
+            assert "[REDACTED_EMAIL]" in record["message"]

--- a/tests/feedback/test_feedback_status.py
+++ b/tests/feedback/test_feedback_status.py
@@ -1,0 +1,36 @@
+"""Tests for `rosclaw feedback status` output."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from rosclaw.feedback.cli import cmd_feedback_status
+from rosclaw.feedback.installation import InstallationManager
+
+
+class TestFeedbackStatus:
+    def test_status_shows_anonymous_id(self, tmp_path: Path, capsys) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        args = argparse.Namespace(workspace=str(home))
+
+        code = cmd_feedback_status(args)
+        captured = capsys.readouterr()
+
+        assert code == 0
+        assert "ROSClaw Feedback & Telemetry Status" in captured.out
+        assert "anonymous_installation_id:" in captured.out
+        assert "rci_" in captured.out
+
+    def test_status_local_store_section(self, tmp_path: Path, capsys) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        args = argparse.Namespace(workspace=str(home))
+
+        cmd_feedback_status(args)
+        captured = capsys.readouterr()
+
+        assert "Local Store:" in captured.out
+        assert re.search(r"telemetry_events:\s+\d+", captured.out)

--- a/tests/feedback/test_firstboot_integration.py
+++ b/tests/feedback/test_firstboot_integration.py
@@ -1,0 +1,51 @@
+"""Integration tests for firstboot telemetry wiring."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+
+import yaml
+
+
+class TestFirstbootTelemetryIntegration:
+    def test_firstboot_creates_telemetry_and_feedback_dirs(self, tmp_path, monkeypatch) -> None:
+        home = tmp_path / ".rosclaw"
+        monkeypatch.setenv("ROSCLAW_HOME", str(home))
+        from rosclaw.cli import main
+
+        sys.argv = ["rosclaw", "firstboot", "--yes", "--profile", "offline", "--telemetry"]
+        code = main()
+        assert code in (0, 2)
+
+        assert (home / "telemetry" / "events").exists()
+        assert (home / "feedback" / "events").exists()
+        assert (home / "config" / "telemetry.yaml").exists()
+        assert (home / "config" / "feedback.yaml").exists()
+        assert (home / "config" / "installation.json").exists()
+
+    def test_firstboot_records_firstboot_completed_event(self, tmp_path, monkeypatch) -> None:
+        home = tmp_path / ".rosclaw"
+        monkeypatch.setenv("ROSCLAW_HOME", str(home))
+        from rosclaw.cli import main
+
+        sys.argv = ["rosclaw", "firstboot", "--yes", "--profile", "offline", "--telemetry"]
+        main()
+
+        events_path = home / "telemetry" / "events" / f"{datetime.now(UTC).date().isoformat()}.jsonl"
+        if events_path.exists():
+            lines = [json.loads(line) for line in events_path.read_text(encoding="utf-8").strip().split("\n") if line.strip()]
+            types = [e["event_type"] for e in lines]
+            assert "firstboot_completed" in types
+
+    def test_firstboot_telemetry_default_on(self, tmp_path, monkeypatch) -> None:
+        home = tmp_path / ".rosclaw"
+        monkeypatch.setenv("ROSCLAW_HOME", str(home))
+        from rosclaw.cli import main
+
+        sys.argv = ["rosclaw", "firstboot", "--yes", "--profile", "offline"]
+        main()
+
+        cfg = yaml.safe_load((home / "config" / "telemetry.yaml").read_text(encoding="utf-8"))
+        assert cfg["mode"]["product_telemetry"] is True

--- a/tests/feedback/test_installation.py
+++ b/tests/feedback/test_installation.py
@@ -1,0 +1,70 @@
+"""Tests for InstallationManager."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rosclaw.feedback.installation import InstallationManager
+
+
+class TestInstallationManager:
+    def test_ensure_installation_creates_installation_json(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        mgr = InstallationManager(home)
+        install = mgr.ensure_installation()
+
+        assert (home / "config" / "installation.json").exists()
+        assert (home / "telemetry" / "local_salt").exists()
+        assert install.installation_id
+        assert install.telemetry_enabled is True
+        assert install.diagnostics_enabled is False
+        assert install.rich_feedback_enabled is False
+
+    def test_anonymous_id_is_stable(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        mgr = InstallationManager(home)
+        mgr.ensure_installation()
+
+        anon1 = mgr.get_anonymous_installation_id()
+        anon2 = mgr.get_anonymous_installation_id()
+
+        assert anon1 is not None
+        assert anon1 == anon2
+        assert anon1.startswith("rci_")
+        assert len(anon1) == 36  # "rci_" + 32 hex chars
+
+    def test_anonymous_id_changes_on_reset(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        mgr = InstallationManager(home)
+        mgr.ensure_installation()
+        anon1 = mgr.get_anonymous_installation_id()
+
+        mgr.reset_installation_id()
+        anon2 = mgr.get_anonymous_installation_id()
+
+        assert anon2 is not None
+        assert anon1 != anon2
+        assert anon2.startswith("rci_")
+
+    def test_set_telemetry_enabled_persists(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        mgr = InstallationManager(home)
+        mgr.ensure_installation(telemetry_enabled=True)
+        assert mgr.get_installation().telemetry_enabled is True
+
+        mgr.set_telemetry_enabled(False)
+        assert mgr.get_installation().telemetry_enabled is False
+
+        mgr.set_telemetry_enabled(True)
+        assert mgr.get_installation().telemetry_enabled is True
+
+    def test_no_hostname_or_username_in_installation(self, tmp_path: Path) -> None:
+        import socket
+
+        home = tmp_path / ".rosclaw"
+        mgr = InstallationManager(home)
+        mgr.ensure_installation()
+
+        raw = (home / "config" / "installation.json").read_text(encoding="utf-8")
+        assert socket.gethostname() not in raw
+        assert "username" not in raw.lower()

--- a/tests/feedback/test_redaction_text.py
+++ b/tests/feedback/test_redaction_text.py
@@ -1,0 +1,32 @@
+"""Tests for TextRedactor."""
+
+from __future__ import annotations
+
+from rosclaw.feedback.redactor.text_redactor import TextRedactor
+
+
+class TestTextRedactor:
+    def test_redacts_email(self) -> None:
+        r = TextRedactor()
+        assert r.redact("contact me at foo@example.com please") == "contact me at [REDACTED_EMAIL] please"
+
+    def test_redacts_ipv4(self) -> None:
+        r = TextRedactor()
+        assert "[REDACTED_IP]" in r.redact("server at 192.168.1.1")
+
+    def test_redacts_url(self) -> None:
+        r = TextRedactor()
+        assert r.redact("see https://example.com/path") == "see [REDACTED_URL]"
+
+    def test_redacts_secret(self) -> None:
+        r = TextRedactor()
+        assert "[REDACTED_SECRET]" in r.redact("api_key=abc1234567890abcdef")
+
+    def test_redacts_serial(self) -> None:
+        r = TextRedactor()
+        assert "[REDACTED_SERIAL]" in r.redact("serial=SN123456789")
+
+    def test_disabled_returns_original(self) -> None:
+        r = TextRedactor(enabled=False)
+        text = "foo@example.com"
+        assert r.redact(text) == text

--- a/tests/feedback/test_telemetry_config.py
+++ b/tests/feedback/test_telemetry_config.py
@@ -1,0 +1,63 @@
+"""Tests for TelemetryConfig and FeedbackConfig."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rosclaw.feedback.config import FeedbackConfig, TelemetryConfig
+
+
+class TestTelemetryConfig:
+    def test_defaults_match_spec(self) -> None:
+        cfg = TelemetryConfig()
+        assert cfg.mode["enabled"] is True
+        assert cfg.mode["product_telemetry"] is True
+        assert cfg.mode["diagnostics_upload"] is False
+        assert cfg.product_telemetry["heartbeat_interval_hours"] == 24
+        assert cfg.diagnostics["enabled"] is False
+        assert cfg.rich_feedback["enabled"] is False
+        assert cfg.upload["timeout_seconds"] == 3
+
+    def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        cfg = TelemetryConfig()
+        cfg.mode["enabled"] = False
+        cfg.mode["product_telemetry"] = False
+        path = cfg.save(home)
+
+        assert path.exists()
+        loaded = TelemetryConfig.load(home)
+        assert loaded.mode["enabled"] is False
+        assert loaded.mode["product_telemetry"] is False
+        assert loaded.product_telemetry["heartbeat_interval_hours"] == 24
+
+    def test_opt_out_persisted(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        cfg = TelemetryConfig()
+        cfg.product_telemetry["enabled"] = False
+        cfg.save(home)
+
+        loaded = TelemetryConfig.load(home)
+        assert loaded.product_telemetry["enabled"] is False
+
+
+class TestFeedbackConfig:
+    def test_defaults_match_spec(self) -> None:
+        cfg = FeedbackConfig()
+        assert cfg.mode["enabled"] is True
+        assert cfg.mode["local_store"] is True
+        assert cfg.mode["upload"] is False
+        assert cfg.retention["local_days"] == 30
+        assert cfg.collect["crash_reports"]["enabled"] is True
+        assert cfg.redaction["text"]["replace_emails"] is True
+        assert "/camera" in cfg.redaction["mcap"]["deny_topics"]
+
+    def test_save_and_load(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        cfg = FeedbackConfig()
+        cfg.mode["upload"] = True
+        _path = cfg.save(home)
+
+        loaded = FeedbackConfig.load(home)
+        assert loaded.mode["upload"] is True
+        assert loaded.retention["max_local_size_mb"] == 512

--- a/tests/feedback/test_telemetry_events.py
+++ b/tests/feedback/test_telemetry_events.py
@@ -1,0 +1,92 @@
+"""Tests for TelemetryClient event recording."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from rosclaw.feedback.installation import InstallationManager
+from rosclaw.feedback.store import read_events
+from rosclaw.feedback.telemetry_client import TelemetryClient, duration_bucket, error_class_bucket
+
+
+class TestDurationAndErrorBuckets:
+    def test_duration_bucket(self) -> None:
+        assert duration_bucket(50) == "<100ms"
+        assert duration_bucket(500) == "100ms-1s"
+        assert duration_bucket(2500) == "1s-5s"
+        assert duration_bucket(20000) == "5s-30s"
+        assert duration_bucket(120000) == "30s-5m"
+        assert duration_bucket(400000) == ">5m"
+
+    def test_error_class_bucket(self) -> None:
+        assert error_class_bucket(None) is None
+        assert error_class_bucket(ValueError("boom")) == "ValidationError"
+        assert error_class_bucket(ImportError("no module")) == "ImportError"
+        assert error_class_bucket(RuntimeError("oops")) == "RuntimeError"
+        assert error_class_bucket(TypeError("bad")) == "Unknown"
+
+
+class TestTelemetryClientRecording:
+    def test_record_event_writes_jsonl(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        client = TelemetryClient(home)
+
+        client.record_event("command_completed", command_name="doctor", command_status="success")
+
+        events = read_events(home / "telemetry" / "events" / f"{datetime.now(UTC).date().isoformat()}.jsonl")
+        assert len(events) == 1
+        assert events[0]["event_type"] == "command_completed"
+        assert events[0]["command_name"] == "doctor"
+        assert events[0]["command_status"] == "success"
+        assert events[0]["anonymous_installation_id"].startswith("rci_")
+
+    def test_record_command_no_args_captured(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        client = TelemetryClient(home)
+
+        class Args:
+            command = "doctor"
+            workspace = str(home)
+            secret_arg = "super-secret"
+
+        client.record_command(Args(), "success", 250)
+
+        events = read_events(home / "telemetry" / "events" / f"{datetime.now(UTC).date().isoformat()}.jsonl")
+        payload = json.dumps(events[0])
+        assert "secret_arg" not in payload
+        assert "super-secret" not in payload
+
+    def test_forbidden_fields_scrubbed(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        client = TelemetryClient(home)
+
+        client.record_event(
+            "command_completed",
+            payload={"hostname": "mybox", "ip": "1.2.3.4", "allowed": True},
+        )
+
+        events = read_events(home / "telemetry" / "events" / f"{datetime.now(UTC).date().isoformat()}.jsonl")
+        payload = events[0].get("payload", {})
+        assert "hostname" not in payload
+        assert "ip" not in payload
+        assert payload.get("allowed") is True
+
+    @patch("urllib.request.urlopen")
+    def test_upload_failure_silent(self, mock_urlopen, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        mock_urlopen.side_effect = urllib.error.URLError("offline")
+
+        client = TelemetryClient(home)
+        # Should not raise.
+        client.record_event("command_completed", command_name="status")
+
+        events = read_events(home / "telemetry" / "events" / f"{datetime.now(UTC).date().isoformat()}.jsonl")
+        assert len(events) == 1

--- a/tests/feedback/test_upload.py
+++ b/tests/feedback/test_upload.py
@@ -1,0 +1,36 @@
+"""Tests for FeedbackUploader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from rosclaw.feedback.installation import InstallationManager
+from rosclaw.feedback.upload import FeedbackUploader
+
+
+class TestFeedbackUploader:
+    def test_upload_requires_redact(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        result = FeedbackUploader(home).upload(redact=False)
+        assert result["ok"] is False
+        assert result["error"] == "redaction_required"
+
+    def test_dry_run_does_not_upload(self, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        result = FeedbackUploader(home).upload(redact=True, dry_run=True)
+        assert result["ok"] is True
+        assert result["dry_run"] is True
+        assert "bundle_path" in result
+
+    @patch("urllib.request.urlopen")
+    def test_upload_posts_bundle(self, mock_urlopen, tmp_path: Path) -> None:
+        home = tmp_path / ".rosclaw"
+        InstallationManager(home).ensure_installation()
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b'{"ok": true, "request_id": "fb_123"}'
+
+        result = FeedbackUploader(home).upload(redact=True, dry_run=False)
+        assert result["ok"] is True
+        mock_urlopen.assert_called_once()

--- a/tests/test_firstboot.py
+++ b/tests/test_firstboot.py
@@ -122,6 +122,8 @@ class TestFirstbootInteractive:
             robot="turtlebot",
             safety="strict",
             telemetry_enabled=True,
+            diagnostics_enabled=False,
+            rich_feedback_enabled=False,
             enable_mcp=False,
             use_cases={"sandbox": True, "mcp": False},
         )

--- a/tests/test_firstboot_config.py
+++ b/tests/test_firstboot_config.py
@@ -70,7 +70,7 @@ class TestFirstbootConfig:
         config = FirstbootConfig()
         config.apply_profile("offline")
         assert config.cloud["enabled"] is False
-        assert config.telemetry["enabled"] is False
+        assert config.telemetry["enabled"] is True
         assert config.provider["mode"] == "local"
 
     def test_apply_profile_cloud_enables_cloud_configs(self):
@@ -107,7 +107,7 @@ class TestGenerateRosclawYaml:
         loaded = load_rosclaw_yaml(home)
         assert loaded["custom_key"] == 42
         assert loaded["workspace"]["profile"] == "offline"
-        assert loaded["telemetry"]["enabled"] is False
+        assert loaded["telemetry"]["enabled"] is True
 
     def test_load_rosclaw_yaml_returns_empty_when_missing(self, tmp_path):
         home = tmp_path / ".rosclaw"


### PR DESCRIPTION
## Summary

Implement the ROSClaw v1.0 Feedback & Telemetry module per `rosclaw_feedback_v1.md`.

### What's included

- **Local identity & config**
  - `src/rosclaw/feedback/installation.py` — anonymous `rci_...` installation ID via HMAC-SHA256 + local salt
  - `src/rosclaw/feedback/config.py` — `TelemetryConfig` / `FeedbackConfig` with v1 defaults
  - `src/rosclaw/feedback/directories.py` — `~/.rosclaw/telemetry/*` and `~/.rosclaw/feedback/*` layout

- **Telemetry client**
  - `src/rosclaw/feedback/telemetry_client.py` — JSONL spooling, duration/error bucketing, heartbeat throttling, silent upload failures
  - `src/rosclaw/feedback/hooks.py` — `telemetry_command_hook` wraps every CLI command and records privacy-safe `command_completed`

- **Redaction & consent**
  - `src/rosclaw/feedback/redactor/` — text, prompt, MCAP, secret scanners
  - `src/rosclaw/feedback/consent.py` — diagnostics / rich-feedback consent with audit log
  - `src/rosclaw/feedback/export.py` / `upload.py` — local bundle export and manual redacted upload

- **CLI**
  - `src/rosclaw/feedback/cli.py` — `rosclaw feedback {status,telemetry,consent,export,upload}`
  - `src/rosclaw/cli.py` — registers the `feedback` parser and wraps dispatch with the telemetry hook

- **Firstboot integration**
  - Default-on product telemetry, clear notice, opt-out via `--no-telemetry`
  - `--diagnostics` / `--no-diagnostics` / `--rich-feedback` / `--no-rich-feedback` flags
  - Generates `telemetry.yaml`, `feedback.yaml`, `installation.json`, and records `firstboot_completed`

- **Supabase schema**
  - `supabase/migrations/004_telemetry_feedback_schema.sql` — tables, indexes, RLS policies for the website team

### Out of scope

Website Next.js API routes, admin dashboard pages, and Vercel Cron implementation are left for the website-side developer as requested.

### Verification

```bash
pytest -q
# 3203 passed, 3 skipped, 23 deselected

export ROSCLAW_HOME=$(mktemp -d)
rosclaw firstboot --yes --profile offline --robot sim_ur5e
rosclaw feedback status
rosclaw feedback telemetry off
rosclaw feedback telemetry on
rosclaw feedback telemetry ping
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
