### PR TITLE
fix(skill): add catalog stages and User-Agent for Cloudflare upload

### DIFF
--- a/src/rosclaw/skill/hub_client.py
+++ b/src/rosclaw/skill/hub_client.py
@@ -20,6 +20,7 @@ class SkillHubClient:
         return {
             "x-api-key": self.api_key,
             "Content-Type": "application/json",
+            "User-Agent": "Mozilla/5.0 (compatible; rosclaw-cli/1.0)",
         }
 
     def _request(

--- a/src/rosclaw/skill/models.py
+++ b/src/rosclaw/skill/models.py
@@ -24,7 +24,7 @@ SUPPORTED_DOJO_SCHEMA = "rosclaw.dojo.v1"
 SUPPORTED_DARWIN_EVAL_SCHEMA = "rosclaw.darwin_eval.v1"
 SUPPORTED_LINEAGE_SCHEMA = "rosclaw.lineage.v1"
 
-STAGES = {"draft", "candidate", "validated", "deprecated", "revoked"}
+STAGES = {"draft", "candidate", "validated", "deprecated", "revoked", "source_verified", "ci_passed", "official_verified", "installable"}
 VALID_NAME_PATTERN = r"^[a-z0-9_\-]+$"
 VALID_NAMESPACE_PATTERN = r"^[a-z0-9][a-z0-9_-]{0,63}$"
 


### PR DESCRIPTION
Adds the catalog-specific lifecycle stages used by the official ros-claw/skills repo, and sets a User-Agent header on SkillHubClient so uploads to rosclaw.io are not blocked by Cloudflare.