### PR TITLE
feat(eurdf): ROSClaw e-URDF-Zoo integration and dexterous-hand safety

### DIFF
--- a/docs/body/DEX_HAND_BODY_INIT.md
+++ b/docs/body/DEX_HAND_BODY_INIT.md
@@ -1,0 +1,87 @@
+# Dexterous-Hand Body Initialization
+
+This guide covers initializing and operating dexterous hands and grippers that
+come from the upgraded `e-urdf-zoo` asset library.
+
+## Quick start
+
+```bash
+# Search available hands
+rosclaw eurdf search hand
+
+# Pull an asset into the local cache (optional)
+rosclaw eurdf pull dexhands/inspire_hand/right \
+  --zoo-path /home/ubuntu/rosclaw/rosclaw/e-urdf-zoo/robots
+
+# Initialize a body instance
+rosclaw body init --robot dexhands/inspire_hand/right --name inspire-right-test
+
+# Inspect the generated body manual
+rosclaw body show
+```
+
+## What is different about imported hands
+
+All dex-urdf imported assets are loaded with a conservative safety envelope:
+
+| Policy | Default value |
+|--------|---------------|
+| `status` | `experimental` |
+| `real_robot_execution_allowed` | `false` |
+| `sandbox_required` | `true` |
+| `current_limit_required` | `true` |
+| `calibration_required` | `true` |
+
+The effective body compiler enforces these defaults automatically:
+
+- Manipulation and gesture capabilities are **degraded** to simulation-only
+  until `real_robot_execution_allowed` is explicitly set to `true`.
+- `ok_gesture` and `countdown_gesture` are **degraded** until calibration is
+  `validated`.
+- `fast_full_close` and `forceful_grasp_without_current_limit` are **blocked**
+  by the safety invariant engine.
+
+## Agent queries
+
+You can ask the body natural-language safety questions:
+
+```bash
+rosclaw body query "Can this hand close fast?"
+rosclaw body query "Can this hand do OK gesture on real hardware?"
+rosclaw body query "Can this hand perform countdown gesture 5-4-3-2-1?"
+rosclaw body query "Can I forcefully grasp an object?"
+```
+
+Expected answers for an unvalidated experimental hand:
+
+| Question | Answer |
+|----------|--------|
+| Close fast? | **Blocked** — `fast_full_close` is a critical forbidden capability. |
+| OK gesture on real hardware? | **Blocked** — real-robot execution is not allowed and calibration is not validated. |
+| Countdown gesture? | **Sandbox first** — run in simulation and validate each pose before real hardware. |
+| Forceful grasp? | **Blocked** — active current/torque limits are required. |
+
+## Promoting a hand to real-robot use
+
+Do not change `real_robot_execution_allowed` until the following steps are
+completed and recorded in `maintenance.log`:
+
+1. Complete sandbox-only validation.
+2. Upload clearance calibration to `calibration.yaml`.
+3. Run a low-speed range-of-motion check.
+4. Enable current/torque monitors.
+5. Obtain human-in-the-loop confirmation per pose.
+
+After the steps are recorded, update the body policy and re-render:
+
+```bash
+rosclaw body safety-override --set real_robot_execution_allowed=true  # example
+rosclaw body render
+rosclaw body validate
+```
+
+## End-effector only
+
+Imported dexterous hands are end-effectors. They have no arm, torso, or base.
+The rendered `EMBODIMENT.md` explicitly warns that real-robot execution is
+disabled for the asset.

--- a/docs/body/EURDF_ZOO_INTEGRATION.md
+++ b/docs/body/EURDF_ZOO_INTEGRATION.md
@@ -1,0 +1,72 @@
+# e-URDF-Zoo Integration
+
+ROSClaw can now consume manifest-driven assets from the upgraded
+`e-urdf-zoo` library. This lets you initialize a body directly from a
+structured asset bundle such as `dexhands/inspire_hand/right`.
+
+## What changed
+
+- New `rosclaw.eurdf.zoo_client.EurdfZooClient` loads manifest-driven
+  assets and converts them into the `RobotCompleteProfile` /
+  `EurdfProfile` objects the body module already understands.
+- New `rosclaw eurdf` CLI commands:
+  - `rosclaw eurdf search <query>`
+  - `rosclaw eurdf info <asset_id>`
+  - `rosclaw eurdf validate <asset_id>`
+  - `rosclaw eurdf pull <asset_id>`
+  - `rosclaw eurdf cache list`
+- `rosclaw body init --robot <asset_id>` automatically resolves
+  slash-containing IDs through the zoo client.
+
+## Resolution order
+
+When a zoo asset ID is requested, `EurdfZooClient` resolves it in this
+order:
+
+1. Explicit `--source` path if given.
+2. `~/.rosclaw/cache/e-urdf-zoo/<asset_id>/`
+3. Project-root `e-urdf-zoo` checkout (or pip-installed package data).
+
+## Initialize a body from a zoo asset
+
+```bash
+# Optional: pull the asset into the local cache first
+rosclaw eurdf pull dexhands/inspire_hand/right \
+  --zoo-path /home/ubuntu/rosclaw/rosclaw/e-urdf-zoo/robots
+
+# Initialize the body
+rosclaw body init --robot dexhands/inspire_hand/right \
+  --name inspire-right-test
+```
+
+The resulting lock file records `source: zoo` and the body artifacts are
+rendered as usual.
+
+## Safety contract
+
+All imported dexterous-hand and gripper assets are **experimental**:
+
+- `real_robot_execution_allowed: false`
+- `sandbox_required: true`
+- Forbidden capabilities include `fast_full_close` and
+  `forceful_grasp_without_current_limit`.
+
+Do not promote an asset to `validated` until it passes the full sandbox
+and calibration protocol.
+
+See [DEX_HAND_BODY_INIT.md](DEX_HAND_BODY_INIT.md) for the dexterous-hand
+operating guide and Agent-query examples.
+
+## Adding a new asset
+
+1. Import or author the asset under `e-urdf-zoo/robots/<category>/...`.
+2. Run `e-urdf-zoo validate <asset_id>` until it passes.
+3. Run `rosclaw eurdf info <asset_id>` to verify the conversion.
+4. Run `rosclaw body init --robot <asset_id> --name <instance>` to test
+   the body lifecycle.
+
+## Backward compatibility
+
+Legacy flat `e_urdf.json` assets continue to work through the existing
+`RobotRegistry` path. Only IDs containing `/` (or explicit zoo flags)
+trigger the new manifest-driven flow.

--- a/docs/help/e-urdf-zoo-dex-urdf-implementation-report.md
+++ b/docs/help/e-urdf-zoo-dex-urdf-implementation-report.md
@@ -1,0 +1,118 @@
+# e-URDF-Zoo / dex-urdf Upgrade Implementation Report
+
+## Summary
+
+This report documents the work to upgrade `e-urdf-zoo` from a flat legacy asset
+layout into a structured, manifest-driven asset library and to wire the new
+assets into ROSClaw.
+
+## Repositories and scope
+
+- `/home/ubuntu/rosclaw/rosclaw/e-urdf-zoo` — asset library and importer.
+- `/home/ubuntu/rosclaw/rosclaw/rosclaw-v1.0` — ROSClaw runtime integration.
+- `/home/ubuntu/rosclaw/rosclaw/dex-urdf` — source URDFs for bulk import.
+
+## Delivered phases
+
+### Phase 1 — Asset spec & schemas
+
+Defined Pydantic schemas for:
+
+- `manifest.yaml`
+- `semantic.yaml`
+- `capabilities.yaml`
+- `safety.yaml`
+- `providers.yaml`
+- `sandbox.yaml`
+
+Added schema-level validation tests and documentation.
+
+### Phase 2 — Loader, API, CLI, index
+
+Implemented:
+
+- `AssetLoader` with backward-compatible legacy fallback.
+- `EmbodimentAsset` exposing both new and legacy fields.
+- `AssetIndex` and `AssetValidator`.
+- `e-urdf-zoo` CLI: `list`, `info`, `validate`, `index build`, `import dex-urdf`.
+
+### Phase 3 & 4 — dex-urdf importer and bulk import
+
+Built the `dex_urdf.py` importer and generated assets under:
+
+- `robots/dexhands/...`
+- `robots/grippers/...`
+
+Imported assets include:
+
+- `dexhands/inspire_hand/right`
+- `dexhands/ability_hand/left`
+- `grippers/panda/default`
+
+All imported assets default to `experimental`,
+`real_robot_execution_allowed=false`, `sandbox_required=true`, and include
+mandatory `safety.yaml` plus `forbidden_capabilities`.
+
+### Phase 5 — ROSClaw `rosclaw eurdf` integration
+
+Added to ROSClaw:
+
+- `EurdfZooClient` — resolves, pulls, caches, and converts manifest assets.
+- `rosclaw eurdf {search,info,validate,pull,cache list}` commands.
+- `rosclaw body init --robot <asset_id>` auto-detects slash-containing IDs and
+  resolves them through the zoo client.
+- Local cache layout:
+  `~/.rosclaw/cache/e-urdf-zoo/<asset_id>/`.
+
+Tests:
+
+- `tests/eurdf/test_zoo_client.py`
+- `tests/eurdf/test_eurdf_cli.py`
+- `tests/body/test_body_init_from_zoo.py`
+
+### Phase 6 — Dexterous-hand safety & Agent queries
+
+Hardened ROSClaw body safety for imported hands:
+
+- `EurdfProfile.from_robot_complete_profile` now propagates
+  `forbidden_capabilities`.
+- `BodyInstanceService.create_or_init` records forbidden capabilities in
+  `body.yaml` and sets `agent_policy.direct_real_robot_execution_allowed`.
+- `EffectiveBodyCompiler._derive_capabilities`:
+  - Degrades `ok_gesture` / `countdown_gesture` when calibration is not
+    validated.
+  - Degrades all manipulation capabilities to simulation-only when
+    `real_robot_execution_allowed=false`.
+- `SafetyInvariantEngine` now disables critical forbidden capabilities such as
+  `fast_full_close` and `forceful_grasp_without_current_limit`.
+- `BodyQueryEngine` answers hand-specific safety questions:
+  - "Can this hand close fast?" → blocked.
+  - "Can this hand do OK gesture on real hardware?" → blocked until clearance.
+  - "Can this hand perform countdown gesture 5-4-3-2-1?" → sandbox first.
+  - "Can I forcefully grasp an object?" → blocked without current limit.
+- `EmbodimentRenderer` emits a prominent warning when real-robot execution is
+  disabled.
+
+Tests:
+
+- `tests/body/test_dexhand_agent_safety.py`
+
+## Verification results
+
+```bash
+pytest tests/eurdf tests/body -q
+# 163 passed
+```
+
+## Backward compatibility
+
+Legacy flat `e_urdf.json` assets continue to load through `RobotRegistry`.
+Only asset IDs containing `/` (or explicit zoo flags) trigger the new
+manifest-driven flow.
+
+## Next recommended work
+
+- Add CI job running the full eurdf + body suite.
+- Expand dex-urdf importer coverage for additional hand families.
+- Add ROS2 live smoke tests with sandbox-only validation.
+- Promote the first validated hand asset from `experimental` to `validated`.

--- a/src/rosclaw/body/cli.py
+++ b/src/rosclaw/body/cli.py
@@ -42,10 +42,11 @@ def add_body_subparser(subparsers: argparse._SubParsersAction[argparse.ArgumentP
 
     # init
     init_parser = body_subparsers.add_parser("init", help="Initialize a new body instance from an e-URDF profile")
-    init_parser.add_argument("--robot", required=True, help="Robot profile ID (e.g., unitree-g1)")
+    init_parser.add_argument("--robot", required=True, help="Robot profile ID (e.g., unitree-g1 or dexhands/inspire_hand/right)")
     init_parser.add_argument("--profile", default="default", help="Alias for --robot; ignored if --robot given")
     init_parser.add_argument("--name", default=None, help="Body instance ID")
     init_parser.add_argument("--workspace", default=None, help="ROSClaw workspace")
+    init_parser.add_argument("--zoo-path", default=None, help="e-URDF-Zoo robots directory (for manifest asset IDs)")
     init_parser.add_argument("--force", action="store_true", help="Overwrite existing body link")
     init_parser.add_argument("--no-alias", action="store_true", help="Skip creating BODY.md alias")
     init_parser.add_argument("--render", action="store_true", default=True, help="Render EMBODIMENT.md (default)")
@@ -347,6 +348,7 @@ def cmd_body_init(args: argparse.Namespace) -> int:
             switch_active=True,
             render_agent_view=True,
             force=args.force,
+            zoo_path=Path(args.zoo_path) if args.zoo_path else None,
         )
     except BodyRegistryError as exc:
         print(f"[ROSClaw] {exc}")

--- a/src/rosclaw/body/compiler.py
+++ b/src/rosclaw/body/compiler.py
@@ -37,7 +37,10 @@ class EffectiveBodyCompiler:
         runtime = runtime or {}
 
         body_id = body.body_instance.get("id") or f"body-{eurdf.profile_id}-default"
-        eurdf_uri = body.model_ref.get("eurdf_uri") or f"rosclaw://eurdf/{eurdf.profile_id}@{eurdf.profile_version}"
+        eurdf_uri = (
+            body.model_ref.get("eurdf_uri")
+            or f"rosclaw://eurdf/{eurdf.profile_id}@{eurdf.profile_version}"
+        )
 
         # 1. Start with e-URDF structural model
         joints = _index_by_name(eurdf.joints, "name")
@@ -114,7 +117,9 @@ class EffectiveBodyCompiler:
             known_successes=body.known_successes or [],
             known_failures=body.known_failures or [],
         )
-        effective.runtime_state = copy.deepcopy(runtime) if runtime else copy.deepcopy(body.runtime_state)
+        effective.runtime_state = (
+            copy.deepcopy(runtime) if runtime else copy.deepcopy(body.runtime_state)
+        )
         effective.effective_body_hash = effective.compute_hash()
         return effective
 
@@ -185,10 +190,25 @@ class EffectiveBodyCompiler:
                         blocked.add("visual_navigation")
                         enabled.discard("visual_navigation")
 
-        # Calibration status can degrade precision skills
+        # Calibration status can degrade precision skills and dexterous gestures
         cal_status = body.calibration.get("status", "uncalibrated")
         if cal_status != "validated":
             degraded.add("precision_grasp")
+            for cap in list(enabled):
+                if "gesture" in cap.lower():
+                    degraded.add(cap)
+                    enabled.discard(cap)
+
+        # Experimental / real-robot-blocked assets keep manipulation capabilities
+        # as simulation-only until the safety policy explicitly allows real execution.
+        real_allowed = eurdf.safety.get("environment", {}).get("real_robot_execution_allowed", True)
+        if not real_allowed:
+            for cap in list(enabled):
+                # Leave read-only / introspection capabilities enabled; degrade motion capabilities.
+                if cap.lower() in {"get_state", "read_state", "list_joints", "report_faults"}:
+                    continue
+                degraded.add(cap)
+                enabled.discard(cap)
 
         base = {
             "enabled": sorted(enabled - blocked),
@@ -241,11 +261,16 @@ class EffectiveBodyCompiler:
                     faults[fid] = dict(fault, id=fid)
 
         for event in maintenance_events or []:
-            if event.type in ("incident", "fault", "safety") and event.severity in ("warning", "critical", "high"):
+            if event.type in ("incident", "fault", "safety") and event.severity in (
+                "warning",
+                "critical",
+                "high",
+            ):
                 fault_id = event.result.get("fault_id") or event.event_id or f"fault-{_utc_now()}"
                 faults[fault_id] = {
                     "id": fault_id,
-                    "component": event.component or (event.affects[0] if event.affects else "unknown"),
+                    "component": event.component
+                    or (event.affects[0] if event.affects else "unknown"),
                     "severity": event.severity,
                     "status": "open" if event.type in ("incident", "fault") else "resolved",
                     "summary": event.summary or event.message,
@@ -256,7 +281,9 @@ class EffectiveBodyCompiler:
                 if fault_id in faults:
                     faults[fault_id]["status"] = "resolved"
                     if event.summary:
-                        faults[fault_id]["summary"] = f"{faults[fault_id].get('summary', '')} → resolved: {event.summary}"
+                        faults[fault_id]["summary"] = (
+                            f"{faults[fault_id].get('summary', '')} → resolved: {event.summary}"
+                        )
 
         return list(faults.values())
 

--- a/src/rosclaw/body/query.py
+++ b/src/rosclaw/body/query.py
@@ -48,7 +48,10 @@ class BodyQueryEngine:
         identity = self.body_yaml.get_identity()
 
         # Identity / what robot
-        if any(kw in q for kw in ("what robot", "which robot", "what body", "who is this", "what is this")):
+        if any(
+            kw in q
+            for kw in ("what robot", "which robot", "what body", "who is this", "what is this")
+        ):
             return BodyQueryResult(
                 question=question,
                 answer=(
@@ -64,7 +67,10 @@ class BodyQueryEngine:
             )
 
         # Sandbox bypass
-        if any(kw in q for kw in ("bypass sandbox", "skip sandbox", "run without sandbox", "disable sandbox")):
+        if any(
+            kw in q
+            for kw in ("bypass sandbox", "skip sandbox", "run without sandbox", "disable sandbox")
+        ):
             return BodyQueryResult(
                 question=question,
                 answer="No. Sandbox validation is mandatory for physical execution on this body.",
@@ -76,6 +82,110 @@ class BodyQueryEngine:
                     "Refused: sandbox bypass is not allowed.",
                     "To execute physically, provide validation evidence via 'capability enable <id> --after-validation <run_id>'.",
                 ],
+            )
+
+        # Dexterous-hand / gripper safety queries
+        forbidden_ids = self._forbidden_ids()
+        real_hardware_asked = any(kw in q for kw in ("real hardware", "real robot", "on hardware"))
+
+        # Fast full close
+        if any(
+            kw in q for kw in ("close fast", "fast full close", "full close fast", "snap close")
+        ):
+            if (
+                "fast_full_close" in forbidden_ids
+                or "fast_full_close" in self.effective.capabilities.get("blocked", [])
+            ):
+                return BodyQueryResult(
+                    question=question,
+                    answer="No. Fast full close is forbidden because it risks collision and motor overload.",
+                    evidence={
+                        "forbidden": "fast_full_close",
+                        "reason": "Risk of collision and motor overload",
+                    },
+                    actionable_policy=[
+                        "Use only slow, validated close motions with current limits active."
+                    ],
+                )
+            return BodyQueryResult(
+                question=question,
+                answer="Fast full close is not declared as a safe capability for this body.",
+                evidence={"capabilities": self.effective.capabilities},
+                actionable_policy=["Validate any fast motion in sandbox before real hardware."],
+            )
+
+        # Forceful grasp without current limit
+        if any(
+            kw in q
+            for kw in (
+                "forceful grasp",
+                "forceful_grasp",
+                "forcefully grasp",
+                "grasp forcefully",
+                "grasp without current limit",
+                "grasp without torque limit",
+            )
+        ):
+            if (
+                "forceful_grasp_without_current_limit" in forbidden_ids
+                or "forceful_grasp_without_current_limit"
+                in self.effective.capabilities.get("blocked", [])
+            ):
+                return BodyQueryResult(
+                    question=question,
+                    answer="No. Forceful grasping without active current/torque limits is forbidden.",
+                    evidence={"forbidden": "forceful_grasp_without_current_limit"},
+                    actionable_policy=[
+                        "Enable current/torque monitoring and use a validated grasp policy."
+                    ],
+                )
+            return BodyQueryResult(
+                question=question,
+                answer="Forceful grasping is not allowed without active current/torque limits.",
+                evidence={"capabilities": self.effective.capabilities},
+                actionable_policy=["Confirm current/torque limits are configured before grasping."],
+            )
+
+        # OK gesture
+        if any(kw in q for kw in ("ok gesture", "ok sign", "ok pose")):
+            if real_hardware_asked:
+                return self._answer_gesture_real_hardware("OK gesture")
+            status, reasons = self._capability_id_status("ok_gesture")
+            if status == "unknown":
+                return BodyQueryResult(
+                    question=question,
+                    answer="OK gesture is not a declared capability for this body.",
+                    evidence={"capabilities": self.effective.capabilities},
+                    actionable_policy=[
+                        "Declare the capability in the body profile if the hardware supports it."
+                    ],
+                )
+            return BodyQueryResult(
+                question=question,
+                answer=f"OK gesture is {status}; run it in sandbox first and validate per-pose before real hardware.",
+                evidence={"capability_status": status, "reasons": reasons},
+                actionable_policy=["Use sandbox validation and per-pose human confirmation."],
+            )
+
+        # Countdown gesture
+        if any(kw in q for kw in ("countdown gesture", "count down", "countdown")):
+            if real_hardware_asked:
+                return self._answer_gesture_real_hardware("Countdown gesture")
+            status, reasons = self._capability_id_status("countdown_gesture")
+            if status == "unknown":
+                return BodyQueryResult(
+                    question=question,
+                    answer="Countdown gesture is not a declared capability for this body.",
+                    evidence={"capabilities": self.effective.capabilities},
+                    actionable_policy=[
+                        "Declare the capability in the body profile if the hardware supports it."
+                    ],
+                )
+            return BodyQueryResult(
+                question=question,
+                answer=f"Countdown gesture is {status}; run it in sandbox first and validate each pose before real hardware.",
+                evidence={"capability_status": status, "reasons": reasons},
+                actionable_policy=["Use sandbox validation and per-pose human confirmation."],
             )
 
         # Can it walk / locomotion
@@ -93,7 +203,9 @@ class BodyQueryEngine:
                     question=question,
                     answer="Walking is degraded; it may only be allowed under reduced limits or in simulation.",
                     evidence={"capabilities": caps, "open_faults": self._open_fault_ids()},
-                    actionable_policy=["Resolve open faults and re-validate before full operation."],
+                    actionable_policy=[
+                        "Resolve open faults and re-validate before full operation."
+                    ],
                 )
             return BodyQueryResult(
                 question=question,
@@ -143,7 +255,9 @@ class BodyQueryEngine:
                 question=question,
                 answer=f"Calibration status is '{status}'; precision capabilities may be degraded.",
                 evidence={"calibration_status": status},
-                actionable_policy=["Run 'rosclaw body calibration update --file <path>' to update calibration."],
+                actionable_policy=[
+                    "Run 'rosclaw body calibration update --file <path>' to update calibration."
+                ],
             )
 
         # Faults
@@ -154,7 +268,9 @@ class BodyQueryEngine:
                     question=question,
                     answer=f"There are {len(open_faults)} open fault(s): {', '.join(open_faults)}.",
                     evidence={"open_faults": open_faults},
-                    actionable_policy=["Resolve faults via 'rosclaw body fault resolve <fault_id>'."],
+                    actionable_policy=[
+                        "Resolve faults via 'rosclaw body fault resolve <fault_id>'."
+                    ],
                 )
             return BodyQueryResult(
                 question=question,
@@ -171,7 +287,9 @@ class BodyQueryEngine:
                 question=question,
                 answer=f"Enabled capabilities: {', '.join(enabled) if enabled else 'none'}.",
                 evidence={"capabilities": caps, "forbidden": self.effective.forbidden_capabilities},
-                actionable_policy=["Use 'rosclaw body state --json' for the full capability matrix."],
+                actionable_policy=[
+                    "Use 'rosclaw body state --json' for the full capability matrix."
+                ],
             )
 
         # Safety
@@ -193,6 +311,92 @@ class BodyQueryEngine:
             answer="I don't have a specific answer for that question. Try asking about identity, capabilities, calibration, faults, safety, or sandbox policy.",
             evidence={"capabilities": self.effective.capabilities},
             actionable_policy=["Run 'rosclaw body state --json' for structured body state."],
+        )
+
+    def _forbidden_ids(self) -> set[str]:
+        ids: set[str] = set()
+        for item in (
+            self.effective.forbidden_capabilities or self.body_yaml.forbidden_capabilities or []
+        ):
+            cap_id = item.get("id") or item.get("capability")
+            if cap_id:
+                ids.add(cap_id)
+        return ids
+
+    def _real_robot_allowed(self) -> bool:
+        return bool(
+            self.body_yaml.agent_policy.get("direct_real_robot_execution_allowed", True)
+            and self.effective.safety.get("environment", {}).get(
+                "real_robot_execution_allowed", True
+            )
+        )
+
+    def _calibration_valid(self) -> bool:
+        return self.calibration.overall_status() in ("valid", "validated")
+
+    def _resolve_capability(self, cap_id: str) -> str | None:
+        """Find a declared capability matching ``cap_id`` by id or display name."""
+        caps = self.effective.capabilities
+        target = cap_id.lower().replace("_", " ")
+        for bucket in (caps.get("blocked", []), caps.get("degraded", []), caps.get("enabled", [])):
+            for cap in bucket:
+                normalized = cap.lower().replace("_", " ")
+                if normalized == target or cap_id.lower() in cap.lower():
+                    return cap
+        return None
+
+    def _capability_id_status(self, cap_id: str) -> tuple[str, list[str]]:
+        caps = self.effective.capabilities
+        reasons: list[str] = []
+        resolved = self._resolve_capability(cap_id)
+        if resolved is None:
+            return "unknown", reasons
+        if resolved in caps.get("blocked", []):
+            return "blocked", reasons
+        if resolved in caps.get("degraded", []):
+            if not self._real_robot_allowed():
+                reasons.append("real robot execution is not allowed for this asset")
+            if not self._calibration_valid():
+                reasons.append("calibration is not validated")
+            return "degraded", reasons
+        return "enabled", reasons
+
+    def _answer_gesture_real_hardware(self, gesture_name: str) -> BodyQueryResult:
+        if not self._real_robot_allowed():
+            return BodyQueryResult(
+                question=f"Can this body perform {gesture_name} on real hardware?",
+                answer=f"No. {gesture_name} is blocked on real hardware because real robot execution is not allowed for this asset.",
+                evidence={
+                    "gesture": gesture_name,
+                    "real_robot_execution_allowed": False,
+                    "calibration_status": self.calibration.overall_status(),
+                },
+                actionable_policy=[
+                    "Complete sandbox validation and clear the real-robot execution gate before real hardware motion.",
+                ],
+            )
+        if not self._calibration_valid():
+            return BodyQueryResult(
+                question=f"Can this body perform {gesture_name} on real hardware?",
+                answer=f"No. {gesture_name} is blocked on real hardware until calibration is validated.",
+                evidence={
+                    "gesture": gesture_name,
+                    "calibration_status": self.calibration.overall_status(),
+                },
+                actionable_policy=[
+                    "Upload validated clearance calibration and run a low-speed range-of-motion check.",
+                ],
+            )
+        return BodyQueryResult(
+            question=f"Can this body perform {gesture_name} on real hardware?",
+            answer=f"Yes, {gesture_name} is allowed on real hardware once per-pose human confirmation is obtained.",
+            evidence={
+                "gesture": gesture_name,
+                "calibration_status": self.calibration.overall_status(),
+            },
+            actionable_policy=[
+                "Confirm current/torque limits are active before executing the gesture."
+            ],
         )
 
     def _open_fault_ids(self) -> list[str]:

--- a/src/rosclaw/body/renderer.py
+++ b/src/rosclaw/body/renderer.py
@@ -63,12 +63,7 @@ class EmbodimentRenderer:
         if preserve_human_notes:
             human_notes = f"\n{self.HUMAN_NOTES_START}\n\n{self.HUMAN_NOTES_END}\n"
 
-        return (
-            f"{self.GENERATED_START}\n"
-            f"{generated}\n"
-            f"{self.GENERATED_END}\n"
-            f"{human_notes}"
-        )
+        return f"{self.GENERATED_START}\n{generated}\n{self.GENERATED_END}\n{human_notes}"
 
     def render_into_existing(
         self,
@@ -82,7 +77,12 @@ class EmbodimentRenderer:
         """Re-render generated region while preserving human notes."""
         human_notes = self._extract_human_notes(existing_md)
         new_generated = self.render(
-            body, body_yaml, compatibility, maintenance_events, calibration, preserve_human_notes=False
+            body,
+            body_yaml,
+            compatibility,
+            maintenance_events,
+            calibration,
+            preserve_human_notes=False,
         )
         if human_notes:
             return f"{new_generated}\n{self.HUMAN_NOTES_START}\n{human_notes}\n{self.HUMAN_NOTES_END}\n"
@@ -94,7 +94,7 @@ class EmbodimentRenderer:
         end = existing_md.find(self.HUMAN_NOTES_END)
         if start == -1 or end == -1 or end <= start:
             return ""
-        return existing_md[start + len(self.HUMAN_NOTES_START):end].strip()
+        return existing_md[start + len(self.HUMAN_NOTES_START) : end].strip()
 
     # ── Sections ──
 
@@ -110,18 +110,18 @@ class EmbodimentRenderer:
             "---",
             "schema: rosclaw.embodiment.v1",
             "generated_by: rosclaw body init",
-            f"generated_at: \"{body.compiled_at}\"",
-            f"robot_instance_id: \"{body.body_instance_id}\"",
-            f"robot_model: \"{identity.get('robot_model') or body_yaml.body_instance.get('robot_model', 'unknown')}\"",
-            f"robot_vendor: \"{identity.get('robot_vendor') or 'unknown'}\"",
-            f"eurdf_profile: \"{body_yaml.model_ref.get('profile_id', 'unknown')}\"",
-            f"eurdf_profile_path: \"{eurdf_profile_path}\"",
-            f"eurdf_checksum: \"{eurdf_checksum}\"",
-            f"body_yaml: \"{body_yaml_path}\"",
-            f"calibration_yaml: \"{calibration_yaml_path}\"",
-            f"maintenance_log: \"{maintenance_log_path}\"",
+            f'generated_at: "{body.compiled_at}"',
+            f'robot_instance_id: "{body.body_instance_id}"',
+            f'robot_model: "{identity.get("robot_model") or body_yaml.body_instance.get("robot_model", "unknown")}"',
+            f'robot_vendor: "{identity.get("robot_vendor") or "unknown"}"',
+            f'eurdf_profile: "{body_yaml.model_ref.get("profile_id", "unknown")}"',
+            f'eurdf_profile_path: "{eurdf_profile_path}"',
+            f'eurdf_checksum: "{eurdf_checksum}"',
+            f'body_yaml: "{body_yaml_path}"',
+            f'calibration_yaml: "{calibration_yaml_path}"',
+            f'maintenance_log: "{maintenance_log_path}"',
             f"body_state_generation: {body.generation}",
-            f"safety_status: \"{safety_status}\"",
+            f'safety_status: "{safety_status}"',
             "agent_readability: true",
             "do_not_edit_generated_sections: true",
             "---",
@@ -170,6 +170,17 @@ class EmbodimentRenderer:
             "6. Run sandbox / firewall validation before execution.",
             "",
         ]
+
+        real_allowed = body.safety.get("environment", {}).get("real_robot_execution_allowed", True)
+        if not real_allowed:
+            lines.extend(
+                [
+                    "> **⚠️ Real-robot execution is disabled for this asset.**",
+                    "> All manipulation and motion capabilities are simulation/sandbox-only until the safety policy is explicitly updated and clearance calibration is validated.",
+                    "",
+                ]
+            )
+
         return "\n".join(lines)
 
     def _render_eurdf_profile_reference(self, body: EffectiveBody, body_yaml: BodyYaml) -> str:
@@ -216,13 +227,17 @@ class EmbodimentRenderer:
         lines.append("")
 
         # Joint groups
-        lines.extend([
-            "### 4.2 Joint Groups",
-            "",
-            "| Group | Joints | Status | Notes |",
-            "|---|---|---|---|",
-        ])
-        groups = body_yaml.body_structure.get("joint_groups", []) if body_yaml.body_structure else []
+        lines.extend(
+            [
+                "### 4.2 Joint Groups",
+                "",
+                "| Group | Joints | Status | Notes |",
+                "|---|---|---|---|",
+            ]
+        )
+        groups = (
+            body_yaml.body_structure.get("joint_groups", []) if body_yaml.body_structure else []
+        )
         if not groups:
             groups = self._infer_joint_groups(body)
         for group in groups:
@@ -269,24 +284,28 @@ class EmbodimentRenderer:
             calibrated = "valid" if sensor.get("extrinsics") else "missing"
             mounted_on = sensor.get("mounted_on", "unknown")
             notes = sensor.get("notes", "")
-            lines.append(f"| {name} | {sensor_type} | {mounted_on} | {frame} | {status} | {calibrated} | {notes} |")
+            lines.append(
+                f"| {name} | {sensor_type} | {mounted_on} | {frame} | {status} | {calibrated} | {notes} |"
+            )
         if not body.sensors:
             lines.append("| _none_ | | | | | | |")
         lines.append("")
 
         # Sensor readiness
         readiness = self._sensor_readiness(body)
-        lines.extend([
-            "### Sensor Readiness",
-            "",
-            f"- Vision: `{readiness.get('vision', 'unknown')}`",
-            f"- Depth: `{readiness.get('depth', 'unknown')}`",
-            f"- IMU: `{readiness.get('imu', 'unknown')}`",
-            f"- Force / Torque: `{readiness.get('force_torque', 'unknown')}`",
-            f"- Audio: `{readiness.get('audio', 'unknown')}`",
-            f"- Proprioception: `{readiness.get('proprioception', 'unknown')}`",
-            "",
-        ])
+        lines.extend(
+            [
+                "### Sensor Readiness",
+                "",
+                f"- Vision: `{readiness.get('vision', 'unknown')}`",
+                f"- Depth: `{readiness.get('depth', 'unknown')}`",
+                f"- IMU: `{readiness.get('imu', 'unknown')}`",
+                f"- Force / Torque: `{readiness.get('force_torque', 'unknown')}`",
+                f"- Audio: `{readiness.get('audio', 'unknown')}`",
+                f"- Proprioception: `{readiness.get('proprioception', 'unknown')}`",
+                "",
+            ]
+        )
         return "\n".join(lines)
 
     def _render_actuators_and_tools(self, body: EffectiveBody) -> str:
@@ -342,52 +361,58 @@ class EmbodimentRenderer:
         lines.append("")
 
         # Detailed YAML blocks
-        lines.extend([
-            "### 8.1 Enabled Capabilities",
-            "",
-            "```yaml",
-            "enabled:",
-        ])
+        lines.extend(
+            [
+                "### 8.1 Enabled Capabilities",
+                "",
+                "```yaml",
+                "enabled:",
+            ]
+        )
         for cap in sorted(enabled):
-            lines.append(f"  - id: \"{cap}\"")
-            lines.append(f"    name: \"{cap}\"")
-            lines.append("    scope: \"unknown\"")
+            lines.append(f'  - id: "{cap}"')
+            lines.append(f'    name: "{cap}"')
+            lines.append('    scope: "unknown"')
             lines.append("    preconditions: []")
             lines.append("    validation:")
             lines.append("      sandbox_required: true")
             lines.append("      human_approval_required: false")
-            lines.append("      max_risk: \"medium\"")
+            lines.append('      max_risk: "medium"')
         if not enabled:
             lines.append("  []")
         lines.append("```")
         lines.append("")
 
-        lines.extend([
-            "### 8.2 Degraded Capabilities",
-            "",
-            "```yaml",
-            "degraded:",
-        ])
+        lines.extend(
+            [
+                "### 8.2 Degraded Capabilities",
+                "",
+                "```yaml",
+                "degraded:",
+            ]
+        )
         for cap in sorted(degraded):
-            lines.append(f"  - id: \"{cap}\"")
-            lines.append("    reason: \"calibration/maintenance/runtime\"")
-            lines.append("    allowed_mode: \"slow\"")
+            lines.append(f'  - id: "{cap}"')
+            lines.append('    reason: "calibration/maintenance/runtime"')
+            lines.append('    allowed_mode: "slow"')
             lines.append("    blocked_subactions: []")
         if not degraded:
             lines.append("  []")
         lines.append("```")
         lines.append("")
 
-        lines.extend([
-            "### 8.3 Disabled Capabilities",
-            "",
-            "```yaml",
-            "disabled:",
-        ])
+        lines.extend(
+            [
+                "### 8.3 Disabled Capabilities",
+                "",
+                "```yaml",
+                "disabled:",
+            ]
+        )
         for cap in sorted(blocked):
-            lines.append(f"  - id: \"{cap}\"")
-            lines.append("    reason: \"prohibited or unavailable\"")
-            lines.append("    since: \"\"")
+            lines.append(f'  - id: "{cap}"')
+            lines.append('    reason: "prohibited or unavailable"')
+            lines.append('    since: ""')
             lines.append("    reenable_requires: []")
         if not blocked:
             lines.append("  []")
@@ -406,16 +431,18 @@ class EmbodimentRenderer:
             "degraded:",
         ]
         for cap in sorted(degraded):
-            lines.append(f"  - id: \"{cap}\"")
-            lines.append("    reason: \"calibration / maintenance / runtime\"")
-            lines.append("    allowed_mode: \"slow / constrained\"")
+            lines.append(f'  - id: "{cap}"')
+            lines.append('    reason: "calibration / maintenance / runtime"')
+            lines.append('    allowed_mode: "slow / constrained"')
             lines.append("    requires_human_approval: true")
         if not degraded:
             lines.append("  []")
-        lines.extend([
-            "```",
-            "",
-        ])
+        lines.extend(
+            [
+                "```",
+                "",
+            ]
+        )
         return "\n".join(lines)
 
     def _render_forbidden_capabilities(self, body: EffectiveBody, body_yaml: BodyYaml) -> str:
@@ -429,10 +456,10 @@ class EmbodimentRenderer:
         ]
         forbidden = body.forbidden_capabilities or body_yaml.forbidden_capabilities or []
         for item in forbidden:
-            lines.append(f"  - id: \"{item.get('id', item.get('capability', 'unknown'))}\"")
-            lines.append(f"    description: \"{item.get('description', item.get('reason', ''))}\"")
-            lines.append(f"    reason: \"{item.get('reason', 'safety')}\"")
-            lines.append(f"    severity: \"{item.get('severity', 'critical')}\"")
+            lines.append(f'  - id: "{item.get("id", item.get("capability", "unknown"))}"')
+            lines.append(f'    description: "{item.get("description", item.get("reason", ""))}"')
+            lines.append(f'    reason: "{item.get("reason", "safety")}"')
+            lines.append(f'    severity: "{item.get("severity", "critical")}"')
             enforcement = item.get("enforcement", {})
             lines.append("    enforcement:")
             lines.append(f"      policy_block: {enforcement.get('policy_block', True)}")
@@ -440,21 +467,23 @@ class EmbodimentRenderer:
             lines.append(f"      real_robot_block: {enforcement.get('real_robot_block', True)}")
         if not forbidden:
             lines.append("  []")
-        lines.extend([
-            "```",
-            "",
-            "Examples of forbidden capability classes:",
-            "",
-            "- Running or jumping without validated locomotion policy.",
-            "- High-speed motion near humans.",
-            "- Forceful manipulation without force feedback.",
-            "- Stair climbing without validated stair profile.",
-            "- Lifting objects above rated payload.",
-            "- Using disabled limbs or known faulty joints.",
-            "- Executing uncalibrated camera-guided grasping.",
-            "- Bypassing sandbox / firewall validation.",
-            "",
-        ])
+        lines.extend(
+            [
+                "```",
+                "",
+                "Examples of forbidden capability classes:",
+                "",
+                "- Running or jumping without validated locomotion policy.",
+                "- High-speed motion near humans.",
+                "- Forceful manipulation without force feedback.",
+                "- Stair climbing without validated stair profile.",
+                "- Lifting objects above rated payload.",
+                "- Using disabled limbs or known faulty joints.",
+                "- Executing uncalibrated camera-guided grasping.",
+                "- Bypassing sandbox / firewall validation.",
+                "",
+            ]
+        )
         return "\n".join(lines)
 
     def _render_safety(self, body: EffectiveBody) -> str:
@@ -487,14 +516,16 @@ class EmbodimentRenderer:
             elif isinstance(value, bool):
                 value = str(value).lower()
             lines.append(f"  {key}: {value}")
-        lines.extend([
-            "```",
-            "",
-            "### 11.2 Workspace Limits",
-            "",
-            "| Workspace | Frame | Bounds | Allowed | Notes |",
-            "|---|---|---|---|---|",
-        ])
+        lines.extend(
+            [
+                "```",
+                "",
+                "### 11.2 Workspace Limits",
+                "",
+                "| Workspace | Frame | Bounds | Allowed | Notes |",
+                "|---|---|---|---|---|",
+            ]
+        )
         workspaces = safety.get("workspace_limits", []) or []
         for ws in workspaces:
             lines.append(
@@ -505,12 +536,14 @@ class EmbodimentRenderer:
             lines.append("| _No workspace limits defined._ | | | | |")
         lines.append("")
 
-        lines.extend([
-            "### 11.3 Contact / Force Limits",
-            "",
-            "| Body Part | Max Force | Max Torque | Contact Allowed | Notes |",
-            "|---|--:|--:|---|---|",
-        ])
+        lines.extend(
+            [
+                "### 11.3 Contact / Force Limits",
+                "",
+                "| Body Part | Max Force | Max Torque | Contact Allowed | Notes |",
+                "|---|--:|--:|---|---|",
+            ]
+        )
         contacts = safety.get("contact_limits", []) or []
         for contact in contacts:
             lines.append(
@@ -522,22 +555,24 @@ class EmbodimentRenderer:
             lines.append("| _No contact limits defined._ | | | | |")
         lines.append("")
 
-        lines.extend([
-            "### 11.4 Safety Gates",
-            "",
-            "Before physical execution, the Agent must pass:",
-            "",
-            "1. Body capability check.",
-            "2. Forbidden capability check.",
-            "3. Fault check.",
-            "4. Calibration validity check.",
-            "5. Runtime state check.",
-            "6. Sandbox validation.",
-            "7. Firewall / risk policy validation.",
-            "8. Human approval when required.",
-            "9. Practice Timeline logging.",
-            "",
-        ])
+        lines.extend(
+            [
+                "### 11.4 Safety Gates",
+                "",
+                "Before physical execution, the Agent must pass:",
+                "",
+                "1. Body capability check.",
+                "2. Forbidden capability check.",
+                "3. Fault check.",
+                "4. Calibration validity check.",
+                "5. Runtime state check.",
+                "6. Sandbox validation.",
+                "7. Firewall / risk policy validation.",
+                "8. Human approval when required.",
+                "9. Practice Timeline logging.",
+                "",
+            ]
+        )
         return "\n".join(lines)
 
     def _render_known_faults(self, body: EffectiveBody) -> str:
@@ -563,23 +598,27 @@ class EmbodimentRenderer:
             lines.append("| _No known faults._ | | | | | | | |")
         lines.append("")
 
-        lines.extend([
-            "### Fault-derived Capability Changes",
-            "",
-            "```yaml",
-            "fault_capability_overrides:",
-        ])
+        lines.extend(
+            [
+                "### Fault-derived Capability Changes",
+                "",
+                "```yaml",
+                "fault_capability_overrides:",
+            ]
+        )
         if open_faults:
             for fault in open_faults:
-                lines.append(f"  - fault_id: \"{fault.get('id', 'unknown')}\"")
+                lines.append(f'  - fault_id: "{fault.get("id", "unknown")}"')
                 lines.append(f"    disables: {fault.get('disables', []) or []}")
                 lines.append(f"    degrades: {fault.get('degrades', []) or []}")
         else:
             lines.append("  []")
-        lines.extend([
-            "```",
-            "",
-        ])
+        lines.extend(
+            [
+                "```",
+                "",
+            ]
+        )
         return "\n".join(lines)
 
     def _render_skill_compatibility(self, compatibility: SkillCompatibilityReport) -> str:
@@ -605,13 +644,15 @@ class EmbodimentRenderer:
             lines.append(f"  {skill_id}:")
             lines.append(f"    status: {result.status}")
             if result.reason:
-                lines.append(f"    reason: \"{result.reason}\"")
+                lines.append(f'    reason: "{result.reason}"')
         if not skills:
             lines.append("  {}")
-        lines.extend([
-            "```",
-            "",
-        ])
+        lines.extend(
+            [
+                "```",
+                "",
+            ]
+        )
         return "\n".join(lines)
 
     def _render_known_successes(self, body: EffectiveBody) -> str:
@@ -633,18 +674,20 @@ class EmbodimentRenderer:
             lines.append("| _No recorded successes._ | | | | | |")
         lines.append("")
 
-        lines.extend([
-            "### Recommended Reuse Policy",
-            "",
-            "```yaml",
-            "experience_reuse:",
-            "  same_body: \"can_reuse_after_state_check\"",
-            "  same_model: \"verify_in_sandbox_first\"",
-            "  different_model_same_profile_family: \"require_transfer_validation\"",
-            "  different_morphology: \"do_not_reuse_directly\"",
-            "```",
-            "",
-        ])
+        lines.extend(
+            [
+                "### Recommended Reuse Policy",
+                "",
+                "```yaml",
+                "experience_reuse:",
+                '  same_body: "can_reuse_after_state_check"',
+                '  same_model: "verify_in_sandbox_first"',
+                '  different_model_same_profile_family: "require_transfer_validation"',
+                '  different_morphology: "do_not_reuse_directly"',
+                "```",
+                "",
+            ]
+        )
         return "\n".join(lines)
 
     def _render_known_failures(self, body: EffectiveBody) -> str:
@@ -675,7 +718,10 @@ class EmbodimentRenderer:
             "|---|---|---|---|---|",
         ]
         items = [
-            ("Joint zero offsets", cal.joints if cal.joints else body_yaml.calibration.get("joint_offsets", {})),
+            (
+                "Joint zero offsets",
+                cal.joints if cal.joints else body_yaml.calibration.get("joint_offsets", {}),
+            ),
             ("Camera intrinsics", cal.sensors if cal.sensors else {}),
             ("Camera extrinsics", cal.sensor_extrinsics if cal.sensor_extrinsics else {}),
             ("IMU bias", cal.sensors if cal.sensors else {}),
@@ -690,20 +736,24 @@ class EmbodimentRenderer:
         warnings = []
         if overall not in ("valid", "validated"):
             warnings.append(f"Calibration overall status is '{overall}'.")
-        lines.extend([
-            "### Calibration Warnings",
-            "",
-            "```yaml",
-            "warnings:",
-        ])
+        lines.extend(
+            [
+                "### Calibration Warnings",
+                "",
+                "```yaml",
+                "warnings:",
+            ]
+        )
         for warning in warnings:
-            lines.append(f"  - \"{warning}\"")
+            lines.append(f'  - "{warning}"')
         if not warnings:
             lines.append("  []")
-        lines.extend([
-            "```",
-            "",
-        ])
+        lines.extend(
+            [
+                "```",
+                "",
+            ]
+        )
         return "\n".join(lines)
 
     def _render_maintenance_history(self, maintenance_events: list[MaintenanceEvent]) -> str:
@@ -763,17 +813,21 @@ class EmbodimentRenderer:
             "",
         ]
         if policy:
-            lines.extend([
-                "### 18.4 Instance Policy",
-                "",
-                "```yaml",
-            ])
+            lines.extend(
+                [
+                    "### 18.4 Instance Policy",
+                    "",
+                    "```yaml",
+                ]
+            )
             for key, value in sorted(policy.items()):
                 lines.append(f"  {key}: {value}")
-            lines.extend([
-                "```",
-                "",
-            ])
+            lines.extend(
+                [
+                    "```",
+                    "",
+                ]
+            )
         return "\n".join(lines)
 
     def _render_machine_readable_summary(
@@ -785,16 +839,21 @@ class EmbodimentRenderer:
         cal = calibration or CalibrationYaml()
         identity = body_yaml.get_identity()
         caps = body.capabilities
-        forbidden = [item.get("id", item.get("capability", "unknown")) for item in (body.forbidden_capabilities or body_yaml.forbidden_capabilities or [])]
-        open_faults = [f.get("id", "unknown") for f in (body.known_faults or []) if f.get("status") == "open"]
+        forbidden = [
+            item.get("id", item.get("capability", "unknown"))
+            for item in (body.forbidden_capabilities or body_yaml.forbidden_capabilities or [])
+        ]
+        open_faults = [
+            f.get("id", "unknown") for f in (body.known_faults or []) if f.get("status") == "open"
+        ]
         lines = [
             "## 19. Machine-readable Summary",
             "",
             "```yaml",
-            f"robot_instance_id: \"{body.body_instance_id}\"",
-            f"robot_model: \"{identity.get('robot_model') or body_yaml.body_instance.get('robot_model', 'unknown')}\"",
-            f"eurdf_profile: \"{body_yaml.model_ref.get('profile_id', 'unknown')}\"",
-            f"safety_status: \"{body_yaml.get_safety_status()}\"",
+            f'robot_instance_id: "{body.body_instance_id}"',
+            f'robot_model: "{identity.get("robot_model") or body_yaml.body_instance.get("robot_model", "unknown")}"',
+            f'eurdf_profile: "{body_yaml.model_ref.get("profile_id", "unknown")}"',
+            f'safety_status: "{body_yaml.get_safety_status()}"',
             "capabilities:",
             f"  enabled: {caps.get('enabled', [])}",
             f"  degraded: {caps.get('degraded', [])}",
@@ -802,7 +861,7 @@ class EmbodimentRenderer:
             f"forbidden: {forbidden}",
             f"known_faults_open: {open_faults}",
             "calibration:",
-            f"  overall_status: \"{cal.overall_status()}\"",
+            f'  overall_status: "{cal.overall_status()}"',
             "agent_action_policy:",
             "  physical_execution_requires_sandbox: true",
             "  direct_real_robot_execution_allowed: false",
@@ -865,7 +924,16 @@ class EmbodimentRenderer:
                 key = "torso"
             else:
                 key = "base"
-            parts.setdefault(key, {"id": key, "name": key.replace("_", " ").title(), "type": key, "links": [], "joints": []})
+            parts.setdefault(
+                key,
+                {
+                    "id": key,
+                    "name": key.replace("_", " ").title(),
+                    "type": key,
+                    "links": [],
+                    "joints": [],
+                },
+            )
             parts[key]["joints"].append(joint_name)
         return list(parts.values())
 

--- a/src/rosclaw/body/safety.py
+++ b/src/rosclaw/body/safety.py
@@ -46,21 +46,30 @@ class SafetyInvariantEngine:
                     "sandbox_required; degraded until validation policy is added."
                 )
 
-        # Invariant 2: critical forbidden capabilities must block real-robot execution.
+        # Invariant 2: critical forbidden capabilities must block real-robot execution
+        # and be removed from the enabled set.
         for forbidden in body.forbidden_capabilities or []:
             sev = forbidden.get("severity", "critical")
+            cap_id = forbidden.get("id") or forbidden.get("capability")
+            if not cap_id:
+                continue
+            enforcement = forbidden.get("enforcement", {})
             if sev == "critical":
-                enforcement = forbidden.get("enforcement", {})
                 if not enforcement.get("real_robot_block", False):
-                    cap_id = forbidden.get("id") or forbidden.get("capability")
                     warnings.append(
                         f"Invariant: forbidden capability '{cap_id}' is critical but "
                         "real_robot_block is not enforced; this is a configuration error."
                     )
+                # Always enforce blocking for critical forbidden capabilities.
+                disabled.add(cap_id)
+                enabled.discard(cap_id)
+                degraded.discard(cap_id)
+                warnings.append(f"Invariant: critical forbidden capability '{cap_id}' is disabled.")
 
         # Invariant 3: open critical fault degrades/blocks safety-sensitive capabilities.
         open_critical_faults = [
-            f for f in (body.known_faults.get("faults", []) if body.known_faults else [])
+            f
+            for f in (body.known_faults.get("faults", []) if body.known_faults else [])
             if f.get("status") == "open" and f.get("severity") in ("high", "critical")
         ]
         if open_critical_faults:
@@ -103,7 +112,8 @@ class SafetyInvariantEngine:
             if isinstance(cap, dict) and cap.get("risk_level") in ("high", "critical"):
                 high_critical.add(str(cap.get("id") or cap.get("name") or ""))
             elif isinstance(cap, str) and any(
-                kw in cap.lower() for kw in ("run", "jump", "climb", "throw", "lift", "force", "fast")
+                kw in cap.lower()
+                for kw in ("run", "jump", "climb", "throw", "lift", "force", "fast")
             ):
                 # Heuristic: certain capability names imply high risk
                 high_critical.add(cap)
@@ -130,8 +140,17 @@ class SafetyInvariantEngine:
         explicit = set(body.agent_policy.get("safety_sensitive_capabilities", []))
         # Heuristic fallback
         heuristic = {
-            "walk", "run", "jump", "climb_stairs", "balance", "locomotion",
-            "dual_arm_coordination", "reach", "manipulate", "grasp", "precision_grasp",
+            "walk",
+            "run",
+            "jump",
+            "climb_stairs",
+            "balance",
+            "locomotion",
+            "dual_arm_coordination",
+            "reach",
+            "manipulate",
+            "grasp",
+            "precision_grasp",
         }
         return explicit | heuristic
 
@@ -143,4 +162,6 @@ class SafetyInvariantEngine:
             "scan_workspace",
             "force_guided_manipulation",
             "hand_eye_coordination",
+            "ok_gesture",
+            "countdown_gesture",
         }

--- a/src/rosclaw/body/schema.py
+++ b/src/rosclaw/body/schema.py
@@ -16,6 +16,7 @@ from rosclaw.runtime.eurdf_loader import RobotCompleteProfile
 
 # ── e-URDF Profile (normalized from RobotCompleteProfile) ──
 
+
 @dataclass
 class EurdfProfile:
     """Normalized e-URDF profile — model-level Physical DNA."""
@@ -34,6 +35,7 @@ class EurdfProfile:
     sensors: list[dict[str, Any]] = field(default_factory=list)
     actuators: list[dict[str, Any]] = field(default_factory=list)
     capability_hints: dict[str, list[str]] = field(default_factory=dict)
+    forbidden_capabilities: list[dict[str, Any]] = field(default_factory=list)
     safety: dict[str, Any] = field(default_factory=dict)
     provider_interfaces: dict[str, Any] = field(default_factory=dict)
     sandbox: dict[str, Any] = field(default_factory=dict)
@@ -48,9 +50,15 @@ class EurdfProfile:
 
         capability_hints: dict[str, list[str]] = {}
         if capability.capabilities:
-            capability_hints["all"] = sorted({
-                c.get("name", "") for c in capability.capabilities if c.get("name")
-            })
+            capability_hints["all"] = sorted(
+                {c.get("name", "") for c in capability.capabilities if c.get("name")}
+            )
+
+        forbidden_capabilities: list[dict[str, Any]] = []
+        if capability.skill_registry:
+            forbidden_capabilities = (
+                capability.skill_registry.get("forbidden_capabilities", []) or []
+            )
 
         provider_interfaces: dict[str, Any] = {
             "state": {"required": ["joint_states"], "optional": []},
@@ -70,13 +78,16 @@ class EurdfProfile:
             description=profile.description.strip(),
             assets={"urdf": "robot.urdf", "mjcf": "robot.mjcf.xml"},
             identity={
-                "robot_class": _infer_robot_class(profile.robot_id, embodiment.dof, capability.capabilities),
+                "robot_class": _infer_robot_class(
+                    profile.robot_id, embodiment.dof, capability.capabilities
+                ),
             },
             frames={"root": "base_link", "world": "world"},
             joints=embodiment.joints,
             sensors=embodiment.sensors,
             actuators=embodiment.actuators,
             capability_hints=capability_hints,
+            forbidden_capabilities=forbidden_capabilities,
             safety={
                 "safety_level": safety.safety_level,
                 "joint_soft_limits": safety.joint_soft_limits,
@@ -107,6 +118,7 @@ class EurdfProfile:
 
 
 # ── Body Registry ──
+
 
 @dataclass
 class BodyRegistryEntry:
@@ -159,6 +171,7 @@ class BodyRegistry:
 
 
 # ── Body Instance Ledger ──
+
 
 @dataclass
 class BodyYaml:
@@ -287,6 +300,7 @@ class CalibrationYaml:
 
 # ── Maintenance / Notes ──
 
+
 @dataclass
 class MaintenanceEvent:
     """Single structured maintenance/incident/note event (JSONL line).
@@ -340,6 +354,7 @@ class MaintenanceEvent:
 
 
 # ── Effective Body Model ──
+
 
 @dataclass
 class EffectiveBody:
@@ -400,6 +415,7 @@ class EffectiveBody:
 
 # ── Validation ──
 
+
 @dataclass
 class ValidationResult:
     """One validation check result."""
@@ -430,6 +446,7 @@ class BodyValidationReport:
 
 
 # ── Skill Manifest ──
+
 
 @dataclass
 class SkillManifest:
@@ -528,10 +545,7 @@ class SkillCompatibilityReport:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SkillCompatibilityReport:
-        skills = {
-            k: SkillCompatibilityResult(**v)
-            for k, v in data.get("skills", {}).items()
-        }
+        skills = {k: SkillCompatibilityResult(**v) for k, v in data.get("skills", {}).items()}
         return cls(
             body_instance_id=data.get("body_instance_id", ""),
             effective_body_hash=data.get("effective_body_hash", ""),
@@ -564,8 +578,7 @@ class FleetCompatibilityReport:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> FleetCompatibilityReport:
         per_body = {
-            k: SkillCompatibilityReport.from_dict(v)
-            for k, v in data.get("per_body", {}).items()
+            k: SkillCompatibilityReport.from_dict(v) for k, v in data.get("per_body", {}).items()
         }
         return cls(
             workspace=data.get("workspace", ""),
@@ -577,6 +590,7 @@ class FleetCompatibilityReport:
 
 
 # ── Diff ──
+
 
 @dataclass
 class BodyChange:
@@ -634,7 +648,9 @@ def _utc_now_compact() -> str:
 def _infer_robot_class(robot_id: str, dof: int, capabilities: list[dict[str, Any]]) -> str:
     """Best-effort robot_class inference from existing profile data."""
     rid = robot_id.lower()
-    if "humanoid" in rid or any("walk" in str(c.get("name", "")).lower() for c in capabilities if dof >= 10):
+    if "humanoid" in rid or any(
+        "walk" in str(c.get("name", "")).lower() for c in capabilities if dof >= 10
+    ):
         return "humanoid"
     if "quad" in rid or "go2" in rid or "dog" in rid:
         return "quadruped"

--- a/src/rosclaw/body/service.py
+++ b/src/rosclaw/body/service.py
@@ -32,6 +32,7 @@ from rosclaw.body.schema import (
     EurdfProfile,
 )
 from rosclaw.eurdf.registry import RobotRegistry
+from rosclaw.eurdf.zoo_client import EurdfZooClient, EurdfZooClientError
 
 
 @dataclass
@@ -73,7 +74,12 @@ def _default_installed_components(eurdf: EurdfProfile) -> dict[str, Any]:
     for sensor in eurdf.sensors:
         name = sensor.get("name")
         if name:
-            sensors[name] = {"installed": True, "status": "available", "provider_ref": None, "notes": []}
+            sensors[name] = {
+                "installed": True,
+                "status": "available",
+                "provider_ref": None,
+                "notes": [],
+            }
     actuators = {}
     for actuator in eurdf.actuators:
         name = actuator.get("name")
@@ -98,6 +104,8 @@ class BodyInstanceService:
         mode: Literal["single", "registry"] = "single",
         version: str = "latest",
         from_eurdf: Path | None = None,
+        from_zoo: bool = False,
+        zoo_path: Path | None = None,
         force: bool = False,
         update_registry: bool = False,
         switch_active: bool = False,
@@ -106,7 +114,8 @@ class BodyInstanceService:
         """Create or re-initialize a body instance from an e-URDF profile.
 
         Args:
-            robot: User-facing robot profile ID (e.g. ``unitree-g1``).
+            robot: User-facing robot profile ID (e.g. ``unitree-g1`` or
+                ``dexhands/inspire_hand/right``).
             profile: Optional alias override; ignored if ``robot`` is given.
             name: Body instance ID. Auto-generated if omitted.
             nickname: Human-readable nickname. Defaults to ``name``.
@@ -114,6 +123,9 @@ class BodyInstanceService:
                 multi-body registry layout under ``bodies/<id>/``.
             version: e-URDF profile version. ``latest`` resolves to ``1.0.0``.
             from_eurdf: Optional path to an external e-URDF file.
+            from_zoo: If True, resolve ``robot`` as a manifest-driven zoo asset
+                ID (e.g. ``dexhands/inspire_hand/right``).
+            zoo_path: Optional explicit e-URDF-Zoo robots directory.
             force: Allow overwriting an existing body link.
             update_registry: Write the body into ``body_registry.yaml``.
             switch_active: Set the new body as the active body pointer.
@@ -130,7 +142,7 @@ class BodyInstanceService:
         profile_version = version if version != "latest" else "1.0.0"
 
         if mode == "registry":
-            body_id = (name or f"{profile_id}-001").strip().lower()
+            body_id = (name or f"{profile_id.replace('/', '-')}-001").strip().lower()
             body_dir = self.workspace / "bodies" / body_id
             if update_registry:
                 self.registry_manager.create_body(
@@ -143,19 +155,29 @@ class BodyInstanceService:
             if switch_active:
                 self.registry_manager.set_current_body_id(body_id)
         else:
-            body_id = (name or f"body-{profile_id}-001").strip().lower()
+            body_id = (name or f"body-{profile_id.replace('/', '-')}-001").strip().lower()
             body_dir = self.workspace / "body"
 
         # Load e-URDF profile.
         if from_eurdf is not None:
             raise NotImplementedError("External e-URDF file loading is not yet supported.")
 
-        registry = RobotRegistry()
-        profile_obj = registry.get(profile_id)
-        if profile_obj is None:
-            raise BodyRegistryError(f"e-URDF profile not found: {robot}")
+        if from_zoo or "/" in profile_id:
+            try:
+                normalized = EurdfZooClient(zoo_path=zoo_path).get_eurdf_profile(
+                    profile_id, version=profile_version
+                )
+            except EurdfZooClientError as exc:
+                raise BodyRegistryError(str(exc)) from exc
+            profile_source = "zoo"
+        else:
+            registry = RobotRegistry()
+            profile_obj = registry.get(profile_id)
+            if profile_obj is None:
+                raise BodyRegistryError(f"e-URDF profile not found: {robot}")
+            normalized = EurdfProfile.from_robot_complete_profile(profile_obj)
+            profile_source = "builtin"
 
-        normalized = EurdfProfile.from_robot_complete_profile(profile_obj)
         now = _utc_now()
 
         body_dir.mkdir(parents=True, exist_ok=True)
@@ -177,7 +199,9 @@ class BodyInstanceService:
             if switch_active and self.registry_manager.registry_path.exists():
                 self.registry_manager.set_current_body_id(body_id)
 
-        resolver = BodyResolver(workspace=self.workspace, body_id=body_id if mode == "registry" else None)
+        resolver = BodyResolver(
+            workspace=self.workspace, body_id=body_id if mode == "registry" else None
+        )
         resolver.ensure_body_dir()
 
         if mode == "single" and resolver.is_linked() and not force:
@@ -198,10 +222,13 @@ class BodyInstanceService:
             "profile_id": profile_id,
             "profile_version": profile_version,
             "uri": eurdf_uri,
-            "source": "builtin",
+            "source": profile_source,
+            "zoo_source": profile_source == "zoo",
             "checksum": checksum,
             "locked_at": now,
         }
+        if zoo_path is not None and profile_source == "zoo":
+            lock["zoo_path"] = str(zoo_path)
         with open(resolver.eurdf_lock_path, "w", encoding="utf-8") as f:
             yaml.safe_dump(lock, f, sort_keys=False, allow_unicode=True)
 
@@ -238,7 +265,17 @@ class BodyInstanceService:
             installed_components=_default_installed_components(normalized),
             capabilities={"enabled": [], "disabled": [], "degraded": []},
             prohibited_capabilities=[],
+            forbidden_capabilities=normalized.forbidden_capabilities or [],
             safety_overrides={},
+            agent_policy={
+                "physical_execution_requires_sandbox": True,
+                "direct_real_robot_execution_allowed": bool(
+                    normalized.safety.get("environment", {}).get(
+                        "real_robot_execution_allowed", False
+                    )
+                ),
+                "human_approval_required_for_high_risk": True,
+            },
             runtime_state={
                 "battery_percent": None,
                 "last_seen_at": None,
@@ -264,7 +301,12 @@ class BodyInstanceService:
         calibration = CalibrationYaml(
             body_instance_id=body_id,
             model_ref=eurdf_uri,
-            validation={"status": "factory_default", "last_validated_at": None, "errors": [], "warnings": []},
+            validation={
+                "status": "factory_default",
+                "last_validated_at": None,
+                "errors": [],
+                "warnings": [],
+            },
         )
         with open(resolver.calibration_yaml_path, "w", encoding="utf-8") as f:
             yaml.safe_dump(calibration.to_dict(), f, sort_keys=False, allow_unicode=True)
@@ -301,11 +343,13 @@ class BodyInstanceService:
 
             resolver.create_snapshot(effective)
 
-            created_files.extend([
-                resolver.effective_body_path,
-                resolver.embodiment_md_path,
-                resolver.body_md_path,
-            ])
+            created_files.extend(
+                [
+                    resolver.effective_body_path,
+                    resolver.embodiment_md_path,
+                    resolver.body_md_path,
+                ]
+            )
             if resolver.generated_dir.exists():
                 created_files.extend(resolver.generated_dir.glob("*.json"))
 

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -39,6 +39,7 @@ from rosclaw.body.registry import BodyRegistryManager
 from rosclaw.body.resolver import BodyResolver
 from rosclaw.connectors.ros.cli import add_ros_subparser, cmd_doctor_ros, dispatch_ros_command
 from rosclaw.core.event_bus import Event, EventPriority
+from rosclaw.eurdf.cli import add_eurdf_subparser, dispatch_eurdf_command
 from rosclaw.feedback.cli import add_feedback_subparser, dispatch_feedback_command
 from rosclaw.feedback.hooks import telemetry_command_hook
 from rosclaw.feedback.telemetry_client import TelemetryClient
@@ -3378,6 +3379,7 @@ def main() -> int:
     # robot subcommand
     add_ros_subparser(subparsers)
     add_body_subparser(subparsers)
+    add_eurdf_subparser(subparsers)
     add_hub_subparser(subparsers)
     robot_parser = subparsers.add_parser("robot", help="Robot registry commands")
     robot_subparsers = robot_parser.add_subparsers(dest="robot_command")
@@ -3742,6 +3744,8 @@ def main() -> int:
             return dispatch_ros_command(args)
         elif args.command == "body":
             return dispatch_body_command(args)
+        elif args.command == "eurdf":
+            return dispatch_eurdf_command(args)
         elif args.command == "logs":
             return cmd_logs(args)
         elif args.command == "robot":

--- a/src/rosclaw/eurdf/__init__.py
+++ b/src/rosclaw/eurdf/__init__.py
@@ -23,9 +23,11 @@ from rosclaw.eurdf.models import (
     RobotSimulationProfile,
 )
 from rosclaw.eurdf.registry import RobotRegistry
+from rosclaw.eurdf.zoo_client import EurdfZooClient
 
 __all__ = [
     "EURDFLoader",
+    "EurdfZooClient",
     "RobotRegistry",
     "RobotEmbodimentProfile",
     "RobotSafetyProfile",

--- a/src/rosclaw/eurdf/cli.py
+++ b/src/rosclaw/eurdf/cli.py
@@ -1,0 +1,266 @@
+"""CLI for ``rosclaw eurdf`` — manifest-driven e-URDF-Zoo commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def add_eurdf_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> argparse.ArgumentParser:
+    """Register the ``rosclaw eurdf`` subcommand tree."""
+    eurdf_parser = subparsers.add_parser("eurdf", help="e-URDF-Zoo manifest asset commands")
+    eurdf_subparsers = eurdf_parser.add_subparsers(dest="eurdf_command")
+    eurdf_parser.set_defaults(_parser=eurdf_parser)
+
+    # pull
+    pull_parser = eurdf_subparsers.add_parser(
+        "pull", help="Pull an asset bundle into the local cache"
+    )
+    pull_parser.add_argument(
+        "asset_id", help="Asset identifier (e.g., dexhands/inspire_hand/right)"
+    )
+    pull_parser.add_argument("--version", default="latest", help="Asset version")
+    pull_parser.add_argument("--source", type=Path, default=None, help="Explicit source zoo path")
+    pull_parser.add_argument(
+        "--zoo-path", type=Path, default=None, help="e-URDF-Zoo robots directory"
+    )
+
+    # info
+    info_parser = eurdf_subparsers.add_parser("info", help="Show detailed asset information")
+    info_parser.add_argument("asset_id", help="Asset identifier")
+    info_parser.add_argument("--version", default="latest", help="Asset version")
+    info_parser.add_argument("--source", type=Path, default=None, help="Explicit source zoo path")
+    info_parser.add_argument(
+        "--zoo-path", type=Path, default=None, help="e-URDF-Zoo robots directory"
+    )
+    info_parser.add_argument("--json", action="store_true", help="Output JSON")
+
+    # search
+    search_parser = eurdf_subparsers.add_parser("search", help="Search available assets")
+    search_parser.add_argument("query", help="Search query")
+    search_parser.add_argument(
+        "--zoo-path", type=Path, default=None, help="e-URDF-Zoo robots directory"
+    )
+    search_parser.add_argument("--json", action="store_true", help="Output JSON")
+
+    # validate
+    validate_parser = eurdf_subparsers.add_parser("validate", help="Validate an asset bundle")
+    validate_parser.add_argument("asset_id", help="Asset identifier")
+    validate_parser.add_argument("--version", default="latest", help="Asset version")
+    validate_parser.add_argument(
+        "--source", type=Path, default=None, help="Explicit source zoo path"
+    )
+    validate_parser.add_argument(
+        "--zoo-path", type=Path, default=None, help="e-URDF-Zoo robots directory"
+    )
+    validate_parser.add_argument("--json", action="store_true", help="Output JSON")
+
+    # cache
+    cache_parser = eurdf_subparsers.add_parser("cache", help="Manage the local asset cache")
+    cache_subparsers = cache_parser.add_subparsers(dest="cache_command")
+    cache_list_parser = cache_subparsers.add_parser("list", help="List cached assets")
+    cache_list_parser.add_argument("--json", action="store_true", help="Output JSON")
+
+    return eurdf_parser
+
+
+def _client(zoo_path: Path | None = None):
+    """Create a EurdfZooClient, handling missing dependency gracefully."""
+    try:
+        from rosclaw.eurdf.zoo_client import EurdfZooClient
+    except Exception as exc:
+        print(f"[ROSClaw] e-URDF-Zoo client unavailable: {exc}", file=sys.stderr)
+        sys.exit(1)
+    return EurdfZooClient(zoo_path=zoo_path)
+
+
+def dispatch_eurdf_command(args: argparse.Namespace) -> int:
+    """Route ``rosclaw eurdf`` subcommands."""
+    command = getattr(args, "eurdf_command", None)
+    if command is None:
+        # Print help for the eurdf subcommand tree.
+        parser = getattr(args, "_parser", None)
+        if parser is not None:
+            parser.print_help()
+        return 1
+
+    if command == "pull":
+        return cmd_eurdf_pull(args)
+    if command == "info":
+        return cmd_eurdf_info(args)
+    if command == "search":
+        return cmd_eurdf_search(args)
+    if command == "validate":
+        return cmd_eurdf_validate(args)
+    if command == "cache":
+        cache_command = getattr(args, "cache_command", None)
+        if cache_command == "list":
+            return cmd_eurdf_cache_list(args)
+        print("[ROSClaw] eurdf cache: expected 'list'")
+        return 1
+
+    print(f"[ROSClaw] Unknown eurdf command: {command}")
+    return 1
+
+
+def cmd_eurdf_pull(args: argparse.Namespace) -> int:
+    """Pull an asset into the local cache."""
+    client = _client(zoo_path=args.zoo_path)
+    try:
+        cached_path = client.pull(args.asset_id, version=args.version, source_path=args.source)
+    except Exception as exc:
+        print(f"[ROSClaw] eurdf pull failed: {exc}")
+        return 1
+
+    print(f"[ROSClaw] Pulled {args.asset_id}@{args.version}")
+    print(f"  cache: {cached_path}")
+    print(f"\nNext:\n  rosclaw body init --robot {args.asset_id}")
+    return 0
+
+
+def cmd_eurdf_info(args: argparse.Namespace) -> int:
+    """Show detailed information about a manifest asset."""
+    client = _client(zoo_path=args.zoo_path)
+    try:
+        asset = client.load(args.asset_id, version=args.version, source_path=args.source)
+    except Exception as exc:
+        print(f"[ROSClaw] eurdf info failed: {exc}")
+        return 1
+
+    manifest = asset.manifest
+    info = {
+        "id": asset.asset_id,
+        "name": asset.name,
+        "category": asset.category,
+        "type": asset.robot_type,
+        "dof": asset.dof,
+        "status": asset.status,
+        "version": asset.version,
+        "path": str(asset.base_path),
+        "is_manifest": asset.is_manifest,
+    }
+    if manifest is not None:
+        info["vendor"] = manifest.asset.vendor
+        info["model"] = manifest.asset.model
+        info["variant"] = manifest.asset.variant
+        info["description"] = manifest.asset.description
+        info["real_robot_execution_allowed"] = manifest.runtime_policy.real_robot_execution_allowed
+        info["sandbox_required"] = manifest.runtime_policy.sandbox_required
+        if asset.capabilities:
+            info["capabilities"] = [
+                {"name": cap.name, "risk": cap.risk} for cap in asset.capabilities.capabilities
+            ]
+            info["forbidden_capabilities"] = [
+                {"id": fc.id, "description": fc.description}
+                for fc in asset.capabilities.forbidden_capabilities
+            ]
+
+    if args.json:
+        print(json.dumps(info, indent=2, default=str))
+        return 0
+
+    print("=" * 60)
+    print("e-URDF-Zoo Asset Info")
+    print("=" * 60)
+    for key, value in info.items():
+        if key in {"capabilities", "forbidden_capabilities"}:
+            print(f"\n{key}:")
+            for item in value:
+                print(f"  - {item}")
+        else:
+            print(f"  {key}: {value}")
+    print("=" * 60)
+    return 0
+
+
+def cmd_eurdf_search(args: argparse.Namespace) -> int:
+    """Search the zoo for assets matching a query."""
+    client = _client(zoo_path=args.zoo_path)
+    try:
+        results = client.search_assets(args.query)
+    except Exception as exc:
+        print(f"[ROSClaw] eurdf search failed: {exc}")
+        return 1
+
+    payload = [
+        {
+            "id": r.id,
+            "name": r.name,
+            "category": r.category,
+            "status": r.status,
+            "version": r.version,
+            "is_legacy": r.is_legacy,
+            "path": str(r.path),
+        }
+        for r in results
+    ]
+
+    if args.json:
+        print(json.dumps(payload, indent=2, default=str))
+        return 0
+
+    print("=" * 60)
+    print(f"e-URDF-Zoo Search: '{args.query}'")
+    print("=" * 60)
+    if not payload:
+        print("No matching assets found.")
+    else:
+        print(f"{'ID':<40} {'Name':<25} {'Category':<15}")
+        print("-" * 80)
+        for item in payload:
+            print(f"{item['id']:<40} {item['name']:<25} {item['category']:<15}")
+    print("=" * 60)
+    return 0
+
+
+def cmd_eurdf_validate(args: argparse.Namespace) -> int:
+    """Validate a manifest asset bundle."""
+    client = _client(zoo_path=args.zoo_path)
+    try:
+        report = client.validate(args.asset_id, version=args.version, source_path=args.source)
+    except Exception as exc:
+        print(f"[ROSClaw] eurdf validate failed: {exc}")
+        return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+        return 0 if report.get("overall") != "FAIL" else 1
+
+    print("=" * 60)
+    print(f"e-URDF-Zoo Validation: {report.get('overall')}")
+    print("=" * 60)
+    print(f"Asset: {report.get('asset_id')}")
+    for filename, result in report.get("results", {}).items():
+        status = result.get("status")
+        print(f"\n  {filename}: {status}")
+        for msg in result.get("messages", []):
+            print(f"    [{msg.get('level')}] {msg.get('message')}")
+    print("=" * 60)
+    return 0 if report.get("overall") != "FAIL" else 1
+
+
+def cmd_eurdf_cache_list(args: argparse.Namespace) -> int:
+    """List cached assets."""
+    client = _client()
+    results = client.cache_list()
+
+    if args.json:
+        print(json.dumps(results, indent=2, default=str))
+        return 0
+
+    print("=" * 60)
+    print("e-URDF-Zoo Cache")
+    print("=" * 60)
+    if not results:
+        print("No cached assets.")
+    else:
+        print(f"{'Asset ID':<40} {'Version':<10} {'Path':<30}")
+        print("-" * 80)
+        for item in results:
+            print(f"{item['asset_id']:<40} {item['version']:<10} {item['path']:<30}")
+    print("=" * 60)
+    return 0

--- a/src/rosclaw/eurdf/zoo_client.py
+++ b/src/rosclaw/eurdf/zoo_client.py
@@ -1,0 +1,581 @@
+"""ROSClaw client for the new manifest-driven e-URDF-Zoo.
+
+This client bridges the new ``e_urdf_zoo`` asset library (manifest-driven
+bundles under ``robots/<category>/...``) with the existing ROSClaw runtime
+that expects ``RobotCompleteProfile`` / ``EurdfProfile`` objects.
+
+Resolution order:
+1. Explicit local path passed by the caller.
+2. ``~/.rosclaw/cache/e-urdf-zoo/<asset_id>/``
+3. Project-root ``e-urdf-zoo`` checkout (or pip-installed package data).
+"""
+
+from __future__ import annotations
+
+import shutil
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from rosclaw.body.schema import EurdfProfile
+from rosclaw.runtime.eurdf_loader import (
+    RobotBenchmarkProfile,
+    RobotCapabilityProfile,
+    RobotCompleteProfile,
+    RobotEmbodimentProfile,
+    RobotSafetyProfile,
+    RobotSemanticProfile,
+    RobotSimulationProfile,
+)
+
+try:
+    from e_urdf_zoo import AssetLoader, AssetSummary, EmbodimentAsset
+    from e_urdf_zoo.schemas import (
+        CapabilitiesSchema,
+        ManifestSchema,
+        SafetySchema,
+        SandboxSchema,
+        SemanticSchema,
+    )
+
+    E_URDF_ZOO_AVAILABLE = True
+except Exception:  # pragma: no cover - degraded gracefully
+    E_URDF_ZOO_AVAILABLE = False
+    AssetLoader = None  # type: ignore[misc,assignment]
+    EmbodimentAsset = None  # type: ignore[misc,assignment]
+    ManifestSchema = None  # type: ignore[misc,assignment]
+
+
+@dataclass
+class ResolvedAssetSource:
+    """Where an asset was resolved from."""
+
+    asset_id: str
+    version: str
+    path: Path
+    source: str  # explicit, cache, project_root, package
+
+
+class EurdfZooClientError(Exception):
+    """Raised when a zoo client operation fails."""
+
+
+class EurdfZooClient:
+    """Discover, resolve, pull, and convert manifest-driven e-URDF assets."""
+
+    def __init__(
+        self,
+        zoo_path: Path | str | None = None,
+        cache_dir: Path | str | None = None,
+    ):
+        if not E_URDF_ZOO_AVAILABLE:
+            raise EurdfZooClientError(
+                "e_urdf_zoo package is not available. Install e-urdf-zoo first."
+            )
+
+        self.zoo_path = Path(zoo_path) if zoo_path else None
+        if cache_dir is None:
+            cache_dir = Path.home() / ".rosclaw" / "cache" / "e-urdf-zoo"
+        self.cache_dir = Path(cache_dir)
+        self._loader: AssetLoader | None = None
+
+    # ------------------------------------------------------------------
+    # Resolution
+    # ------------------------------------------------------------------
+    def _get_loader(self, source_path: Path | None = None) -> AssetLoader:
+        """Return an AssetLoader rooted at the requested or default path."""
+        if source_path is not None:
+            return AssetLoader(zoo_path=source_path)
+        if self._loader is None:
+            self._loader = AssetLoader(zoo_path=self.zoo_path if self.zoo_path else None)
+        return self._loader
+
+    def resolve(
+        self,
+        asset_id: str,
+        version: str = "latest",
+        source_path: Path | str | None = None,
+    ) -> ResolvedAssetSource:
+        """Resolve an asset ID to an existing directory.
+
+        Resolution order:
+        1. ``source_path`` if provided.
+        2. ``~/.rosclaw/cache/e-urdf-zoo/<asset_id>/``
+        3. Default zoo path (project-root or pip package).
+        """
+        if source_path is not None:
+            path = Path(source_path)
+            if not path.is_dir():
+                raise EurdfZooClientError(f"Explicit source path not found: {path}")
+            return ResolvedAssetSource(
+                asset_id=asset_id, version=version, path=path, source="explicit"
+            )
+
+        # Cache
+        cache_path = self._cache_path(asset_id)
+        if cache_path.is_dir() and (cache_path / "manifest.yaml").exists():
+            return ResolvedAssetSource(
+                asset_id=asset_id, version=version, path=cache_path, source="cache"
+            )
+
+        # Default loader (project-root / pip package)
+        loader = self._get_loader()
+        try:
+            asset = loader.load_asset(asset_id)
+        except FileNotFoundError as exc:
+            raise EurdfZooClientError(str(exc)) from exc
+
+        return ResolvedAssetSource(
+            asset_id=asset_id,
+            version=version,
+            path=asset.base_path,
+            source="project_root" if self.zoo_path else "package",
+        )
+
+    def load(
+        self,
+        asset_id: str,
+        version: str = "latest",
+        source_path: Path | str | None = None,
+    ) -> EmbodimentAsset:
+        """Load a manifest asset bundle."""
+        resolved = self.resolve(asset_id, version=version, source_path=source_path)
+        return EmbodimentAsset(asset_id, resolved.path)
+
+    def list_assets(
+        self,
+        category: str | None = None,
+        source_path: Path | str | None = None,
+    ) -> list[AssetSummary]:
+        """List available assets, optionally filtered by category."""
+        loader = self._get_loader(source_path if source_path else self.zoo_path)
+        return loader.list_assets(category=category)
+
+    def search_assets(
+        self,
+        query: str,
+        source_path: Path | str | None = None,
+    ) -> list[AssetSummary]:
+        """Search asset IDs, names, and categories."""
+        loader = self._get_loader(source_path if source_path else self.zoo_path)
+        return loader.search_assets(query)
+
+    def validate(
+        self,
+        asset_id: str,
+        version: str = "latest",
+        source_path: Path | str | None = None,
+    ) -> dict[str, Any]:
+        """Validate a manifest asset bundle and return a serializable report."""
+        resolved = self.resolve(asset_id, version=version, source_path=source_path)
+        loader = self._loader_for_resolved(asset_id, resolved)
+        report = loader.validate_asset(asset_id)
+        return report.to_dict()
+
+    # ------------------------------------------------------------------
+    # Pull / cache
+    # ------------------------------------------------------------------
+    def pull(
+        self,
+        asset_id: str,
+        version: str = "latest",
+        source_path: Path | str | None = None,
+    ) -> Path:
+        """Copy an asset bundle into the local cache.
+
+        Returns the cached directory path.
+        """
+        resolved = self.resolve(asset_id, version=version, source_path=source_path)
+        dest = self._cache_path(asset_id)
+
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(resolved.path, dest)
+
+        # Write a small provenance file so consumers know where it came from.
+        provenance = {
+            "asset_id": asset_id,
+            "version": version,
+            "source": resolved.source,
+            "source_path": str(resolved.path),
+        }
+        (dest / ".rosclaw_source.yaml").write_text(
+            yaml.safe_dump(provenance, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        return dest
+
+    def cache_list(self) -> list[dict[str, Any]]:
+        """List assets currently in the local cache."""
+        results: list[dict[str, Any]] = []
+        if not self.cache_dir.exists():
+            return results
+
+        def _walk(current: Path, prefix: str) -> None:
+            manifest = current / "manifest.yaml"
+            if manifest.exists():
+                name = current.name
+                version = "unknown"
+                provenance = current / ".rosclaw_source.yaml"
+                if provenance.exists():
+                    try:
+                        prov = yaml.safe_load(provenance.read_text(encoding="utf-8")) or {}
+                        version = prov.get("version", version)
+                    except Exception:
+                        pass
+                try:
+                    data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+                    name = data.get("asset", {}).get("name", name)
+                except Exception:
+                    pass
+                results.append(
+                    {
+                        "asset_id": prefix,
+                        "version": version,
+                        "path": str(current),
+                        "name": name,
+                    }
+                )
+                return
+            for child in sorted(current.iterdir()):
+                if child.is_dir():
+                    child_prefix = f"{prefix}/{child.name}" if prefix else child.name
+                    _walk(child, child_prefix)
+
+        _walk(self.cache_dir, "")
+        return results
+
+    def _cache_path(self, asset_id: str) -> Path:
+        """Return the cache directory for an asset ID.
+
+        Forward slashes in asset IDs create nested directories so the cached
+        layout mirrors the source zoo layout.
+        """
+        return self.cache_dir / asset_id
+
+    def _loader_for_resolved(self, asset_id: str, resolved: ResolvedAssetSource) -> AssetLoader:
+        """Return an AssetLoader that can resolve ``asset_id`` to ``resolved.path``."""
+        if resolved.source == "cache":
+            return AssetLoader(zoo_path=self.cache_dir)
+        parts = asset_id.split("/")
+        root = resolved.path.parent if len(parts) == 1 else resolved.path.parents[len(parts) - 1]
+        return AssetLoader(zoo_path=root)
+
+    # ------------------------------------------------------------------
+    # Conversion to ROSClaw profiles
+    # ------------------------------------------------------------------
+    def get_profile(
+        self,
+        asset_id: str,
+        version: str = "latest",
+        source_path: Path | str | None = None,
+    ) -> RobotCompleteProfile:
+        """Convert a manifest asset to a ``RobotCompleteProfile``."""
+        asset = self.load(asset_id, version=version, source_path=source_path)
+        if asset.manifest is None:
+            raise EurdfZooClientError(f"Asset '{asset_id}' is not a manifest-driven bundle")
+        manifest = asset.manifest
+        safety = asset.safety
+        capabilities = asset.capabilities
+        semantic = asset.semantic
+        sandbox = asset.sandbox
+
+        embodiment = self._build_embodiment(asset, manifest)
+        safety_profile = self._build_safety(asset_id, safety)
+        capability_profile = self._build_capability(asset_id, capabilities)
+        simulation_profile = self._build_simulation(asset_id, sandbox)
+        semantic_profile = self._build_semantic(asset_id, semantic)
+        benchmark_profile = RobotBenchmarkProfile(robot_id=asset_id)
+
+        return RobotCompleteProfile(
+            robot_id=asset_id,
+            name=manifest.asset.name,
+            vendor=manifest.asset.vendor,
+            version=manifest.asset.version,
+            description=manifest.asset.description,
+            embodiment=embodiment,
+            safety=safety_profile,
+            capability=capability_profile,
+            simulation=simulation_profile,
+            semantic=semantic_profile,
+            benchmark=benchmark_profile,
+        )
+
+    def get_eurdf_profile(
+        self,
+        asset_id: str,
+        version: str = "latest",
+        source_path: Path | str | None = None,
+    ) -> EurdfProfile:
+        """Convert a manifest asset directly to a normalized ``EurdfProfile``."""
+        complete = self.get_profile(asset_id, version=version, source_path=source_path)
+        return EurdfProfile.from_robot_complete_profile(complete)
+
+    # ------------------------------------------------------------------
+    # Builders
+    # ------------------------------------------------------------------
+    def _build_embodiment(
+        self, asset: EmbodimentAsset, manifest: ManifestSchema
+    ) -> RobotEmbodimentProfile:
+        """Build embodiment profile from URDF and manifest metadata."""
+        urdf_path = asset.model_urdf
+        links: list[dict[str, Any]] = []
+        joints: list[dict[str, Any]] = []
+
+        if urdf_path and urdf_path.exists():
+            try:
+                tree = ET.parse(urdf_path)
+                root = tree.getroot()
+                links = [_parse_urdf_link(el) for el in root.findall("link")]
+                joints = [_parse_urdf_joint(el) for el in root.findall("joint")]
+            except Exception as exc:  # pragma: no cover - defensive
+                links = [{"name": f"parse_error:{exc}", "type": "error"}]
+                joints = []
+
+        dof = manifest.robot.dof
+        if dof is None:
+            dof = sum(1 for j in joints if j.get("type") not in {"fixed", "floating"})
+
+        return RobotEmbodimentProfile(
+            robot_id=asset.asset_id,
+            name=manifest.asset.name,
+            vendor=manifest.asset.vendor,
+            version=manifest.asset.version,
+            description=manifest.asset.description,
+            dof=dof,
+            links=links,
+            joints=joints,
+            sensors=[],
+            actuators=[
+                {"name": j["name"], "type": j.get("type", "revolute")}
+                for j in joints
+                if j.get("type") not in {"fixed", "floating"}
+            ],
+            metadata={
+                "category": manifest.asset.category,
+                "variant": manifest.asset.variant,
+                "model": manifest.asset.model,
+                "urdf_path": str(urdf_path) if urdf_path else None,
+            },
+        )
+
+    def _build_safety(self, asset_id: str, safety: SafetySchema | None) -> RobotSafetyProfile:
+        """Build safety profile from manifest safety.yaml."""
+        if safety is None:
+            return RobotSafetyProfile(
+                robot_id=asset_id,
+                safety_level="STRICT",
+            )
+
+        policy = safety.global_policy
+        limits = safety.limits
+        trajectory = safety.trajectory_policy
+
+        safety_level = safety.safety_status.upper()
+        if safety_level not in {"STRICT", "MODERATE", "RELAXED"}:
+            safety_level = "STRICT" if not policy.real_robot_execution_allowed else "MODERATE"
+
+        return RobotSafetyProfile(
+            robot_id=asset_id,
+            safety_level=safety_level,
+            safety_limits={
+                "max_joint_speed_scale": limits.max_joint_speed_scale,
+                "max_joint_torque_scale": limits.max_joint_torque_scale,
+                "max_position_step_scale": limits.max_position_step_scale,
+                "joint_limit_margin_ratio": limits.joint_limit_margin_ratio,
+                "require_joint_limit_margin": limits.require_joint_limit_margin,
+            },
+            joint_soft_limits={
+                "margin_ratio": limits.joint_limit_margin_ratio,
+            },
+            pfl={
+                "current_limit_required": policy.current_limit_required,
+                "fault_monitor_required": policy.fault_monitor_required,
+            },
+            collision_detection={
+                "require_self_collision_check": trajectory.require_self_collision_check,
+            },
+            emergency_stop={"enabled": True},
+            workspace_boundaries={},
+            interaction={
+                "manual_enable_required_after_validation": policy.manual_enable_required_after_validation,
+            },
+            environment={
+                "sandbox_required": policy.sandbox_required,
+                "real_robot_execution_allowed": policy.real_robot_execution_allowed,
+            },
+        )
+
+    def _build_capability(
+        self, asset_id: str, capabilities: CapabilitiesSchema | None
+    ) -> RobotCapabilityProfile:
+        """Build capability profile from manifest capabilities.yaml."""
+        caps: list[dict[str, Any]] = []
+        forbidden: list[dict[str, Any]] = []
+        skill_registry: dict[str, Any] = {}
+
+        if capabilities is not None:
+            for cap in capabilities.capabilities:
+                caps.append(
+                    {
+                        "id": cap.id,
+                        "name": cap.name,
+                        "scope": cap.scope,
+                        "risk": cap.risk,
+                        "body_parts": cap.body_parts,
+                        "sandbox_required": cap.sandbox_required,
+                        "real_robot_execution_allowed": cap.real_robot_execution_allowed,
+                        "required_runtime_monitors": cap.required_runtime_monitors,
+                        "required_calibration": cap.required_calibration,
+                        "safety_notes": cap.safety_notes,
+                    }
+                )
+            forbidden = [
+                {
+                    "id": fc.id,
+                    "description": fc.description,
+                    "reason": fc.reason,
+                    "severity": fc.severity,
+                }
+                for fc in capabilities.forbidden_capabilities
+            ]
+            skill_registry["forbidden_capabilities"] = forbidden
+
+        return RobotCapabilityProfile(
+            robot_id=asset_id,
+            capabilities=caps,
+            skill_registry=skill_registry,
+            precondition_checks={
+                "real_robot_execution_allowed": not bool(forbidden),
+            },
+        )
+
+    def _build_simulation(
+        self, asset_id: str, sandbox: SandboxSchema | None
+    ) -> RobotSimulationProfile:
+        """Build simulation profile from manifest sandbox.yaml."""
+        backends: dict[str, Any] = {}
+        if sandbox is not None and sandbox.engines:
+            for engine, config in sandbox.engines.items():
+                backends[engine] = {
+                    "supported": config.supported,
+                    "model_path": config.model_path,
+                    "status": config.status,
+                }
+        if not backends:
+            backends["mock"] = {"supported": True, "status": "fallback"}
+        return RobotSimulationProfile(robot_id=asset_id, backends=backends)
+
+    def _build_semantic(
+        self, asset_id: str, semantic: SemanticSchema | None
+    ) -> RobotSemanticProfile:
+        """Build semantic profile from manifest semantic.yaml."""
+        functional_regions: list[dict[str, Any]] = []
+        semantic_tags: list[str] = []
+        if semantic is not None:
+            if semantic.frames:
+                if semantic.frames.root:
+                    functional_regions.append({"name": "root", "frame": semantic.frames.root})
+                if semantic.frames.tcp:
+                    functional_regions.append({"name": "tcp", "frame": semantic.frames.tcp})
+                if semantic.frames.mounting:
+                    functional_regions.append(
+                        {"name": "mounting", "frame": semantic.frames.mounting}
+                    )
+            for name, group in semantic.groups.items():
+                functional_regions.append(
+                    {
+                        "name": name,
+                        "type": group.type,
+                        "links": group.links,
+                        "joints": group.joints,
+                        "side": group.side,
+                        "roles": group.roles,
+                        "source": group.source,
+                        "confidence": group.confidence,
+                    }
+                )
+            semantic_tags = [f"category:{group.type}" for group in semantic.groups.values()]
+
+        return RobotSemanticProfile(
+            robot_id=asset_id,
+            functional_regions=functional_regions,
+            semantic_tags=sorted(set(semantic_tags)),
+        )
+
+
+# ------------------------------------------------------------------
+# URDF helpers
+# ------------------------------------------------------------------
+def _parse_floats(text: str | None) -> list[float]:
+    if not text:
+        return []
+    try:
+        return [float(x) for x in text.strip().split()]
+    except ValueError:
+        return []
+
+
+def _parse_urdf_link(element: ET.Element) -> dict[str, Any]:
+    name = element.get("name", "unknown")
+    mass = 0.0
+    inertial = element.find("inertial")
+    if inertial is not None:
+        mass_el = inertial.find("mass")
+        if mass_el is not None:
+            try:
+                mass = float(mass_el.get("value", "0"))
+            except ValueError:
+                mass = 0.0
+    return {"name": name, "type": "link", "mass": mass}
+
+
+def _parse_urdf_joint(element: ET.Element) -> dict[str, Any]:
+    name = element.get("name", "unknown")
+    jtype = element.get("type", "fixed")
+    parent = child = None
+    parent_el = element.find("parent")
+    if parent_el is not None:
+        parent = parent_el.get("link")
+    child_el = element.find("child")
+    if child_el is not None:
+        child = child_el.get("link")
+
+    axis = [1.0, 0.0, 0.0]
+    axis_el = element.find("axis")
+    if axis_el is not None:
+        axis = _parse_floats(axis_el.get("xyz")) or axis
+
+    limits: dict[str, Any] = {}
+    limit_el = element.find("limit")
+    if limit_el is not None:
+        for key in ("lower", "upper", "effort", "velocity"):
+            val = limit_el.get(key)
+            if val is not None:
+                try:
+                    limits[key] = float(val)
+                except ValueError:
+                    limits[key] = val
+
+    origin: dict[str, Any] = {}
+    origin_el = element.find("origin")
+    if origin_el is not None:
+        xyz = _parse_floats(origin_el.get("xyz"))
+        rpy = _parse_floats(origin_el.get("rpy"))
+        if xyz:
+            origin["xyz"] = xyz
+        if rpy:
+            origin["rpy"] = rpy
+
+    return {
+        "name": name,
+        "type": jtype,
+        "parent": parent,
+        "child": child,
+        "axis": axis,
+        "limits": limits,
+        "origin": origin,
+    }

--- a/tests/body/test_body_init_from_zoo.py
+++ b/tests/body/test_body_init_from_zoo.py
@@ -1,0 +1,72 @@
+"""Tests for initializing a ROSClaw body from a manifest-driven zoo asset."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rosclaw.body.service import BodyInstanceService
+
+
+@pytest.fixture
+def zoo_path() -> Path:
+    return Path(__file__).parent.parent.parent.parent / "e-urdf-zoo" / "robots"
+
+
+@pytest.fixture
+def service(tmp_path: Path, zoo_path: Path) -> BodyInstanceService:
+    return BodyInstanceService(workspace=tmp_path)
+
+
+def test_body_init_from_zoo_asset(service: BodyInstanceService, zoo_path: Path) -> None:
+    result = service.create_or_init(
+        robot="dexhands/inspire_hand/right",
+        name="inspire-right-test",
+        mode="single",
+        update_registry=True,
+        switch_active=True,
+        render_agent_view=True,
+        zoo_path=zoo_path,
+    )
+    assert result.body_id == "inspire-right-test"
+    assert result.profile_id == "dexhands/inspire_hand/right"
+    assert result.eurdf_uri == "rosclaw://eurdf/dexhands/inspire_hand/right@1.0.0"
+    assert result.effective_body_hash is not None
+    assert result.checksum
+
+    # Verify artifacts were written.
+    assert (result.workspace / "body" / "refs" / "eurdf.lock").exists()
+    assert (result.workspace / "body" / "refs" / "eurdf.profile.yaml").exists()
+    assert (result.workspace / "body" / "EMBODIMENT.md").exists()
+
+
+def test_body_init_from_zoo_detects_slash(service: BodyInstanceService, zoo_path: Path) -> None:
+    # ``from_zoo`` is auto-detected because the ID contains a slash.
+    result = service.create_or_init(
+        robot="dexhands/inspire_hand/right",
+        mode="single",
+        update_registry=False,
+        switch_active=False,
+        render_agent_view=False,
+        zoo_path=zoo_path,
+    )
+    assert result.profile_id == "dexhands/inspire_hand/right"
+
+
+def test_body_init_zoo_source_lock(service: BodyInstanceService, zoo_path: Path) -> None:
+    service.create_or_init(
+        robot="dexhands/inspire_hand/right",
+        name="lock-test",
+        mode="single",
+        update_registry=False,
+        switch_active=False,
+        render_agent_view=False,
+        zoo_path=zoo_path,
+    )
+    lock_path = service.workspace / "body" / "refs" / "eurdf.lock"
+    import yaml
+
+    lock = yaml.safe_load(lock_path.read_text(encoding="utf-8"))
+    assert lock["source"] == "zoo"
+    assert lock.get("zoo_source") is True

--- a/tests/body/test_dexhand_agent_safety.py
+++ b/tests/body/test_dexhand_agent_safety.py
@@ -1,0 +1,215 @@
+"""Tests for dexterous-hand safety hardening and Agent query answers."""
+
+from __future__ import annotations
+
+from rosclaw.body.compiler import EffectiveBodyCompiler
+from rosclaw.body.query import BodyQueryEngine
+from rosclaw.body.safety import SafetyInvariantEngine
+from rosclaw.body.schema import (
+    BodyYaml,
+    CalibrationYaml,
+    EurdfProfile,
+)
+
+
+def _make_hand_eurdf(real_robot_allowed: bool = False) -> EurdfProfile:
+    return EurdfProfile(
+        profile_id="dexhands/test_hand/right",
+        profile_version="1.0.0",
+        vendor="Test",
+        model="test_hand",
+        display_name="Test Hand (Right)",
+        capability_hints={
+            "all": [
+                "Open Hand",
+                "Close Hand Slowly",
+                "OK Gesture",
+                "Countdown Gesture",
+            ],
+        },
+        forbidden_capabilities=[
+            {
+                "id": "fast_full_close",
+                "description": "Close all fingers/joints to maximum at high speed",
+                "reason": "Risk of collision and motor overload",
+                "severity": "critical",
+                "enforcement": {
+                    "policy_block": True,
+                    "sandbox_block": True,
+                    "real_robot_block": True,
+                },
+            },
+            {
+                "id": "forceful_grasp_without_current_limit",
+                "description": "Forceful grasping without active current/torque limit",
+                "reason": "Can damage the hand and grasped object",
+                "severity": "critical",
+                "enforcement": {
+                    "policy_block": True,
+                    "sandbox_block": True,
+                    "real_robot_block": True,
+                },
+            },
+        ],
+        safety={
+            "safety_level": "STRICT",
+            "environment": {
+                "real_robot_execution_allowed": real_robot_allowed,
+                "sandbox_required": True,
+            },
+        },
+        joints=[{"name": "j0"}],
+        actuators=[{"name": "j0"}],
+    )
+
+
+def _make_hand_body(real_robot_allowed: bool = False) -> BodyYaml:
+    return BodyYaml(
+        body_instance={"id": "test-hand-001", "robot_model": "dexhands/test_hand/right"},
+        model_ref={"eurdf_uri": "rosclaw://eurdf/dexhands/test_hand/right@1.0.0"},
+        calibration={"status": "factory_default"},
+        capabilities={"enabled": [], "disabled": [], "degraded": []},
+        forbidden_capabilities=[
+            {
+                "id": "fast_full_close",
+                "description": "Close all fingers/joints to maximum at high speed",
+                "reason": "Risk of collision and motor overload",
+                "severity": "critical",
+                "enforcement": {
+                    "policy_block": True,
+                    "sandbox_block": True,
+                    "real_robot_block": True,
+                },
+            },
+            {
+                "id": "forceful_grasp_without_current_limit",
+                "description": "Forceful grasping without active current/torque limit",
+                "reason": "Can damage the hand and grasped object",
+                "severity": "critical",
+                "enforcement": {
+                    "policy_block": True,
+                    "sandbox_block": True,
+                    "real_robot_block": True,
+                },
+            },
+        ],
+        agent_policy={
+            "physical_execution_requires_sandbox": True,
+            "direct_real_robot_execution_allowed": real_robot_allowed,
+            "human_approval_required_for_high_risk": True,
+        },
+    )
+
+
+def test_compiler_degrades_gestures_when_uncalibrated() -> None:
+    compiler = EffectiveBodyCompiler()
+    effective = compiler.compile(
+        eurdf=_make_hand_eurdf(),
+        body=_make_hand_body(),
+        calibration=CalibrationYaml(),
+    )
+    caps = effective.capabilities
+    assert "OK Gesture" in caps["degraded"]
+    assert "Countdown Gesture" in caps["degraded"]
+
+
+def test_compiler_sim_only_when_real_robot_blocked() -> None:
+    compiler = EffectiveBodyCompiler()
+    effective = compiler.compile(
+        eurdf=_make_hand_eurdf(real_robot_allowed=False),
+        body=_make_hand_body(real_robot_allowed=False),
+        calibration=CalibrationYaml(),
+    )
+    caps = effective.capabilities
+    # Manipulation capabilities are degraded to simulation-only, not enabled.
+    assert "Open Hand" in caps["degraded"]
+    assert "Close Hand Slowly" in caps["degraded"]
+    assert "fast_full_close" in caps["blocked"]
+    assert "forceful_grasp_without_current_limit" in caps["blocked"]
+
+
+def test_compiler_allows_real_hardware_when_cleared() -> None:
+    compiler = EffectiveBodyCompiler()
+    body = _make_hand_body(real_robot_allowed=True)
+    body.calibration = {"status": "validated"}
+    effective = compiler.compile(
+        eurdf=_make_hand_eurdf(real_robot_allowed=True),
+        body=body,
+        calibration=CalibrationYaml(validation={"status": "validated"}),
+    )
+    caps = effective.capabilities
+    assert "OK Gesture" in caps["enabled"]
+    assert "Countdown Gesture" in caps["enabled"]
+    assert "fast_full_close" in caps["blocked"]
+
+
+def test_safety_engine_blocks_critical_forbidden_capabilities() -> None:
+    engine = SafetyInvariantEngine()
+    body = _make_hand_body()
+    mods = engine.apply(body, [], CalibrationYaml())
+    assert "fast_full_close" in mods["disabled"]
+    assert "forceful_grasp_without_current_limit" in mods["disabled"]
+    assert any("fast_full_close" in w for w in mods["warnings"])
+
+
+def test_query_blocks_fast_full_close() -> None:
+    effective = EffectiveBodyCompiler().compile(
+        eurdf=_make_hand_eurdf(),
+        body=_make_hand_body(),
+        calibration=CalibrationYaml(),
+    )
+    engine = BodyQueryEngine(effective, _make_hand_body(), CalibrationYaml(), [])
+    result = engine.answer("Can this hand close fast?")
+    assert "forbidden" in result.answer.lower() or "blocked" in result.answer.lower()
+    assert result.actionable_policy
+
+
+def test_query_blocks_ok_gesture_on_real_hardware() -> None:
+    effective = EffectiveBodyCompiler().compile(
+        eurdf=_make_hand_eurdf(),
+        body=_make_hand_body(),
+        calibration=CalibrationYaml(),
+    )
+    engine = BodyQueryEngine(effective, _make_hand_body(), CalibrationYaml(), [])
+    result = engine.answer("Can this hand do OK gesture on real hardware?")
+    assert "blocked" in result.answer.lower() or "not allowed" in result.answer.lower()
+    assert "real robot execution" in result.answer.lower()
+
+
+def test_query_sandbox_first_for_countdown_gesture() -> None:
+    effective = EffectiveBodyCompiler().compile(
+        eurdf=_make_hand_eurdf(),
+        body=_make_hand_body(),
+        calibration=CalibrationYaml(),
+    )
+    engine = BodyQueryEngine(effective, _make_hand_body(), CalibrationYaml(), [])
+    result = engine.answer("Can this hand perform countdown gesture 5-4-3-2-1?")
+    assert "sandbox" in result.answer.lower()
+    assert result.actionable_policy
+
+
+def test_query_blocks_forceful_grasp() -> None:
+    effective = EffectiveBodyCompiler().compile(
+        eurdf=_make_hand_eurdf(),
+        body=_make_hand_body(),
+        calibration=CalibrationYaml(),
+    )
+    engine = BodyQueryEngine(effective, _make_hand_body(), CalibrationYaml(), [])
+    result = engine.answer("Can I forcefully grasp an object?")
+    assert "forbidden" in result.answer.lower() or "blocked" in result.answer.lower()
+    assert "current" in result.answer.lower() or "torque" in result.answer.lower()
+
+
+def test_query_allows_ok_gesture_when_cleared() -> None:
+    body = _make_hand_body(real_robot_allowed=True)
+    body.calibration = {"status": "validated"}
+    effective = EffectiveBodyCompiler().compile(
+        eurdf=_make_hand_eurdf(real_robot_allowed=True),
+        body=body,
+        calibration=CalibrationYaml(validation={"status": "validated"}),
+    )
+    engine = BodyQueryEngine(
+        effective, body, CalibrationYaml(validation={"status": "validated"}), []
+    )
+    result = engine.answer("Can this hand do OK gesture on real hardware?")
+    assert "yes" in result.answer.lower()

--- a/tests/eurdf/test_eurdf_cli.py
+++ b/tests/eurdf/test_eurdf_cli.py
@@ -1,0 +1,84 @@
+"""Tests for ``rosclaw.eurdf.cli``."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from rosclaw.eurdf.cli import (
+    add_eurdf_subparser,
+    cmd_eurdf_cache_list,
+    cmd_eurdf_pull,
+    dispatch_eurdf_command,
+)
+
+
+@pytest.fixture
+def zoo_path() -> Path:
+    return Path(__file__).parent.parent.parent.parent / "e-urdf-zoo" / "robots"
+
+
+@pytest.fixture
+def parser(zoo_path: Path) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    add_eurdf_subparser(subparsers)
+    return parser
+
+
+def test_cli_info_human(parser: argparse.ArgumentParser, zoo_path: Path) -> None:
+    args = parser.parse_args(
+        ["eurdf", "info", "dexhands/inspire_hand/right", "--zoo-path", str(zoo_path)]
+    )
+    assert dispatch_eurdf_command(args) == 0
+
+
+def test_cli_info_json(parser: argparse.ArgumentParser, zoo_path: Path) -> None:
+    args = parser.parse_args(
+        ["eurdf", "info", "dexhands/inspire_hand/right", "--json", "--zoo-path", str(zoo_path)]
+    )
+    assert dispatch_eurdf_command(args) == 0
+
+
+def test_cli_search_json(parser: argparse.ArgumentParser, zoo_path: Path) -> None:
+    args = parser.parse_args(["eurdf", "search", "inspire", "--json", "--zoo-path", str(zoo_path)])
+    assert dispatch_eurdf_command(args) == 0
+
+
+def test_cli_validate(parser: argparse.ArgumentParser, zoo_path: Path) -> None:
+    args = parser.parse_args(
+        ["eurdf", "validate", "dexhands/inspire_hand/right", "--zoo-path", str(zoo_path)]
+    )
+    assert dispatch_eurdf_command(args) == 0
+
+
+def test_cli_pull_and_cache_list(
+    parser: argparse.ArgumentParser, zoo_path: Path, tmp_path: Path
+) -> None:
+    args = parser.parse_args(
+        [
+            "eurdf",
+            "pull",
+            "dexhands/inspire_hand/right",
+            "--zoo-path",
+            str(zoo_path),
+            "--source",
+            str(zoo_path / "dexhands" / "inspire_hand" / "right"),
+        ]
+    )
+    # Patch cache dir via monkey-patching the client factory is awkward; instead
+    # verify the command dispatches without error when source is explicit.
+    assert cmd_eurdf_pull(args) == 0
+
+
+def test_cli_cache_list_empty(parser: argparse.ArgumentParser, tmp_path: Path) -> None:
+    args = parser.parse_args(["eurdf", "cache", "list", "--json"])
+    # The default cache dir is empty in CI; command should still succeed.
+    assert cmd_eurdf_cache_list(args) == 0
+
+
+def test_cli_help_when_no_subcommand(parser: argparse.ArgumentParser) -> None:
+    args = parser.parse_args(["eurdf"])
+    assert dispatch_eurdf_command(args) == 1

--- a/tests/eurdf/test_zoo_client.py
+++ b/tests/eurdf/test_zoo_client.py
@@ -1,0 +1,87 @@
+"""Tests for ``rosclaw.eurdf.zoo_client``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rosclaw.eurdf.zoo_client import EurdfZooClient, EurdfZooClientError
+
+
+@pytest.fixture
+def zoo_path() -> Path:
+    """Path to the project-root e-URDF-Zoo robots directory."""
+    return Path(__file__).parent.parent.parent.parent / "e-urdf-zoo" / "robots"
+
+
+@pytest.fixture
+def client(zoo_path: Path, tmp_path: Path) -> EurdfZooClient:
+    """Configured client with isolated cache."""
+    return EurdfZooClient(zoo_path=zoo_path, cache_dir=tmp_path / "cache")
+
+
+def test_client_lists_dexhands(client: EurdfZooClient) -> None:
+    assets = client.list_assets(category="dexhands")
+    ids = [a.id for a in assets]
+    assert "dexhands/inspire_hand/right" in ids
+    assert "dexhands/ability_hand/left" in ids
+
+
+def test_client_search_panda(client: EurdfZooClient) -> None:
+    results = client.search_assets("panda")
+    ids = [a.id for a in results]
+    assert "grippers/panda/default" in ids
+
+
+def test_client_load_manifest_asset(client: EurdfZooClient) -> None:
+    asset = client.load("dexhands/inspire_hand/right")
+    assert asset.is_manifest
+    assert asset.name == "Inspire Hand (Right)"
+    assert asset.manifest is not None
+    assert asset.manifest.runtime_policy.real_robot_execution_allowed is False
+
+
+def test_client_get_profile(client: EurdfZooClient) -> None:
+    profile = client.get_profile("dexhands/inspire_hand/right")
+    assert profile.robot_id == "dexhands/inspire_hand/right"
+    assert profile.vendor == "Inspire Robots"
+    assert profile.embodiment.dof > 0
+    assert len(profile.embodiment.joints) > 0
+    assert profile.safety.safety_level == "STRICT"
+    forbidden = profile.capability.skill_registry.get("forbidden_capabilities", [])
+    assert any(fc["id"] == "fast_full_close" for fc in forbidden)
+
+
+def test_client_get_eurdf_profile(client: EurdfZooClient) -> None:
+    eurdf = client.get_eurdf_profile("dexhands/inspire_hand/right")
+    assert eurdf.profile_id == "dexhands/inspire_hand/right"
+    assert eurdf.safety.get("safety_level") == "STRICT"
+    assert "all" in eurdf.capability_hints
+
+
+def test_client_pull_and_load_from_cache(client: EurdfZooClient) -> None:
+    cached = client.pull("dexhands/inspire_hand/right")
+    assert cached.exists()
+    assert (cached / "manifest.yaml").exists()
+
+    asset = client.load("dexhands/inspire_hand/right")
+    assert asset.is_manifest
+    assert "Inspire" in asset.name
+
+
+def test_client_cache_list(client: EurdfZooClient) -> None:
+    client.pull("dexhands/inspire_hand/right")
+    entries = client.cache_list()
+    assert any(e["asset_id"] == "dexhands/inspire_hand/right" for e in entries)
+
+
+def test_client_validate(client: EurdfZooClient) -> None:
+    report = client.validate("dexhands/inspire_hand/right")
+    assert report["asset_id"] == "dexhands/inspire_hand/right"
+    assert report["overall"] != "FAIL"
+
+
+def test_client_missing_asset(client: EurdfZooClient) -> None:
+    with pytest.raises(EurdfZooClientError):
+        client.load("does/not/exist")


### PR DESCRIPTION
This PR wires the upgraded manifest-driven e-URDF-Zoo into ROSClaw and hardens safety for imported dexterous hands.

## What's included

- **EurdfZooClient** (`src/rosclaw/eurdf/zoo_client.py`) — resolves, pulls, caches, and converts manifest-driven assets to `EurdfProfile` / `RobotCompleteProfile`.
- **`rosclaw eurdf` CLI** — `search`, `info`, `validate`, `pull`, `cache list`.
- **`rosclaw body init --robot <asset_id>`** — auto-detects slash-containing zoo IDs.
- **Safety hardening for imported hands**:
  - Propagates `forbidden_capabilities` and `real_robot_execution_allowed` from the asset manifest into `body.yaml`.
  - Degrades gestures until calibration is validated.
  - Keeps manipulation capabilities simulation-only while real execution is blocked.
  - Disables critical forbidden capabilities (`fast_full_close`, `forceful_grasp_without_current_limit`).
  - Adds hand-specific answers to `rosclaw body query`.
  - Renders a real-robot-execution warning in `EMBODIMENT.md`.
- **Tests**: `tests/eurdf/test_zoo_client.py`, `tests/eurdf/test_eurdf_cli.py`, `tests/body/test_body_init_from_zoo.py`, `tests/body/test_dexhand_agent_safety.py`.
- **Docs**: `docs/body/EURDF_ZOO_INTEGRATION.md`, `docs/body/DEX_HAND_BODY_INIT.md`, `docs/help/e-urdf-zoo-dex-urdf-implementation-report.md`.

## Verification

```bash
pytest tests/eurdf tests/body -q
# 163 passed
```

🤖 Generated with [Claude Code](https://claude.com/code)