### PR TITLE
feat(body): expose RealSense D405/D435i/dual as builtin e-URDF profiles

### DIFF
--- a/src/rosclaw/body/cli.py
+++ b/src/rosclaw/body/cli.py
@@ -319,12 +319,15 @@ def dispatch_body_command(args: argparse.Namespace) -> int:
 
 
 def _resolve_profile_alias(profile_id: str) -> str:
-    """Map common user-facing profile IDs to zoo directory names."""
+    """Map common user-facing profile IDs to registry names."""
     aliases = {
         "unitree-g1": "g1",
         "unitree-go2": "unitree_go2",
         "franka-panda": "franka_panda",
         "fetch": "fetch_robot",
+        "realsense-d405": "realsense_d405",
+        "realsense-d435i": "realsense_d435i",
+        "realsense-dual": "realsense_dual",
     }
     return aliases.get(profile_id, profile_id)
 

--- a/src/rosclaw/body/registry.py
+++ b/src/rosclaw/body/registry.py
@@ -308,12 +308,15 @@ class BodyRegistryManager:
 
         return entry
 
-    # Common user-facing profile IDs → zoo directory names.
+    # Common user-facing profile IDs → registry names.
     _PROFILE_ALIASES: dict[str, str] = {
         "unitree-g1": "g1",
         "unitree-go2": "unitree_go2",
         "franka-panda": "franka_panda",
         "fetch": "fetch_robot",
+        "realsense-d405": "realsense_d405",
+        "realsense-d435i": "realsense_d435i",
+        "realsense-dual": "realsense_dual",
     }
 
     def _resolve_profile_alias(self, profile_id: str) -> str:

--- a/src/rosclaw/body/service.py
+++ b/src/rosclaw/body/service.py
@@ -51,12 +51,15 @@ class BodyCreateResult:
 
 
 def _resolve_profile_alias(profile_id: str) -> str:
-    """Map common user-facing profile IDs to zoo directory names."""
+    """Map common user-facing profile IDs to registry names."""
     aliases = {
         "unitree-g1": "g1",
         "unitree-go2": "unitree_go2",
         "franka-panda": "franka_panda",
         "fetch": "fetch_robot",
+        "realsense-d405": "realsense_d405",
+        "realsense-d435i": "realsense_d435i",
+        "realsense-dual": "realsense_dual",
     }
     return aliases.get(profile_id, profile_id)
 

--- a/src/rosclaw/eurdf_zoo/profiles/__init__.py
+++ b/src/rosclaw/eurdf_zoo/profiles/__init__.py
@@ -2,10 +2,16 @@
 
 from rosclaw.eurdf_zoo.profiles.fetch_robot import FETCH_ROBOT_PROFILE
 from rosclaw.eurdf_zoo.profiles.franka_panda import FRANKA_PANDA_PROFILE
+from rosclaw.eurdf_zoo.profiles.realsense_d405 import REALSENSE_D405_PROFILE
+from rosclaw.eurdf_zoo.profiles.realsense_d435i import REALSENSE_D435I_PROFILE
+from rosclaw.eurdf_zoo.profiles.realsense_dual import REALSENSE_DUAL_PROFILE
 from rosclaw.eurdf_zoo.profiles.unitree_go2 import UNITREE_GO2_PROFILE
 
 __all__ = [
     "FRANKA_PANDA_PROFILE",
     "UNITREE_GO2_PROFILE",
     "FETCH_ROBOT_PROFILE",
+    "REALSENSE_D405_PROFILE",
+    "REALSENSE_D435I_PROFILE",
+    "REALSENSE_DUAL_PROFILE",
 ]

--- a/src/rosclaw/eurdf_zoo/profiles/realsense_d405.py
+++ b/src/rosclaw/eurdf_zoo/profiles/realsense_d405.py
@@ -1,0 +1,152 @@
+"""Intel RealSense D405 — sensor robot profile.
+
+Short-range RGB-D camera imported from realsense-ros.
+"""
+
+from rosclaw.runtime.eurdf_loader import (
+    RobotBenchmarkProfile,
+    RobotCapabilityProfile,
+    RobotCompleteProfile,
+    RobotEmbodimentProfile,
+    RobotSafetyProfile,
+    RobotSemanticProfile,
+    RobotSimulationProfile,
+)
+
+EMBODIMENT = RobotEmbodimentProfile(
+    robot_id="realsense_d405",
+    name="Intel RealSense D405",
+    vendor="Intel RealSense",
+    version="1.0",
+    description="Short-range RGB-D camera with nominal extrinsics from realsense-ros.",
+    dof=0,
+    links=[
+        {"name": "realsense_d405_mount", "type": "base", "mass": 0.0},
+        {"name": "camera_bottom_screw_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_link", "type": "link", "mass": 0.05},
+        {"name": "camera_depth_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_depth_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "camera_infra1_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_infra1_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "camera_infra2_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_infra2_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "camera_color_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_color_optical_frame", "type": "optical_frame", "mass": 0.0},
+    ],
+    joints=[
+        {"name": "camera_joint", "type": "fixed", "parent": "realsense_d405_mount", "child": "camera_bottom_screw_frame"},
+        {"name": "camera_link_joint", "type": "fixed", "parent": "camera_bottom_screw_frame", "child": "camera_link"},
+        {"name": "camera_depth_joint", "type": "fixed", "parent": "camera_link", "child": "camera_depth_frame"},
+        {"name": "camera_depth_optical_joint", "type": "fixed", "parent": "camera_depth_frame", "child": "camera_depth_optical_frame"},
+        {"name": "camera_infra1_joint", "type": "fixed", "parent": "camera_link", "child": "camera_infra1_frame"},
+        {"name": "camera_infra1_optical_joint", "type": "fixed", "parent": "camera_infra1_frame", "child": "camera_infra1_optical_frame"},
+        {"name": "camera_infra2_joint", "type": "fixed", "parent": "camera_link", "child": "camera_infra2_frame"},
+        {"name": "camera_infra2_optical_joint", "type": "fixed", "parent": "camera_infra2_frame", "child": "camera_infra2_optical_frame"},
+        {"name": "camera_color_joint", "type": "fixed", "parent": "camera_link", "child": "camera_color_frame"},
+        {"name": "camera_color_optical_joint", "type": "fixed", "parent": "camera_color_frame", "child": "camera_color_optical_frame"},
+    ],
+    sensors=[
+        {"name": "color_camera", "type": "camera", "parent_link": "camera_color_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30},
+        {"name": "depth_camera", "type": "depth_camera", "parent_link": "camera_depth_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30, "min_range": 0.05, "max_range": 6.0},
+        {"name": "infrared_left", "type": "camera", "parent_link": "camera_infra1_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30},
+        {"name": "infrared_right", "type": "camera", "parent_link": "camera_infra2_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30},
+    ],
+    actuators=[],
+    metadata={
+        "category": "rgbd_camera",
+        "urdf_version": "1.0",
+        "ros2_package": "realsense2_description",
+        "asset_id": "sensors/realsense/d405/default",
+    },
+)
+
+SAFETY = RobotSafetyProfile(
+    robot_id="realsense_d405",
+    safety_level="STRICT",
+    safety_limits={
+        "perception_only": True,
+        "depth_for_safety_requires_calibration": True,
+        "visual_servo_requires_hand_eye_calibration": True,
+    },
+    joint_soft_limits={},
+    pfl={"enabled": False},
+    collision_detection={"method": "none"},
+    emergency_stop={"enabled": False},
+    workspace_boundaries={"type": "bounding_box", "center": [0, 0, 0], "dimensions": [0.1, 0.1, 0.1]},
+    interaction={"hand_guiding": False, "human_collaboration": False},
+    environment={"real_robot_execution_allowed": False, "sandbox_required": True},
+)
+
+CAPABILITY = RobotCapabilityProfile(
+    robot_id="realsense_d405",
+    capabilities=[
+        {"id": "rgb_observation", "name": "rgb_observation", "category": "perception", "skill_type": "programmed", "risk": "low"},
+        {"id": "depth_observation", "name": "depth_observation", "category": "perception", "skill_type": "programmed", "risk": "medium", "calibration_required": True},
+        {"id": "infrared_observation", "name": "infrared_observation", "category": "perception", "skill_type": "programmed", "risk": "medium"},
+        {"id": "rgbd_scene_understanding", "name": "rgbd_scene_understanding", "category": "perception", "skill_type": "composed", "risk": "medium", "calibration_required": True},
+    ],
+    skill_registry={
+        "forbidden_capabilities": [
+            {"id": "depth_collision_avoidance_without_calibration", "reason": "uncalibrated depth safety risk", "severity": "critical"},
+            {"id": "visual_servo_without_hand_eye_calibration", "reason": "unverified camera-to-end-effector transform", "severity": "critical"},
+        ],
+    },
+    precondition_checks={
+        "camera_info_available": {"check": "camera_info topic publishing", "description": "Camera intrinsics must be available"},
+        "tf_available": {"check": "camera frame in tf tree", "description": "Camera extrinsics must be resolved"},
+    },
+)
+
+SIMULATION = RobotSimulationProfile(
+    robot_id="realsense_d405",
+    backends={
+        "mujoco": {"model_file": "model/model_mujoco.urdf", "status": "experimental"},
+        "ros2": {"model_file": "model/model.urdf", "status": "validated"},
+        "rviz": {"model_file": "model/model.urdf", "status": "validated"},
+    },
+)
+
+SEMANTIC = RobotSemanticProfile(
+    robot_id="realsense_d405",
+    semantic_version="1.0",
+    functional_regions=[
+        {"name": "mount", "link": "realsense_d405_mount", "tags": ["mount", "base", "attachment"], "description": "Mechanical mount to robot body", "affordances": ["attach"]},
+        {"name": "camera_body", "link": "camera_link", "tags": ["camera_body", "sensor_housing"], "description": "Main camera housing"},
+        {"name": "color_optical", "link": "camera_color_optical_frame", "tags": ["color_sensor", "optical_frame"], "description": "Color image optical center"},
+        {"name": "depth_optical", "link": "camera_depth_optical_frame", "tags": ["depth_sensor", "optical_frame"], "description": "Depth image optical center"},
+    ],
+    grasp_points=[],
+    visual_features=[
+        {"name": "camera_housing", "type": "rectangular_sensor", "links": ["camera_link"], "visual_cues": ["black_rectangular_housing"], "llm_description": "Small rectangular RGB-D camera housing"},
+        {"name": "lens_assembly", "type": "lens_cluster", "links": ["camera_color_frame", "camera_depth_frame"], "visual_cues": ["lenses", "infrared_projector"], "llm_description": "Cluster of color/depth lenses on the camera face"},
+    ],
+    task_descriptions={
+        "rgb_observation": {"relevant_links": ["camera_color_optical_frame"], "description": "Capture color images"},
+        "depth_observation": {"relevant_links": ["camera_depth_optical_frame"], "description": "Capture depth images", "safety": "Requires calibration for metric use"},
+    },
+    semantic_tags=["rgbd_camera", "depth_camera", "sensor", "perception", "intel_realsense", "experimental"],
+)
+
+BENCHMARK = RobotBenchmarkProfile(
+    robot_id="realsense_d405",
+    kinematic_benchmarks=[],
+    dynamic_benchmarks=[],
+    simulation_benchmarks={},
+    task_benchmarks=[],
+    safety_benchmarks=[],
+    baseline_hardware={},
+)
+
+REALSENSE_D405_PROFILE = RobotCompleteProfile(
+    robot_id="realsense_d405",
+    name="Intel RealSense D405",
+    vendor="Intel RealSense",
+    version="1.0",
+    description="Short-range RGB-D camera with nominal extrinsics from realsense-ros.",
+    embodiment=EMBODIMENT,
+    safety=SAFETY,
+    capability=CAPABILITY,
+    simulation=SIMULATION,
+    semantic=SEMANTIC,
+    benchmark=BENCHMARK,
+)

--- a/src/rosclaw/eurdf_zoo/profiles/realsense_d435i.py
+++ b/src/rosclaw/eurdf_zoo/profiles/realsense_d435i.py
@@ -1,0 +1,164 @@
+"""Intel RealSense D435i — sensor robot profile.
+
+RGB-D camera with integrated IMU imported from realsense-ros.
+"""
+
+from rosclaw.runtime.eurdf_loader import (
+    RobotBenchmarkProfile,
+    RobotCapabilityProfile,
+    RobotCompleteProfile,
+    RobotEmbodimentProfile,
+    RobotSafetyProfile,
+    RobotSemanticProfile,
+    RobotSimulationProfile,
+)
+
+EMBODIMENT = RobotEmbodimentProfile(
+    robot_id="realsense_d435i",
+    name="Intel RealSense D435i",
+    vendor="Intel RealSense",
+    version="1.0",
+    description="RGB-D camera with integrated IMU, imported from realsense-ros.",
+    dof=0,
+    links=[
+        {"name": "realsense_d435i_mount", "type": "base", "mass": 0.0},
+        {"name": "camera_bottom_screw_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_link", "type": "link", "mass": 0.05},
+        {"name": "camera_depth_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_depth_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "camera_infra1_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_infra1_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "camera_infra2_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_infra2_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "camera_color_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_color_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "camera_accel_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_accel_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "camera_gyro_frame", "type": "link", "mass": 0.0},
+        {"name": "camera_gyro_optical_frame", "type": "optical_frame", "mass": 0.0},
+    ],
+    joints=[
+        {"name": "camera_joint", "type": "fixed", "parent": "realsense_d435i_mount", "child": "camera_bottom_screw_frame"},
+        {"name": "camera_link_joint", "type": "fixed", "parent": "camera_bottom_screw_frame", "child": "camera_link"},
+        {"name": "camera_depth_joint", "type": "fixed", "parent": "camera_link", "child": "camera_depth_frame"},
+        {"name": "camera_depth_optical_joint", "type": "fixed", "parent": "camera_depth_frame", "child": "camera_depth_optical_frame"},
+        {"name": "camera_infra1_joint", "type": "fixed", "parent": "camera_link", "child": "camera_infra1_frame"},
+        {"name": "camera_infra1_optical_joint", "type": "fixed", "parent": "camera_infra1_frame", "child": "camera_infra1_optical_frame"},
+        {"name": "camera_infra2_joint", "type": "fixed", "parent": "camera_link", "child": "camera_infra2_frame"},
+        {"name": "camera_infra2_optical_joint", "type": "fixed", "parent": "camera_infra2_frame", "child": "camera_infra2_optical_frame"},
+        {"name": "camera_color_joint", "type": "fixed", "parent": "camera_link", "child": "camera_color_frame"},
+        {"name": "camera_color_optical_joint", "type": "fixed", "parent": "camera_color_frame", "child": "camera_color_optical_frame"},
+        {"name": "camera_accel_joint", "type": "fixed", "parent": "camera_link", "child": "camera_accel_frame"},
+        {"name": "camera_accel_optical_joint", "type": "fixed", "parent": "camera_accel_frame", "child": "camera_accel_optical_frame"},
+        {"name": "camera_gyro_joint", "type": "fixed", "parent": "camera_link", "child": "camera_gyro_frame"},
+        {"name": "camera_gyro_optical_joint", "type": "fixed", "parent": "camera_gyro_frame", "child": "camera_gyro_optical_frame"},
+    ],
+    sensors=[
+        {"name": "color_camera", "type": "camera", "parent_link": "camera_color_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30},
+        {"name": "depth_camera", "type": "depth_camera", "parent_link": "camera_depth_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30, "min_range": 0.1, "max_range": 10.0},
+        {"name": "infrared_left", "type": "camera", "parent_link": "camera_infra1_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30},
+        {"name": "infrared_right", "type": "camera", "parent_link": "camera_infra2_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30},
+        {"name": "imu", "type": "imu", "parent_link": "camera_link", "noise_std": {"accel": 0.01, "gyro": 0.001}},
+    ],
+    actuators=[],
+    metadata={
+        "category": "rgbd_camera",
+        "urdf_version": "1.0",
+        "ros2_package": "realsense2_description",
+        "asset_id": "sensors/realsense/d435i/default",
+    },
+)
+
+SAFETY = RobotSafetyProfile(
+    robot_id="realsense_d435i",
+    safety_level="STRICT",
+    safety_limits={
+        "perception_only": True,
+        "depth_for_safety_requires_calibration": True,
+        "visual_servo_requires_hand_eye_calibration": True,
+    },
+    joint_soft_limits={},
+    pfl={"enabled": False},
+    collision_detection={"method": "none"},
+    emergency_stop={"enabled": False},
+    workspace_boundaries={"type": "bounding_box", "center": [0, 0, 0], "dimensions": [0.1, 0.1, 0.1]},
+    interaction={"hand_guiding": False, "human_collaboration": False},
+    environment={"real_robot_execution_allowed": False, "sandbox_required": True},
+)
+
+CAPABILITY = RobotCapabilityProfile(
+    robot_id="realsense_d435i",
+    capabilities=[
+        {"id": "rgb_observation", "name": "rgb_observation", "category": "perception", "skill_type": "programmed", "risk": "low"},
+        {"id": "depth_observation", "name": "depth_observation", "category": "perception", "skill_type": "programmed", "risk": "medium", "calibration_required": True},
+        {"id": "infrared_observation", "name": "infrared_observation", "category": "perception", "skill_type": "programmed", "risk": "medium"},
+        {"id": "rgbd_scene_understanding", "name": "rgbd_scene_understanding", "category": "perception", "skill_type": "composed", "risk": "medium", "calibration_required": True},
+        {"id": "imu_observation", "name": "imu_observation", "category": "perception", "skill_type": "programmed", "risk": "low"},
+    ],
+    skill_registry={
+        "forbidden_capabilities": [
+            {"id": "depth_collision_avoidance_without_calibration", "reason": "uncalibrated depth safety risk", "severity": "critical"},
+            {"id": "visual_servo_without_hand_eye_calibration", "reason": "unverified camera-to-end-effector transform", "severity": "critical"},
+        ],
+    },
+    precondition_checks={
+        "camera_info_available": {"check": "camera_info topic publishing", "description": "Camera intrinsics must be available"},
+        "tf_available": {"check": "camera frame in tf tree", "description": "Camera extrinsics must be resolved"},
+    },
+)
+
+SIMULATION = RobotSimulationProfile(
+    robot_id="realsense_d435i",
+    backends={
+        "mujoco": {"model_file": "model/model_mujoco.urdf", "status": "experimental"},
+        "ros2": {"model_file": "model/model.urdf", "status": "validated"},
+        "rviz": {"model_file": "model/model.urdf", "status": "validated"},
+    },
+)
+
+SEMANTIC = RobotSemanticProfile(
+    robot_id="realsense_d435i",
+    semantic_version="1.0",
+    functional_regions=[
+        {"name": "mount", "link": "realsense_d435i_mount", "tags": ["mount", "base", "attachment"], "description": "Mechanical mount to robot body", "affordances": ["attach"]},
+        {"name": "camera_body", "link": "camera_link", "tags": ["camera_body", "sensor_housing"], "description": "Main camera housing with integrated IMU"},
+        {"name": "color_optical", "link": "camera_color_optical_frame", "tags": ["color_sensor", "optical_frame"], "description": "Color image optical center"},
+        {"name": "depth_optical", "link": "camera_depth_optical_frame", "tags": ["depth_sensor", "optical_frame"], "description": "Depth image optical center"},
+        {"name": "imu", "link": "camera_accel_frame", "tags": ["imu", "accelerometer", "gyroscope"], "description": "Integrated IMU frame"},
+    ],
+    grasp_points=[],
+    visual_features=[
+        {"name": "camera_housing", "type": "rectangular_sensor", "links": ["camera_link"], "visual_cues": ["black_rectangular_housing"], "llm_description": "Small rectangular RGB-D camera housing with IMU"},
+        {"name": "lens_assembly", "type": "lens_cluster", "links": ["camera_color_frame", "camera_depth_frame"], "visual_cues": ["lenses", "infrared_projector"], "llm_description": "Cluster of color/depth lenses on the camera face"},
+    ],
+    task_descriptions={
+        "rgb_observation": {"relevant_links": ["camera_color_optical_frame"], "description": "Capture color images"},
+        "depth_observation": {"relevant_links": ["camera_depth_optical_frame"], "description": "Capture depth images", "safety": "Requires calibration for metric use"},
+        "imu_observation": {"relevant_links": ["camera_accel_frame", "camera_gyro_frame"], "description": "Capture accelerometer/gyro data"},
+    },
+    semantic_tags=["rgbd_camera", "depth_camera", "sensor", "perception", "intel_realsense", "imu", "experimental"],
+)
+
+BENCHMARK = RobotBenchmarkProfile(
+    robot_id="realsense_d435i",
+    kinematic_benchmarks=[],
+    dynamic_benchmarks=[],
+    simulation_benchmarks={},
+    task_benchmarks=[],
+    safety_benchmarks=[],
+    baseline_hardware={},
+)
+
+REALSENSE_D435I_PROFILE = RobotCompleteProfile(
+    robot_id="realsense_d435i",
+    name="Intel RealSense D435i",
+    vendor="Intel RealSense",
+    version="1.0",
+    description="RGB-D camera with integrated IMU, imported from realsense-ros.",
+    embodiment=EMBODIMENT,
+    safety=SAFETY,
+    capability=CAPABILITY,
+    simulation=SIMULATION,
+    semantic=SEMANTIC,
+    benchmark=BENCHMARK,
+)

--- a/src/rosclaw/eurdf_zoo/profiles/realsense_dual.py
+++ b/src/rosclaw/eurdf_zoo/profiles/realsense_dual.py
@@ -1,0 +1,159 @@
+"""Dual RealSense sensor robot profile.
+
+Example composite body with a head-mounted D405 and a wrist-mounted D435i.
+This is a perception-only configuration with no actuators.
+"""
+
+from rosclaw.runtime.eurdf_loader import (
+    RobotBenchmarkProfile,
+    RobotCapabilityProfile,
+    RobotCompleteProfile,
+    RobotEmbodimentProfile,
+    RobotSafetyProfile,
+    RobotSemanticProfile,
+    RobotSimulationProfile,
+)
+
+EMBODIMENT = RobotEmbodimentProfile(
+    robot_id="realsense_dual",
+    name="Dual RealSense D405 + D435i",
+    vendor="Intel RealSense",
+    version="1.0",
+    description="Composite perception body with head RGB-D (D405) and wrist RGB-D+IMU (D435i).",
+    dof=0,
+    links=[
+        {"name": "base_link", "type": "base", "mass": 0.0},
+        {"name": "head_mount", "type": "link", "mass": 0.0},
+        {"name": "head_realsense_d405_mount", "type": "link", "mass": 0.0},
+        {"name": "head_camera_link", "type": "link", "mass": 0.05},
+        {"name": "head_camera_depth_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "head_camera_color_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "wrist_mount", "type": "link", "mass": 0.0},
+        {"name": "wrist_realsense_d435i_mount", "type": "link", "mass": 0.0},
+        {"name": "wrist_camera_link", "type": "link", "mass": 0.05},
+        {"name": "wrist_camera_depth_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "wrist_camera_color_optical_frame", "type": "optical_frame", "mass": 0.0},
+        {"name": "wrist_camera_accel_frame", "type": "link", "mass": 0.0},
+        {"name": "wrist_camera_gyro_frame", "type": "link", "mass": 0.0},
+    ],
+    joints=[
+        {"name": "head_mount_joint", "type": "fixed", "parent": "base_link", "child": "head_mount"},
+        {"name": "head_camera_joint", "type": "fixed", "parent": "head_mount", "child": "head_realsense_d405_mount"},
+        {"name": "head_camera_optical_joint", "type": "fixed", "parent": "head_realsense_d405_mount", "child": "head_camera_link"},
+        {"name": "head_depth_optical_joint", "type": "fixed", "parent": "head_camera_link", "child": "head_camera_depth_optical_frame"},
+        {"name": "head_color_optical_joint", "type": "fixed", "parent": "head_camera_link", "child": "head_camera_color_optical_frame"},
+        {"name": "wrist_mount_joint", "type": "fixed", "parent": "base_link", "child": "wrist_mount"},
+        {"name": "wrist_camera_joint", "type": "fixed", "parent": "wrist_mount", "child": "wrist_realsense_d435i_mount"},
+        {"name": "wrist_camera_optical_joint", "type": "fixed", "parent": "wrist_realsense_d435i_mount", "child": "wrist_camera_link"},
+        {"name": "wrist_depth_optical_joint", "type": "fixed", "parent": "wrist_camera_link", "child": "wrist_camera_depth_optical_frame"},
+        {"name": "wrist_color_optical_joint", "type": "fixed", "parent": "wrist_camera_link", "child": "wrist_camera_color_optical_frame"},
+        {"name": "wrist_accel_joint", "type": "fixed", "parent": "wrist_camera_link", "child": "wrist_camera_accel_frame"},
+        {"name": "wrist_gyro_joint", "type": "fixed", "parent": "wrist_camera_link", "child": "wrist_camera_gyro_frame"},
+    ],
+    sensors=[
+        {"name": "head_color_camera", "type": "camera", "parent_link": "head_camera_color_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30},
+        {"name": "head_depth_camera", "type": "depth_camera", "parent_link": "head_camera_depth_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30, "min_range": 0.05, "max_range": 6.0},
+        {"name": "wrist_color_camera", "type": "camera", "parent_link": "wrist_camera_color_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30},
+        {"name": "wrist_depth_camera", "type": "depth_camera", "parent_link": "wrist_camera_depth_optical_frame", "resolution": [1280, 720], "fov": 90.0, "fps": 30, "min_range": 0.1, "max_range": 10.0},
+        {"name": "wrist_imu", "type": "imu", "parent_link": "wrist_camera_link", "noise_std": {"accel": 0.01, "gyro": 0.001}},
+    ],
+    actuators=[],
+    metadata={
+        "category": "rgbd_camera",
+        "urdf_version": "1.0",
+        "ros2_package": "realsense2_description",
+        "composition": ["sensors/realsense/d405/default", "sensors/realsense/d435i/default"],
+    },
+)
+
+SAFETY = RobotSafetyProfile(
+    robot_id="realsense_dual",
+    safety_level="STRICT",
+    safety_limits={
+        "perception_only": True,
+        "depth_for_safety_requires_calibration": True,
+        "visual_servo_requires_hand_eye_calibration": True,
+    },
+    joint_soft_limits={},
+    pfl={"enabled": False},
+    collision_detection={"method": "none"},
+    emergency_stop={"enabled": False},
+    workspace_boundaries={"type": "bounding_box", "center": [0, 0, 0], "dimensions": [0.5, 0.5, 0.5]},
+    interaction={"hand_guiding": False, "human_collaboration": False},
+    environment={"real_robot_execution_allowed": False, "sandbox_required": True},
+)
+
+CAPABILITY = RobotCapabilityProfile(
+    robot_id="realsense_dual",
+    capabilities=[
+        {"id": "head_rgb_observation", "name": "head_rgb_observation", "category": "perception", "skill_type": "programmed", "risk": "low"},
+        {"id": "head_depth_observation", "name": "head_depth_observation", "category": "perception", "skill_type": "programmed", "risk": "medium", "calibration_required": True},
+        {"id": "wrist_rgb_observation", "name": "wrist_rgb_observation", "category": "perception", "skill_type": "programmed", "risk": "low"},
+        {"id": "wrist_depth_observation", "name": "wrist_depth_observation", "category": "perception", "skill_type": "programmed", "risk": "medium", "calibration_required": True},
+        {"id": "wrist_imu_observation", "name": "wrist_imu_observation", "category": "perception", "skill_type": "programmed", "risk": "low"},
+        {"id": "hand_eye_visual_servo", "name": "hand_eye_visual_servo", "category": "manipulation", "skill_type": "composed", "risk": "high", "calibration_required": True, "sandbox_required": True},
+    ],
+    skill_registry={
+        "forbidden_capabilities": [
+            {"id": "depth_collision_avoidance_without_calibration", "reason": "uncalibrated depth safety risk", "severity": "critical"},
+            {"id": "visual_servo_without_hand_eye_calibration", "reason": "unverified camera-to-end-effector transform", "severity": "critical"},
+        ],
+    },
+    precondition_checks={
+        "camera_info_available": {"check": "camera_info topics publishing", "description": "Camera intrinsics must be available"},
+        "tf_available": {"check": "camera frames in tf tree", "description": "Camera extrinsics must be resolved"},
+    },
+)
+
+SIMULATION = RobotSimulationProfile(
+    robot_id="realsense_dual",
+    backends={
+        "mujoco": {"model_file": "model/model_mujoco.urdf", "status": "experimental"},
+        "ros2": {"model_file": "model/model.urdf", "status": "validated"},
+        "rviz": {"model_file": "model/model.urdf", "status": "validated"},
+    },
+)
+
+SEMANTIC = RobotSemanticProfile(
+    robot_id="realsense_dual",
+    semantic_version="1.0",
+    functional_regions=[
+        {"name": "base", "link": "base_link", "tags": ["base", "foundation"], "description": "Common reference frame", "affordances": ["attach"]},
+        {"name": "head_camera", "link": "head_camera_link", "tags": ["head", "rgbd_camera"], "description": "Head-mounted short-range RGB-D camera"},
+        {"name": "wrist_camera", "link": "wrist_camera_link", "tags": ["wrist", "rgbd_camera", "imu"], "description": "Wrist-mounted RGB-D camera with IMU"},
+    ],
+    grasp_points=[],
+    visual_features=[
+        {"name": "head_sensor", "type": "rectangular_sensor", "links": ["head_camera_link"], "visual_cues": ["black_rectangular_housing"], "llm_description": "Head-mounted RealSense D405"},
+        {"name": "wrist_sensor", "type": "rectangular_sensor", "links": ["wrist_camera_link"], "visual_cues": ["black_rectangular_housing"], "llm_description": "Wrist-mounted RealSense D435i with IMU"},
+    ],
+    task_descriptions={
+        "head_rgb_observation": {"relevant_links": ["head_camera_color_optical_frame"], "description": "Capture head color images"},
+        "wrist_depth_observation": {"relevant_links": ["wrist_camera_depth_optical_frame"], "description": "Capture wrist depth images", "safety": "Requires hand-eye calibration"},
+    },
+    semantic_tags=["rgbd_camera", "depth_camera", "sensor", "perception", "intel_realsense", "dual_camera", "hand_eye", "experimental"],
+)
+
+BENCHMARK = RobotBenchmarkProfile(
+    robot_id="realsense_dual",
+    kinematic_benchmarks=[],
+    dynamic_benchmarks=[],
+    simulation_benchmarks={},
+    task_benchmarks=[],
+    safety_benchmarks=[],
+    baseline_hardware={},
+)
+
+REALSENSE_DUAL_PROFILE = RobotCompleteProfile(
+    robot_id="realsense_dual",
+    name="Dual RealSense D405 + D435i",
+    vendor="Intel RealSense",
+    version="1.0",
+    description="Composite perception body with head RGB-D (D405) and wrist RGB-D+IMU (D435i).",
+    embodiment=EMBODIMENT,
+    safety=SAFETY,
+    capability=CAPABILITY,
+    simulation=SIMULATION,
+    semantic=SEMANTIC,
+    benchmark=BENCHMARK,
+)

--- a/src/rosclaw/runtime/eurdf_loader.py
+++ b/src/rosclaw/runtime/eurdf_loader.py
@@ -412,17 +412,73 @@ class EURDFLoader:
 # ── Registry ──
 
 class RobotRegistry:
-    """In-memory registry of loaded robot profiles."""
+    """In-memory registry of loaded robot profiles.
+
+    Falls back to builtin Python profile modules when a profile is not found in
+    the e-URDF-Zoo directory layout.
+    """
 
     def __init__(self, loader: EURDFLoader | None = None):
         self.loader = loader or EURDFLoader()
         self._profiles: dict[str, RobotCompleteProfile] = {}
 
+    @staticmethod
+    def _profile_aliases() -> dict[str, str]:
+        """User-facing aliases -> canonical registry IDs."""
+        return {
+            "unitree-g1": "g1",
+            "unitree-go2": "unitree_go2",
+            "franka-panda": "franka_panda",
+            "fetch": "fetch_robot",
+            "realsense-d405": "realsense_d405",
+            "realsense-d435i": "realsense_d435i",
+            "realsense-dual": "realsense_dual",
+        }
+
+    @classmethod
+    def _canonical_id(cls, robot_id: str) -> str:
+        """Resolve a user-facing alias to the canonical registry ID."""
+        normalized = robot_id.strip().lower()
+        return cls._profile_aliases().get(normalized, normalized)
+
+    @staticmethod
+    def _builtin_profiles() -> dict[str, RobotCompleteProfile]:
+        """Discover profile constants exported by ``rosclaw.eurdf_zoo.profiles``."""
+        try:
+            from rosclaw.eurdf_zoo import profiles as profile_modules
+        except Exception:  # pragma: no cover - optional fallback
+            return {}
+
+        builtins: dict[str, RobotCompleteProfile] = {}
+        for attr_name in getattr(profile_modules, "__all__", []):
+            if not attr_name.endswith("_PROFILE"):
+                continue
+            try:
+                profile = getattr(profile_modules, attr_name)
+            except AttributeError:
+                continue
+            if isinstance(profile, RobotCompleteProfile):
+                builtins[profile.robot_id] = profile
+                # Also register under the module-level alias name for convenience.
+                builtins[attr_name[:-8].lower()] = profile
+        return builtins
+
     def install(self, robot_id: str) -> RobotCompleteProfile:
         """Load and register a robot profile."""
-        profile = self.loader.load(robot_id)
-        # Store under both the directory name and the canonical robot_id
+        canonical = self._canonical_id(robot_id)
+
+        # Try directory-based e-URDF first.
+        try:
+            profile = self.loader.load(canonical)
+        except FileNotFoundError:
+            builtins = self._builtin_profiles()
+            profile = builtins.get(canonical)
+            if profile is None:
+                raise FileNotFoundError(f"Robot '{robot_id}' not found")
+
+        # Store under both the requested name and the canonical robot_id.
         self._profiles[robot_id] = profile
+        self._profiles[canonical] = profile
         self._profiles[profile.robot_id] = profile
         return profile
 
@@ -440,8 +496,16 @@ class RobotRegistry:
         return list(self._profiles.keys())
 
     def list_available(self) -> list[str]:
-        """List all available robots in the zoo."""
-        return self.loader.list_robots()
+        """List all available robots in the zoo and builtin Python profiles."""
+        available: set[str] = set(self.loader.list_robots())
+        builtins = self._builtin_profiles()
+        available.update(builtins.keys())
+        # Also expose user-facing aliases.
+        aliases = self._profile_aliases()
+        for alias, canonical in aliases.items():
+            if canonical in available:
+                available.add(alias)
+        return sorted(available)
 
     def validate(self, robot_id: str) -> dict:
         """Validate a robot's e-URDF."""

--- a/tests/integration/test_realsense_profiles.py
+++ b/tests/integration/test_realsense_profiles.py
@@ -1,0 +1,207 @@
+"""Tests for RealSense D400-series sensor profiles.
+
+Covers the three builtin Python profiles:
+- realsense_d405
+- realsense_d435i
+- realsense_dual
+"""
+
+from rosclaw.eurdf_zoo.profiles import (
+    REALSENSE_D405_PROFILE,
+    REALSENSE_D435I_PROFILE,
+    REALSENSE_DUAL_PROFILE,
+)
+from rosclaw.runtime import (
+    RobotBenchmarkProfile,
+    RobotCapabilityProfile,
+    RobotEmbodimentProfile,
+    RobotRegistry,
+    RobotSafetyProfile,
+    RobotSemanticProfile,
+    RobotSimulationProfile,
+)
+
+
+class TestRealSenseD405:
+    """Test Intel RealSense D405 profile."""
+
+    def test_registry_lists_d405(self):
+        reg = RobotRegistry()
+        available = reg.list_available()
+        assert "realsense_d405" in available
+        assert "realsense-d405" in available
+
+    def test_load_complete_profile(self):
+        reg = RobotRegistry()
+        profile = reg.get("realsense-d405")
+        assert profile is not None
+        assert profile.robot_id == "realsense_d405"
+        assert profile.name == "Intel RealSense D405"
+        assert profile.vendor == "Intel RealSense"
+        assert profile.version == "1.0"
+        assert profile.embodiment.dof == 0
+
+    def test_embodiment_profile(self):
+        profile = REALSENSE_D405_PROFILE
+        emb = profile.embodiment
+        assert isinstance(emb, RobotEmbodimentProfile)
+        assert len(emb.links) == 11
+        assert len(emb.joints) == 10
+        assert len(emb.sensors) == 4
+        assert len(emb.actuators) == 0
+        sensor_types = {s["type"] for s in emb.sensors}
+        assert sensor_types == {"camera", "depth_camera"}
+
+    def test_safety_profile(self):
+        profile = REALSENSE_D405_PROFILE
+        safety = profile.safety
+        assert isinstance(safety, RobotSafetyProfile)
+        assert safety.safety_level == "STRICT"
+        assert safety.safety_limits.get("perception_only") is True
+        assert safety.environment.get("real_robot_execution_allowed") is False
+        assert safety.environment.get("sandbox_required") is True
+
+    def test_capability_profile(self):
+        profile = REALSENSE_D405_PROFILE
+        cap = profile.capability
+        assert isinstance(cap, RobotCapabilityProfile)
+        assert len(cap.capabilities) == 4
+        cap_names = {c["name"] for c in cap.capabilities}
+        assert "rgb_observation" in cap_names
+        assert "depth_observation" in cap_names
+        forbidden = cap.skill_registry.get("forbidden_capabilities", [])
+        assert len(forbidden) == 2
+
+    def test_simulation_profile(self):
+        profile = REALSENSE_D405_PROFILE
+        sim = profile.simulation
+        assert isinstance(sim, RobotSimulationProfile)
+        assert "mujoco" in sim.backends
+        assert "ros2" in sim.backends
+        assert "rviz" in sim.backends
+
+    def test_semantic_profile(self):
+        profile = REALSENSE_D405_PROFILE
+        sem = profile.semantic
+        assert isinstance(sem, RobotSemanticProfile)
+        assert "rgbd_camera" in sem.semantic_tags
+        assert "depth_camera" in sem.semantic_tags
+        assert len(sem.functional_regions) == 4
+        assert len(sem.visual_features) == 2
+
+    def test_benchmark_profile(self):
+        profile = REALSENSE_D405_PROFILE
+        bench = profile.benchmark
+        assert isinstance(bench, RobotBenchmarkProfile)
+        assert bench.robot_id == "realsense_d405"
+
+
+class TestRealSenseD435i:
+    """Test Intel RealSense D435i profile."""
+
+    def test_registry_lists_d435i(self):
+        reg = RobotRegistry()
+        available = reg.list_available()
+        assert "realsense_d435i" in available
+        assert "realsense-d435i" in available
+
+    def test_load_complete_profile(self):
+        reg = RobotRegistry()
+        profile = reg.get("realsense-d435i")
+        assert profile is not None
+        assert profile.robot_id == "realsense_d435i"
+        assert profile.name == "Intel RealSense D435i"
+        assert profile.embodiment.dof == 0
+
+    def test_embodiment_profile(self):
+        profile = REALSENSE_D435I_PROFILE
+        emb = profile.embodiment
+        assert isinstance(emb, RobotEmbodimentProfile)
+        assert len(emb.links) == 15
+        assert len(emb.joints) == 14
+        assert len(emb.sensors) == 5
+        assert len(emb.actuators) == 0
+        sensor_types = {s["type"] for s in emb.sensors}
+        assert "imu" in sensor_types
+
+    def test_semantic_profile(self):
+        profile = REALSENSE_D435I_PROFILE
+        sem = profile.semantic
+        assert isinstance(sem, RobotSemanticProfile)
+        assert "imu" in sem.semantic_tags
+        assert len(sem.functional_regions) == 5
+
+    def test_safety_blocks_real_execution(self):
+        profile = REALSENSE_D435I_PROFILE
+        assert profile.safety.environment.get("real_robot_execution_allowed") is False
+
+
+class TestRealSenseDual:
+    """Test dual RealSense composite profile."""
+
+    def test_registry_lists_dual(self):
+        reg = RobotRegistry()
+        available = reg.list_available()
+        assert "realsense_dual" in available
+        assert "realsense-dual" in available
+
+    def test_load_complete_profile(self):
+        reg = RobotRegistry()
+        profile = reg.get("realsense-dual")
+        assert profile is not None
+        assert profile.robot_id == "realsense_dual"
+        assert profile.name == "Dual RealSense D405 + D435i"
+
+    def test_embodiment_profile(self):
+        profile = REALSENSE_DUAL_PROFILE
+        emb = profile.embodiment
+        assert isinstance(emb, RobotEmbodimentProfile)
+        assert len(emb.links) == 13
+        assert len(emb.joints) == 12
+        assert len(emb.sensors) == 5
+        assert len(emb.actuators) == 0
+        sensor_names = {s["name"] for s in emb.sensors}
+        assert "head_color_camera" in sensor_names
+        assert "wrist_imu" in sensor_names
+
+    def test_semantic_profile(self):
+        profile = REALSENSE_DUAL_PROFILE
+        sem = profile.semantic
+        assert isinstance(sem, RobotSemanticProfile)
+        assert "dual_camera" in sem.semantic_tags
+        assert len(sem.functional_regions) == 3
+
+
+class TestRegistry:
+    """Test RobotRegistry with RealSense profiles."""
+
+    def test_install_and_get_d405(self):
+        reg = RobotRegistry()
+        profile = reg.install("realsense-d405")
+        assert profile.robot_id == "realsense_d405"
+        assert reg.get("realsense_d405") is not None
+        assert reg.get("realsense-d405") is not None
+
+    def test_install_and_get_d435i(self):
+        reg = RobotRegistry()
+        profile = reg.install("realsense-d435i")
+        assert profile.robot_id == "realsense_d435i"
+        assert reg.get("realsense_d435i") is not None
+
+    def test_install_and_get_dual(self):
+        reg = RobotRegistry()
+        profile = reg.install("realsense-dual")
+        assert profile.robot_id == "realsense_dual"
+        assert reg.get("realsense_dual") is not None
+
+    def test_inspect_all(self):
+        reg = RobotRegistry()
+        for rid in ["realsense-d405", "realsense-d435i", "realsense-dual"]:
+            reg.install(rid)
+            d = reg.inspect(rid)
+            assert "embodiment" in d
+            assert "safety" in d
+            assert "capability" in d
+            assert "simulation" in d
+            assert "semantic" in d
+            assert "benchmark" in d

--- a/tests/mcp/test_health_binding.py
+++ b/tests/mcp/test_health_binding.py
@@ -82,16 +82,23 @@ def test_optional_profile_missing_does_not_fail(
 
 
 def test_required_profile_missing_fails(
-    unitree_manifest: McpManifest,
+    unitree_manifest_dict: dict[str, Any],
     fake_home: Path,
     project_root: Path,
     body_yaml_empty: Path,
 ) -> None:
+    # Use a manifest that references a profile which definitely does not exist.
+    data = dict(unitree_manifest_dict)
+    data["eurdf"] = {
+        "profiles": [{"id": "missing-robot-xyz", "version": "1.0.0", "required": True}],
+        "defaultProfile": "missing-robot-xyz",
+    }
+    manifest = McpManifest.from_dict(data)
     runner = HealthRunner(
         home=fake_home,
         claude_merge=ClaudeMcpMerge(project_root=project_root),
     )
-    report = runner.check(unitree_manifest.server_name, manifest=unitree_manifest)
+    report = runner.check(manifest.server_name, manifest=manifest)
     binding = next(c for c in report.checks if c.category == "binding")
     assert not binding.passed
     assert "required e-URDF profile not installed" in binding.message

--- a/tests/test_edge_cases_eurdf.py
+++ b/tests/test_edge_cases_eurdf.py
@@ -86,9 +86,13 @@ def test_registry_empty_robot_id():
 
 
 def test_registry_list_available_empty_zoo():
-    """Registry with empty zoo returns empty list."""
+    """Registry with empty zoo still exposes builtin Python profiles."""
     reg = RobotRegistry(loader=EURDFLoader(zoo_path="/tmp/nonexistent_zoo"))
-    assert reg.list_available() == []
+    available = reg.list_available()
+    assert "franka_panda" in available
+    assert "realsense-d405" in available
+    assert "realsense-d435i" in available
+    assert "realsense-dual" in available
 
 
 def test_loader_validate_empty_robot_id(tmp_path):

--- a/tests/test_runtime_coverage.py
+++ b/tests/test_runtime_coverage.py
@@ -1074,7 +1074,12 @@ class TestRobotRegistry:
 
         reg = RobotRegistry(loader=EURDFLoader(str(zoo)))
         available = reg.list_available()
-        assert sorted(available) == ["panda", "ur5e", "xarm"]
+        for name in ["panda", "ur5e", "xarm"]:
+            assert name in available
+        # Builtin Python profiles are also discoverable.
+        assert "realsense-d405" in available
+        assert "realsense-d435i" in available
+        assert "realsense-dual" in available
 
     def test_list_empty(self, tmp_path):
         from rosclaw.runtime.eurdf_loader import EURDFLoader, RobotRegistry
@@ -1082,7 +1087,11 @@ class TestRobotRegistry:
         zoo = tmp_path / "zoo"
         zoo.mkdir(parents=True)
         reg = RobotRegistry(loader=EURDFLoader(str(zoo)))
-        assert reg.list_available() == []
+        available = reg.list_available()
+        # Builtin Python profiles are still exposed when the zoo is empty.
+        assert "realsense-d405" in available
+        assert "realsense-d435i" in available
+        assert "realsense-dual" in available
         assert reg.list() == []
 
     def test_validate(self, tmp_path):


### PR DESCRIPTION
Adds RealSense D400-series sensor profiles to the ROSClaw source tree so that `rosclaw robot list`, `rosclaw body init --robot realsense-d405`, and sandbox sensor/action checks can find them.

### What changed
- Added Python profile modules for `realsense_d405`, `realsense_d435i`, and `realsense_dual` under `src/rosclaw/eurdf_zoo/profiles/`.
- Exported the new `REALSENSE_*_PROFILE` constants from `profiles/__init__.py`.
- Extended `RobotRegistry` to fall back to builtin Python profiles and resolve hyphenated aliases (`realsense-d405` → `realsense_d405`, etc.).
- Wired the same aliases through `body/cli.py`, `body/service.py`, and `body/registry.py`.
- Added `tests/integration/test_realsense_profiles.py` covering embodiment, safety, capability, simulation, semantic, and benchmark profiles.
- Updated existing registry and health-binding tests to reflect that builtin profiles are now discoverable.

### Verification
- `rosclaw robot list` now includes the three RealSense variants.
- `rosclaw body init --robot realsense-d405` succeeds.
- `rosclaw sandbox check --robot realsense-d405 --action capture_depth` returns `ALLOW`.
- Targeted pytest suites pass, including the new RealSense integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)