### PR TITLE
fix(realsense): Practice event production, Dashboard streams/frames, bench semantics

### DIFF
--- a/src/rosclaw/bench/realsense.py
+++ b/src/rosclaw/bench/realsense.py
@@ -95,14 +95,25 @@ def _capture_with_pyrealsense2(duration_sec: float) -> dict[str, Any]:
         pipeline.stop()
 
     elapsed = time.time() - t0
+    color_fps = round(color_frames / elapsed, 2) if elapsed > 0 else 0.0
+    depth_fps = round(depth_frames / elapsed, 2) if elapsed > 0 else 0.0
     return {
         "backend": "pyrealsense2",
         "color_frames": color_frames,
         "depth_frames": depth_frames,
-        "fps": round(color_frames / elapsed, 2) if elapsed > 0 else 0.0,
+        "fps": round((color_fps + depth_fps) / 2, 2) if (color_frames or depth_frames) else 0.0,
         "drops": dropped,
         "usb_mode": usb_mode,
         "degraded": "USB2" in str(usb_mode).upper(),
+        "streams": {
+            "color": {"frame_count": color_frames, "fps": color_fps},
+            "depth": {"frame_count": depth_frames, "fps": depth_fps},
+        },
+        "aggregate": {
+            "total_frame_count": color_frames + depth_frames,
+            "average_fps": round((color_fps + depth_fps) / 2, 2) if (color_frames or depth_frames) else 0.0,
+            "drop_count": dropped,
+        },
         **device_info,
     }
 
@@ -169,7 +180,51 @@ def parse_rs_data_collect(stdout: str) -> dict[str, Any]:
             result["usb_mode"] = usb_match.group(1)
 
     result["degraded"] = "USB2" in str(result["usb_mode"]).upper()
+
+    # Stream-level metrics (per-stream fps may be refined by the caller once
+    # the requested duration is known).
+    stream_fps = result["fps"] if result["fps"] else 0.0
+    result["streams"] = {
+        "color": {"frame_count": result["color_frames"], "fps": stream_fps},
+        "depth": {"frame_count": result["depth_frames"], "fps": stream_fps},
+    }
+    result["aggregate"] = {
+        "total_frame_count": result["color_frames"] + result["depth_frames"],
+        "average_fps": stream_fps,
+        "drop_count": result["drops"],
+    }
     return result
+
+
+def _compute_stream_fps(report: dict[str, Any], duration_sec: float) -> None:
+    """Fill or refine per-stream fps and aggregate metrics using duration."""
+    if "streams" not in report:
+        report["streams"] = {
+            "color": {"frame_count": report.get("color_frames", 0), "fps": 0.0},
+            "depth": {"frame_count": report.get("depth_frames", 0), "fps": 0.0},
+        }
+    streams = report["streams"]
+    for stream_name in ("color", "depth"):
+        stream = streams.setdefault(stream_name, {})
+        stream.setdefault("frame_count", report.get(f"{stream_name}_frames", 0))
+        count = stream.get("frame_count", 0)
+        if duration_sec > 0 and count > 0 and not stream.get("fps"):
+            stream["fps"] = round(count / duration_sec, 2)
+        elif "fps" not in stream:
+            stream["fps"] = 0.0
+
+    color_fps = streams.get("color", {}).get("fps", 0.0)
+    depth_fps = streams.get("depth", {}).get("fps", 0.0)
+    color_count = streams.get("color", {}).get("frame_count", 0)
+    depth_count = streams.get("depth", {}).get("frame_count", 0)
+
+    report["aggregate"] = {
+        "total_frame_count": color_count + depth_count,
+        "average_fps": round((color_fps + depth_fps) / 2, 2) if (color_count or depth_count) else 0.0,
+        "drop_count": report.get("drops", 0),
+    }
+    if report.get("fps") == 0.0:
+        report["fps"] = report["aggregate"]["average_fps"]
 
 
 def _capture_with_rs_data_collect(duration_sec: float) -> dict[str, Any]:
@@ -289,9 +344,8 @@ def bench_realsense(duration_sec: float, output_dir: str | Path) -> dict[str, An
             report["errors"].append(f"rs-data-collect capture failed: {exc}")
             logger.debug("rs-data-collect capture failed: %s", exc)
 
-    # Derive FPS from frame count and duration if the parser did not provide it.
-    if report["fps"] == 0.0 and report["color_frames"] > 0 and duration_sec > 0:
-        report["fps"] = round(report["color_frames"] / duration_sec, 2)
+    # Ensure per-stream fps and aggregate metrics are explicit.
+    _compute_stream_fps(report, duration_sec)
 
     if report["camera"] == "unknown":
         report.update(_enumerate_device_info())

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -1127,36 +1127,69 @@ def cmd_practice_list(args: argparse.Namespace) -> int:
 
 
 def cmd_practice_show(args: argparse.Namespace) -> int:
-    """Show practice session details from the local catalog."""
+    """Show practice episode details from the local episode.json."""
     practice_id = args.episode_id
     data_root = Path(getattr(args, "data_root", "/data/rosclaw/practice"))
     layout = PracticeLayout(data_root)
-    catalog = PracticeCatalog(layout.catalog_db_path)
-    record = catalog.get_practice(practice_id)
+    session_dir = layout.session_dir(practice_id)
 
-    if record is None:
-        print(f"[ROSClaw] Practice '{practice_id}' not found.", file=sys.stderr)
+    # Support passing a direct path as the episode id.
+    if not session_dir.exists() and Path(practice_id).exists():
+        session_dir = Path(practice_id)
+
+    if not session_dir.exists():
+        print(f"[ROSClaw] Episode '{practice_id}' not found.", file=sys.stderr)
         return 1
 
-    event_count = catalog.count_events(practice_id)
+    episode_path = session_dir / "episode.json"
+    if not episode_path.exists():
+        print(f"[ROSClaw] episode.json missing for '{practice_id}'.", file=sys.stderr)
+        return 1
+
+    try:
+        episode = json.loads(episode_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"[ROSClaw] Failed to read episode.json: {exc}", file=sys.stderr)
+        return 1
+
+    # Derive per-source counts from the timeline.
+    timeline_path = session_dir / "timeline.jsonl"
+    timeline: list[dict[str, Any]] = []
+    if timeline_path.exists():
+        with open(timeline_path, encoding="utf-8") as f:
+            timeline = [json.loads(line) for line in f if line.strip()]
+
+    camera_frames = sum(1 for ev in timeline if ev.get("event_type") == "rgbd_frame")
+    provider_results = sum(1 for ev in timeline if ev.get("event_type") == "provider.result")
+    sandbox_decisions = sum(1 for ev in timeline if ev.get("event_type") == "decision")
+
+    frames_dir = session_dir / "artifacts" / "frames"
+    color_artifacts = sorted(frames_dir.glob("color_*.png")) if frames_dir.exists() else []
+    depth_artifacts = sorted(frames_dir.glob("depth_*.png")) if frames_dir.exists() else []
+
     if args.json:
-        record["event_count"] = event_count
-        print(json.dumps(record, indent=2, default=str))
+        print(json.dumps(episode, indent=2, default=str))
         return 0
 
     print("=" * 60)
-    print(f"Practice: {practice_id}")
+    print(f"Episode: {practice_id}")
     print("=" * 60)
-    print(f"Robot:        {record.get('robot_id', 'N/A')} ({record.get('robot_type', 'unknown')})")
-    print(f"Task:         {record.get('task_name') or record.get('task_id', 'N/A')}")
-    print(f"Status:       {record.get('outcome', 'UNKNOWN')}")
-    print(f"Reward:       {record.get('reward', 'N/A')}")
-    print(f"Duration:     {record.get('duration_ms', 'N/A')} ms")
-    print(f"Events:       {event_count}")
-    print(f"Start:        {record.get('start_time', 'N/A')}")
-    print(f"End:          {record.get('end_time', 'N/A')}")
-    print(f"Manifest:     {record.get('manifest_path', 'N/A')}")
-    print(f"Events JSONL: {record.get('events_jsonl_path', 'N/A')}")
+    print(f"Outcome:           {episode.get('outcome', 'UNKNOWN')}")
+    print(f"Events:            {episode.get('event_count', len(timeline))}")
+    print(f"Camera frames:     {camera_frames}")
+    print(f"Provider results:  {provider_results}")
+    print(f"Sandbox decisions: {sandbox_decisions}")
+    print("Artifacts:")
+    if color_artifacts:
+        print(f"  color: {color_artifacts[0].relative_to(session_dir)}")
+    else:
+        print("  color: (none)")
+    if depth_artifacts:
+        print(f"  depth: {depth_artifacts[0].relative_to(session_dir)}")
+    else:
+        print("  depth: (none)")
+    if episode.get("failure_labels"):
+        print(f"Failure labels:    {', '.join(episode['failure_labels'])}")
     print("=" * 60)
     return 0
 
@@ -1280,13 +1313,65 @@ def _parse_duration(value: str | None) -> float | None:
 
 
 def _parse_sources(value: str | None) -> SourceConfig:
+    """Parse a comma-separated source list into a SourceConfig.
+
+    An empty or whitespace-only string disables all sources.  When a list is
+    provided, only the named sources are enabled; the dataclass defaults are
+    intentionally cleared so ``--sources runtime`` means *only* runtime.
+    """
     sources = SourceConfig()
-    if not value:
+    # Start from all-False so callers get exactly what they asked for.
+    for name in vars(sources):
+        setattr(sources, name, False)
+
+    if not value or not value.strip():
         return sources
     for name in [p.strip() for p in value.split(",") if p.strip()]:
         if hasattr(sources, name):
             setattr(sources, name, True)
     return sources
+
+
+def _resolve_practice_body_id(home: Path, robot: str) -> str:
+    """Resolve ``--robot`` to a registered body id.
+
+    The CLI accepts either a body instance id (e.g. ``d405_latest``) or a
+    robot/profile identifier (e.g. ``realsense-d405``).  When the literal
+    identifier is not a registered body, we fall back to the first workspace
+    body whose profile matches.
+    """
+    from rosclaw.body.registry import BodyRegistryError
+    from rosclaw.body.resolver import BodyResolver
+
+    robot_norm = robot.strip().lower().replace("-", "_")
+
+    # 1. Try literal body id.
+    try:
+        resolver = BodyResolver(workspace=home, body_id=robot)
+        if resolver.is_linked():
+            return robot
+    except BodyRegistryError:
+        pass
+
+    # 2. Fall back to profile id match.
+    for entry in BodyResolver.list_workspace_bodies(home):
+        entry_profile = entry.profile_id.strip().lower().replace("-", "_")
+        if entry_profile == robot_norm:
+            return entry.body_id
+
+    # 3. Return original and let downstream body checks produce a clear error.
+    return robot
+
+
+# Default camera skill when a RealSense source is requested without --skill.
+_DEFAULT_CAMERA_SKILL_BY_ROBOT: dict[str, str] = {
+    "realsense-d405": "realsense_capture_rgbd",
+    "realsense_d405": "realsense_capture_rgbd",
+    "realsense-d435i": "realsense_capture_rgbd",
+    "realsense_d435i": "realsense_capture_rgbd",
+    "realsense-dual": "realsense_capture_rgbd",
+    "realsense_dual": "realsense_capture_rgbd",
+}
 
 
 def cmd_practice_init(args: argparse.Namespace) -> int:
@@ -1320,12 +1405,11 @@ seekdb:
 def cmd_practice_start(args: argparse.Namespace) -> int:
     """Start a practice session using PracticeCoordinator.
 
-    When ``--skill`` is provided, the session immediately executes one skill
-    iteration and records real events (``runtime.start``, ``skill.start``,
-    ``skill.result``, ``camera.rgbd_frame``, provider request/result,
-    ``sandbox.decision``).  The session then keeps running until the requested
-    duration expires or a signal is received.  Without ``--skill`` the session
-    remains passive and will record zero events.
+    The session always writes ``runtime.start`` and ``runtime.stop`` when the
+    ``runtime`` source is enabled.  If ``camera`` is requested without an
+    explicit ``--skill``, a default RealSense capture skill is used.  The skill
+    is executed periodically according to ``--sample-hz`` until the requested
+    duration expires or a signal is received.
     """
     import signal
 
@@ -1335,6 +1419,10 @@ def cmd_practice_start(args: argparse.Namespace) -> int:
     skill_id = getattr(args, "skill", None)
     provider_id = getattr(args, "provider", None)
     capability = getattr(args, "capability", "vlm.risk_assessment")
+    sample_hz = getattr(args, "sample_hz", None) or 1.0
+    sample_hz = float(sample_hz)
+    if sample_hz <= 0:
+        sample_hz = 1.0
 
     try:
         duration_sec = _parse_duration(args.duration)
@@ -1342,20 +1430,51 @@ def cmd_practice_start(args: argparse.Namespace) -> int:
         print(f"[rosclaw-practice] Invalid duration: {exc}", file=sys.stderr)
         return 1
 
-    # If a skill is requested, force the sources that record real evidence.
+    sources = _parse_sources(args.sources)
+
+    # If a skill is explicitly requested, force the evidence sources it needs.
     if skill_id:
-        sources = SourceConfig(
-            camera=True,
-            provider=bool(provider_id),
-            sandbox=True,
-            runtime=True,
-            agent=False,
+        sources.camera = True
+        sources.provider = sources.provider or bool(provider_id)
+        sources.sandbox = True
+        sources.runtime = True
+        sources.agent = False
+
+    home = get_rosclaw_home()
+    resolved_body_id = _resolve_practice_body_id(home, args.robot)
+
+    # Default camera skill for RealSense bodies when camera source is enabled.
+    if sources.camera and not skill_id:
+        robot_norm = args.robot.strip().lower()
+        skill_id = _DEFAULT_CAMERA_SKILL_BY_ROBOT.get(robot_norm)
+        if not skill_id:
+            # Fall back to the registered body's profile id.
+            try:
+                from rosclaw.body.resolver import BodyResolver
+                from rosclaw.body.schema import EurdfProfile
+
+                resolver = BodyResolver(workspace=home, body_id=resolved_body_id)
+                if resolver.is_linked() and resolver.eurdf_profile_path.exists():
+                    profile = EurdfProfile.from_yaml(resolver.eurdf_profile_path)
+                    profile_norm = profile.profile_id.strip().lower()
+                    skill_id = _DEFAULT_CAMERA_SKILL_BY_ROBOT.get(profile_norm)
+            except Exception:
+                pass
+        if skill_id:
+            print(
+                f"[rosclaw-practice] No --skill provided; using default camera skill "
+                f"'{skill_id}' for {args.robot}."
+            )
+
+    if sources.camera and not skill_id:
+        print(
+            "[rosclaw-practice] camera source requires --skill or a registered camera source adapter.",
+            file=sys.stderr,
         )
-    else:
-        sources = _parse_sources(args.sources)
+        return 1
 
     config = PracticeConfig(
-        robot_id=args.robot,
+        robot_id=resolved_body_id,
         robot_type=args.robot_type,
         task_id=args.task,
         task_name=args.task,
@@ -1364,6 +1483,7 @@ def cmd_practice_start(args: argparse.Namespace) -> int:
         sources=sources,
         mock=args.mock,
         duration_sec=duration_sec,
+        sample_hz=sample_hz,
         publish_to_event_bus=True,
     )
     config.seekdb.enabled = seekdb_enabled
@@ -1381,7 +1501,7 @@ def cmd_practice_start(args: argparse.Namespace) -> int:
 
             bridge = SeekDBBridge(seekdb_url=seekdb_url, fallback_dir=fallback_dir)
             recorder = EpisodeRecorder(
-                robot_id=args.robot,
+                robot_id=resolved_body_id,
                 event_bus=coordinator.event_bus,
                 seekdb_bridge=bridge,
             )
@@ -1398,28 +1518,6 @@ def cmd_practice_start(args: argparse.Namespace) -> int:
 
     print(f"[rosclaw-practice] Started session {practice_id}")
 
-    # Execute a single skill iteration up-front when --skill is given.
-    if skill_id:
-        home = get_rosclaw_home()
-        result = _run_practice_skill_iteration(
-            coordinator,
-            home=home,
-            robot_id=args.robot,
-            skill_id=skill_id,
-            provider_id=provider_id,
-            capability=capability,
-            task_id=args.task,
-            robot_type=args.robot_type,
-            data_root=args.data_root,
-        )
-        if result != 0:
-            coordinator.stop()
-            if recorder is not None:
-                recorder.stop()
-            if pid_file.exists():
-                pid_file.unlink()
-            return 1
-
     stop_requested = False
 
     def _handle_signal(signum, frame):
@@ -1429,27 +1527,61 @@ def cmd_practice_start(args: argparse.Namespace) -> int:
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
 
-    try:
-        if config.duration_sec:
-            deadline = time.time() + config.duration_sec
-            while not stop_requested and time.time() < deadline:
-                time.sleep(0.1)
-        else:
-            while not stop_requested:
-                time.sleep(0.1)
-    finally:
-        coordinator.stop()
-        if recorder is not None:
-            recorder.stop()
-        if pid_file.exists():
-            pid_file.unlink()
+    # Execute the capture skill periodically for the requested duration.
+    if skill_id:
+        interval = 1.0 / sample_hz
+        next_run = time.time()
+        deadline = time.time() + duration_sec if duration_sec else None
+        iteration = 0
+        while not stop_requested and (deadline is None or time.time() < deadline):
+            now = time.time()
+            if now >= next_run:
+                result = _run_practice_skill_iteration(
+                    coordinator,
+                    home=home,
+                    robot_id=resolved_body_id,
+                    skill_id=skill_id,
+                    provider_id=provider_id,
+                    capability=capability,
+                    task_id=args.task,
+                    robot_type=args.robot_type,
+                    data_root=args.data_root,
+                    iteration_index=iteration,
+                )
+                if result != 0:
+                    coordinator.record_failure(["skill_failure"])
+                    print(
+                        f"[rosclaw-practice] Skill iteration {iteration} failed; stopping session.",
+                        file=sys.stderr,
+                    )
+                    break
+                iteration += 1
+                next_run += interval
+            time.sleep(0.05)
+    else:
+        try:
+            if config.duration_sec:
+                deadline = time.time() + config.duration_sec
+                while not stop_requested and time.time() < deadline:
+                    time.sleep(0.1)
+            else:
+                while not stop_requested:
+                    time.sleep(0.1)
+        except KeyboardInterrupt:
+            pass
+
+    coordinator.stop()
+    if recorder is not None:
+        recorder.stop()
+    if pid_file.exists():
+        pid_file.unlink()
 
     summary = coordinator.summary
     if summary:
         print(f"[rosclaw-practice] Stopped {summary.practice_id}")
         print(f"  events:   {summary.event_count}")
-        print(f"  duration: {summary.duration_ms:.1f} ms")
-        print(f"  outcome:  {summary.outcome}")
+        print(f"  duration:  {summary.duration_ms:.1f} ms")
+        print(f"  outcome:   {summary.outcome}")
         print(f"  artifacts: {summary.artifact_dir}")
     return 0
 
@@ -1509,15 +1641,14 @@ def _run_practice_skill_iteration(
     task_id: str | None = None,
     robot_type: str | None = None,
     data_root: str = "/data/rosclaw/practice",
+    iteration_index: int = 0,
 ) -> int:
     """Execute one skill iteration and emit practice events into a live session.
 
     The coordinator session must already be started.  This helper emits
-    ``runtime.start``, ``skill.start``, ``skill.result``, ``camera.rgbd_frame``,
-    provider request/result (when ``provider_id`` is given), and ``sandbox.decision``
-    events.  It does **not** emit ``runtime.stop`` or stop the coordinator, so the
-    caller can keep the session open (``practice start``) or finalize it
-    immediately (``practice run``).
+    ``skill.start``, ``skill.result``, ``camera.rgbd_frame``, provider
+    request/result (when ``provider_id`` is given), and ``sandbox.decision``
+    events.  Runtime start/stop are owned by the coordinator lifecycle.
 
     Returns 0 on success, 1 on failure.
     """
@@ -1621,25 +1752,6 @@ def _run_practice_skill_iteration(
         return 1
 
     # ------------------------------------------------------------------
-    # runtime.start
-    # ------------------------------------------------------------------
-    _emit(
-        "runtime",
-        "runtime.start",
-        {
-            "phase": "start",
-            "data_root": str(data_root),
-            "sources": {
-                "camera": True,
-                "provider": bool(provider_id),
-                "sandbox": True,
-                "runtime": True,
-            },
-        },
-        tags=["runtime", "start"],
-    )
-
-    # ------------------------------------------------------------------
     # skill.start
     # ------------------------------------------------------------------
     _emit(
@@ -1671,9 +1783,11 @@ def _run_practice_skill_iteration(
     # ------------------------------------------------------------------
     frames_dir = session_dir / "artifacts" / "frames"
     frames_dir.mkdir(parents=True, exist_ok=True)
-    sequence = 1
+    existing_color_frames = len(list(frames_dir.glob("color_*.png")))
+    sequence = max(iteration_index + 1, existing_color_frames + 1)
 
     def _copy_frame(src: str | None, suffix: str) -> str | None:
+        nonlocal sequence
         if not src:
             return None
         src_path = Path(src)
@@ -1683,6 +1797,7 @@ def _run_practice_skill_iteration(
         import shutil
 
         shutil.copy2(src_path, dst)
+        sequence += 1
         return _relative_artifact_ref(str(dst), session_dir)
 
     color_ref = _copy_frame(color_path, "color")
@@ -1715,20 +1830,22 @@ def _run_practice_skill_iteration(
     if provider_id and color_path and Path(color_path).exists():
         provider_dir = session_dir / "provider"
         provider_dir.mkdir(parents=True, exist_ok=True)
-        provider_out = provider_dir / "provider_result.json"
+        provider_out = provider_dir / f"provider_result_{iteration_index:06d}.json"
         requests_jsonl = provider_dir / "requests.jsonl"
         responses_jsonl = provider_dir / "responses.jsonl"
         question = "Analyze physical risks in this RealSense image."
 
+        request_event_id = f"{practice_id}_provider_request_{iteration_index:06d}"
         request_record = {
-            "event_id": f"{practice_id}_provider_request",
+            "event_id": request_event_id,
             "provider": provider_id,
             "capability": capability,
             "input_artifact": color_ref,
             "question": question,
             "timestamp": _utc_now_iso(),
         }
-        requests_jsonl.write_text(json.dumps(request_record) + "\n", encoding="utf-8")
+        with requests_jsonl.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(request_record) + "\n")
 
         prov_args = argparse.Namespace(
             provider_id=provider_id,
@@ -1749,15 +1866,16 @@ def _run_practice_skill_iteration(
             provider_data = {"normalized": {}, "latency_ms": 0, "errors": [str(exc)]}
 
         response_record = {
-            "event_id": f"{practice_id}_provider_response",
+            "event_id": f"{practice_id}_provider_response_{iteration_index:06d}",
             "provider": provider_id,
             "input_artifact": color_ref,
-            "request_event_id": request_record["event_id"],
+            "request_event_id": request_event_id,
             "response_path": _relative_artifact_ref(str(provider_out), session_dir),
             "timestamp": _utc_now_iso(),
             "result": provider_data,
         }
-        responses_jsonl.write_text(json.dumps(response_record) + "\n", encoding="utf-8")
+        with responses_jsonl.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(response_record) + "\n")
 
         normalized = provider_data.get("normalized", {})
         provider_event_id = _emit(
@@ -1797,7 +1915,7 @@ def _run_practice_skill_iteration(
     sandbox_action = {"type": "provider_reasoning" if provider_id else "capture_rgbd"}
     sandbox_result = _evaluate_sandbox_policy(profile_id, sandbox_action)
     sandbox_payload = SandboxDecisionPayload(
-        decision_id=f"{practice_id}_sandbox",
+        decision_id=f"{practice_id}_sandbox_{iteration_index:06d}",
         action_id=skill_id,
         requested_action=sandbox_action,
         decision=sandbox_result["decision"],
@@ -1842,6 +1960,8 @@ def cmd_practice_run(args: argparse.Namespace) -> int:
     capability = getattr(args, "capability", "vlm.risk_assessment")
     data_root = getattr(args, "output_root", None) or getattr(args, "data_root", None) or "/data/rosclaw/practice"
 
+    resolved_body_id = _resolve_practice_body_id(home, robot_id)
+
     sources = SourceConfig(
         camera=True,
         provider=bool(provider_id),
@@ -1850,7 +1970,7 @@ def cmd_practice_run(args: argparse.Namespace) -> int:
         agent=False,
     )
     config = PracticeConfig(
-        robot_id=robot_id,
+        robot_id=resolved_body_id,
         robot_type=getattr(args, "robot_type", None),
         task_id=getattr(args, "task", None),
         task_name=getattr(args, "task", None),
@@ -1868,7 +1988,7 @@ def cmd_practice_run(args: argparse.Namespace) -> int:
     result = _run_practice_skill_iteration(
         coordinator,
         home=home,
-        robot_id=robot_id,
+        robot_id=resolved_body_id,
         skill_id=skill_id,
         provider_id=provider_id,
         capability=capability,
@@ -1878,22 +1998,10 @@ def cmd_practice_run(args: argparse.Namespace) -> int:
     )
 
     if result != 0:
+        coordinator.record_failure(["skill_failure"])
         coordinator.stop()
         return 1
 
-    # Finalize the single-shot episode.
-    coordinator.emit_event(
-        PracticeEventEnvelope(
-            practice_id=coordinator.session.practice_id,
-            robot_id=robot_id,
-            source="runtime",
-            event_type="runtime.stop",
-            skill_id=skill_id,
-            trace_id=coordinator.session.practice_id,
-            payload={"phase": "stop"},
-            tags=["runtime", "stop"],
-        )
-    )
     coordinator.stop()
 
     summary = coordinator.summary
@@ -1986,12 +2094,14 @@ def cmd_practice_validate(args: argparse.Namespace) -> int:
             errors.append(f"failed to parse events.jsonl: {exc}")
 
     timeline: list[dict[str, Any]] = []
-    if timeline_path.exists():
+    if not timeline_path.exists():
+        errors.append(f"missing timeline.jsonl: {timeline_path}")
+    else:
         try:
             with open(timeline_path, encoding="utf-8") as f:
                 timeline = [json.loads(line) for line in f if line.strip()]
         except Exception as exc:
-            warnings.append(f"failed to parse timeline.jsonl: {exc}")
+            errors.append(f"failed to parse timeline.jsonl: {exc}")
 
     event_count = episode.get("event_count", len(events))
     checks["event_count"] = event_count
@@ -2010,14 +2120,46 @@ def cmd_practice_validate(args: argparse.Namespace) -> int:
     if timeline and len(timeline) != len(events):
         warnings.append(f"timeline count ({len(timeline)}) does not match events count ({len(events)})")
 
+    # Event-type and source checks.
+    timeline_types = {ev.get("event_type") for ev in timeline}
+    checks["event_types"] = sorted(timeline_types)
+    if "runtime.start" not in timeline_types:
+        errors.append("missing runtime.start event")
+    if "runtime.stop" not in timeline_types:
+        errors.append("missing runtime.stop event")
+
+    sources = episode.get("sources", {}) if episode else {}
+    checks["sources_requested"] = sources
+    if sources.get("camera") and "rgbd_frame" not in timeline_types:
+        errors.append("camera source enabled but no camera.rgbd_frame event")
+    if sources.get("provider") and "provider.result" not in timeline_types:
+        errors.append("provider source enabled but no provider.result event")
+    if sources.get("sandbox") and "decision" not in timeline_types:
+        errors.append("sandbox source enabled but no sandbox.decision event")
+
+    # Artifact existence checks.
+    if sources.get("camera"):
+        frames_dir = session_dir / "artifacts" / "frames"
+        color_frames = list(frames_dir.glob("color_*.png")) if frames_dir.exists() else []
+        depth_frames = list(frames_dir.glob("depth_*.png")) if frames_dir.exists() else []
+        checks["color_frame_count"] = len(color_frames)
+        checks["depth_frame_count"] = len(depth_frames)
+        if not color_frames:
+            errors.append("camera source enabled but no color frame artifact found")
+        if not depth_frames:
+            warnings.append("no depth frame artifact found")
+    else:
+        checks["color_frame_count"] = 0
+        checks["depth_frame_count"] = 0
+
     if strict:
-        sources = {ev.get("source") for ev in events}
-        checks["sources"] = sorted(sources)
-        if "camera" not in sources:
+        present_sources = {ev.get("source") for ev in events}
+        checks["sources_present"] = sorted(present_sources)
+        if "camera" not in present_sources:
             errors.append("strict validation requires a camera event")
-        if "sandbox" not in sources:
+        if "sandbox" not in present_sources:
             errors.append("strict validation requires a sandbox event")
-        if "provider" not in sources:
+        if "provider" not in present_sources:
             errors.append("strict validation requires a provider event")
 
     valid = len(errors) == 0
@@ -4296,15 +4438,21 @@ def cmd_bench_realsense(args: argparse.Namespace) -> int:
         print(json.dumps(report, indent=2, default=str))
         return 0
 
+    streams = report.get("streams", {})
+    color = streams.get("color", {})
+    depth = streams.get("depth", {})
+    aggregate = report.get("aggregate", {})
+
     print("=" * 60)
     print("ROSClaw Bench — RealSense Capture")
     print("=" * 60)
     print(f"Duration:      {report.get('duration_requested_sec')}s")
     print(f"Backend:       {report.get('backend') or 'none'}")
-    print(f"Color frames:  {report.get('color_frames')}")
-    print(f"Depth frames:  {report.get('depth_frames')}")
-    print(f"FPS:           {report.get('fps')}")
-    print(f"Drops:         {report.get('drops')}")
+    print(f"Color frames:  {color.get('frame_count')} @ {color.get('fps')} fps")
+    print(f"Depth frames:  {depth.get('frame_count')} @ {depth.get('fps')} fps")
+    print(f"Total frames:  {aggregate.get('total_frame_count')}")
+    print(f"Average FPS:   {aggregate.get('average_fps')}")
+    print(f"Drops:         {aggregate.get('drop_count')}")
     print(f"USB mode:      {report.get('usb_mode')}")
     print(f"Degraded:      {report.get('degraded')}")
     print(f"Report:        {output_dir}/report.json")
@@ -4917,6 +5065,7 @@ def main() -> int:
     )
     practice_start_parser.add_argument("--mock", action="store_true", help="Use mock adapters")
     practice_start_parser.add_argument("--duration", default=None, help="Duration like 5s, 2m, 1h")
+    practice_start_parser.add_argument("--sample-hz", type=float, default=1.0, help="Capture frequency when camera source is enabled")
     practice_start_parser.add_argument("--seekdb", action="store_true", help="Enable SeekDB commit")
     practice_start_parser.add_argument("--data-root", default="/data/rosclaw/practice", help="Practice data root")
 

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -1175,6 +1175,7 @@ def cmd_practice_show(args: argparse.Namespace) -> int:
     print(f"Episode: {practice_id}")
     print("=" * 60)
     print(f"Outcome:           {episode.get('outcome', 'UNKNOWN')}")
+    print(f"Robot:             {episode.get('robot_id', 'UNKNOWN')}")
     print(f"Events:            {episode.get('event_count', len(timeline))}")
     print(f"Camera frames:     {camera_frames}")
     print(f"Provider results:  {provider_results}")
@@ -1363,6 +1364,40 @@ def _resolve_practice_body_id(home: Path, robot: str) -> str:
     return robot
 
 
+def _resolve_default_provider(home: Path, capability: str) -> str | None:
+    """Resolve a default provider for the requested capability.
+
+    Resolution order:
+    1. ``ROSCLAW_PRACTICE_DEFAULT_PROVIDER`` environment variable.
+    2. First provider found in the workspace ``providers/`` directory or GPU
+       environment config that advertises ``capability``.
+
+    Returns the provider id, or ``None`` if no default can be found.
+    """
+    import os
+
+    env_default = os.environ.get("ROSCLAW_PRACTICE_DEFAULT_PROVIDER")
+    if env_default:
+        return env_default
+
+    try:
+        from rosclaw.provider.core.registry import ProviderRegistry
+        from rosclaw.provider.loader import ProviderLoader
+
+        registry = ProviderRegistry()
+        loader = ProviderLoader(registry)
+        loader.scan_directory(home / "providers")
+        _register_gpu_providers(registry)
+
+        candidates = registry.find_by_capability(capability, healthy_only=False)
+        if candidates:
+            return candidates[0].manifest.name
+    except Exception:
+        pass
+
+    return None
+
+
 # Default camera skill when a RealSense source is requested without --skill.
 _DEFAULT_CAMERA_SKILL_BY_ROBOT: dict[str, str] = {
     "realsense-d405": "realsense_capture_rgbd",
@@ -1472,6 +1507,25 @@ def cmd_practice_start(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+
+    # Default provider selection when provider source is enabled.
+    if provider_id:
+        sources.provider = True
+    elif sources.provider:
+        provider_id = _resolve_default_provider(home, capability)
+        if provider_id:
+            print(
+                f"[rosclaw-practice] No --provider provided; using default provider "
+                f"'{provider_id}' for capability '{capability}'."
+            )
+        else:
+            print(
+                "[rosclaw-practice] provider source requires --provider, "
+                "ROSCLAW_PRACTICE_DEFAULT_PROVIDER, or a registered provider "
+                f"supporting '{capability}'.",
+                file=sys.stderr,
+            )
+            return 1
 
     config = PracticeConfig(
         robot_id=resolved_body_id,

--- a/src/rosclaw/dashboard/web_server.py
+++ b/src/rosclaw/dashboard/web_server.py
@@ -555,19 +555,6 @@ class DashboardWebServer:
                 "decisions": sandbox_events,
             }
 
-        @self.app.get("/api/artifacts/{path:path}")
-        async def serve_artifact(path: str, data_root: str | None = None) -> Any:
-            root = _practice_data_root(data_root)
-            base = (root / "sessions").resolve()
-            artifact_path = (base / path).resolve()
-            try:
-                artifact_path.relative_to(base)
-            except ValueError as exc:
-                raise HTTPException(status_code=403, detail="Access denied") from exc
-            if not artifact_path.exists() or not artifact_path.is_file():
-                raise HTTPException(status_code=404, detail="Artifact not found")
-            return FileResponse(artifact_path)
-
         # ── RealSense page and API ──────────────────────────────────────
 
         @self.app.get("/realsense")
@@ -621,6 +608,23 @@ class DashboardWebServer:
             data_root: str | None = None, limit: int = 50
         ) -> dict[str, Any]:
             return _list_realsense_frames(_practice_data_root(data_root), limit=limit)
+
+        # ── Artifact serving ────────────────────────────────────────────
+        # Registered AFTER the RealSense routes so the greedy {path:path}
+        # pattern does not shadow /api/realsense/streams or /api/realsense/frames.
+
+        @self.app.get("/api/artifacts/{path:path}")
+        async def serve_artifact(path: str, data_root: str | None = None) -> Any:
+            root = _practice_data_root(data_root)
+            base = (root / "sessions").resolve()
+            artifact_path = (base / path).resolve()
+            try:
+                artifact_path.relative_to(base)
+            except ValueError as exc:
+                raise HTTPException(status_code=403, detail="Access denied") from exc
+            if not artifact_path.exists() or not artifact_path.is_file():
+                raise HTTPException(status_code=404, detail="Artifact not found")
+            return FileResponse(artifact_path)
 
         @self.app.websocket("/ws")
         async def websocket_endpoint(websocket: WebSocket) -> None:

--- a/src/rosclaw/dashboard/web_server.py
+++ b/src/rosclaw/dashboard/web_server.py
@@ -533,9 +533,13 @@ class DashboardWebServer:
         async def api_practice_provider(episode_id: str, data_root: str | None = None) -> dict[str, Any]:
             root = _practice_data_root(data_root)
             session_dir = _episode_dir(root, episode_id)
-            provider_path = session_dir / "provider" / "provider_result.json"
-            if not provider_path.exists():
+            provider_files = sorted(
+                (session_dir / "provider").glob("provider_result_*.json"),
+                key=lambda p: p.name,
+            )
+            if not provider_files:
                 raise HTTPException(status_code=404, detail="No provider result for this episode")
+            provider_path = provider_files[-1]
             try:
                 provider_data = json.loads(provider_path.read_text(encoding="utf-8"))
             except Exception as exc:

--- a/src/rosclaw/practice/config.py
+++ b/src/rosclaw/practice/config.py
@@ -82,6 +82,7 @@ class PracticeConfig:
     # Runtime knobs
     mock: bool = False
     duration_sec: float | None = None
+    sample_hz: float = 1.0
     publish_to_event_bus: bool = True
 
     # Optional pre-built objects (used by Runtime and tests)

--- a/src/rosclaw/practice/coordinator.py
+++ b/src/rosclaw/practice/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import time
@@ -38,6 +39,8 @@ class PracticeCoordinator(LifecycleMixin):
         self._stop_event = threading.Event()
         self._poll_hz = 10.0
         self._event_count = 0
+        self._source_event_count = 0
+        self._failure_labels: list[str] = []
         self._lock = threading.RLock()
 
     @property
@@ -151,6 +154,21 @@ class PracticeCoordinator(LifecycleMixin):
             except Exception as e:
                 logger.error("Failed to start adapter %s: %s", adapter.source_name, e)
 
+        if self.config.sources.runtime:
+            self._emit(
+                PracticeEventEnvelope(
+                    practice_id=practice_id,
+                    robot_id=self.config.robot_id,
+                    source="runtime",
+                    event_type="runtime.start",
+                    timestamp_ns=start_ns,
+                    timestamp_utc=start_utc,
+                    trace_id=practice_id,
+                    payload={"phase": "start", "sources": self._sources_dict()},
+                    tags=["runtime", "start"],
+                )
+            )
+
         if self.config.publish_to_event_bus:
             self._event_bus.publish(
                 Event(
@@ -189,7 +207,36 @@ class PracticeCoordinator(LifecycleMixin):
         if self._session is not None:
             duration_ms = (time.monotonic_ns() - self._session.start_time_ns) / 1_000_000.0
 
+        if self.config.sources.runtime and self._session is not None:
+            self._emit(
+                PracticeEventEnvelope(
+                    practice_id=self._session.practice_id,
+                    robot_id=self.config.robot_id,
+                    source="runtime",
+                    event_type="runtime.stop",
+                    trace_id=self._session.practice_id,
+                    payload={"phase": "stop", "event_count": self._event_count, "duration_ms": duration_ms},
+                    tags=["runtime", "stop"],
+                )
+            )
+
+        # Determine outcome. A session that wrote no events at all is never
+        # considered successful. Runtime lifecycle events alone are not enough
+        # when real data sources were requested.
+        requested_sources = self._sources_dict()
+        requested_non_runtime = {
+            k: v for k, v in requested_sources.items() if k != "runtime" and v
+        }
+
         if self._event_count == 0:
+            outcome = "FAILED"
+            reward = 0.0
+            failure_labels = ["zero_events"]
+        elif self._failure_labels:
+            outcome = "FAILED"
+            reward = 0.0
+            failure_labels = list(self._failure_labels)
+        elif requested_non_runtime and self._source_event_count == 0:
             outcome = "FAILED"
             reward = 0.0
             failure_labels = ["zero_events"]
@@ -280,10 +327,19 @@ class PracticeCoordinator(LifecycleMixin):
         """Public entry for external callers to inject events."""
         self._emit(event)
 
+    def record_failure(self, labels: list[str]) -> None:
+        """Record failure labels that will force the session outcome to FAILED."""
+        with self._lock:
+            for label in labels:
+                if label not in self._failure_labels:
+                    self._failure_labels.append(label)
+
     def _emit(self, event: PracticeEventEnvelope) -> None:
         with self._lock:
             self._event_count += 1
             event.sequence_id = self._event_count
+            if event.event_type not in {"runtime.start", "runtime.stop"}:
+                self._source_event_count += 1
 
         # Local JSONL
         if self._writer is not None:

--- a/tests/test_bench_realsense_metric_semantics.py
+++ b/tests/test_bench_realsense_metric_semantics.py
@@ -1,0 +1,77 @@
+"""Verify RealSense bench report exposes stream-level metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rosclaw.bench.realsense import bench_realsense, parse_rs_data_collect
+
+
+class TestBenchRealSenseMetricSemantics:
+    """P2 bench metric semantics verification."""
+
+    def test_parser_includes_stream_and_aggregate_fields(self):
+        stdout = json.dumps(
+            {
+                "color_frames": 120,
+                "depth_frames": 130,
+                "fps": 25.0,
+                "drops": 2,
+                "usb_mode": "USB3",
+            }
+        )
+        result = parse_rs_data_collect(stdout)
+        assert "streams" in result
+        assert "aggregate" in result
+        assert result["streams"]["color"]["frame_count"] == 120
+        assert result["streams"]["depth"]["frame_count"] == 130
+        assert result["aggregate"]["total_frame_count"] == 250
+        assert result["aggregate"]["drop_count"] == 2
+
+    def test_report_refines_stream_fps_with_duration(self, tmp_path):
+        """When frame counts come from a backend without per-stream fps, bench
+        should compute per-stream fps using the requested duration.
+        """
+        # Simulate a backend that only gives counts.
+        def _fake_capture(_duration):
+            return {
+                "backend": "fake",
+                "color_frames": 50,
+                "depth_frames": 60,
+                "fps": 0.0,
+                "drops": 0,
+                "usb_mode": "USB2",
+                "degraded": True,
+            }
+
+        from rosclaw.bench import realsense as bench_mod
+
+        original_capture = bench_mod._capture_with_pyrealsense2
+        original_fallback = bench_mod._capture_with_rs_data_collect
+        bench_mod._capture_with_pyrealsense2 = _fake_capture
+        bench_mod._capture_with_rs_data_collect = _fake_capture
+        try:
+            report = bench_realsense(duration_sec=2.0, output_dir=str(tmp_path))
+        finally:
+            bench_mod._capture_with_pyrealsense2 = original_capture
+            bench_mod._capture_with_rs_data_collect = original_fallback
+
+        assert report["streams"]["color"]["fps"] == 25.0
+        assert report["streams"]["depth"]["fps"] == 30.0
+        assert report["aggregate"]["average_fps"] == 27.5
+        assert report["aggregate"]["total_frame_count"] == 110
+
+        saved = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+        assert "streams" in saved
+        assert "aggregate" in saved
+
+    def test_report_no_data_still_has_stream_schema(self, tmp_path):
+        report = bench_realsense(duration_sec=0.05, output_dir=str(tmp_path))
+        assert "streams" in report
+        assert report["streams"]["color"]["frame_count"] == 0
+        assert report["streams"]["depth"]["frame_count"] == 0
+        assert "aggregate" in report
+        assert report["aggregate"]["total_frame_count"] == 0

--- a/tests/test_practice_records_events.py
+++ b/tests/test_practice_records_events.py
@@ -162,7 +162,7 @@ def test_practice_start_records_real_events(practice_home, monkeypatch):
 
 
 def test_practice_start_without_skill_records_zero_events(practice_home):
-    args = _start_args(practice_home, skill=None, duration="1s")
+    args = _start_args(practice_home, skill=None, sources="", duration="1s")
     assert cmd_practice_start(args) == 0
 
     session_dir = next((practice_home / "practice_output" / "sessions").iterdir())

--- a/tests/test_practice_records_mcp_artifacts.py
+++ b/tests/test_practice_records_mcp_artifacts.py
@@ -65,8 +65,10 @@ class TestPracticeRecordsMcpArtifacts:
         assert camera_events[0]["event_type"] == "rgbd_frame"
         assert camera_events[0]["payload"]["rgb_ref"].endswith("color_000001.png")
 
-        # Provider artifact was written.
-        provider_result = session_dir / "provider" / "provider_result.json"
+        # Provider artifact was written (iterations are zero-padded).
+        provider_files = sorted((session_dir / "provider").glob("provider_result_*.json"))
+        assert provider_files, "expected provider_result_*.json file"
+        provider_result = provider_files[-1]
         assert provider_result.exists()
         provider_data = json.loads(provider_result.read_text())
         assert provider_data["provider_id"] == "cosmos-reason2-lan"

--- a/tests/test_practice_runtime_source.py
+++ b/tests/test_practice_runtime_source.py
@@ -1,0 +1,116 @@
+"""Verify that the runtime source always writes lifecycle events."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from rosclaw.cli import cmd_practice_start
+from rosclaw.firstboot.workspace import init_workspace
+
+
+def _start_args(practice_home: Path, **overrides) -> SimpleNamespace:
+    defaults = {
+        "robot": "d405_lab_01",
+        "robot_type": None,
+        "task": None,
+        "skill": None,
+        "provider": None,
+        "capability": "vlm.risk_assessment",
+        "sources": "runtime",
+        "mock": False,
+        "duration": "1s",
+        "seekdb": False,
+        "data_root": str(practice_home / "practice_output"),
+        "sample_hz": 1.0,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def practice_home(tmp_path, monkeypatch):
+    """Create an isolated ROSClaw home with a linked RealSense D405 body."""
+    home = tmp_path / "rosclaw_home"
+    monkeypatch.setenv("ROSCLAW_HOME", str(home))
+    init_workspace(home)
+    from rosclaw.body.service import BodyInstanceService
+
+    service = BodyInstanceService(workspace=home)
+    service.create_or_init(
+        robot="realsense-d405",
+        name="d405_lab_01",
+        nickname="d405_lab_01",
+        mode="single",
+        update_registry=True,
+        switch_active=True,
+        render_agent_view=True,
+        force=True,
+    )
+    return home
+
+
+def _event_types(session_dir: Path) -> list[str]:
+    timeline_jsonl = session_dir / "timeline.jsonl"
+    if not timeline_jsonl.exists():
+        return []
+    types = []
+    for line in timeline_jsonl.read_text(encoding="utf-8").strip().splitlines():
+        if line:
+            types.append(json.loads(line)["event_type"])
+    return types
+
+
+def test_practice_runtime_source_writes_lifecycle_events(practice_home):
+    """A runtime-only session must record runtime.start and runtime.stop."""
+    args = _start_args(practice_home)
+    assert cmd_practice_start(args) == 0
+
+    session_dir = next((practice_home / "practice_output" / "sessions").iterdir())
+    types = _event_types(session_dir)
+
+    assert "runtime.start" in types
+    assert "runtime.stop" in types
+    assert len(types) >= 2
+
+    episode = json.loads((session_dir / "episode.json").read_text())
+    assert episode["event_count"] >= 2
+    assert episode["outcome"] == "SUCCESS"
+
+
+def test_practice_default_camera_skill_when_none_provided(practice_home, monkeypatch):
+    """If camera source is enabled without --skill, default to realsense_capture_rgbd."""
+
+    def _fake_execute(self, skill_name: str, parameters: dict | None = None):
+        output_dir = Path(parameters.get("output_dir", "/tmp"))
+        output_dir.mkdir(parents=True, exist_ok=True)
+        color_path = output_dir / "color.png"
+        color_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20)
+        return {
+            "status": "success",
+            "handler_result": {
+                "artifacts": {"color": str(color_path)},
+                "metrics": {"latency_ms": 10.0},
+            },
+        }
+
+    monkeypatch.setattr(
+        "rosclaw.skill_manager.executor.SkillExecutor.execute",
+        _fake_execute,
+    )
+
+    args = _start_args(practice_home, skill=None, sources="camera,runtime", duration="1s")
+    assert cmd_practice_start(args) == 0
+
+    session_dir = next((practice_home / "practice_output" / "sessions").iterdir())
+    types = _event_types(session_dir)
+    assert "skill.start" in types
+    assert "rgbd_frame" in types
+    assert "decision" in types
+
+    episode = json.loads((session_dir / "episode.json").read_text())
+    assert episode["outcome"] == "SUCCESS"
+    assert episode["event_count"] >= 4

--- a/tests/test_practice_validate_cli.py
+++ b/tests/test_practice_validate_cli.py
@@ -20,11 +20,17 @@ class TestPracticeValidateCli:
         session_dir = tmp_path / "sessions" / "prac_20260101T000000Z_abcdef"
         session_dir.mkdir(parents=True)
         (session_dir / "raw").mkdir()
+        frames_dir = session_dir / "artifacts" / "frames"
+        frames_dir.mkdir(parents=True)
+        (frames_dir / "color_000001.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20)
+        (frames_dir / "depth_000001.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20)
 
         events = [
+            {"source": "runtime", "event_type": "runtime.start", "practice_id": session_dir.name},
             {"source": "camera", "event_type": "rgbd_frame", "practice_id": session_dir.name},
-            {"source": "provider", "event_type": "result", "practice_id": session_dir.name},
+            {"source": "provider", "event_type": "provider.result", "practice_id": session_dir.name},
             {"source": "sandbox", "event_type": "decision", "practice_id": session_dir.name},
+            {"source": "runtime", "event_type": "runtime.stop", "practice_id": session_dir.name},
         ]
         events_jsonl = session_dir / "raw" / "events.jsonl"
         events_jsonl.write_text("\n".join(json.dumps(ev) for ev in events) + "\n")
@@ -39,6 +45,7 @@ class TestPracticeValidateCli:
             "outcome": "SUCCESS",
             "event_count": len(events),
             "failure_labels": [],
+            "sources": {"camera": True, "provider": True, "sandbox": True, "runtime": True},
         }
         (session_dir / "episode.json").write_text(json.dumps(episode))
         (session_dir / "manifest.yaml").write_text("status:\n  outcome: SUCCESS\n")

--- a/tests/test_practice_validate_show.py
+++ b/tests/test_practice_validate_show.py
@@ -1,0 +1,140 @@
+"""Verify practice validate and show semantics for RealSense episodes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from rosclaw.cli import cmd_practice_run, cmd_practice_show, cmd_practice_validate
+from rosclaw.firstboot.workspace import init_workspace
+
+
+def _fake_execute(self, skill_name: str, parameters: dict | None = None):
+    """SkillExecutor.execute replacement that writes a fake color frame."""
+    output_dir = Path(parameters.get("output_dir", "/tmp"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    color_path = output_dir / "color.png"
+    color_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20)
+    return {
+        "status": "success",
+        "handler_result": {
+            "artifacts": {"color": str(color_path)},
+            "metrics": {"latency_ms": 12.3},
+        },
+    }
+
+
+@pytest.fixture
+def practice_home(tmp_path, monkeypatch):
+    home = tmp_path / "rosclaw_home"
+    monkeypatch.setenv("ROSCLAW_HOME", str(home))
+    init_workspace(home)
+    from rosclaw.body.service import BodyInstanceService
+
+    service = BodyInstanceService(workspace=home)
+    service.create_or_init(
+        robot="realsense-d405",
+        name="d405_lab_01",
+        nickname="d405_lab_01",
+        mode="single",
+        update_registry=True,
+        switch_active=True,
+        render_agent_view=True,
+        force=True,
+    )
+    return home
+
+
+def _run_episode(practice_home: Path) -> Path:
+    args = SimpleNamespace(
+        robot="d405_lab_01",
+        robot_type=None,
+        task=None,
+        skill="realsense_capture_rgbd",
+        provider=None,
+        capability="vlm.risk_assessment",
+        output_root=str(practice_home / "practice_output"),
+        data_root=None,
+        workspace=str(practice_home),
+        json=False,
+    )
+    assert cmd_practice_run(args) == 0
+    return next((practice_home / "practice_output" / "sessions").iterdir())
+
+
+def test_practice_validate_real_realsense_episode(practice_home, monkeypatch):
+    monkeypatch.setattr(
+        "rosclaw.skill_manager.executor.SkillExecutor.execute",
+        _fake_execute,
+    )
+    session_dir = _run_episode(practice_home)
+
+    validate_args = SimpleNamespace(
+        episode_id=session_dir.name,
+        data_root=str(practice_home / "practice_output"),
+        strict=False,
+        json=False,
+    )
+    assert cmd_practice_validate(validate_args) == 0
+
+
+def test_practice_validate_strict_requires_all_sources(practice_home, monkeypatch):
+    monkeypatch.setattr(
+        "rosclaw.skill_manager.executor.SkillExecutor.execute",
+        _fake_execute,
+    )
+    session_dir = _run_episode(practice_home)
+
+    validate_args = SimpleNamespace(
+        episode_id=session_dir.name,
+        data_root=str(practice_home / "practice_output"),
+        strict=True,
+        json=False,
+    )
+    # No provider was requested, so strict validation should fail.
+    assert cmd_practice_validate(validate_args) == 1
+
+
+def test_practice_show_realsense_episode_summary(practice_home, monkeypatch, capsys):
+    monkeypatch.setattr(
+        "rosclaw.skill_manager.executor.SkillExecutor.execute",
+        _fake_execute,
+    )
+    session_dir = _run_episode(practice_home)
+
+    show_args = SimpleNamespace(
+        episode_id=session_dir.name,
+        data_root=str(practice_home / "practice_output"),
+        json=False,
+    )
+    assert cmd_practice_show(show_args) == 0
+
+    captured = capsys.readouterr().out
+    assert "Episode:" in captured
+    assert "Camera frames:" in captured
+    assert "color:" in captured
+
+
+def test_practice_show_json_outputs_episode(practice_home, monkeypatch, capsys):
+    monkeypatch.setattr(
+        "rosclaw.skill_manager.executor.SkillExecutor.execute",
+        _fake_execute,
+    )
+    session_dir = _run_episode(practice_home)
+
+    # Flush stdout from the run command so the JSON output is isolated.
+    capsys.readouterr()
+
+    show_args = SimpleNamespace(
+        episode_id=session_dir.name,
+        data_root=str(practice_home / "practice_output"),
+        json=True,
+    )
+    assert cmd_practice_show(show_args) == 0
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["practice_id"] == session_dir.name
+    assert report["outcome"] == "SUCCESS"

--- a/tests/test_practice_zero_events_not_success.py
+++ b/tests/test_practice_zero_events_not_success.py
@@ -24,7 +24,7 @@ class TestPracticeZeroEventsNotSuccess:
             task_id="test",
             skill_id="realsense_capture_rgbd",
             data_root=str(tmp_path),
-            sources=SourceConfig(camera=True, sandbox=True),
+            sources=SourceConfig(camera=True, sandbox=True, runtime=False),
             publish_to_event_bus=False,
         )
         coordinator = PracticeCoordinator(config)
@@ -102,8 +102,9 @@ class TestPracticeZeroEventsNotSuccess:
             session_dir = next((output_root / "sessions").iterdir())
             episode = json.loads((session_dir / "episode.json").read_text())
             assert episode["outcome"] == "FAILED"
-            assert episode["event_count"] == 0
-            assert "zero_events" in episode["failure_labels"]
+            assert "skill_failure" in episode["failure_labels"]
+            # Runtime lifecycle events are still recorded even when the skill fails.
+            assert episode["event_count"] >= 2
 
             validate_args = SimpleNamespace(
                 episode_id=session_dir.name,


### PR DESCRIPTION
修复 RealSense D405 MVP 复测中的核心问题：\n\n- Practice 真正写入 runtime/camera/provider/sandbox 事件并落盘 artifact\n- Dashboard /api/realsense/streams 和 /api/realsense/frames 返回 200 并从 episode 读取\n- bench realsense 输出 stream-level fps 和 aggregate 指标\n- practice validate/show 对齐验收要求\n\n回归测试：\n\n```bash\npytest tests/test_practice_records_events.py tests/test_practice_zero_events_not_success.py tests/test_practice_runtime_source.py tests/test_practice_validate_show.py tests/test_dashboard_realsense_api.py tests/test_bench_realsense_rs_data_collect_parser.py tests/test_bench_realsense_metric_semantics.py -q\n```\n\n28 passed.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code),description:Create cross-fork PR to ros-claw/rosclaw,timeout:120000}