### PR TITLE
fix(realsense): MCP cleanup, profile-aware serial selection, better practice error messages

### DIFF
--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -1810,15 +1810,19 @@ def _run_practice_skill_iteration(
     print(f"[rosclaw-practice] Running skill: {skill_id}")
     skill_result = executor.execute(skill_id, parameters=skill_params)
     skill_status = skill_result.get("status") if isinstance(skill_result, dict) else "error"
+    handler_result = skill_result.get("handler_result") if isinstance(skill_result, dict) else None
     if skill_status not in ("success", "degraded"):
-        reason = skill_result.get("reason") if isinstance(skill_result, dict) else None
+        reason = None
+        if isinstance(skill_result, dict):
+            reason = skill_result.get("reason") or (
+                handler_result.get("reason") if isinstance(handler_result, dict) else None
+            )
         print(
             f"[rosclaw-practice] Skill failed: {skill_id} ({skill_status}){f' — {reason}' if reason else ''}",
             file=sys.stderr,
         )
         return 1
 
-    handler_result = skill_result.get("handler_result") if isinstance(skill_result, dict) else None
     artifacts = handler_result.get("artifacts", {}) if isinstance(handler_result, dict) else {}
     color_path = artifacts.get("color") or artifacts.get("color_path") or artifacts.get("save_path")
     depth_path = artifacts.get("depth") or artifacts.get("depth_path")

--- a/src/rosclaw/mcp/onboarding/cli.py
+++ b/src/rosclaw/mcp/onboarding/cli.py
@@ -487,7 +487,7 @@ def dispatch_mcp_health(args: argparse.Namespace) -> int:
         record = registry.get(server_name)
         source_type = record.extra.get("source_type") if record else None
         if source_type in ("git", "local_path"):
-            return stdio_client.health_smoke(server_name, timeout=10.0)
+            return stdio_client.health_smoke(server_name, timeout=20.0)
         runner = HealthRunner()
         report = runner.check(server_name, full=args.full)
         return {

--- a/src/rosclaw/mcp/onboarding/stdio_client.py
+++ b/src/rosclaw/mcp/onboarding/stdio_client.py
@@ -207,7 +207,7 @@ def call_server_tool(
     client: McpStdioClient | None = None
     try:
         client = McpStdioClient(command, args, env=env)
-        client.start(timeout=min(timeout, 10.0))
+        client.start(timeout=min(timeout, 20.0))
         response = client.call_tool(tool_name, arguments or {}, timeout=timeout)
         if "error" in response:
             raise McpStdioError(f"Tool error: {response['error']}")
@@ -220,7 +220,7 @@ def call_server_tool(
 def list_server_tools(
     server_name: str,
     home: Path | str | None = None,
-    timeout: float = 10.0,
+    timeout: float = 20.0,
 ) -> list[dict[str, Any]]:
     """List tools advertised by an installed MCP server."""
     config = load_runtime_config(server_name, home=home)
@@ -242,7 +242,7 @@ def list_server_tools(
             client.stop()
 
 
-def health_smoke(server_name: str, home: Path | str | None = None, timeout: float = 10.0) -> dict[str, Any]:
+def health_smoke(server_name: str, home: Path | str | None = None, timeout: float = 20.0) -> dict[str, Any]:
     """Run a lightweight health smoke test: handshake and list tools."""
     try:
         tools = list_server_tools(server_name, home=home, timeout=timeout)

--- a/src/rosclaw/mcp/onboarding/stdio_client.py
+++ b/src/rosclaw/mcp/onboarding/stdio_client.py
@@ -107,8 +107,13 @@ class McpStdioClient:
         if self._proc is None:
             return
         try:
+            # The server may have already exited (e.g. after a tool crash or
+            # natural shutdown). Writing to a closed stdin raises BrokenPipe;
+            # that is expected and should not pollute stderr.
             self._proc.stdin.write("\n")
             self._proc.stdin.flush()
+        except BrokenPipeError:
+            pass
         except Exception:
             pass
         try:
@@ -117,6 +122,15 @@ class McpStdioClient:
         except subprocess.TimeoutExpired:
             self._proc.kill()
             self._proc.wait()
+        except Exception:
+            pass
+        # Explicitly close stdio streams so the Popen finalizer does not emit
+        # BrokenPipe warnings when the server has already exited.
+        for stream_name in ("stdin", "stdout", "stderr"):
+            stream = getattr(self._proc, stream_name, None)
+            if stream is not None:
+                with contextlib.suppress(BrokenPipeError, OSError, ValueError):
+                    stream.close()
         self._proc = None
 
     def _next_id(self) -> int:

--- a/src/rosclaw/skill/builtins/realsense_capture_rgbd/runner.py
+++ b/src/rosclaw/skill/builtins/realsense_capture_rgbd/runner.py
@@ -24,8 +24,8 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
-def _load_body(params: dict[str, Any]) -> tuple[Path | None, str | None, dict[str, Any]]:
-    """Resolve body workspace and id from parameters."""
+def _load_body(params: dict[str, Any]) -> tuple[Path | None, str | None, dict[str, Any], dict[str, Any]]:
+    """Resolve body workspace, id, body yaml, and eurdf profile from parameters."""
     from rosclaw.body.resolver import BodyResolver
     from rosclaw.firstboot.workspace import resolve_home
 
@@ -41,26 +41,51 @@ def _load_body(params: dict[str, Any]) -> tuple[Path | None, str | None, dict[st
     if resolver is None:
         resolver = BodyResolver(workspace=home)
     if not resolver.is_linked():
-        return home, body_id, {}
+        return home, body_id, {}, {}
     try:
         body = resolver.get_current_body_yaml().to_dict()
     except Exception:
         body = {}
-    return home, body_id, body
+    profile: dict[str, Any] = {}
+    try:
+        import yaml
+
+        profile_text = resolver.eurdf_profile_path.read_text(encoding="utf-8")
+        profile = yaml.safe_load(profile_text) or {}
+    except Exception:
+        profile = {}
+    return home, body_id, body, profile
 
 
-def _is_perception_only(body: dict[str, Any]) -> bool:
-    """Check whether the active body is a perception-only camera rig."""
+def _is_perception_only(body: dict[str, Any], profile: dict[str, Any] | None = None) -> bool:
+    """Check whether the active body is a perception-only camera rig.
+
+    The body yaml may not carry the perception-only marker if it was generated
+    from an older body service; fall back to the linked e-URDF profile.
+    """
     safety = body.get("safety", {})
     if isinstance(safety, dict):
         env = safety.get("environment", {})
         if env.get("perception_only") or env.get("no_actuation"):
             return True
+        limits = safety.get("safety_limits", {})
+        if limits.get("perception_only") or limits.get("no_actuation"):
+            return True
     meta = body.get("metadata", {})
     if meta.get("perception_only") or meta.get("no_actuation"):
         return True
     forbidden = body.get("forbidden_capabilities", []) or []
-    return "actuation" in forbidden or "motion" in forbidden
+    if "actuation" in forbidden or "motion" in forbidden:
+        return True
+    if profile:
+        identity = profile.get("identity", {})
+        if identity.get("robot_class") in ("perception_only_camera", "realsense_d405", "realsense_d435i"):
+            return True
+        profile_safety = profile.get("safety", {})
+        limits = profile_safety.get("safety_limits", {}) if isinstance(profile_safety, dict) else {}
+        if limits.get("perception_only") or limits.get("no_actuation"):
+            return True
+    return False
 
 
 def _discover_realsense_mcp(home: Path | None) -> tuple[str, str] | tuple[None, None]:
@@ -83,7 +108,7 @@ def _discover_realsense_mcp(home: Path | None) -> tuple[str, str] | tuple[None, 
 
     for _prio, server_name in candidates:
         try:
-            tools = list_server_tools(server_name, home=home, timeout=5.0)
+            tools = list_server_tools(server_name, home=home, timeout=20.0)
             tool_names = {t.get("name") for t in tools}
             if "capture_aligned_rgbd" in tool_names:
                 return server_name, "capture_aligned_rgbd"
@@ -116,7 +141,7 @@ def _resolve_serial(body: dict[str, Any], params: dict[str, Any], home: Path | N
         if "realsense" not in rec.server_name.lower():
             continue
         try:
-            result = call_server_tool(rec.server_name, "list_devices", {}, home=resolved_home, timeout=10.0)
+            result = call_server_tool(rec.server_name, "list_devices", {}, home=resolved_home, timeout=20.0)
             content = result.get("content", [])
             text = content[0].get("text", "{}") if content else "{}"
             data = json.loads(text)
@@ -151,9 +176,9 @@ def run(params: dict[str, Any]) -> dict[str, Any]:
     from rosclaw.mcp.onboarding.stdio_client import McpServerSession, McpStdioError
 
     t0 = time.time()
-    home, body_id, body = _load_body(params)
+    home, body_id, body, profile = _load_body(params)
 
-    if body_id and not _is_perception_only(body):
+    if body_id and not _is_perception_only(body, profile):
         return {
             "status": "blocked",
             "reason": "Skill requires a perception-only RealSense body",

--- a/src/rosclaw/skill/builtins/realsense_capture_rgbd/runner.py
+++ b/src/rosclaw/skill/builtins/realsense_capture_rgbd/runner.py
@@ -122,15 +122,23 @@ def _discover_realsense_mcp(home: Path | None) -> tuple[str, str] | tuple[None, 
     return None, None
 
 
-def _resolve_serial(body: dict[str, Any], params: dict[str, Any], home: Path | None = None) -> str | None:
-    """Pick a RealSense serial number."""
+def _resolve_serial(body: dict[str, Any], params: dict[str, Any], home: Path | None = None, profile: dict[str, Any] | None = None) -> str | None:
+    """Pick a RealSense serial number.
+
+    The explicit ``--serial`` parameter wins, then the linked body's
+    ``serial_number``.  If the body has no serial (or it is ``UNKNOWN``), ask
+    the MCP to enumerate devices and pick one that matches the e-URDF profile
+    when possible.  This avoids grabbing the wrong camera on a multi-RealSense
+    rig (e.g. D435I when the body is a D405).
+    """
     serial = params.get("serial")
     if serial:
         return serial
     serial = body.get("body_instance", {}).get("serial_number")
     if serial and serial != "UNKNOWN":
         return serial
-    # Ask the MCP to enumerate devices.
+
+    # Ask the MCP to enumerate devices and match against the profile.
     from rosclaw.firstboot.workspace import resolve_home
     from rosclaw.mcp.onboarding.installed import InstalledRegistry
     from rosclaw.mcp.onboarding.stdio_client import call_server_tool
@@ -146,11 +154,35 @@ def _resolve_serial(body: dict[str, Any], params: dict[str, Any], home: Path | N
             text = content[0].get("text", "{}") if content else "{}"
             data = json.loads(text)
             devices = data.get("devices", [])
-            if devices:
-                return str(devices[0].get("serial", devices[0].get("serial_number")))
+            if not devices:
+                continue
+            # Prefer a device whose product line matches the e-URDF profile.
+            matched = [d for d in devices if _device_matches_profile(d, profile)]
+            chosen = matched[0] if matched else devices[0]
+            return str(chosen.get("serial", chosen.get("serial_number")))
         except Exception:
             continue
     return None
+
+
+def _device_matches_profile(device: dict[str, Any], profile: dict[str, Any] | None) -> bool:
+    """Return True if a RealSense device matches the e-URDF profile."""
+    if not profile:
+        return False
+    name = (device.get("name") or "").lower()
+    identity = profile.get("identity", {}) if isinstance(profile, dict) else {}
+    robot_class = (identity.get("robot_class") or profile.get("profile_id") or "").lower()
+    if not robot_class:
+        return False
+    if "d405" in robot_class and "d405" in name:
+        return True
+    if "d435i" in robot_class and "d435i" in name:
+        return True
+    if "d435" in robot_class and ("d435" in name or "d435i" in name):
+        return True
+    if "dual" in robot_class:
+        return "realsense" in name
+    return False
 
 
 def _copy_artifact(src: str, dst_dir: Path) -> Path | None:
@@ -198,7 +230,7 @@ def run(params: dict[str, Any]) -> dict[str, Any]:
             "artifacts": {},
         }
 
-    serial = _resolve_serial(body, params, home=home)
+    serial = _resolve_serial(body, params, home=home, profile=profile)
     if not serial:
         return {
             "status": "error",


### PR DESCRIPTION
This follow-up fixes three issues found during the D405/D435i hardware regression:

- Suppresses MCP stdio BrokenPipe errors when the server process exits before the client cleanup.
- Makes realsense_capture_rgbd choose the correct camera serial by matching the e-URDF profile (D405 vs D435i) instead of always taking the first enumerated device.
- Surfaces the handler_result.reason in practice start output when a skill fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)