### PR TITLE
fix(skill): point new skills at ros-claw/skills catalog and guard upload

### DIFF
--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -2551,13 +2551,14 @@ def _call_provider_http(
     import urllib.error
     import urllib.request
 
+    inputs = dict(input_payload)
     payload = {
         "provider": provider_id,
         "capability": capability,
-        "inputs": input_payload,
+        "inputs": inputs,
     }
     if image_b64:
-        payload["inputs"]["image"] = f"data:{image_mime};base64,{image_b64}"
+        inputs["image"] = f"data:{image_mime};base64,{image_b64}"
 
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(

--- a/src/rosclaw/skill/catalog.py
+++ b/src/rosclaw/skill/catalog.py
@@ -1,0 +1,217 @@
+"""Helpers for contributing Skills to the official ros-claw/skills catalog."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from rosclaw.skill.models import SkillPackage
+from rosclaw.skill.validators import validate_package
+
+CATALOG_REPO = "ros-claw/skills"
+CATALOG_DEFAULT_BRANCH = "main"
+
+
+def _run(cmd: list[str], cwd: Path | None = None, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _has_gh() -> bool:
+    return shutil.which("gh") is not None
+
+
+def _gh_auth_status() -> bool:
+    try:
+        _run(["gh", "auth", "status"])
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def _ensure_git_config(workdir: Path) -> None:
+    """Set a fallback git user name/email only if none are configured."""
+    for key, value in (("user.name", "ROSClaw Skill Bot"), ("user.email", "noreply@rosclaw.io")):
+        try:
+            _run(["git", "config", "--global", key], cwd=workdir)
+        except subprocess.CalledProcessError:
+            _run(["git", "config", "--global", key, value], cwd=workdir)
+
+
+def submit_to_catalog(
+    pkg: SkillPackage,
+    *,
+    dry_run: bool = False,
+    catalog_repo: str = CATALOG_REPO,
+    base_branch: str = CATALOG_DEFAULT_BRANCH,
+    branch_prefix: str = "add",
+) -> dict[str, Any]:
+    """Submit a local skill to the official catalog by opening a GitHub PR.
+
+    This does **not** require ``ROSCLAW_ADMIN_API_KEY``. It requires only a
+    working ``gh`` CLI login (``gh auth login``) with permission to fork
+    ``ros-claw/skills``.
+    """
+    if pkg.skill is None:
+        raise RuntimeError("skill.yaml not loaded")
+
+    if not _has_gh():
+        raise RuntimeError(
+            "`gh` (GitHub CLI) is not installed. "
+            "Install it from https://cli.github.com and run `gh auth login`."
+        )
+
+    if not _gh_auth_status():
+        raise RuntimeError(
+            "`gh` is not authenticated. Run `gh auth login` first."
+        )
+
+    # Validate the local skill first.
+    report = validate_package(pkg)
+    if not report.ok:
+        raise RuntimeError(
+            "Local skill validation failed:\n  "
+            + "\n  ".join(report.errors)
+        )
+
+    name = pkg.skill.metadata.name
+    namespace = pkg.skill.metadata.namespace or "ros-claw"
+    version = pkg.skill.metadata.version
+    display_name = pkg.skill.metadata.display_name or name
+    branch_name = f"{branch_prefix}-{name}-v{version}"
+
+    if dry_run:
+        return {
+            "ok": True,
+            "dry_run": True,
+            "catalog_repo": catalog_repo,
+            "base_branch": base_branch,
+            "branch": branch_name,
+            "skill_name": f"{namespace}/{name}",
+            "version": version,
+        }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = Path(tmp) / "skills"
+
+        # Fork the catalog repo (no-op if already forked).
+        try:
+            _run(["gh", "repo", "fork", catalog_repo, "--clone=false", "--default-branch-only"])
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Failed to fork {catalog_repo}: {exc.stderr}") from exc
+
+        # Determine the user's fork owner.
+        try:
+            viewer_res = _run(["gh", "api", "user", "-q", ".login"])
+            fork_owner = viewer_res.stdout.strip()
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Failed to get GitHub user login: {exc.stderr}") from exc
+
+        if not fork_owner:
+            raise RuntimeError("Could not determine GitHub login from `gh api user`.")
+
+        fork_repo = f"{fork_owner}/skills"
+
+        # Clone the fork.
+        try:
+            _run(["gh", "repo", "clone", fork_repo, str(workdir), "--", "--depth=1"])
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Failed to clone {fork_repo}: {exc.stderr}") from exc
+
+        _ensure_git_config(workdir)
+
+        # Create a feature branch.
+        try:
+            _run(["git", "checkout", "-b", branch_name], cwd=workdir)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Failed to create branch {branch_name}: {exc.stderr}") from exc
+
+        target_dir = workdir / "skills" / name
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        shutil.copytree(pkg.root, target_dir)
+
+        # Run catalog validation scripts inside the clone.
+        try:
+            _run([sys.executable, "scripts/validate_skill.py", f"skills/{name}"], cwd=workdir)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                "Catalog validation failed:\n" + (exc.stdout or "") + (exc.stderr or "")
+            ) from exc
+
+        try:
+            _run([sys.executable, "scripts/build_registry.py"], cwd=workdir)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                "Registry build failed:\n" + (exc.stdout or "") + (exc.stderr or "")
+            ) from exc
+
+        # Commit changes.
+        try:
+            _run(["git", "add", "--all"], cwd=workdir)
+            _run(
+                [
+                    "git",
+                    "commit",
+                    "-m",
+                    f"Add {name} skill v{version}\n\nSubmitted from rosclaw CLI.",
+                ],
+                cwd=workdir,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Failed to commit changes: {exc.stderr}") from exc
+
+        # Push the branch to the fork.
+        env = os.environ.copy()
+        env["GIT_ASKPASS"] = "echo"
+        try:
+            _run(["git", "push", "-u", "origin", branch_name], cwd=workdir, env=env)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Failed to push branch {branch_name}: {exc.stderr}") from exc
+
+        # Open the PR against the upstream catalog repo.
+        try:
+            pr_res = _run(
+                [
+                    "gh",
+                    "pr",
+                    "create",
+                    "--repo",
+                    catalog_repo,
+                    "--base",
+                    base_branch,
+                    "--head",
+                    f"{fork_owner}:{branch_name}",
+                    "--title",
+                    f"Add {display_name} skill v{version}",
+                    "--body",
+                    f"Proposes adding `{namespace}/{name}` v{version} to the official ROSClaw Skills Catalog.\n\n"
+                    "Please review validation output before merging.",
+                ],
+                cwd=workdir,
+            )
+            pr_url = pr_res.stdout.strip()
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Failed to create pull request: {exc.stderr}") from exc
+
+        return {
+            "ok": True,
+            "dry_run": False,
+            "catalog_repo": catalog_repo,
+            "fork_repo": fork_repo,
+            "branch": branch_name,
+            "skill_name": f"{namespace}/{name}",
+            "version": version,
+            "pr_url": pr_url,
+        }

--- a/src/rosclaw/skill/cli.py
+++ b/src/rosclaw/skill/cli.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from rosclaw.firstboot.workspace import resolve_home
 from rosclaw.skill.builtins import get_builtin_skill, list_builtin_skills
+from rosclaw.skill.catalog import submit_to_catalog
 from rosclaw.skill.eval import evaluate_skill
 from rosclaw.skill.mining import mine_skill_candidate
 from rosclaw.skill.models import SkillPackage, SkillRef
@@ -348,6 +349,48 @@ def cmd_skill_upload(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Submit catalog
+# ---------------------------------------------------------------------------
+
+
+def cmd_skill_submit_catalog(args: argparse.Namespace) -> int:
+    skill_dir = _load_skill_dir_arg(args)
+    if not skill_dir.exists():
+        print(f"[ROSClaw] Skill not found: {skill_dir}")
+        return 1
+    pkg = SkillPackage(skill_dir).try_load()
+
+    try:
+        result = submit_to_catalog(
+            pkg,
+            dry_run=args.dry_run,
+            catalog_repo=args.catalog_repo,
+            base_branch=args.base_branch,
+            branch_prefix=args.branch_prefix,
+        )
+    except RuntimeError as exc:
+        print(f"[ROSClaw] Submit to catalog failed: {exc}")
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        if result["dry_run"]:
+            print("[ROSClaw] Submit to catalog: DRY-RUN")
+            print(f"  skill: {result['skill_name']}")
+            print(f"  version: {result['version']}")
+            print(f"  target repo: {result['catalog_repo']}")
+            print(f"  base branch: {result['base_branch']}")
+            print(f"  proposed branch: {result['branch']}")
+        else:
+            print("[ROSClaw] Submit to catalog: PR created")
+            print(f"  skill: {result['skill_name']}")
+            print(f"  version: {result['version']}")
+            print(f"  PR: {result.get('pr_url', 'unknown')}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Rollback
 # ---------------------------------------------------------------------------
 
@@ -523,7 +566,7 @@ def add_skill_hub_parsers(skill_subparsers: Any) -> None:
     verify_pkg_parser.add_argument("--json", action="store_true", help="Output JSON")
     verify_pkg_parser.set_defaults(func=cmd_skill_verify_package)
 
-    upload_parser = skill_subparsers.add_parser("upload", help="Upload skill metadata to ROSClaw Hub")
+    upload_parser = skill_subparsers.add_parser("upload", help="Upload skill metadata to ROSClaw Hub (admin only)")
     upload_parser.add_argument("skill_dir", nargs="?", help="Skill directory")
     upload_parser.add_argument("--name", default=None, help="Skill name")
     upload_parser.add_argument("--visibility", default="private", choices=["public", "private", "org", "unlisted"], help="Visibility")
@@ -534,3 +577,17 @@ def add_skill_hub_parsers(skill_subparsers: Any) -> None:
     upload_parser.add_argument("--workspace", default=None, help="Workspace root")
     upload_parser.add_argument("--json", action="store_true", help="Output JSON")
     upload_parser.set_defaults(func=cmd_skill_upload)
+
+    submit_catalog_parser = skill_subparsers.add_parser(
+        "submit-catalog",
+        help="Submit a local skill to the official ros-claw/skills catalog via GitHub PR",
+    )
+    submit_catalog_parser.add_argument("skill_dir", nargs="?", help="Skill directory")
+    submit_catalog_parser.add_argument("--name", default=None, help="Skill name")
+    submit_catalog_parser.add_argument("--catalog-repo", default="ros-claw/skills", help="Upstream catalog repo")
+    submit_catalog_parser.add_argument("--base-branch", default="main", help="Base branch in upstream repo")
+    submit_catalog_parser.add_argument("--branch-prefix", default="add", help="Feature branch prefix")
+    submit_catalog_parser.add_argument("--workspace", default=None, help="Workspace root")
+    submit_catalog_parser.add_argument("--dry-run", action="store_true", help="Dry run")
+    submit_catalog_parser.add_argument("--json", action="store_true", help="Output JSON")
+    submit_catalog_parser.set_defaults(func=cmd_skill_submit_catalog)

--- a/src/rosclaw/skill/models.py
+++ b/src/rosclaw/skill/models.py
@@ -166,6 +166,8 @@ class SkillIdentity(BaseModel):
     package_name: str | None = None
     canonical_uri: str | None = None
     git_repo: str | None = None
+    git_ref: str | None = None
+    source_subdir: str | None = None
     git_commit: str | None = None
 
 

--- a/src/rosclaw/skill/templates/default/skill.yaml
+++ b/src/rosclaw/skill/templates/default/skill.yaml
@@ -21,7 +21,9 @@ identity:
   skill_id: "{namespace}/{name}"
   package_name: "{namespace}/{name}"
   canonical_uri: "rosclaw://skills/{namespace}/{name}"
-  git_repo: "https://github.com/{namespace}/{name}"
+  git_repo: "https://github.com/ros-claw/skills"
+  git_ref: "main"
+  source_subdir: "skills/{name}"
   git_commit: null
 
 task:

--- a/src/rosclaw/skill/upload.py
+++ b/src/rosclaw/skill/upload.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import urllib.request
 from datetime import UTC, datetime
 from typing import Any
 
@@ -10,6 +11,45 @@ import semver
 
 from rosclaw.skill.hub_client import SkillHubClient
 from rosclaw.skill.models import SkillPackage
+
+
+def _github_repo_url(pkg: SkillPackage) -> str:
+    """Return the public-facing GitHub URL for this skill.
+
+    For official catalog skills the canonical source lives in a subdir of
+    ``ros-claw/skills``. The Hub only stores one ``github_repo_url`` field, so
+    we point it at the actual subdir path to avoid 404 links.
+    """
+    if pkg.skill is None:
+        raise RuntimeError("skill.yaml not loaded")
+
+    identity = pkg.skill.identity
+    base = (identity.git_repo or "").rstrip("/")
+    if not base:
+        return ""
+
+    ref = identity.git_ref or "main"
+    subdir = identity.source_subdir or ""
+    if subdir:
+        return f"{base}/tree/{ref}/{subdir}"
+    return base
+
+
+def _verify_repo_url(url: str) -> bool:
+    """Do a lightweight HEAD check against a GitHub URL.
+
+    Returns ``True`` if the URL responds with 2xx/3xx, ``False`` otherwise.
+    """
+    try:
+        request = urllib.request.Request(
+            url,
+            method="HEAD",
+            headers={"User-Agent": "Mozilla/5.0 (compatible; rosclaw-cli/1.0)"},
+        )
+        with urllib.request.urlopen(request, timeout=15) as response:
+            return 200 <= response.getcode() < 400
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def build_hub_payload(pkg: SkillPackage, visibility: str = "private") -> dict[str, Any]:
@@ -44,13 +84,14 @@ def build_hub_payload(pkg: SkillPackage, visibility: str = "private") -> dict[st
         dependencies = lock.get("dependencies", [])
 
     name = pkg.skill.identity.package_name or pkg.skill_id
+    github_url = _github_repo_url(pkg)
 
     return {
         "name": name,
         "display_name": pkg.skill.metadata.display_name or pkg.skill.metadata.name,
         "description": pkg.skill.metadata.description,
         "long_description": long_description,
-        "github_repo_url": pkg.skill.identity.git_repo or "",
+        "github_repo_url": github_url,
         "author_name": author_name,
         "author_url": author_url,
         "category": pkg.skill.metadata.category or "general",
@@ -87,9 +128,14 @@ def upload_skill(
 ) -> dict[str, Any]:
     api_key = os.environ.get(api_key_env)
     if not api_key:
-        raise RuntimeError(f"Missing API key in environment variable {api_key_env}")
+        raise RuntimeError(
+            f"Missing API key in environment variable {api_key_env}. "
+            "Metadata upload to rosclaw.io is reserved for administrators. "
+            "To contribute a Skill without an admin key, use `rosclaw skill submit-catalog`."
+        )
 
     payload = build_hub_payload(pkg, visibility=visibility)
+    github_url = payload.get("github_repo_url", "")
 
     if dry_run:
         return {
@@ -98,6 +144,20 @@ def upload_skill(
             "payload": payload,
             "receipt": None,
         }
+
+    if not github_url:
+        raise RuntimeError(
+            "skill.yaml identity.git_repo is empty. "
+            "Set a valid GitHub repository URL before uploading."
+        )
+
+    if not _verify_repo_url(github_url):
+        raise RuntimeError(
+            f"GitHub source is not reachable: {github_url}\n"
+            "The Hub record would point to a 404 page. "
+            "For official Skills, submit the source via `rosclaw skill submit-catalog`. "
+            "For external/community Skills, ensure the repository exists and is public."
+        )
 
     client = SkillHubClient(hub_base_url, api_key)
     response = client.create_skill(payload)

--- a/tests/skill/test_package.py
+++ b/tests/skill/test_package.py
@@ -110,6 +110,7 @@ def test_upload_receipt_written(tmp_path: Path, monkeypatch: MonkeyPatch):
     pkg = _validated_pkg(tmp_path)
     monkeypatch.setenv("ROSCLAW_ADMIN_API_KEY", "test-key")
     monkeypatch.setattr("rosclaw.skill.upload.SkillHubClient", FakeHubClient)
+    monkeypatch.setattr("rosclaw.skill.upload._verify_repo_url", lambda _url: True)
     result = upload_skill(pkg)
     assert result["ok"] is True
     receipt_path = pkg.root / ".rosclaw" / "upload_receipt.json"


### PR DESCRIPTION
Fixes the phantom 404 GitHub repo problem by making new skills default to the official ros-claw/skills catalog and adding a no-API-key submit-catalog PR flow.