### PR TITLE
feat(body): generic force-feedback, contact-event, body-cognition types

### DIFF
--- a/src/rosclaw/body/__init__.py
+++ b/src/rosclaw/body/__init__.py
@@ -1,7 +1,18 @@
 """rosclaw.body — Physical AI Body Runtime layer."""
 
+from rosclaw.body.body_cognition import BodyCognition, PromotionGateResult
 from rosclaw.body.compatibility import SkillCompatibilityChecker, SkillCompatibilityStore
 from rosclaw.body.compiler import EffectiveBodyCompiler
+from rosclaw.body.contact_event import (
+    CONTACT_EVENT_LABELS,
+    PRIMARY_EVENT_PRIORITY,
+    ContactEvent,
+    event_distribution,
+    select_primary_event,
+    tag_distribution,
+)
+from rosclaw.body.force_model import DofForceWindow, ForceBaseline, ForceModel
+from rosclaw.body.physical_feedback_frame import PhysicalFeedbackFrame
 from rosclaw.body.renderer import EmbodimentRenderer
 from rosclaw.body.resolver import BodyNotLinkedError, BodyResolver
 from rosclaw.body.schema import (
@@ -20,9 +31,18 @@ from rosclaw.body.schema import (
 )
 
 __all__ = [
+    "BodyCognition",
     "BodyResolver",
     "BodyNotLinkedError",
+    "ContactEvent",
+    "CONTACT_EVENT_LABELS",
+    "DofForceWindow",
     "EffectiveBodyCompiler",
+    "ForceBaseline",
+    "ForceModel",
+    "PhysicalFeedbackFrame",
+    "PRIMARY_EVENT_PRIORITY",
+    "PromotionGateResult",
     "SkillCompatibilityChecker",
     "SkillCompatibilityStore",
     "EmbodimentRenderer",
@@ -38,4 +58,7 @@ __all__ = [
     "BodyDiff",
     "ValidationResult",
     "BodyValidationReport",
+    "event_distribution",
+    "select_primary_event",
+    "tag_distribution",
 ]

--- a/src/rosclaw/body/body_cognition.py
+++ b/src/rosclaw/body/body_cognition.py
@@ -1,0 +1,76 @@
+"""Generic body-cognition and promotion-gate types.
+
+BodyCognition stores learned traits about a physical body: force-model
+configuration, sim2real deltas, promoted policies, and known safe poses.
+PromotionGateResult records whether a candidate policy passed repeatability
+and safety gates.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class PromotionGateResult:
+    """Result of a promotion gate evaluation for one policy."""
+
+    policy_id: str = ""
+    passed: bool = False
+    rounds: int = 0
+    contact_detected_rate: float = 0.0
+    force_window_pass_rate: float = 0.0
+    shape_score_mean: float = 0.0
+    max_force_net: Optional[float] = None
+    max_temp_c: Optional[float] = None
+    errors: int = 0
+    status_protection_events: int = 0
+    over_contact_events: int = 0
+    failures: List[str] = field(default_factory=list)
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    timestamp: str = ""
+    evidence_files: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PromotionGateResult":
+        return cls(**data)
+
+
+@dataclass
+class BodyCognition:
+    """Generic learned-body-knowledge container.
+
+    Mirrors the structure used by RH56's ~/.rosclaw-rh56/body/body_cognition.yaml
+    but without RH56-specific field names, so other bodies can reuse it.
+    """
+
+    body_id: str = ""
+    schema_version: str = "rosclaw.body.cognition.v1"
+    updated_at: str = ""
+
+    force_model: Dict[str, Any] = field(default_factory=dict)
+    known_traits: List[str] = field(default_factory=list)
+    promoted_policies: List[Dict[str, Any]] = field(default_factory=list)
+    countdown_validations: List[Dict[str, Any]] = field(default_factory=list)
+    sim2real_deltas: Dict[str, Any] = field(default_factory=dict)
+    search_history: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Free-form notes for humans and agents.
+    notes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BodyCognition":
+        return cls(**data)
+
+    def get_promoted_policy(self, policy_id: str) -> Optional[Dict[str, Any]]:
+        """Return the latest promoted policy with the given id."""
+        for policy in reversed(self.promoted_policies):
+            if policy.get("policy_id") == policy_id:
+                return policy
+        return None

--- a/src/rosclaw/body/contact_event.py
+++ b/src/rosclaw/body/contact_event.py
@@ -1,0 +1,90 @@
+"""Generic contact-event types shared across bodies."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+# Canonical event labels used by the generic event detector.
+# Bodies may map their local labels to these.
+CONTACT_EVENT_LABELS = [
+    "no_contact",
+    "weak_contact",
+    "desired_contact",
+    "over_contact",
+    "emergency_contact",
+    "early_contact",
+    "late_contact",
+    "self_collision",
+    "position_stall",
+    "motion_blocked",
+    "hardware_protection",
+    "temperature_limited",
+    "force_sensor_drift",
+    "unknown",
+]
+
+# Safety-priority order for selecting a mutually-exclusive primary event.
+PRIMARY_EVENT_PRIORITY = [
+    "hardware_protection",
+    "motion_blocked",
+    "emergency_contact",
+    "over_contact",
+    "position_stall",
+    "temperature_limited",
+    "early_contact",
+    "self_collision",
+    "desired_contact",
+    "late_contact",
+    "weak_contact",
+    "force_sensor_drift",
+    "no_contact",
+    "unknown",
+]
+
+
+@dataclass
+class ContactEvent:
+    """A single inferred contact event."""
+
+    event_type: str = "unknown"
+    confidence: float = 1.0
+    dofs: List[str] = field(default_factory=list)
+    timestamp: float = 0.0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ContactEvent":
+        return cls(**data)
+
+
+def select_primary_event(tags: List[str]) -> str:
+    """Pick the highest-priority tag from a list of labels."""
+    tag_set = set(tags)
+    for event in PRIMARY_EVENT_PRIORITY:
+        if event in tag_set:
+            return event
+    return "unknown"
+
+
+def event_distribution(events: List[ContactEvent]) -> Dict[str, int]:
+    """Count events by type."""
+    dist: Dict[str, int] = {}
+    for ev in events:
+        dist[ev.event_type] = dist.get(ev.event_type, 0) + 1
+    return dist
+
+
+def tag_distribution(events: List[ContactEvent], secondary: Optional[List[List[str]]] = None) -> Dict[str, int]:
+    """Count all tags, optionally including secondary tag lists."""
+    dist: Dict[str, int] = {}
+    for ev in events:
+        dist[ev.event_type] = dist.get(ev.event_type, 0) + 1
+    if secondary:
+        for tags in secondary:
+            for tag in tags:
+                dist[tag] = dist.get(tag, 0) + 1
+    return dist

--- a/src/rosclaw/body/force_model.py
+++ b/src/rosclaw/body/force_model.py
@@ -1,0 +1,162 @@
+"""Generic force model for physical feedback frames.
+
+Manages per-DOF force baselines and classifies net-force magnitudes into
+contact levels. The units are body-defined (grams-force for RH56, Newtons
+for larger arms, etc.).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+
+@dataclass
+class ForceBaseline:
+    """Per-DOF baseline statistics."""
+
+    mean: float = 0.0
+    std: float = 0.0
+    min: float = 0.0
+    max: float = 0.0
+    samples: int = 0
+
+
+@dataclass
+class DofForceWindow:
+    """Per-DOF force thresholds."""
+
+    desired_min: float = 0.0
+    desired_max: float = 0.0
+    hard: float = 0.0
+    emergency: float = 0.0
+
+
+class ForceModel:
+    """Body-agnostic force baseline and contact-level classifier."""
+
+    def __init__(
+        self,
+        baseline: Optional[Dict[str, ForceBaseline]] = None,
+        thresholds: Optional[Dict[str, float]] = None,
+        contact_windows: Optional[Dict[str, DofForceWindow]] = None,
+        policy: Optional[Dict[str, bool]] = None,
+    ):
+        self.baseline: Dict[str, ForceBaseline] = baseline or {}
+        self.thresholds: Dict[str, float] = thresholds or self._default_thresholds()
+        self.contact_windows: Dict[str, DofForceWindow] = contact_windows or {}
+        self.policy: Dict[str, bool] = policy or self._default_policy()
+
+    @staticmethod
+    def _default_thresholds() -> Dict[str, float]:
+        return {
+            "soft_contact": 0.0,
+            "contact_detect_sigma": 5.0,
+        }
+
+    @staticmethod
+    def _default_policy() -> Dict[str, bool]:
+        return {
+            "baseline_required": True,
+            "use_force_for_static_contact": True,
+            "use_current_for_static_contact": False,
+        }
+
+    def window(self, dof: str) -> DofForceWindow:
+        return self.contact_windows.get(dof, DofForceWindow())
+
+    def net_force(
+        self,
+        force_raw: Dict[str, Optional[float]],
+        dofs: Optional[List[str]] = None,
+    ) -> Dict[str, Optional[float]]:
+        """Subtract baseline mean from raw force for each DOF."""
+        dofs = dofs or list(force_raw.keys())
+        result: Dict[str, Optional[float]] = {}
+        for name in dofs:
+            raw = force_raw.get(name)
+            if raw is None:
+                result[name] = None
+                continue
+            baseline = self.baseline.get(name, ForceBaseline()).mean
+            result[name] = raw - baseline
+        return result
+
+    def contact_level(self, net_force: Optional[float], dof: str) -> Optional[str]:
+        """Classify a single net-force magnitude into a contact level."""
+        if net_force is None:
+            return None
+        w = self.window(dof)
+        if w.emergency and net_force >= w.emergency:
+            return "emergency"
+        if w.hard and net_force >= w.hard:
+            return "hard"
+        if w.desired_max and net_force >= w.desired_max:
+            return "strong"
+        if w.desired_min and net_force >= w.desired_min:
+            return "desired"
+        soft = self.thresholds.get("soft_contact", 0.0)
+        if soft and net_force >= soft:
+            return "soft"
+        return "none"
+
+    def is_contact(
+        self,
+        net_force: Optional[float],
+        dof: str,
+        min_force: Optional[float] = None,
+    ) -> bool:
+        if net_force is None:
+            return False
+        threshold = min_force if min_force is not None else self.window(dof).desired_min
+        return threshold is not None and net_force >= threshold
+
+    def is_desired_contact(self, net_force: Optional[float], dof: str) -> bool:
+        if net_force is None:
+            return False
+        w = self.window(dof)
+        if w.desired_min is None or w.desired_max is None:
+            return False
+        return w.desired_min <= net_force <= w.desired_max
+
+    def is_over_contact(self, net_force: Optional[float], dof: str) -> bool:
+        if net_force is None:
+            return False
+        hard = self.window(dof).hard
+        return hard is not None and net_force >= hard
+
+    def list_missing_baselines(self, dofs: List[str]) -> List[str]:
+        """Return DOFs with no baseline samples."""
+        return [
+            name
+            for name in dofs
+            if self.baseline.get(name, ForceBaseline()).samples == 0
+        ]
+
+    def save_policy_yaml(self, path: Path) -> None:
+        """Write force policy config to YAML."""
+        data = {
+            "force_policy": {
+                "baseline_required": self.policy.get("baseline_required", True),
+                "use_force_for_static_contact": self.policy.get(
+                    "use_force_for_static_contact", True
+                ),
+                "use_current_for_static_contact": self.policy.get(
+                    "use_current_for_static_contact", False
+                ),
+                "contact_windows": {
+                    name: {
+                        "desired_min": w.desired_min,
+                        "desired_max": w.desired_max,
+                        "hard": w.hard,
+                        "emergency": w.emergency,
+                    }
+                    for name, w in self.contact_windows.items()
+                },
+            }
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)

--- a/src/rosclaw/body/physical_feedback_frame.py
+++ b/src/rosclaw/body/physical_feedback_frame.py
@@ -1,0 +1,76 @@
+"""Generic physical feedback frame for embodied agents.
+
+A PhysicalFeedbackFrame is a body-agnostic snapshot of one telemetry sample:
+target/actual state, force readings, safety channels, and inferred contact
+events. It is intentionally not RH56-specific so it can be reused for any
+end-effector or body that exposes per-DOF force/status/temperature data.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class PhysicalFeedbackFrame:
+    """A single body-agnostic telemetry frame.
+
+    All per-DOF maps use the body's native DOF names as keys (e.g. "thumb",
+    "index", "joint_0"). Values are floats or arbitrary diagnostic payloads.
+    """
+
+    frame_id: str = ""
+    body_id: str = ""
+    timestamp: float = 0.0
+
+    # Kinematic state
+    target: Dict[str, float] = field(default_factory=dict)
+    actual: Dict[str, float] = field(default_factory=dict)
+    position_error: Dict[str, float] = field(default_factory=dict)
+
+    # Force pipeline (units are body-specific; RH56 uses grams-force)
+    force_raw: Dict[str, Optional[float]] = field(default_factory=dict)
+    force_baseline: Dict[str, Optional[float]] = field(default_factory=dict)
+    force_net: Dict[str, Optional[float]] = field(default_factory=dict)
+    force_delta: Dict[str, Optional[float]] = field(default_factory=dict)
+    force_derivative: Dict[str, Optional[float]] = field(default_factory=dict)
+
+    # Auxiliary telemetry
+    current: Dict[str, Optional[float]] = field(default_factory=dict)
+    status: Dict[str, Any] = field(default_factory=dict)
+    error: Dict[str, Any] = field(default_factory=dict)
+    temperature: Dict[str, Optional[float]] = field(default_factory=dict)
+
+    # Inferred semantics
+    primary_event: str = "unknown"
+    secondary_tags: List[str] = field(default_factory=list)
+    serial_timeout: bool = False
+
+    # Extension point for body-specific fields (e.g. voltage, encoder ticks)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dict; safe for JSONL/Parquet."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PhysicalFeedbackFrame":
+        """Restore from a plain dict."""
+        return cls(**data)
+
+    def dof_names(self) -> List[str]:
+        """Return the union of DOF names seen across all per-DOF maps."""
+        names: set[str] = set()
+        for d in (
+            self.target,
+            self.actual,
+            self.position_error,
+            self.force_raw,
+            self.force_net,
+            self.current,
+            self.status,
+            self.error,
+            self.temperature,
+        ):
+            names.update(d.keys())
+        return sorted(names)

--- a/tests/body/test_body_cognition.py
+++ b/tests/body/test_body_cognition.py
@@ -1,0 +1,31 @@
+"""Tests for generic BodyCognition and PromotionGateResult."""
+from __future__ import annotations
+
+from rosclaw.body.body_cognition import BodyCognition, PromotionGateResult
+
+
+def test_promotion_gate_result_passed():
+    gate = PromotionGateResult(
+        policy_id="ok_contact_safe_v2",
+        passed=True,
+        rounds=10,
+        contact_detected_rate=1.0,
+        force_window_pass_rate=1.0,
+        max_force_net=169.0,
+        failures=[],
+    )
+    assert gate.to_dict()["passed"] is True
+    assert gate.to_dict()["rounds"] == 10
+
+
+def test_body_cognition_roundtrip():
+    cog = BodyCognition(
+        body_id="inspire_rh56_right_dev_ttyUSB0",
+        schema_version="rosclaw.body.cognition.v2_1",
+        known_traits=["FORCE_ACT must be baseline-subtracted"],
+        promoted_policies=[{"policy_id": "ok_contact_safe_v2", "version": "0.3.0"}],
+    )
+    restored = BodyCognition.from_dict(cog.to_dict())
+    assert restored.body_id == cog.body_id
+    assert restored.get_promoted_policy("ok_contact_safe_v2")["version"] == "0.3.0"
+    assert restored.get_promoted_policy("missing") is None

--- a/tests/body/test_contact_event.py
+++ b/tests/body/test_contact_event.py
@@ -1,0 +1,41 @@
+"""Tests for generic contact-event types."""
+from __future__ import annotations
+
+from rosclaw.body.contact_event import (
+    ContactEvent,
+    event_distribution,
+    select_primary_event,
+    tag_distribution,
+)
+
+
+def test_select_primary_event_safety_priority():
+    assert select_primary_event(["desired_contact", "over_contact"]) == "over_contact"
+    assert select_primary_event(["hardware_protection", "over_contact"]) == "hardware_protection"
+    assert select_primary_event([]) == "unknown"
+
+
+def test_event_distribution():
+    events = [
+        ContactEvent(event_type="desired_contact"),
+        ContactEvent(event_type="desired_contact"),
+        ContactEvent(event_type="no_contact"),
+    ]
+    assert event_distribution(events) == {"desired_contact": 2, "no_contact": 1}
+
+
+def test_tag_distribution_includes_secondary():
+    events = [ContactEvent(event_type="desired_contact")]
+    secondary = [["stable", "low_temp"]]
+    dist = tag_distribution(events, secondary=secondary)
+    assert dist["desired_contact"] == 1
+    assert dist["stable"] == 1
+    assert dist["low_temp"] == 1
+
+
+def test_contact_event_roundtrip():
+    ev = ContactEvent(event_type="over_contact", dofs=["thumb"], confidence=0.9)
+    restored = ContactEvent.from_dict(ev.to_dict())
+    assert restored.event_type == "over_contact"
+    assert restored.dofs == ["thumb"]
+    assert restored.confidence == 0.9

--- a/tests/body/test_force_model.py
+++ b/tests/body/test_force_model.py
@@ -1,0 +1,58 @@
+"""Tests for generic ForceModel."""
+from __future__ import annotations
+
+from rosclaw.body.force_model import DofForceWindow, ForceBaseline, ForceModel
+
+
+def test_net_force_subtracts_baseline():
+    model = ForceModel(
+        baseline={
+            "thumb": ForceBaseline(mean=-50.0),
+            "index": ForceBaseline(mean=-35.0),
+        }
+    )
+    raw = {"thumb": 100.0, "index": 50.0, "middle": 0.0}
+    net = model.net_force(raw)
+    assert net["thumb"] == 150.0
+    assert net["index"] == 85.0
+    assert net["middle"] == 0.0
+
+
+def test_contact_levels_with_window():
+    model = ForceModel(
+        contact_windows={
+            "thumb": DofForceWindow(desired_min=80.0, desired_max=180.0, hard=250.0, emergency=350.0)
+        }
+    )
+    assert model.contact_level(10.0, "thumb") == "none"
+    assert model.contact_level(100.0, "thumb") == "desired"
+    assert model.contact_level(200.0, "thumb") == "strong"
+    assert model.contact_level(260.0, "thumb") == "hard"
+    assert model.contact_level(400.0, "thumb") == "emergency"
+
+
+def test_is_desired_contact_per_dof():
+    model = ForceModel(
+        contact_windows={
+            "thumb": DofForceWindow(desired_min=80.0, desired_max=180.0),
+            "index": DofForceWindow(desired_min=80.0, desired_max=200.0),
+        }
+    )
+    assert model.is_desired_contact(190.0, "index")
+    assert not model.is_desired_contact(190.0, "thumb")
+
+
+def test_missing_baselines():
+    model = ForceModel(
+        baseline={
+            "thumb": ForceBaseline(samples=10),
+            "index": ForceBaseline(samples=0),
+        }
+    )
+    assert model.list_missing_baselines(["thumb", "index"]) == ["index"]
+
+
+def test_current_not_used_for_static_contact():
+    model = ForceModel()
+    assert model.policy["use_current_for_static_contact"] is False
+    assert model.policy["use_force_for_static_contact"] is True

--- a/tests/body/test_physical_feedback_frame.py
+++ b/tests/body/test_physical_feedback_frame.py
@@ -1,0 +1,40 @@
+"""Tests for generic PhysicalFeedbackFrame."""
+from __future__ import annotations
+
+from rosclaw.body.physical_feedback_frame import PhysicalFeedbackFrame
+
+
+def test_roundtrip_dict():
+    frame = PhysicalFeedbackFrame(
+        frame_id="f1",
+        body_id="body_1",
+        timestamp=1.0,
+        target={"thumb": 420.0},
+        actual={"thumb": 418.0},
+        force_net={"thumb": 100.0},
+        primary_event="desired_contact",
+        secondary_tags=["stable"],
+    )
+    restored = PhysicalFeedbackFrame.from_dict(frame.to_dict())
+    assert restored.frame_id == "f1"
+    assert restored.force_net["thumb"] == 100.0
+    assert restored.primary_event == "desired_contact"
+
+
+def test_default_primary_event_is_unknown():
+    frame = PhysicalFeedbackFrame(timestamp=0.0)
+    assert frame.primary_event == "unknown"
+    assert frame.secondary_tags == []
+
+
+def test_dof_names_union():
+    frame = PhysicalFeedbackFrame(
+        target={"thumb": 0.0, "index": 0.0},
+        force_net={"index": 5.0, "middle": 1.0},
+    )
+    assert frame.dof_names() == ["index", "middle", "thumb"]
+
+
+def test_serial_timeout_flag():
+    frame = PhysicalFeedbackFrame(serial_timeout=True)
+    assert frame.to_dict()["serial_timeout"] is True


### PR DESCRIPTION
Adds reusable, body-agnostic building blocks for force-closed-loop skills used by the Inspire RH56 v2.1 work:

- `PhysicalFeedbackFrame` — per-DOF target/actual/force/status/temperature telemetry frame
- `ForceModel` / `ForceBaseline` / `DofForceWindow` — baseline subtraction and contact-level classification
- `ContactEvent` + priority helpers for mutually-exclusive primary events
- `BodyCognition` / `PromotionGateResult` for persisted body knowledge and promotion gates

Includes unit tests under `tests/body/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
