### PR TITLE
chore(pytest): use underscore plugin names in addopts to avoid ROS PYTHONPATH pollution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 asyncio_mode = "auto"
-addopts = "-p no:launch-testing-ros -p no:launch-testing -p no:ament-pep257 -p no:ament-lint -p no:ament-copyright -p no:ament-flake8 -p no:ament-xmllint -p no:colcon-core -m 'not integration and not deployment'"
+addopts = "-p no:launch_ros -p no:launch_testing -p no:ament_pep257 -p no:ament_lint -p no:ament_copyright -p no:ament_flake8 -p no:ament_xmllint -p no:colcon_core -m 'not integration and not deployment'"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as requiring external services (deselect with '-k not integration')",


### PR DESCRIPTION
P3 baseline cleanup.

The pytest `-p no:<plugin>` names must match the actual entry-point names. Using hyphens caused external ROS `PYTHONPATH` to load conflicting plugins and break core doctor/integration test collection.

This change aligns the `addopts` plugin names with their real entry points (`launch_ros`, `launch_testing`, `ament_pep257`, etc.) so the core suite is isolated from external ROS runtime configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)