### PR TITLE
add structured physical intelligence tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ See [QUICKSTART.md](QUICKSTART.md) for four guided paths: local simulation, agen
 
 ---
 
+## Structured Runtime Trace
+
+ROSClaw records a causal span tree across Runtime, Provider, MCP, Skill, Sandbox, and Firewall
+boundaries. Model/tool I/O is bounded and redacted, binary perception data is stored as references,
+and private chain-of-thought fields are omitted by default in favor of structured decision summaries.
+
+```bash
+rosclaw trace list
+rosclaw trace show <trace-id> --tree
+rosclaw trace tail --kind VLM,MCP,SANDBOX
+rosclaw dashboard --trace <trace-id>
+```
+
+The built-in Trace view is available at `/traces`.
+
+See [docs/TRACE.md](docs/TRACE.md) for the schema, instrumentation API, capture modes, CLI, and
+Dashboard endpoints.
+
+---
+
 ## Hub & Assets
 
 The ROSClaw Hub is a **Physical-AI Asset Hub** for skills, providers, hardware MCP servers, digital twins, and cognitive wikis. Assets can be kept entirely local or synced with a registry.

--- a/docs/TRACE.md
+++ b/docs/TRACE.md
@@ -1,0 +1,121 @@
+# ROSClaw Trace
+
+ROSClaw Trace is the structured decision and runtime evidence layer for physical AI. It records
+what the runtime observed and did, which model/tool/safety boundary was involved, how long each
+operation took, and what evidence supports the result.
+
+It does **not** expose private model chain-of-thought by default. The `standard` capture mode omits
+fields such as `cot`, `reasoning`, and `chain_of_thought`; use `DecisionSummary` for auditable goals,
+observations, constraints, candidates, decisions, short reasons, confidence, and evidence refs.
+
+## Data flow
+
+```text
+Runtime / Provider / MCP / Skill / Sandbox / Firewall
+                         │
+                    TraceSpan
+                         │
+          ┌──────────────┴──────────────┐
+          │                             │
+  EventBus live events        bounded writer queue
+          │                             │
+ events/live.jsonl              traces/live.jsonl
+          │                             │
+          └──────── Dashboard / CLI ────┘
+```
+
+Every completed span follows `rosclaw.trace.v1` and has a `trace_id`, `span_id`, optional
+`parent_span_id`, timing, status, kind, redacted input/output, attributes, and evidence references.
+Binary data, arrays, images, and point clouds are represented as metadata or artifact references.
+
+## Use it
+
+Tracing is enabled by default for `Runtime`. Records are stored at
+`$ROSCLAW_HOME/traces/live.jsonl` (normally `~/.rosclaw/traces/live.jsonl`).
+
+```bash
+rosclaw trace list
+rosclaw trace tail --kind LLM,VLM,MCP,SANDBOX
+rosclaw trace show <trace-id> --tree
+rosclaw trace show <trace-id> --provider
+rosclaw trace explain <event-id>
+rosclaw trace replay <trace-id>
+rosclaw trace export <trace-id> --format json --output trace.json
+rosclaw dashboard
+# open http://localhost:8765/traces
+```
+
+Dashboard APIs:
+
+```text
+GET /api/traces
+GET /api/traces?trace_id=...&kind=VLM,MCP&status=ERROR
+GET /api/traces/{trace_id}
+GET /api/traces/events/{event_id}
+```
+
+## Instrument an integration
+
+Components sharing an `EventBus` also share a tracer and causal context:
+
+```python
+from rosclaw.observability import DecisionSummary, get_tracer
+
+tracer = get_tracer(event_bus)
+
+async with tracer.start_span(
+    "camera.detect",
+    "PERCEPTION",
+    source="front_camera",
+    operation="object_detection",
+) as span:
+    span.set_input({"image": frame})  # array data is omitted; metadata is retained
+    detections = await detector(frame)
+    span.set_output(detections)
+    span.add_evidence("artifact://episode-7/front/1842.jpg")
+
+summary = DecisionSummary(
+    goal="navigate to the door",
+    observations=["person on the right"],
+    constraints=["minimum clearance 0.8m"],
+    candidates=[{"action": "left bypass", "score": 0.83}],
+    decision="left bypass",
+    reason_summary="highest-clearance candidate",
+    confidence=0.83,
+)
+```
+
+Exceptions mark spans as `ERROR`. Safety rejections should explicitly call
+`span.set_status("BLOCKED", reason)`. Trace failures are swallowed and never change the provider,
+sandbox, skill, or robot-control result.
+
+## Runtime configuration
+
+```python
+RuntimeConfig(
+    enable_tracing=True,
+    trace_capture_mode="standard",  # minimal | standard | research
+    trace_queue_size=4096,
+    trace_rotate_mb=64.0,
+    trace_home=None,
+)
+```
+
+`ROSCLAW_TRACE_MODE` can set the default capture mode. Secrets remain redacted in every mode.
+`research` permits explicit reasoning fields for controlled laboratory use; it does not disable
+credential redaction. The exporter queue is bounded and non-blocking. If saturated, normal spans
+may be dropped; an error or blocked span displaces a normal queued record.
+
+## Current instrumentation
+
+- Runtime closed-loop missions and structured planning decisions
+- Every `Runtime.execute()` mission includes a nested `PLANNER` decision summary, including when
+  provider planning is unavailable and the deterministic requested action is retained
+- Provider routing, real inference input/output, model metadata, token usage, fallback, and errors
+- MCP tool arguments/results, side-effect classification, robot/session identity, timeout/error state
+- Skill execution input/output and block/error state
+- Runtime sandbox validation, digital-twin rollout, firewall layers, violations, and replay refs
+- EventBus envelope propagation of `trace_id`, `span_id`, and `parent_span_id`
+
+High-frequency robot state should continue to use Practice/MCAP. Trace is for causal semantic
+operations; it should reference large physical artifacts rather than embed them.

--- a/src/rosclaw/agent_runtime/mcp_hub.py
+++ b/src/rosclaw/agent_runtime/mcp_hub.py
@@ -82,6 +82,7 @@ class MCPHub(LifecycleMixin):
         event_bus: EventBus,
         robot_id: str = "rosclaw_default",
         runtime: Any | None = None,
+        tracer: Any | None = None,
     ):
         super().__init__()
         self.event_bus = event_bus
@@ -95,6 +96,16 @@ class MCPHub(LifecycleMixin):
         self._server: Any | None = None
         self._pending_requests: dict[str, asyncio.Future] = {}
         self._default_timeout: float = 30.0
+        if tracer is None:
+            from rosclaw.observability.tracer import Tracer, get_tracer
+
+            runtime_tracer = getattr(runtime, "tracer", None)
+            tracer = (
+                runtime_tracer
+                if isinstance(runtime_tracer, Tracer)
+                else get_tracer(event_bus)
+            )
+        self._tracer = tracer
 
     def _do_initialize(self) -> None:
         """Initialize MCP server and register tools."""
@@ -524,6 +535,36 @@ class MCPHub(LifecycleMixin):
     # Tool call dispatch
     # ------------------------------------------------------------------
     async def handle_tool_call(self, name: str, arguments: dict) -> dict:
+        """Trace and dispatch one real MCP tool invocation."""
+
+        trace_id = arguments.get("trace_id") or f"mcp_{uuid.uuid4().hex[:16]}"
+        side_effect = name in {"move_joints", "grasp", "emergency_stop", "delegate_skill"}
+        async with self._tracer.start_span(
+            "mcp.call_tool",
+            "MCP",
+            source="mcp_hub",
+            operation=name,
+            trace_id=str(trace_id),
+            attributes={
+                "mcp.server": "rosclaw-mcp",
+                "tool.name": name,
+                "tool.side_effect": side_effect,
+                "safety.level": self.context.safety_level,
+            },
+            robot_id=self.robot_id,
+            session_id=self.context.session_id,
+        ) as span:
+            span.set_input(arguments)
+            result = await self._dispatch_tool_call(name, arguments)
+            span.set_output(result)
+            status = str(result.get("status", "")).lower()
+            if status == "blocked":
+                span.set_status("BLOCKED", result.get("error") or result.get("message"))
+            elif status in {"failed", "error", "timeout"} or "error" in result:
+                span.set_status("ERROR", result.get("error") or result.get("message"))
+            return result
+
+    async def _dispatch_tool_call(self, name: str, arguments: dict) -> dict:
         """
         Handle an MCP tool call from an LLM.
 

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -958,9 +958,11 @@ def cmd_dashboard(args: argparse.Namespace) -> int:
 
         host = getattr(args, "host", "0.0.0.0")
         port = getattr(args, "port", 8765)
+        trace_id = getattr(args, "trace", None)
         print("ROSClaw v1.0 Dashboard")
         print("[ROSClaw] Starting Dashboard Web Server...")
-        print(f"[ROSClaw] Dashboard URL: http://localhost:{port}")
+        dashboard_path = f"/traces?trace_id={trace_id}" if trace_id else "/traces"
+        print(f"[ROSClaw] Trace Dashboard URL: http://localhost:{port}{dashboard_path}")
         print("[ROSClaw] Press Ctrl+C to stop")
         serve_dashboard(host=host, port=port)
     except ImportError as exc:
@@ -973,6 +975,146 @@ def cmd_dashboard(args: argparse.Namespace) -> int:
             print(f"[ROSClaw] Server exited (code={exc.code}). Port may be in use.")
         return 0
     return 0
+
+
+def _trace_store_from_args(args: argparse.Namespace) -> Any:
+    from rosclaw.observability.store import TraceStore
+
+    return TraceStore(
+        home=getattr(args, "home", None),
+        path=getattr(args, "path", None),
+    )
+
+
+def _trace_filters(args: argparse.Namespace) -> tuple[set[str] | None, set[str] | None]:
+    kind = getattr(args, "kind", None)
+    status = getattr(args, "status", None)
+    kinds = {part.strip().upper() for part in kind.split(",") if part.strip()} if kind else None
+    statuses = (
+        {part.strip().upper() for part in status.split(",") if part.strip()} if status else None
+    )
+    return kinds, statuses
+
+
+def _print_trace_span(span: dict[str, Any], *, indent: int = 0) -> None:
+    started = time.strftime("%H:%M:%S", time.localtime(span.get("started_at") or 0))
+    duration = float(span.get("duration_ms") or 0)
+    prefix = "  " * indent
+    print(
+        f"{started}  {prefix}{str(span.get('span_kind', '?')):<12} "
+        f"{str(span.get('status', '?')):<8} {duration:9.2f} ms  {span.get('name', '?')}"
+    )
+
+
+def _print_trace_tree(nodes: list[dict[str, Any]], depth: int = 0) -> None:
+    for node in nodes:
+        _print_trace_span(node, indent=depth)
+        _print_trace_tree(node.get("children", []), depth + 1)
+
+
+def cmd_trace(args: argparse.Namespace) -> int:
+    """Inspect, tail, explain, replay, or export structured ROSClaw traces."""
+
+    store = _trace_store_from_args(args)
+    command = getattr(args, "trace_command", None)
+
+    if command == "list":
+        traces = store.list_traces(limit=args.limit)
+        if args.json:
+            print(json.dumps({"count": len(traces), "traces": traces}, indent=2))
+            return 0
+        if not traces:
+            print(f"No traces found in {store.path}")
+            return 0
+        print("TRACE ID                         STATUS    SPANS   DURATION   KINDS")
+        for item in traces:
+            kinds = ",".join(item["kinds"])
+            print(
+                f"{item['trace_id']:<32} {item['status']:<9} {item['span_count']:>5}   "
+                f"{item['duration_ms']:>8.2f}ms   {kinds}"
+            )
+        return 0
+
+    if command in {"show", "replay"}:
+        trace = store.get_trace(args.trace_id)
+        if not trace["spans"]:
+            print(f"Trace not found: {args.trace_id}", file=sys.stderr)
+            return 1
+        if getattr(args, "provider", False):
+            trace["spans"] = [
+                span for span in trace["spans"] if span.get("span_kind") in {"LLM", "VLM"}
+            ]
+            trace["span_count"] = len(trace["spans"])
+        if getattr(args, "json", False):
+            print(json.dumps(trace, indent=2, ensure_ascii=False, default=str))
+            return 0
+        print(f"Trace {trace['trace_id']} ({trace['span_count']} spans)")
+        if command == "replay" or getattr(args, "provider", False):
+            for span in trace["spans"]:
+                _print_trace_span(span)
+        else:
+            _print_trace_tree(trace["tree"])
+        return 0
+
+    if command == "tail":
+        kinds, statuses = _trace_filters(args)
+        seen: set[str] = set()
+        try:
+            while True:
+                spans = store.read(
+                    trace_id=args.trace_id,
+                    kinds=kinds,
+                    statuses=statuses,
+                    limit=args.limit,
+                )
+                for span in spans:
+                    event_id = str(span.get("event_id"))
+                    if event_id in seen:
+                        continue
+                    seen.add(event_id)
+                    if args.json:
+                        print(json.dumps(span, ensure_ascii=False, default=str), flush=True)
+                    else:
+                        _print_trace_span(span)
+                if not args.follow:
+                    break
+                time.sleep(0.5)
+        except KeyboardInterrupt:
+            pass
+        return 0
+
+    if command == "explain":
+        event = store.find_event(args.event_id)
+        if event is None:
+            print(f"Trace event not found: {args.event_id}", file=sys.stderr)
+            return 1
+        print(json.dumps(event, indent=2, ensure_ascii=False, default=str))
+        return 0
+
+    if command == "export":
+        trace = store.get_trace(args.trace_id)
+        if not trace["spans"]:
+            print(f"Trace not found: {args.trace_id}", file=sys.stderr)
+            return 1
+        if args.format == "jsonl":
+            rendered = (
+                "\n".join(
+                    json.dumps(span, ensure_ascii=False, default=str) for span in trace["spans"]
+                )
+                + "\n"
+            )
+        else:
+            rendered = json.dumps(trace, indent=2, ensure_ascii=False, default=str) + "\n"
+        if args.output:
+            output = Path(args.output).expanduser()
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(rendered, encoding="utf-8")
+            print(str(output))
+        else:
+            print(rendered, end="")
+        return 0
+
+    return 1
 
 
 def _print_dashboard_status() -> int:
@@ -6230,6 +6372,57 @@ def main() -> int:
     dashboard_parser.add_argument(
         "--port", type=int, default=8765, help="Port to bind the dashboard server"
     )
+    dashboard_parser.add_argument("--trace", default=None, help="Open the dashboard on a trace ID")
+
+    # structured physical-intelligence trace
+    trace_parser = subparsers.add_parser("trace", help="Inspect structured runtime traces")
+    trace_subparsers = trace_parser.add_subparsers(dest="trace_command")
+
+    def add_trace_store_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--home", default=None, help="ROSCLAW_HOME containing traces/")
+        parser.add_argument("--path", default=None, help="Explicit live.jsonl trace path")
+
+    trace_list_parser = trace_subparsers.add_parser("list", help="List recent traces")
+    trace_list_parser.add_argument("--limit", type=int, default=50)
+    trace_list_parser.add_argument("--json", action="store_true")
+    add_trace_store_args(trace_list_parser)
+
+    trace_show_parser = trace_subparsers.add_parser("show", help="Show one trace as a span tree")
+    trace_show_parser.add_argument("trace_id")
+    trace_show_parser.add_argument("--tree", action="store_true", help="Show tree (default)")
+    trace_show_parser.add_argument(
+        "--provider", action="store_true", help="Show only LLM/VLM spans"
+    )
+    trace_show_parser.add_argument("--json", action="store_true")
+    add_trace_store_args(trace_show_parser)
+
+    trace_tail_parser = trace_subparsers.add_parser("tail", help="Show recent completed spans")
+    trace_tail_parser.add_argument("--trace-id", default=None)
+    trace_tail_parser.add_argument("--kind", default=None, help="Comma-separated span kinds")
+    trace_tail_parser.add_argument("--status", default=None, help="Comma-separated statuses")
+    trace_tail_parser.add_argument("--limit", type=int, default=100)
+    trace_tail_parser.add_argument("--follow", action="store_true")
+    trace_tail_parser.add_argument("--json", action="store_true")
+    add_trace_store_args(trace_tail_parser)
+
+    trace_explain_parser = trace_subparsers.add_parser(
+        "explain", help="Show one span/event with its evidence"
+    )
+    trace_explain_parser.add_argument("event_id")
+    add_trace_store_args(trace_explain_parser)
+
+    trace_export_parser = trace_subparsers.add_parser("export", help="Export one trace")
+    trace_export_parser.add_argument("trace_id")
+    trace_export_parser.add_argument("--format", choices=["json", "jsonl"], default="json")
+    trace_export_parser.add_argument("--output", default=None)
+    add_trace_store_args(trace_export_parser)
+
+    trace_replay_parser = trace_subparsers.add_parser(
+        "replay", help="Replay a trace as an ordered textual timeline"
+    )
+    trace_replay_parser.add_argument("trace_id")
+    trace_replay_parser.add_argument("--json", action="store_true")
+    add_trace_store_args(trace_replay_parser)
 
     # doctor
     doctor_parser = subparsers.add_parser("doctor", help="Run health diagnosis")
@@ -7800,6 +7993,11 @@ def main() -> int:
             return cmd_status(args)
         elif args.command == "dashboard":
             return cmd_dashboard(args)
+        elif args.command == "trace":
+            if getattr(args, "trace_command", None):
+                return cmd_trace(args)
+            trace_parser.print_help()
+            return 1
         elif args.command == "doctor":
             if getattr(args, "ros", False):
                 return cmd_doctor_ros(args)

--- a/src/rosclaw/core/async_utils.py
+++ b/src/rosclaw/core/async_utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextvars
 import threading
 from collections.abc import Coroutine
 from typing import Any, TypeVar
@@ -44,7 +45,8 @@ def run_sync(coro: Coroutine[Any, Any, T]) -> T:
 
     # Inside an event loop. asyncio.run would raise RuntimeError here.
     # Schedule the coroutine on a background thread with its own loop.
-    return _SYNC_RUN_EXECUTOR.submit(asyncio.run, coro).result()
+    context = contextvars.copy_context()
+    return _SYNC_RUN_EXECUTOR.submit(context.run, asyncio.run, coro).result()
 
 
 def fire_and_forget(coro: Coroutine[Any, Any, Any]) -> None:
@@ -58,7 +60,8 @@ def fire_and_forget(coro: Coroutine[Any, Any, Any]) -> None:
         loop = asyncio.get_running_loop()
     except RuntimeError:
         # No running loop — run in a daemon thread so the caller is not blocked.
-        threading.Thread(target=lambda: asyncio.run(coro), daemon=True).start()
+        context = contextvars.copy_context()
+        threading.Thread(target=lambda: context.run(asyncio.run, coro), daemon=True).start()
     else:
         # Already inside an event loop — schedule as a task.
         loop.create_task(coro)

--- a/src/rosclaw/core/event_bus.py
+++ b/src/rosclaw/core/event_bus.py
@@ -53,6 +53,9 @@ class Event:
         timestamp: Unix timestamp when event was created
         priority: Processing priority
         event_id: Unique identifier
+        trace_id: End-to-end causal trace identifier
+        span_id: Operation that emitted this event
+        parent_span_id: Parent operation, when known
         metadata: Additional context
     """
 
@@ -63,6 +66,8 @@ class Event:
     priority: EventPriority = EventPriority.NORMAL
     event_id: str = field(default_factory=lambda: str(uuid.uuid4())[:8])
     trace_id: str = ""  # correlation ID for distributed tracing across the pipeline
+    span_id: str = ""  # active operation that emitted this event
+    parent_span_id: str = ""  # parent operation, when known
     metadata: dict = field(default_factory=dict)
 
     def derive(self, **overrides) -> "Event":
@@ -82,6 +87,8 @@ class Event:
             priority=overrides.get("priority", self.priority),
             event_id=overrides.get("event_id", str(uuid.uuid4())[:8]),
             trace_id=overrides.get("trace_id", self.trace_id),
+            span_id=overrides.get("span_id", self.span_id),
+            parent_span_id=overrides.get("parent_span_id", self.parent_span_id),
             metadata=overrides.get("metadata", self.metadata.copy()),
         )
 
@@ -214,17 +221,36 @@ class EventBus:
         # event.topic so existing tests and consumers are not broken.
         norm_topic = self._norm(event.topic)
 
-        # CRITICAL FIX: auto-inject trace_id for distributed tracing if missing.
-        # Derive from payload request_id/correlation_id/episode_id first so the
-        # entire pipeline shares one trace_id.
+        # Auto-inject causal trace/span identity. ``contextvars`` propagates
+        # through sync and async call paths; legacy request IDs remain the
+        # fallback for publishers that have not adopted structured spans yet.
+        trace_context = None
+        try:
+            from rosclaw.observability.context import current_trace_context
+
+            trace_context = current_trace_context()
+        except ImportError:
+            pass
         if not event.trace_id:
             payload = event.payload if isinstance(event.payload, dict) else {}
+            metadata = event.metadata if isinstance(event.metadata, dict) else {}
             event.trace_id = (
-                payload.get("request_id")
+                (trace_context.trace_id if trace_context else "")
+                or payload.get("trace_id")
+                or payload.get("request_id")
                 or payload.get("correlation_id")  # noqa: W503
                 or payload.get("episode_id")  # noqa: W503
+                or metadata.get("trace_id")  # noqa: W503
+                or metadata.get("request_id")  # noqa: W503
+                or metadata.get("correlation_id")  # noqa: W503
+                or metadata.get("episode_id")  # noqa: W503
                 or f"trace_{uuid.uuid4().hex[:12]}"  # noqa: W503
             )
+        if trace_context is not None and event.trace_id == trace_context.trace_id:
+            if not event.span_id:
+                event.span_id = trace_context.span_id
+            if not event.parent_span_id:
+                event.parent_span_id = trace_context.parent_span_id or ""
 
         # Store in history
         with self._lock:

--- a/src/rosclaw/core/event_sink.py
+++ b/src/rosclaw/core/event_sink.py
@@ -83,6 +83,8 @@ class JsonlEventSink:
             "source": getattr(event, "source", None),
             "event_id": getattr(event, "event_id", None),
             "trace_id": getattr(event, "trace_id", None),
+            "span_id": getattr(event, "span_id", None),
+            "parent_span_id": getattr(event, "parent_span_id", None),
             "priority": getattr(event, "priority", None),
             "metadata": getattr(event, "metadata", None),
             "payload": getattr(event, "payload", None),

--- a/src/rosclaw/core/event_topics.py
+++ b/src/rosclaw/core/event_topics.py
@@ -40,6 +40,7 @@ class EventTopics:
     AGENT_COMMAND = "rosclaw.agent.command"
     AGENT_RESPONSE = "rosclaw.agent.response"
     AGENT_CAPABILITY_REQUEST = "rosclaw.agent.capability.request"
+    AGENT_DECISION_MADE = "rosclaw.agent.decision.made"
 
     # ── Skill Execution ──
     SKILL_EXECUTION_START = "rosclaw.skill.execution.start"
@@ -50,6 +51,11 @@ class EventTopics:
     PROVIDER_INFERENCE_COMPLETED = "rosclaw.provider.inference.completed"
     PROVIDER_REGISTERED = "rosclaw.provider.registered"
     PROVIDER_HEALTH_CHANGED = "rosclaw.provider.health_changed"
+
+    # ── Unified Trace ──
+    TRACE_SPAN_STARTED = "rosclaw.trace.span.started"
+    TRACE_SPAN_COMPLETED = "rosclaw.trace.span.completed"
+    TRACE_SPAN_FAILED = "rosclaw.trace.span.failed"
 
     # ── Sandbox / Firewall ──
     SANDBOX_EPISODE_STARTED = "rosclaw.sandbox.episode.started"

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -115,6 +115,14 @@ class RuntimeConfig:
     sense_replay_path: str | None = None
     # Persist all EventBus events to ~/.rosclaw/events/live.jsonl for dashboard tail
     enable_event_persistence: bool = True
+    # Structured ROSClaw Trace. Model/tool I/O is redacted by default.
+    enable_tracing: bool = True
+    trace_capture_mode: str = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_TRACE_MODE", "standard")
+    )
+    trace_queue_size: int = 4096
+    trace_rotate_mb: float = 64.0
+    trace_home: str | None = None
 
 
 class Runtime(LifecycleMixin):
@@ -133,6 +141,10 @@ class Runtime(LifecycleMixin):
         # Core infrastructure: accept external EventBus or create one
         self.event_bus = event_bus or self.config.event_bus or EventBus()
         self._event_sink: Any | None = None
+        from rosclaw.observability.tracer import get_tracer
+
+        self._tracer = get_tracer(self.event_bus)
+        self._trace_exporter: Any | None = None
 
         # Grounding engines (initialized on demand)
         self._firewall: Any | None = None
@@ -183,6 +195,35 @@ class Runtime(LifecycleMixin):
             self._event_sink = JsonlEventSink()
             self._event_sink.attach(self.event_bus)
 
+        # Trace persistence has its own bounded writer thread: observation
+        # cannot block a provider, sandbox, or robot-control call.
+        if self.config.enable_tracing:
+            from rosclaw.observability.exporters.jsonl import JsonlTraceExporter
+            from rosclaw.observability.schema import ObservabilityConfig
+
+            try:
+                trace_config = ObservabilityConfig(
+                    enabled=True,
+                    capture_mode=self.config.trace_capture_mode,
+                    home=self.config.trace_home,
+                    queue_size=self.config.trace_queue_size,
+                    rotate_mb=self.config.trace_rotate_mb,
+                )
+                self._trace_exporter = JsonlTraceExporter(
+                    home=trace_config.home,
+                    filename=trace_config.filename,
+                    queue_size=trace_config.queue_size,
+                    rotate_mb=trace_config.rotate_mb,
+                )
+                self._tracer.configure(trace_config, exporters=[self._trace_exporter])
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Trace persistence unavailable; keeping live spans only: %s", exc)
+                self._tracer.configure(ObservabilityConfig(enabled=True), exporters=[])
+        else:
+            from rosclaw.observability.schema import ObservabilityConfig
+
+            self._tracer.configure(ObservabilityConfig(enabled=False), exporters=[])
+
         # Initialize Physical Grounding (e-URDF)
         self._load_e_urdf()
 
@@ -196,6 +237,7 @@ class Runtime(LifecycleMixin):
                     event_bus=self.event_bus,
                     mujoco_model_path=self.config.robot_model_path,
                     safety_level=self.config.safety_level,
+                    tracer=self._tracer,
                 )
                 self._modules.append(self._firewall)
                 logger.info("Action Grounding (FirewallValidator) initialized")
@@ -362,6 +404,7 @@ class Runtime(LifecycleMixin):
                     registry,
                     seekdb_client=seekdb,
                     sense_interface=self._sense,
+                    tracer=self._tracer,
                 )
                 self._modules.append(registry)
                 self._modules.append(self._skill_manager)
@@ -466,7 +509,9 @@ class Runtime(LifecycleMixin):
                 self._guard_pipeline.add(ActionGuard())
                 # Create router early so it's always available even if
                 # some provider registrations fail downstream.
-                self._capability_router = CapabilityRouter(self._provider_registry)
+                self._capability_router = CapabilityRouter(
+                    self._provider_registry, tracer=self._tracer
+                )
                 # Register providers — non-fatal if individual steps fail
                 try:
                     self._register_builtin_providers()
@@ -566,6 +611,9 @@ class Runtime(LifecycleMixin):
             for module in reversed(self._modules):
                 if isinstance(module, LifecycleMixin):
                     module.stop()
+        if self._tracer is not None:
+            self._tracer.close()
+            self._trace_exporter = None
         logger.info("Shutdown complete")
 
     def _setup_internal_subscriptions(self) -> None:
@@ -820,7 +868,9 @@ class Runtime(LifecycleMixin):
         request_id = payload.get("request_id", "")
         capability = payload.get("capability", "")
         inputs = payload.get("inputs", {})
-        context = payload.get("context", {})
+        context = dict(payload.get("context", {}))
+        if event.trace_id:
+            context.setdefault("trace_id", event.trace_id)
 
         try:
             from rosclaw.provider.core.request import ProviderRequest
@@ -846,6 +896,7 @@ class Runtime(LifecycleMixin):
                         },
                     },
                     source="runtime",
+                    trace_id=event.trace_id,
                 )
             )
         except Exception as e:
@@ -857,6 +908,7 @@ class Runtime(LifecycleMixin):
                         "result": {"status": "error", "error": str(e)},
                     },
                     source="runtime",
+                    trace_id=event.trace_id,
                 )
             )
 
@@ -929,6 +981,12 @@ class Runtime(LifecycleMixin):
     @property
     def guard_pipeline(self) -> Any | None:
         return self._guard_pipeline
+
+    @property
+    def tracer(self) -> Any:
+        """Return the shared structured tracer for runtime integrations."""
+
+        return self._tracer
 
     @property
     def sandbox(self) -> Any | None:
@@ -1385,7 +1443,9 @@ class Runtime(LifecycleMixin):
         ):
             try:
                 self._provider_registry = ProviderRegistry(event_bus=self.event_bus)
-                self._capability_router = CapabilityRouter(self._provider_registry)
+                self._capability_router = CapabilityRouter(
+                    self._provider_registry, tracer=self._tracer
+                )
                 self._register_builtin_providers()
                 logger.info("Provider layer auto-initialized on first capability_invoke")
             except Exception as e:
@@ -1438,6 +1498,173 @@ class Runtime(LifecycleMixin):
             return {"error": str(e), "capability": capability_name, "status": "error"}
 
     def plan_action(self, instruction: str, perception_result: dict[str, Any]) -> dict[str, Any]:
+        """Build and publish a structured decision summary under a Planner span."""
+
+        with self._tracer.start_span(
+            "agent.plan_action",
+            "PLANNER",
+            source="runtime",
+            operation="action.plan",
+            attributes={"robot.id": self.config.robot_id},
+            robot_id=self.config.robot_id,
+        ) as span:
+            span.set_input({"instruction": instruction, "perception": perception_result})
+            result = self._plan_action(instruction, perception_result)
+            action = result.get("action") if isinstance(result, dict) else None
+            summary = self._build_decision_summary(
+                instruction=instruction,
+                action=action,
+                context=perception_result,
+                reason_summary=(
+                    "Selected the plan produced by the configured skill planner."
+                    if self._skill_manager is not None and hasattr(self._skill_manager, "plan")
+                    else "Used the deterministic fallback plan grounded to the first observed target."
+                ),
+            )
+            result["decision_summary"] = summary.to_dict()
+            span.set_output(result)
+            for reference in summary.evidence_refs:
+                span.add_evidence(reference)
+            if result.get("status") == "error":
+                span.set_status("ERROR", result.get("error"))
+            self.event_bus.publish(
+                Event(
+                    topic="rosclaw.agent.decision.made",
+                    payload=summary.to_dict(),
+                    source="runtime",
+                    priority=EventPriority.NORMAL,
+                )
+            )
+            return result
+
+    def _build_decision_summary(
+        self,
+        *,
+        instruction: str,
+        action: Any,
+        context: dict[str, Any],
+        reason_summary: str,
+    ) -> Any:
+        """Build an auditable decision summary without private model reasoning."""
+
+        from rosclaw.observability.schema import DecisionSummary
+
+        payload = context.get("result", context)
+        if not isinstance(payload, dict):
+            payload = {}
+        objects = payload.get("objects", context.get("objects", []))
+        if not isinstance(objects, list):
+            objects = []
+        observations = [
+            str(item.get("label", item)) if isinstance(item, dict) else str(item)
+            for item in objects[:20]
+        ]
+        provider_status = context.get("status")
+        if not observations and provider_status:
+            observations.append(f"provider_status={provider_status}")
+
+        constraints = [f"safety_level={self.config.safety_level}", "sandbox_validation=required"]
+        supplied_constraints = context.get("constraints", [])
+        if isinstance(supplied_constraints, list):
+            constraints.extend(str(item) for item in supplied_constraints[:20])
+
+        confidence = context.get("confidence", payload.get("confidence"))
+        if not isinstance(confidence, (int, float)) or not 0.0 <= confidence <= 1.0:
+            confidence = None
+
+        if isinstance(action, dict):
+            decision = {
+                key: self._tracer.redactor.redact(action[key])
+                for key in (
+                    "type",
+                    "action",
+                    "skill_name",
+                    "capability",
+                    "target",
+                    "parameters",
+                )
+                if key in action
+            }
+            if not decision:
+                decision = {"action": "structured_action"}
+        else:
+            decision = action
+
+        evidence_refs = [
+            str(item.get("artifact_ref"))
+            for item in objects
+            if isinstance(item, dict) and item.get("artifact_ref")
+        ]
+        explicit_refs = context.get("evidence_refs", [])
+        if isinstance(explicit_refs, list):
+            evidence_refs.extend(str(reference) for reference in explicit_refs[:50])
+
+        return DecisionSummary(
+            goal=instruction,
+            observations=observations,
+            constraints=constraints,
+            candidates=[{"action": decision}] if decision is not None else [],
+            decision=decision,
+            reason_summary=reason_summary,
+            confidence=confidence,
+            evidence_refs=list(dict.fromkeys(evidence_refs)),
+        )
+
+    def _trace_execution_decision(
+        self,
+        *,
+        instruction: str,
+        action: dict[str, Any],
+        provider_result: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Record the actual closed-loop action decision inside the mission trace."""
+
+        with self._tracer.start_span(
+            "agent.execution_decision",
+            "PLANNER",
+            source="runtime",
+            operation="action.select",
+            attributes={
+                "robot.id": self.config.robot_id,
+                "provider": provider_result.get("provider", ""),
+                "provider.status": provider_result.get("status", "unknown"),
+            },
+            robot_id=self.config.robot_id,
+        ) as span:
+            span.set_input(
+                {
+                    "instruction": instruction,
+                    "requested_action": action,
+                    "provider_result": provider_result,
+                }
+            )
+            summary = self._build_decision_summary(
+                instruction=instruction,
+                action=action,
+                context=provider_result,
+                reason_summary=(
+                    "Selected the requested action after provider planning; sandbox validation is "
+                    "required before execution."
+                    if provider_result.get("status") == "ok"
+                    else "Kept the deterministic requested action after provider planning was "
+                    "unavailable; sandbox validation is required before execution."
+                ),
+            )
+            output = {"decision_summary": summary.to_dict()}
+            span.set_output(output)
+            for reference in summary.evidence_refs:
+                span.add_evidence(reference)
+            self.event_bus.publish(
+                Event(
+                    topic="rosclaw.agent.decision.made",
+                    payload=summary.to_dict(),
+                    source="runtime",
+                    priority=EventPriority.NORMAL,
+                )
+            )
+            return output["decision_summary"]
+
+    def _plan_action(self, instruction: str, perception_result: dict[str, Any]) -> dict[str, Any]:
         """Plan a robot action from natural language instruction + perception.
 
         Returns a structured action dict ready for sandbox_check().
@@ -1472,6 +1699,25 @@ class Runtime(LifecycleMixin):
             return {"error": str(e), "instruction": instruction, "status": "error"}
 
     def sandbox_check(self, action: dict[str, Any]) -> dict[str, Any]:
+        """Trace and evaluate one action against the sandbox/firewall boundary."""
+
+        with self._tracer.start_span(
+            "sandbox.validate_action",
+            "SANDBOX",
+            source="runtime",
+            operation=str(action.get("type") or action.get("action") or "validate"),
+            trace_id=str(action.get("request_id") or "") or None,
+            attributes={"safety.level": self.config.safety_level},
+            robot_id=self.config.robot_id,
+        ) as span:
+            span.set_input(action)
+            result = self._sandbox_check(action)
+            span.set_output(result)
+            if result.get("decision") == "BLOCK":
+                span.set_status("BLOCKED", result.get("reason"))
+            return result
+
+    def _sandbox_check(self, action: dict[str, Any]) -> dict[str, Any]:
         """Check an action against the sandbox firewall.
 
         Returns:
@@ -1505,6 +1751,36 @@ class Runtime(LifecycleMixin):
             return {"decision": "BLOCK", "reason": str(e), "violations": []}
 
     def execute(self, action: dict[str, Any]) -> dict[str, Any]:
+        """Execute one mission under a root Agent span."""
+
+        traced_action = dict(action)
+        traced_action.setdefault("request_id", str(uuid.uuid4())[:8])
+        with self._tracer.start_span(
+            "runtime.execute",
+            "MISSION",
+            source="runtime",
+            operation="agent.closed_loop",
+            trace_id=str(traced_action["request_id"]),
+            attributes={
+                "skill.name": traced_action.get("skill_name", "unknown"),
+                "capability": traced_action.get("capability", ""),
+            },
+            robot_id=self.config.robot_id,
+            mission_id=str(traced_action.get("task_id") or traced_action["request_id"]),
+        ) as span:
+            span.set_input(traced_action)
+            result = self._execute_closed_loop(traced_action)
+            span.episode_id = result.get("episode_id")
+            span.set_output(result)
+            status = str(result.get("status", "")).lower()
+            if status == "blocked":
+                span.set_status("BLOCKED", result.get("reason"))
+            elif status in {"error", "failed"}:
+                span.set_status("ERROR", result.get("error"))
+            result.setdefault("trace_id", span.trace_id)
+            return result
+
+    def _execute_closed_loop(self, action: dict[str, Any]) -> dict[str, Any]:
         """Execute an action through the **full closed loop**.
 
         1. Publish ``skill.execution.start``
@@ -1557,6 +1833,14 @@ class Runtime(LifecycleMixin):
             provider_result = self.capability_invoke(capability, provider_inputs)
         except Exception as e:
             provider_result = {"status": "error", "error": str(e)}
+
+        # Record the actual action choice as an auditable reasoning summary in
+        # the same mission trace. This is structured evidence, not private CoT.
+        decision_summary = self._trace_execution_decision(
+            instruction=instruction,
+            action=action,
+            provider_result=provider_result,
+        )
 
         # 3. Sandbox firewall check
         sandbox_result = self.sandbox_check(action)
@@ -1782,6 +2066,9 @@ class Runtime(LifecycleMixin):
                     "result": result,
                     "duration_sec": duration,
                     "trajectory_waypoints": len(trajectory_data),
+                    # The Runtime publishes an explicit praxis terminal event
+                    # after critic evaluation; standalone skills do not.
+                    "praxis_pending": True,
                 },
                 source="runtime",
                 priority=EventPriority.HIGH,
@@ -1918,6 +2205,9 @@ class Runtime(LifecycleMixin):
             except Exception as e:
                 logger.info(f"KNOW post-execution recording failed (non-fatal): {e}")
 
+        result.setdefault("episode_id", episode_id)
+        result.setdefault("request_id", request_id)
+        result.setdefault("decision_summary", decision_summary)
         return result
 
     def _generate_trajectory(self, action: dict[str, Any]) -> list[list[float]]:

--- a/src/rosclaw/dashboard/server.py
+++ b/src/rosclaw/dashboard/server.py
@@ -87,6 +87,9 @@ class DashboardServer:
             EventTopics.SANDBOX_EPISODE_FINISHED,
             EventTopics.SANDBOX_ACTION_BLOCKED,
             EventTopics.PROVIDER_INFERENCE_COMPLETED,
+            EventTopics.TRACE_SPAN_STARTED,
+            EventTopics.TRACE_SPAN_COMPLETED,
+            EventTopics.TRACE_SPAN_FAILED,
             EventTopics.CRITIC_SUCCESS_DETECTED,
             EventTopics.DASHBOARD_TRACE_UPDATED,
             EventTopics.HOW_RECOVERY_HINT_GENERATED,
@@ -119,7 +122,11 @@ class DashboardServer:
         self.metrics.increment_event(topic, getattr(event, "payload", None))
 
         # Record full traces for dashboard display
-        if topic == EventTopics.DASHBOARD_TRACE_UPDATED:
+        if topic in {
+            EventTopics.DASHBOARD_TRACE_UPDATED,
+            EventTopics.TRACE_SPAN_COMPLETED,
+            EventTopics.TRACE_SPAN_FAILED,
+        }:
             payload = getattr(event, "payload", {})
             if isinstance(payload, dict):
                 self.metrics.record_trace(payload)

--- a/src/rosclaw/dashboard/trace_page.py
+++ b/src/rosclaw/dashboard/trace_page.py
@@ -1,0 +1,83 @@
+"""Self-contained lightweight ROSClaw Trace dashboard page."""
+
+TRACE_PAGE_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ROSClaw Trace</title>
+<style>
+:root { color-scheme: dark; --bg:#080b12; --panel:#101622; --line:#253047;
+  --text:#e8eefb; --muted:#8fa0ba; --ok:#42d392; --err:#ff657a; --warn:#ffc857; }
+* { box-sizing:border-box } body { margin:0; background:var(--bg); color:var(--text);
+  font:14px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace; }
+header { height:58px; padding:0 18px; border-bottom:1px solid var(--line); display:flex;
+  align-items:center; justify-content:space-between; background:#0c111b; }
+h1 { font-size:18px; margin:0 } button { color:var(--text); background:#182237;
+  border:1px solid #344564; border-radius:6px; padding:7px 11px; cursor:pointer; }
+.layout { display:grid; grid-template-columns:280px minmax(420px,1fr) 390px;
+  height:calc(100vh - 58px); }
+.panel { overflow:auto; border-right:1px solid var(--line); padding:14px; }
+.panel:last-child { border-right:0 }.hint,.meta { color:var(--muted); font-size:12px }
+.trace { padding:10px; margin-bottom:8px; border:1px solid var(--line); border-radius:7px;
+  cursor:pointer; background:var(--panel) }.trace:hover,.trace.active { border-color:#6889c6 }
+.trace-id { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; margin-bottom:5px }
+.badge { font-size:11px; padding:2px 6px; border-radius:9px; background:#26344c }
+.OK { color:var(--ok) }.ERROR { color:var(--err) }.BLOCKED { color:var(--warn) }
+.timeline { position:relative; min-width:560px }.track { display:grid; grid-template-columns:115px 1fr;
+  min-height:40px; border-bottom:1px solid #182033 }.track-name { color:var(--muted); padding:11px 8px }
+.lane { position:relative }.span { position:absolute; top:8px; height:24px; min-width:3px;
+  border-radius:4px; padding:3px 6px; overflow:hidden; white-space:nowrap; cursor:pointer;
+  color:#071019; background:#68a6ff; font-size:11px }.span.ERROR { background:var(--err) }
+.span.BLOCKED { background:var(--warn) }.span.OK { background:var(--ok) }
+.tree { margin-top:18px }.tree-row { padding:5px 7px; border-left:2px solid #344564;
+  margin:2px 0; cursor:pointer }.tree-row:hover { background:#182237 }
+pre { white-space:pre-wrap; word-break:break-word; background:#090d15; border:1px solid var(--line);
+  padding:10px; border-radius:6px; max-height:36vh; overflow:auto; }
+.section { margin-bottom:14px }.section h2 { font-size:13px; color:#b9c9e5; margin:0 0 7px }
+@media(max-width:1050px){.layout{grid-template-columns:240px 1fr}.inspector{display:none}}
+</style>
+</head>
+<body>
+<header><div><h1>ROSClaw Trace</h1><div class="hint">Physical intelligence decision & runtime evidence</div></div>
+<button id="refresh">Refresh</button></header>
+<main class="layout">
+  <aside class="panel"><div id="trace-list"><span class="hint">No traces yet.</span></div></aside>
+  <section class="panel"><div id="summary" class="meta">Select a trace.</div>
+    <div id="timeline" class="timeline"></div><div id="tree" class="tree"></div></section>
+  <aside class="panel inspector"><div id="inspector"><span class="hint">Select a span to inspect redacted I/O.</span></div></aside>
+</main>
+<script>
+const q = s => document.querySelector(s); let selectedTrace = null;
+const el = (tag, cls, text) => { const n=document.createElement(tag); if(cls)n.className=cls;
+  if(text!==undefined)n.textContent=text; return n; };
+const fmtMs = n => `${Number(n||0).toFixed(1)} ms`;
+async function loadList(){
+  const data=await fetch('/api/traces?limit=100').then(r=>r.json()); const root=q('#trace-list'); root.replaceChildren();
+  if(!data.traces.length){root.append(el('span','hint','No completed traces yet.'));return;}
+  data.traces.forEach(t=>{const card=el('div','trace'+(t.trace_id===selectedTrace?' active':''));
+    card.onclick=()=>loadTrace(t.trace_id); card.append(el('div','trace-id',t.trace_id));
+    const m=el('div','meta'); m.append(el('span','badge '+t.status,t.status));
+    m.append(document.createTextNode(`  ${t.span_count} spans · ${fmtMs(t.duration_ms)}`)); card.append(m); root.append(card);});
+}
+async function loadTrace(id){selectedTrace=id; const data=await fetch('/api/traces/'+encodeURIComponent(id)).then(r=>r.json());
+  q('#summary').textContent=`${id} · ${data.span_count} spans`; renderTimeline(data.spans); renderTree(data.tree); loadList();}
+function renderTimeline(spans){const root=q('#timeline');root.replaceChildren();if(!spans.length)return;
+  const start=Math.min(...spans.map(s=>s.started_at)), end=Math.max(...spans.map(s=>s.ended_at||s.started_at));
+  const total=Math.max(end-start,.001); const groups=Object.groupBy?Object.groupBy(spans,s=>s.span_kind):spans.reduce((a,s)=>((a[s.span_kind]??=[]).push(s),a),{});
+  Object.entries(groups).forEach(([kind,items])=>{const track=el('div','track'),name=el('div','track-name',kind),lane=el('div','lane');
+    items.forEach(s=>{const bar=el('div','span '+s.status,s.name);bar.style.left=`${(s.started_at-start)/total*100}%`;
+      bar.style.width=`${Math.max(1,(s.duration_ms||0)/(total*10))}%`;bar.title=`${s.name} · ${fmtMs(s.duration_ms)}`;bar.onclick=()=>inspect(s);lane.append(bar);});
+    track.append(name,lane);root.append(track);});}
+function renderTree(roots){const root=q('#tree');root.replaceChildren(el('h3','', 'Span tree'));
+  const walk=(nodes,depth)=>nodes.forEach(s=>{const row=el('div','tree-row',`${s.span_kind}  ${s.name}  ${fmtMs(s.duration_ms)}`);
+    row.style.marginLeft=`${depth*16}px`;row.onclick=()=>inspect(s);root.append(row);walk(s.children||[],depth+1);});walk(roots,0);}
+function inspect(s){const root=q('#inspector');root.replaceChildren();const title=el('div','section');
+  title.append(el('h2','',s.name),el('div','meta',`${s.span_kind} · ${s.status} · ${fmtMs(s.duration_ms)}`));root.append(title);
+  [['Attributes',s.attributes],['Input (redacted)',s.input],['Output (redacted)',s.output],['Error',s.error],['Evidence',s.evidence_refs]].forEach(([name,value])=>{
+    if(value===null||value===undefined)return;const sec=el('div','section');sec.append(el('h2','',name),el('pre','',JSON.stringify(value,null,2)));root.append(sec);});}
+q('#refresh').onclick=()=>{loadList();if(selectedTrace)loadTrace(selectedTrace)};
+const initialTrace=new URLSearchParams(location.search).get('trace_id');
+if(initialTrace)loadTrace(initialTrace);else loadList(); setInterval(loadList,3000);
+</script>
+</body></html>"""

--- a/src/rosclaw/dashboard/web_server.py
+++ b/src/rosclaw/dashboard/web_server.py
@@ -446,12 +446,18 @@ class DashboardWebServer:
         host: str = "0.0.0.0",
         port: int = 8765,
         runtime_bus: RuntimeBus | None = None,
+        trace_store: Any | None = None,
     ) -> None:
         self.metrics = DashboardMetrics()
         self.server = DashboardServer(self.metrics, host=host, port=port)
         self.app = FastAPI(title="ROSClaw Dashboard", version="1.0.0")
         self._runtime_bus = runtime_bus
         self._query_api = RuntimeQueryAPI(runtime_bus) if runtime_bus is not None else None
+        if trace_store is None:
+            from rosclaw.observability.store import TraceStore
+
+            trace_store = TraceStore()
+        self._trace_store = trace_store
         self._setup_routes()
 
     def attach_to_event_bus(self, event_bus: Any) -> None:
@@ -526,6 +532,49 @@ class DashboardWebServer:
         @self.app.get("/api/firstboot")
         async def api_firstboot() -> dict[str, Any]:
             return self.server.get_firstboot_state()
+
+        # ── Structured Trace API ──────────────────────────────────────
+
+        @self.app.get("/traces")
+        async def traces_page() -> Any:
+            from rosclaw.dashboard.trace_page import TRACE_PAGE_HTML
+
+            return HTMLResponse(TRACE_PAGE_HTML)
+
+        @self.app.get("/api/traces")
+        async def api_traces(
+            trace_id: str | None = None,
+            kind: str | None = None,
+            status: str | None = None,
+            limit: int = 100,
+        ) -> dict[str, Any]:
+            safe_limit = max(1, min(limit, 5000))
+            if trace_id or kind or status:
+                spans = self._trace_store.read(
+                    trace_id=trace_id,
+                    kinds={part.strip().upper() for part in kind.split(",")} if kind else None,
+                    statuses={part.strip().upper() for part in status.split(",")}
+                    if status
+                    else None,
+                    limit=safe_limit,
+                )
+                return {"count": len(spans), "spans": spans}
+            traces = self._trace_store.list_traces(limit=safe_limit)
+            return {"count": len(traces), "traces": traces}
+
+        @self.app.get("/api/traces/events/{event_id}")
+        async def api_trace_event(event_id: str) -> dict[str, Any]:
+            event = self._trace_store.find_event(event_id)
+            if event is None:
+                raise HTTPException(status_code=404, detail="Trace event not found")
+            return event
+
+        @self.app.get("/api/traces/{trace_id}")
+        async def api_trace(trace_id: str) -> dict[str, Any]:
+            trace = self._trace_store.get_trace(trace_id)
+            if not trace["spans"]:
+                raise HTTPException(status_code=404, detail="Trace not found")
+            return trace
 
         @self.app.post("/api/firstboot/preview")
         async def firstboot_preview(request: Request) -> dict[str, Any]:

--- a/src/rosclaw/firewall/validator.py
+++ b/src/rosclaw/firewall/validator.py
@@ -9,6 +9,7 @@ Sprint 3 of DESIGN_SPRINT3_5.
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 import numpy as np
 
@@ -129,6 +130,7 @@ class FirewallValidator(LifecycleMixin):
         event_bus: EventBus,
         mujoco_model_path: str | None = None,
         safety_level: str = "MODERATE",
+        tracer: Any | None = None,
     ):
         super().__init__()
         self._robot_model = robot_model
@@ -138,6 +140,11 @@ class FirewallValidator(LifecycleMixin):
         self._envelope: SafetyEnvelope | None = None
         self._mj_model = None
         self._mj_data = None
+        if tracer is None:
+            from rosclaw.observability.tracer import get_tracer
+
+            tracer = get_tracer(event_bus)
+        self._tracer = tracer
 
     def _do_initialize(self) -> None:
         """Build SafetyEnvelope from e-URDF, optionally load MuJoCo."""
@@ -253,6 +260,54 @@ class FirewallValidator(LifecycleMixin):
             )
 
     def validate(self, request: ValidationRequest) -> ValidationResponse:
+        """Trace and run the deterministic three-layer firewall."""
+
+        with self._tracer.start_span(
+            "firewall.validate",
+            "GUARDRAIL",
+            source="firewall_validator",
+            operation="trajectory.validate",
+            trace_id=request.request_id,
+            attributes={
+                "safety.level": self._safety_level,
+                "trajectory.waypoints": len(request.trajectory),
+            },
+            robot_id=request.robot_id,
+        ) as span:
+            span.set_input(
+                {
+                    "trajectory": request.trajectory,
+                    "duration_per_waypoint": request.duration_per_waypoint,
+                    "metadata": request.metadata,
+                }
+            )
+            response = self._validate(request)
+            output = {
+                "request_id": response.request_id,
+                "is_safe": response.is_safe,
+                "layers_checked": [layer.value for layer in response.layers_checked],
+                "violations": [
+                    {
+                        "layer": item.layer.value,
+                        "severity": item.severity,
+                        "joint_index": item.joint_index,
+                        "description": item.description,
+                        "actual_value": item.actual_value,
+                        "limit_value": item.limit_value,
+                    }
+                    for item in response.violations
+                ],
+                "warnings": response.warnings,
+                "simulation_duration_ms": response.simulation_duration_ms,
+            }
+            span.set_output(output)
+            if not response.is_safe:
+                span.set_status(
+                    "BLOCKED", "; ".join(item.description for item in response.violations)
+                )
+            return response
+
+    def _validate(self, request: ValidationRequest) -> ValidationResponse:
         """Run 3-layer validation pipeline."""
         violations = []
         warnings = []

--- a/src/rosclaw/observability/__init__.py
+++ b/src/rosclaw/observability/__init__.py
@@ -1,0 +1,28 @@
+"""ROSClaw Trace — structured physical-intelligence observability."""
+
+from rosclaw.observability.context import TraceContext, current_trace_context
+from rosclaw.observability.schema import (
+    CaptureMode,
+    DecisionSummary,
+    ObservabilityConfig,
+    SpanKind,
+    SpanStatus,
+    TraceRecord,
+)
+from rosclaw.observability.store import TraceStore
+from rosclaw.observability.tracer import Tracer, TraceSpan, get_tracer
+
+__all__ = [
+    "CaptureMode",
+    "DecisionSummary",
+    "ObservabilityConfig",
+    "SpanKind",
+    "SpanStatus",
+    "TraceContext",
+    "TraceRecord",
+    "TraceSpan",
+    "TraceStore",
+    "Tracer",
+    "current_trace_context",
+    "get_tracer",
+]

--- a/src/rosclaw/observability/context.py
+++ b/src/rosclaw/observability/context.py
@@ -1,0 +1,38 @@
+"""Trace context propagation across sync and async ROSClaw call paths."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TraceContext:
+    """The causal identity of the operation currently executing."""
+
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None = None
+
+
+_CURRENT_TRACE_CONTEXT: ContextVar[TraceContext | None] = ContextVar(
+    "rosclaw_trace_context", default=None
+)
+
+
+def current_trace_context() -> TraceContext | None:
+    """Return the current trace context, if one is active."""
+
+    return _CURRENT_TRACE_CONTEXT.get()
+
+
+def attach_trace_context(context: TraceContext) -> Token[TraceContext | None]:
+    """Make ``context`` current and return a token used to restore the parent."""
+
+    return _CURRENT_TRACE_CONTEXT.set(context)
+
+
+def detach_trace_context(token: Token[TraceContext | None]) -> None:
+    """Restore the context that preceded ``attach_trace_context``."""
+
+    _CURRENT_TRACE_CONTEXT.reset(token)

--- a/src/rosclaw/observability/exporters/__init__.py
+++ b/src/rosclaw/observability/exporters/__init__.py
@@ -1,0 +1,5 @@
+"""Trace exporter implementations."""
+
+from rosclaw.observability.exporters.jsonl import JsonlTraceExporter
+
+__all__ = ["JsonlTraceExporter"]

--- a/src/rosclaw/observability/exporters/base.py
+++ b/src/rosclaw/observability/exporters/base.py
@@ -1,0 +1,17 @@
+"""Trace exporter contract."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from rosclaw.observability.schema import TraceRecord
+
+
+class TraceExporter(Protocol):
+    """Non-blocking destination for completed trace records."""
+
+    def export(self, record: TraceRecord) -> bool: ...
+
+    def flush(self, timeout: float = 5.0) -> None: ...
+
+    def close(self, timeout: float = 5.0) -> None: ...

--- a/src/rosclaw/observability/exporters/jsonl.py
+++ b/src/rosclaw/observability/exporters/jsonl.py
@@ -1,0 +1,137 @@
+"""Non-blocking, bounded JSONL exporter for ROSClaw Trace."""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from rosclaw.firstboot.workspace import resolve_home
+from rosclaw.observability.schema import SpanStatus, TraceRecord
+
+logger = logging.getLogger("rosclaw.observability.exporters.jsonl")
+
+
+class JsonlTraceExporter:
+    """Write trace records on a daemon thread so control paths never wait on disk."""
+
+    def __init__(
+        self,
+        home: str | Path | None = None,
+        filename: str = "live.jsonl",
+        queue_size: int = 4096,
+        rotate_mb: float = 64.0,
+        output_path: str | Path | None = None,
+    ) -> None:
+        if output_path is not None:
+            self._path = Path(output_path).expanduser()
+        else:
+            root = resolve_home(str(home) if home else None)
+            self._path = root / "traces" / filename
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._rotate_bytes = int(rotate_mb * 1024 * 1024)
+        self._queue: queue.Queue[TraceRecord | object] = queue.Queue(maxsize=queue_size)
+        self._sentinel = object()
+        self._closed = False
+        self._dropped = 0
+        self._thread = threading.Thread(
+            target=self._writer_loop,
+            name="rosclaw-trace-writer",
+            daemon=True,
+        )
+        self._thread.start()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def dropped_records(self) -> int:
+        return self._dropped
+
+    def export(self, record: TraceRecord) -> bool:
+        """Enqueue without blocking; terminal failures displace a normal record if full."""
+
+        if self._closed:
+            return False
+        try:
+            self._queue.put_nowait(record)
+            return True
+        except queue.Full:
+            if record.status not in {SpanStatus.ERROR, SpanStatus.BLOCKED}:
+                self._dropped += 1
+                return False
+            try:
+                self._queue.get_nowait()
+                self._queue.task_done()
+                self._dropped += 1
+                self._queue.put_nowait(record)
+                return True
+            except (queue.Empty, queue.Full):
+                self._dropped += 1
+                return False
+
+    def _writer_loop(self) -> None:
+        file: Any | None = None
+        try:
+            file = self._path.open("a", encoding="utf-8")
+            while True:
+                item = self._queue.get()
+                try:
+                    if item is self._sentinel:
+                        break
+                    assert isinstance(item, TraceRecord)
+                    file.write(json.dumps(item.to_dict(), ensure_ascii=False, default=str) + "\n")
+                    file.flush()
+                    if self._rotate_bytes and self._path.stat().st_size >= self._rotate_bytes:
+                        file.close()
+                        self._rotate()
+                        file = self._path.open("a", encoding="utf-8")
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Trace persistence failed: %s", exc)
+                finally:
+                    self._queue.task_done()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Trace writer stopped: %s", exc)
+        finally:
+            if file is not None and not file.closed:
+                file.flush()
+                file.close()
+
+    def _rotate(self) -> None:
+        suffix = 1
+        while True:
+            rotated = self._path.with_name(f"{self._path.name}.{suffix:03d}")
+            if not rotated.exists():
+                self._path.rename(rotated)
+                return
+            suffix += 1
+
+    def flush(self, timeout: float = 5.0) -> None:
+        """Wait briefly for already-enqueued records; never wait indefinitely."""
+
+        deadline = time.monotonic() + timeout
+        while self._queue.unfinished_tasks and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+    def close(self, timeout: float = 5.0) -> None:
+        if self._closed:
+            return
+        self.flush(timeout=timeout)
+        self._closed = True
+        try:
+            self._queue.put_nowait(self._sentinel)
+        except queue.Full:
+            # Flush above normally prevents this. If the writer is stalled,
+            # discard one normal record without corrupting Queue accounting.
+            try:
+                self._queue.get_nowait()
+                self._queue.task_done()
+                self._queue.put_nowait(self._sentinel)
+            except (queue.Empty, queue.Full):
+                pass
+        self._thread.join(timeout=timeout)

--- a/src/rosclaw/observability/redaction.py
+++ b/src/rosclaw/observability/redaction.py
@@ -1,0 +1,135 @@
+"""Bounded, secret-aware trace payload capture."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from rosclaw.observability.schema import CaptureMode
+
+_SECRET_KEY = re.compile(
+    r"(^|[_-])(api[_-]?key|password|passwd|secret|authorization|access[_-]?token|"
+    r"refresh[_-]?token|bearer[_-]?token|private[_-]?key)($|[_-])",
+    re.IGNORECASE,
+)
+_BEARER_VALUE = re.compile(r"(?i)bearer\s+[a-z0-9._~+/=-]+")
+_PRIVATE_REASONING_KEY = re.compile(
+    r"^(cot|chain[_-]?of[_-]?thought|reasoning|reasoning[_-]?trace|internal[_-]?reasoning|"
+    r"hidden[_-]?reasoning)$",
+    re.IGNORECASE,
+)
+
+
+class TraceRedactor:
+    """Convert arbitrary runtime values into safe, bounded JSON-like values."""
+
+    def __init__(
+        self,
+        mode: CaptureMode | str = CaptureMode.STANDARD,
+        max_text_chars: int = 16_384,
+        max_collection_items: int = 256,
+    ) -> None:
+        self.mode = CaptureMode(mode)
+        self.max_text_chars = max_text_chars
+        self.max_collection_items = max_collection_items
+
+    def redact(self, value: Any) -> Any:
+        """Redact secrets and replace large/binary values with stable references."""
+
+        try:
+            if self.mode == CaptureMode.MINIMAL:
+                return self._summarize(value)
+            return self._convert(value, depth=0)
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "type": type(value).__name__,
+                "capture_error": type(exc).__name__,
+            }
+
+    def _convert(self, value: Any, depth: int) -> Any:
+        if depth > 20:
+            return {"type": type(value).__name__, "truncated": "max_depth"}
+        if value is None or isinstance(value, (bool, int, float)):
+            return value
+        if isinstance(value, str):
+            safe = _BEARER_VALUE.sub("Bearer [REDACTED]", value)
+            if len(safe) <= self.max_text_chars:
+                return safe
+            return {
+                "text": safe[: self.max_text_chars],
+                "truncated": True,
+                "original_chars": len(safe),
+                "sha256": hashlib.sha256(safe.encode("utf-8")).hexdigest(),
+            }
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            data = bytes(value)
+            return {
+                "artifact": "inline-binary-omitted",
+                "bytes": len(data),
+                "sha256": hashlib.sha256(data).hexdigest(),
+            }
+        if isinstance(value, Path):
+            return str(value)
+        if isinstance(value, Enum):
+            return value.value
+        if is_dataclass(value) and not isinstance(value, type):
+            return self._convert(asdict(value), depth + 1)
+        if isinstance(value, dict):
+            converted: dict[str, Any] = {}
+            items = list(value.items())
+            for key, item in items[: self.max_collection_items]:
+                key_text = str(key)
+                if _SECRET_KEY.search(key_text):
+                    converted[key_text] = "[REDACTED]"
+                elif self.mode != CaptureMode.RESEARCH and _PRIVATE_REASONING_KEY.match(key_text):
+                    converted[key_text] = "[PRIVATE_REASONING_OMITTED]"
+                else:
+                    converted[key_text] = self._convert(item, depth + 1)
+            if len(items) > self.max_collection_items:
+                converted["_trace_truncated_items"] = len(items) - self.max_collection_items
+            return converted
+        if isinstance(value, (list, tuple, set, frozenset)):
+            items = list(value)
+            converted = [
+                self._convert(item, depth + 1) for item in items[: self.max_collection_items]
+            ]
+            if len(items) > self.max_collection_items:
+                converted.append({"truncated_items": len(items) - self.max_collection_items})
+            return converted
+
+        # NumPy arrays, tensors, images, and point clouds remain artifact metadata.
+        shape = getattr(value, "shape", None)
+        dtype = getattr(value, "dtype", None)
+        if shape is not None:
+            return {
+                "artifact": "array-omitted",
+                "type": type(value).__name__,
+                "shape": list(shape),
+                "dtype": str(dtype) if dtype is not None else None,
+            }
+        if hasattr(value, "to_dict") and callable(value.to_dict):
+            try:
+                return self._convert(value.to_dict(), depth + 1)
+            except Exception:
+                pass
+        return {"type": type(value).__name__, "repr": repr(value)[:512]}
+
+    def _summarize(self, value: Any) -> Any:
+        if value is None or isinstance(value, (bool, int, float)):
+            return value
+        if isinstance(value, str):
+            return {"type": "str", "chars": len(value)}
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            return {"type": "binary", "bytes": len(value)}
+        if isinstance(value, dict):
+            return {"type": "object", "keys": [str(k) for k in list(value)[:32]]}
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return {"type": type(value).__name__, "items": len(value)}
+        shape = getattr(value, "shape", None)
+        if shape is not None:
+            return {"type": type(value).__name__, "shape": list(shape)}
+        return {"type": type(value).__name__}

--- a/src/rosclaw/observability/schema.py
+++ b/src/rosclaw/observability/schema.py
@@ -1,0 +1,133 @@
+"""Canonical ROSClaw Trace v1 schema."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+class SpanKind(StrEnum):
+    """Physical-AI operation categories used by the timeline and span tree."""
+
+    MISSION = "MISSION"
+    AGENT = "AGENT"
+    PERCEPTION = "PERCEPTION"
+    CONTEXT = "CONTEXT"
+    PROMPT = "PROMPT"
+    LLM = "LLM"
+    VLM = "VLM"
+    WORLD_MODEL = "WORLD_MODEL"
+    PLANNER = "PLANNER"
+    TOOL = "TOOL"
+    MCP = "MCP"
+    SKILL = "SKILL"
+    SANDBOX = "SANDBOX"
+    GUARDRAIL = "GUARDRAIL"
+    ROBOT_ACTION = "ROBOT_ACTION"
+    ROBOT_STATE = "ROBOT_STATE"
+    CRITIC = "CRITIC"
+    MEMORY = "MEMORY"
+    RECOVERY = "RECOVERY"
+    DATA_PIPELINE = "DATA_PIPELINE"
+
+
+class SpanStatus(StrEnum):
+    """Terminal and in-flight span states."""
+
+    RUNNING = "RUNNING"
+    OK = "OK"
+    ERROR = "ERROR"
+    BLOCKED = "BLOCKED"
+    CANCELLED = "CANCELLED"
+
+
+class CaptureMode(StrEnum):
+    """How much input/output detail a trace may retain."""
+
+    MINIMAL = "minimal"
+    STANDARD = "standard"
+    RESEARCH = "research"
+
+
+@dataclass
+class ObservabilityConfig:
+    """Runtime-independent trace capture and persistence configuration."""
+
+    enabled: bool = True
+    capture_mode: CaptureMode | str = CaptureMode.STANDARD
+    home: str | Path | None = None
+    filename: str = "live.jsonl"
+    queue_size: int = 4096
+    rotate_mb: float = 64.0
+    max_text_chars: int = 16_384
+    max_collection_items: int = 256
+
+    def __post_init__(self) -> None:
+        self.capture_mode = CaptureMode(self.capture_mode)
+        if self.queue_size <= 0:
+            raise ValueError("queue_size must be positive")
+        if self.rotate_mb < 0:
+            raise ValueError("rotate_mb cannot be negative")
+
+
+@dataclass
+class DecisionSummary:
+    """Auditable decision evidence; intentionally not private chain-of-thought."""
+
+    goal: str
+    observations: list[str] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+    candidates: list[dict[str, Any]] = field(default_factory=list)
+    decision: Any | None = None
+    reason_summary: str = ""
+    confidence: float | None = None
+    evidence_refs: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class TraceRecord:
+    """One completed (or live-start) operation in a ROSClaw trace tree."""
+
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None
+    name: str
+    span_kind: str
+    source: str
+    operation: str
+    started_at: float
+    status: str
+    event_id: str = field(default_factory=lambda: f"evt_{uuid.uuid4().hex[:16]}")
+    schema_version: str = "rosclaw.trace.v1"
+    record_type: str = "span"
+    ended_at: float | None = None
+    duration_ms: float | None = None
+    severity: str = "INFO"
+    mission_id: str | None = None
+    episode_id: str | None = None
+    robot_id: str | None = None
+    session_id: str | None = None
+    input: Any | None = None
+    output: Any | None = None
+    attributes: dict[str, Any] = field(default_factory=dict)
+    evidence_refs: list[str] = field(default_factory=list)
+    privacy_class: str = "redacted"
+    payload_hash: str | None = None
+    error: dict[str, Any] | None = None
+    emitted_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dictionary."""
+
+        return asdict(self)

--- a/src/rosclaw/observability/store.py
+++ b/src/rosclaw/observability/store.py
@@ -1,0 +1,110 @@
+"""Read/query utilities shared by the CLI and Dashboard trace APIs."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from rosclaw.firstboot.workspace import resolve_home
+
+
+class TraceStore:
+    """Read completed spans from the local JSONL trace store."""
+
+    def __init__(
+        self,
+        home: str | Path | None = None,
+        path: str | Path | None = None,
+    ) -> None:
+        self.path = (
+            Path(path).expanduser()
+            if path is not None
+            else resolve_home(str(home) if home else None) / "traces" / "live.jsonl"
+        )
+
+    def _paths(self) -> list[Path]:
+        rotated = sorted(self.path.parent.glob(f"{self.path.name}.[0-9][0-9][0-9]"))
+        return [*rotated, *([self.path] if self.path.exists() else [])]
+
+    def read(
+        self,
+        *,
+        trace_id: str | None = None,
+        kinds: set[str] | None = None,
+        statuses: set[str] | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        records: list[dict[str, Any]] = []
+        for path in self._paths():
+            try:
+                with path.open(encoding="utf-8") as stream:
+                    for line in stream:
+                        try:
+                            record = json.loads(line)
+                        except (json.JSONDecodeError, TypeError):
+                            continue
+                        if not isinstance(record, dict):
+                            continue
+                        if trace_id and record.get("trace_id") != trace_id:
+                            continue
+                        if kinds and str(record.get("span_kind", "")).upper() not in kinds:
+                            continue
+                        if statuses and str(record.get("status", "")).upper() not in statuses:
+                            continue
+                        records.append(record)
+            except OSError:
+                continue
+        records.sort(key=lambda item: (item.get("started_at") or 0, item.get("span_id") or ""))
+        return records[-limit:] if limit is not None and limit >= 0 else records
+
+    def list_traces(self, limit: int = 50) -> list[dict[str, Any]]:
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for record in self.read():
+            trace_id = record.get("trace_id")
+            if trace_id:
+                grouped[str(trace_id)].append(record)
+        summaries = []
+        for trace_id, records in grouped.items():
+            first = min((item.get("started_at") or 0 for item in records), default=0)
+            last = max(
+                (item.get("ended_at") or item.get("started_at") or 0 for item in records), default=0
+            )
+            statuses = {str(item.get("status", "")) for item in records}
+            summaries.append(
+                {
+                    "trace_id": trace_id,
+                    "started_at": first,
+                    "ended_at": last,
+                    "duration_ms": round(max(0.0, last - first) * 1000, 3),
+                    "span_count": len(records),
+                    "status": "ERROR"
+                    if "ERROR" in statuses
+                    else ("BLOCKED" if "BLOCKED" in statuses else "OK"),
+                    "kinds": sorted({str(item.get("span_kind", "")) for item in records}),
+                }
+            )
+        summaries.sort(key=lambda item: item["started_at"], reverse=True)
+        return summaries[:limit]
+
+    def get_trace(self, trace_id: str) -> dict[str, Any]:
+        records = self.read(trace_id=trace_id)
+        nodes = {str(item.get("span_id")): {**item, "children": []} for item in records}
+        roots: list[dict[str, Any]] = []
+        for item in records:
+            node = nodes[str(item.get("span_id"))]
+            parent = nodes.get(str(item.get("parent_span_id")))
+            if parent is None:
+                roots.append(node)
+            else:
+                parent["children"].append(node)
+        return {
+            "trace_id": trace_id,
+            "span_count": len(records),
+            "spans": records,
+            "tree": roots,
+        }
+
+    def find_event(self, event_id: str) -> dict[str, Any] | None:
+        return next((item for item in self.read() if item.get("event_id") == event_id), None)

--- a/src/rosclaw/observability/tracer.py
+++ b/src/rosclaw/observability/tracer.py
@@ -1,0 +1,340 @@
+"""Span lifecycle, EventBus streaming, and exporter fan-out."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+import time
+import uuid
+from types import TracebackType
+from typing import Any
+
+from rosclaw.observability.context import (
+    TraceContext,
+    attach_trace_context,
+    current_trace_context,
+    detach_trace_context,
+)
+from rosclaw.observability.exporters.base import TraceExporter
+from rosclaw.observability.redaction import TraceRedactor
+from rosclaw.observability.schema import (
+    ObservabilityConfig,
+    SpanKind,
+    SpanStatus,
+    TraceRecord,
+)
+
+logger = logging.getLogger("rosclaw.observability.tracer")
+_TRACER_LOCK = threading.Lock()
+
+
+class Tracer:
+    """Create structured spans and stream them without affecting runtime outcomes."""
+
+    def __init__(
+        self,
+        event_bus: Any | None = None,
+        config: ObservabilityConfig | None = None,
+        exporters: list[TraceExporter] | None = None,
+    ) -> None:
+        self.event_bus = event_bus
+        self.config = config or ObservabilityConfig()
+        self.redactor = TraceRedactor(
+            mode=self.config.capture_mode,
+            max_text_chars=self.config.max_text_chars,
+            max_collection_items=self.config.max_collection_items,
+        )
+        self._exporters: list[TraceExporter] = list(exporters or [])
+        self._closed = False
+
+    def configure(
+        self,
+        config: ObservabilityConfig,
+        exporters: list[TraceExporter] | None = None,
+    ) -> None:
+        """Apply runtime configuration before traced operations begin."""
+
+        self.config = config
+        self.redactor = TraceRedactor(
+            mode=config.capture_mode,
+            max_text_chars=config.max_text_chars,
+            max_collection_items=config.max_collection_items,
+        )
+        if exporters is not None:
+            self._exporters = list(exporters)
+        self._closed = False
+
+    def start_span(
+        self,
+        name: str,
+        kind: SpanKind | str,
+        *,
+        source: str = "rosclaw",
+        operation: str | None = None,
+        trace_id: str | None = None,
+        parent_span_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+        mission_id: str | None = None,
+        episode_id: str | None = None,
+        robot_id: str | None = None,
+        session_id: str | None = None,
+    ) -> TraceSpan:
+        parent = current_trace_context()
+        # A child can never switch trace IDs while retaining the current span
+        # as its parent. Explicit IDs only seed a root operation.
+        resolved_trace_id = parent.trace_id if parent else trace_id
+        return TraceSpan(
+            tracer=self,
+            name=name,
+            kind=SpanKind(kind),
+            source=source,
+            operation=operation or name,
+            trace_id=resolved_trace_id or f"trace_{uuid.uuid4().hex[:24]}",
+            parent_span_id=(
+                parent_span_id
+                if parent_span_id is not None
+                else (parent.span_id if parent else None)
+            ),
+            attributes=attributes or {},
+            mission_id=mission_id,
+            episode_id=episode_id,
+            robot_id=robot_id,
+            session_id=session_id,
+        )
+
+    def _publish(self, topic: str, record: TraceRecord) -> None:
+        if not self.config.enabled or self.event_bus is None:
+            return
+        try:
+            from rosclaw.core.event_bus import Event, EventPriority
+
+            priority = (
+                EventPriority.HIGH
+                if record.status in {SpanStatus.ERROR, SpanStatus.BLOCKED}
+                else EventPriority.LOW
+            )
+            self.event_bus.publish(
+                Event(
+                    topic=topic,
+                    payload=record.to_dict(),
+                    source="trace",
+                    priority=priority,
+                    trace_id=record.trace_id,
+                    span_id=record.span_id,
+                    parent_span_id=record.parent_span_id or "",
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Trace EventBus publish failed: %s", exc)
+
+    def _export(self, record: TraceRecord) -> None:
+        if not self.config.enabled:
+            return
+        for exporter in list(self._exporters):
+            try:
+                exporter.export(record)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Trace exporter failed: %s", exc)
+
+    def close(self, timeout: float = 5.0) -> None:
+        if self._closed:
+            return
+        for exporter in list(self._exporters):
+            try:
+                exporter.close(timeout=timeout)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Trace exporter close failed: %s", exc)
+        self._closed = True
+
+
+class TraceSpan:
+    """Sync/async context manager for one timed, causally-linked operation."""
+
+    def __init__(
+        self,
+        *,
+        tracer: Tracer,
+        name: str,
+        kind: SpanKind,
+        source: str,
+        operation: str,
+        trace_id: str,
+        parent_span_id: str | None,
+        attributes: dict[str, Any],
+        mission_id: str | None,
+        episode_id: str | None,
+        robot_id: str | None,
+        session_id: str | None,
+    ) -> None:
+        self.tracer = tracer
+        self.name = name
+        self.kind = kind
+        self.source = source
+        self.operation = operation
+        self.trace_id = trace_id
+        self.span_id = f"span_{uuid.uuid4().hex[:16]}"
+        self.parent_span_id = parent_span_id
+        self.attributes = dict(attributes)
+        self.mission_id = mission_id
+        self.episode_id = episode_id
+        self.robot_id = robot_id
+        self.session_id = session_id
+        self.started_at = 0.0
+        self.ended_at: float | None = None
+        self.status = SpanStatus.RUNNING
+        self.severity = "INFO"
+        self.input: Any | None = None
+        self.output: Any | None = None
+        self.evidence_refs: list[str] = []
+        self.error: dict[str, Any] | None = None
+        self._token: Any | None = None
+        self._finished = False
+
+    def __enter__(self) -> TraceSpan:
+        self.started_at = time.time()
+        self._token = attach_trace_context(
+            TraceContext(
+                trace_id=self.trace_id,
+                span_id=self.span_id,
+                parent_span_id=self.parent_span_id,
+            )
+        )
+        self.tracer._publish("rosclaw.trace.span.started", self._record())
+        return self
+
+    async def __aenter__(self) -> TraceSpan:
+        return self.__enter__()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        if exc is not None:
+            self.status = (
+                SpanStatus.CANCELLED if exc_type is asyncio_cancelled_error() else SpanStatus.ERROR
+            )
+            self.severity = "ERROR"
+            self.error = {"type": type(exc).__name__, "message": str(exc)}
+        elif self.status == SpanStatus.RUNNING:
+            self.status = SpanStatus.OK
+        self.finish()
+        return False
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        return self.__exit__(exc_type, exc, traceback)
+
+    def set_input(self, value: Any) -> TraceSpan:
+        self.input = self.tracer.redactor.redact(value)
+        return self
+
+    def set_output(self, value: Any) -> TraceSpan:
+        self.output = self.tracer.redactor.redact(value)
+        return self
+
+    def set_attribute(self, key: str, value: Any) -> TraceSpan:
+        self.attributes[key] = self.tracer.redactor.redact(value)
+        return self
+
+    def set_status(self, status: SpanStatus | str, message: str | None = None) -> TraceSpan:
+        self.status = SpanStatus(status)
+        if self.status in {SpanStatus.ERROR, SpanStatus.BLOCKED}:
+            self.severity = "ERROR" if self.status == SpanStatus.ERROR else "WARNING"
+        if message:
+            self.attributes["status.message"] = self.tracer.redactor.redact(message)
+        return self
+
+    def add_evidence(self, reference: str) -> TraceSpan:
+        self.evidence_refs.append(reference)
+        return self
+
+    def finish(self) -> TraceRecord:
+        if self._finished:
+            return self._record()
+        self._finished = True
+        self.ended_at = time.time()
+        record = self._record()
+        topic = (
+            "rosclaw.trace.span.failed"
+            if self.status in {SpanStatus.ERROR, SpanStatus.BLOCKED, SpanStatus.CANCELLED}
+            else "rosclaw.trace.span.completed"
+        )
+        self.tracer._publish(topic, record)
+        self.tracer._export(record)
+        if self._token is not None:
+            detach_trace_context(self._token)
+            self._token = None
+        return record
+
+    def _record(self) -> TraceRecord:
+        attributes = self.tracer.redactor.redact(self.attributes)
+        material = {"input": self.input, "output": self.output}
+        try:
+            payload_hash = hashlib.sha256(
+                json.dumps(material, sort_keys=True, default=str).encode("utf-8")
+            ).hexdigest()
+        except Exception:
+            payload_hash = None
+        duration_ms = (
+            round((self.ended_at - self.started_at) * 1000, 3)
+            if self.ended_at is not None and self.started_at
+            else None
+        )
+        return TraceRecord(
+            trace_id=self.trace_id,
+            span_id=self.span_id,
+            parent_span_id=self.parent_span_id,
+            name=self.name,
+            span_kind=self.kind.value,
+            source=self.source,
+            operation=self.operation,
+            started_at=self.started_at or time.time(),
+            ended_at=self.ended_at,
+            duration_ms=duration_ms,
+            status=self.status.value,
+            severity=self.severity,
+            mission_id=self.mission_id,
+            episode_id=self.episode_id,
+            robot_id=self.robot_id,
+            session_id=self.session_id,
+            input=self.input,
+            output=self.output,
+            attributes=attributes if isinstance(attributes, dict) else {},
+            evidence_refs=list(self.evidence_refs),
+            privacy_class=self.tracer.config.capture_mode.value,
+            payload_hash=payload_hash,
+            error=self.error,
+        )
+
+
+def asyncio_cancelled_error() -> type[BaseException]:
+    """Import lazily to keep the tracer lightweight during module import."""
+
+    import asyncio
+
+    return asyncio.CancelledError
+
+
+def get_tracer(event_bus: Any | None = None) -> Tracer:
+    """Return the tracer shared by all components attached to one EventBus."""
+
+    if event_bus is None:
+        return Tracer()
+    existing = getattr(event_bus, "_rosclaw_tracer", None)
+    if isinstance(existing, Tracer):
+        return existing
+    with _TRACER_LOCK:
+        existing = getattr(event_bus, "_rosclaw_tracer", None)
+        if isinstance(existing, Tracer):
+            return existing
+        tracer = Tracer(event_bus=event_bus)
+        event_bus._rosclaw_tracer = tracer
+        return tracer

--- a/src/rosclaw/practice/episode_recorder.py
+++ b/src/rosclaw/practice/episode_recorder.py
@@ -51,6 +51,7 @@ class _EpisodeBuffer:
     critic_status: str | None = None
     praxis_status: str | None = None
     praxis_reward: float | None = None
+    praxis_pending: bool = False
     duration_sec: float | None = None
     # CRITICAL FIX: agent_request stores the original user/agent request for full traceability
     agent_request: dict[str, Any] | None = None
@@ -258,6 +259,7 @@ class EpisodeRecorder(LifecycleMixin):
         buf = self._get_or_create_buffer(episode_id)
         buf.received_events.add("skill.execution.complete")
         buf.final_state = payload.get("final_state", payload.get("state"))
+        buf.praxis_pending = bool(payload.get("praxis_pending", False))
         result = payload.get("result", {})
         duration = payload.get("duration_sec")
         if duration is None and buf.created_at:
@@ -272,9 +274,8 @@ class EpisodeRecorder(LifecycleMixin):
             }
         )
         buf.last_event_at = time.time()
-        # Note: skill.execution.complete does NOT auto-finalize;
-        # we wait for praxis.completed/failed or other terminal events
-        # so that all context (provider, critic, sandbox) can be collected.
+        # Finalization waits for a critic or explicit praxis terminal event so
+        # that skill output is not mistaken for an evaluated physical outcome.
 
     def _on_praxis_completed(self, event: Event) -> None:
         """External praxis.completed handler (fallback for non-skill paths)."""
@@ -422,7 +423,7 @@ class EpisodeRecorder(LifecycleMixin):
         buf.last_event_at = time.time()
 
     def _on_critic_success(self, event: Event) -> None:
-        """Stub for rosclaw.critic.success.detected (future sprint)."""
+        """Capture a critic terminal result and finalize standalone skills."""
         payload = event.payload if isinstance(event.payload, dict) else {}
         episode_id = self._extract_episode_id(payload)
         buf = self._get_or_create_buffer(episode_id)
@@ -430,6 +431,8 @@ class EpisodeRecorder(LifecycleMixin):
         buf.critic_reward = payload.get("reward", 1.0 if payload.get("success") else 0.0)
         buf.critic_status = "SUCCESS" if payload.get("success", True) else "FAILED"
         buf.last_event_at = time.time()
+        if buf.is_complete() and not buf.praxis_pending:
+            self._finalize_episode(episode_id, reason="critic_terminal")
 
     def _on_sandbox_episode_finished(self, event: Event) -> None:
         """Stub for rosclaw.sandbox.episode.finished (Sprint 3)."""

--- a/src/rosclaw/practice/recorder.py
+++ b/src/rosclaw/practice/recorder.py
@@ -696,7 +696,12 @@ class PracticeRecorder(RuntimeConsumer):
             return
         result = payload.get("result", {})
         status = result.get("status")
-        correlation_id = payload.get("correlation_id", "")
+        correlation_id = (
+            payload.get("correlation_id")
+            or payload.get("episode_id")
+            or payload.get("request_id")
+            or ""
+        )
         skill_name = payload.get("skill_name", "")
 
         self._failure_context["current_iteration"] += 1
@@ -709,6 +714,8 @@ class PracticeRecorder(RuntimeConsumer):
                     topic="praxis.completed",
                     payload={
                         "practice_id": correlation_id,
+                        "episode_id": correlation_id,
+                        "correlation_id": correlation_id,
                         "event_type": "praxis.completed",
                         "robot_id": self.robot_id,
                         "outcome": {
@@ -734,6 +741,8 @@ class PracticeRecorder(RuntimeConsumer):
                     topic="praxis.failed",
                     payload={
                         "practice_id": correlation_id,
+                        "episode_id": correlation_id,
+                        "correlation_id": correlation_id,
                         "event_type": "praxis.failed",
                         "robot_id": self.robot_id,
                         "outcome": {

--- a/src/rosclaw/provider/core/router.py
+++ b/src/rosclaw/provider/core/router.py
@@ -6,6 +6,7 @@ embodiment compatibility, latency budget, safety level, health, and fallback cha
 
 import time
 from dataclasses import dataclass, field
+from typing import Any
 
 from rosclaw.provider.core.errors import ProviderNotFoundError, ProviderUnavailableError
 from rosclaw.provider.core.provider import Provider
@@ -41,8 +42,13 @@ class CapabilityRouter:
     9. fallback priority
     """
 
-    def __init__(self, registry: ProviderRegistry):
+    def __init__(self, registry: ProviderRegistry, tracer: Any | None = None):
         self.registry = registry
+        if tracer is None:
+            from rosclaw.observability.tracer import get_tracer
+
+            tracer = get_tracer(getattr(registry, "_event_bus", None))
+        self.tracer = tracer
 
     # ------------------------------------------------------------------
     # Public API
@@ -98,6 +104,48 @@ class CapabilityRouter:
         request: ProviderRequest,
         trace: ProviderTrace | None = None,
     ) -> ProviderResponse:
+        """Invoke a capability under a routed Provider span."""
+
+        trace_id = request.context.get("trace_id") or request.request_id
+        kind = self._span_kind_for_capability(request.capability)
+        async with self.tracer.start_span(
+            "provider.invoke",
+            kind,
+            source="provider_router",
+            operation=request.capability,
+            trace_id=trace_id,
+            attributes={
+                "request.id": request.request_id,
+                "capability": request.capability,
+                "robot.id": request.robot_id,
+                "safety.level": request.safety_level,
+            },
+            robot_id=request.robot_id or None,
+            episode_id=request.context.get("episode_id"),
+            mission_id=request.context.get("task_id"),
+        ) as span:
+            span.set_input(
+                {
+                    "inputs": request.inputs,
+                    "context": request.context,
+                    "constraints": request.constraints,
+                    "output_schema": request.output_schema,
+                }
+            )
+            response = await self._invoke_routed(request, trace)
+            span.set_attribute("provider.selected", response.provider)
+            span.set_attribute("latency_ms", response.latency_ms)
+            span.set_attribute("fallback.used", response.trace.get("fallback_used", False))
+            span.set_output(self._response_payload(response))
+            if not response.is_ok:
+                span.set_status("ERROR", "; ".join(response.errors) or response.status)
+            return response
+
+    async def _invoke_routed(
+        self,
+        request: ProviderRequest,
+        trace: ProviderTrace | None = None,
+    ) -> ProviderResponse:
         """Full invoke pipeline: route -> infer -> fallback if needed.
 
         Args:
@@ -137,6 +185,36 @@ class CapabilityRouter:
         # All failed — return primary response (with errors)
         response.trace["fallbacks_exhausted"] = True
         return response
+
+    @staticmethod
+    def _span_kind_for_capability(capability: str) -> str:
+        prefix = capability.split(".", 1)[0].lower()
+        return {
+            "vlm": "VLM",
+            "llm": "LLM",
+            "critic": "CRITIC",
+            "skill": "SKILL",
+            "world": "WORLD_MODEL",
+            "perception": "PERCEPTION",
+            "planner": "PLANNER",
+        }.get(prefix, "LLM")
+
+    @staticmethod
+    def _response_payload(response: ProviderResponse) -> dict[str, Any]:
+        return {
+            "request_id": response.request_id,
+            "provider": response.provider,
+            "capability": response.capability,
+            "result": response.result,
+            "confidence": response.confidence,
+            "evidence": response.evidence,
+            "latency_ms": response.latency_ms,
+            "model_info": response.model_info,
+            "trace": response.trace,
+            "warnings": response.warnings,
+            "errors": response.errors,
+            "status": response.status,
+        }
 
     # ------------------------------------------------------------------
     # Scoring
@@ -220,19 +298,65 @@ class CapabilityRouter:
         trace: ProviderTrace | None,
     ) -> ProviderResponse:
         """Invoke a single provider with timing and error handling."""
-        t0 = time.monotonic()
-        try:
-            response = await provider.infer(request)
-        except Exception as e:
-            response = ProviderResponse(
-                request_id=request.request_id,
-                provider=provider.name,
-                capability=request.capability,
-                status="failed",
-                errors=[str(e)],
+        async with self.tracer.start_span(
+            "provider.inference",
+            self._span_kind_for_capability(request.capability),
+            source=provider.name,
+            operation=request.capability,
+            attributes={
+                "provider.name": provider.name,
+                "provider.version": provider.version,
+                "provider.type": provider.manifest.type,
+                "runtime.backend": provider.manifest.runtime.backend,
+                "request.id": request.request_id,
+            },
+            robot_id=request.robot_id or None,
+            episode_id=request.context.get("episode_id"),
+            mission_id=request.context.get("task_id"),
+        ) as span:
+            span.set_input(request.inputs)
+            self._publish_inference_event(
+                "rosclaw.provider.inference.requested",
+                request,
+                provider,
+                {"input": span.input},
             )
+            t0 = time.monotonic()
+            try:
+                response = await provider.infer(request)
+            except Exception as e:
+                response = ProviderResponse(
+                    request_id=request.request_id,
+                    provider=provider.name,
+                    capability=request.capability,
+                    status="failed",
+                    errors=[str(e)],
+                )
 
-        response.latency_ms = int((time.monotonic() - t0) * 1000)
+            response.latency_ms = int((time.monotonic() - t0) * 1000)
+            output = self._response_payload(response)
+            span.set_output(output)
+            span.set_attribute("latency_ms", response.latency_ms)
+            span.set_attribute("model.info", response.model_info)
+            usage = response.trace.get("usage", {}) if isinstance(response.trace, dict) else {}
+            if usage:
+                span.set_attribute("token.usage", usage)
+            if not response.is_ok:
+                span.set_status("ERROR", "; ".join(response.errors) or response.status)
+            self._publish_inference_event(
+                "rosclaw.provider.inference.completed",
+                request,
+                provider,
+                {
+                    "status": response.status,
+                    "latency_ms": response.latency_ms,
+                    "model": response.model_info,
+                    "tokens": usage,
+                    "output": span.output,
+                    "errors": response.errors,
+                    "warnings": response.warnings,
+                },
+            )
 
         if trace:
             trace.add_step(
@@ -245,3 +369,37 @@ class CapabilityRouter:
             )
 
         return response
+
+    def _publish_inference_event(
+        self,
+        topic: str,
+        request: ProviderRequest,
+        provider: Provider,
+        details: dict[str, Any],
+    ) -> None:
+        event_bus = getattr(self.registry, "_event_bus", None)
+        if event_bus is None:
+            return
+        try:
+            from rosclaw.core.event_bus import Event, EventPriority
+
+            event_bus.publish(
+                Event(
+                    topic=topic,
+                    payload={
+                        "request_id": request.request_id,
+                        "episode_id": request.context.get("episode_id"),
+                        "task_id": request.context.get("task_id"),
+                        "robot_id": request.robot_id,
+                        "provider": provider.name,
+                        "provider_version": provider.version,
+                        "capability": request.capability,
+                        **details,
+                    },
+                    source="provider_router",
+                    priority=EventPriority.NORMAL,
+                )
+            )
+        except Exception:
+            # Observability cannot change inference behavior.
+            pass

--- a/src/rosclaw/sandbox/runtime_adapter.py
+++ b/src/rosclaw/sandbox/runtime_adapter.py
@@ -46,6 +46,12 @@ class SandboxRuntimeAdapter(LifecycleMixin):
         self._engine_name = config.get("engine", "mujoco")
         self._world_id = config.get("world_id", "empty")
         self._robot_id = config.get("robot_id", "")
+        from rosclaw.observability.tracer import Tracer, get_tracer
+
+        runtime_tracer = getattr(runtime, "tracer", None)
+        self._tracer = (
+            runtime_tracer if isinstance(runtime_tracer, Tracer) else get_tracer(event_bus)
+        )
         if self._runtime is not None:
             sense_runtime = getattr(self._runtime, "sense", None)
             if sense_runtime is not None:
@@ -106,6 +112,41 @@ class SandboxRuntimeAdapter(LifecycleMixin):
             logger.info("Sandbox closed")
 
     def validate_trajectory(
+        self,
+        trajectory: list[list[float]],
+        safety_level: str = "MODERATE",
+    ) -> dict[str, Any]:
+        """Trace one digital-twin trajectory validation."""
+
+        with self._tracer.start_span(
+            "sandbox.validate_trajectory",
+            "SANDBOX",
+            source="sandbox",
+            operation="trajectory.rollout",
+            attributes={
+                "sandbox.engine": self._engine_name,
+                "sandbox.world": self._world_id,
+                "safety.level": safety_level,
+                "trajectory.waypoints": len(trajectory),
+            },
+            robot_id=self._robot_id or None,
+        ) as span:
+            span.set_input({"trajectory": trajectory})
+            result = self._validate_trajectory(trajectory, safety_level)
+            span.set_output(result)
+            if not result.get("is_safe", False):
+                reason = str(result.get("reason", "unsafe"))
+                span.set_status(
+                    "ERROR"
+                    if "error" in reason.lower() or "not initialized" in reason.lower()
+                    else "BLOCKED",
+                    reason,
+                )
+            if result.get("replay_id"):
+                span.add_evidence(f"sandbox://replay/{result['replay_id']}")
+            return result
+
+    def _validate_trajectory(
         self,
         trajectory: list[list[float]],
         safety_level: str = "MODERATE",

--- a/src/rosclaw/skill_manager/executor.py
+++ b/src/rosclaw/skill_manager/executor.py
@@ -37,6 +37,7 @@ class SkillExecutor(LifecycleMixin):
         seekdb_client: Any | None = None,
         sense_interface: Any | None = None,
         body_resolver: BodyResolver | None = None,
+        tracer: Any | None = None,
     ):
         super().__init__()
         self.event_bus = event_bus
@@ -52,6 +53,11 @@ class SkillExecutor(LifecycleMixin):
             except Exception:
                 logger.warning("Failed to initialize SkillRequirementsAdapter", exc_info=True)
         self._body_resolver = body_resolver
+        if tracer is None:
+            from rosclaw.observability.tracer import get_tracer
+
+            tracer = get_tracer(event_bus)
+        self._tracer = tracer
         # Ensure runtime skill handlers are discovered from entry points.
         try:
             get_runtime_plugin().discover_handlers()
@@ -62,6 +68,29 @@ class SkillExecutor(LifecycleMixin):
         logger.info("Initialized")
 
     def execute(self, skill_name: str, parameters: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Execute one skill under a structured Skill span."""
+
+        with self._tracer.start_span(
+            "skill.execute",
+            "SKILL",
+            source="skill_executor",
+            operation=skill_name,
+            attributes={"skill.name": skill_name},
+        ) as span:
+            span.set_input(parameters or {})
+            result = self._execute_skill(skill_name, parameters)
+            span.set_output(result)
+            status = str(result.get("status", "")).lower()
+            if status in {"blocked", "precondition_failed"}:
+                span.set_status("BLOCKED", result.get("message") or result.get("reason"))
+            elif status == "error":
+                span.set_status("ERROR", result.get("error") or result.get("message"))
+            result.setdefault("trace_id", span.trace_id)
+            return result
+
+    def _execute_skill(
+        self, skill_name: str, parameters: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """
         Execute a skill by name.
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -499,9 +499,9 @@ class TestDashboardServerEventBus:
         mock_bus.subscribe.return_value = mock_subscription
 
         server.attach_to_event_bus(mock_bus)
-        # Subscribes to original topics plus rosclaw.sense.* topics.
-        assert mock_bus.subscribe.call_count == 25
-        assert len(server._event_bus_subscriptions) == 25
+        # Subscribes to original topics, rosclaw.sense.*, and three trace lifecycle topics.
+        assert mock_bus.subscribe.call_count == 28
+        assert len(server._event_bus_subscriptions) == 28
 
     def test_detach_from_event_bus(self):
         metrics = DashboardMetrics()

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,390 @@
+"""ROSClaw Trace schema, propagation, persistence, and runtime integration tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.observability.context import current_trace_context
+from rosclaw.observability.exporters.jsonl import JsonlTraceExporter
+from rosclaw.observability.redaction import TraceRedactor
+from rosclaw.observability.schema import ObservabilityConfig
+from rosclaw.observability.store import TraceStore
+from rosclaw.observability.tracer import Tracer
+from rosclaw.provider.core.manifest import ProviderManifest
+from rosclaw.provider.core.provider import Provider
+from rosclaw.provider.core.registry import ProviderRegistry
+from rosclaw.provider.core.request import ProviderRequest
+from rosclaw.provider.core.response import ProviderResponse
+from rosclaw.provider.core.router import CapabilityRouter
+
+
+class _ArrayLike:
+    shape = (480, 640, 3)
+    dtype = "uint8"
+
+
+class _Provider(Provider):
+    name = "trace-provider"
+    version = "1.2.3"
+    capabilities = ["vlm.scene_understanding"]
+
+    async def infer(self, request: ProviderRequest) -> ProviderResponse:
+        return ProviderResponse(
+            request_id=request.request_id,
+            provider=self.name,
+            capability=request.capability,
+            result={"objects": ["door"]},
+            model_info={"model": "test-vlm"},
+            trace={"usage": {"input_tokens": 12, "output_tokens": 3}},
+        )
+
+
+def test_redactor_removes_secrets_and_large_artifacts():
+    redactor = TraceRedactor(max_text_chars=8)
+    result = redactor.redact(
+        {
+            "api_key": "super-secret",
+            "input_tokens": 42,
+            "authorization": "Bearer abc.def",
+            "chain_of_thought": "private scratch work",
+            "reason_summary": "auditable reason",
+            "image": _ArrayLike(),
+            "blob": b"binary",
+            "prompt": "0123456789",
+        }
+    )
+
+    assert result["api_key"] == "[REDACTED]"
+    assert result["input_tokens"] == 42
+    assert result["authorization"] == "[REDACTED]"
+    assert result["chain_of_thought"] == "[PRIVATE_REASONING_OMITTED]"
+    assert result["reason_summary"]["text"] == "auditabl"
+    assert result["image"]["artifact"] == "array-omitted"
+    assert result["blob"]["artifact"] == "inline-binary-omitted"
+    assert result["prompt"]["truncated"] is True
+
+
+def test_span_tree_event_context_and_nonblocking_export(tmp_path):
+    path = tmp_path / "traces" / "live.jsonl"
+    exporter = JsonlTraceExporter(output_path=path, queue_size=8, rotate_mb=0)
+    bus = EventBus()
+    events = []
+    bus.subscribe("#", events.append)
+    tracer = Tracer(
+        event_bus=bus,
+        config=ObservabilityConfig(capture_mode="standard"),
+        exporters=[exporter],
+    )
+
+    with tracer.start_span("mission", "MISSION", trace_id="trace-test") as root:
+        root.set_input({"password": "do-not-store", "goal": "inspect"})
+        emitted = Event(topic="custom.runtime.event", payload={"state": "running"})
+        bus.publish(emitted)
+        with tracer.start_span("model", "VLM") as child:
+            child.set_output({"answer": "door"})
+
+    tracer.close()
+    records = TraceStore(path=path).read(trace_id="trace-test")
+
+    assert len(records) == 2
+    by_name = {record["name"]: record for record in records}
+    assert by_name["model"]["parent_span_id"] == by_name["mission"]["span_id"]
+    assert by_name["mission"]["input"]["password"] == "[REDACTED]"
+    assert emitted.trace_id == "trace-test"
+    assert emitted.span_id == root.span_id
+    assert {event.topic for event in events} >= {
+        "rosclaw.trace.span.started",
+        "rosclaw.trace.span.completed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_trace_context_crosses_sync_async_worker_boundary():
+    from rosclaw.core.async_utils import run_sync
+
+    async def read_context():
+        return current_trace_context()
+
+    tracer = Tracer()
+    with tracer.start_span("root", "AGENT", trace_id="cross-thread") as root:
+        propagated = run_sync(read_context())
+
+    assert propagated is not None
+    assert propagated.trace_id == "cross-thread"
+    assert propagated.span_id == root.span_id
+
+
+@pytest.mark.asyncio
+async def test_provider_router_emits_real_nested_provider_trace(tmp_path):
+    bus = EventBus()
+    registry = ProviderRegistry(event_bus=bus)
+    manifest = ProviderManifest.from_dict(
+        {
+            "name": "trace-provider",
+            "version": "1.2.3",
+            "type": "vlm",
+            "capabilities": ["vlm.scene_understanding"],
+        }
+    )
+    registry.register(manifest, lambda item: _Provider(item), auto_load=False)
+    registry.set_provider_health("trace-provider", ok=True)
+    path = tmp_path / "live.jsonl"
+    exporter = JsonlTraceExporter(output_path=path, rotate_mb=0)
+    tracer = Tracer(event_bus=bus, exporters=[exporter])
+    router = CapabilityRouter(registry, tracer=tracer)
+
+    response = await router.invoke(
+        ProviderRequest(
+            request_id="provider-request",
+            capability="vlm.scene_understanding",
+            inputs={"image": _ArrayLike(), "text": "find the door"},
+        )
+    )
+    tracer.close()
+
+    assert response.is_ok
+    topics = [event.topic for event in bus.get_history(limit=100)]
+    assert "rosclaw.provider.inference.requested" in topics
+    assert "rosclaw.provider.inference.completed" in topics
+    trace = TraceStore(path=path).get_trace("provider-request")
+    assert trace["span_count"] == 2
+    assert trace["tree"][0]["name"] == "provider.invoke"
+    inference = trace["tree"][0]["children"][0]
+    assert inference["name"] == "provider.inference"
+    assert inference["input"]["image"]["artifact"] == "array-omitted"
+    assert inference["attributes"]["token.usage"]["input_tokens"] == 12
+
+
+@pytest.mark.asyncio
+async def test_mcp_runtime_provider_chain_shares_one_trace_tree(tmp_path):
+    from rosclaw.agent_runtime.mcp_hub import MCPHub
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    bus = EventBus()
+    path = tmp_path / "live.jsonl"
+    exporter = JsonlTraceExporter(output_path=path, rotate_mb=0)
+    tracer = Tracer(event_bus=bus, exporters=[exporter])
+    bus._rosclaw_tracer = tracer
+
+    registry = ProviderRegistry(event_bus=bus)
+    manifest = ProviderManifest.from_dict(
+        {
+            "name": "trace-provider",
+            "version": "1.2.3",
+            "type": "vlm",
+            "capabilities": ["vlm.scene_understanding"],
+        }
+    )
+    registry.register(manifest, lambda item: _Provider(item), auto_load=False)
+    registry.set_provider_health("trace-provider", ok=True)
+    router = CapabilityRouter(registry, tracer=tracer)
+
+    runtime = Runtime(
+        RuntimeConfig(enable_provider=False, enable_tracing=False),
+        event_bus=bus,
+    )
+    runtime._capability_router = router
+    bus.subscribe("agent.capability.request", runtime._on_capability_request)
+    hub = MCPHub(event_bus=bus, robot_id="test-robot", runtime=runtime, tracer=tracer)
+    hub.initialize()
+
+    result = await hub.handle_tool_call(
+        "observe_scene",
+        {"image_topic": "/camera/front", "query": "find the door"},
+    )
+    hub.stop()
+    tracer.close()
+
+    assert result["status"] == "ok"
+    traces = TraceStore(path=path).list_traces()
+    assert len(traces) == 1
+    trace = TraceStore(path=path).get_trace(traces[0]["trace_id"])
+    assert [span["name"] for span in trace["spans"]] == [
+        "mcp.call_tool",
+        "provider.invoke",
+        "provider.inference",
+    ]
+    root = trace["tree"][0]
+    assert root["name"] == "mcp.call_tool"
+    assert root["children"][0]["name"] == "provider.invoke"
+    assert root["children"][0]["children"][0]["name"] == "provider.inference"
+
+
+def test_runtime_closed_loop_persists_replayable_trace(tmp_path):
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    runtime = Runtime(
+        RuntimeConfig(
+            robot_id="trace-test-robot",
+            enable_firewall=False,
+            enable_memory=False,
+            enable_practice=False,
+            enable_swarm=False,
+            enable_skill_manager=False,
+            enable_knowledge=False,
+            enable_how=False,
+            enable_auto=False,
+            enable_provider=False,
+            enable_sense=False,
+            enable_event_persistence=False,
+            enable_tracing=True,
+            trace_home=str(tmp_path),
+        )
+    )
+    runtime.initialize()
+    plan = runtime.plan_action(
+        "inspect the door",
+        {"confidence": 0.8, "result": {"objects": [{"label": "door"}]}},
+    )
+    result = runtime.execute(
+        {
+            "request_id": "mission-123",
+            "instruction": "dry-run test",
+            "skill_name": "inspect",
+            "trajectory": [[0.0] * 6],
+        }
+    )
+    runtime.stop()
+
+    assert plan["decision_summary"]["goal"] == "inspect the door"
+    assert plan["decision_summary"]["observations"] == ["door"]
+    assert "chain_of_thought" not in plan["decision_summary"]
+    assert result["status"] == "ok"
+    assert result["trace_id"] == "mission-123"
+    trace = TraceStore(home=tmp_path).get_trace("mission-123")
+    assert {span["span_kind"] for span in trace["spans"]} >= {
+        "MISSION",
+        "PLANNER",
+        "SANDBOX",
+    }
+    assert trace["tree"][0]["name"] == "runtime.execute"
+    assert trace["tree"][0]["output"]["status"] == "ok"
+    planner = next(span for span in trace["spans"] if span["span_kind"] == "PLANNER")
+    assert planner["parent_span_id"] == trace["tree"][0]["span_id"]
+    decision = planner["output"]["decision_summary"]
+    assert decision["goal"] == "dry-run test"
+    assert decision["constraints"]
+    assert decision["candidates"]
+    assert decision["decision"]
+    assert decision["reason_summary"]
+    assert "chain_of_thought" not in decision
+
+
+def test_runtime_mission_links_provider_decision_and_sandbox(tmp_path):
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    runtime = Runtime(
+        RuntimeConfig(
+            robot_id="trace-test-robot",
+            enable_firewall=False,
+            enable_memory=False,
+            enable_practice=False,
+            enable_swarm=False,
+            enable_skill_manager=False,
+            enable_knowledge=False,
+            enable_how=False,
+            enable_auto=False,
+            enable_provider=False,
+            enable_sense=False,
+            enable_event_persistence=False,
+            enable_tracing=True,
+            trace_home=str(tmp_path),
+        )
+    )
+    runtime.initialize()
+    registry = ProviderRegistry(event_bus=runtime.event_bus)
+    manifest = ProviderManifest.from_dict(
+        {
+            "name": "trace-provider",
+            "version": "1.2.3",
+            "type": "vlm",
+            "capabilities": ["vlm.scene_understanding"],
+        }
+    )
+    registry.register(manifest, lambda item: _Provider(item), auto_load=False)
+    registry.set_provider_health("trace-provider", ok=True)
+    runtime._capability_router = CapabilityRouter(registry, tracer=runtime.tracer)
+
+    result = runtime.execute(
+        {
+            "request_id": "mission-provider-123",
+            "instruction": "find the door and inspect it",
+            "skill_name": "inspect",
+            "capability": "vlm.scene_understanding",
+            "parameters": {"image": _ArrayLike(), "text": "find the door"},
+            "trajectory": [[0.0] * 6],
+        }
+    )
+    runtime.stop()
+
+    assert result["status"] == "ok"
+    trace = TraceStore(home=tmp_path).get_trace("mission-provider-123")
+    spans = {span["name"]: span for span in trace["spans"]}
+    mission = spans["runtime.execute"]
+    provider = spans["provider.invoke"]
+    inference = spans["provider.inference"]
+    planner = spans["agent.execution_decision"]
+    sandbox = spans["sandbox.validate_action"]
+
+    assert provider["parent_span_id"] == mission["span_id"]
+    assert inference["parent_span_id"] == provider["span_id"]
+    assert planner["parent_span_id"] == mission["span_id"]
+    assert sandbox["parent_span_id"] == mission["span_id"]
+    assert inference["input"]["image"]["artifact"] == "array-omitted"
+    assert inference["output"]["result"] == {"objects": ["door"]}
+    decision = planner["output"]["decision_summary"]
+    assert decision["goal"] == "find the door and inspect it"
+    assert decision["observations"] == ["door"]
+    assert decision["constraints"] == [
+        "safety_level=MODERATE",
+        "sandbox_validation=required",
+    ]
+    assert decision["decision"] == {
+        "skill_name": "inspect",
+        "capability": "vlm.scene_understanding",
+        "parameters": {
+            "image": {
+                "artifact": "array-omitted",
+                "shape": [480, 640, 3],
+                "dtype": "uint8",
+                "type": "_ArrayLike",
+            },
+            "text": "find the door",
+        },
+    }
+    assert result["decision_summary"]["reason_summary"]
+
+
+def test_trace_store_ignores_malformed_lines(tmp_path):
+    path = tmp_path / "live.jsonl"
+    path.write_text(
+        "not-json\n"
+        + json.dumps(
+            {
+                "trace_id": "t1",
+                "span_id": "s1",
+                "parent_span_id": None,
+                "started_at": 1.0,
+                "ended_at": 2.0,
+                "status": "OK",
+                "span_kind": "AGENT",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert TraceStore(path=path).list_traces() == [
+        {
+            "trace_id": "t1",
+            "started_at": 1.0,
+            "ended_at": 2.0,
+            "duration_ms": 1000.0,
+            "span_count": 1,
+            "status": "OK",
+            "kinds": ["AGENT"],
+        }
+    ]

--- a/tests/test_practice_events.py
+++ b/tests/test_practice_events.py
@@ -87,6 +87,31 @@ def test_praxis_completed_event_priority():
     recorder.stop()
 
 
+def test_praxis_completed_falls_back_to_episode_id():
+    """Skill events without correlation_id keep their episode identity."""
+    bus = EventBus()
+    recorder = PracticeRecorder("ur5e_01", joint_dof=6, event_bus=bus)
+    recorder.initialize()
+
+    captured = []
+    bus.subscribe("praxis.completed", lambda event: captured.append(event.payload))
+    bus.publish(
+        Event(
+            topic="skill.execution.complete",
+            payload={
+                "episode_id": "ep_reach_001",
+                "skill_name": "reach",
+                "result": {"status": "success", "reward": 0.92},
+            },
+        )
+    )
+
+    assert captured[0]["practice_id"] == "ep_reach_001"
+    assert captured[0]["episode_id"] == "ep_reach_001"
+    assert captured[0]["correlation_id"] == "ep_reach_001"
+    recorder.stop()
+
+
 def test_praxis_completed_payload_structure():
     """praxis.completed payload has all required fields for KNOW/DASHBOARD."""
     bus = EventBus()

--- a/tests/test_trace_surface.py
+++ b/tests/test_trace_surface.py
@@ -1,0 +1,112 @@
+"""CLI and Dashboard surfaces over the local structured trace store."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from fastapi.testclient import TestClient
+
+from rosclaw.cli import main
+from rosclaw.dashboard.web_server import DashboardWebServer
+from rosclaw.observability.store import TraceStore
+
+
+def _write_trace(path):
+    records = [
+        {
+            "schema_version": "rosclaw.trace.v1",
+            "record_type": "span",
+            "event_id": "evt-root",
+            "trace_id": "trace-ui",
+            "span_id": "span-root",
+            "parent_span_id": None,
+            "name": "runtime.execute",
+            "span_kind": "MISSION",
+            "source": "runtime",
+            "operation": "agent.closed_loop",
+            "started_at": 1.0,
+            "ended_at": 1.2,
+            "duration_ms": 200.0,
+            "status": "OK",
+            "attributes": {},
+            "input": {"goal": "inspect"},
+            "output": {"status": "ok"},
+        },
+        {
+            "schema_version": "rosclaw.trace.v1",
+            "record_type": "span",
+            "event_id": "evt-child",
+            "trace_id": "trace-ui",
+            "span_id": "span-child",
+            "parent_span_id": "span-root",
+            "name": "provider.inference",
+            "span_kind": "VLM",
+            "source": "mock-vlm",
+            "operation": "vlm.scene_understanding",
+            "started_at": 1.02,
+            "ended_at": 1.1,
+            "duration_ms": 80.0,
+            "status": "OK",
+            "attributes": {"model": "mock"},
+            "input": {"image": "artifact://frame.jpg"},
+            "output": {"objects": ["door"]},
+        },
+    ]
+    path.write_text("".join(json.dumps(item) + "\n" for item in records), encoding="utf-8")
+
+
+def test_dashboard_trace_api_and_page(tmp_path):
+    path = tmp_path / "live.jsonl"
+    _write_trace(path)
+    web = DashboardWebServer(trace_store=TraceStore(path=path))
+    client = TestClient(web.app)
+
+    listing = client.get("/api/traces").json()
+    assert listing["count"] == 1
+    assert listing["traces"][0]["span_count"] == 2
+
+    trace = client.get("/api/traces/trace-ui").json()
+    assert trace["tree"][0]["children"][0]["name"] == "provider.inference"
+    assert client.get("/api/traces/events/evt-child").json()["span_kind"] == "VLM"
+    page = client.get("/traces")
+    assert page.status_code == 200
+    assert "ROSClaw Trace" in page.text
+    assert "Input (redacted)" in page.text
+
+
+def test_trace_cli_list_show_and_export(tmp_path, capsys, monkeypatch):
+    path = tmp_path / "live.jsonl"
+    output = tmp_path / "export.json"
+    _write_trace(path)
+
+    monkeypatch.setattr(sys, "argv", ["rosclaw", "trace", "list", "--path", str(path)])
+    assert main() == 0
+    assert "trace-ui" in capsys.readouterr().out
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["rosclaw", "trace", "show", "trace-ui", "--path", str(path)],
+    )
+    assert main() == 0
+    shown = capsys.readouterr().out
+    assert "runtime.execute" in shown
+    assert "provider.inference" in shown
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "rosclaw",
+            "trace",
+            "export",
+            "trace-ui",
+            "--path",
+            str(path),
+            "--output",
+            str(output),
+        ],
+    )
+    assert main() == 0
+    assert json.loads(output.read_text(encoding="utf-8"))["span_count"] == 2


### PR DESCRIPTION
## What changed

- add ROSClaw Trace v1 schema, nested span context, bounded JSONL export, redaction, and trace storage
- instrument Runtime, Provider, MCP, Skill, Sandbox, Firewall, EventBus, and worker-thread context propagation
- add a structured DecisionSummary to every Runtime.execute mission instead of exposing private model chain-of-thought
- add trace CLI commands and a built-in Dashboard timeline/tree/detail view
- fix standalone skill episode finalization after critic judgment while preserving full Runtime praxis completion
- document the trace model, privacy modes, instrumentation API, CLI, and Dashboard APIs

## Why

ROSClaw needed an auditable physical-intelligence trace showing model/tool I/O, causal data flow, structured decision evidence, safety decisions, and runtime outcomes. The initial implementation also exposed a gap where Runtime.execute did not include its planning decision in the mission trace.

## Impact

A mission now records a single causal tree such as Mission → Provider/Inference → Planner DecisionSummary → Sandbox. Secrets and private reasoning fields are redacted by default. Trace export is bounded and non-blocking, so observability failure does not change runtime control results.

## Validation

- 388 focused EventBus/Provider/MCP/Skill/Firewall/Runtime/Dashboard tests passed
- 8 observability tests passed, including real mock Provider → Decision → Sandbox hierarchy
- 59 Runtime/Practice/EpisodeRecorder/Scene A/Scene B regression tests passed
- 590 tests after the README checkpoint passed
- full run reached 3,190 passed before an isolated test-environment dev-dependency check; README commands then passed 39 with 6 skipped after installing declared dev dependencies
- Ruff, compileall, diff-check, and strict Mypy for the observability package passed
- manual no-hardware smoke verified six nested spans, DecisionSummary fields, secret redaction, private reasoning omission, and trace list/show/explain/export

No real ROS topics, robot motion, or hardware were used.
