### PR TITLE
fix trace CLI type check

### DIFF
--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -1028,10 +1028,10 @@ def cmd_trace(args: argparse.Namespace) -> int:
             return 0
         print("TRACE ID                         STATUS    SPANS   DURATION   KINDS")
         for item in traces:
-            kinds = ",".join(item["kinds"])
+            kind_text = ",".join(item["kinds"])
             print(
                 f"{item['trace_id']:<32} {item['status']:<9} {item['span_count']:>5}   "
-                f"{item['duration_ms']:>8.2f}ms   {kinds}"
+                f"{item['duration_ms']:>8.2f}ms   {kind_text}"
             )
         return 0
 


### PR DESCRIPTION
## Root cause

`cmd_trace` reused the function-scoped name `kinds` first as formatted text and later as a `set[str] | None` filter. CI's strict Mypy configuration therefore rejected the assignment.

## Fix

Rename the display-only value to `kind_text`, leaving the typed filter variables unambiguous.

## Validation

- CI Type Check command: success, 90 source files
- Ruff 0.15.21 on `src/rosclaw/cli.py`: passed
- Trace CLI/Dashboard surface tests: 2 passed

The repository-wide Lint job already failed on the previous `main` commit. Its 68 Ruff findings are in unchanged Body/LeRobot files and are not caused by this fix.
