### PR TITLE
Preserve navigation decision evidence in traces

### DIFF
--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -1491,8 +1491,16 @@ class Runtime(LifecycleMixin):
             return {
                 "capability": capability_name,
                 "status": "ok" if response.is_ok else "error",
-                "result": response.result if response.is_ok else {"error": response.error},
+                "result": response.result
+                if response.is_ok
+                else {"error": "; ".join(response.errors) or response.status},
                 "provider": response.provider,
+                "confidence": response.confidence,
+                "evidence": response.evidence,
+                "model_info": response.model_info,
+                "provider_trace": response.trace,
+                "warnings": response.warnings,
+                "errors": response.errors,
             }
         except Exception as e:
             return {"error": str(e), "capability": capability_name, "status": "error"}
@@ -1564,9 +1572,13 @@ class Runtime(LifecycleMixin):
             observations.append(f"provider_status={provider_status}")
 
         constraints = [f"safety_level={self.config.safety_level}", "sandbox_validation=required"]
-        supplied_constraints = context.get("constraints", [])
-        if isinstance(supplied_constraints, list):
-            constraints.extend(str(item) for item in supplied_constraints[:20])
+        for supplied_constraints in (
+            context.get("constraints", []),
+            payload.get("constraints", []),
+        ):
+            if isinstance(supplied_constraints, list):
+                constraints.extend(str(item) for item in supplied_constraints[:20])
+        constraints = list(dict.fromkeys(constraints))
 
         confidence = context.get("confidence", payload.get("confidence"))
         if not isinstance(confidence, (int, float)) or not 0.0 <= confidence <= 1.0:
@@ -1590,20 +1602,42 @@ class Runtime(LifecycleMixin):
         else:
             decision = action
 
+        supplied_candidates = payload.get("candidates", context.get("candidates", []))
+        if isinstance(supplied_candidates, list):
+            candidates = [
+                self._tracer.redactor.redact(candidate)
+                for candidate in supplied_candidates[:20]
+                if isinstance(candidate, dict)
+            ]
+        else:
+            candidates = []
+        if not candidates and decision is not None:
+            candidates = [{"action": decision}]
+
         evidence_refs = [
             str(item.get("artifact_ref"))
             for item in objects
             if isinstance(item, dict) and item.get("artifact_ref")
         ]
-        explicit_refs = context.get("evidence_refs", [])
-        if isinstance(explicit_refs, list):
-            evidence_refs.extend(str(reference) for reference in explicit_refs[:50])
+        for explicit_refs in (
+            context.get("evidence_refs", []),
+            payload.get("evidence_refs", []),
+        ):
+            if isinstance(explicit_refs, list):
+                evidence_refs.extend(str(reference) for reference in explicit_refs[:50])
+        for evidence in context.get("evidence", []):
+            if isinstance(evidence, str):
+                evidence_refs.append(evidence)
+            elif isinstance(evidence, dict):
+                reference = evidence.get("artifact_ref") or evidence.get("ref")
+                if reference:
+                    evidence_refs.append(str(reference))
 
         return DecisionSummary(
             goal=instruction,
             observations=observations,
             constraints=constraints,
-            candidates=[{"action": decision}] if decision is not None else [],
+            candidates=candidates,
             decision=decision,
             reason_summary=reason_summary,
             confidence=confidence,
@@ -1618,6 +1652,11 @@ class Runtime(LifecycleMixin):
         provider_result: dict[str, Any],
     ) -> dict[str, Any]:
         """Record the actual closed-loop action decision inside the mission trace."""
+
+        payload = provider_result.get("result", {})
+        provider_reason = payload.get("reason_summary") if isinstance(payload, dict) else None
+        if not isinstance(provider_reason, str) or not provider_reason.strip():
+            provider_reason = None
 
         with self._tracer.start_span(
             "agent.execution_decision",
@@ -1643,11 +1682,14 @@ class Runtime(LifecycleMixin):
                 action=action,
                 context=provider_result,
                 reason_summary=(
-                    "Selected the requested action after provider planning; sandbox validation is "
-                    "required before execution."
-                    if provider_result.get("status") == "ok"
-                    else "Kept the deterministic requested action after provider planning was "
-                    "unavailable; sandbox validation is required before execution."
+                    provider_reason
+                    or (
+                        "Selected the requested action after provider planning; sandbox validation "
+                        "is required before execution."
+                        if provider_result.get("status") == "ok"
+                        else "Kept the deterministic requested action after provider planning was "
+                        "unavailable; sandbox validation is required before execution."
+                    )
                 ),
             )
             output = {"decision_summary": summary.to_dict()}

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -32,6 +32,46 @@ class _Provider(Provider):
     capabilities = ["vlm.scene_understanding"]
 
     async def infer(self, request: ProviderRequest) -> ProviderResponse:
+        if request.inputs.get("scenario") == "corridor_patrol":
+            return ProviderResponse(
+                request_id=request.request_id,
+                provider=self.name,
+                capability=request.capability,
+                result={
+                    "objects": [
+                        {
+                            "label": "right-side pedestrian at 0.65 m",
+                            "artifact_ref": "artifact://patrol/camera/front/1842.jpg",
+                        },
+                        {"label": "conference-room door to the north-east"},
+                    ],
+                    "constraints": [
+                        "minimum pedestrian clearance 0.8 m",
+                        "maximum linear speed 0.5 m/s",
+                    ],
+                    "candidates": [
+                        {
+                            "action": "pass on the right",
+                            "score": 0.31,
+                            "risk": "clearance below threshold",
+                        },
+                        {
+                            "action": "slow down and pass on the left",
+                            "score": 0.86,
+                            "risk": "adds about 3 seconds",
+                        },
+                    ],
+                    "reason_summary": (
+                        "The left detour preserves pedestrian clearance with the lowest risk."
+                    ),
+                    "evidence_refs": ["artifact://patrol/local_costmap/301.json"],
+                    "chain_of_thought": "private scratch reasoning must not be exposed",
+                },
+                confidence=0.86,
+                evidence=[{"artifact_ref": "artifact://patrol/mocap/9921.json"}],
+                model_info={"model": "test-navigation-vlm"},
+                trace={"usage": {"input_tokens": 128, "output_tokens": 47}},
+            )
         return ProviderResponse(
             request_id=request.request_id,
             provider=self.name,
@@ -356,6 +396,99 @@ def test_runtime_mission_links_provider_decision_and_sandbox(tmp_path):
         },
     }
     assert result["decision_summary"]["reason_summary"]
+
+
+def test_runtime_navigation_decision_preserves_auditable_model_evidence(tmp_path):
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    runtime = Runtime(
+        RuntimeConfig(
+            robot_id="trace-navigation-robot",
+            enable_firewall=False,
+            enable_memory=False,
+            enable_practice=False,
+            enable_swarm=False,
+            enable_skill_manager=False,
+            enable_knowledge=False,
+            enable_how=False,
+            enable_auto=False,
+            enable_provider=False,
+            enable_sense=False,
+            enable_event_persistence=False,
+            enable_tracing=True,
+            trace_home=str(tmp_path),
+        )
+    )
+    runtime.initialize()
+    registry = ProviderRegistry(event_bus=runtime.event_bus)
+    manifest = ProviderManifest.from_dict(
+        {
+            "name": "trace-provider",
+            "version": "1.2.3",
+            "type": "vlm",
+            "capabilities": ["vlm.scene_understanding"],
+        }
+    )
+    registry.register(manifest, lambda item: _Provider(item), auto_load=False)
+    registry.set_provider_health("trace-provider", ok=True)
+    runtime._capability_router = CapabilityRouter(registry, tracer=runtime.tracer)
+
+    result = runtime.execute(
+        {
+            "request_id": "mission-navigation-123",
+            "instruction": "patrol the corridor and inspect the conference-room door",
+            "skill_name": "navigate_and_inspect",
+            "capability": "vlm.scene_understanding",
+            "parameters": {
+                "scenario": "corridor_patrol",
+                "api_key": "must-not-leak",
+            },
+            "trajectory": [[0.0] * 6, [0.3, 0.1, 0.0, 0.0, 0.0, 0.0]],
+        }
+    )
+    runtime.stop()
+
+    assert result["status"] == "ok"
+    trace = TraceStore(home=tmp_path).get_trace("mission-navigation-123")
+    spans = {span["name"]: span for span in trace["spans"]}
+    decision = spans["agent.execution_decision"]["output"]["decision_summary"]
+
+    assert decision["observations"] == [
+        "right-side pedestrian at 0.65 m",
+        "conference-room door to the north-east",
+    ]
+    assert decision["constraints"] == [
+        "safety_level=MODERATE",
+        "sandbox_validation=required",
+        "minimum pedestrian clearance 0.8 m",
+        "maximum linear speed 0.5 m/s",
+    ]
+    assert decision["candidates"] == [
+        {
+            "action": "pass on the right",
+            "score": 0.31,
+            "risk": "clearance below threshold",
+        },
+        {
+            "action": "slow down and pass on the left",
+            "score": 0.86,
+            "risk": "adds about 3 seconds",
+        },
+    ]
+    assert decision["confidence"] == 0.86
+    assert decision["reason_summary"] == (
+        "The left detour preserves pedestrian clearance with the lowest risk."
+    )
+    assert decision["evidence_refs"] == [
+        "artifact://patrol/camera/front/1842.jpg",
+        "artifact://patrol/local_costmap/301.json",
+        "artifact://patrol/mocap/9921.json",
+    ]
+    assert decision["decision"]["parameters"]["api_key"] == "[REDACTED]"
+    assert "chain_of_thought" not in decision
+    assert spans["provider.inference"]["output"]["result"]["chain_of_thought"] == (
+        "[PRIVATE_REASONING_OMITTED]"
+    )
 
 
 def test_trace_store_ignores_malformed_lines(tmp_path):


### PR DESCRIPTION
## What changed

- Preserve provider confidence, evidence, model metadata, warnings, errors, and provider trace metadata through `Runtime.capability_invoke()`.
- Populate `DecisionSummary` from model-produced constraints, candidate actions, reason summaries, and evidence references.
- Keep the executed action as the auditable final decision and continue redacting secrets and private chain-of-thought.
- Add an integration regression for a corridor patrol/navigation decision with two candidate routes.

## Why

The mission trace previously retained model observations but dropped nested constraints, route candidates, the model's concise reason summary, and top-level confidence/evidence. This made a real navigation decision trace materially less useful than the documented Physical Intelligence Trace contract.

## Validation

- `ruff format --check` and `ruff check` on changed files
- 164 Trace/Runtime/Provider/Sandbox tests passed after rebasing onto latest `main`
- 212 Runtime capability/coverage tests passed before rebase; no overlapping upstream changes
- Manual no-hardware cabinet inspection: 6/6 spans OK, Sandbox ALLOW, secrets redacted, private reasoning omitted
- Manual no-hardware corridor navigation: model decision traced correctly; Sandbox exposed the existing lack of mobile-base trajectory semantics instead of falsely passing joint validation
- Full suite executed: 3937 passed, 35 skipped, 66 environment/pre-existing failures (old system semver in subprocesses, missing parquet engine, LeRobot worker timeouts)
