### PR TITLE
Distinguish selected and executed trace decisions

### DIFF
--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -1602,6 +1602,18 @@ class Runtime(LifecycleMixin):
         else:
             decision = action
 
+        selected_candidate = payload.get("decision")
+        if selected_candidate is not None:
+            selected_candidate = self._tracer.redactor.redact(selected_candidate)
+            decision = (
+                {
+                    "selected_candidate": selected_candidate,
+                    "executed_action": decision,
+                }
+                if decision is not None
+                else {"selected_candidate": selected_candidate}
+            )
+
         supplied_candidates = payload.get("candidates", context.get("candidates", []))
         if isinstance(supplied_candidates, list):
             candidates = [

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -61,6 +61,7 @@ class _Provider(Provider):
                             "risk": "adds about 3 seconds",
                         },
                     ],
+                    "decision": "slow down and pass on the left",
                     "reason_summary": (
                         "The left detour preserves pedestrian clearance with the lowest risk."
                     ),
@@ -484,7 +485,8 @@ def test_runtime_navigation_decision_preserves_auditable_model_evidence(tmp_path
         "artifact://patrol/local_costmap/301.json",
         "artifact://patrol/mocap/9921.json",
     ]
-    assert decision["decision"]["parameters"]["api_key"] == "[REDACTED]"
+    assert decision["decision"]["selected_candidate"] == "slow down and pass on the left"
+    assert decision["decision"]["executed_action"]["parameters"]["api_key"] == "[REDACTED]"
     assert "chain_of_thought" not in decision
     assert spans["provider.inference"]["output"]["result"]["chain_of_thought"] == (
         "[PRIVATE_REASONING_OMITTED]"


### PR DESCRIPTION
## What changed

- Record a provider-selected candidate separately from the action actually sent to Runtime/Sandbox.
- Keep both values under `DecisionSummary.decision` as `selected_candidate` and `executed_action`.
- Extend the navigation decision regression to require this distinction and secret redaction.

## Why

A model recommendation is not necessarily the action ultimately executed. Keeping the two values separate makes the trace auditable and prevents a recommendation from being presented as physical execution evidence.

## Validation

- 164 Trace/Runtime/Provider/Sandbox tests passed
- Changed files pass Ruff format and lint checks
- Manual no-hardware cabinet inspection produced 6/6 OK spans, an explicit selected/executed decision pair, Sandbox ALLOW, secret redaction, and private-reasoning omission
