### PR TITLE
Revert P4.1 direct push to restore PR workflow

### DIFF
--- a/ROSCLAW_LEROBOT_P4_POLICY_RUNTIME_REPORT.md
+++ b/ROSCLAW_LEROBOT_P4_POLICY_RUNTIME_REPORT.md
@@ -460,29 +460,10 @@ After the P4.1 hardening pass, the following verification was run on local `main
 Verification results:
 
 ```bash
-# LeRobot unit + integration regression
 python -m pytest tests/integrations/test_lerobot_*.py tests/unit/integrations/lerobot/ -q  # 284 passed, 3 skipped
-
-# Runtime boundary: core Python never imports torch/lerobot
-env -u PYTHONPATH python -m pytest tests/integrations/test_lerobot_runtime_boundary.py -q  # 19 passed
-
-# End-to-end proposal-only rollout → Practice lifecycle → strict verify
-python -m rosclaw.cli lerobot rollout proposal-only \
-  --policy.path /home/dell/.rosclaw/cache/lerobot/policies/lerobot_act_aloha_sim_transfer_cube_human_migrated \
-  --observation-fixture examples/lerobot/sample_observation_aloha_act.json \
-  --steps 100 --control-hz 10 --practice-root /tmp/rosclaw_lerobot_practice --json
-
-python -m rosclaw.cli practice verify --strict --data-root /tmp/rosclaw_lerobot_practice <practice_id>
-# Passed: True (catalog_exists, practice_record, manifest_exists, events_jsonl_exists,
-#              session_record, episode_records, event_types, event_count, artifact_records)
 ```
 
-Push status:
-
-- The P4.1 changes were committed on local `main`, merged with the latest upstream
-  commits, and pushed successfully to `ros-claw/rosclaw` `main` (`bd8adfd`).
-- Full LeRobot unit + integration regression was re-run after the merge and remains
-  green (`284 passed, 3 skipped`).
+The P4.1 changes are staged on local `main` and ready to push to `ros-claw/rosclaw` `main`.
 
 ---
 

--- a/src/rosclaw/integrations/lerobot/cli.py
+++ b/src/rosclaw/integrations/lerobot/cli.py
@@ -1248,14 +1248,13 @@ def _build_warmup_params(args: argparse.Namespace) -> dict[str, Any]:
     params: dict[str, Any] = {"iterations": 1}
     fixture_path = getattr(args, "observation_fixture", None)
     if fixture_path:
-        from rosclaw.integrations.lerobot.observation_adapter import adapt_observation_for_worker
         from rosclaw.integrations.lerobot.rollout.observation_source import FixtureObservationSource
 
         source = FixtureObservationSource(fixture_path)
         obs = source.get_observation(0)
         if obs is None:
             raise ValueError(f"No observation found in fixture: {fixture_path}")
-        params["observation"] = adapt_observation_for_worker(obs)
+        params["observation"] = obs
     return params
 
 

--- a/src/rosclaw/integrations/lerobot/rollout/practice_bridge.py
+++ b/src/rosclaw/integrations/lerobot/rollout/practice_bridge.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import shutil
 import time
@@ -12,15 +11,6 @@ from typing import Any
 from rosclaw.practice.config import DEFAULT_DATA_ROOT, PracticeSession, PracticeSummary
 from rosclaw.practice.storage.catalog import PracticeCatalog
 from rosclaw.practice.storage.layout import PracticeLayout, generate_practice_id
-
-
-def _compute_sha256(path: Path) -> str:
-    """Return the SHA-256 hex digest of a file."""
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
-    return h.hexdigest()
 
 
 def finalize_rollout_practice_session(
@@ -66,20 +56,18 @@ def finalize_rollout_practice_session(
     duration_ms = (end_time_ns - start_time_ns) / 1e6 if end_time_ns >= start_time_ns else 0.0
 
     start_time_utc = _ns_to_iso(start_time_ns)
-    session_dir = layout.session_dir(practice_id)
 
     session = PracticeSession(
         practice_id=practice_id,
         robot_id=robot_id,
+        robot_type=None,
         task_id=task_id,
         task_name=task_id,
         skill_id=None,
-        session_dir=session_dir,
-        start_time_ns=start_time_ns,
-        start_time_utc=start_time_utc,
-        robot_type=None,
         session_id=session_id,
         episode_id=episode_id,
+        start_time_ns=start_time_ns,
+        start_time_utc=start_time_utc,
         metadata={"body_id": body_id, "policy_id": policy_id, "source": "lerobot_rollout"},
     )
 
@@ -157,58 +145,6 @@ def finalize_rollout_practice_session(
                 "metrics": rollout_result.get("metrics", {}),
             }
         )
-
-        # Import events into the legacy events table for catalog-based queries.
-        for ev in events:
-            catalog.insert_event(
-                {
-                    "event_id": ev.get("event_id") or f"event_{practice_id}_{ev.get('sequence_id', 0)}",
-                    "practice_id": practice_id,
-                    "source": ev.get("source", "runtime"),
-                    "event_type": ev.get("event_type", "unknown"),
-                    "timestamp_ns": ev.get("timestamp_ns", start_time_ns),
-                    "timestamp_utc": ev.get("timestamp_utc", start_time_utc),
-                    "action_id": ev.get("action_id"),
-                    "task_id": ev.get("task_id", task_id),
-                    "skill_id": ev.get("skill_id"),
-                    "payload_ref": json.dumps(ev.get("payload_ref", {}) or {}),
-                    "tags": json.dumps(ev.get("tags", []) or []),
-                }
-            )
-
-        # Register v2 artifacts for the events JSONL and timeline.
-        timeline_path = layout.timeline_jsonl_path(practice_id)
-        artifact_records = [
-            {
-                "artifact_id": f"artifact_{practice_id}_events_jsonl",
-                "session_id": session_id,
-                "episode_id": episode_id,
-                "artifact_type": "events_jsonl",
-                "path": str(target_events),
-                "sha256": _compute_sha256(target_events),
-                "size_bytes": target_events.stat().st_size,
-                "schema_name": "practice.event.v1",
-                "created_at": _ns_to_iso(end_time_ns),
-                "metadata": {"role": "trace", "source": "lerobot_rollout"},
-            },
-        ]
-        if timeline_path.exists():
-            artifact_records.append(
-                {
-                    "artifact_id": f"artifact_{practice_id}_timeline_jsonl",
-                    "session_id": session_id,
-                    "episode_id": episode_id,
-                    "artifact_type": "timeline_jsonl",
-                    "path": str(timeline_path),
-                    "sha256": _compute_sha256(timeline_path),
-                    "size_bytes": timeline_path.stat().st_size,
-                    "schema_name": "practice.event.v1",
-                    "created_at": _ns_to_iso(end_time_ns),
-                    "metadata": {"role": "timeline", "source": "lerobot_rollout"},
-                }
-            )
-        for record in artifact_records:
-            catalog.insert_artifact_v2(record)
     finally:
         catalog.close()
 

--- a/src/rosclaw/integrations/lerobot/rollout/recorder.py
+++ b/src/rosclaw/integrations/lerobot/rollout/recorder.py
@@ -63,7 +63,6 @@ class RolloutRecorder:
             body_id=self.body_id,
             source=source,  # type: ignore[arg-type]
             event_type=event_type,
-            trace_id=self.session_id,
             timestamp_ns=int(time.time_ns()),
             source_timestamp_ns=int(time.monotonic() * 1e9),
             sequence_id=self._sequence,

--- a/tests/integrations/test_lerobot_doctor.py
+++ b/tests/integrations/test_lerobot_doctor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib.util
-import sys
 from pathlib import Path
 
 import pytest
@@ -69,7 +68,7 @@ def test_doctor_validation_status_reflects_successful_smoke(
         },
         runtime={
             "lerobot_version": "0.6.1",
-            "python_executable": sys.executable,
+            "python_executable": "/fake/python",
             "device": "cpu",
         },
     )


### PR DESCRIPTION
Reverts the direct push of P4.1 changes so they can go through a proper pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)