### PR TITLE
feat(storage): PR-DB-1 post-merge durability and reconciliation

### DIFF
--- a/scripts/acceptance/replay_1m.py
+++ b/scripts/acceptance/replay_1m.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""PR-DB-1 acceptance: 1M-event replay through recorder + catalog.
+
+Generates N synthetic events through PracticeRecorder, finalizes with the
+flush barrier, then reconciles generated == JSONL == catalog == event_index.
+Writes machine-readable results to the report directory given as argv[1].
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from rosclaw.practice.recorder import PracticeRecorder
+from rosclaw.runtime.bus import RuntimeBus
+from rosclaw.runtime.event import RuntimeEvent
+from rosclaw.storage.cli import reconcile_practice
+
+
+def main() -> int:
+    report_dir = Path(sys.argv[1])
+    report_dir.mkdir(parents=True, exist_ok=True)
+    total = int(os.environ.get("REPLAY_EVENTS", "1000000"))
+    data_root = report_dir / "replay_data"
+
+    bus = RuntimeBus()
+    recorder = PracticeRecorder(bus, data_root=str(data_root), publish_to_event_bus=False)
+    recorder.initialize()
+    recorder.start()
+
+    practice_id = "prac_replay_1m"
+    started = time.monotonic()
+    recorder.on_event(
+        RuntimeEvent(
+            id="start-1",
+            timestamp=datetime.datetime.now(datetime.UTC),
+            source="replay",
+            robot="replay_bot",
+            type="practice.start",
+            payload={"practice_id": practice_id, "robot_id": "replay_bot"},
+        )
+    )
+
+    produce_start = time.monotonic()
+    for i in range(total):
+        recorder.on_event(
+            RuntimeEvent(
+                id=f"replay-{i}",
+                timestamp=datetime.datetime.now(datetime.UTC),
+                source="replay",
+                robot="replay_bot",
+                type="skill.invoke",
+                payload={"seq": i, "kind": "replay"},
+            )
+        )
+    produce_s = time.monotonic() - produce_start
+
+    barrier_start = time.monotonic()
+    recorder.on_event(
+        RuntimeEvent(
+            id="stop-1",
+            timestamp=datetime.datetime.now(datetime.UTC),
+            source="replay",
+            robot="replay_bot",
+            type="practice.stop",
+            payload={"outcome": "SUCCESS"},
+        )
+    )
+    barrier_s = time.monotonic() - barrier_start
+    recorder.stop()
+
+    reconcile = reconcile_practice(practice_id, str(data_root))
+    result = {
+        "generated_events": total,
+        "produce_seconds": round(produce_s, 2),
+        "events_per_second": round(total / produce_s, 1),
+        "finalize_barrier_seconds": round(barrier_s, 2),
+        "total_seconds": round(time.monotonic() - started, 2),
+        "flush_barrier": recorder.last_flush_barrier,
+        "reconcile": reconcile,
+        "passed": bool(reconcile["passed"]),
+    }
+    (report_dir / "replay_1m.json").write_text(json.dumps(result, indent=2))
+    print(json.dumps({k: v for k, v in result.items() if k != "reconcile"}, indent=2))
+    print("reconcile passed:", reconcile["passed"], "raw_jsonl:", reconcile["raw_jsonl"])
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -98,7 +98,7 @@ from rosclaw.sense.cli import (
     cmd_sense_watch,
 )
 from rosclaw.skill.cli import add_skill_hub_parsers
-from rosclaw.storage.cli import add_db_subparser, cmd_db_doctor, cmd_db_status
+from rosclaw.storage.cli import add_db_subparser, cmd_db_doctor, cmd_db_reconcile, cmd_db_status
 
 
 def _cmd_mcp_serve(args: argparse.Namespace) -> int:
@@ -8422,6 +8422,8 @@ def main() -> int:
                 return cmd_db_status(args)
             elif args.db_command == "doctor":
                 return cmd_db_doctor(args)
+            elif args.db_command == "reconcile":
+                return cmd_db_reconcile(args)
             else:
                 db_parser.print_help()
                 return 1

--- a/src/rosclaw/practice/config.py
+++ b/src/rosclaw/practice/config.py
@@ -38,6 +38,12 @@ class RecorderConfig:
     rgb_format: str = "jpg"
     depth_format: str = "png16"
 
+    # Maximum time session finalize waits for the catalog batch writers to
+    # commit every queued event before the manifest is written.  A timeout
+    # never aborts finalize (the robot must not be blocked); an unsatisfied
+    # barrier is logged CRITICAL and surfaced via ``db reconcile``.
+    finalize_flush_timeout_sec: float = 30.0
+
 
 @dataclass
 class SeekDBConfig:

--- a/src/rosclaw/practice/recorder.py
+++ b/src/rosclaw/practice/recorder.py
@@ -132,6 +132,12 @@ class PracticeRecorder(RuntimeConsumer):
         self._source_event_count = 0
         self._failure_labels: list[str] = []
         self._lock = threading.RLock()
+        # Durability watermarks: each counts the highest per-session sequence
+        # number known to be persisted on that path.  ``_catalog_watermarks``
+        # is delegated to PracticeCatalog.flush_until.
+        self._jsonl_watermark = 0
+        self._mcap_watermark = 0
+        self._last_flush_barrier: dict[str, Any] | None = None
 
         # Legacy state.
         self._flywheel: DataFlywheel | None = None
@@ -310,6 +316,9 @@ class PracticeRecorder(RuntimeConsumer):
         self._source_event_count = 0
         self._failure_labels = []
         self._summary = None
+        self._jsonl_watermark = 0
+        self._mcap_watermark = 0
+        self._last_flush_barrier = None
 
         self._writer = JsonlWriter(self.layout.events_jsonl_path(practice_id), rotate_mb=None)
         self._catalog = PracticeCatalog(self.layout.catalog_db_path)
@@ -405,6 +414,19 @@ class PracticeRecorder(RuntimeConsumer):
             duration_ms = (time.monotonic_ns() - self._session.start_time_ns) / 1_000_000.0
         if event_count is None:
             event_count = self._event_count
+
+        # Commit-point barrier: before the manifest declares the session
+        # complete, every produced event must be durably committed on each
+        # persistence path.  A failure never aborts finalize (the robot must
+        # not be blocked) but is logged CRITICAL so ``db reconcile`` and the
+        # operator see the discrepancy.
+        barrier = self.flush_barrier(event_count)
+        if not barrier["ok"]:
+            logger.critical(
+                "Flush barrier not satisfied before finalizing session %s: %s",
+                self._session.practice_id,
+                barrier,
+            )
 
         self._summary = PracticeSummary(
             practice_id=self._session.practice_id,
@@ -584,7 +606,8 @@ class PracticeRecorder(RuntimeConsumer):
 
         with self._lock:
             self._event_count += 1
-            envelope.sequence_id = self._event_count
+            sequence_id = self._event_count
+            envelope.sequence_id = sequence_id
             if envelope.event_type not in {"runtime.start", "runtime.stop"}:
                 self._source_event_count += 1
 
@@ -593,6 +616,8 @@ class PracticeRecorder(RuntimeConsumer):
             try:
                 byte_offset = self._writer.bytes_written
                 self._writer.write(envelope.model_dump(mode="json"))
+                with self._lock:
+                    self._jsonl_watermark = sequence_id
             except Exception as e:
                 logger.error("Failed to write event to JSONL: %s", e)
                 byte_offset = None
@@ -600,6 +625,8 @@ class PracticeRecorder(RuntimeConsumer):
         if self._mcap_writer is not None:
             try:
                 self._mcap_writer.write(envelope.model_dump(mode="json"))
+                with self._lock:
+                    self._mcap_watermark = sequence_id
             except Exception as e:
                 logger.error("Failed to write event to MCAP: %s", e)
 
@@ -620,6 +647,7 @@ class PracticeRecorder(RuntimeConsumer):
                         if envelope.payload_ref
                         else None,
                         "tags": ",".join(envelope.tags),
+                        "_wm": sequence_id,
                     }
                 )
             except Exception as e:
@@ -643,10 +671,19 @@ class PracticeRecorder(RuntimeConsumer):
                                 "task_id": envelope.task_id,
                                 "skill_id": envelope.skill_id,
                             },
+                            "_wm": sequence_id,
                         }
                     )
                 except Exception as e:
                     logger.error("Failed to insert event index into catalog: %s", e)
+            else:
+                # No index row will be queued for this sequence (e.g. JSONL
+                # write failed); advance the index watermark so flush_until
+                # does not wait for a record that will never arrive.
+                try:
+                    self._catalog.advance_event_index_watermark(sequence_id)
+                except Exception as e:
+                    logger.error("Failed to advance event-index watermark: %s", e)
 
         if self._publish_to_event_bus and self._legacy_event_bus is not None:
             try:
@@ -711,6 +748,52 @@ class PracticeRecorder(RuntimeConsumer):
     @property
     def summary(self) -> PracticeSummary | None:
         return self._summary
+
+    @property
+    def last_flush_barrier(self) -> dict[str, Any] | None:
+        """Result of the most recent :meth:`flush_barrier` call, if any."""
+        return self._last_flush_barrier
+
+    def flush_barrier(
+        self,
+        sequence_id: int | None = None,
+        timeout_sec: float | None = None,
+    ) -> dict[str, Any]:
+        """Wait until every produced event up to *sequence_id* is persisted.
+
+        "Persisted" means actually committed on each storage path — JSONL
+        (synchronous), MCAP (synchronous), and the catalog batch writers —
+        never merely dequeued from an in-memory queue.  Returns a
+        machine-readable barrier report.
+        """
+        with self._lock:
+            target = sequence_id if sequence_id is not None else self._event_count
+        if timeout_sec is None:
+            timeout_sec = self._config.finalize_flush_timeout_sec
+
+        catalog_report: dict[str, Any] = {
+            "ok": True,
+            "events_watermark": target,
+            "event_index_watermark": target,
+        }
+        if self._catalog is not None and target > 0:
+            catalog_report = self._catalog.flush_until(target, timeout_sec)
+
+        with self._lock:
+            jsonl_watermark = self._jsonl_watermark
+            mcap_watermark = self._mcap_watermark
+        jsonl_ok = jsonl_watermark >= target or self._writer is None or target == 0
+        ok = bool(jsonl_ok and catalog_report.get("ok", False))
+        report = {
+            "ok": ok,
+            "target": target,
+            "jsonl_watermark": jsonl_watermark,
+            "mcap_watermark": mcap_watermark,
+            "events_watermark": catalog_report.get("events_watermark"),
+            "event_index_watermark": catalog_report.get("event_index_watermark"),
+        }
+        self._last_flush_barrier = report
+        return report
 
     # ------------------------------------------------------------------
     # Legacy DataFlywheel / EventBus API (preserved for compatibility)

--- a/src/rosclaw/practice/recorder.py
+++ b/src/rosclaw/practice/recorder.py
@@ -138,6 +138,15 @@ class PracticeRecorder(RuntimeConsumer):
         self._jsonl_watermark = 0
         self._mcap_watermark = 0
         self._last_flush_barrier: dict[str, Any] | None = None
+        # Sequences that failed to persist on a given path.  The flush
+        # barrier treats any failed sequence <= target as not-ok even when
+        # later watermarks have advanced past it.
+        self._failed_persist_sequences: dict[str, set[int]] = {
+            "jsonl": set(),
+            "mcap": set(),
+            "catalog_events": set(),
+            "catalog_event_index": set(),
+        }
 
         # Legacy state.
         self._flywheel: DataFlywheel | None = None
@@ -319,6 +328,8 @@ class PracticeRecorder(RuntimeConsumer):
         self._jsonl_watermark = 0
         self._mcap_watermark = 0
         self._last_flush_barrier = None
+        for failed_set in self._failed_persist_sequences.values():
+            failed_set.clear()
 
         self._writer = JsonlWriter(self.layout.events_jsonl_path(practice_id), rotate_mb=None)
         self._catalog = PracticeCatalog(self.layout.catalog_db_path)
@@ -621,6 +632,8 @@ class PracticeRecorder(RuntimeConsumer):
             except Exception as e:
                 logger.error("Failed to write event to JSONL: %s", e)
                 byte_offset = None
+                with self._lock:
+                    self._failed_persist_sequences["jsonl"].add(sequence_id)
 
         if self._mcap_writer is not None:
             try:
@@ -629,6 +642,8 @@ class PracticeRecorder(RuntimeConsumer):
                     self._mcap_watermark = sequence_id
             except Exception as e:
                 logger.error("Failed to write event to MCAP: %s", e)
+                with self._lock:
+                    self._failed_persist_sequences["mcap"].add(sequence_id)
 
         if self._catalog is not None:
             try:
@@ -652,6 +667,12 @@ class PracticeRecorder(RuntimeConsumer):
                 )
             except Exception as e:
                 logger.error("Failed to insert event into catalog: %s", e)
+                with self._lock:
+                    self._failed_persist_sequences["catalog_events"].add(sequence_id)
+                try:
+                    self._catalog.advance_events_watermark(sequence_id)
+                except Exception:  # noqa: BLE001
+                    logger.debug("Failed to advance events watermark after insert failure")
 
             if byte_offset is not None:
                 try:
@@ -676,6 +697,12 @@ class PracticeRecorder(RuntimeConsumer):
                     )
                 except Exception as e:
                     logger.error("Failed to insert event index into catalog: %s", e)
+                    with self._lock:
+                        self._failed_persist_sequences["catalog_event_index"].add(sequence_id)
+                    try:
+                        self._catalog.advance_event_index_watermark(sequence_id)
+                    except Exception:  # noqa: BLE001
+                        logger.debug("Failed to advance index watermark after insert failure")
             else:
                 # No index row will be queued for this sequence (e.g. JSONL
                 # write failed); advance the index watermark so flush_until
@@ -782,8 +809,13 @@ class PracticeRecorder(RuntimeConsumer):
         with self._lock:
             jsonl_watermark = self._jsonl_watermark
             mcap_watermark = self._mcap_watermark
+            failed_below_target = {
+                path: sorted(seq for seq in seqs if seq <= target)
+                for path, seqs in self._failed_persist_sequences.items()
+            }
         jsonl_ok = jsonl_watermark >= target or self._writer is None or target == 0
-        ok = bool(jsonl_ok and catalog_report.get("ok", False))
+        gaps = {path: seqs for path, seqs in failed_below_target.items() if seqs}
+        ok = bool(jsonl_ok and catalog_report.get("ok", False) and not gaps)
         report = {
             "ok": ok,
             "target": target,
@@ -791,6 +823,7 @@ class PracticeRecorder(RuntimeConsumer):
             "mcap_watermark": mcap_watermark,
             "events_watermark": catalog_report.get("events_watermark"),
             "event_index_watermark": catalog_report.get("event_index_watermark"),
+            "failed_sequences": gaps,
         }
         self._last_flush_barrier = report
         return report

--- a/src/rosclaw/practice/seekdb_bridge.py
+++ b/src/rosclaw/practice/seekdb_bridge.py
@@ -100,7 +100,13 @@ class SeekDBBridge:
         practice_event = self._convert(event)
         payload = practice_event.model_dump()
         if self._outbox is not None:
-            self._outbox.enqueue("seekdb_http", payload)
+            self._outbox.enqueue(
+                "seekdb_http",
+                payload,
+                idempotency_key=f"praxis_event:{event.event_id}",
+                entity_type="praxis_event",
+                entity_id=event.event_id,
+            )
             return
         self._committer.save_to_seekdb(payload)
 

--- a/src/rosclaw/practice/storage/catalog.py
+++ b/src/rosclaw/practice/storage/catalog.py
@@ -15,6 +15,13 @@ from typing import Any
 logger = logging.getLogger("rosclaw.practice.storage.catalog")
 
 
+def _strip_watermark_key(record: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *record* without the internal ``_wm`` sequence key."""
+    if "_wm" not in record:
+        return record
+    return {k: v for k, v in record.items() if k != "_wm"}
+
+
 class _BatchWriter:
     """Threaded batch inserter for catalog tables.
 
@@ -36,6 +43,7 @@ class _BatchWriter:
         batch_size: int = 500,
         flush_interval_ms: float = 300.0,
         max_queue_size: int = 2000,
+        on_watermark: Any | None = None,
     ):
         self.name = name
         self._flush_fn = flush_fn
@@ -47,6 +55,9 @@ class _BatchWriter:
         self._overflow_fallbacks = 0
         self._failed_records: list[dict[str, Any]] = []
         self._flush_error: Exception | None = None
+        # ``on_watermark`` is called with the max ``_wm`` sequence of every
+        # successfully flushed batch so callers can track durable progress.
+        self._on_watermark = on_watermark
         self._thread = threading.Thread(
             target=self._worker, name=f"catalog-batch-{name}", daemon=True
         )
@@ -143,6 +154,22 @@ class _BatchWriter:
         except Exception:
             logger.exception("Batch writer %s flush failed", self.name)
             raise
+        self._report_watermark(batch)
+
+    def _report_watermark(self, batch: list[dict[str, Any]]) -> None:
+        """Forward the max ``_wm`` sequence of a flushed batch to the catalog."""
+        if self._on_watermark is None:
+            return
+        watermark = 0
+        for record in batch:
+            value = record.get("_wm")
+            if isinstance(value, int) and value > watermark:
+                watermark = value
+        if watermark:
+            try:
+                self._on_watermark(watermark)
+            except Exception:  # noqa: BLE001
+                logger.exception("Batch writer %s watermark callback failed", self.name)
 
 
 class PracticeCatalog:
@@ -356,21 +383,48 @@ class PracticeCatalog:
         self._event_batch_size = event_batch_size
         self._event_flush_ms = event_flush_ms
         self._event_max_queue = event_max_queue
-        self._event_writer: _BatchWriter | None = _BatchWriter(
+        # Durable-progress watermarks, keyed by the per-session ``_wm``
+        # sequence the recorder attaches to every queued record.  They only
+        # advance after the batch containing that sequence has been committed,
+        # so ``flush_until`` never confuses "dequeued" with "persisted".
+        self._events_watermark = 0
+        self._event_index_watermark = 0
+        self._watermark_cond = threading.Condition()
+        self._event_writer: _BatchWriter | None = self._new_event_writer()
+        self._event_index_writer: _BatchWriter | None = self._new_event_index_writer()
+        self._init_schema()
+
+    def _new_event_writer(self) -> _BatchWriter:
+        return _BatchWriter(
             "events",
             self._flush_events,
-            batch_size=event_batch_size,
-            flush_interval_ms=event_flush_ms,
-            max_queue_size=event_max_queue,
+            batch_size=self._event_batch_size,
+            flush_interval_ms=self._event_flush_ms,
+            max_queue_size=self._event_max_queue,
+            on_watermark=self._on_events_watermark,
         )
-        self._event_index_writer: _BatchWriter | None = _BatchWriter(
+
+    def _new_event_index_writer(self) -> _BatchWriter:
+        return _BatchWriter(
             "event_index",
             self._flush_event_index,
-            batch_size=event_batch_size,
-            flush_interval_ms=event_flush_ms,
-            max_queue_size=event_max_queue,
+            batch_size=self._event_batch_size,
+            flush_interval_ms=self._event_flush_ms,
+            max_queue_size=self._event_max_queue,
+            on_watermark=self._on_event_index_watermark,
         )
-        self._init_schema()
+
+    def _on_events_watermark(self, watermark: int) -> None:
+        with self._watermark_cond:
+            if watermark > self._events_watermark:
+                self._events_watermark = watermark
+            self._watermark_cond.notify_all()
+
+    def _on_event_index_watermark(self, watermark: int) -> None:
+        with self._watermark_cond:
+            if watermark > self._event_index_watermark:
+                self._event_index_watermark = watermark
+            self._watermark_cond.notify_all()
 
     def _init_schema(self) -> None:
         with self._lock:
@@ -413,22 +467,60 @@ class PracticeCatalog:
         """Flush any pending batched writes before reading."""
         if self._event_writer is not None:
             self._event_writer.close()
-            self._event_writer = _BatchWriter(
-                "events",
-                self._flush_events,
-                batch_size=self._event_batch_size,
-                flush_interval_ms=self._event_flush_ms,
-                max_queue_size=self._event_max_queue,
-            )
+            self._event_writer = self._new_event_writer()
         if self._event_index_writer is not None:
             self._event_index_writer.close()
-            self._event_index_writer = _BatchWriter(
-                "event_index",
-                self._flush_event_index,
-                batch_size=self._event_batch_size,
-                flush_interval_ms=self._event_flush_ms,
-                max_queue_size=self._event_max_queue,
+            self._event_index_writer = self._new_event_index_writer()
+
+    # ------------------------------------------------------------------
+    # Durability watermarks
+    # ------------------------------------------------------------------
+
+    def advance_event_index_watermark(self, sequence_id: int) -> None:
+        """Advance the event-index watermark for intentionally skipped rows.
+
+        The recorder only queues an event-index row when the JSONL write
+        succeeded; for sequences without an index row the watermark must
+        still advance so ``flush_until`` does not wait forever.
+        """
+        self._on_event_index_watermark(sequence_id)
+
+    def watermarks(self) -> dict[str, int]:
+        """Return current durable-progress watermarks."""
+        with self._watermark_cond:
+            return {
+                "events": self._events_watermark,
+                "event_index": self._event_index_watermark,
+            }
+
+    def flush_until(self, sequence_id: int, timeout_sec: float = 30.0) -> dict[str, Any]:
+        """Wait until both batch writers have persisted up to *sequence_id*.
+
+        This is the commit-point barrier used before session finalize: it
+        returns only when every queued event and event-index record whose
+        ``_wm`` sequence is ``<= sequence_id`` has actually been committed to
+        SQLite — never merely when the in-memory queue is empty.
+        """
+        deadline = time.monotonic() + max(0.0, timeout_sec)
+        with self._watermark_cond:
+            while (
+                self._events_watermark < sequence_id
+                or self._event_index_watermark < sequence_id
+            ):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._watermark_cond.wait(timeout=min(remaining, 0.05))
+            ok = (
+                self._events_watermark >= sequence_id
+                and self._event_index_watermark >= sequence_id
             )
+            return {
+                "ok": ok,
+                "target": sequence_id,
+                "events_watermark": self._events_watermark,
+                "event_index_watermark": self._event_index_watermark,
+            }
 
     # ------------------------------------------------------------------
     # Legacy compatibility
@@ -453,9 +545,10 @@ class PracticeCatalog:
     def _flush_events(self, batch: list[dict[str, Any]]) -> None:
         if not batch:
             return
-        cols = ", ".join(batch[0].keys())
-        placeholders = ", ".join("?" for _ in batch[0])
-        values = [list(record.values()) for record in batch]
+        clean = [_strip_watermark_key(record) for record in batch]
+        cols = ", ".join(clean[0].keys())
+        placeholders = ", ".join("?" for _ in clean[0])
+        values = [list(record.values()) for record in clean]
         with self._lock:
             self._conn.executemany(
                 f"INSERT OR REPLACE INTO events ({cols}) VALUES ({placeholders})",
@@ -749,9 +842,10 @@ class PracticeCatalog:
     def _flush_event_index(self, batch: list[dict[str, Any]]) -> None:
         if not batch:
             return
-        cols = ", ".join(batch[0].keys())
-        placeholders = ", ".join("?" for _ in batch[0])
-        values = [list(record.values()) for record in batch]
+        clean = [_strip_watermark_key(record) for record in batch]
+        cols = ", ".join(clean[0].keys())
+        placeholders = ", ".join("?" for _ in clean[0])
+        values = [list(record.values()) for record in clean]
         with self._lock:
             self._conn.executemany(
                 f"INSERT OR REPLACE INTO practice_event_index ({cols}) VALUES ({placeholders})",

--- a/src/rosclaw/practice/storage/catalog.py
+++ b/src/rosclaw/practice/storage/catalog.py
@@ -22,6 +22,14 @@ def _strip_watermark_key(record: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in record.items() if k != "_wm"}
 
 
+def _is_transient_flush_error(exc: Exception) -> bool:
+    """True for database errors worth retrying (locks, busy), not logic bugs."""
+    if not isinstance(exc, sqlite3.Error):
+        return False
+    message = str(exc).lower()
+    return "locked" in message or "busy" in message
+
+
 class _BatchWriter:
     """Threaded batch inserter for catalog tables.
 
@@ -44,6 +52,7 @@ class _BatchWriter:
         flush_interval_ms: float = 300.0,
         max_queue_size: int = 2000,
         on_watermark: Any | None = None,
+        max_flush_retries: int = 10,
     ):
         self.name = name
         self._flush_fn = flush_fn
@@ -55,6 +64,9 @@ class _BatchWriter:
         self._overflow_fallbacks = 0
         self._failed_records: list[dict[str, Any]] = []
         self._flush_error: Exception | None = None
+        # Transient flush failures (e.g. ``database is locked``) are retried
+        # with backoff before the writer gives up and fails loudly.
+        self._max_flush_retries = max(0, int(max_flush_retries))
         # ``on_watermark`` is called with the max ``_wm`` sequence of every
         # successfully flushed batch so callers can track durable progress.
         self._on_watermark = on_watermark
@@ -83,33 +95,58 @@ class _BatchWriter:
             )
             self._flush([record])
 
-    def close(self) -> None:
+    def close(self, timeout: float = 10.0) -> bool:
+        """Stop the writer and drain pending records.  Returns True when the
+        worker thread is confirmed dead and all queued records were flushed;
+        returns False (loudly) when the worker outlived the join timeout, in
+        which case the caller must NOT close the underlying database
+        connection underneath the live writer.
+        """
         with self._lock:
             if self._closed:
-                return
+                return True
             self._closed = True
+        poisoned = True
         try:
-            self._queue.put(self._POISON, block=True, timeout=5.0)
+            self._queue.put(self._POISON, block=True, timeout=timeout)
         except queue.Full:
+            poisoned = False
             logger.warning("Batch writer %s queue full on close; draining inline", self.name)
-        self._thread.join(timeout=5.0)
-        # Final drain in case the worker did not process everything.
+        self._thread.join(timeout=timeout)
+        if self._thread.is_alive():
+            logger.critical(
+                "Batch writer %s did not stop within %.1fs; refusing to let the "
+                "database close underneath a live writer",
+                self.name,
+                timeout,
+            )
+            return False
         final = list(self._failed_records)
-        while not self._queue.empty():
-            try:
-                item = self._queue.get_nowait()
-                if item is not self._POISON:
-                    final.append(item)
-            except queue.Empty:
-                break
+        if not poisoned:
+            while not self._queue.empty():
+                try:
+                    item = self._queue.get_nowait()
+                    if item is not self._POISON:
+                        final.append(item)
+                except queue.Empty:
+                    break
         if final:
-            self._flush(final)
+            try:
+                self._flush_with_retry(final)
+            except Exception:  # noqa: BLE001
+                logger.critical(
+                    "Batch writer %s failed to flush %s records on close",
+                    self.name,
+                    len(final),
+                )
+                return False
         if self._overflow_fallbacks:
             logger.info(
                 "Batch writer %s used synchronous overflow fallback %s times",
                 self.name,
                 self._overflow_fallbacks,
             )
+        return True
 
     def _worker(self) -> None:
         while True:
@@ -138,13 +175,41 @@ class _BatchWriter:
 
     def _try_worker_flush(self, batch: list[dict[str, Any]]) -> bool:
         try:
-            self._flush(batch)
+            self._flush_with_retry(batch)
         except Exception as exc:
             with self._lock:
                 self._failed_records.extend(batch)
                 self._flush_error = exc
             return False
         return True
+
+    def _flush_with_retry(self, batch: list[dict[str, Any]]) -> None:
+        """Flush with exponential backoff on transient lock errors.
+
+        A locked database (checkpoint, concurrent writer) must not kill the
+        writer thread: events keep queueing and the flush is retried until it
+        succeeds or the retry budget is exhausted, in which case the writer
+        fails loudly instead of silently dropping the batch.
+        """
+        attempt = 0
+        while True:
+            try:
+                self._flush(batch)
+                return
+            except Exception as exc:
+                attempt += 1
+                if attempt > self._max_flush_retries or not _is_transient_flush_error(exc):
+                    raise
+                backoff = min(0.05 * (2 ** (attempt - 1)), 2.0)
+                logger.warning(
+                    "Batch writer %s flush failed (attempt %s/%s): %s; retrying in %.2fs",
+                    self.name,
+                    attempt,
+                    self._max_flush_retries,
+                    exc,
+                    backoff,
+                )
+                time.sleep(backoff)
 
     def _flush(self, batch: list[dict[str, Any]]) -> None:
         if not batch:
@@ -429,6 +494,9 @@ class PracticeCatalog:
     def _init_schema(self) -> None:
         with self._lock:
             self._conn.execute("PRAGMA journal_mode=WAL")
+            # Wait on short-lived lock contention (e.g. a checkpoint or a
+            # concurrent reader's write txn) instead of failing the flush.
+            self._conn.execute("PRAGMA busy_timeout=5000")
             self._migrate_legacy_tables()
             self._conn.executescript(self._SCHEMA)
             self._conn.commit()
@@ -453,15 +521,25 @@ class PracticeCatalog:
 
     def close(self) -> None:
         # Close writers first (they need the lock to flush) before closing the
-        # underlying connection.
+        # underlying connection.  If a writer refuses to die, keep the
+        # connection open: a leaked connection is recoverable, a
+        # use-after-close flush is silent data loss.
+        writers_ok = True
         if self._event_writer is not None:
-            self._event_writer.close()
+            writers_ok = self._event_writer.close() and writers_ok
             self._event_writer = None
         if self._event_index_writer is not None:
-            self._event_index_writer.close()
+            writers_ok = self._event_index_writer.close() and writers_ok
             self._event_index_writer = None
         with self._lock:
-            self._conn.close()
+            if writers_ok:
+                self._conn.close()
+            else:
+                logger.critical(
+                    "PracticeCatalog %s closed with live batch writers; leaving the "
+                    "connection open so in-flight flushes can commit",
+                    self._db_path,
+                )
 
     def flush(self) -> None:
         """Flush any pending batched writes before reading."""
@@ -484,6 +562,14 @@ class PracticeCatalog:
         still advance so ``flush_until`` does not wait forever.
         """
         self._on_event_index_watermark(sequence_id)
+
+    def advance_events_watermark(self, sequence_id: int) -> None:
+        """Advance the events watermark for sequences that will never queue.
+
+        Called by the recorder when a catalog insert itself failed loudly;
+        the gap is reported separately by the flush barrier.
+        """
+        self._on_events_watermark(sequence_id)
 
     def watermarks(self) -> dict[str, int]:
         """Return current durable-progress watermarks."""

--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -6,6 +6,7 @@ Adds ``rosclaw db status`` and ``rosclaw db doctor``.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sqlite3
@@ -629,6 +630,286 @@ def cmd_db_doctor(args: argparse.Namespace) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# rosclaw db reconcile
+# ---------------------------------------------------------------------------
+
+
+def _id_set_hash(ids: set[str]) -> str:
+    """SHA-256 over the sorted event-id set (order-independent)."""
+    digest = hashlib.sha256()
+    for event_id in sorted(ids):
+        digest.update(event_id.encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _jsonl_event_stats(events_path: Path) -> dict[str, Any]:
+    """Stream events.jsonl: line count, duplicate ids, and the event-id set."""
+    count = 0
+    duplicates = 0
+    parse_errors = 0
+    ids: set[str] = set()
+    if not events_path.exists():
+        return {"count": 0, "duplicates": 0, "parse_errors": 0, "ids": ids, "exists": False}
+    with events_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            count += 1
+            try:
+                event_id = json.loads(line).get("event_id")
+            except json.JSONDecodeError:
+                parse_errors += 1
+                continue
+            if not event_id:
+                parse_errors += 1
+                continue
+            if event_id in ids:
+                duplicates += 1
+            else:
+                ids.add(event_id)
+    return {"count": count, "duplicates": duplicates, "parse_errors": parse_errors,
+            "ids": ids, "exists": True}
+
+
+def _manifest_event_count(session_dir: Path) -> int | None:
+    manifest_path = session_dir / "manifest.yaml"
+    if not manifest_path.exists():
+        return None
+    try:
+        import yaml
+
+        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            value = data.get("event_count")
+            return int(value) if value is not None else None
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _episode_event_count(session_dir: Path) -> int | None:
+    episode_path = session_dir / "episode.json"
+    if not episode_path.exists():
+        return None
+    try:
+        value = json.loads(episode_path.read_text(encoding="utf-8")).get("event_count")
+        return int(value) if value is not None else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _remote_counts(client: Any, practice_id: str) -> dict[str, Any]:
+    """Best-effort remote episode/memory counts for *practice_id*."""
+    result: dict[str, Any] = {"remote_episode": None, "remote_memories": None}
+    try:
+        result["remote_episode"] = client.count("episodes", {"practice_id": practice_id})
+    except Exception as exc:  # noqa: BLE001
+        result["remote_episode_error"] = str(exc)
+    try:
+        result["remote_memories"] = client.count("body_cognition", {"practice_id": practice_id})
+    except Exception as exc:  # noqa: BLE001
+        result["remote_memories_error"] = str(exc)
+    return result
+
+
+def reconcile_practice(
+    practice_id: str,
+    data_root: str,
+    *,
+    remote_client: Any | None = None,
+    max_missing: int = 20,
+) -> dict[str, Any]:
+    """Reconcile one practice session across JSONL, catalog, index, and manifest."""
+    root = Path(data_root)
+    session_dir = root / "sessions" / practice_id
+    events_path = session_dir / "raw" / "events.jsonl"
+
+    jsonl = _jsonl_event_stats(events_path)
+    manifest_count = _manifest_event_count(session_dir)
+    episode_count = _episode_event_count(session_dir)
+
+    report: dict[str, Any] = {
+        "practice_id": practice_id,
+        "session_dir": str(session_dir),
+        "raw_jsonl": jsonl["count"],
+        "catalog_events": None,
+        "event_index": None,
+        "manifest_event_count": manifest_count,
+        "episode_event_count": episode_count,
+        "duplicates": jsonl["duplicates"],
+        "parse_errors": jsonl["parse_errors"],
+        "missing": [],
+        "missing_in_index": [],
+        "hashes": {},
+        "passed": False,
+    }
+    if not jsonl["exists"]:
+        report["error"] = "events.jsonl not found"
+        return report
+
+    catalog_path = _practice_catalog_path(data_root)
+    catalog_ids: set[str] = set()
+    index_ids: set[str] = set()
+    if catalog_path.exists():
+        conn = sqlite3.connect(f"file:{catalog_path}?mode=ro", uri=True)
+        try:
+            rows = conn.execute(
+                "SELECT event_id FROM events WHERE practice_id = ?", (practice_id,)
+            ).fetchall()
+            catalog_ids = {row[0] for row in rows if row[0]}
+            practice_row = conn.execute(
+                "SELECT session_id, episode_id FROM practices WHERE practice_id = ?",
+                (practice_id,),
+            ).fetchone()
+            if practice_row and (practice_row[0] or practice_row[1]):
+                if practice_row[1]:
+                    idx_rows = conn.execute(
+                        "SELECT event_id FROM practice_event_index WHERE episode_id = ?",
+                        (practice_row[1],),
+                    ).fetchall()
+                else:
+                    idx_rows = conn.execute(
+                        "SELECT event_id FROM practice_event_index WHERE session_id = ?",
+                        (practice_row[0],),
+                    ).fetchall()
+                index_ids = {row[0] for row in idx_rows if row[0]}
+        finally:
+            conn.close()
+    else:
+        report["error"] = f"catalog not found at {catalog_path}"
+        return report
+
+    report["catalog_events"] = len(catalog_ids)
+    report["event_index"] = len(index_ids)
+
+    jsonl_ids: set[str] = jsonl["ids"]
+    missing_in_catalog = jsonl_ids - catalog_ids
+    missing_in_index = jsonl_ids - index_ids
+    report["missing"] = sorted(missing_in_catalog)[:max_missing]
+    report["missing_in_index"] = sorted(missing_in_index)[:max_missing]
+    report["missing_count"] = len(missing_in_catalog)
+    report["missing_in_index_count"] = len(missing_in_index)
+
+    report["hashes"] = {
+        "jsonl_event_ids": _id_set_hash(jsonl_ids),
+        "catalog_event_ids": _id_set_hash(catalog_ids),
+        "event_index_ids": _id_set_hash(index_ids),
+    }
+    hash_match = (
+        report["hashes"]["jsonl_event_ids"] == report["hashes"]["catalog_event_ids"]
+        and report["hashes"]["jsonl_event_ids"] == report["hashes"]["event_index_ids"]
+    )
+
+    counts_match = (
+        jsonl["count"] == len(catalog_ids) == len(index_ids)
+        and (manifest_count is None or manifest_count == jsonl["count"])
+        and (episode_count is None or episode_count == jsonl["count"])
+    )
+    local_ok = (
+        counts_match
+        and hash_match
+        and jsonl["duplicates"] == 0
+        and jsonl["parse_errors"] == 0
+    )
+
+    if remote_client is not None:
+        report.update(_remote_counts(remote_client, practice_id))
+        remote_ok = (
+            report.get("remote_episode") is not None
+            and report.get("remote_episode", 0) >= 1
+            and report.get("remote_memories") is not None
+        )
+        report["remote_checked"] = True
+        report["passed"] = bool(local_ok and remote_ok)
+    else:
+        report["remote_checked"] = False
+        report["passed"] = bool(local_ok)
+    return report
+
+
+def cmd_db_reconcile(args: argparse.Namespace) -> int:
+    """Reconcile practice event persistence across all local/remote paths."""
+    cfg = _load_storage_config(args)
+    data_root = getattr(args, "data_root", None) or cfg["practice_data_root"]
+
+    remote_client = None
+    if getattr(args, "remote", False):
+        try:
+            remote_client = _create_client(cfg)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[rosclaw db reconcile] Cannot create remote client: {exc}", file=sys.stderr)
+            return 1
+
+    try:
+        practice_ids: list[str] = []
+        if getattr(args, "all", False):
+            sessions_root = Path(data_root) / "sessions"
+            if sessions_root.exists():
+                # Only prac_* dirs are practice event sessions; sess_* dirs
+                # are ArtifactStore layout dirs without raw/events.jsonl.
+                practice_ids = sorted(
+                    p.name
+                    for p in sessions_root.iterdir()
+                    if p.is_dir() and p.name.startswith("prac_")
+                )
+        elif getattr(args, "practice_id", None):
+            practice_ids = [args.practice_id]
+        else:
+            latest = _latest_session_dir(data_root)
+            if latest is not None:
+                practice_ids = [latest.name]
+
+        if not practice_ids:
+            print("[rosclaw db reconcile] No practice sessions found", file=sys.stderr)
+            return 1
+
+        reports = [
+            reconcile_practice(
+                pid,
+                data_root,
+                remote_client=remote_client,
+                max_missing=getattr(args, "max_missing", 20),
+            )
+            for pid in practice_ids
+        ]
+    finally:
+        if remote_client is not None:
+            _close_client(remote_client)
+
+    all_passed = all(r["passed"] for r in reports)
+    if getattr(args, "json", False):
+        output: Any = reports[0] if len(reports) == 1 else {
+            "passed": all_passed,
+            "sessions": reports,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        for report in reports:
+            icon = "✅" if report["passed"] else "❌"
+            print(f"{icon} {report['practice_id']}")
+            for key in (
+                "raw_jsonl",
+                "catalog_events",
+                "event_index",
+                "manifest_event_count",
+                "episode_event_count",
+                "duplicates",
+                "missing_count",
+                "missing_in_index_count",
+            ):
+                if key in report:
+                    print(f"    {key:<24} {report[key]}")
+            if report.get("remote_checked"):
+                print(f"    {'remote_episode':<24} {report.get('remote_episode')}")
+                print(f"    {'remote_memories':<24} {report.get('remote_memories')}")
+            if report.get("error"):
+                print(f"    error: {report['error']}")
+    return 0 if all_passed else 1
+
+
 def add_db_subparser(subparsers: Any) -> Any:
     """Add ``rosclaw db`` subcommands."""
     db_parser = subparsers.add_parser("db", help="Storage backend diagnostics")
@@ -646,6 +927,28 @@ def add_db_subparser(subparsers: Any) -> Any:
     doctor_parser.add_argument("--backend", default=None, help="Override backend")
     doctor_parser.add_argument("--url", default=None, help="Override SQL URL")
     doctor_parser.add_argument("--path", default=None, help="Override SQLite path")
+
+    reconcile_parser = db_subparsers.add_parser(
+        "reconcile",
+        help="Verify JSONL/catalog/event-index/manifest event consistency",
+    )
+    reconcile_parser.add_argument("--practice-id", default=None, help="Practice to reconcile")
+    reconcile_parser.add_argument(
+        "--all", action="store_true", help="Reconcile every session in the data root"
+    )
+    reconcile_parser.add_argument(
+        "--data-root", default=None, help="Practice data root (default: from rosclaw.yaml)"
+    )
+    reconcile_parser.add_argument(
+        "--remote", action="store_true", help="Also reconcile against the remote knowledge store"
+    )
+    reconcile_parser.add_argument("--json", action="store_true", help="Output JSON")
+    reconcile_parser.add_argument("--backend", default=None, help="Override backend")
+    reconcile_parser.add_argument("--url", default=None, help="Override SQL URL")
+    reconcile_parser.add_argument("--path", default=None, help="Override SQLite path")
+    reconcile_parser.add_argument(
+        "--max-missing", type=int, default=20, help="Max missing event ids to list"
+    )
     return db_parser
 
 

--- a/src/rosclaw/storage/outbox.py
+++ b/src/rosclaw/storage/outbox.py
@@ -2,16 +2,38 @@
 
 The outbox decouples event producers (e.g. :class:`SeekDBBridge`) from the
 availability of the remote SeekDB HTTP adapter.  Events are written to a local
-SQLite outbox synchronously; a background worker drains the outbox by calling
+SQLite outbox synchronously; background workers drain the outbox by calling
 the upstream committer.  If the upstream is down, records accumulate with
 exponential backoff until they succeed or exceed ``max_retries`` and are moved
 to the dead-letter table.
+
+Delivery semantics (PR-DB-1):
+
+* **At-least-once delivery** — records are claimed under a lease, only marked
+  ``delivered`` after the remote commit succeeded, and reclaimed when a worker
+  crashes mid-flight (lease expiry).
+* **Idempotent enqueue** — every record carries an ``idempotency_key`` with a
+  partial unique index; re-enqueueing the same logical entity returns the
+  existing record instead of duplicating it.
+* **Idempotent remote upsert** — the worker injects the key into the payload
+  before handing it to the committer, so the remote side can upsert by key.
+  At-least-once + idempotent upsert = effectively once; never advertised as
+  strict exactly-once.
+
+State machine::
+
+    pending ──claim──▶ inflight ──commit ok──▶ delivered (retained, then purged)
+    pending/inflight ──failure──▶ retry ──claim──▶ inflight
+    retry over limit ──▶ outbox_dead_letters
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import os
+import socket
 import sqlite3
 import threading
 import time
@@ -21,6 +43,15 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger("rosclaw.storage.outbox")
+
+_ACTIVE_STATUSES = ("pending", "retry", "inflight")
+_ACTIVE_PLACEHOLDERS = ", ".join("?" for _ in _ACTIVE_STATUSES)
+
+
+def _canonical_sha256(payload: dict[str, Any]) -> str:
+    """SHA-256 over the canonical JSON encoding of *payload*."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 @dataclass
@@ -34,6 +65,15 @@ class OutboxRecord:
     retry_count: int = 0
     next_retry_at: float | None = None
     error_log: str | None = None
+    idempotency_key: str | None = None
+    entity_type: str | None = None
+    entity_id: str | None = None
+    payload_sha256: str | None = None
+    status: str = "pending"
+    lease_owner: str | None = None
+    lease_expires_at: float | None = None
+    updated_at: float | None = None
+    remote_revision: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -44,21 +84,56 @@ class OutboxRecord:
             "retry_count": self.retry_count,
             "next_retry_at": self.next_retry_at,
             "error_log": self.error_log,
+            "idempotency_key": self.idempotency_key,
+            "entity_type": self.entity_type,
+            "entity_id": self.entity_id,
+            "payload_sha256": self.payload_sha256,
+            "status": self.status,
+            "lease_owner": self.lease_owner,
+            "lease_expires_at": self.lease_expires_at,
+            "updated_at": self.updated_at,
+            "remote_revision": self.remote_revision,
         }
 
 
 class OutboxStore:
-    """SQLite-backed durable outbox for upstream events."""
+    """SQLite-backed durable outbox for upstream events.
+
+    Schema v2 adds idempotency keys, a pending/inflight/retry/delivered
+    status machine, and lease-based multi-worker claiming.  Existing v1
+    databases are migrated in place via ``ALTER TABLE ADD COLUMN``.
+    """
+
+    _NEW_OUTBOX_COLUMNS = {
+        "idempotency_key": "TEXT",
+        "entity_type": "TEXT",
+        "entity_id": "TEXT",
+        "payload_sha256": "TEXT",
+        "status": "TEXT DEFAULT 'pending'",
+        "lease_owner": "TEXT",
+        "lease_expires_at": "REAL",
+        "updated_at": "REAL",
+        "remote_revision": "TEXT",
+    }
+
+    _NEW_DEAD_LETTER_COLUMNS = {
+        "idempotency_key": "TEXT",
+        "entity_type": "TEXT",
+        "entity_id": "TEXT",
+        "payload_sha256": "TEXT",
+    }
 
     def __init__(
         self,
         db_path: str = "~/.rosclaw/storage/outbox.sqlite",
         max_records: int = 100_000,
+        delivered_retention_sec: float = 3600.0,
     ):
         if max_records < 1:
             raise ValueError("max_records must be at least 1")
         self._db_path = db_path
         self._max_records = max_records
+        self._delivered_retention_sec = delivered_retention_sec
         self._conn: sqlite3.Connection | None = None
         self._lock = threading.RLock()
 
@@ -94,11 +169,23 @@ class OutboxStore:
                 )
                 """
             )
+            self._migrate_columns("outbox", self._NEW_OUTBOX_COLUMNS)
             self._connection.execute(
                 "CREATE INDEX IF NOT EXISTS idx_outbox_next_retry ON outbox(next_retry_at)"
             )
             self._connection.execute(
                 "CREATE INDEX IF NOT EXISTS idx_outbox_created_at ON outbox(created_at)"
+            )
+            self._connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_outbox_status_retry ON outbox(status, next_retry_at)"
+            )
+            # Partial unique index: NULL keys (legacy rows) are ignored, every
+            # real idempotency key is claimable exactly once.
+            self._connection.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_outbox_idempotency
+                ON outbox(idempotency_key) WHERE idempotency_key IS NOT NULL
+                """
             )
             self._connection.execute(
                 """
@@ -113,46 +200,242 @@ class OutboxStore:
                 )
                 """
             )
+            self._migrate_columns("outbox_dead_letters", self._NEW_DEAD_LETTER_COLUMNS)
             self._connection.execute(
                 "CREATE INDEX IF NOT EXISTS idx_dead_letters_created_at ON outbox_dead_letters(created_at)"
             )
+            # Normalize legacy rows that predate the status column.
+            self._connection.execute(
+                "UPDATE outbox SET status = CASE WHEN retry_count > 0 THEN 'retry' ELSE 'pending' END "
+                "WHERE status IS NULL"
+            )
             self._connection.commit()
 
-    def enqueue(self, target: str, payload: dict[str, Any]) -> str:
+    def _migrate_columns(self, table: str, columns: dict[str, str]) -> None:
+        existing = {row[1] for row in self._connection.execute(f"PRAGMA table_info({table})")}
+        for name, ddl in columns.items():
+            if name not in existing:
+                logger.info("Migrating outbox table %s: adding column %s", table, name)
+                self._connection.execute(f"ALTER TABLE {table} ADD COLUMN {name} {ddl}")
+
+    # ------------------------------------------------------------------
+    # Enqueue
+    # ------------------------------------------------------------------
+
+    def enqueue(
+        self,
+        target: str,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        entity_type: str | None = None,
+        entity_id: str | None = None,
+    ) -> str:
         """Add *payload* to the outbox for *target*.
 
         Capacity exhaustion is reported to the producer instead of deleting an
         older, unacknowledged record. This preserves the durable-outbox
         guarantee and lets the caller apply backpressure or stop safely.
+
+        Enqueue is idempotent on ``idempotency_key``: enqueueing the same
+        logical entity twice returns the existing record id instead of
+        creating a duplicate.  When no key is supplied one is derived as
+        ``<entity_type|record>:<entity_id|uuid>:<payload-hash-prefix>``.
         """
         record_id = str(uuid.uuid4())
         now = time.time()
+        payload_json = json.dumps(payload)
+        payload_sha = _canonical_sha256(payload)
+        if idempotency_key is None:
+            idempotency_key = (
+                f"{entity_type or 'record'}:{entity_id or record_id}:{payload_sha[:16]}"
+            )
         with self._lock:
-            count = self._connection.execute("SELECT COUNT(*) FROM outbox").fetchone()[0]
+            count = self._connection.execute(
+                f"SELECT COUNT(*) FROM outbox WHERE status IN ({_ACTIVE_PLACEHOLDERS})",
+                _ACTIVE_STATUSES,
+            ).fetchone()[0]
             if count >= self._max_records:
                 raise OverflowError(
                     f"Outbox capacity exhausted ({self._max_records} records); "
                     "refusing to discard unacknowledged data"
                 )
-            self._connection.execute(
-                """
-                INSERT INTO outbox (id, target, payload_json, created_at, retry_count, next_retry_at)
-                VALUES (?, ?, ?, ?, 0, ?)
-                """,
-                (record_id, target, json.dumps(payload), now, now),
-            )
-            self._connection.commit()
+            try:
+                self._connection.execute(
+                    """
+                    INSERT INTO outbox (
+                        id, target, payload_json, created_at, retry_count, next_retry_at,
+                        idempotency_key, entity_type, entity_id, payload_sha256,
+                        status, updated_at
+                    )
+                    VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, 'pending', ?)
+                    """,
+                    (
+                        record_id,
+                        target,
+                        payload_json,
+                        now,
+                        now,
+                        idempotency_key,
+                        entity_type,
+                        entity_id,
+                        payload_sha,
+                        now,
+                    ),
+                )
+                self._connection.commit()
+            except sqlite3.IntegrityError:
+                self._connection.rollback()
+                existing = self._connection.execute(
+                    "SELECT id FROM outbox WHERE idempotency_key = ?",
+                    (idempotency_key,),
+                ).fetchone()
+                if existing is not None:
+                    logger.info(
+                        "Outbox enqueue deduplicated by idempotency key %s (existing %s)",
+                        idempotency_key,
+                        existing["id"],
+                    )
+                    return str(existing["id"])
+                raise
         return record_id
 
+    # ------------------------------------------------------------------
+    # Claim / delivery lifecycle
+    # ------------------------------------------------------------------
+
+    def claim(
+        self,
+        limit: int = 100,
+        *,
+        owner: str,
+        lease_sec: float = 30.0,
+        max_retries: int = 10,
+    ) -> list[OutboxRecord]:
+        """Atomically claim up to *limit* ready records under a lease.
+
+        A record is claimable when it is ``pending``/``retry``, due for
+        delivery, and under the retry cap — or when it is ``inflight`` with an
+        expired lease (its previous worker crashed).  The UPDATE re-checks the
+        predicate inside the same transaction so two workers can never claim
+        the same record.  Claimed records whose stored payload no longer
+        matches its SHA-256 are moved straight to dead letters (corrupt
+        payloads must never be uploaded as ``{}``).
+        """
+        now = time.time()
+        lease_expires = now + lease_sec
+        with self._lock:
+            candidates = self._connection.execute(
+                f"""
+                SELECT id FROM outbox
+                WHERE (
+                        (status IN ('pending', 'retry'))
+                        AND (next_retry_at IS NULL OR next_retry_at <= ?)
+                        AND retry_count < ?
+                      )
+                   OR (status = 'inflight' AND lease_expires_at IS NOT NULL AND lease_expires_at < ?)
+                ORDER BY created_at ASC
+                LIMIT ?
+                """,
+                (now, max_retries, now, limit),
+            ).fetchall()
+            candidate_ids = [row["id"] for row in candidates]
+            if not candidate_ids:
+                return []
+            placeholders = ", ".join("?" for _ in candidate_ids)
+            self._connection.execute(
+                f"""
+                UPDATE outbox
+                SET status = 'inflight', lease_owner = ?, lease_expires_at = ?, updated_at = ?
+                WHERE id IN ({placeholders})
+                  AND (
+                        ((status IN ('pending', 'retry'))
+                         AND (next_retry_at IS NULL OR next_retry_at <= ?)
+                         AND retry_count < ?)
+                     OR (status = 'inflight' AND lease_expires_at IS NOT NULL AND lease_expires_at < ?)
+                      )
+                """,
+                (owner, lease_expires, now, *candidate_ids, now, max_retries, now),
+            )
+            self._connection.commit()
+            rows = self._connection.execute(
+                f"SELECT * FROM outbox WHERE lease_owner = ? AND status = 'inflight' "
+                f"AND id IN ({placeholders}) ORDER BY created_at ASC",
+                (owner, *candidate_ids),
+            ).fetchall()
+
+        records: list[OutboxRecord] = []
+        for row in rows:
+            record = self._row_to_record(row)
+            stored_sha = row["payload_sha256"] if "payload_sha256" in row.keys() else None
+            if stored_sha and not self._payload_hash_matches(row["payload_json"], stored_sha):
+                logger.error(
+                    "Outbox record %s payload checksum mismatch; moving to dead letters",
+                    record.id,
+                )
+                self._move_to_dead_letters(row, retry_count=row["retry_count"], error="payload checksum mismatch")
+                continue
+            records.append(record)
+        return records
+
+    @staticmethod
+    def _payload_hash_matches(payload_json: str, stored_sha: str) -> bool:
+        """Compare the raw stored JSON against the canonical-form SHA.
+
+        The enqueue hash is computed over the canonical (sorted-key) JSON
+        while the column stores the original serialization, so verification
+        re-parses and re-hashes the canonical form.  A payload that cannot be
+        parsed or re-hashed is treated as corrupt.
+        """
+        try:
+            payload = json.loads(payload_json)
+        except (json.JSONDecodeError, TypeError):
+            return False
+        try:
+            return _canonical_sha256(payload) == stored_sha
+        except (TypeError, ValueError):
+            return False
+
+    def _move_to_dead_letters(self, row: sqlite3.Row, *, retry_count: int, error: str | None) -> None:
+        now = time.time()
+        keys = row.keys()
+        self._connection.execute(
+            """
+            INSERT OR REPLACE INTO outbox_dead_letters
+                (id, target, payload_json, created_at, retry_count, failed_at, error_log,
+                 idempotency_key, entity_type, entity_id, payload_sha256)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row["id"],
+                row["target"],
+                row["payload_json"],
+                row["created_at"],
+                retry_count,
+                now,
+                error,
+                row["idempotency_key"] if "idempotency_key" in keys else None,
+                row["entity_type"] if "entity_type" in keys else None,
+                row["entity_id"] if "entity_id" in keys else None,
+                row["payload_sha256"] if "payload_sha256" in keys else None,
+            ),
+        )
+        self._connection.execute("DELETE FROM outbox WHERE id = ?", (row["id"],))
+        self._connection.commit()
+
     def pending(self, limit: int = 100, max_retries: int = 10) -> list[OutboxRecord]:
-        """Return records that are ready for retry."""
+        """Return records that are ready for retry (read-only, no lease).
+
+        Kept for inspection and backward compatibility; workers use
+        :meth:`claim` so concurrent drainers cannot double-deliver.
+        """
         now = time.time()
         with self._lock:
             rows = self._connection.execute(
                 """
-                SELECT id, target, payload_json, created_at, retry_count, next_retry_at, error_log
-                FROM outbox
-                WHERE (next_retry_at IS NULL OR next_retry_at <= ?)
+                SELECT * FROM outbox
+                WHERE status IN ('pending', 'retry')
+                  AND (next_retry_at IS NULL OR next_retry_at <= ?)
                   AND retry_count < ?
                 ORDER BY created_at ASC
                 LIMIT ?
@@ -161,42 +444,88 @@ class OutboxStore:
             ).fetchall()
         return [self._row_to_record(row) for row in rows]
 
-    def mark_delivered(self, record_id: str) -> None:
+    def mark_delivered(
+        self,
+        record_id: str,
+        *,
+        owner: str | None = None,
+        remote_revision: str | None = None,
+    ) -> None:
+        """Mark a record delivered after the remote commit succeeded.
+
+        Delivered rows are retained for ``delivered_retention_sec`` so the
+        delivery is observable and reconcilable, then purged.  When *owner*
+        is given, only the lease owner may mark delivery.
+        """
+        now = time.time()
         with self._lock:
-            self._connection.execute("DELETE FROM outbox WHERE id = ?", (record_id,))
+            if owner is not None:
+                cursor = self._connection.execute(
+                    """
+                    UPDATE outbox
+                    SET status = 'delivered', lease_owner = NULL, lease_expires_at = NULL,
+                        updated_at = ?, remote_revision = ?
+                    WHERE id = ? AND lease_owner = ?
+                    """,
+                    (now, remote_revision, record_id, owner),
+                )
+                if cursor.rowcount == 0:
+                    logger.warning(
+                        "mark_delivered(%s) ignored: lease not owned by %s", record_id, owner
+                    )
+                    return
+            else:
+                self._connection.execute(
+                    """
+                    UPDATE outbox
+                    SET status = 'delivered', lease_owner = NULL, lease_expires_at = NULL,
+                        updated_at = ?, remote_revision = ?
+                    WHERE id = ?
+                    """,
+                    (now, remote_revision, record_id),
+                )
             self._connection.commit()
 
+    def purge_delivered(self, retention_sec: float | None = None) -> int:
+        """Delete delivered rows older than the retention window."""
+        retention = self._delivered_retention_sec if retention_sec is None else retention_sec
+        cutoff = time.time() - retention
+        with self._lock:
+            cursor = self._connection.execute(
+                "DELETE FROM outbox WHERE status = 'delivered' AND updated_at < ?",
+                (cutoff,),
+            )
+            self._connection.commit()
+        return cursor.rowcount
+
     def mark_failed(
-        self, record_id: str, error: str | None = None, *, max_retries: int = 10
+        self,
+        record_id: str,
+        error: str | None = None,
+        *,
+        owner: str | None = None,
+        max_retries: int = 10,
     ) -> None:
         now = time.time()
         with self._lock:
             row = self._connection.execute(
-                "SELECT target, payload_json, created_at, retry_count FROM outbox WHERE id = ?",
+                "SELECT * FROM outbox WHERE id = ?",
                 (record_id,),
             ).fetchone()
             if row is None:
                 return
+            if owner is not None and row["lease_owner"] not in (None, owner):
+                logger.warning(
+                    "mark_failed(%s) ignored: lease owned by %s, not %s",
+                    record_id,
+                    row["lease_owner"],
+                    owner,
+                )
+                return
             retry_count = row["retry_count"] + 1
             if retry_count >= max_retries:
                 # Exhausted: move to dead letters so the queue does not retry forever.
-                self._connection.execute(
-                    """
-                    INSERT INTO outbox_dead_letters
-                        (id, target, payload_json, created_at, retry_count, failed_at, error_log)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        record_id,
-                        row["target"],
-                        row["payload_json"],
-                        row["created_at"],
-                        retry_count,
-                        now,
-                        error,
-                    ),
-                )
-                self._connection.execute("DELETE FROM outbox WHERE id = ?", (record_id,))
+                self._move_to_dead_letters(row, retry_count=retry_count, error=error)
             else:
                 # Exponential backoff capped at 5 minutes.
                 backoff = min(2**retry_count, 300)
@@ -204,19 +533,89 @@ class OutboxStore:
                 self._connection.execute(
                     """
                     UPDATE outbox
-                    SET retry_count = ?, next_retry_at = ?, error_log = ?
+                    SET retry_count = ?, next_retry_at = ?, error_log = ?,
+                        status = 'retry', lease_owner = NULL, lease_expires_at = NULL,
+                        updated_at = ?
                     WHERE id = ?
                     """,
-                    (retry_count, next_retry, error, record_id),
+                    (retry_count, next_retry, error, now, record_id),
                 )
+                self._connection.commit()
+
+    def requeue_dead_letter(self, record_id: str) -> bool:
+        """Move a dead-letter record back to ``pending`` for another attempt."""
+        now = time.time()
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT * FROM outbox_dead_letters WHERE id = ?",
+                (record_id,),
+            ).fetchone()
+            if row is None:
+                return False
+            keys = row.keys()
+            try:
+                self._connection.execute(
+                    """
+                    INSERT INTO outbox (
+                        id, target, payload_json, created_at, retry_count, next_retry_at,
+                        idempotency_key, entity_type, entity_id, payload_sha256,
+                        status, updated_at
+                    )
+                    VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, 'pending', ?)
+                    """,
+                    (
+                        row["id"],
+                        row["target"],
+                        row["payload_json"],
+                        row["created_at"],
+                        now,
+                        row["idempotency_key"] if "idempotency_key" in keys else None,
+                        row["entity_type"] if "entity_type" in keys else None,
+                        row["entity_id"] if "entity_id" in keys else None,
+                        row["payload_sha256"] if "payload_sha256" in keys else None,
+                        now,
+                    ),
+                )
+            except sqlite3.IntegrityError:
+                self._connection.rollback()
+                logger.warning(
+                    "requeue_dead_letter(%s) skipped: id already present in outbox", record_id
+                )
+                return False
+            self._connection.execute(
+                "DELETE FROM outbox_dead_letters WHERE id = ?",
+                (record_id,),
+            )
             self._connection.commit()
+        return True
+
+    # ------------------------------------------------------------------
+    # Inspection
+    # ------------------------------------------------------------------
 
     def stats(self) -> dict[str, Any]:
+        now = time.time()
         with self._lock:
-            total = self._connection.execute("SELECT COUNT(*) FROM outbox").fetchone()[0]
+            total = self._connection.execute(
+                f"SELECT COUNT(*) FROM outbox WHERE status IN ({_ACTIVE_PLACEHOLDERS})",
+                _ACTIVE_STATUSES,
+            ).fetchone()[0]
             pending = self._connection.execute(
-                "SELECT COUNT(*) FROM outbox WHERE next_retry_at IS NULL OR next_retry_at <= ?",
-                (time.time(),),
+                """
+                SELECT COUNT(*) FROM outbox
+                WHERE status IN ('pending', 'retry')
+                  AND (next_retry_at IS NULL OR next_retry_at <= ?)
+                """,
+                (now,),
+            ).fetchone()[0]
+            inflight = self._connection.execute(
+                "SELECT COUNT(*) FROM outbox WHERE status = 'inflight'"
+            ).fetchone()[0]
+            retry = self._connection.execute(
+                "SELECT COUNT(*) FROM outbox WHERE status = 'retry'"
+            ).fetchone()[0]
+            delivered = self._connection.execute(
+                "SELECT COUNT(*) FROM outbox WHERE status = 'delivered'"
             ).fetchone()[0]
             failed = self._connection.execute(
                 "SELECT COUNT(*) FROM outbox WHERE retry_count > 0"
@@ -227,24 +626,28 @@ class OutboxStore:
             oldest_pending_row = self._connection.execute(
                 """
                 SELECT MIN(created_at) FROM outbox
-                WHERE next_retry_at IS NULL OR next_retry_at <= ?
+                WHERE status IN ('pending', 'retry')
+                  AND (next_retry_at IS NULL OR next_retry_at <= ?)
                 """,
-                (time.time(),),
+                (now,),
             ).fetchone()
             oldest_created = oldest_pending_row[0] if oldest_pending_row else None
         oldest_pending_sec: float | None = None
         if oldest_created is not None:
-            oldest_pending_sec = round(time.time() - oldest_created, 3)
+            oldest_pending_sec = round(now - oldest_created, 3)
         return {
             "total": total,
             "pending": pending,
+            "inflight": inflight,
+            "retry": retry,
+            "delivered": delivered,
             "failed": failed,
             "dead_letters": dead_letters,
             "oldest_pending_sec": oldest_pending_sec,
         }
 
     def records(self, limit: int | None = None) -> list[OutboxRecord]:
-        """Return all records (ignoring backoff), newest first."""
+        """Return all records (ignoring backoff and status), newest first."""
         with self._lock:
             sql = "SELECT * FROM outbox ORDER BY created_at DESC"
             params: tuple = ()
@@ -270,16 +673,28 @@ class OutboxStore:
             payload = json.loads(row["payload_json"])
         except json.JSONDecodeError:
             payload = {}
-        # Dead-letter rows do not have next_retry_at; normalize absent columns to None.
         keys = row.keys()
+
+        def col(name: str, default: Any = None) -> Any:
+            return row[name] if name in keys else default
+
         return OutboxRecord(
             id=row["id"],
             target=row["target"],
             payload=payload,
             created_at=row["created_at"],
             retry_count=row["retry_count"],
-            next_retry_at=row["next_retry_at"] if "next_retry_at" in keys else None,
-            error_log=row["error_log"] if "error_log" in keys else None,
+            next_retry_at=col("next_retry_at"),
+            error_log=col("error_log"),
+            idempotency_key=col("idempotency_key"),
+            entity_type=col("entity_type"),
+            entity_id=col("entity_id"),
+            payload_sha256=col("payload_sha256"),
+            status=col("status", "pending") or "pending",
+            lease_owner=col("lease_owner"),
+            lease_expires_at=col("lease_expires_at"),
+            updated_at=col("updated_at"),
+            remote_revision=col("remote_revision"),
         )
 
     def close(self) -> None:
@@ -290,7 +705,13 @@ class OutboxStore:
 
 
 class OutboxWorker:
-    """Background worker that drains an :class:`OutboxStore` through a committer."""
+    """Background worker that drains an :class:`OutboxStore` through a committer.
+
+    The worker claims records under a lease identified by ``owner_id``; if it
+    crashes, another worker (or its own restart) re-claims the records once
+    the lease expires.  Before each commit the record's ``idempotency_key`` is
+    injected into the payload so the remote side can upsert idempotently.
+    """
 
     def __init__(
         self,
@@ -301,6 +722,8 @@ class OutboxWorker:
         batch_size: int = 100,
         max_retries: int = 10,
         name: str = "outbox-worker",
+        owner_id: str | None = None,
+        lease_sec: float = 30.0,
     ):
         self._outbox = outbox
         self._committer = committer
@@ -311,6 +734,12 @@ class OutboxWorker:
         self._thread: threading.Thread | None = None
         self._name = name
         self._drain_lock = threading.Lock()
+        self._owner_id = owner_id or f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:8]}"
+        self._lease_sec = lease_sec
+
+    @property
+    def owner_id(self) -> str:
+        return self._owner_id
 
     def start(self) -> None:
         if self._thread is not None and self._thread.is_alive():
@@ -318,7 +747,7 @@ class OutboxWorker:
         self._stop.clear()
         self._thread = threading.Thread(target=self._run, daemon=True, name=self._name)
         self._thread.start()
-        logger.info("Started %s", self._name)
+        logger.info("Started %s (owner=%s)", self._name, self._owner_id)
 
     def stop(self, timeout: float = 5.0) -> None:
         self._stop.set()
@@ -364,14 +793,23 @@ class OutboxWorker:
                 self._stop.wait(timeout=sleep_for)
 
     def _drain_once(self) -> int:
-        records = self._outbox.pending(self._batch_size, self._max_retries)
+        records = self._outbox.claim(
+            self._batch_size,
+            owner=self._owner_id,
+            lease_sec=self._lease_sec,
+            max_retries=self._max_retries,
+        )
+        try:
+            self._outbox.purge_delivered()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to purge delivered outbox rows: %s", exc)
         if not records:
             return 0
 
         batch_commit = getattr(self._committer, "save_to_seekdb_batch", None)
         if batch_commit is not None and len(records) > 1:
             try:
-                batch_commit([record.payload for record in records])
+                batch_commit([self._payload_for_commit(record) for record in records])
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "Batch commit failed for %s record(s) to %s: %s; falling back to per-record",
@@ -382,13 +820,13 @@ class OutboxWorker:
                 batch_commit = None
             else:
                 for record in records:
-                    self._outbox.mark_delivered(record.id)
+                    self._outbox.mark_delivered(record.id, owner=self._owner_id)
                 return len(records)
 
         for record in records:
             try:
-                self._committer.save_to_seekdb(record.payload)
-                self._outbox.mark_delivered(record.id)
+                self._committer.save_to_seekdb(self._payload_for_commit(record))
+                self._outbox.mark_delivered(record.id, owner=self._owner_id)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "Failed to commit outbox record %s to %s: %s",
@@ -396,5 +834,15 @@ class OutboxWorker:
                     record.target,
                     exc,
                 )
-                self._outbox.mark_failed(record.id, str(exc), max_retries=self._max_retries)
+                self._outbox.mark_failed(
+                    record.id, str(exc), owner=self._owner_id, max_retries=self._max_retries
+                )
         return len(records)
+
+    @staticmethod
+    def _payload_for_commit(record: OutboxRecord) -> dict[str, Any]:
+        """Return the payload with the idempotency key attached for upsert."""
+        payload = dict(record.payload)
+        if record.idempotency_key:
+            payload.setdefault("idempotency_key", record.idempotency_key)
+        return payload

--- a/src/rosclaw/storage/outbox.py
+++ b/src/rosclaw/storage/outbox.py
@@ -326,7 +326,7 @@ class OutboxStore:
         lease_expires = now + lease_sec
         with self._lock:
             candidates = self._connection.execute(
-                f"""
+                """
                 SELECT id FROM outbox
                 WHERE (
                         (status IN ('pending', 'retry'))
@@ -367,13 +367,17 @@ class OutboxStore:
         records: list[OutboxRecord] = []
         for row in rows:
             record = self._row_to_record(row)
-            stored_sha = row["payload_sha256"] if "payload_sha256" in row.keys() else None
+            stored_sha = (
+                row["payload_sha256"] if "payload_sha256" in row.keys() else None  # noqa: SIM118
+            )
             if stored_sha and not self._payload_hash_matches(row["payload_json"], stored_sha):
                 logger.error(
                     "Outbox record %s payload checksum mismatch; moving to dead letters",
                     record.id,
                 )
-                self._move_to_dead_letters(row, retry_count=row["retry_count"], error="payload checksum mismatch")
+                self._move_to_dead_letters(
+                    row, retry_count=row["retry_count"], error="payload checksum mismatch"
+                )
                 continue
             records.append(record)
         return records
@@ -396,7 +400,9 @@ class OutboxStore:
         except (TypeError, ValueError):
             return False
 
-    def _move_to_dead_letters(self, row: sqlite3.Row, *, retry_count: int, error: str | None) -> None:
+    def _move_to_dead_letters(
+        self, row: sqlite3.Row, *, retry_count: int, error: str | None
+    ) -> None:
         now = time.time()
         keys = row.keys()
         self._connection.execute(

--- a/tests/practice/test_flush_barrier.py
+++ b/tests/practice/test_flush_barrier.py
@@ -96,7 +96,7 @@ def test_watermark_key_is_not_persisted() -> None:
         catalog.insert_event({"event_id": "e1", "practice_id": "p1", "_wm": 7})
         row = catalog._conn.execute("SELECT * FROM events WHERE event_id = 'e1'").fetchone()
         assert row is not None
-        assert "_wm" not in row.keys()
+        assert "_wm" not in row.keys()  # noqa: SIM118 - sqlite3.Row lacks __contains__
         assert catalog.watermarks()["events"] >= 7
         catalog.close()
 
@@ -115,7 +115,6 @@ def test_flush_barrier_satisfied_after_events() -> None:
             assert report["event_index_watermark"] >= 20
         finally:
             recorder.stop()
-
 
 
 def test_flush_barrier_called_on_finalize() -> None:
@@ -138,4 +137,3 @@ def test_flush_barrier_called_on_finalize() -> None:
                 catalog.close()
         finally:
             recorder.stop()
-

--- a/tests/practice/test_flush_barrier.py
+++ b/tests/practice/test_flush_barrier.py
@@ -1,0 +1,141 @@
+"""Tests for PracticeRecorder/PracticeCatalog durability watermarks and flush barrier."""
+
+from __future__ import annotations
+
+import tempfile
+import time
+from pathlib import Path
+
+from rosclaw.practice.recorder import PracticeRecorder
+from rosclaw.practice.storage.catalog import PracticeCatalog
+from rosclaw.runtime.bus import RuntimeBus
+from rosclaw.runtime.event import RuntimeEvent
+
+
+def _make_event(event_type: str, payload: dict | None = None) -> RuntimeEvent:
+    import datetime
+
+    return RuntimeEvent(
+        id=f"evt-{event_type}-{time.monotonic_ns()}",
+        timestamp=datetime.datetime.now(datetime.UTC),
+        source="test",
+        robot="test_bot",
+        type=event_type,
+        payload=payload or {},
+    )
+
+
+def _start_recorder(tmp: str) -> tuple[RuntimeBus, PracticeRecorder]:
+    bus = RuntimeBus()
+    recorder = PracticeRecorder(bus, data_root=tmp, publish_to_event_bus=False)
+    recorder.initialize()
+    recorder.start()
+    recorder.on_event(
+        _make_event("practice.start", {"practice_id": "prac_test_barrier", "robot_id": "test_bot"})
+    )
+    return bus, recorder
+
+
+def test_flush_until_waits_for_batch_commit() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        catalog = PracticeCatalog(
+            Path(tmp) / "catalog.sqlite",
+            event_batch_size=500,
+            event_flush_ms=50.0,
+        )
+        for i in range(1, 11):
+            catalog.insert_event({"event_id": f"e{i}", "practice_id": "p1", "_wm": i})
+            catalog.insert_event_index(
+                {"event_id": f"e{i}", "session_id": "s1", "summary": {}, "_wm": i}
+            )
+        result = catalog.flush_until(10, timeout_sec=5.0)
+        assert result["ok"]
+        assert result["events_watermark"] >= 10
+        assert result["event_index_watermark"] >= 10
+        assert catalog.count_events("p1") == 10
+        catalog.close()
+
+
+def test_flush_until_times_out_for_missing_sequence() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        catalog = PracticeCatalog(
+            Path(tmp) / "catalog.sqlite",
+            event_batch_size=500,
+            event_flush_ms=50.0,
+        )
+        catalog.insert_event({"event_id": "e1", "practice_id": "p1", "_wm": 1})
+        catalog.insert_event_index({"event_id": "e1", "session_id": "s1", "summary": {}, "_wm": 1})
+        start = time.monotonic()
+        result = catalog.flush_until(5, timeout_sec=0.3)
+        assert not result["ok"]
+        assert time.monotonic() - start < 2.0
+        catalog.close()
+
+
+def test_advance_event_index_watermark_skips_missing_rows() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        catalog = PracticeCatalog(
+            Path(tmp) / "catalog.sqlite",
+            event_batch_size=500,
+            event_flush_ms=50.0,
+        )
+        catalog.insert_event({"event_id": "e1", "practice_id": "p1", "_wm": 1})
+        # No index row for sequence 1 (e.g. JSONL write failed upstream).
+        catalog.advance_event_index_watermark(1)
+        result = catalog.flush_until(1, timeout_sec=5.0)
+        assert result["ok"]
+        catalog.close()
+
+
+def test_watermark_key_is_not_persisted() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        catalog = PracticeCatalog(
+            Path(tmp) / "catalog.sqlite",
+            event_batch_size=1,  # synchronous flush path
+        )
+        catalog.insert_event({"event_id": "e1", "practice_id": "p1", "_wm": 7})
+        row = catalog._conn.execute("SELECT * FROM events WHERE event_id = 'e1'").fetchone()
+        assert row is not None
+        assert "_wm" not in row.keys()
+        assert catalog.watermarks()["events"] >= 7
+        catalog.close()
+
+
+def test_flush_barrier_satisfied_after_events() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        bus, recorder = _start_recorder(tmp)
+        try:
+            for i in range(20):
+                recorder.on_event(_make_event("skill.invoke", {"seq": i}))
+            report = recorder.flush_barrier(timeout_sec=10.0)
+            assert report["ok"], report
+            assert report["target"] == 20
+            assert report["jsonl_watermark"] == 20
+            assert report["events_watermark"] >= 20
+            assert report["event_index_watermark"] >= 20
+        finally:
+            recorder.stop()
+
+
+
+def test_flush_barrier_called_on_finalize() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        bus, recorder = _start_recorder(tmp)
+        try:
+            for i in range(5):
+                recorder.on_event(_make_event("skill.invoke", {"seq": i}))
+            recorder.on_event(_make_event("practice.stop", {"outcome": "SUCCESS"}))
+            barrier = recorder.last_flush_barrier
+            assert barrier is not None
+            assert barrier["ok"], barrier
+            assert barrier["target"] == 5
+
+            # After a clean finalize the catalog agrees with the JSONL count.
+            catalog = PracticeCatalog(Path(tmp) / "indexes" / "practice_catalog.sqlite")
+            try:
+                assert catalog.count_events("prac_test_barrier") == 5
+            finally:
+                catalog.close()
+        finally:
+            recorder.stop()
+

--- a/tests/storage/faults/test_batch_writer_crash.py
+++ b/tests/storage/faults/test_batch_writer_crash.py
@@ -1,0 +1,99 @@
+"""Fault injection: batch writer crash — retry, loud failure, close-under-load."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from rosclaw.practice.storage.catalog import PracticeCatalog, _BatchWriter
+
+
+def test_transient_lock_error_is_retried_without_data_loss() -> None:
+    attempts = {"n": 0}
+    committed: list[int] = []
+
+    def flaky_flush(batch: list[dict]) -> None:
+        attempts["n"] += 1
+        if attempts["n"] <= 2:
+            raise sqlite3.OperationalError("database is locked")
+        committed.extend(r["_wm"] for r in batch)
+
+    writer = _BatchWriter("test", flaky_flush, batch_size=10, flush_interval_ms=50.0)
+    for i in range(1, 6):
+        writer.put({"event_id": f"e{i}", "_wm": i})
+    assert writer.close(timeout=5.0)
+    assert sorted(committed) == [1, 2, 3, 4, 5]
+    assert attempts["n"] == 3
+
+
+def test_permanent_flush_error_fails_loudly_not_silently() -> None:
+    def bad_flush(batch: list[dict]) -> None:
+        raise sqlite3.OperationalError("no such table: events")
+
+    writer = _BatchWriter(
+        "test", bad_flush, batch_size=10, flush_interval_ms=50.0, max_flush_retries=1
+    )
+    writer.put({"event_id": "e1", "_wm": 1})
+    # After the retry budget is exhausted the writer dies and put() raises.
+    for _ in range(50):
+        if writer._flush_error is not None:
+            break
+        time.sleep(0.02)
+    assert writer._flush_error is not None
+    with pytest.raises(RuntimeError, match="previously failed"):
+        writer.put({"event_id": "e2", "_wm": 2})
+    # The failed record is preserved for inspection, not silently dropped.
+    assert writer._failed_records
+    writer._max_flush_retries = 0
+    writer.close(timeout=2.0)
+
+
+def test_close_under_load_does_not_close_connection_under_live_writer() -> None:
+    """Reproduces the 7x24 session #6 'Cannot operate on a closed database' race."""
+    slow_committed: list[int] = []
+
+    def slow_flush(batch: list[dict]) -> None:
+        time.sleep(0.5)
+        slow_committed.extend(r["_wm"] for r in batch)
+
+    # batch_size > 1 so the flush happens on the worker thread, not inline.
+    writer = _BatchWriter("slow", slow_flush, batch_size=10, flush_interval_ms=10.0)
+    writer.put({"event_id": "e1", "_wm": 1})
+    # Close with a tiny timeout while the worker is mid-flush.
+    ok = writer.close(timeout=0.05)
+    assert not ok
+    assert writer._thread.is_alive()
+    # The worker eventually commits; nothing is lost.
+    for _ in range(100):
+        if slow_committed:
+            break
+        time.sleep(0.02)
+    assert slow_committed == [1]
+
+
+def test_catalog_close_keeps_connection_open_when_writer_stuck() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        catalog = PracticeCatalog(Path(tmp) / "catalog.sqlite", event_batch_size=500)
+        assert catalog._event_writer is not None
+        # Force the writer into a stuck state by monkeypatching its flush.
+        original_flush_fn = catalog._event_writer._flush_fn
+
+        def stuck_flush(batch: list[dict]) -> None:
+            time.sleep(2.0)
+            original_flush_fn(batch)
+
+        catalog._event_writer._flush_fn = stuck_flush
+        catalog.insert_event({"event_id": "e1", "practice_id": "p1", "_wm": 1})
+        catalog._event_writer._closed = False
+        # Replace close timeout by calling the writer's close directly.
+        ok = catalog._event_writer.close(timeout=0.05)
+        if not ok:
+            # Connection must remain open until the writer finishes.
+            catalog._conn.execute("SELECT 1")
+        # Let the writer actually finish and clean up.
+        catalog._event_writer._thread.join(timeout=5.0)
+        catalog._conn.close()

--- a/tests/storage/faults/test_corrupt_payload.py
+++ b/tests/storage/faults/test_corrupt_payload.py
@@ -58,7 +58,9 @@ def test_corrupt_jsonl_line_fails_reconcile(tmp_path: Path) -> None:
     conn = sqlite3.connect(str(indexes / "practice_catalog.sqlite"))
     conn.execute("CREATE TABLE practices (practice_id TEXT, session_id TEXT, episode_id TEXT)")
     conn.execute("CREATE TABLE events (event_id TEXT, practice_id TEXT)")
-    conn.execute("CREATE TABLE practice_event_index (event_id TEXT, session_id TEXT, episode_id TEXT)")
+    conn.execute(
+        "CREATE TABLE practice_event_index (event_id TEXT, session_id TEXT, episode_id TEXT)"
+    )
     conn.execute("INSERT INTO practices VALUES ('prac_corrupt', 's1', 'ep1')")
     for eid in ("e1", "e2"):
         conn.execute("INSERT INTO events VALUES (?, 'prac_corrupt')", (eid,))

--- a/tests/storage/faults/test_corrupt_payload.py
+++ b/tests/storage/faults/test_corrupt_payload.py
@@ -1,0 +1,71 @@
+"""Fault injection: corrupt payload — dead letter, never uploaded as {}."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from rosclaw.storage.cli import reconcile_practice
+from rosclaw.storage.outbox import OutboxStore, OutboxWorker
+
+
+@pytest.fixture
+def outbox(tmp_path: Path) -> OutboxStore:
+    store = OutboxStore(db_path=str(tmp_path / "outbox.sqlite"))
+    store.connect()
+    return store
+
+
+def test_corrupt_payload_dead_lettered_and_never_sent(outbox: OutboxStore) -> None:
+    rid = outbox.enqueue("seekdb_http", {"valid": True})
+    # Simulate on-disk corruption of the stored JSON.
+    outbox._connection.execute(
+        "UPDATE outbox SET payload_json = ? WHERE id = ?",
+        ('{"broken": truncated', rid),
+    )
+    outbox._connection.commit()
+
+    committer = MagicMock()
+    committer.save_to_seekdb_batch = None
+    worker = OutboxWorker(outbox, committer, interval_sec=60.0)
+    worker._drain_once()
+    worker.stop()
+
+    committer.save_to_seekdb.assert_not_called()
+    dead = outbox.dead_letters()
+    assert len(dead) == 1
+    assert dead[0].id == rid
+    assert dead[0].error_log == "payload checksum mismatch"
+
+
+def test_corrupt_jsonl_line_fails_reconcile(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "prac_corrupt"
+    raw = session_dir / "raw"
+    raw.mkdir(parents=True)
+    with (raw / "events.jsonl").open("w", encoding="utf-8") as f:
+        f.write(json.dumps({"event_id": "e1", "practice_id": "prac_corrupt"}) + "\n")
+        f.write("{not valid json\n")
+        f.write(json.dumps({"event_id": "e2", "practice_id": "prac_corrupt"}) + "\n")
+    (session_dir / "episode.json").write_text(json.dumps({"event_count": 3}))
+    (session_dir / "manifest.yaml").write_text("event_count: 3\n")
+
+    indexes = tmp_path / "indexes"
+    indexes.mkdir()
+    conn = sqlite3.connect(str(indexes / "practice_catalog.sqlite"))
+    conn.execute("CREATE TABLE practices (practice_id TEXT, session_id TEXT, episode_id TEXT)")
+    conn.execute("CREATE TABLE events (event_id TEXT, practice_id TEXT)")
+    conn.execute("CREATE TABLE practice_event_index (event_id TEXT, session_id TEXT, episode_id TEXT)")
+    conn.execute("INSERT INTO practices VALUES ('prac_corrupt', 's1', 'ep1')")
+    for eid in ("e1", "e2"):
+        conn.execute("INSERT INTO events VALUES (?, 'prac_corrupt')", (eid,))
+        conn.execute("INSERT INTO practice_event_index VALUES (?, 's1', 'ep1')", (eid,))
+    conn.commit()
+    conn.close()
+
+    report = reconcile_practice("prac_corrupt", str(tmp_path))
+    assert not report["passed"]
+    assert report["parse_errors"] == 1

--- a/tests/storage/faults/test_disk_full.py
+++ b/tests/storage/faults/test_disk_full.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import datetime
 import errno
 import tempfile
-from pathlib import Path
 
 from rosclaw.practice.recorder import PracticeRecorder
 from rosclaw.runtime.bus import RuntimeBus

--- a/tests/storage/faults/test_disk_full.py
+++ b/tests/storage/faults/test_disk_full.py
@@ -1,0 +1,70 @@
+"""Fault injection: disk full — recorder keeps the session alive, barrier reports."""
+
+from __future__ import annotations
+
+import datetime
+import errno
+import tempfile
+from pathlib import Path
+
+from rosclaw.practice.recorder import PracticeRecorder
+from rosclaw.runtime.bus import RuntimeBus
+from rosclaw.runtime.event import RuntimeEvent
+
+
+def _evt(event_type: str, payload: dict | None = None) -> RuntimeEvent:
+    import time
+
+    return RuntimeEvent(
+        id=f"evt-{event_type}-{time.monotonic_ns()}",
+        timestamp=datetime.datetime.now(datetime.UTC),
+        source="test",
+        robot="test_bot",
+        type=event_type,
+        payload=payload or {},
+    )
+
+
+def test_disk_full_keeps_session_alive_and_flags_barrier() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        bus = RuntimeBus()
+        recorder = PracticeRecorder(bus, data_root=tmp, publish_to_event_bus=False)
+        recorder.initialize()
+        recorder.start()
+        try:
+            recorder.on_event(
+                _evt("practice.start", {"practice_id": "prac_enospc", "robot_id": "test_bot"})
+            )
+            recorder.on_event(_evt("skill.invoke", {"seq": 1}))
+
+            # Simulate ENOSPC on the JSONL path for the next event only.
+            original_write = recorder._writer.write
+
+            def _failing_write(record: dict) -> None:
+                raise OSError(errno.ENOSPC, "No space left on device")
+
+            recorder._writer.write = _failing_write  # type: ignore[method-assign]
+            recorder.on_event(_evt("skill.invoke", {"seq": 2}))
+            recorder._writer.write = original_write  # type: ignore[method-assign]
+            recorder.on_event(_evt("skill.invoke", {"seq": 3}))
+
+            # The session is still alive (robot task not blocked by disk).
+            assert recorder.session is not None
+            assert recorder._event_count == 3
+
+            report = recorder.flush_barrier(timeout_sec=10.0)
+            # Event 2 never hit the JSONL file; later events did, so the
+            # watermark advanced but the gap is tracked explicitly.
+            assert report["jsonl_watermark"] == 3
+            assert not report["ok"]
+            assert report["failed_sequences"]["jsonl"] == [2]
+            # But the catalog batch path still committed everything, and the
+            # index watermark advanced past the skipped sequence.
+            assert report["events_watermark"] >= 3
+            assert report["event_index_watermark"] >= 3
+
+            # Finalize must not raise; the CRITICAL log surfaces the gap.
+            recorder.on_event(_evt("practice.stop", {"outcome": "UNKNOWN"}))
+            assert recorder.last_flush_barrier is not None
+        finally:
+            recorder.stop()

--- a/tests/storage/faults/test_duplicate_delivery.py
+++ b/tests/storage/faults/test_duplicate_delivery.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/storage/faults/test_duplicate_delivery.py
+++ b/tests/storage/faults/test_duplicate_delivery.py
@@ -1,0 +1,54 @@
+"""Fault injection: duplicate delivery — remote holds exactly one record."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from rosclaw.storage.outbox import OutboxStore, OutboxWorker
+
+
+@pytest.fixture
+def outbox(tmp_path: Path) -> OutboxStore:
+    store = OutboxStore(db_path=str(tmp_path / "outbox.sqlite"))
+    store.connect()
+    return store
+
+
+def test_duplicate_enqueue_same_episode_creates_one_record(outbox: OutboxStore) -> None:
+    key = "episode:ep_2026:v2"
+    first = outbox.enqueue("seekdb_http", {"ep": 1}, idempotency_key=key)
+    second = outbox.enqueue("seekdb_http", {"ep": 1}, idempotency_key=key)
+    third = outbox.enqueue("seekdb_http", {"ep": 1}, idempotency_key=key)
+    assert first == second == third
+    assert outbox.stats()["total"] == 1
+
+
+def test_two_workers_cannot_double_deliver(outbox: OutboxStore) -> None:
+    remote: dict[str, dict] = {}
+
+    class IdempotentCommitter:
+        save_to_seekdb_batch = None
+
+        def save_to_seekdb(self, payload: dict) -> None:
+            time.sleep(0.01)  # widen the race window
+            remote[payload["idempotency_key"]] = payload
+
+    for i in range(10):
+        outbox.enqueue("seekdb_http", {"seq": i}, idempotency_key=f"memory:m{i}:v1")
+
+    w1 = OutboxWorker(outbox, IdempotentCommitter(), interval_sec=0.01, batch_size=4)
+    w2 = OutboxWorker(outbox, IdempotentCommitter(), interval_sec=0.01, batch_size=4)
+    w1.start()
+    w2.start()
+    for _ in range(1000):
+        if outbox.stats()["total"] == 0 and len(remote) == 10:
+            break
+        time.sleep(0.02)
+    w1.stop()
+    w2.stop()
+    assert len(remote) == 10
+    assert outbox.stats()["delivered"] == 10

--- a/tests/storage/faults/test_network_partition.py
+++ b/tests/storage/faults/test_network_partition.py
@@ -1,0 +1,53 @@
+"""Fault injection: network partition — outbox backlogs, robot task unaffected."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from rosclaw.storage.outbox import OutboxStore, OutboxWorker
+
+
+@pytest.fixture
+def outbox(tmp_path: Path) -> OutboxStore:
+    store = OutboxStore(db_path=str(tmp_path / "outbox.sqlite"))
+    store.connect()
+    return store
+
+
+def test_partition_backlogs_outbox_without_blocking_producer(outbox: OutboxStore) -> None:
+    committer = MagicMock()
+    committer.save_to_seekdb_batch = None
+    committer.save_to_seekdb.side_effect = ConnectionError("network unreachable")
+    worker = OutboxWorker(outbox, committer, interval_sec=0.05, batch_size=10, max_retries=100)
+    worker.start()
+    try:
+        # Producer (robot task) keeps enqueueing during the partition — no raise.
+        for i in range(25):
+            outbox.enqueue("seekdb_http", {"seq": i}, idempotency_key=f"memory:m{i}:h{i}")
+        time.sleep(0.4)
+        stats = outbox.stats()
+        assert stats["total"] == 25  # nothing delivered, nothing lost
+        assert stats["delivered"] == 0
+    finally:
+        worker.stop()
+
+    # Partition heals: drain everything.
+    delivered_seqs: list[int] = []
+
+    def _record_delivery(payload: dict) -> None:
+        delivered_seqs.append(payload["seq"])
+
+    committer.save_to_seekdb.side_effect = _record_delivery
+    worker2 = OutboxWorker(outbox, committer, interval_sec=0.02, batch_size=10)
+    worker2.start()
+    for _ in range(500):
+        if outbox.stats()["total"] == 0:
+            break
+        time.sleep(0.02)
+    worker2.stop()
+    assert outbox.stats()["delivered"] == 25
+    assert sorted(delivered_seqs) == list(range(25))

--- a/tests/storage/faults/test_outbox_worker_crash.py
+++ b/tests/storage/faults/test_outbox_worker_crash.py
@@ -49,9 +49,9 @@ def test_crash_after_remote_commit_redelivers_but_remote_stays_idempotent(
             # Idempotent upsert by the injected key.
             remote[payload["idempotency_key"]] = payload
             # Simulate the worker dying right after a successful remote commit:
-            raise _WorkerDied() if payload.get("_die_once") else None
+            raise _WorkerDiedError() if payload.get("_die_once") else None
 
-    class _WorkerDied(Exception):
+    class _WorkerDiedError(Exception):
         pass
 
     outbox.enqueue("seekdb_http", {"event": "a"}, idempotency_key="episode:ep2:v1")

--- a/tests/storage/faults/test_outbox_worker_crash.py
+++ b/tests/storage/faults/test_outbox_worker_crash.py
@@ -1,0 +1,77 @@
+"""Fault injection: outbox worker crash — lease expiry, reclaim, redelivery."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from rosclaw.storage.outbox import OutboxStore, OutboxWorker
+
+
+@pytest.fixture
+def outbox(tmp_path: Path) -> OutboxStore:
+    store = OutboxStore(db_path=str(tmp_path / "outbox.sqlite"))
+    store.connect()
+    return store
+
+
+def test_worker_crash_mid_claim_recovers_via_lease(outbox: OutboxStore) -> None:
+    outbox.enqueue("seekdb_http", {"event": "a"}, idempotency_key="episode:ep1:v1")
+    # Worker 1 claims and "crashes" (never delivers, never releases).
+    claimed = outbox.claim(10, owner="crashed-worker", lease_sec=0.05)
+    assert len(claimed) == 1
+    assert outbox.stats()["inflight"] == 1
+
+    time.sleep(0.08)
+    committer = MagicMock()
+    committer.save_to_seekdb_batch = None
+    worker2 = OutboxWorker(outbox, committer, interval_sec=60.0)
+    worker2._drain_once()
+    worker2.stop()
+    assert committer.save_to_seekdb.call_count == 1
+    assert outbox.stats()["delivered"] == 1
+
+
+def test_crash_after_remote_commit_redelivers_but_remote_stays_idempotent(
+    outbox: OutboxStore,
+) -> None:
+    """Worker delivers remotely, crashes before mark_delivered: the redelivery
+    must not duplicate the remote record (idempotency key upsert)."""
+    remote: dict[str, dict] = {}
+
+    class IdempotentRemote:
+        save_to_seekdb_batch = None
+
+        def save_to_seekdb(self, payload: dict) -> None:
+            # Idempotent upsert by the injected key.
+            remote[payload["idempotency_key"]] = payload
+            # Simulate the worker dying right after a successful remote commit:
+            raise _WorkerDied() if payload.get("_die_once") else None
+
+    class _WorkerDied(Exception):
+        pass
+
+    outbox.enqueue("seekdb_http", {"event": "a"}, idempotency_key="episode:ep2:v1")
+    # First worker: remote commit succeeds but process "dies" before marking.
+    claimed = outbox.claim(10, owner="w1", lease_sec=0.05)
+    assert len(claimed) == 1
+    remote[claimed[0].idempotency_key] = claimed[0].payload  # remote commit OK
+    # (crash: no mark_delivered)
+
+    time.sleep(0.08)
+    committer = MagicMock()
+    committer.save_to_seekdb_batch = None
+
+    def upsert(payload: dict) -> None:
+        remote[payload["idempotency_key"]] = payload
+
+    committer.save_to_seekdb.side_effect = upsert
+    worker2 = OutboxWorker(outbox, committer, interval_sec=60.0)
+    worker2._drain_once()
+    worker2.stop()
+    # Redelivery happened, but the remote still has exactly one record.
+    assert len(remote) == 1
+    assert outbox.stats()["delivered"] == 1

--- a/tests/storage/faults/test_process_restart.py
+++ b/tests/storage/faults/test_process_restart.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 
 from rosclaw.practice.storage.catalog import PracticeCatalog
@@ -16,9 +15,7 @@ def test_restart_reconcile_and_backfill(tmp_path: Path) -> None:
     catalog_a = PracticeCatalog(db, event_batch_size=500, event_flush_ms=60_000.0)
     expected_ids = {f"e{i:03d}" for i in range(50)}
     for i, event_id in enumerate(sorted(expected_ids), start=1):
-        catalog_a.insert_event(
-            {"event_id": event_id, "practice_id": "p1", "_wm": i}
-        )
+        catalog_a.insert_event({"event_id": event_id, "practice_id": "p1", "_wm": i})
     # Kill the writers without flushing (process crash simulation).
     catalog_a._event_writer._closed = True
     catalog_a._event_index_writer._closed = True
@@ -27,9 +24,7 @@ def test_restart_reconcile_and_backfill(tmp_path: Path) -> None:
     catalog_b = PracticeCatalog(db, event_batch_size=1)
     persisted = {
         row[0]
-        for row in catalog_b._conn.execute(
-            "SELECT event_id FROM events WHERE practice_id = 'p1'"
-        )
+        for row in catalog_b._conn.execute("SELECT event_id FROM events WHERE practice_id = 'p1'")
     }
     missing = expected_ids - persisted
     assert len(missing) == 50  # nothing was committed before the crash
@@ -39,9 +34,7 @@ def test_restart_reconcile_and_backfill(tmp_path: Path) -> None:
         catalog_b.insert_event({"event_id": event_id, "practice_id": "p1"})
     persisted = {
         row[0]
-        for row in catalog_b._conn.execute(
-            "SELECT event_id FROM events WHERE practice_id = 'p1'"
-        )
+        for row in catalog_b._conn.execute("SELECT event_id FROM events WHERE practice_id = 'p1'")
     }
     assert persisted == expected_ids
     catalog_b.close()

--- a/tests/storage/faults/test_process_restart.py
+++ b/tests/storage/faults/test_process_restart.py
@@ -1,0 +1,47 @@
+"""Fault injection: process restart — reconcile finds the gap, repair closes it."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from rosclaw.practice.storage.catalog import PracticeCatalog
+
+
+def test_restart_reconcile_and_backfill(tmp_path: Path) -> None:
+    db = tmp_path / "catalog.sqlite"
+
+    # Process A: queue 50 events with a very slow flush interval, then "die"
+    # before any flush (simulated by abandoning the catalog without close).
+    catalog_a = PracticeCatalog(db, event_batch_size=500, event_flush_ms=60_000.0)
+    expected_ids = {f"e{i:03d}" for i in range(50)}
+    for i, event_id in enumerate(sorted(expected_ids), start=1):
+        catalog_a.insert_event(
+            {"event_id": event_id, "practice_id": "p1", "_wm": i}
+        )
+    # Kill the writers without flushing (process crash simulation).
+    catalog_a._event_writer._closed = True
+    catalog_a._event_index_writer._closed = True
+
+    # Process B: reopen and reconcile — the unflushed events are missing.
+    catalog_b = PracticeCatalog(db, event_batch_size=1)
+    persisted = {
+        row[0]
+        for row in catalog_b._conn.execute(
+            "SELECT event_id FROM events WHERE practice_id = 'p1'"
+        )
+    }
+    missing = expected_ids - persisted
+    assert len(missing) == 50  # nothing was committed before the crash
+
+    # Backfill from the raw JSONL (source of truth) and reconcile again.
+    for event_id in sorted(missing):
+        catalog_b.insert_event({"event_id": event_id, "practice_id": "p1"})
+    persisted = {
+        row[0]
+        for row in catalog_b._conn.execute(
+            "SELECT event_id FROM events WHERE practice_id = 'p1'"
+        )
+    }
+    assert persisted == expected_ids
+    catalog_b.close()

--- a/tests/storage/faults/test_remote_timeout.py
+++ b/tests/storage/faults/test_remote_timeout.py
@@ -1,0 +1,60 @@
+"""Fault injection: remote timeout — backoff, dead letter with payload, replay."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from rosclaw.storage.outbox import OutboxStore, OutboxWorker
+
+
+@pytest.fixture
+def outbox(tmp_path: Path) -> OutboxStore:
+    store = OutboxStore(db_path=str(tmp_path / "outbox.sqlite"))
+    store.connect()
+    return store
+
+
+def test_repeated_timeouts_dead_letter_with_full_payload(outbox: OutboxStore) -> None:
+    committer = MagicMock()
+    committer.save_to_seekdb_batch = None
+    committer.save_to_seekdb.side_effect = TimeoutError("read timed out")
+    worker = OutboxWorker(outbox, committer, interval_sec=0.02, max_retries=3)
+    rid = outbox.enqueue(
+        "seekdb_http",
+        {"event": "important", "data": [1, 2, 3]},
+        idempotency_key="failure:f1:v1",
+        entity_type="failure",
+        entity_id="f1",
+    )
+    worker.start()
+    for _ in range(500):
+        if outbox.stats()["dead_letters"] == 1:
+            break
+        time.sleep(0.02)
+    worker.stop()
+
+    dead = outbox.dead_letters()
+    assert len(dead) == 1
+    assert dead[0].id == rid
+    # Payload and identity survive dead-lettering (no {} upload, no loss).
+    assert dead[0].payload == {"event": "important", "data": [1, 2, 3]}
+    assert dead[0].idempotency_key == "failure:f1:v1"
+    assert "timed out" in (dead[0].error_log or "")
+
+    # Operator replays the dead letter once the remote is healthy again.
+    assert outbox.requeue_dead_letter(rid)
+    committer.save_to_seekdb.side_effect = None
+    worker2 = OutboxWorker(outbox, committer, interval_sec=0.02)
+    worker2.start()
+    for _ in range(500):
+        if outbox.stats()["delivered"] == 1:
+            break
+        time.sleep(0.02)
+    worker2.stop()
+    assert outbox.stats()["delivered"] == 1
+    payload = committer.save_to_seekdb.call_args_list[-1][0][0]
+    assert payload["idempotency_key"] == "failure:f1:v1"

--- a/tests/storage/faults/test_schema_drift.py
+++ b/tests/storage/faults/test_schema_drift.py
@@ -1,0 +1,49 @@
+"""Fault injection: migration schema drift — runtime refuses the database."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from rosclaw.storage.migrations import MigrationRunner
+
+
+def _make_migrations(dir_path: Path, sql: str) -> Path:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / "001_create_widgets.sql").write_text(sql, encoding="utf-8")
+    return dir_path
+
+
+def test_checksum_mismatch_is_rejected(tmp_path: Path) -> None:
+    mig_dir = _make_migrations(
+        tmp_path / "migrations",
+        "CREATE TABLE widgets (id TEXT PRIMARY KEY, value INTEGER);\n",
+    )
+    db = tmp_path / "app.sqlite"
+    conn = sqlite3.connect(str(db))
+    runner = MigrationRunner(migrations_dir=mig_dir)
+    applied = runner.apply(conn, "sqlite")
+    assert applied == ["001"]
+
+    # An operator/hot-patcher edits the applied migration: drift.
+    (mig_dir / "001_create_widgets.sql").write_text(
+        "CREATE TABLE widgets (id TEXT PRIMARY KEY, value INTEGER, extra TEXT);\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        runner.apply(conn, "sqlite")
+    conn.close()
+
+
+def test_pending_reports_nothing_after_clean_apply(tmp_path: Path) -> None:
+    mig_dir = _make_migrations(
+        tmp_path / "migrations",
+        "CREATE TABLE widgets (id TEXT PRIMARY KEY);\n",
+    )
+    conn = sqlite3.connect(str(tmp_path / "app.sqlite"))
+    runner = MigrationRunner(migrations_dir=mig_dir)
+    runner.apply(conn, "sqlite")
+    assert runner.pending(conn, "sqlite") == []
+    conn.close()

--- a/tests/storage/faults/test_sqlite_locked.py
+++ b/tests/storage/faults/test_sqlite_locked.py
@@ -19,15 +19,11 @@ def test_catalog_retries_flush_while_database_locked() -> None:
         # Hold an exclusive write lock from a second connection ("SQLite 被锁").
         locker = sqlite3.connect(str(db), check_same_thread=False)
         locker.execute("BEGIN IMMEDIATE")
-        locker.execute(
-            "INSERT INTO practices (practice_id) VALUES ('lock_holder')"
-        )
+        locker.execute("INSERT INTO practices (practice_id) VALUES ('lock_holder')")
 
         # Events keep queueing while the database is locked.
         for i in range(1, 21):
-            catalog.insert_event(
-                {"event_id": f"e{i}", "practice_id": "p1", "_wm": i}
-            )
+            catalog.insert_event({"event_id": f"e{i}", "practice_id": "p1", "_wm": i})
             catalog.insert_event_index(
                 {"event_id": f"e{i}", "session_id": "s1", "summary": {}, "_wm": i}
             )

--- a/tests/storage/faults/test_sqlite_locked.py
+++ b/tests/storage/faults/test_sqlite_locked.py
@@ -1,0 +1,58 @@
+"""Fault injection: SQLite locked — raw writes continue, catalog retries."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+from rosclaw.practice.storage.catalog import PracticeCatalog
+
+
+def test_catalog_retries_flush_while_database_locked() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "catalog.sqlite"
+        catalog = PracticeCatalog(db, event_batch_size=500, event_flush_ms=50.0)
+
+        # Hold an exclusive write lock from a second connection ("SQLite 被锁").
+        locker = sqlite3.connect(str(db), check_same_thread=False)
+        locker.execute("BEGIN IMMEDIATE")
+        locker.execute(
+            "INSERT INTO practices (practice_id) VALUES ('lock_holder')"
+        )
+
+        # Events keep queueing while the database is locked.
+        for i in range(1, 21):
+            catalog.insert_event(
+                {"event_id": f"e{i}", "practice_id": "p1", "_wm": i}
+            )
+            catalog.insert_event_index(
+                {"event_id": f"e{i}", "session_id": "s1", "summary": {}, "_wm": i}
+            )
+
+        # Release the lock after ~1.5s; the writer must retry, not die.
+        def _unlock() -> None:
+            time.sleep(1.5)
+            locker.commit()
+            locker.close()
+
+        threading.Thread(target=_unlock, daemon=True).start()
+
+        result = catalog.flush_until(20, timeout_sec=30.0)
+        assert result["ok"], result
+        assert catalog.count_events("p1") == 20
+        catalog.close()
+
+
+def test_lock_error_eventually_surfaces_loudly() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "catalog.sqlite"
+        catalog = PracticeCatalog(db, event_batch_size=1)
+        # Simulate a non-transient failure (schema mismatch) via direct SQL.
+        import pytest
+
+        with pytest.raises(sqlite3.Error):
+            catalog._conn.execute("INSERT INTO no_such_table VALUES (1)")
+        catalog.close()

--- a/tests/storage/test_db_reconcile.py
+++ b/tests/storage/test_db_reconcile.py
@@ -54,9 +54,7 @@ def _write_session(
     conn.execute(
         "CREATE TABLE IF NOT EXISTS practices (practice_id TEXT PRIMARY KEY, session_id TEXT, episode_id TEXT)"
     )
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS events (event_id TEXT PRIMARY KEY, practice_id TEXT)"
-    )
+    conn.execute("CREATE TABLE IF NOT EXISTS events (event_id TEXT PRIMARY KEY, practice_id TEXT)")
     conn.execute(
         "CREATE TABLE IF NOT EXISTS practice_event_index (event_id TEXT PRIMARY KEY, session_id TEXT, episode_id TEXT)"
     )

--- a/tests/storage/test_db_reconcile.py
+++ b/tests/storage/test_db_reconcile.py
@@ -1,0 +1,159 @@
+"""Tests for rosclaw db reconcile."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+import yaml
+
+from rosclaw.storage.cli import cmd_db_reconcile, reconcile_practice
+
+
+def _write_session(
+    root: Path,
+    practice_id: str,
+    event_ids: list[str],
+    *,
+    session_id: str | None = None,
+    episode_id: str | None = None,
+) -> Path:
+    session_id = session_id or f"sess_{practice_id}"
+    episode_id = episode_id or f"ep_{practice_id}"
+    session_dir = root / "sessions" / practice_id
+    raw = session_dir / "raw"
+    raw.mkdir(parents=True, exist_ok=True)
+    with (raw / "events.jsonl").open("w", encoding="utf-8") as f:
+        for i, event_id in enumerate(event_ids):
+            f.write(
+                json.dumps(
+                    {
+                        "event_id": event_id,
+                        "practice_id": practice_id,
+                        "session_id": session_id,
+                        "episode_id": episode_id,
+                        "event_type": "skill.invoke",
+                        "sequence_id": i + 1,
+                    }
+                )
+                + "\n"
+            )
+    (session_dir / "episode.json").write_text(
+        json.dumps({"event_count": len(event_ids)}), encoding="utf-8"
+    )
+    (session_dir / "manifest.yaml").write_text(
+        yaml.safe_dump({"practice_id": practice_id, "event_count": len(event_ids)}),
+        encoding="utf-8",
+    )
+
+    indexes = root / "indexes"
+    indexes.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(indexes / "practice_catalog.sqlite"))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS practices (practice_id TEXT PRIMARY KEY, session_id TEXT, episode_id TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS events (event_id TEXT PRIMARY KEY, practice_id TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS practice_event_index (event_id TEXT PRIMARY KEY, session_id TEXT, episode_id TEXT)"
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO practices (practice_id, session_id, episode_id) VALUES (?, ?, ?)",
+        (practice_id, session_id, episode_id),
+    )
+    for event_id in event_ids:
+        conn.execute(
+            "INSERT OR REPLACE INTO events (event_id, practice_id) VALUES (?, ?)",
+            (event_id, practice_id),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO practice_event_index (event_id, session_id, episode_id) VALUES (?, ?, ?)",
+            (event_id, session_id, episode_id),
+        )
+    conn.commit()
+    conn.close()
+    return session_dir
+
+
+def test_reconcile_passes_for_consistent_session(tmp_path: Path) -> None:
+    ids = [f"evt_{i:04d}" for i in range(50)]
+    _write_session(tmp_path, "prac_ok", ids)
+    report = reconcile_practice("prac_ok", str(tmp_path))
+    assert report["passed"]
+    assert report["raw_jsonl"] == 50
+    assert report["catalog_events"] == 50
+    assert report["event_index"] == 50
+    assert report["manifest_event_count"] == 50
+    assert report["episode_event_count"] == 50
+    assert report["duplicates"] == 0
+    hashes = report["hashes"]
+    assert hashes["jsonl_event_ids"] == hashes["catalog_event_ids"] == hashes["event_index_ids"]
+
+
+def test_reconcile_fails_when_catalog_missing_events(tmp_path: Path) -> None:
+    ids = [f"evt_{i:04d}" for i in range(10)]
+    _write_session(tmp_path, "prac_gap", ids)
+    catalog = tmp_path / "indexes" / "practice_catalog.sqlite"
+    conn = sqlite3.connect(str(catalog))
+    conn.execute("DELETE FROM events WHERE event_id = 'evt_0003'")
+    conn.commit()
+    conn.close()
+    report = reconcile_practice("prac_gap", str(tmp_path))
+    assert not report["passed"]
+    assert report["missing"] == ["evt_0003"]
+    assert report["missing_count"] == 1
+
+
+def test_reconcile_detects_duplicate_event_ids(tmp_path: Path) -> None:
+    ids = [f"evt_{i:04d}" for i in range(5)]
+    session_dir = _write_session(tmp_path, "prac_dup", ids)
+    with (session_dir / "raw" / "events.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"event_id": "evt_0001", "practice_id": "prac_dup"}) + "\n")
+    report = reconcile_practice("prac_dup", str(tmp_path))
+    assert not report["passed"]
+    assert report["duplicates"] == 1
+
+
+def test_reconcile_missing_session_reports_error(tmp_path: Path) -> None:
+    report = reconcile_practice("prac_missing", str(tmp_path))
+    assert not report["passed"]
+    assert report["error"] == "events.jsonl not found"
+
+
+def test_reconcile_remote_counts(tmp_path: Path) -> None:
+    ids = [f"evt_{i:04d}" for i in range(3)]
+    _write_session(tmp_path, "prac_remote", ids)
+
+    class _FakeRemote:
+        def count(self, table: str, filters: dict | None = None) -> int:
+            assert filters == {"practice_id": "prac_remote"}
+            return {"episodes": 1, "body_cognition": 4}.get(table, 0)
+
+    report = reconcile_practice("prac_remote", str(tmp_path), remote_client=_FakeRemote())
+    assert report["passed"]
+    assert report["remote_episode"] == 1
+    assert report["remote_memories"] == 4
+
+
+def test_cmd_db_reconcile_all_json(tmp_path: Path, capsys) -> None:
+    _write_session(tmp_path, "prac_a", [f"evt_a{i}" for i in range(4)])
+    _write_session(tmp_path, "prac_b", [f"evt_b{i}" for i in range(6)])
+    args = argparse.Namespace(
+        practice_id=None,
+        all=True,
+        data_root=str(tmp_path),
+        remote=False,
+        json=True,
+        backend="sqlite",
+        url=None,
+        path=str(tmp_path / "knowledge.sqlite"),
+        max_missing=20,
+    )
+    rc = cmd_db_reconcile(args)
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["passed"]
+    assert {r["practice_id"] for r in output["sessions"]} == {"prac_a", "prac_b"}

--- a/tests/storage/test_outbox.py
+++ b/tests/storage/test_outbox.py
@@ -276,8 +276,10 @@ def test_worker_drains_to_http_endpoint_per_record(outbox: OutboxStore, http_com
     assert drained == 2
     assert outbox.stats()["total"] == 0
     assert len(http_committer.state["received"]) == 2
-    assert {"event": "a"} in http_committer.state["received"]
-    assert {"event": "b"} in http_committer.state["received"]
+    events = {p.get("event") for p in http_committer.state["received"]}
+    assert events == {"a", "b"}
+    # The worker attaches the record's idempotency key for remote upsert.
+    assert all("idempotency_key" in p for p in http_committer.state["received"])
 
 
 def test_worker_drains_to_http_endpoint_in_batches(outbox: OutboxStore, http_committer) -> None:
@@ -292,8 +294,9 @@ def test_worker_drains_to_http_endpoint_in_batches(outbox: OutboxStore, http_com
     assert len(http_committer.state["received"]) == 1
     payloads = http_committer.state["received"][0]
     assert isinstance(payloads, list)
-    assert {"event": "a"} in payloads
-    assert {"event": "b"} in payloads
+    events = {p.get("event") for p in payloads}
+    assert events == {"a", "b"}
+    assert all("idempotency_key" in p for p in payloads)
 
 
 def test_worker_http_failure_retries_and_dead_letters(outbox: OutboxStore, http_committer) -> None:

--- a/tests/storage/test_outbox_v2.py
+++ b/tests/storage/test_outbox_v2.py
@@ -1,0 +1,200 @@
+"""Tests for outbox schema v2: idempotency, lease claim, delivered retention."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from rosclaw.storage.outbox import OutboxStore, OutboxWorker
+
+
+@pytest.fixture
+def outbox(tmp_path: Path) -> OutboxStore:
+    store = OutboxStore(db_path=str(tmp_path / "outbox.sqlite"))
+    store.connect()
+    return store
+
+
+def test_enqueue_is_idempotent_on_key(outbox: OutboxStore) -> None:
+    first = outbox.enqueue("t", {"a": 1}, idempotency_key="episode:ep1:v1")
+    second = outbox.enqueue("t", {"a": 1}, idempotency_key="episode:ep1:v1")
+    assert first == second
+    assert outbox.stats()["total"] == 1
+
+
+def test_enqueue_derives_key_and_stores_hash(outbox: OutboxStore) -> None:
+    outbox.enqueue("t", {"a": 1}, entity_type="memory", entity_id="m1")
+    record = outbox.pending(limit=1)[0]
+    assert record.idempotency_key is not None
+    assert record.idempotency_key.startswith("memory:m1:")
+    assert record.payload_sha256 is not None
+    assert len(record.payload_sha256) == 64
+
+
+def test_claim_sets_inflight_and_lease(outbox: OutboxStore) -> None:
+    outbox.enqueue("t", {"a": 1})
+    claimed = outbox.claim(10, owner="w1", lease_sec=30.0)
+    assert len(claimed) == 1
+    record = claimed[0]
+    assert record.status == "inflight"
+    assert record.lease_owner == "w1"
+    assert record.lease_expires_at is not None and record.lease_expires_at > time.time()
+    # A second worker cannot claim the leased record.
+    assert outbox.claim(10, owner="w2", lease_sec=30.0) == []
+
+
+def test_claim_recovers_expired_lease(outbox: OutboxStore) -> None:
+    outbox.enqueue("t", {"a": 1})
+    claimed = outbox.claim(10, owner="w1", lease_sec=0.05)
+    assert len(claimed) == 1
+    time.sleep(0.08)
+    reclaimed = outbox.claim(10, owner="w2", lease_sec=30.0)
+    assert len(reclaimed) == 1
+    assert reclaimed[0].lease_owner == "w2"
+
+
+def test_concurrent_workers_claim_disjoint_records(outbox: OutboxStore) -> None:
+    for i in range(6):
+        outbox.enqueue("t", {"i": i})
+    w1 = outbox.claim(3, owner="w1")
+    w2 = outbox.claim(3, owner="w2")
+    w3 = outbox.claim(3, owner="w3")
+    assert len(w1) == 3
+    assert len(w2) == 3
+    assert w3 == []
+    assert {r.id for r in w1}.isdisjoint({r.id for r in w2})
+
+
+def test_mark_delivered_requires_owner(outbox: OutboxStore) -> None:
+    outbox.enqueue("t", {"a": 1})
+    claimed = outbox.claim(10, owner="w1")
+    outbox.mark_delivered(claimed[0].id, owner="intruder")
+    # Not delivered: lease owner mismatch, record still inflight under w1.
+    assert outbox.stats()["inflight"] == 1
+    outbox.mark_delivered(claimed[0].id, owner="w1", remote_revision="rev-7")
+    assert outbox.stats()["inflight"] == 0
+    assert outbox.stats()["delivered"] == 1
+    record = outbox.records()[0]
+    assert record.status == "delivered"
+    assert record.remote_revision == "rev-7"
+
+
+def test_purge_delivered_respects_retention(outbox: OutboxStore) -> None:
+    outbox.enqueue("t", {"a": 1})
+    claimed = outbox.claim(10, owner="w1")
+    outbox.mark_delivered(claimed[0].id, owner="w1")
+    assert outbox.purge_delivered(retention_sec=3600.0) == 0
+    assert outbox.purge_delivered(retention_sec=0.0) == 1
+    assert outbox.stats()["delivered"] == 0
+
+
+def test_corrupt_payload_goes_to_dead_letters(outbox: OutboxStore) -> None:
+    rid = outbox.enqueue("t", {"a": 1})
+    # Simulate on-disk corruption of the stored payload.
+    outbox._connection.execute(
+        "UPDATE outbox SET payload_json = '{corrupted' WHERE id = ?", (rid,)
+    )
+    outbox._connection.commit()
+    claimed = outbox.claim(10, owner="w1")
+    assert claimed == []
+    dead = outbox.dead_letters()
+    assert len(dead) == 1
+    assert dead[0].id == rid
+    assert dead[0].error_log == "payload checksum mismatch"
+
+
+def test_requeue_dead_letter(outbox: OutboxStore) -> None:
+    rid = outbox.enqueue("t", {"a": 1})
+    outbox.mark_failed(rid, "boom", max_retries=1)
+    assert outbox.stats()["dead_letters"] == 1
+    assert outbox.requeue_dead_letter(rid)
+    assert outbox.stats()["dead_letters"] == 0
+    pending = outbox.pending(limit=10)
+    assert len(pending) == 1
+    assert pending[0].id == rid
+    assert pending[0].retry_count == 0
+    # Requeueing a missing id is a no-op.
+    assert not outbox.requeue_dead_letter("missing")
+
+
+def test_worker_injects_idempotency_key(outbox: OutboxStore) -> None:
+    committer = MagicMock()
+    committer.save_to_seekdb_batch = None
+    worker = OutboxWorker(outbox, committer, interval_sec=60.0)
+    outbox.enqueue("t", {"a": 1}, idempotency_key="fact:f1:v2")
+    worker._drain_once()
+    worker.stop()
+    payload = committer.save_to_seekdb.call_args[0][0]
+    assert payload["idempotency_key"] == "fact:f1:v2"
+    assert payload["a"] == 1
+    # Original stored payload is not mutated.
+    assert outbox.records()[0].payload == {"a": 1}
+
+
+def test_worker_restart_resumes_unfinished_records(tmp_path: Path) -> None:
+    store = OutboxStore(db_path=str(tmp_path / "outbox.sqlite"))
+    store.connect()
+    committer = MagicMock()
+    committer.save_to_seekdb_batch = None
+    committer.save_to_seekdb.side_effect = RuntimeError("down")
+    worker = OutboxWorker(store, committer, interval_sec=60.0, lease_sec=0.05, max_retries=5)
+    store.enqueue("t", {"a": 1})
+    worker._drain_once()  # fails, record goes to retry
+    worker.stop()
+    assert store.stats()["total"] == 1
+
+    # Simulate process restart: new store + worker over the same file.
+    store.close()
+    store2 = OutboxStore(db_path=str(tmp_path / "outbox.sqlite"))
+    store2.connect()
+    committer2 = MagicMock()
+    committer2.save_to_seekdb_batch = None
+    worker2 = OutboxWorker(store2, committer2, interval_sec=60.0)
+    # Force the retry to be due.
+    store2._connection.execute("UPDATE outbox SET next_retry_at = 0")
+    store2._connection.commit()
+    worker2._drain_once()
+    worker2.stop()
+    assert committer2.save_to_seekdb.call_count == 1
+    assert store2.stats()["total"] == 0
+    assert store2.stats()["delivered"] == 1
+    store2.close()
+
+
+def test_v1_database_migrates_in_place(tmp_path: Path) -> None:
+    db = tmp_path / "outbox.sqlite"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE outbox (
+            id TEXT PRIMARY KEY,
+            target TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            retry_count INTEGER DEFAULT 0,
+            next_retry_at REAL,
+            error_log TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO outbox (id, target, payload_json, created_at, retry_count) "
+        "VALUES ('r1', 't', '{}', 1.0, 0)"
+    )
+    conn.commit()
+    conn.close()
+
+    store = OutboxStore(db_path=str(db))
+    store.connect()
+    record = store.pending(limit=1)[0]
+    assert record.id == "r1"
+    assert record.status == "pending"
+    # New columns exist and are nullable for legacy rows.
+    columns = {row[1] for row in store._connection.execute("PRAGMA table_info(outbox)")}
+    for expected in ("idempotency_key", "status", "lease_owner", "payload_sha256"):
+        assert expected in columns
+    store.close()

--- a/tests/storage/test_outbox_v2.py
+++ b/tests/storage/test_outbox_v2.py
@@ -95,9 +95,7 @@ def test_purge_delivered_respects_retention(outbox: OutboxStore) -> None:
 def test_corrupt_payload_goes_to_dead_letters(outbox: OutboxStore) -> None:
     rid = outbox.enqueue("t", {"a": 1})
     # Simulate on-disk corruption of the stored payload.
-    outbox._connection.execute(
-        "UPDATE outbox SET payload_json = '{corrupted' WHERE id = ?", (rid,)
-    )
+    outbox._connection.execute("UPDATE outbox SET payload_json = '{corrupted' WHERE id = ?", (rid,))
     outbox._connection.commit()
     claimed = outbox.claim(10, owner="w1")
     assert claimed == []

--- a/tests/storage/test_storage_unification.py
+++ b/tests/storage/test_storage_unification.py
@@ -74,6 +74,9 @@ class TestOutboxAndMigrationsTogether:
         assert stats == {
             "total": 0,
             "pending": 0,
+            "inflight": 0,
+            "retry": 0,
+            "delivered": 0,
             "failed": 0,
             "dead_letters": 0,
             "oldest_pending_sec": None,


### PR DESCRIPTION
## 目标（数据库优化v2.md §4）

从「数据库可用」升级到「数据绝不静默丢失」。证明 RuntimeEvent → JSONL/MCAP → PracticeCatalog → EventIndex → Episode Summary → Outbox → SeekDB 全链路在异常下不静默丢数据。

## 变更

### 1. 统一持久化水位 + Flush Barrier（§4.2）
- Recorder/Catalog 跟踪 `produced_sequence` 与各路径已持久化水位（JSONL / catalog events / event_index / MCAP）。
- 新增 `PracticeCatalog.flush_until(sequence_id, timeout_sec)`：仅在批次**真正提交**后返回，禁止以 `queue.empty()` 冒充 flush 完成。
- 新增 `PracticeRecorder.flush_barrier()`；Session Finalize 前强制执行（不满足记 CRITICAL，不阻塞机器人）；各路径失败序列号独立记账，后续水位不会掩盖缺口。

### 2. Outbox 升级（§4.3）
- `idempotency_key`（partial unique index）+ enqueue 去重：同一逻辑实体重复投递不产生重复远程记录。
- `payload_sha256` claim 时校验：损坏 payload 直送 dead letter，绝不上传 `{}`。
- pending → inflight → delivered / retry / dead_letter 状态机；租约式**多 worker 原子 claim**（同事务内重检谓词）；worker 崩溃经租约过期自动接管；delivered 保留期 + purge；`requeue_dead_letter()`。
- 传输语义 = At-least-once + Idempotent remote upsert（effectively once，不宣称严格 Exactly Once）。
- SeekDBBridge 以 `praxis_event:<event_id>` 幂等键入队。

### 3. `rosclaw db reconcile`（§4.4）
- `--practice-id / --all / --remote / --json`；核对 raw_jsonl = catalog = event_index = manifest = episode.json，event-id 集合哈希比对，列出缺失 id，机器可读 JSON。

### 4. 真实世界验证（7×24 压力测试，35 小时）
- 140 sessions / **5,310,841 events** 全量对账：**PR #79 时代 29/29 sessions 完全一致**（0 缺失、0 重复、三方哈希相等）。
- 工具**定位到唯一真实丢失事件**：7×24 session #6 的最后一条 `runtime.stop`，根因 = 批写线程在连接关闭后 flush（`Cannot operate on a closed database`）。
- 本 PR 修复该竞态：writer 未停不关闭连接 + flush 瞬态锁重试（backoff）+ `PRAGMA busy_timeout=5000` + finalize 前 flush barrier。

### 5. Fault Injection（§4.5）
`tests/storage/faults/` 10 文件 24 用例：SQLite 锁定、磁盘满、批写崩溃、outbox worker 崩溃、网络分区、远程超时、重复投递、payload 损坏、进程重启、schema 漂移。

## 验收（§4.6）— 全绿，证据在 reports/storage/20260716T194012Z/

- [x] **100 万 Event Replay 无静默丢失**（17.3k ev/s，barrier 0.42s，reconcile 通过）
- [x] generated = JSONL = Catalog = EventIndex
- [x] Outbox 重复投递远程无重复
- [x] Network Partition 不影响机器人执行
- [x] Worker Restart 自动续传
- [x] SQLite integrity_check 通过（practice_catalog / seekdb 均 ok）
- [x] db reconcile 输出可机器读取 JSON
- [x] 所有 Fault Injection 有原始日志

## 测试

- `tests/storage/` + `tests/practice/`：271 passed, 4 skipped
- 全套件：4040 passed；3–5 个 serial mock flake 已确认在 pristine main 同样失败（与本 PR 无关）
- ruff check / ruff format（变更文件）/ mypy（变更文件）全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)