### PR TITLE
feat(storage): PR-SDB-1 native SeekDB embedded/server backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ practice-export = [
     "pandas>=2.0.0",
     "pyarrow>=15.0.0",
 ]
+seekdb = [
+    # Native SeekDB embedded/server backend (PR-SDB-1).  Pinned to the
+    # version validated on Jetson aarch64 (glibc 2.39, Python 3.12).
+    "pyseekdb==1.3.0",
+]
 lerobot = [
     "lerobot>=0.6,<0.7",
 ]

--- a/src/rosclaw/memory/v2/repository.py
+++ b/src/rosclaw/memory/v2/repository.py
@@ -28,8 +28,12 @@ class MemoryRepository:
     telemetry windows, human feedback, or critic results.
     """
 
-    def __init__(self, client: Any):
+    def __init__(self, client: Any, projection: Any | None = None):
         self._client = client
+        # Optional SQLite → native SeekDB retrieval projection (§7.5).
+        # When present, every successful local write is projected (via the
+        # projection's outbox or directly) so the native index stays current.
+        self._projection = projection
 
     # ------------------------------------------------------------------
     # Write path
@@ -59,6 +63,7 @@ class MemoryRepository:
         for ev in rows:
             ev.memory_id = item.memory_id
             self._client.insert(EVIDENCE_TABLE, ev.to_record())
+        self._project(item.to_record())
         return item.memory_id
 
     def merge_into(self, target_id: str, item: MemoryItem) -> bool:
@@ -108,11 +113,25 @@ class MemoryRepository:
         return self.store(new_item)
 
     def mark_status(self, memory_id: str, status: str) -> bool:
-        return bool(
+        updated = bool(
             self._client.update(
                 ITEMS_TABLE, memory_id, {"status": status, "updated_at": time.time()}
             )
         )
+        if updated and self._projection is not None:
+            item = self.get(memory_id)
+            if item is not None:
+                self._project(item.to_record())
+        return updated
+
+    def _project(self, record: dict[str, Any]) -> None:
+        """Best-effort projection into native SeekDB (never blocks the write)."""
+        if self._projection is None:
+            return
+        try:
+            self._projection.project(record)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("SeekDB projection failed for %s: %s", record.get("id"), exc)
 
     def pin(self, memory_id: str, pinned: bool = True) -> bool:
         """Safety/human-approved pinning: pinned memories never decay or expire."""

--- a/src/rosclaw/storage/factory.py
+++ b/src/rosclaw/storage/factory.py
@@ -149,8 +149,42 @@ class StorageFactory:
                 write_timeout=10.0,
             )
 
+        if chosen == "seekdb_embedded":
+            from rosclaw.storage.seekdb_native import SeekDBEmbeddedStore
+
+            db_path = path or (str(url) if url and not _is_http_url(url) else None)
+            logger.info("Knowledge store backend: seekdb_embedded (%s)", db_path or "default")
+            if db_path:
+                return SeekDBEmbeddedStore(path=db_path)
+            return SeekDBEmbeddedStore()
+
+        if chosen == "seekdb_server":
+            from urllib.parse import urlparse
+
+            from rosclaw.storage.seekdb_native import SeekDBServerStore
+
+            if not url:
+                raise ValueError(
+                    "seekdb_backend='seekdb_server' requires seekdb_url "
+                    "(e.g. mysql://root@127.0.0.1:2881/rosclaw or seekdb://root@host:2881/db)."
+                )
+            if _is_http_url(url):
+                raise ValueError(
+                    f"seekdb_backend='seekdb_server' but seekdb_url looks like HTTP ({url})."
+                )
+            parsed = urlparse(str(url))
+            logger.info("Knowledge store backend: seekdb_server (%s)", _sanitize_url(str(url)))
+            return SeekDBServerStore(
+                host=parsed.hostname or "127.0.0.1",
+                port=parsed.port or 2881,
+                user=parsed.username or "root",
+                password=parsed.password or "",
+                database=parsed.path.lstrip("/") or "rosclaw",
+            )
+
         raise ValueError(
-            f"Unknown knowledge-store backend '{chosen}'. Supported: memory, sqlite, mysql."
+            f"Unknown knowledge-store backend '{chosen}'. "
+            "Supported: memory, sqlite, mysql, seekdb_embedded, seekdb_server."
         )
 
     @staticmethod

--- a/src/rosclaw/storage/seekdb_native.py
+++ b/src/rosclaw/storage/seekdb_native.py
@@ -1,0 +1,382 @@
+"""Native SeekDB backend via pyseekdb (PR-SDB-1, §7).
+
+``SeekDBNativeStore`` implements the :class:`SeekDBClient` knowledge-store
+interface on top of native SeekDB collections — one collection per knowledge
+table.  Records live as collection metadata; the built-in server-side
+embedder vectorizes the document text, giving:
+
+* native vector search (:meth:`similar`);
+* native BM25 full-text (``hybrid_search`` ``where_document.$contains``);
+* native metadata filters (``where``);
+* native RRF hybrid fusion (:meth:`hybrid_search`).
+
+Nothing here is a Python full-table scan masquerading as native SeekDB:
+relational ``query()`` with filters uses SeekDB's own metadata filtering;
+when an ``order_by`` is requested the result is sorted client-side *after*
+the filtered fetch, which is documented in the docstring.
+
+Two deployments share the class:
+
+* embedded — ``SeekDBNativeStore(path="~/.rosclaw/data/seekdb")``;
+* server — ``SeekDBNativeStore(host=..., port=2881, user=..., password=...)``
+  (also works against OceanBase, which speaks the same protocol).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from rosclaw.memory.seekdb_client import SeekDBClient
+
+logger = logging.getLogger("rosclaw.storage.seekdb_native")
+
+# Fields whose text is used as the embedding document, per table family.
+_TEXT_FIELDS = (
+    "title",
+    "document",
+    "instruction",
+    "description",
+    "error_details",
+    "summary",
+    "subject",
+    "predicate",
+    "object",
+    "condition",
+    "action",
+    "name",
+    "root_cause",
+    "recovery_hint",
+    "hypothesis",
+    "rejection_reason",
+)
+
+
+def _require_pyseekdb():
+    try:
+        import pyseekdb
+    except ImportError as exc:  # pragma: no cover - depends on optional dep
+        raise ImportError(
+            "pyseekdb is required for the native SeekDB backend. "
+            "Install it with: pip install 'rosclaw[seekdb]' (or pip install pyseekdb)"
+        ) from exc
+    return pyseekdb
+
+
+class SeekDBNativeStore(SeekDBClient):
+    """Native SeekDB knowledge store (embedded or server)."""
+
+    def __init__(
+        self,
+        *,
+        path: str | None = None,
+        host: str | None = None,
+        port: int = 2881,
+        user: str = "root",
+        password: str = "",
+        database: str = "rosclaw",
+        protocol: str | None = None,
+    ):
+        if path is None and host is None:
+            raise ValueError("SeekDBNativeStore requires either path (embedded) or host (server)")
+        self._path = path
+        self._host = host
+        self._port = port
+        self._user = user
+        self._password = password
+        self._database = database
+        self._client: Any | None = None
+        self._collections: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def connect(self) -> None:
+        if self._client is not None:
+            return
+        pyseekdb = _require_pyseekdb()
+        if self._path is not None:
+            admin = pyseekdb.AdminClient(path=self._path)
+            self._ensure_database(admin)
+            self._client = pyseekdb.Client(path=self._path, database=self._database)
+        else:
+            admin = pyseekdb.AdminClient(
+                host=self._host, port=self._port, user=self._user, password=self._password
+            )
+            self._ensure_database(admin)
+            self._client = pyseekdb.Client(
+                host=self._host,
+                port=self._port,
+                user=self._user,
+                password=self._password,
+                database=self._database,
+            )
+        logger.info(
+            "SeekDBNativeStore connected (%s, database=%s)",
+            f"embedded:{self._path}" if self._path else f"server:{self._host}:{self._port}",
+            self._database,
+        )
+
+    def _ensure_database(self, admin: Any) -> None:
+        try:
+            admin.create_database(self._database)
+            logger.info("Created SeekDB database %s", self._database)
+        except Exception as exc:  # noqa: BLE001
+            # Database already exists — expected on every start after the first.
+            logger.debug("create_database(%s): %s", self._database, exc)
+
+    def is_connected(self) -> bool:
+        return self._client is not None
+
+    def disconnect(self) -> None:
+        self._client = None
+        self._collections = {}
+
+    # ------------------------------------------------------------------
+    # Collections
+    # ------------------------------------------------------------------
+
+    def _collection(self, table: str) -> Any:
+        if table in self._collections:
+            return self._collections[table]
+        client = self._client
+        if client is None:
+            raise RuntimeError("SeekDBNativeStore is not connected")
+        try:
+            collection = client.get_collection(table)
+        except Exception:  # noqa: BLE001
+            collection = client.create_collection(name=table)
+        self._collections[table] = collection
+        return collection
+
+    @staticmethod
+    def _document_text(record: dict) -> str:
+        parts = [str(record[key]) for key in _TEXT_FIELDS if record.get(key)]
+        if parts:
+            return "\n".join(parts)
+        # Fallback: embed a compact dump so every record is searchable.
+        return " ".join(
+            f"{key}={value}" for key, value in sorted(record.items()) if value is not None
+        )
+
+    @staticmethod
+    def _metadata(record: dict) -> dict[str, Any]:
+        """Collection metadata must be JSON-primitive."""
+        meta: dict[str, Any] = {}
+        for key, value in record.items():
+            if value is None or isinstance(value, (str, int, float, bool)):
+                meta[key] = value
+            else:
+                import json
+
+                meta[key] = json.dumps(value, ensure_ascii=False)
+        return meta
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def insert(self, table: str, record: dict) -> str:
+        collection = self._collection(table)
+        record_id = str(record.get("id") or record.get("memory_id") or "")
+        if not record_id:
+            import uuid
+
+            record_id = str(uuid.uuid4())
+            record = {**record, "id": record_id}
+        collection.upsert(
+            ids=[record_id],
+            documents=[self._document_text(record)],
+            metadatas=[self._metadata(record)],
+        )
+        return record_id
+
+    def insert_many(self, table: str, records: list[dict]) -> int:
+        """Batch upsert, then one index refresh (vector visibility is
+        eventually consistent; refreshing per record is prohibitively slow)."""
+        if not records:
+            return 0
+        collection = self._collection(table)
+        ids = []
+        documents = []
+        metadatas = []
+        import uuid
+
+        for record in records:
+            record_id = str(record.get("id") or record.get("memory_id") or uuid.uuid4())
+            ids.append(record_id)
+            documents.append(self._document_text(record))
+            metadatas.append(self._metadata(record))
+        collection.upsert(ids=ids, documents=documents, metadatas=metadatas)
+        self.refresh_index(table)
+        return len(ids)
+
+    def refresh_index(self, table: str) -> None:
+        """Force the vector index to pick up recent writes."""
+        try:
+            self._collection(table).refresh_index()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("refresh_index(%s): %s", table, exc)
+
+    def query(
+        self,
+        table: str,
+        filters: dict | None = None,
+        order_by: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        collection = self._collection(table)
+        result = collection.get(
+            where=filters or None,
+            limit=limit,
+            include=["metadatas"],
+        )
+        records = self._records_from_result(result)
+        if order_by:
+            reverse = order_by.startswith("-")
+            key = order_by.lstrip("+-")
+            records.sort(key=lambda r: (r.get(key) is None, r.get(key)), reverse=reverse)
+        return records[:limit]
+
+    @staticmethod
+    def _records_from_result(result: dict | None) -> list[dict]:
+        if not result:
+            return []
+        ids = result.get("ids") or []
+        metadatas = result.get("metadatas") or []
+        # get() returns flat lists; query() returns nested lists.
+        if ids and isinstance(ids[0], list):
+            ids = ids[0]
+            metadatas = metadatas[0] if metadatas else []
+        records = []
+        for record_id, metadata in zip(ids, metadatas, strict=False):
+            record = dict(metadata or {})
+            record.setdefault("id", record_id)
+            records.append(record)
+        return records
+
+    def update(self, table: str, record_id: str, updates: dict) -> bool:
+        collection = self._collection(table)
+        existing = collection.get(ids=[record_id], include=["metadatas", "documents"])
+        ids = (existing or {}).get("ids") or []
+        if not ids:
+            return False
+        metadata = dict((existing.get("metadatas") or [{}])[0] or {})
+        metadata.update(self._metadata(updates))
+        document = updates and self._document_text({**metadata, **updates})
+        collection.update(
+            ids=[record_id],
+            documents=[document] if document else None,
+            metadatas=[metadata],
+        )
+        return True
+
+    def count(self, table: str, filters: dict | None = None) -> int:
+        collection = self._collection(table)
+        if not filters:
+            return int(collection.count())
+        return len(self.query(table, filters=filters, limit=100_000))
+
+    def delete(self, table: str, record_id: str) -> bool:
+        collection = self._collection(table)
+        existing = collection.get(ids=[record_id], include=[])
+        if not (existing or {}).get("ids"):
+            return False
+        collection.delete(ids=[record_id])
+        return True
+
+    def delete_where(self, table: str, filters: dict) -> int:
+        records = self.query(table, filters=filters, limit=100_000)
+        ids = [record["id"] for record in records]
+        if ids:
+            self._collection(table).delete(ids=ids)
+        return len(ids)
+
+    # ------------------------------------------------------------------
+    # Native retrieval
+    # ------------------------------------------------------------------
+
+    def similar(
+        self,
+        table: str,
+        query_text: str,
+        filters: dict | None = None,
+        limit: int = 5,
+    ) -> list[dict]:
+        """Native vector search with optional metadata pre-filter."""
+        collection = self._collection(table)
+        result = collection.query(
+            query_texts=[query_text],
+            where=filters or None,
+            n_results=limit,
+            include=["metadatas", "distances"],
+        )
+        records = self._records_from_result(result)
+        distances = (result or {}).get("distances") or [[]]
+        flat = distances[0] if distances and isinstance(distances[0], list) else distances
+        for record, distance in zip(records, flat, strict=False):
+            record["score"] = 1.0 - float(distance) if distance is not None else 0.0
+        return records
+
+    def hybrid_search(
+        self,
+        table: str,
+        query_text: str,
+        filters: dict | None = None,
+        limit: int = 5,
+    ) -> list[dict]:
+        """Native BM25 + vector + metadata filter with RRF fusion."""
+        collection = self._collection(table)
+        result = collection.hybrid_search(
+            query={"where_document": {"$contains": query_text}, "n_results": limit},
+            knn={
+                "query_texts": [query_text],
+                "n_results": limit,
+                **({"where": filters} if filters else {}),
+            },
+            rank={"rrf": {}},
+            n_results=limit,
+            include=["metadatas"],
+        )
+        return self._records_from_result(result)
+
+    def embedding_info(self, table: str) -> dict[str, Any]:
+        """Model identity of the collection's built-in embedder (for §6.5 registry)."""
+        collection = self._collection(table)
+        info: dict[str, Any] = {}
+        try:
+            ef = collection.embedding_function
+            info["embedder_type"] = type(ef).__name__ if ef is not None else None
+            info["model_name"] = getattr(ef, "model_name", None) or getattr(ef, "_model_name", None)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            info["dimension"] = collection.dimension
+        except Exception:  # noqa: BLE001
+            info["dimension"] = None
+        return info
+
+
+# Deployment-specific aliases matching the PR-SDB-1 naming (§7.3).
+class SeekDBEmbeddedStore(SeekDBNativeStore):
+    """Embedded SeekDB (library-in-process) knowledge store."""
+
+    def __init__(self, path: str = "~/.rosclaw/data/seekdb", database: str = "rosclaw"):
+        from pathlib import Path
+
+        super().__init__(path=str(Path(path).expanduser()), database=database)
+
+
+class SeekDBServerStore(SeekDBNativeStore):
+    """Server-mode SeekDB / OceanBase knowledge store."""
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 2881,
+        user: str = "root",
+        password: str = "",
+        database: str = "rosclaw",
+    ):
+        super().__init__(host=host, port=port, user=user, password=password, database=database)

--- a/src/rosclaw/storage/seekdb_projection.py
+++ b/src/rosclaw/storage/seekdb_projection.py
@@ -1,0 +1,104 @@
+"""SQLite → native SeekDB retrieval projection (PR-SDB-1 §7.5).
+
+Transition architecture::
+
+    MemoryRepository
+        → Transaction (local store commit)
+        → Local Store  (SQLite = source of truth)
+        → Outbox       (durable, at-least-once)
+        → SeekDB Projection  (native vector/BM25/hybrid retrieval index)
+
+The projection is *disposable*: it can be dropped and rebuilt from the local
+store at any time (:meth:`SeekDBProjection.rebuild`).  Projection writes are
+idempotent (keyed by ``memory:<memory_id>``), so outbox redelivery never
+duplicates the remote record.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger("rosclaw.storage.seekdb_projection")
+
+PROJECTION_TABLE = "memory_items"
+PROJECTION_TARGET = "seekdb_projection"
+
+
+class SeekDBProjectionCommitter:
+    """Outbox committer that upserts memory records into native SeekDB.
+
+    Implements the ``save_to_seekdb`` / ``save_to_seekdb_batch`` protocol used
+    by :class:`rosclaw.storage.outbox.OutboxWorker`.
+    """
+
+    def __init__(self, store: Any):
+        self._store = store
+
+    def save_to_seekdb(self, payload: dict[str, Any]) -> None:
+        record = dict(payload)
+        record.pop("idempotency_key", None)
+        self._store.connect()
+        self._store.insert(PROJECTION_TABLE, record)
+        self._store.refresh_index(PROJECTION_TABLE)
+
+    def save_to_seekdb_batch(self, payloads: list[dict[str, Any]]) -> None:
+        records = []
+        for payload in payloads:
+            record = dict(payload)
+            record.pop("idempotency_key", None)
+            records.append(record)
+        self._store.connect()
+        self._store.insert_many(PROJECTION_TABLE, records)
+
+
+class SeekDBProjection:
+    """Maintains the native SeekDB retrieval projection of memory_items."""
+
+    def __init__(self, store: Any, outbox: Any | None = None):
+        self._store = store
+        self._outbox = outbox
+
+    def project(self, item_record: dict[str, Any]) -> None:
+        """Project one memory record (post local-commit).
+
+        With an outbox the projection is asynchronous and durable; without one
+        it is a direct synchronous upsert (still idempotent).
+        """
+        memory_id = item_record.get("id")
+        if not memory_id:
+            logger.warning("projection skipped: record without id")
+            return
+        if self._outbox is not None:
+            self._outbox.enqueue(
+                PROJECTION_TARGET,
+                item_record,
+                idempotency_key=f"memory:{memory_id}:projection",
+                entity_type="memory",
+                entity_id=str(memory_id),
+            )
+            return
+        self._store.connect()
+        self._store.insert(PROJECTION_TABLE, item_record)
+
+    def project_delete(self, memory_id: str) -> None:
+        """Remove a memory from the projection (delete sync)."""
+        self._store.connect()
+        self._store.delete(PROJECTION_TABLE, memory_id)
+
+    def rebuild(self, repository: Any, *, batch_size: int = 200) -> dict[str, Any]:
+        """Rebuild the whole projection from the SQLite source of truth."""
+        started = time.time()
+        items = repository.query(limit=500_000)
+        self._store.connect()
+        total = 0
+        for offset in range(0, len(items), batch_size):
+            batch = [item.to_record() for item in items[offset : offset + batch_size]]
+            total += self._store.insert_many(PROJECTION_TABLE, batch)
+        self._store.refresh_index(PROJECTION_TABLE)
+        return {
+            "rebuilt": total,
+            "elapsed_s": round(time.time() - started, 2),
+            "projection": type(self._store).__name__,
+        }

--- a/tests/storage/test_seekdb_native.py
+++ b/tests/storage/test_seekdb_native.py
@@ -206,3 +206,56 @@ def test_native_benchmark_vs_sqlite_scan(tmp_path) -> None:
     )
     assert native_ms < sqlite_ms, f"native {native_ms}ms not faster than sqlite {sqlite_ms}ms"
     sqlite_client.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Server-mode SeekDB (real container: quay.io/oceanbase/seekdb on :2881)
+# ---------------------------------------------------------------------------
+
+
+def _server_reachable() -> bool:
+    import socket
+
+    try:
+        with socket.create_connection(("127.0.0.1", 2881), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(
+    not _server_reachable(), reason="seekdb server container not reachable on :2881"
+)
+def test_server_mode_native_retrieval() -> None:
+    """Real server-mode SeekDB: CRUD + native vector + hybrid + metadata."""
+    from rosclaw.storage.seekdb_native import SeekDBServerStore
+
+    store = SeekDBServerStore(
+        host="127.0.0.1", port=2881, user="root", password="", database="rosclaw_pytest_server"
+    )
+    store.connect()
+    try:
+        records = [
+            {
+                "id": f"srv_t_{i:03d}",
+                "memory_type": "failure",
+                "robot_id": "rh56_rps_robot",
+                "title": f"server failure {i}",
+                "document": f"服务器模式 剪刀失败 {i} overcurrent",
+                "status": "active",
+            }
+            for i in range(20)
+        ]
+        store.insert_many("memory_items", records)
+        assert store.count("memory_items") == 20
+        hits = store.similar("memory_items", "剪刀 过流", limit=5)
+        assert hits
+        assert store.hybrid_search("memory_items", "剪刀", limit=5)
+        assert store.query("memory_items", {"robot_id": "rh56_rps_robot"}, limit=5)
+        assert store.delete("memory_items", "srv_t_000")
+        assert store.count("memory_items") == 19
+        info = store.embedding_info("memory_items")
+        assert info["dimension"] == 384
+    finally:
+        store.delete_where("memory_items", {"robot_id": "rh56_rps_robot"})
+        store.disconnect()

--- a/tests/storage/test_seekdb_native.py
+++ b/tests/storage/test_seekdb_native.py
@@ -1,0 +1,208 @@
+"""Real native SeekDB tests (PR-SDB-1) — no mocks, real embedded engine.
+
+Skipped when pyseekdb is not installed (optional dependency).
+"""
+# ruff: noqa: E402 - imports follow pytest.importorskip by design
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+pyseekdb = pytest.importorskip(  # noqa: E402
+    "pyseekdb", reason="pyseekdb optional dependency not installed"
+)
+
+from rosclaw.memory.v2.models import MemoryItem
+from rosclaw.memory.v2.repository import MemoryRepository
+from rosclaw.storage.seekdb_native import SeekDBEmbeddedStore
+from rosclaw.storage.seekdb_projection import SeekDBProjection
+
+TEST_PATH = "/tmp/seekdb_native_tests"
+
+
+@pytest.fixture
+def store(tmp_path):
+    path = tmp_path / "seekdb"
+    store = SeekDBEmbeddedStore(path=str(path), database="test_db")
+    store.connect()
+    yield store
+    store.disconnect()
+
+
+def _sample_records() -> list[dict]:
+    return [
+        {
+            "id": f"mem_{i:03d}",
+            "memory_type": "failure",
+            "robot_id": "rh56_rps_robot",
+            "body_id": "rh56_right",
+            "task_id": "rh56_rps",
+            "title": f"failure case {i}: scissors overcurrent",
+            "document": f"剪刀手势失败 {i}，食指过流 overcurrent，温度 {40 + i % 5}°C。",
+            "status": "active",
+            "event_time": time.time(),
+        }
+        for i in range(20)
+    ] + [
+        {
+            "id": "mem_other",
+            "memory_type": "failure",
+            "robot_id": "other_robot",
+            "body_id": "other_body",
+            "task_id": "painting",
+            "title": "other robot scissors failure",
+            "document": "scissors failure on another robot.",
+            "status": "active",
+            "event_time": time.time(),
+        }
+    ]
+
+
+def test_crud_roundtrip(store: SeekDBEmbeddedStore) -> None:
+    records = _sample_records()
+    for record in records:
+        store.insert("memory_items", record)
+    assert store.count("memory_items") == len(records)
+    rh56 = store.query("memory_items", {"robot_id": "rh56_rps_robot"}, limit=50)
+    assert len(rh56) == 20
+    assert store.update("memory_items", "mem_000", {"status": "superseded"})
+    row = store.query("memory_items", {"id": "mem_000"}, limit=1)[0]
+    assert row["status"] == "superseded"
+    assert store.delete("memory_items", "mem_000")
+    assert store.count("memory_items") == len(records) - 1
+
+
+def test_native_vector_search(store: SeekDBEmbeddedStore) -> None:
+    store.insert_many("memory_items", _sample_records())
+    hits = store.similar("memory_items", "剪刀 过流", limit=5)
+    assert hits, "native vector search returned nothing"
+    assert all(hit["robot_id"] in {"rh56_rps_robot", "other_robot"} for hit in hits)
+    # Metadata pre-filter isolates robots.
+    rh56_hits = store.similar(
+        "memory_items", "scissors failure", filters={"robot_id": "rh56_rps_robot"}, limit=5
+    )
+    assert rh56_hits
+    assert all(hit["robot_id"] == "rh56_rps_robot" for hit in rh56_hits)
+
+
+def test_native_hybrid_search(store: SeekDBEmbeddedStore) -> None:
+    store.insert_many("memory_items", _sample_records())
+    hits = store.hybrid_search("memory_items", "剪刀", limit=5)
+    assert hits, "native hybrid search returned nothing"
+
+
+def test_restart_persistence(tmp_path) -> None:
+    path = tmp_path / "seekdb"
+    store = SeekDBEmbeddedStore(path=str(path), database="persist_db")
+    store.connect()
+    store.insert_many("memory_items", _sample_records())
+    store.disconnect()
+
+    store2 = SeekDBEmbeddedStore(path=str(path), database="persist_db")
+    store2.connect()
+    assert store2.count("memory_items") == len(_sample_records())
+    hits = store2.similar("memory_items", "剪刀", limit=3)
+    assert hits
+    store2.disconnect()
+
+
+def test_embedding_info(store: SeekDBEmbeddedStore) -> None:
+    info = store.embedding_info("memory_items")
+    assert info["dimension"] == 384
+    assert info["model_name"] == "all-MiniLM-L6-v2"
+
+
+def test_projection_rebuild(tmp_path) -> None:
+    from rosclaw.memory.seekdb_client import SQLiteKnowledgeStore
+
+    sqlite_client = SQLiteKnowledgeStore(str(tmp_path / "knowledge.sqlite"))
+    sqlite_client.connect()
+    repo = MemoryRepository(sqlite_client)
+    for record in _sample_records()[:10]:
+        repo.store(
+            MemoryItem(
+                memory_type=record["memory_type"],
+                robot_id=record["robot_id"],
+                title=record["title"],
+                document=record["document"],
+                evidence_refs=["evt_1"],
+            )
+        )
+
+    store = SeekDBEmbeddedStore(path=str(tmp_path / "seekdb"), database="proj_db")
+    projection = SeekDBProjection(store)
+    result = projection.rebuild(repo)
+    assert result["rebuilt"] == 10
+    hits = store.similar("memory_items", "剪刀 过流", limit=5)
+    assert hits
+    sqlite_client.disconnect()
+
+
+def test_repository_dual_write_via_projection(tmp_path) -> None:
+    from rosclaw.memory.seekdb_client import SQLiteKnowledgeStore
+
+    sqlite_client = SQLiteKnowledgeStore(str(tmp_path / "knowledge.sqlite"))
+    sqlite_client.connect()
+    store = SeekDBEmbeddedStore(path=str(tmp_path / "seekdb"), database="dual_db")
+    projection = SeekDBProjection(store)
+    repo = MemoryRepository(sqlite_client, projection=projection)
+
+    item = MemoryItem(
+        memory_type="failure",
+        robot_id="rh56_rps_robot",
+        title="dual write test failure",
+        document="双手剪刀失败 dual write。",
+        evidence_refs=["evt_1"],
+    )
+    repo.store(item)
+    store.refresh_index("memory_items")
+    assert store.count("memory_items") == 1
+    sqlite_client.disconnect()
+
+
+def test_native_benchmark_vs_sqlite_scan(tmp_path) -> None:
+    """Native HNSW vector search must beat SQLite full-table scan at 10k records."""
+    from rosclaw.memory.seekdb_client import SQLiteKnowledgeStore
+    from rosclaw.storage.vector import SQLiteVectorStore, TfidfEmbedder
+
+    base = _sample_records()
+    records = [
+        {
+            **record,
+            "id": f"{record['id']}_{copy}",
+            "document": f"{record['document']} variant {copy}",
+        }
+        for copy in range(480)
+        for record in base
+    ]  # 10,080 records
+    # Native SeekDB (HNSW index)
+    store = SeekDBEmbeddedStore(path=str(tmp_path / "seekdb"), database="bench_db")
+    store.connect()
+    for offset in range(0, len(records), 1000):
+        store.insert_many("memory_items", records[offset : offset + 1000])
+    t0 = time.perf_counter()
+    for _ in range(10):
+        store.similar("memory_items", "剪刀 过流", limit=5)
+    native_ms = (time.perf_counter() - t0) / 10 * 1000
+
+    # SQLite TF-IDF fallback (full table scan)
+    sqlite_client = SQLiteKnowledgeStore(str(tmp_path / "knowledge.sqlite"))
+    sqlite_client.connect()
+    vector = SQLiteVectorStore(sqlite_client)
+    embedder = TfidfEmbedder().fit([r["document"] for r in records])
+    vector.upsert_many(
+        "memory_items", [(r["id"], r["document"], embedder.encode(r["document"])) for r in records]
+    )
+    query_vec = embedder.encode("剪刀 过流")
+    t0 = time.perf_counter()
+    for _ in range(10):
+        vector.search("memory_items", query_vec, limit=5)
+    sqlite_ms = (time.perf_counter() - t0) / 10 * 1000
+
+    print(
+        f"\nnative hnsw: {native_ms:.1f}ms  sqlite tfidf scan: {sqlite_ms:.1f}ms  ({len(records)} records)"
+    )
+    assert native_ms < sqlite_ms, f"native {native_ms}ms not faster than sqlite {sqlite_ms}ms"
+    sqlite_client.disconnect()


### PR DESCRIPTION
## 目标（数据库优化v2.md §7）

从「SQLite 模拟向量检索」升级为**原生 SeekDB**：原生 HNSW 向量、原生 BM25、原生 metadata 过滤、原生 RRF hybrid —— 无任何 Python 全表扫描冒充原生。

> ⚠️ Stacked on PR #83（PR-MEM-2），base 为其分支；#83 合并后请将 base 改为 main。

## 变更

### 1. `SeekDBNativeStore`（§7.3）
实现 `SeekDBClient` 接口：一表一 pyseekdb collection，记录存为 collection metadata，服务端**内建 embedder**（all-MiniLM-L6-v2, dim=384）自动向量化。
- `similar()` = 原生 HNSW 向量检索（支持 metadata 预过滤）
- `hybrid_search()` = 原生 BM25（`$contains`）+ 向量 + RRF 融合
- `query()` = 原生 metadata 过滤
- `embedding_info()` 输出模型身份供 §6.5 索引注册表使用

部署别名：`SeekDBEmbeddedStore(path)` / `SeekDBServerStore(host, port, user, password, database)`（同协议兼容 OceanBase）。

### 2. StorageFactory + 配置（§7.3）
新增后端 `seekdb_embedded` / `seekdb_server`（DSN 解析 `mysql://user:pass@host:2881/db`）；pyproject 可选依赖 `seekdb = ["pyseekdb==1.3.0"]`（Jetson aarch64 实测通过版本，按要求 pin）。

### 3. Dual-write Projection（§7.5）
```
MemoryRepository → SQLite (source of truth) → Outbox/direct → SeekDBProjection → native index
```
- 幂等键 `memory:<memory_id>:projection`；Projection 是 disposable index，`rebuild()` 可随时从 SQLite 真相源全量重建（10/10 验证）。
- `insert_many` 批量 upsert + 一次 `refresh_index`（向量可见性最终一致）。

## Jetson 真机验证（§7.7，无 Mock）

- Python 3.12 / glibc 2.39 / aarch64 全达标；pyseekdb 1.3.0 安装导入正常
- Embedded 启动 3.25s；1000 插入 99.75s（含 86MB 模型一次性下载）；100 查询 5.79s；重启持久化完好
- 8/8 真实测试通过（pyseekdb 缺失时自动 skip）

## 验收（§7.8）

- [x] Embedded SeekDB 真机测试通过
- [x] Native Vector / BM25 / Hybrid / Metadata Filter 生效
- [x] Restart 后数据与索引完整
- [x] SQLite → SeekDB Projection 可重建
- [x] **Native Benchmark 优于 SQLite 全表扫描**：10,080 条，HNSW **57.9ms** vs TF-IDF 扫描 **376.1ms**（6.5×）
- [ ] Server SeekDB 容器测试：**暂缓** — Docker Hub 网络不可达（pull 超时）；DSN 构造级已验证，未用 Mock 冒充，网络恢复后补测

测试：289 passed（storage+memory+practice）；ruff/mypy 全过。报告：reports/seekdb/20260716T220000Z/

🤖 Generated with [Claude Code](https://claude.com/claude-code)