### PR TITLE
fix(tests/storage): deterministic no-hardware bench tests + seekdb engine readiness

### DIFF
--- a/src/rosclaw/storage/seekdb_native.py
+++ b/src/rosclaw/storage/seekdb_native.py
@@ -112,11 +112,35 @@ class SeekDBNativeStore(SeekDBClient):
                 password=self._password,
                 database=self._database,
             )
+        self._wait_ready()
         logger.info(
             "SeekDBNativeStore connected (%s, database=%s)",
             f"embedded:{self._path}" if self._path else f"server:{self._host}:{self._port}",
             self._database,
         )
+
+    def _wait_ready(self, timeout_s: float = 30.0) -> None:
+        """Block until the (embedded) engine answers catalog queries.
+
+        The embedded SeekDB engine opens asynchronously; under load (full
+        suite) early catalog calls can hit a not-yet-ready engine and lose
+        writes or report missing collections.  Probe with retries so callers
+        never see a half-open engine.
+        """
+        import time
+
+        deadline = time.monotonic() + timeout_s
+        last_exc: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                self._client.list_collections()
+                return
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                time.sleep(0.5)
+        raise RuntimeError(
+            f"SeekDBNativeStore engine not ready within {timeout_s}s: {last_exc}"
+        ) from last_exc
 
     def _ensure_database(self, admin: Any) -> None:
         try:

--- a/tests/test_bench_realsense_metric_semantics.py
+++ b/tests/test_bench_realsense_metric_semantics.py
@@ -67,7 +67,23 @@ class TestBenchRealSenseMetricSemantics:
         assert "aggregate" in saved
 
     def test_report_no_data_still_has_stream_schema(self, tmp_path):
-        report = bench_realsense(duration_sec=0.05, output_dir=str(tmp_path))
+        # Force the no-data path deterministically: a healthy camera on the
+        # test host would otherwise deliver frames within the 50 ms window
+        # and break the (unrelated) schema assertions.
+        from rosclaw.bench import realsense as bench_mod
+
+        def _no_hardware(_duration):
+            raise RuntimeError("no camera")
+
+        original_capture = bench_mod._capture_with_pyrealsense2
+        original_fallback = bench_mod._capture_with_rs_data_collect
+        bench_mod._capture_with_pyrealsense2 = _no_hardware
+        bench_mod._capture_with_rs_data_collect = _no_hardware
+        try:
+            report = bench_realsense(duration_sec=0.05, output_dir=str(tmp_path))
+        finally:
+            bench_mod._capture_with_pyrealsense2 = original_capture
+            bench_mod._capture_with_rs_data_collect = original_fallback
         assert "streams" in report
         assert report["streams"]["color"]["frame_count"] == 0
         assert report["streams"]["depth"]["frame_count"] == 0

--- a/tests/test_bench_realsense_rs_data_collect_parser.py
+++ b/tests/test_bench_realsense_rs_data_collect_parser.py
@@ -59,7 +59,22 @@ class TestBenchRealSenseNoStub:
     def test_bench_realsense_falls_back_without_hardware(self, tmp_path):
         """Without pyrealsense2 or rs-data-collect, bench still writes a report."""
         output_dir = tmp_path / "bench"
-        report = bench_realsense(duration_sec=0.1, output_dir=str(output_dir))
+        # Force the no-hardware path deterministically — on hosts with a
+        # working camera the bench succeeds and errors stay empty.
+        from rosclaw.bench import realsense as bench_mod
+
+        def _no_hardware(_duration):
+            raise RuntimeError("no camera")
+
+        original_capture = bench_mod._capture_with_pyrealsense2
+        original_fallback = bench_mod._capture_with_rs_data_collect
+        bench_mod._capture_with_pyrealsense2 = _no_hardware
+        bench_mod._capture_with_rs_data_collect = _no_hardware
+        try:
+            report = bench_realsense(duration_sec=0.1, output_dir=str(output_dir))
+        finally:
+            bench_mod._capture_with_pyrealsense2 = original_capture
+            bench_mod._capture_with_rs_data_collect = original_fallback
 
         assert report["schema_version"] == "rosclaw.bench.realsense.v1"
         assert report["duration_requested_sec"] == 0.1


### PR DESCRIPTION
## Why

Two environment-flaky failure classes surfaced in the full-suite run on the Jetson (4370 passed / 10 failed):

1. **RealSense bench no-hardware tests** assumed the ambient host has no working camera (`0 frames in 50 ms`, `errors` non-empty). With a healthy camera present they fail by design — including right after the camera recovers from its wedge state.
2. **SeekDB embedded engine startup race**: `SeekDBEmbeddedStore.connect()` returned before the engine was ready; under full-suite load, early catalog calls hit a half-open engine and restart-persistence failed with `Collection not found`.

## Fix

- Both bench tests now force the no-data path explicitly via monkeypatched capture backends (the same pattern already used in these files) — deterministic on any host.
- `SeekDBNativeStore.connect()` probes catalog readiness with retries (30 s budget) so callers never see a half-open engine.

## Verification

- `tests/test_bench_realsense_metric_semantics.py` + `tests/test_bench_realsense_rs_data_collect_parser.py`: 10/10 pass on a host WITH a working camera.
- `tests/storage/test_seekdb_native.py`: 8 passed / 1 skipped standalone (was failing 3 tests in the full-suite run).
- Confirmed pre-existing on main (base-commit rerun reproduced the same failures) — this PR closes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)