### PR TITLE
feat(cli): seekdb+native:// backend for practice ingest/query + setup script fixture fix

### DIFF
--- a/scripts/setup_lerobot_rh56.sh
+++ b/scripts/setup_lerobot_rh56.sh
@@ -47,9 +47,26 @@ log "rosclaw ${SETUP_ARGS[*]}"
 "${ROSCLAW_PYTHON}" -m rosclaw.cli "${SETUP_ARGS[@]}"
 
 # 3. proposal-only smoke -------------------------------------------------------
+# proposal-only requires an observation fixture — generate a 5-step RH56
+# hold_current fixture locally (no dev-machine assumptions).
+SMOKE_FIXTURE="$(mktemp /tmp/rh56_smoke_obs.XXXXXX.json)"
+trap 'rm -f "${SMOKE_FIXTURE}"' EXIT
+"${ROSCLAW_PYTHON}" - <<'PYEOF' > "${SMOKE_FIXTURE}"
+import json
+obs = [
+    {
+        "observation.state": [1000.0] * 6,
+        "state_names": ["little", "ring", "middle", "index", "thumb", "thumb_rot"],
+        "task": "hold_current",
+    }
+    for _ in range(5)
+]
+print(json.dumps({"observations": obs}))
+PYEOF
 log "proposal-only smoke"
 "${ROSCLAW_PYTHON}" -m rosclaw.cli lerobot rollout proposal-only \
   --policy.path "${REPO_ROOT}/policies/rh56_reference_policy_v1" \
+  --observation-fixture "${SMOKE_FIXTURE}" \
   --steps 5 --json || {
     echo "[setup-lerobot-rh56] proposal-only smoke FAILED" >&2; exit 1; }
 

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -1494,13 +1494,37 @@ def _memory_db_path() -> Path:
 
 
 def _practice_seekdb_client(args: argparse.Namespace) -> Any:
-    """Build the configured Practice SeekDB backend from args or env."""
+    """Build the configured Practice SeekDB backend from args or env.
+
+    URL forms:
+
+    - ``seekdb+native://[user[:password]@]host[:port][/database]`` — the real
+      SeekDB / OceanBase server over the native pyseekdb protocol (port 2881);
+    - ``mysql://`` / ``mysql+pymysql://`` / ``seekdb://`` — the experimental
+      MySQL-protocol backend;
+    - no URL — the local SQLite knowledge store (``--seekdb-path``).
+    """
     import os
+    from urllib.parse import urlparse
 
     from rosclaw.memory.seekdb_client import SeekDBMySQLClient, SQLiteKnowledgeStore
 
     seekdb_url = getattr(args, "seekdb_url", None) or os.environ.get("ROSCLAW_SEEKDB_URL")
     if seekdb_url:
+        if urlparse(seekdb_url).scheme == "seekdb+native":
+            from rosclaw.storage.seekdb_native import SeekDBServerStore
+
+            parsed = urlparse(seekdb_url)
+            database = parsed.path.lstrip("/") or "rosclaw"
+            store = SeekDBServerStore(
+                host=parsed.hostname or "127.0.0.1",
+                port=parsed.port or 2881,
+                user=parsed.username or "root",
+                password=parsed.password or "",
+                database=database,
+            )
+            store.connect()
+            return store
         return SeekDBMySQLClient(seekdb_url)
 
     db_path = Path(getattr(args, "seekdb_path", None) or _memory_db_path())
@@ -7965,7 +7989,11 @@ def main() -> int:
         backend_group.add_argument(
             "--seekdb-url",
             default=None,
-            help=("SeekDB MySQL-compatible DSN, e.g. mysql://root@127.0.0.1:2881/rosclaw"),
+            help=(
+                "SeekDB backend DSN: seekdb+native://root@127.0.0.1:2881/rosclaw "
+                "(real SeekDB/OceanBase server, native protocol) or "
+                "mysql://root@127.0.0.1:2881/rosclaw (experimental MySQL protocol)"
+            ),
         )
 
     practice_ingest_seekdb_parser = practice_subparsers.add_parser(


### PR DESCRIPTION
## What

1. **`seekdb+native://` backend for `rosclaw practice ingest-seekdb` / `query`** — `_practice_seekdb_client` now accepts `seekdb+native://[user[:pass]@]host[:port][/database]` and routes to `SeekDBServerStore` (real SeekDB/OceanBase server over the native pyseekdb protocol, port 2881). Previously only the experimental MySQL-protocol DSN or local SQLite were usable; the native server store (proven in PR-SDB-1) had no CLI entry point. `--seekdb-url` help documents both DSN forms.

2. **`scripts/setup_lerobot_rh56.sh` fixture fix** — the proposal-only smoke step failed with `observation_required_missing` (proposal-only requires an observation fixture, which the script didn't provide). The script now generates a 5-step hold_current fixture locally and passes `--observation-fixture`.

## Verification

- End-to-end on the quay.io SeekDB container: `practice ingest-seekdb prac_20260720T075820Z_4ee919 --seekdb-url seekdb+native://root@127.0.0.1:2881/rosclaw` → success (episodes + body_cognition, 0 errors), records queryable via hybrid CJK search.
- Proposal-only smoke: 5/5 steps completed with the generated fixture.
- 149 body/lerobot + 691 cli/practice tests pass; ruff + mypy clean.

## Note (pre-existing, not in scope)

`tests/practice/test_export_lerobot_structure.py::test_lerobot_export_cli` fails identically with and without this change (CLI requires `--output`, the test expects success without it) — pre-existing on main, flagged for the owning team's area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)