### PR TITLE
fix(lerobot): instantiate processor device steps with the requested device

### DIFF
--- a/src/rosclaw/integrations/lerobot/policy_worker_service.py
+++ b/src/rosclaw/integrations/lerobot/policy_worker_service.py
@@ -138,6 +138,15 @@ class PolicyWorkerService:
         preprocessor, postprocessor = make_pre_post_processors(
             policy.config,
             pretrained_path=str(local_path),
+            # Instantiate device steps with the requested device from the
+            # start: a pipeline saved with device='cuda' must still load on a
+            # machine where CUDA is (or became) unavailable.
+            preprocessor_overrides={
+                "device_processor": {"device": device, "float_dtype": None}
+            },
+            postprocessor_overrides={
+                "device_processor": {"device": device, "float_dtype": None}
+            },
         )
         self._move_processor_to_device(preprocessor, device)
         self._move_processor_to_device(postprocessor, device)


### PR DESCRIPTION
A pipeline saved with `device='cuda'` previously failed to load on a machine where CUDA became unavailable: `DeviceProcessorStep(device='cuda')` asserts at construction, before `_move_processor_to_device` could relocate it. `make_pre_post_processors` now receives overrides pinning `device_processor` to the requested device.

Surfaced while verifying upstream main on a host whose GPU disappeared: `test_persistent_runtime_100_inferences` and `test_persistent_runtime_action_proposal_has_semantics` failed. Both pass again; full integration suite **228 passed / 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)