### PR TITLE
fix(storage): meaningful embedding documents for episodes (BM25 + vector)

### DIFF
--- a/src/rosclaw/storage/seekdb_native.py
+++ b/src/rosclaw/storage/seekdb_native.py
@@ -32,13 +32,22 @@ from rosclaw.memory.seekdb_client import SeekDBClient
 logger = logging.getLogger("rosclaw.storage.seekdb_native")
 
 # Fields whose text is used as the embedding document, per table family.
+# Task/outcome fields lead: without them the episode document degrades to an
+# opaque ``artifact_uri=...`` key-value dump, which is useless for retrieval
+# (found while decomposing a CJK-vs-English BM25 check on the RPS episodes).
 _TEXT_FIELDS = (
     "title",
     "document",
     "instruction",
     "description",
-    "error_details",
     "summary",
+    "task_name",
+    "task_id",
+    "task",
+    "skill_id",
+    "outcome",
+    "result",
+    "error_details",
     "subject",
     "predicate",
     "object",
@@ -176,7 +185,22 @@ class SeekDBNativeStore(SeekDBClient):
 
     @staticmethod
     def _document_text(record: dict) -> str:
-        parts = [str(record[key]) for key in _TEXT_FIELDS if record.get(key)]
+        # Text fields from the top level AND the nested metadata dict — the
+        # episode schema nests task_name/session info under ``metadata``, and
+        # without looking inside, the document degenerates to an opaque
+        # ``artifact_uri=...`` dump (useless for both BM25 and embedding).
+        metadata = record.get("metadata")
+        sources = [record]
+        if isinstance(metadata, dict):
+            sources.append(metadata)
+        seen: set[str] = set()
+        parts: list[str] = []
+        for source in sources:
+            for key in _TEXT_FIELDS:
+                value = source.get(key)
+                if value and str(value) not in seen:
+                    seen.add(str(value))
+                    parts.append(str(value))
         if parts:
             return "\n".join(parts)
         # Fallback: embed a compact dump so every record is searchable.


### PR DESCRIPTION
## Why

The distilled episode's embedding document was an opaque `artifact_uri=...` key-value dump: `_TEXT_FIELDS` lacked task fields and the nested `metadata` dict (task_name, session info) was never consulted. Found while decomposing a tester's CJK-vs-English BM25 check on the RPS episode records:

- English `Rock-Paper-Scissors` matched BM25 only accidentally (inside the JSON blob)
- CJK `石头剪刀布` matched nothing on either path
- Vector scores were weak (0.417)

## Fix

`_document_text` now collects text fields from the top level AND the nested metadata dict; `_TEXT_FIELDS` gains `task_id/task_name/task/skill_id/outcome/result`. Re-ingested RPS episode document:

```
rh56_rps
SUCCESS
RH56 Rock-Paper-Scissors
```

| Query | BM25 | Vector |
|---|---|---|
| `Rock-Paper-Scissors` | 1 | 0.695 |
| `rh56_rps` | 1 | 0.690 |
| `石头剪刀布` | 0 (see limitation) | 0.122 |

## Honest limitation (not fixed here)

CJK full-text still scores 0: this collection has no CJK tokenizer/synonym config, and MiniLM is English-dominant. Proper CJK retrieval needs bilingual distilled documents or a SeekDB-side CJK tokenizer — a separate product decision, not slipped into this PR.

## Tests

300 storage/practice tests pass (1 failure in `test_export_lerobot_structure.py::test_lerobot_export_cli` — pre-existing on main, identical with and without this change). ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)