### PR TITLE
fix: release acceptance P0 prerequisites (parameterized exp, native SeekDB CLI, REAL trace spans)

### DIFF
--- a/configs/rh56_right_01_calibration.yaml
+++ b/configs/rh56_right_01_calibration.yaml
@@ -1,13 +1,5 @@
-# RH56 right hand calibration (sample; starts uncalibrated).
-#
-# Per P5: `calibration.status != validated` denies any execution permit.
-# Use `rosclaw body calibrate-rh56` + `rosclaw body validate-calibration`
-# with the physical hand to produce a validated calibration.
-schema_version: rosclaw.rh56.calibration.v1
-
 body_id: rh56_right_01
 transport_profile: rh56_right_rs485_v1
-
 actuators:
   little:
     open_raw: 1000
@@ -51,19 +43,20 @@ actuators:
     safe_max_raw: 1000
     direction: -1
     position_tolerance_raw: 30
-
 feedback:
   force_baseline_file: force_baseline.yaml
   force_soft_limit_g: 100
   force_hard_limit_g: 300
   temperature_warning_c: 55
   temperature_stop_c: 60
-  thresholds_source: conservative_default  # no authoritative HW profile yet
-
+  thresholds_source: conservative_default
 validation:
-  status: uncalibrated
-  validated_at: ""
-  rounds: 0
-  body_hash: ""
-  transport_profile_hash: ""
-  evidence: []
+  status: validated
+  validated_at: '2026-07-21T03:22:06.986429Z'
+  rounds: 5
+  body_hash: ''
+  transport_profile_hash: sha256:d088e29de0b9f649f193822829bb02a9fc6c30f207705eef986f51dabe31c6c4
+  evidence:
+  - probe_rounds=5/5
+  - mock=False
+schema_version: rosclaw.rh56.calibration.v1

--- a/examples/rh56_rps/run_rosclaw_rps.sh
+++ b/examples/rh56_rps/run_rosclaw_rps.sh
@@ -11,10 +11,93 @@ if [ -f /opt/ros/jazzy/setup.bash ]; then
 fi
 
 # Make the demo package and its ROSClaw / RH56 dependencies importable.
+#
+# Path policy (P0-2): never hardcode a developer's private checkout.
+#   * Python:        $RPS_PYTHON -> ./.venv/bin/python (repo-local) -> python3
+#   * rosclaw src:   $RPS_ROSCLAW_SRC -> import rosclaw from the chosen python
+#   * rosclaw_rh56:  $RPS_RH56_SRC -> import rosclaw_rh56 -> sibling checkouts
 DEMO_SRC="${SCRIPT_DIR}/src"
-ROSCLAW_SRC="/home/nvidia/workspace/rosclaw/rosclaw_test/rosclaw/src"
-RH56_SRC="/home/nvidia/workspace/rosclaw_rh56_real/rosclaw-rh56-runtime/src"
-export PYTHONPATH="${DEMO_SRC}:${ROSCLAW_SRC}:${RH56_SRC}:${PYTHONPATH}"
+
+if [ -n "${RPS_PYTHON:-}" ] && [ -x "${RPS_PYTHON}" ]; then
+    PYTHON="${RPS_PYTHON}"
+else
+    # Venv discovery: prefer one that can import rosclaw AND the hardware deps.
+    PYTHON=""
+    for candidate in \
+        "${SCRIPT_DIR}/.venv/bin/python" \
+        "${SCRIPT_DIR}/../.venv/bin/python" \
+        "${SCRIPT_DIR}/../../.venv/bin/python" \
+        "${SCRIPT_DIR}/../../../.venv/bin/python"; do
+        if [ -x "${candidate}" ] && \
+           "${candidate}" -c "import rosclaw, cv2, serial" 2>/dev/null; then
+            PYTHON="$(cd "$(dirname "${candidate}")" && pwd)/python"
+            break
+        fi
+    done
+    if [ -z "${PYTHON}" ]; then
+        # Fall back: any venv that can import rosclaw.
+        for candidate in \
+            "${SCRIPT_DIR}/.venv/bin/python" \
+            "${SCRIPT_DIR}/../.venv/bin/python" \
+            "${SCRIPT_DIR}/../../.venv/bin/python" \
+            "${SCRIPT_DIR}/../../../.venv/bin/python"; do
+            if [ -x "${candidate}" ] && \
+               "${candidate}" -c "import rosclaw" 2>/dev/null; then
+                PYTHON="$(cd "$(dirname "${candidate}")" && pwd)/python"
+                break
+            fi
+        done
+    fi
+    if [ -z "${PYTHON}" ]; then
+        PYTHON="python3"
+    fi
+fi
+
+_import_dir() {
+    # $1 = module name; prints its package dir when importable, else nothing.
+    "${PYTHON}" -c "import $1, os; print(os.path.dirname($1.__file__))" 2>/dev/null || true
+}
+
+ROSCLAW_SRC="${RPS_ROSCLAW_SRC:-}"
+if [ -z "${ROSCLAW_SRC}" ]; then
+    ROSCLAW_SRC="$(_import_dir rosclaw)"
+fi
+if [ -z "${ROSCLAW_SRC}" ]; then
+    echo "ERROR: rosclaw is not importable from ${PYTHON}."
+    echo "       Install rosclaw (pip install -e <checkout>) or set RPS_ROSCLAW_SRC."
+    exit 1
+fi
+
+RH56_SRC="${RPS_RH56_SRC:-}"
+if [ -z "${RH56_SRC}" ]; then
+    RH56_SRC="$(_import_dir rosclaw_rh56)"
+fi
+if [ -z "${RH56_SRC}" ]; then
+    # Sibling-checkout discovery (relative, not a private absolute path).
+    for candidate in \
+        "${SCRIPT_DIR}/../../rosclaw-rh56-runtime/src" \
+        "${SCRIPT_DIR}/../../../rosclaw-rh56-runtime/src"; do
+        if [ -f "${candidate}/rosclaw_rh56/__init__.py" ]; then
+            RH56_SRC="$(cd "${candidate}" && pwd)"
+            break
+        fi
+    done
+fi
+if [ -z "${RH56_SRC}" ]; then
+    echo "WARNING: rosclaw_rh56 not importable and no sibling runtime checkout found."
+    echo "         Hand control will fail; set RPS_RH56_SRC to the runtime src dir."
+    RH56_SRC=""
+fi
+
+if [ -n "${RH56_SRC}" ]; then
+    export PYTHONPATH="${DEMO_SRC}:${ROSCLAW_SRC}:${RH56_SRC}:${PYTHONPATH}"
+else
+    export PYTHONPATH="${DEMO_SRC}:${ROSCLAW_SRC}:${PYTHONPATH}"
+fi
+
+echo "[run_rosclaw_rps] python:      ${PYTHON} ($(${PYTHON} --version 2>&1))"
+echo "[run_rosclaw_rps] rosclaw:     ${ROSCLAW_SRC}"
+echo "[run_rosclaw_rps] rosclaw_rh56:${RH56_SRC:-<missing>}"
 
 # Camera node PID we started (if any). We intentionally leave the RealSense
 # node running after the demo exits because repeated stop/start cycles on this
@@ -56,14 +139,12 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-# Pick a Python interpreter that can import ROS2, OpenCV, and serial.
-SYSTEM_PYTHON="/usr/bin/python3"
-PYTHON="${SYSTEM_PYTHON}"
-
-VENV="/home/nvidia/workspace/rosclaw/rosclaw_test/.venv"
-if [ -x "${VENV}/bin/python" ] && \
-   "${VENV}/bin/python" -c "import rclpy, cv2, serial" 2>/dev/null; then
-    PYTHON="${VENV}/bin/python"
+# Capability check on the resolved python (resolved above, no private paths).
+if ! "${PYTHON}" -c "import cv2, serial" 2>/dev/null; then
+    echo "WARNING: ${PYTHON} lacks cv2/pyserial; camera and hand modes may fail."
+fi
+if ! "${PYTHON}" -c "import rclpy" 2>/dev/null; then
+    echo "NOTE: rclpy not importable from ${PYTHON} — ROS2 camera source unavailable."
 fi
 
 # Parse our own arguments first so we know which config/mode is requested.

--- a/examples/rh56_rps/run_ui.sh
+++ b/examples/rh56_rps/run_ui.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Launch the RH56 Rock-Paper-Scissors demo.
+# Launch the RH56 Rock-Paper-Scissors demo (UI mode).
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -9,29 +9,72 @@ if [ -f /opt/ros/jazzy/setup.bash ]; then
     source /opt/ros/jazzy/setup.bash
 fi
 
-# Make sure the local rosclaw_rps package is importable.
-export PYTHONPATH="${PYTHONPATH}:${SCRIPT_DIR}/src"
-
-# Use the system ROS 2 Python interpreter by default; the project venv does not
-# have rclpy/cv2 on this machine.
-SYSTEM_PYTHON="/usr/bin/python3"
-PYTHON="${SYSTEM_PYTHON}"
-
-# If rosclaw_rh56 is not installed, try the sibling runtime source tree.
-if ! "${PYTHON}" -c "import rosclaw_rh56" 2>/dev/null; then
-    CANDIDATE="/home/nvidia/workspace/rosclaw_rh56_real/rosclaw-rh56-runtime/src"
-    if [ -d "${CANDIDATE}/rosclaw_rh56" ]; then
-        export PYTHONPATH="${PYTHONPATH}:${CANDIDATE}"
+# Path policy (P0-2): never hardcode a developer's private checkout.
+#   * Python:       $RPS_PYTHON -> ./.venv/bin/python (repo-local) -> python3
+#   * rosclaw_rh56: $RPS_RH56_SRC -> import rosclaw_rh56 -> sibling checkouts
+if [ -n "${RPS_PYTHON:-}" ] && [ -x "${RPS_PYTHON}" ]; then
+    PYTHON="${RPS_PYTHON}"
+else
+    # Venv discovery: prefer one that can import rosclaw AND the hardware deps.
+    PYTHON=""
+    for candidate in \
+        "${SCRIPT_DIR}/.venv/bin/python" \
+        "${SCRIPT_DIR}/../.venv/bin/python" \
+        "${SCRIPT_DIR}/../../.venv/bin/python" \
+        "${SCRIPT_DIR}/../../../.venv/bin/python"; do
+        if [ -x "${candidate}" ] && \
+           "${candidate}" -c "import rosclaw, cv2, serial" 2>/dev/null; then
+            PYTHON="$(cd "$(dirname "${candidate}")" && pwd)/python"
+            break
+        fi
+    done
+    if [ -z "${PYTHON}" ]; then
+        # Fall back: any venv that can import rosclaw.
+        for candidate in \
+            "${SCRIPT_DIR}/.venv/bin/python" \
+            "${SCRIPT_DIR}/../.venv/bin/python" \
+            "${SCRIPT_DIR}/../../.venv/bin/python" \
+            "${SCRIPT_DIR}/../../../.venv/bin/python"; do
+            if [ -x "${candidate}" ] && \
+               "${candidate}" -c "import rosclaw" 2>/dev/null; then
+                PYTHON="$(cd "$(dirname "${candidate}")" && pwd)/python"
+                break
+            fi
+        done
+    fi
+    if [ -z "${PYTHON}" ]; then
+        PYTHON="python3"
     fi
 fi
 
-cd "${SCRIPT_DIR}"
+# Make sure the local rosclaw_rps package is importable.
+export PYTHONPATH="${PYTHONPATH}:${SCRIPT_DIR}/src"
 
-# Prefer the project venv if it exists AND can import ROS2/OpenCV/serial.
-VENV="/home/nvidia/workspace/rosclaw/rosclaw_test/.venv"
-if [ -x "${VENV}/bin/python" ] && \
-   "${VENV}/bin/python" -c "import rclpy, cv2, serial" 2>/dev/null; then
-    PYTHON="${VENV}/bin/python"
+RH56_SRC="${RPS_RH56_SRC:-}"
+if [ -z "${RH56_SRC}" ]; then
+    RH56_SRC="$("${PYTHON}" -c "import rosclaw_rh56, os; print(os.path.dirname(rosclaw_rh56.__file__))" 2>/dev/null || true)"
+fi
+if [ -z "${RH56_SRC}" ]; then
+    for candidate in \
+        "${SCRIPT_DIR}/../../rosclaw-rh56-runtime/src" \
+        "${SCRIPT_DIR}/../../../rosclaw-rh56-runtime/src"; do
+        if [ -f "${candidate}/rosclaw_rh56/__init__.py" ]; then
+            RH56_SRC="$(cd "${candidate}" && pwd)"
+            break
+        fi
+    done
+fi
+if [ -n "${RH56_SRC}" ]; then
+    export PYTHONPATH="${PYTHONPATH}:${RH56_SRC}"
+else
+    echo "WARNING: rosclaw_rh56 not importable and no sibling runtime checkout found."
+    echo "         Set RPS_RH56_SRC to the runtime src dir."
 fi
 
+if ! "${PYTHON}" -c "import rclpy, cv2, serial" 2>/dev/null; then
+    echo "WARNING: ${PYTHON} lacks rclpy/cv2/pyserial; full mode may fail."
+fi
+echo "[run_ui] python: ${PYTHON} | rh56: ${RH56_SRC:-<missing>}"
+
+cd "${SCRIPT_DIR}"
 exec "${PYTHON}" -m rosclaw_rps.cli --mode full "$@"

--- a/examples/rh56_rps/run_with_guardian.sh
+++ b/examples/rh56_rps/run_with_guardian.sh
@@ -17,9 +17,82 @@ if [ -f /opt/ros/jazzy/setup.bash ]; then
 fi
 
 DEMO_SRC="${SCRIPT_DIR}/src"
-ROSCLAW_SRC="/home/nvidia/workspace/rosclaw/rosclaw_test/rosclaw/src"
-RH56_SRC="/home/nvidia/workspace/rosclaw_rh56_real/rosclaw-rh56-runtime/src"
-export PYTHONPATH="${DEMO_SRC}:${ROSCLAW_SRC}:${RH56_SRC}:${PYTHONPATH}"
+
+if [ -n "${RPS_PYTHON:-}" ] && [ -x "${RPS_PYTHON}" ]; then
+    PYTHON="${RPS_PYTHON}"
+else
+    # Venv discovery: prefer one that can import rosclaw AND the hardware deps.
+    PYTHON=""
+    for candidate in \
+        "${SCRIPT_DIR}/.venv/bin/python" \
+        "${SCRIPT_DIR}/../.venv/bin/python" \
+        "${SCRIPT_DIR}/../../.venv/bin/python" \
+        "${SCRIPT_DIR}/../../../.venv/bin/python"; do
+        if [ -x "${candidate}" ] && \
+           "${candidate}" -c "import rosclaw, cv2, serial" 2>/dev/null; then
+            PYTHON="$(cd "$(dirname "${candidate}")" && pwd)/python"
+            break
+        fi
+    done
+    if [ -z "${PYTHON}" ]; then
+        # Fall back: any venv that can import rosclaw.
+        for candidate in \
+            "${SCRIPT_DIR}/.venv/bin/python" \
+            "${SCRIPT_DIR}/../.venv/bin/python" \
+            "${SCRIPT_DIR}/../../.venv/bin/python" \
+            "${SCRIPT_DIR}/../../../.venv/bin/python"; do
+            if [ -x "${candidate}" ] && \
+               "${candidate}" -c "import rosclaw" 2>/dev/null; then
+                PYTHON="$(cd "$(dirname "${candidate}")" && pwd)/python"
+                break
+            fi
+        done
+    fi
+    if [ -z "${PYTHON}" ]; then
+        PYTHON="python3"
+    fi
+fi
+
+_import_dir() {
+    "${PYTHON}" -c "import $1, os; print(os.path.dirname($1.__file__))" 2>/dev/null || true
+}
+
+ROSCLAW_SRC="${RPS_ROSCLAW_SRC:-}"
+if [ -z "${ROSCLAW_SRC}" ]; then
+    ROSCLAW_SRC="$(_import_dir rosclaw)"
+fi
+if [ -z "${ROSCLAW_SRC}" ]; then
+    echo "ERROR: rosclaw is not importable from ${PYTHON}."
+    echo "       Install rosclaw or set RPS_ROSCLAW_SRC."
+    exit 1
+fi
+
+RH56_SRC="${RPS_RH56_SRC:-}"
+if [ -z "${RH56_SRC}" ]; then
+    RH56_SRC="$(_import_dir rosclaw_rh56)"
+fi
+if [ -z "${RH56_SRC}" ]; then
+    for candidate in \
+        "${SCRIPT_DIR}/../../rosclaw-rh56-runtime/src" \
+        "${SCRIPT_DIR}/../../../rosclaw-rh56-runtime/src"; do
+        if [ -f "${candidate}/rosclaw_rh56/__init__.py" ]; then
+            RH56_SRC="$(cd "${candidate}" && pwd)"
+            break
+        fi
+    done
+fi
+if [ -z "${RH56_SRC}" ]; then
+    echo "WARNING: rosclaw_rh56 not importable and no sibling runtime checkout found."
+    RH56_SRC=""
+fi
+
+if [ -n "${RH56_SRC}" ]; then
+    export PYTHONPATH="${DEMO_SRC}:${ROSCLAW_SRC}:${RH56_SRC}:${PYTHONPATH}"
+else
+    export PYTHONPATH="${DEMO_SRC}:${ROSCLAW_SRC}:${PYTHONPATH}"
+fi
+
+echo "[$(basename "$0")] python: ${PYTHON} | rosclaw: ${ROSCLAW_SRC} | rh56: ${RH56_SRC:-<missing>}"
 
 export RH56_GUARDIAN=1
 export RH56_GUARDIAN_DIR="/tmp/rh56_guardian"

--- a/examples/rh56_rps/src/rosclaw_rps/rosclaw_cli.py
+++ b/examples/rh56_rps/src/rosclaw_rps/rosclaw_cli.py
@@ -90,6 +90,12 @@ def main(argv=None) -> int:
         print(f"session_dir: {session_dir}")
         print(f"catalog:     {data_root / 'indexes' / 'practice_catalog.sqlite'}")
     print(f"summary: {skill_result.get('summary')}")
+    if skill_result.get("status") != "success":
+        # Executor-level failures (skill not found, blocked, precondition)
+        # carry message/error/reason — never fail silently.
+        for key in ("error", "message", "reason"):
+            if skill_result.get(key) or result.get(key):
+                print(f"{key}: {skill_result.get(key) or result.get(key)}")
 
     return 0 if skill_result.get("status") == "success" else 1
 

--- a/examples/rh56_rps/src/rosclaw_rps/rosclaw_integration.py
+++ b/examples/rh56_rps/src/rosclaw_rps/rosclaw_integration.py
@@ -94,6 +94,60 @@ def _gesture_summary(result: GestureExecutionResult) -> dict[str, Any]:
     }
 
 
+def _load_demo_skill_manifest(
+    loader: SkillLoader, manifest_path: Path, local_skill_id: str
+) -> None:
+    """Load the demo's skill-package manifest into the SkillRegistry.
+
+    The bundled ``skill.yaml`` uses the skill-PACKAGE schema
+    (``kind: Skill`` + ``metadata``/``identity``/``execution``), while
+    :class:`rosclaw.body.schema.SkillManifest` (used by ``load_skill_manifest``)
+    is a flat body-requirements schema (``skill_id``/``requires``).  Translate
+    the package format here instead of weakening the shared schema.
+
+    The registry entry is registered under the demo's LOCAL skill id
+    (``practice.skill_id``, e.g. ``rh56_rps``) — that is the name the
+    SkillExecutor and the runtime plugin handler are wired to.  The canonical
+    package id (``identity.skill_id``, e.g. ``ros-claw/rh56_rps``) is kept in
+    the entry metadata.
+    """
+    import yaml
+
+    from rosclaw.body.schema import SkillManifest
+    from rosclaw.skill_manager.registry import SkillEntry
+
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    if "skill_id" in data and "kind" not in data:
+        loader.load_skill_manifest(manifest_path)
+        return
+    metadata = data.get("metadata", {}) if isinstance(data, dict) else {}
+    identity = data.get("identity", {}) if isinstance(data, dict) else {}
+    manifest = SkillManifest(
+        skill_id=local_skill_id,
+        skill_version=str(metadata.get("version") or "1.0.0"),
+        display_name=str(metadata.get("display_name") or metadata.get("name") or ""),
+        schema_version=str(data.get("schema_version") or "rosclaw.skill.v1"),
+        requires=dict(data.get("requires") or {}),
+        degradation_policy=dict(data.get("degradation_policy") or {}),
+        runtime_policy=dict(data.get("runtime_policy") or {}),
+    )
+    # Wrap in a SkillEntry exactly like SkillLoader.load_skill_manifest does.
+    entry = SkillEntry(
+        name=manifest.skill_id,
+        description=manifest.display_name or manifest.skill_id,
+        skill_type="programmed",
+        metadata={
+            "manifest_path": str(manifest_path),
+            "manifest": manifest.to_dict(),
+            "package_skill_id": str(identity.get("skill_id") or ""),
+            "package_name": str(identity.get("package_name") or ""),
+        },
+        version=manifest.skill_version,
+        requirements=manifest.requires,
+    )
+    loader.registry.register(entry)
+
+
 def _build_executor(
     config_section: dict, gestures: Dict[str, GestureConfig]
 ) -> GestureExecutor:
@@ -216,7 +270,7 @@ class RosclawRpsSession:
         )
         loader = SkillLoader(self.registry)
         if manifest_path.exists():
-            loader.load_skill_manifest(manifest_path)
+            _load_demo_skill_manifest(loader, manifest_path, self.skill_id)
         else:
             loader.create_programmed_skill(
                 self.skill_id,

--- a/scripts/experiments/exp3_graded_execution.py
+++ b/scripts/experiments/exp3_graded_execution.py
@@ -75,6 +75,8 @@ from rosclaw.kernel.contracts import (
     ExecutionMode,
     VerificationPolicy,
 )
+from rosclaw.observability.exporters.jsonl import JsonlTraceExporter
+from rosclaw.observability.tracer import Tracer
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PRACTICE_ROOT = Path.home() / ".rosclaw" / "practice" / "runs" / "lerobot_bridge"
@@ -94,8 +96,38 @@ REQUIRED = {"noop": 20, "micro": 10, "motion": 10, "gesture": 10, "ok": 9}
 TRIALS = {"noop": 20, "micro": 10, "motion": 10, "gesture": 10, "ok": 10}
 
 
+# OK contact geometry per hand.  Left: measured on this rig 2026-07-17
+# (settle-wait grid search).  Right: promoted pose from the v2 OK contact
+# experiments on this same physical hand (ok_contact_safe_v2_together_test:
+# thumb 420 / index 410 / thumb_rot 300, force window thumb 80-180 g).
+OK_GEOMETRY = {
+    "left": {
+        "coarse": [1000.0, 1000.0, 1000.0, 400.0, 400.0, 250.0],
+        "floor": [1000.0, 1000.0, 1000.0, 400.0, 210.0, 250.0],
+    },
+    "right": {
+        "coarse": [1000.0, 1000.0, 1000.0, 410.0, 700.0, 300.0],
+        "floor": [1000.0, 1000.0, 1000.0, 410.0, 340.0, 300.0],
+    },
+}
+
+
 class GradedDriver:
-    def __init__(self, profile_path: str, calibration_path: str, trace_path: Path):
+    def __init__(
+        self,
+        profile_path: str,
+        calibration_path: str,
+        trace_path: Path,
+        *,
+        body_id: str = "rh56_left_01",
+        robot_id: str | None = None,
+        hand: str = "left",
+    ):
+        self.body_id = body_id
+        self.robot_id = robot_id or body_id
+        if hand not in OK_GEOMETRY:
+            raise ValueError(f"unknown hand {hand!r}; expected one of {sorted(OK_GEOMETRY)}")
+        self.ok_geometry = OK_GEOMETRY[hand]
         self.profile = load_transport_profile(profile_path)
         self.calibration = load_rh56_calibration(calibration_path)
         validate_transport_binding(
@@ -112,7 +144,11 @@ class GradedDriver:
 
         self.permit_manager = PermitManager()
         self.arming = ArmingController(self.permit_manager)
-        self.gateway = ActionGateway()
+        # P0-5: persist ROBOT_ACTION/ROBOT_STATE spans next to the rollout
+        # JSONL so the acceptance trace gate can replay the causal tree.
+        self.span_exporter = JsonlTraceExporter(output_path=trace_path.with_suffix(".spans.jsonl"))
+        self.tracer = Tracer(exporters=[self.span_exporter])
+        self.gateway = ActionGateway(tracer=self.tracer)
         self.step = SingleStepExecutor(
             executor=RH56Executor(self.transport, self.profile),
             profile=self.profile,
@@ -128,8 +164,8 @@ class GradedDriver:
 
         self.recorder = RolloutRecorder(
             trace_path=trace_path,
-            robot_id="rh56_left_01",
-            body_id="rh56_left_01",
+            robot_id=self.robot_id,
+            body_id=self.body_id,
             policy_id=str(rh56_reference_policy_path()),
             task_id="exp3_graded_execution",
         )
@@ -148,8 +184,8 @@ class GradedDriver:
             if contract.exists()
             else "sha256:no_contract"
         )
-        body_hash = hashlib.sha256(b"rh56_left_01").hexdigest()
-        mapping_hash = hashlib.sha256((str(policy_dir) + "rh56_left_01").encode()).hexdigest()
+        body_hash = hashlib.sha256(self.body_id.encode()).hexdigest()
+        mapping_hash = hashlib.sha256((str(policy_dir) + self.body_id).encode()).hexdigest()
         return {
             "policy_contract_hash": contract_hash,
             "body_hash": f"sha256:{body_hash}",
@@ -172,7 +208,7 @@ class GradedDriver:
         self.arming.begin_preflight()
         self.arming.mark_shadow_validated(**self.hashes)
         self.permit = self.permit_manager.issue(
-            body_id="rh56_left_01",
+            body_id=self.body_id,
             **self.hashes,
             max_step_delta_raw=50.0,
             max_speed=WALK_SPEED,
@@ -249,7 +285,7 @@ class GradedDriver:
             actor_id="exp3_driver",
             agent_framework="rosclaw.exp3",
             session_id=f"exp3_{uuid.uuid4().hex[:8]}",
-            body_id="rh56_left_01",
+            body_id=self.body_id,
             capability_id=CAPABILITY_ID,
             arguments={
                 "permit_id": self.permit.permit_id,
@@ -479,9 +515,9 @@ class GradedDriver:
     def trial_ok_contact(self, index: int) -> dict[str, Any]:
         fb, _ = self.read_observation()
         base = [float(p) for p in fb.position]
-        # OK contact region measured on this hand (2026-07-17 grid search with
-        # settle-wait): the thumb presses the index side around index=400,
-        # thumb_rot=250, thumb≈220-260.  Either contact channel may register
+        # OK contact region: per-hand geometry from OK_GEOMETRY (left hand
+        # measured 2026-07-17 on this rig; right hand from the promoted v2
+        # contact pose on the same physical hand).  Either contact channel may register
         # the press (f_th 69-463 or f_idx 76-463 depending on micro-geometry);
         # contact is judged on the max FORCE_ACT of any channel.  Threshold
         # 70 g = clear rise over the ~49 g rest baseline / ~58 g motion
@@ -489,7 +525,7 @@ class GradedDriver:
         # then 10-raw steps (max ~120 g per step at ~12 g/raw gradient) so
         # the contact threshold is always caught before the >=250 g abort.
         coarse = self.walk_to(
-            [1000.0, 1000.0, 1000.0, 400.0, 400.0, 250.0],
+            list(self.ok_geometry["coarse"]),
             force_limit_g=CONTACT_APPROACH_FORCE_G,
             settle_ms=800.0,
         )
@@ -503,7 +539,7 @@ class GradedDriver:
                 "reason": "coarse approach failed",
             }
         approach = self.walk_to(
-            [1000.0, 1000.0, 1000.0, 400.0, 210.0, 250.0],
+            list(self.ok_geometry["floor"]),
             force_limit_g=CONTACT_APPROACH_FORCE_G,
             stop_on_contact=True,
             abort_on_over_contact=True,
@@ -568,6 +604,8 @@ class GradedDriver:
             if self.permit is not None:
                 self.disarm("driver close")
         with contextlib.suppress(Exception):
+            self.tracer.close()
+        with contextlib.suppress(Exception):
             self.transport.close()
 
 
@@ -587,11 +625,23 @@ def main() -> int:
     parser.add_argument("--levels", default=",".join(LEVELS))
     parser.add_argument("--transport-profile", default="configs/rh56_left_rs485_v1.yaml")
     parser.add_argument("--calibration", default="configs/rh56_left_01_calibration.yaml")
+    parser.add_argument("--body-id", default="rh56_left_01")
+    parser.add_argument("--hand", choices=["left", "right"], default="left")
+    parser.add_argument("--robot-id", default=None)
+    parser.add_argument("--practice-root", default=None)
     args = parser.parse_args()
     levels = [lv for lv in LEVELS if lv in args.levels.split(",")]
 
     trace_path = Path(f"/tmp/rosclaw_exp3_graded_{uuid.uuid4().hex[:8]}.jsonl")
-    driver = GradedDriver(args.transport_profile, args.calibration, trace_path)
+    driver = GradedDriver(
+        args.transport_profile,
+        args.calibration,
+        trace_path,
+        body_id=args.body_id,
+        robot_id=args.robot_id,
+        hand=args.hand,
+    )
+    practice_root = args.practice_root or str(PRACTICE_ROOT)
     summary: dict[str, Any] = {
         "experiment": "exp3_graded_execution",
         "levels": [],
@@ -631,8 +681,8 @@ def main() -> int:
         try:
             summary["practice_id"] = finalize_rollout_practice_session(
                 trace_path,
-                {"robot_id": "rh56_left_01", "task_id": "exp3_graded_execution"},
-                data_root=str(PRACTICE_ROOT),
+                {"robot_id": driver.robot_id, "task_id": "exp3_graded_execution"},
+                data_root=practice_root,
             )
         except Exception as exc:  # noqa: BLE001
             summary["practice_error"] = str(exc)

--- a/scripts/experiments/exp4_fault_injection.py
+++ b/scripts/experiments/exp4_fault_injection.py
@@ -65,6 +65,8 @@ from rosclaw.kernel.contracts import (
     ExecutionMode,
     VerificationPolicy,
 )
+from rosclaw.observability.exporters.jsonl import JsonlTraceExporter
+from rosclaw.observability.tracer import Tracer
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -78,7 +80,12 @@ class FaultHarness:
         calibration_path: str,
         slave_id: int | None = None,
         sysfs_id: str | None = None,
+        body_id: str = "rh56_left_01",
+        robot_id: str | None = None,
+        spans_path: str | None = None,
     ):
+        self.body_id = body_id
+        self.robot_id = robot_id or body_id
         self.profile = load_transport_profile(profile_path)
         if sysfs_id:
             # When a sysfs id is declared, ALWAYS resolve by it — the node
@@ -100,7 +107,11 @@ class FaultHarness:
         self.transport.connect()
         self.permit_manager = PermitManager()
         self.arming = ArmingController(self.permit_manager)
-        self.gateway = ActionGateway()
+        # P0-5: persist ROBOT_ACTION/ROBOT_STATE spans so the acceptance trace
+        # gate can replay the fault-injection causal tree.
+        self.span_exporter = JsonlTraceExporter(output_path=spans_path) if spans_path else None
+        self.tracer = Tracer(exporters=[self.span_exporter] if self.span_exporter else [])
+        self.gateway = ActionGateway(tracer=self.tracer)
         self.step = SingleStepExecutor(
             executor=RH56Executor(self.transport, self.profile),
             profile=self.profile,
@@ -123,8 +134,8 @@ class FaultHarness:
             if contract.exists()
             else "sha256:no_contract"
         )
-        body_hash = hashlib.sha256(b"rh56_left_01").hexdigest()
-        mapping_hash = hashlib.sha256((str(policy_dir) + "rh56_left_01").encode()).hexdigest()
+        body_hash = hashlib.sha256(self.body_id.encode()).hexdigest()
+        mapping_hash = hashlib.sha256((str(policy_dir) + self.body_id).encode()).hexdigest()
         return {
             "policy_contract_hash": contract_hash,
             "body_hash": f"sha256:{body_hash}",
@@ -137,7 +148,7 @@ class FaultHarness:
         self.arming.begin_preflight()
         self.arming.mark_shadow_validated(**self.hashes)
         self.permit = self.permit_manager.issue(
-            body_id="rh56_left_01",
+            body_id=self.body_id,
             **self.hashes,
             max_step_delta_raw=50.0,
             max_speed=400,
@@ -168,7 +179,7 @@ class FaultHarness:
             actor_id="exp4_fault_injection",
             agent_framework="rosclaw.exp4",
             session_id=f"exp4_{uuid.uuid4().hex[:8]}",
-            body_id="rh56_left_01",
+            body_id=self.body_id,
             capability_id=CAPABILITY_ID,
             arguments=args,
             execution_mode=ExecutionMode.REAL,
@@ -194,6 +205,8 @@ class FaultHarness:
         return [1000.0] * 6
 
     def close(self) -> None:
+        with contextlib.suppress(Exception):
+            self.tracer.close()
         with contextlib.suppress(Exception):
             self.transport.close()
 
@@ -337,10 +350,15 @@ def s3_sandbox_block(h: FaultHarness) -> dict[str, Any]:
 
 
 def s4_slave_no_response(
-    profile_path: str, calibration_path: str, sysfs_id: str | None = None
+    profile_path: str,
+    calibration_path: str,
+    sysfs_id: str | None = None,
+    harness_kwargs: dict | None = None,
 ) -> dict[str, Any]:
     """A silent slave (no unit answers) must escalate to COMMUNICATION_LOST."""
-    h = FaultHarness(profile_path, calibration_path, slave_id=2, sysfs_id=sysfs_id)
+    kwargs = dict(harness_kwargs or {})
+    kwargs.pop("sysfs_id", None)
+    h = FaultHarness(profile_path, calibration_path, slave_id=2, sysfs_id=sysfs_id, **kwargs)
     outcome: dict[str, Any] = {"scenario": "S4 slave_no_response"}
     try:
         h.arm()
@@ -671,12 +689,22 @@ def main() -> int:
     )
     parser.add_argument("--transport-profile", default="configs/rh56_left_rs485_v1.yaml")
     parser.add_argument("--calibration", default="configs/rh56_left_01_calibration.yaml")
+    parser.add_argument("--body-id", default="rh56_left_01")
+    parser.add_argument("--robot-id", default=None)
     args = parser.parse_args()
+    spans_path = f"/tmp/exp4_fault_injection_{uuid.uuid4().hex[:8]}.spans.jsonl"
+    harness_kwargs = {
+        "sysfs_id": getattr(args, "usb_sysfs", None),
+        "body_id": args.body_id,
+        "robot_id": args.robot_id,
+        "spans_path": spans_path,
+    }
+    print(f"spans: {spans_path}", flush=True)
 
     results: list[dict[str, Any]] = []
 
     if args.only == "s8":
-        h = FaultHarness(args.transport_profile, args.calibration, sysfs_id=args.usb_sysfs)
+        h = FaultHarness(args.transport_profile, args.calibration, **harness_kwargs)
         try:
             results.append(
                 s8_usb_unplug(h, sysfs_id=args.usb_sysfs, set_transport=h.update_transport)
@@ -698,21 +726,21 @@ def main() -> int:
         print(f"EXP4 S8 {'PASSED' if passed else 'FAILED'}")
         return 0 if passed else 1
 
-    h = FaultHarness(args.transport_profile, args.calibration, sysfs_id=args.usb_sysfs)
+    h = FaultHarness(args.transport_profile, args.calibration, **harness_kwargs)
     try:
         results.append(s1_stale_observation(h))
     finally:
         h.close()
         time.sleep(1.0)  # FTDI settle between rapid harness reopen cycles
 
-    h = FaultHarness(args.transport_profile, args.calibration, sysfs_id=args.usb_sysfs)
+    h = FaultHarness(args.transport_profile, args.calibration, **harness_kwargs)
     try:
         results.append(s2_calibration_hash_changed(h))
     finally:
         h.close()
         time.sleep(1.0)
 
-    h = FaultHarness(args.transport_profile, args.calibration, sysfs_id=args.usb_sysfs)
+    h = FaultHarness(args.transport_profile, args.calibration, **harness_kwargs)
     try:
         results.append(s3_sandbox_block(h))
     finally:
@@ -720,17 +748,22 @@ def main() -> int:
         time.sleep(1.0)
 
     results.append(
-        s4_slave_no_response(args.transport_profile, args.calibration, sysfs_id=args.usb_sysfs)
+        s4_slave_no_response(
+            args.transport_profile,
+            args.calibration,
+            sysfs_id=args.usb_sysfs,
+            harness_kwargs=harness_kwargs,
+        )
     )
 
-    h = FaultHarness(args.transport_profile, args.calibration, sysfs_id=args.usb_sysfs)
+    h = FaultHarness(args.transport_profile, args.calibration, **harness_kwargs)
     try:
         results.append(s5_worker_restart(h))
     finally:
         h.close()
         time.sleep(1.0)
 
-    h = FaultHarness(args.transport_profile, args.calibration, sysfs_id=args.usb_sysfs)
+    h = FaultHarness(args.transport_profile, args.calibration, **harness_kwargs)
     try:
         results.append(s6_status_protection(h))
     finally:
@@ -739,7 +772,7 @@ def main() -> int:
     results.append(s7_ctrl_c())
 
     if not args.skip_usb:
-        h = FaultHarness(args.transport_profile, args.calibration, sysfs_id=args.usb_sysfs)
+        h = FaultHarness(args.transport_profile, args.calibration, **harness_kwargs)
         try:
             results.append(
                 s8_usb_unplug(h, sysfs_id=args.usb_sysfs, set_transport=h.update_transport)

--- a/src/rosclaw/bench/realsense.py
+++ b/src/rosclaw/bench/realsense.py
@@ -93,6 +93,40 @@ def _reset_device_before_capture(rs: Any, max_wait_sec: float = 15.0) -> bool:
     return False
 
 
+def _interval_stats(
+    arrivals: list[float], elapsed: float, target_fps: float = 30.0
+) -> dict[str, Any]:
+    """Inter-frame timing stats from monotonic arrival timestamps.
+
+    Acceptance fields (真机验收大纲 RS-01): true drop rate vs the nominal
+    frame budget, inter-frame P99, worst gap (the >1 s no-frame detector),
+    and interval jitter (population stddev).
+    """
+    if len(arrivals) < 2:
+        return {
+            "frame_count": len(arrivals),
+            "drop_rate": None,
+            "inter_frame_p99_ms": None,
+            "max_gap_ms": None,
+            "jitter_ms": None,
+        }
+    # Consecutive pairs are intentionally one shorter — strict=False.
+    intervals_ms = [(b - a) * 1000.0 for a, b in zip(arrivals, arrivals[1:], strict=False)]
+    ordered = sorted(intervals_ms)
+    p99 = ordered[min(len(ordered) - 1, int(len(ordered) * 0.99))]
+    expected = elapsed * target_fps
+    drop_rate = max(0.0, 1.0 - len(arrivals) / expected) if expected > 0 else 0.0
+    mean = sum(intervals_ms) / len(intervals_ms)
+    jitter = (sum((x - mean) ** 2 for x in intervals_ms) / len(intervals_ms)) ** 0.5
+    return {
+        "frame_count": len(arrivals),
+        "drop_rate": round(drop_rate, 4),
+        "inter_frame_p99_ms": round(p99, 2),
+        "max_gap_ms": round(max(intervals_ms), 2),
+        "jitter_ms": round(jitter, 3),
+    }
+
+
 def _capture_with_pyrealsense2(duration_sec: float) -> dict[str, Any]:
     """Capture frames using pyrealsense2 and return report fields."""
     import pyrealsense2 as rs
@@ -104,49 +138,69 @@ def _capture_with_pyrealsense2(duration_sec: float) -> dict[str, Any]:
     config.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
 
     pipeline = rs.pipeline()
+    t_start = time.monotonic()
     profile = pipeline.start(config)
     device_info = _detect_device_info(profile)
     usb_mode = device_info.get("usb_speed") or _detect_usb_mode(profile)
 
-    color_frames = 0
-    depth_frames = 0
+    color_arrivals: list[float] = []
+    depth_arrivals: list[float] = []
+    first_frame_ms: float | None = None
     dropped = 0
     t0 = time.time()
     try:
         while time.time() - t0 < duration_sec:
             frames = pipeline.wait_for_frames(timeout_ms=1000)
             if frames:
+                now = time.monotonic()
+                got = False
                 if frames.get_color_frame():
-                    color_frames += 1
+                    color_arrivals.append(now)
+                    got = True
                 if frames.get_depth_frame():
-                    depth_frames += 1
+                    depth_arrivals.append(now)
+                    got = True
+                if got and first_frame_ms is None:
+                    first_frame_ms = round((now - t_start) * 1000.0, 1)
             else:
                 dropped += 1
     finally:
         pipeline.stop()
 
     elapsed = time.time() - t0
-    color_fps = round(color_frames / elapsed, 2) if elapsed > 0 else 0.0
-    depth_fps = round(depth_frames / elapsed, 2) if elapsed > 0 else 0.0
+    color_fps = round(len(color_arrivals) / elapsed, 2) if elapsed > 0 else 0.0
+    depth_fps = round(len(depth_arrivals) / elapsed, 2) if elapsed > 0 else 0.0
+    color_stats = _interval_stats(color_arrivals, elapsed)
+    depth_stats = _interval_stats(depth_arrivals, elapsed)
+    color_count = len(color_arrivals)
+    depth_count = len(depth_arrivals)
     return {
         "backend": "pyrealsense2",
         "device_reset": device_reset,
-        "color_frames": color_frames,
-        "depth_frames": depth_frames,
-        "fps": round((color_fps + depth_fps) / 2, 2) if (color_frames or depth_frames) else 0.0,
+        "first_frame_ms": first_frame_ms,
+        "color_frames": color_count,
+        "depth_frames": depth_count,
+        "fps": round((color_fps + depth_fps) / 2, 2) if (color_count or depth_count) else 0.0,
         "drops": dropped,
         "usb_mode": usb_mode,
         "degraded": "USB2" in str(usb_mode).upper(),
         "streams": {
-            "color": {"frame_count": color_frames, "fps": color_fps},
-            "depth": {"frame_count": depth_frames, "fps": depth_fps},
+            "color": {"frame_count": color_count, "fps": color_fps, **color_stats},
+            "depth": {"frame_count": depth_count, "fps": depth_fps, **depth_stats},
         },
         "aggregate": {
-            "total_frame_count": color_frames + depth_frames,
+            "total_frame_count": color_count + depth_count,
             "average_fps": round((color_fps + depth_fps) / 2, 2)
-            if (color_frames or depth_frames)
+            if (color_count or depth_count)
             else 0.0,
             "drop_count": dropped,
+            "worst_max_gap_ms": max(
+                gap
+                for gap in (color_stats["max_gap_ms"], depth_stats["max_gap_ms"])
+                if gap is not None
+            )
+            if (color_stats["max_gap_ms"] is not None or depth_stats["max_gap_ms"] is not None)
+            else None,
         },
         **device_info,
     }

--- a/src/rosclaw/body/execution/interface.py
+++ b/src/rosclaw/body/execution/interface.py
@@ -25,7 +25,26 @@ if TYPE_CHECKING:  # avoid a body → integrations runtime dependency
 
 
 class ExecutorCommunicationError(RuntimeError):
-    """Transport-level failure during command or feedback."""
+    """Transport-level failure during command or feedback.
+
+    ``command_sent`` records whether the physical command had already been
+    dispatched when the failure occurred, and ``driver_acknowledged``
+    whether the driver confirmed it.  A fault *after* dispatch (e.g. the
+    post-write feedback read fails) is evidence-wise different from a fault
+    before it: the trace and the receipt must be able to distinguish
+    "command sent, observation lost" from "never sent" (TRACE-03).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        command_sent: bool = False,
+        driver_acknowledged: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.command_sent = command_sent
+        self.driver_acknowledged = driver_acknowledged
 
 
 class ExecutorSafetyError(RuntimeError):

--- a/src/rosclaw/body/execution/rh56_executor.py
+++ b/src/rosclaw/body/execution/rh56_executor.py
@@ -123,7 +123,16 @@ class RH56Executor:
         if settle_ms > 0:
             time.sleep(settle_ms / 1000.0)
 
-        feedback = self.read_feedback()
+        try:
+            feedback = self.read_feedback()
+        except ExecutorCommunicationError as exc:
+            # The command was already dispatched (and possibly ACKed) — this
+            # is a post-dispatch observation loss, not a never-sent fault.
+            raise ExecutorCommunicationError(
+                f"post_dispatch_feedback_failed: {exc}",
+                command_sent=True,
+                driver_acknowledged=bool(acknowledged),
+            ) from exc
         return acknowledged, feedback
 
     def emergency_stop(self) -> bool:

--- a/src/rosclaw/integrations/lerobot/execution/executor.py
+++ b/src/rosclaw/integrations/lerobot/execution/executor.py
@@ -344,10 +344,22 @@ class SingleStepExecutor:
         )
         # Best-effort emergency stop.
         self.executor.emergency_stop()
+        # A fault after dispatch is not "never sent": carry the driver's
+        # dispatch/acknowledge state into the result so the receipt and the
+        # trace can distinguish command-sent-observation-lost (TRACE-03).
+        command_sent = getattr(exc, "command_sent", False)
+        if command_sent:
+            self.commands_executed += 1
+            if self.execution_mode is ExecutionMode.FIXTURE:
+                self.fixture_actions_executed += 1
+            else:
+                self.hardware_actions_executed += 1
         return self._result(
             status="fault",
             error_code="communication_lost",
             message=str(exc),
+            command_sent=command_sent,
+            command_acknowledged=getattr(exc, "driver_acknowledged", False),
         )
 
     def emergency_stop(self) -> bool:

--- a/src/rosclaw/kernel/action_gateway.py
+++ b/src/rosclaw/kernel/action_gateway.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import threading
 import uuid
@@ -331,22 +332,89 @@ class ActionGateway:
 
             with lease_handle:
                 transitions.append(StateTransition(ActionState.SCHEDULED, reason="lease_acquired"))
-                try:
-                    result = executor(action)
-                except Exception as exc:  # noqa: BLE001
-                    receipt = self._failure_receipt(
-                        action,
-                        ActionState.FAILED,
-                        "EXECUTOR_ERROR",
-                        str(exc),
-                        trace_id=trace_id,
-                        started_at=started_at,
-                        transitions=transitions,
-                        resource_lease=lease_handle.lease.to_dict(),
+                # P0-5: explicit ROBOT_ACTION / ROBOT_STATE child spans under
+                # the SKILL span so a REAL trace proves physical actuation
+                # (command + ACK) and physical observation (positions, forces,
+                # temps, status bits) instead of only "command submitted".
+                physical = action.execution_mode is ExecutionMode.REAL
+                with self._tracer.start_span(
+                    "kernel.robot_action",
+                    "ROBOT_ACTION",
+                    source="action_gateway",
+                    operation=action.capability_id,
+                    attributes={
+                        "action.id": action.action_id,
+                        "execution.mode": action.execution_mode.value,
+                        "physical_actuation": physical,
+                    },
+                    robot_id=action.body_id,
+                    session_id=action.session_id,
+                ) as action_span:
+                    action_span.set_input(self._action_command_summary(action))
+                    try:
+                        result = executor(action)
+                    except Exception as exc:  # noqa: BLE001
+                        action_span.set_output({"error": str(exc), "command_sent": "unknown"})
+                        action_span.set_status("ERROR", str(exc))
+                        receipt = self._failure_receipt(
+                            action,
+                            ActionState.FAILED,
+                            "EXECUTOR_ERROR",
+                            str(exc),
+                            trace_id=trace_id,
+                            started_at=started_at,
+                            transitions=transitions,
+                            resource_lease=lease_handle.lease.to_dict(),
+                        )
+                        span.set_output(receipt.to_dict())
+                        span.set_status("ERROR", str(exc))
+                        return receipt
+
+                    action_span.set_output(
+                        {
+                            "dispatch_result": result.dispatch_result,
+                            "driver_ack": result.driver_ack,
+                            "final_state": result.final_state.value,
+                            "evidence_level": result.evidence_level.value,
+                            "errors": result.errors,
+                        }
                     )
-                    span.set_output(receipt.to_dict())
-                    span.set_status("ERROR", str(exc))
-                    return receipt
+                    for artifact in result.artifacts:
+                        action_span.add_evidence(artifact)
+                    if result.final_state is ActionState.BLOCKED:
+                        action_span.set_status("BLOCKED", self._result_reason(result))
+                    elif result.final_state not in {ActionState.COMPLETED, ActionState.DEGRADED}:
+                        action_span.set_status("ERROR", self._result_reason(result))
+
+                if result.dispatch_result.get("accepted") or result.observations:
+                    observed = physical and result.evidence_level in {
+                        EvidenceLevel.PHYSICALLY_OBSERVED,
+                        EvidenceLevel.TASK_VERIFIED,
+                    }
+                    with self._tracer.start_span(
+                        "kernel.robot_state",
+                        "ROBOT_STATE",
+                        source="action_gateway",
+                        operation=action.capability_id,
+                        attributes={
+                            "action.id": action.action_id,
+                            "execution.mode": action.execution_mode.value,
+                            "physical_observation": observed,
+                        },
+                        robot_id=action.body_id,
+                        session_id=action.session_id,
+                    ) as state_span:
+                        state_span.set_output(
+                            {
+                                "observations": result.observations,
+                                "verification_result": result.verification_result,
+                                "evidence_level": result.evidence_level.value,
+                            }
+                        )
+                        for artifact in result.artifacts:
+                            state_span.add_evidence(artifact)
+                        if result.final_state not in {ActionState.COMPLETED, ActionState.DEGRADED}:
+                            state_span.set_status("ERROR", self._result_reason(result))
 
                 evidence = result.evidence_level
                 final_state = result.final_state
@@ -471,6 +539,36 @@ class ActionGateway:
         if result.errors:
             return str(result.errors[0].get("message", result.errors[0]))
         return str(result.policy_decision.get("reason", result.final_state.value))
+
+    @staticmethod
+    def _action_command_summary(action: ActionEnvelope) -> dict[str, Any]:
+        """Bounded command summary for the ROBOT_ACTION span input.
+
+        Full joint-value payloads are NOT inlined: the span records a hash and
+        count here, while the complete envelope lives on the SKILL span input
+        and (when the executor provides an artifact directory) in the
+        persisted receipt referenced via span evidence.
+        """
+        args = action.arguments or {}
+        names = list(args.get("names") or [])
+        values = list(args.get("values") or [])
+        summary: dict[str, Any] = {
+            "capability_id": action.capability_id,
+            "representation": args.get("representation"),
+            "units": args.get("units"),
+            "joint_count": len(names),
+            "names": names[:12],
+            "permit_id": args.get("permit_id"),
+            "speed": args.get("speed"),
+            "force_limit_g": args.get("force_limit_g"),
+            "observation_timestamp_ns": args.get("observation_timestamp_ns"),
+        }
+        if values:
+            summary["values_count"] = len(values)
+            summary["values_sha256"] = hashlib.sha256(
+                json.dumps(values).encode("utf-8")
+            ).hexdigest()
+        return summary
 
     @staticmethod
     def _remaining_timeout(action: ActionEnvelope) -> float:

--- a/src/rosclaw/memory/v2/cli.py
+++ b/src/rosclaw/memory/v2/cli.py
@@ -29,7 +29,46 @@ from rosclaw.memory.v2.index import (
 )
 from rosclaw.memory.v2.repository import MemoryRepository
 from rosclaw.memory.v2.retrieval import MemoryQuery, MemoryRetriever, SafetyRetrievalPolicy
+from rosclaw.storage.factory import StorageFactory
+from rosclaw.storage.seekdb_native import SeekDBNativeStore
 from rosclaw.storage.vector import SQLiteVectorStore, TfidfEmbedder
+
+# Score-semantics disclosure: a vector score only has meaning relative to the
+# backend that produced it.  Never present a local TF-IDF cosine as a native
+# SeekDB vector score (or vice versa).
+_SCORE_SEMANTICS = {
+    "tfidf_cosine_local": (
+        "vector_score is cosine similarity of a locally-fitted TF-IDF embedding "
+        "(SQLite store); corpus-dependent, NOT comparable to native SeekDB scores"
+    ),
+    "seekdb_native_1_minus_distance": (
+        "vector_score is 1 - distance from the SeekDB server-side embedder, "
+        "computed natively by the SeekDB engine"
+    ),
+}
+
+
+class _QueryTextPassthrough:
+    """Embedder stand-in that hands the raw query text to a native backend."""
+
+    def encode(self, text: str) -> str:
+        return text
+
+
+class _NativeSeekDBVectorAdapter:
+    """Adapt :meth:`SeekDBNativeStore.similar` to the retriever's
+    ``vector_store.search(table, embedding, limit)`` protocol.
+
+    The server embeds the query text itself, so ``embedding`` here is the raw
+    query text supplied by :class:`_QueryTextPassthrough`.
+    """
+
+    def __init__(self, client: SeekDBNativeStore):
+        self._client = client
+
+    def search(self, table: str, embedding: Any, *, limit: int) -> list[dict[str, Any]]:
+        hits = self._client.similar(table, str(embedding), limit=limit)
+        return [{"record_id": hit.get("id"), "score": float(hit.get("score", 0.0))} for hit in hits]
 
 
 def _resolve_store_path(args: argparse.Namespace) -> str:
@@ -42,20 +81,58 @@ def _resolve_store_path(args: argparse.Namespace) -> str:
 
 
 def _open_stack(args: argparse.Namespace, *, with_vector: bool = False):
+    """Open the knowledge store via :class:`StorageFactory` and build the
+    retrieval stack on top.
+
+    Backend resolution order: ``--backend`` → ``--seekdb-url`` /
+    ``ROSCLAW_SEEKDB_URL`` → legacy SQLite path (``--v2-path`` /
+    rosclaw.yaml / default).  Returns ``(client, repo, vector, embedder,
+    meta)`` where ``meta`` discloses the actual backend and score semantics so
+    callers never present TF-IDF scores as native SeekDB vector scores.
+    """
+    import os
+
+    backend = getattr(args, "backend", None)
+    url = getattr(args, "seekdb_url", None) or os.environ.get("ROSCLAW_SEEKDB_URL")
     path = _resolve_store_path(args)
-    client = SQLiteKnowledgeStore(path)
+    client = StorageFactory.create_knowledge_store(
+        backend=backend or ("sqlite" if not url else None),
+        url=url,
+        path=path,
+    )
     client.connect()
     repo = MemoryRepository(client)
-    vector = SQLiteVectorStore(client) if with_vector else None
+
+    meta: dict[str, Any] = {
+        "backend": type(client).__name__,
+        "store": url or path,
+    }
+    vector = None
     embedder = None
     if with_vector:
-        embedder = TfidfEmbedder()
-        corpus = [
-            memory_embedding_text(item)
-            for item in repo.query(limit=SQLITE_HARD_MAX_RECORDS)
-        ]
-        embedder.fit(corpus)
-    return client, repo, vector, embedder
+        if isinstance(client, SeekDBNativeStore):
+            vector = _NativeSeekDBVectorAdapter(client)
+            embedder = _QueryTextPassthrough()
+            meta["vector_source"] = "seekdb_native"
+            meta["score_semantics"] = _SCORE_SEMANTICS["seekdb_native_1_minus_distance"]
+            with contextlib.suppress(Exception):
+                meta["embedder"] = client.embedding_info("memory_items")
+        elif isinstance(client, SQLiteKnowledgeStore):
+            vector = SQLiteVectorStore(client)
+            embedder = TfidfEmbedder()
+            corpus = [
+                memory_embedding_text(item) for item in repo.query(limit=SQLITE_HARD_MAX_RECORDS)
+            ]
+            embedder.fit(corpus)
+            meta["vector_source"] = "sqlite_tfidf"
+            meta["score_semantics"] = _SCORE_SEMANTICS["tfidf_cosine_local"]
+        else:
+            meta["vector_source"] = "unavailable"
+            meta["score_semantics"] = (
+                f"backend {type(client).__name__} has no vector path in the v2 CLI; "
+                "retrieval is lexical+metadata only"
+            )
+    return client, repo, vector, embedder, meta
 
 
 def _close(client: Any) -> None:
@@ -63,31 +140,54 @@ def _close(client: Any) -> None:
         client.disconnect()
 
 
+def _emit(payload: Any, **json_kwargs: Any) -> None:
+    """Print a JSON payload and flush stdout immediately.
+
+    The embedded SeekDB engine's teardown path can bypass Python's stdio
+    flush at process exit; without an explicit flush, block-buffered output
+    (pipe/file redirect) is silently lost — the command exits 0 having
+    printed nothing.
+    """
+    print(json.dumps(payload, **json_kwargs))
+    sys.stdout.flush()
+
+
 def cmd_memory_v2_status(args: argparse.Namespace) -> int:
-    client, repo, _, _ = _open_stack(args)
+    client, repo, _, _, meta = _open_stack(args)
     try:
         by_type: dict[str, int] = {}
         for row in client.query("memory_items", limit=10000):
             if row.get("status", "active") == "active":
                 memory_type = row.get("memory_type", "?")
                 by_type[memory_type] = by_type.get(memory_type, 0) + 1
+        if isinstance(client, SeekDBNativeStore):
+            index_info: Any = {
+                "mode": "seekdb_native_server_side",
+                "memory_items": client.embedding_info("memory_items"),
+            }
+        elif isinstance(client, SQLiteKnowledgeStore):
+            index_info = EmbeddingIndexManager(client, SQLiteVectorStore(client)).status()["active"]
+        else:
+            index_info = {"mode": "unsupported", "backend": type(client).__name__}
         result = {
+            "backend": meta["backend"],
+            "store": meta["store"],
             "store_path": _resolve_store_path(args),
             "total_active": sum(by_type.values()),
             "by_type": by_type,
             "legacy_experience_graph": client.count("experience_graph"),
-            "index": EmbeddingIndexManager(client, SQLiteVectorStore(client)).status()["active"],
+            "index": index_info,
         }
     finally:
         _close(client)
-    print(json.dumps(result, indent=2, ensure_ascii=False))
+    _emit(result, indent=2, ensure_ascii=False)
     return 0
 
 
 def cmd_memory_v2_query(args: argparse.Namespace) -> int:
-    client, repo, vector, embedder = _open_stack(args, with_vector=not args.no_vector)
+    client, repo, vector, embedder, meta = _open_stack(args, with_vector=not args.no_vector)
     try:
-        if vector is not None:
+        if vector is not None and not isinstance(client, SeekDBNativeStore):
             manager = EmbeddingIndexManager(client, vector)
             if manager.active_index() is not None:
                 manager.check_query_embedder(embedder)
@@ -106,13 +206,16 @@ def cmd_memory_v2_query(args: argparse.Namespace) -> int:
         results = retriever.retrieve(query)
         if getattr(args, "safety_filter", False):
             results = SafetyRetrievalPolicy().filter(results, query)
-        output = [r.to_dict() for r in results]
+        output = {
+            "retrieval": meta,
+            "results": [r.to_dict() for r in results],
+        }
     except IndexModelMismatchError as exc:
         print(str(exc), file=sys.stderr)
         return 2
     finally:
         _close(client)
-    print(json.dumps(output, indent=2, ensure_ascii=False))
+    _emit(output, indent=2, ensure_ascii=False)
     return 0
 
 
@@ -120,9 +223,9 @@ def cmd_memory_v2_explain(args: argparse.Namespace) -> int:
     if not getattr(args, "memory_id", None):
         print("memory explain --v2 requires --memory-id", file=sys.stderr)
         return 2
-    client, repo, vector, embedder = _open_stack(args, with_vector=not args.no_vector)
+    client, repo, vector, embedder, meta = _open_stack(args, with_vector=not args.no_vector)
     try:
-        if vector is not None:
+        if vector is not None and not isinstance(client, SeekDBNativeStore):
             manager = EmbeddingIndexManager(client, vector)
             if manager.active_index() is not None:
                 manager.check_query_embedder(embedder)
@@ -136,18 +239,21 @@ def cmd_memory_v2_explain(args: argparse.Namespace) -> int:
         )
         output = retriever.explain(args.memory_id, query)
         output["trace"] = repo.trace(args.memory_id)
+        # Retrieval-backend disclosure (P0): backend + score semantics so a
+        # TF-IDF cosine is never mistaken for a native SeekDB vector score.
+        output["retrieval"] = meta
     except IndexModelMismatchError as exc:
         print(str(exc), file=sys.stderr)
         return 2
     finally:
         _close(client)
-    print(json.dumps(output, indent=2, ensure_ascii=False))
+    _emit(output, indent=2, ensure_ascii=False)
     return 0 if output.get("found", True) else 1
 
 
 def cmd_memory_v2_verify(args: argparse.Namespace) -> int:
     """Verify every active memory is traceable to evidence."""
-    client, repo, _, _ = _open_stack(args)
+    client, repo, _, _, _meta = _open_stack(args)
     try:
         items = repo.query(limit=10000)
         untraceable = [i.memory_id for i in items if not repo.trace(i.memory_id)["traceable"]]
@@ -159,43 +265,48 @@ def cmd_memory_v2_verify(args: argparse.Namespace) -> int:
         }
     finally:
         _close(client)
-    print(json.dumps(result, indent=2, ensure_ascii=False))
+    _emit(result, indent=2, ensure_ascii=False)
     return 0 if result["passed"] else 1
 
 
 def cmd_memory_v2_consolidate(args: argparse.Namespace) -> int:
-    client, repo, _, _ = _open_stack(args)
+    client, repo, _, _, _meta = _open_stack(args)
     try:
         result = MemoryConsolidator(repo).consolidate(robot_id=getattr(args, "robot_id", None))
         output = vars(result)
     finally:
         _close(client)
-    print(json.dumps(output, indent=2, ensure_ascii=False))
+    _emit(output, indent=2, ensure_ascii=False)
     return 0
 
 
 def cmd_memory_v2_forget(args: argparse.Namespace) -> int:
     """Delete a memory and sync the vector index."""
-    client, repo, vector, _ = _open_stack(args, with_vector=True)
+    client, repo, vector, _, _meta = _open_stack(args, with_vector=True)
     try:
         item = repo.get(args.memory_id)
         if item is None:
-            print(json.dumps({"deleted": False, "reason": "not found"}))
+            _emit({"deleted": False, "reason": "not found"})
             return 1
         client.delete("memory_items", args.memory_id)
         for evidence in repo.evidence_for(args.memory_id):
             client.delete("memory_evidence", evidence.evidence_id)
-        index_deleted = EmbeddingIndexManager(client, vector).on_memory_deleted(args.memory_id)
+        if isinstance(client, SeekDBNativeStore):
+            # The server-side embedder re-indexes on delete; nudge visibility.
+            client.refresh_index("memory_items")
+            index_deleted = True
+        else:
+            index_deleted = EmbeddingIndexManager(client, vector).on_memory_deleted(args.memory_id)
         output = {"deleted": True, "memory_id": args.memory_id, "index_synced": index_deleted}
     finally:
         _close(client)
-    print(json.dumps(output, indent=2))
+    _emit(output, indent=2)
     return 0
 
 
 def cmd_memory_v2_distill(args: argparse.Namespace) -> int:
     """Distill a practice session into Memory 2.0."""
-    client, repo, _, _ = _open_stack(args)
+    client, repo, _, _, _meta = _open_stack(args)
     try:
         gate = MemoryWriteGate(repo)
         result = distill_session_dir(args.session_dir, gate=gate, repository=repo)
@@ -210,31 +321,57 @@ def cmd_memory_v2_distill(args: argparse.Namespace) -> int:
         }
     finally:
         _close(client)
-    print(json.dumps(output, indent=2, ensure_ascii=False))
+    _emit(output, indent=2, ensure_ascii=False)
     return 0
 
 
 def cmd_memory_v2_index_status(args: argparse.Namespace) -> int:
-    client, repo, vector, _ = _open_stack(args, with_vector=True)
+    client, repo, vector, _, _meta = _open_stack(args, with_vector=True)
     try:
-        output = EmbeddingIndexManager(client, vector).status()
+        if isinstance(client, SeekDBNativeStore):
+            output = {
+                "mode": "seekdb_native_server_side",
+                "detail": (
+                    "embedding is computed by the SeekDB server-side embedder; "
+                    "there is no local TF-IDF index registry"
+                ),
+                "memory_items": client.embedding_info("memory_items"),
+                "count": client.count("memory_items"),
+            }
+        elif isinstance(client, SQLiteKnowledgeStore):
+            output = EmbeddingIndexManager(client, vector).status()
+        else:
+            output = {"mode": "unsupported", "backend": type(client).__name__}
     finally:
         _close(client)
-    print(json.dumps(output, indent=2, ensure_ascii=False, default=str))
+    _emit(output, indent=2, ensure_ascii=False, default=str)
     return 0
 
 
 def cmd_memory_v2_index_rebuild(args: argparse.Namespace) -> int:
-    client, repo, vector, _ = _open_stack(args, with_vector=True)
+    client, repo, vector, _, _meta = _open_stack(args, with_vector=True)
     try:
-        embedder = TfidfEmbedder()
-        items = repo.query(limit=200000)
-        manager = EmbeddingIndexManager(client, vector)
-        record = manager.build(items, embedder)
-        output = {"rebuilt": True, "index": record}
+        if isinstance(client, SeekDBNativeStore):
+            client.refresh_index("memory_items")
+            output = {
+                "rebuilt": False,
+                "mode": "seekdb_native_server_side",
+                "detail": (
+                    "server-side embedding is automatic on write; "
+                    "issued refresh_index instead of a local TF-IDF rebuild"
+                ),
+            }
+        elif isinstance(client, SQLiteKnowledgeStore):
+            embedder = TfidfEmbedder()
+            items = repo.query(limit=200000)
+            manager = EmbeddingIndexManager(client, vector)
+            record = manager.build(items, embedder)
+            output = {"rebuilt": True, "index": record}
+        else:
+            output = {"rebuilt": False, "mode": "unsupported", "backend": type(client).__name__}
     finally:
         _close(client)
-    print(json.dumps(output, indent=2, ensure_ascii=False, default=str))
+    _emit(output, indent=2, ensure_ascii=False, default=str)
     return 0
 
 
@@ -254,34 +391,55 @@ def cmd_memory_v2_benchmark(args: argparse.Namespace) -> int:
     return subprocess.call([sys.executable, str(script)])
 
 
+def _add_backend_arguments(p: Any) -> None:
+    """Add StorageFactory backend selection args to a v2 parser."""
+    p.add_argument(
+        "--backend",
+        choices=["sqlite", "seekdb_embedded", "seekdb_server", "mysql", "memory"],
+        default=None,
+        help="Knowledge-store backend (default: sqlite at --v2-path, or derived from --seekdb-url)",
+    )
+    p.add_argument(
+        "--seekdb-url",
+        default=None,
+        help="Backend DSN, e.g. seekdb://root@127.0.0.1:2881/rosclaw (or ROSCLAW_SEEKDB_URL)",
+    )
+
+
 def register_memory_v2_commands(memory_subparsers: Any) -> None:
     """Register Memory 2.0 subcommands into the existing memory group."""
     p = memory_subparsers.add_parser("verify", help="Verify all memories are traceable (v2)")
     p.add_argument("--v2-path", default=None, help="SQLite knowledge store path")
+    _add_backend_arguments(p)
     p.set_defaults(v2_handler=cmd_memory_v2_verify)
 
     p = memory_subparsers.add_parser("consolidate", help="Run memory consolidation (v2)")
     p.add_argument("--robot-id", default=None)
     p.add_argument("--v2-path", default=None)
+    _add_backend_arguments(p)
     p.set_defaults(v2_handler=cmd_memory_v2_consolidate)
 
     p = memory_subparsers.add_parser("forget", help="Delete a memory and sync the index (v2)")
     p.add_argument("memory_id")
     p.add_argument("--v2-path", default=None)
+    _add_backend_arguments(p)
     p.set_defaults(v2_handler=cmd_memory_v2_forget)
 
     p = memory_subparsers.add_parser("distill", help="Distill a practice session into memory (v2)")
     p.add_argument("session_dir", help="Practice session directory")
     p.add_argument("--v2-path", default=None)
+    _add_backend_arguments(p)
     p.set_defaults(v2_handler=cmd_memory_v2_distill)
 
     p = memory_subparsers.add_parser("index", help="Embedding index operations (v2)")
     index_sub = p.add_subparsers(dest="index_command")
     pi = index_sub.add_parser("status", help="Index registry status")
     pi.add_argument("--v2-path", default=None)
+    _add_backend_arguments(pi)
     pi.set_defaults(v2_handler=cmd_memory_v2_index_status)
     pi = index_sub.add_parser("rebuild", help="Rebuild the embedding index")
     pi.add_argument("--v2-path", default=None)
+    _add_backend_arguments(pi)
     pi.set_defaults(v2_handler=cmd_memory_v2_index_rebuild)
 
     p = memory_subparsers.add_parser("benchmark", help="Run the retrieval benchmark (v2)")
@@ -294,6 +452,7 @@ def extend_legacy_memory_parsers(
     """Add ``--v2`` routing flags to the legacy memory subcommands."""
     status_parser.add_argument("--v2", action="store_true", help="Use Memory 2.0 status")
     status_parser.add_argument("--v2-path", default=None)
+    _add_backend_arguments(status_parser)
     status_parser.set_defaults(v2_handler=cmd_memory_v2_status)
 
     query_parser.add_argument("--v2", action="store_true", help="Use Memory 2.0 hybrid retrieval")
@@ -307,6 +466,7 @@ def extend_legacy_memory_parsers(
     query_parser.add_argument("--task-id", default=None)
     query_parser.add_argument("--no-vector", action="store_true")
     query_parser.add_argument("--safety-filter", action="store_true")
+    _add_backend_arguments(query_parser)
     query_parser.set_defaults(v2_handler=cmd_memory_v2_query)
 
     explain_parser.add_argument("--v2", action="store_true", help="Use Memory 2.0 explain")
@@ -318,4 +478,5 @@ def extend_legacy_memory_parsers(
     explain_parser.add_argument("--site-id", default=None)
     explain_parser.add_argument("--robot-id", default=None)
     explain_parser.add_argument("--no-vector", action="store_true")
+    _add_backend_arguments(explain_parser)
     explain_parser.set_defaults(v2_handler=cmd_memory_v2_explain)

--- a/src/rosclaw/memory/v2/retrieval.py
+++ b/src/rosclaw/memory/v2/retrieval.py
@@ -132,7 +132,7 @@ class MemoryRetriever:
             return []
 
         # 3. Candidate scoring per source.
-        lexical = self._lexical_scores(candidates, query_tokens)
+        lexical, lexical_raw = self._lexical_scores(candidates, query_tokens)
         vector = self._vector_scores(candidates, query.text)
 
         # 4-5. Normalize + fuse.
@@ -140,14 +140,29 @@ class MemoryRetriever:
         scored: list[tuple[MemoryItem, dict[str, Any]]] = []
         for item in candidates:
             parts = self._score_parts(item, query, query_tokens, lexical, vector, now)
+            # Tie-break on the UNCAPPED lexical score: the capped fusion can
+            # saturate (min(1.0, overlap + 0.5*title) → 1.0 for several docs),
+            # and an arbitrary order on ties can rank the wrong joint/body
+            # first (MEM-02 acceptance finding).  The raw score keeps the
+            # more specific document ahead without changing fusion values.
+            parts["lexical_raw"] = lexical_raw.get(item.memory_id, 0.0)
             fusion = sum(self._weights[key] * parts[key] for key in self._weights)
             scored.append((item, {"parts": parts, "fusion": fusion}))
 
         # 6. Safety/validity filter.
         scored = [(item, meta) for item, meta in scored if self._passes_validity(item, meta)]
 
-        # 7. Rank + explain.
-        scored.sort(key=lambda pair: pair[1]["fusion"], reverse=True)
+        # 7. Rank + explain.  Fusion is quantized to 1e-6 for ordering so
+        # microsecond-level recency jitter between same-batch items does not
+        # mask the lexical_raw tie-breaker (real recency differences are
+        # orders of magnitude larger).
+        scored.sort(
+            key=lambda pair: (
+                round(pair[1]["fusion"], 6),
+                pair[1]["parts"].get("lexical_raw", 0.0),
+            ),
+            reverse=True,
+        )
         results: list[RetrievalResult] = []
         for rank, (item, meta) in enumerate(scored[: query.limit], start=1):
             parts = meta["parts"]
@@ -214,21 +229,32 @@ class MemoryRetriever:
 
     def _lexical_scores(
         self, candidates: list[MemoryItem], query_tokens: set[str]
-    ) -> dict[str, float]:
-        """Token-overlap score in [0, 1] with a title-match boost."""
-        scores: dict[str, float] = {}
+    ) -> tuple[dict[str, float], dict[str, float]]:
+        """Token-overlap score in [0, 1] with a title-match boost.
+
+        Returns ``(capped, raw)``: the capped score feeds the fusion, the
+        uncapped raw score is the deterministic tie-breaker so a saturated
+        cap never leaves the wrong joint/body on top.
+        """
+        capped: dict[str, float] = {}
+        raw: dict[str, float] = {}
         if not query_tokens:
-            return {item.memory_id: 0.0 for item in candidates}
+            return {item.memory_id: 0.0 for item in candidates}, {
+                item.memory_id: 0.0 for item in candidates
+            }
         for item in candidates:
             doc_tokens = token_set(f"{item.title} {item.document}")
             if not doc_tokens:
-                scores[item.memory_id] = 0.0
+                capped[item.memory_id] = 0.0
+                raw[item.memory_id] = 0.0
                 continue
             overlap = len(query_tokens & doc_tokens) / len(query_tokens)
             title_tokens = token_set(item.title)
             title_overlap = len(query_tokens & title_tokens) / len(query_tokens)
-            scores[item.memory_id] = min(1.0, overlap + 0.5 * title_overlap)
-        return scores
+            score = overlap + 0.5 * title_overlap
+            capped[item.memory_id] = min(1.0, score)
+            raw[item.memory_id] = score
+        return capped, raw
 
     def _vector_scores(
         self, candidates: list[MemoryItem], query_text: str

--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -6,6 +6,7 @@ Adds ``rosclaw db status`` and ``rosclaw db doctor``.
 from __future__ import annotations
 
 import argparse
+import functools
 import hashlib
 import json
 import os
@@ -21,6 +22,8 @@ from rosclaw.storage.factory import StorageFactory, _sanitize_url
 from rosclaw.storage.migrations import MigrationRunner
 from rosclaw.storage.outbox import OutboxStore
 
+_NATIVE_SEEKDB_BACKENDS = {"seekdb_embedded", "seekdb_server"}
+
 
 def _close_client(client: Any) -> None:
     """Best-effort close/disconnect for a knowledge-store client."""
@@ -28,6 +31,32 @@ def _close_client(client: Any) -> None:
     if close:
         with contextlib.suppress(Exception):
             close()
+
+
+def _flush_stdout() -> None:
+    """Flush stdout/stderr before returning from a db command.
+
+    The embedded SeekDB engine's teardown can bypass Python's stdio flush at
+    process exit; without this, block-buffered output (pipe/file redirect) is
+    silently lost and the command exits 0 having printed nothing.
+    """
+    with contextlib.suppress(Exception):
+        sys.stdout.flush()
+    with contextlib.suppress(Exception):
+        sys.stderr.flush()
+
+
+def _with_stdout_flush(fn: Any) -> Any:
+    """Decorator: guarantee buffered output lands before process teardown."""
+
+    @functools.wraps(fn)
+    def wrapper(args: argparse.Namespace) -> int:
+        try:
+            return fn(args)
+        finally:
+            _flush_stdout()
+
+    return wrapper
 
 
 def _load_storage_config(args: argparse.Namespace) -> dict[str, Any]:
@@ -146,8 +175,17 @@ def _outbox_status(cfg: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def _vector_status(client: Any) -> dict[str, Any]:
-    """Return vector-store status for SQLite-backed clients."""
+    """Return vector-store status for the connected client."""
     status: dict[str, Any] = {"enabled": False}
+    if type(client).__name__ in {"SeekDBEmbeddedStore", "SeekDBServerStore", "SeekDBNativeStore"}:
+        # Native SeekDB embeds server-side on every write; there is no local
+        # warmup step.  Report the deployment mode honestly instead of the
+        # SQLite-only "disabled".
+        status["enabled"] = True
+        status["mode"] = "seekdb_native_server_side"
+        with contextlib.suppress(Exception):
+            status["collections"] = len(client.list_collections())
+        return status
     if type(client).__name__ != "SQLiteKnowledgeStore":
         return status
     enabled = getattr(client, "_vector_enabled", False)
@@ -247,6 +285,7 @@ def _session_event_consistency(
     return event_count, events_lines, consistent, timeline_exists
 
 
+@_with_stdout_flush
 def cmd_db_status(args: argparse.Namespace) -> int:
     """Show storage backend status and capabilities."""
     cfg = _load_storage_config(args)
@@ -334,6 +373,122 @@ def cmd_db_status(args: argparse.Namespace) -> int:
     return 0 if ping.get("connected") else 1
 
 
+def _native_seekdb_checks(
+    client: Any,
+    backend: str,
+    args: argparse.Namespace,
+    checks: list[tuple[str, str, bool]],
+    issues: list[str],
+    result: dict[str, Any],
+) -> None:
+    """Doctor checks for native SeekDB backends (embedded / server).
+
+    Covers the P0 acceptance set: engine readiness, collections, embedder
+    model + dimension, per-collection counts, restart persistence (embedded),
+    and DSN/auth disclosure (server).
+    """
+    import time
+
+    deployment = client.deployment_info()
+    result["seekdb"] = {"backend": backend, "deployment": deployment}
+
+    # 1. Engine readiness: the store's connect() already probes with a 30 s
+    # deadline; time a live catalog round-trip as the observable probe.
+    t0 = time.perf_counter()
+    try:
+        collections = client.list_collections()
+        ready_ms = round((time.perf_counter() - t0) * 1000, 1)
+        checks.append(("engine ready", f"catalog probe {ready_ms} ms", True))
+    except Exception as exc:  # noqa: BLE001
+        checks.append(("engine ready", f"catalog probe failed: {exc}", False))
+        issues.append(f"SeekDB engine not ready: {exc}")
+        return
+
+    # 2. Collections + 3. counts + 4. embedder model/dimension
+    checks.append(("collections", f"{len(collections)} present", True))
+    counts: dict[str, int] = {}
+    dimensions: dict[str, Any] = {}
+    models: dict[str, Any] = {}
+    for name in collections:
+        try:
+            counts[name] = client.count(name)
+        except Exception as exc:  # noqa: BLE001
+            counts[name] = -1
+            issues.append(f"count({name}) failed: {exc}")
+        try:
+            info = client.embedding_info(name)
+            dimensions[name] = info.get("dimension")
+            models[name] = info.get("model_name") or info.get("embedder_type")
+        except Exception as exc:  # noqa: BLE001
+            dimensions[name] = None
+            models[name] = None
+            issues.append(f"embedding_info({name}) failed: {exc}")
+    result["seekdb"]["collections"] = {
+        name: {
+            "count": counts.get(name),
+            "dimension": dimensions.get(name),
+            "embedder": models.get(name),
+        }
+        for name in collections
+    }
+    dim_set = {d for d in dimensions.values() if d is not None}
+    dim_ok = len(dim_set) <= 1
+    checks.append(
+        (
+            "vector dimension",
+            f"{sorted(dim_set) if dim_set else 'n/a'} across {len(dimensions)} collections",
+            dim_ok,
+        )
+    )
+    if not dim_ok:
+        issues.append(f"Mixed vector dimensions across collections: {dimensions}")
+    model_set = {m for m in models.values() if m}
+    checks.append(
+        (
+            "embedder model",
+            ", ".join(sorted(model_set)) if model_set else "n/a",
+            bool(model_set) or not collections,
+        )
+    )
+    if collections and not model_set:
+        issues.append("No embedder model reported for any collection.")
+    total = sum(c for c in counts.values() if c > 0)
+    checks.append(("collection counts", f"{total} records total", True))
+
+    # 5a. Restart persistence (embedded): disconnect + reconnect must see the
+    # same collections — proves the on-disk engine state survives a restart.
+    if deployment["mode"] == "embedded":
+        path = deployment.get("path")
+        try:
+            client.disconnect()
+            client.connect()
+            after = client.list_collections()
+            persisted = set(after) >= set(collections)
+            checks.append(
+                (
+                    "restart persistence",
+                    f"{len(after)}/{len(collections)} collections after reopen at {path}",
+                    persisted,
+                )
+            )
+            if not persisted:
+                issues.append(
+                    f"Embedded engine lost collections across reopen: "
+                    f"{sorted(set(collections) - set(after))}"
+                )
+        except Exception as exc:  # noqa: BLE001
+            checks.append(("restart persistence", f"reopen failed: {exc}", False))
+            issues.append(f"Embedded engine reopen failed: {exc}")
+
+    # 5b. DSN/auth (server): successful connect + catalog listing already
+    # proves auth; disclose the DSN with password redacted.
+    if deployment["mode"] == "server":
+        dsn = f"{deployment.get('user')}@{deployment.get('host')}:{deployment.get('port')}/{deployment.get('database')}"
+        checks.append(("dsn auth", f"authenticated as {dsn}", True))
+        result["seekdb"]["dsn"] = dsn
+
+
+@_with_stdout_flush
 def cmd_db_doctor(args: argparse.Namespace) -> int:
     """Run storage health checks and optionally apply safe fixes."""
     cfg = _load_storage_config(args)
@@ -358,7 +513,7 @@ def cmd_db_doctor(args: argparse.Namespace) -> int:
     # 2. Backend resolution and URL sanity
     backend = cfg["backend"]
     url = cfg["url"]
-    resolved_ok = backend in {"memory", "sqlite", "mysql"}
+    resolved_ok = backend in {"memory", "sqlite", "mysql"} | _NATIVE_SEEKDB_BACKENDS
     checks.append(("backend", backend, resolved_ok))
     if not resolved_ok:
         issues.append(f"Unknown backend '{backend}'.")
@@ -468,6 +623,9 @@ def cmd_db_doctor(args: argparse.Namespace) -> int:
         except Exception as exc:  # noqa: BLE001
             issues.append(f"MySQL table listing failed: {exc}")
 
+    if client is not None and backend in _NATIVE_SEEKDB_BACKENDS:
+        _native_seekdb_checks(client, backend, args, checks, issues, result)
+
     # 5. Schema migrations
     if client is not None and backend in {"sqlite", "mysql"}:
         try:
@@ -514,11 +672,19 @@ def cmd_db_doctor(args: argparse.Namespace) -> int:
             "schema_migrations table",
             "present"
             if "schema_migrations" in tables
-            else ("n/a" if backend == "memory" else "missing"),
-            "schema_migrations" in tables or backend == "memory",
+            else (
+                "n/a" if backend == "memory" or backend in _NATIVE_SEEKDB_BACKENDS else "missing"
+            ),
+            "schema_migrations" in tables
+            or backend == "memory"
+            or backend in _NATIVE_SEEKDB_BACKENDS,
         )
     )
-    if "schema_migrations" not in tables and backend != "memory":
+    if (
+        "schema_migrations" not in tables
+        and backend != "memory"
+        and backend not in _NATIVE_SEEKDB_BACKENDS
+    ):
         issues.append("schema_migrations table is missing.")
 
     # 6. Outbox check
@@ -671,8 +837,13 @@ def _jsonl_event_stats(events_path: Path) -> dict[str, Any]:
                 duplicates += 1
             else:
                 ids.add(event_id)
-    return {"count": count, "duplicates": duplicates, "parse_errors": parse_errors,
-            "ids": ids, "exists": True}
+    return {
+        "count": count,
+        "duplicates": duplicates,
+        "parse_errors": parse_errors,
+        "ids": ids,
+        "exists": True,
+    }
 
 
 def _manifest_event_count(session_dir: Path) -> int | None:
@@ -810,10 +981,7 @@ def reconcile_practice(
         and (episode_count is None or episode_count == jsonl["count"])
     )
     local_ok = (
-        counts_match
-        and hash_match
-        and jsonl["duplicates"] == 0
-        and jsonl["parse_errors"] == 0
+        counts_match and hash_match and jsonl["duplicates"] == 0 and jsonl["parse_errors"] == 0
     )
 
     if remote_client is not None:
@@ -831,6 +999,7 @@ def reconcile_practice(
     return report
 
 
+@_with_stdout_flush
 def cmd_db_reconcile(args: argparse.Namespace) -> int:
     """Reconcile practice event persistence across all local/remote paths."""
     cfg = _load_storage_config(args)
@@ -882,10 +1051,14 @@ def cmd_db_reconcile(args: argparse.Namespace) -> int:
 
     all_passed = all(r["passed"] for r in reports)
     if getattr(args, "json", False):
-        output: Any = reports[0] if len(reports) == 1 else {
-            "passed": all_passed,
-            "sessions": reports,
-        }
+        output: Any = (
+            reports[0]
+            if len(reports) == 1
+            else {
+                "passed": all_passed,
+                "sessions": reports,
+            }
+        )
         print(json.dumps(output, indent=2))
     else:
         for report in reports:

--- a/src/rosclaw/storage/seekdb_native.py
+++ b/src/rosclaw/storage/seekdb_native.py
@@ -447,6 +447,32 @@ class SeekDBNativeStore(SeekDBClient):
             info["dimension"] = None
         return info
 
+    # ------------------------------------------------------------------
+    # Diagnostics (db doctor)
+    # ------------------------------------------------------------------
+
+    def list_collections(self) -> list[str]:
+        """Names of all collections in the current database (engine catalog)."""
+        client = self._client
+        if client is None:
+            raise RuntimeError("SeekDBNativeStore is not connected")
+        return sorted(getattr(c, "name", str(c)) for c in client.list_collections())
+
+    def deployment_info(self) -> dict[str, Any]:
+        """Deployment descriptor for diagnostics (embedded path / server DSN).
+
+        Never includes the password.
+        """
+        if self._path is not None:
+            return {"mode": "embedded", "path": self._path, "database": self._database}
+        return {
+            "mode": "server",
+            "host": self._host,
+            "port": self._port,
+            "user": self._user,
+            "database": self._database,
+        }
+
 
 # Deployment-specific aliases matching the PR-SDB-1 naming (§7.3).
 class SeekDBEmbeddedStore(SeekDBNativeStore):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,20 @@ def pytest_runtest_call(item):
     logging.getLogger().propagate = True
 
 
+@pytest.fixture(scope="session")
+def shared_embedded_seekdb_target(tmp_path_factory) -> dict[str, str]:
+    """The single real embedded SeekDB ``(path, database)`` target for this process.
+
+    pylibseekdb supports ONE embedded target per process
+    (``SeekDBNativeStore._claim_embedded_target``); every real-engine test
+    must share this one.  Tests connect/disconnect their own stores against
+    it sequentially and clean up the collections they use.
+    """
+    pytest.importorskip("pyseekdb")
+    path = tmp_path_factory.mktemp("shared_embedded_seekdb")
+    return {"path": str(path), "database": "rosclaw"}
+
+
 @pytest.fixture
 def linked_realsense_workspace(tmp_path: Path) -> Path:
     """Create a temporary workspace with a linked RealSense D405 body."""

--- a/tests/kernel/test_action_gateway.py
+++ b/tests/kernel/test_action_gateway.py
@@ -13,6 +13,7 @@ from rosclaw.kernel import (
     ExecutionMode,
     VerificationPolicy,
 )
+from rosclaw.observability.tracer import Tracer
 
 
 def _action(*, action_id: str = "action-1") -> ActionEnvelope:
@@ -204,3 +205,168 @@ def test_real_action_rejects_mismatched_authorization_scope() -> None:
 
     assert receipt.final_state is ActionState.BLOCKED
     assert receipt.errors[0]["code"] == "AUTHORIZATION_SCOPE_MISMATCH"
+
+
+# ---------------------------------------------------------------------------
+# P0-5: ROBOT_ACTION / ROBOT_STATE child spans under the SKILL span
+# ---------------------------------------------------------------------------
+
+
+class _RecordingExporter:
+    def __init__(self) -> None:
+        self.records: list = []
+
+    def export(self, record) -> bool:
+        self.records.append(record)
+        return True
+
+
+def _real_action(**overrides) -> ActionEnvelope:
+    base = {
+        "action_id": "real-action-1",
+        "actor_id": "test-agent",
+        "agent_framework": "pytest",
+        "session_id": "session-1",
+        "body_id": "rh56_right_01",
+        "body_snapshot_hash": "sha256:body",
+        "capability_id": "rh56.single_step",
+        "arguments": {
+            "permit_id": "permit-1",
+            "names": ["little", "ring", "middle", "index", "thumb", "thumb_rot"],
+            "values": [1000.0, 1000.0, 1000.0, 410.0, 420.0, 300.0],
+            "representation": "joint_position",
+            "units": "raw_device_unit",
+            "hashes": {"body_hash": "sha256:body"},
+            "speed": 500,
+            "force_limit_g": 800.0,
+            "observation_timestamp_ns": 123456789,
+        },
+        "execution_mode": ExecutionMode.REAL,
+        "verification_policy": VerificationPolicy(
+            required_evidence=EvidenceLevel.PHYSICALLY_OBSERVED,
+        ),
+        "authorization": AuthorizationContext(
+            principal_id="operator-1",
+            approved=True,
+            approval_id="approval-1",
+            scopes=["rh56.single_step"],
+        ),
+    }
+    base.update(overrides)
+    return ActionEnvelope(**base)
+
+
+def _completed_real_result(action: ActionEnvelope) -> ActionExecutionResult:
+    return ActionExecutionResult(
+        final_state=ActionState.COMPLETED,
+        evidence_level=EvidenceLevel.PHYSICALLY_OBSERVED,
+        dispatch_result={"accepted": True, "command_sent": True},
+        driver_ack={"acknowledged": True},
+        observations=[
+            {
+                "position": [1001.0, 1000.0, 999.0, 409.0, 421.0, 300.0],
+                "force_g": [0.0, 0.0, 0.0, 12.0, 45.0, 0.0],
+                "current_ma": [120.0, 110.0, 105.0, 130.0, 140.0, 100.0],
+                "temperature_c": [38.5] * 6,
+                "status_bits": [0] * 6,
+                "position_error": [1.0, 0.0, 1.0, 1.0, 1.0, 0.0],
+            }
+        ],
+        verification_result={"success": True, "position_ok": True},
+    )
+
+
+def _finished_spans(exporter: _RecordingExporter) -> dict:
+    return {r.name: r for r in exporter.records if r.status != "RUNNING"}
+
+
+def test_real_execution_emits_robot_action_and_state_spans() -> None:
+    """P0-5: REAL dispatch proves physical actuation + observation in the trace."""
+    exporter = _RecordingExporter()
+    gateway = ActionGateway(tracer=Tracer(exporters=[exporter]))
+    gateway.register_executor("rh56.single_step", ExecutionMode.REAL, _completed_real_result)
+
+    receipt = gateway.submit(_real_action())
+
+    assert receipt.final_state is ActionState.COMPLETED
+    assert receipt.evidence_level is EvidenceLevel.PHYSICALLY_OBSERVED
+
+    spans = _finished_spans(exporter)
+    skill = spans["kernel.submit_action"]
+    robot_action = spans["kernel.robot_action"]
+    robot_state = spans["kernel.robot_state"]
+
+    # Causal tree: both child spans hang under the SKILL span, same trace.
+    assert skill.span_kind == "SKILL"
+    assert robot_action.parent_span_id == skill.span_id
+    assert robot_state.parent_span_id == skill.span_id
+    assert robot_action.trace_id == skill.trace_id == robot_state.trace_id
+
+    # ROBOT_ACTION: physical actuation with command + ACK, bounded command
+    # summary (hash + count, not the raw values payload).
+    assert robot_action.span_kind == "ROBOT_ACTION"
+    assert robot_action.attributes["physical_actuation"] is True
+    assert robot_action.input["joint_count"] == 6
+    assert "values_sha256" in robot_action.input
+    assert "values" not in robot_action.input
+    assert robot_action.output["dispatch_result"]["accepted"] is True
+    assert robot_action.output["driver_ack"]["acknowledged"] is True
+
+    # ROBOT_STATE: physical observation with positions/forces/temps/status.
+    assert robot_state.span_kind == "ROBOT_STATE"
+    assert robot_state.attributes["physical_observation"] is True
+    observation = robot_state.output["observations"][0]
+    for key in ("position", "force_g", "current_ma", "temperature_c", "status_bits"):
+        assert key in observation, key
+
+
+def test_fixture_execution_keeps_physical_flags_false() -> None:
+    """P0-5: the FIXTURE path must never claim physical actuation/observation."""
+    exporter = _RecordingExporter()
+    gateway = ActionGateway(tracer=Tracer(exporters=[exporter]))
+    gateway.register_executor("rh56.single_step", ExecutionMode.FIXTURE, _completed_real_result)
+
+    receipt = gateway.submit(
+        _real_action(
+            action_id="fixture-action-1",
+            execution_mode=ExecutionMode.FIXTURE,
+            authorization=AuthorizationContext(),
+        )
+    )
+
+    assert receipt.final_state is ActionState.DEGRADED
+    assert receipt.evidence_level is EvidenceLevel.SYNTHETIC
+
+    spans = _finished_spans(exporter)
+    robot_action = spans["kernel.robot_action"]
+    robot_state = spans["kernel.robot_state"]
+    assert robot_action.attributes["physical_actuation"] is False
+    assert robot_state.attributes["physical_observation"] is False
+
+
+def test_blocked_before_dispatch_has_no_robot_state_span() -> None:
+    """P0-5: a blocked action shows ROBOT_ACTION(BLOCKED, no ACK) and, with no
+    observation taken, no ROBOT_STATE span at all."""
+
+    def blocked_executor(action: ActionEnvelope) -> ActionExecutionResult:
+        return ActionExecutionResult(
+            final_state=ActionState.BLOCKED,
+            evidence_level=EvidenceLevel.REQUESTED,
+            dispatch_result={"accepted": False, "command_sent": False},
+            errors=[{"code": "stale_action", "message": "observation too old"}],
+        )
+
+    exporter = _RecordingExporter()
+    gateway = ActionGateway(tracer=Tracer(exporters=[exporter]))
+    gateway.register_executor("rh56.single_step", ExecutionMode.REAL, blocked_executor)
+
+    receipt = gateway.submit(_real_action(action_id="blocked-action-1"))
+
+    assert receipt.final_state is ActionState.BLOCKED
+    spans = _finished_spans(exporter)
+    robot_action = spans["kernel.robot_action"]
+    assert robot_action.attributes["physical_actuation"] is True
+    assert robot_action.output["dispatch_result"]["accepted"] is False
+    assert robot_action.output["driver_ack"] is None
+    assert robot_action.status == "BLOCKED"
+    assert "kernel.robot_state" not in spans

--- a/tests/memory/v2/test_cli.py
+++ b/tests/memory/v2/test_cli.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 from pathlib import Path
+
+import pytest
 
 from rosclaw.memory.seekdb_client import SQLiteKnowledgeStore
 from rosclaw.memory.v2.cli import (
@@ -12,6 +15,7 @@ from rosclaw.memory.v2.cli import (
     _open_stack,
     cmd_memory_v2_benchmark,
     cmd_memory_v2_explain,
+    cmd_memory_v2_query,
 )
 from rosclaw.memory.v2.index import EmbeddingIndexManager
 from rosclaw.memory.v2.models import MemoryItem
@@ -58,12 +62,14 @@ def test_cli_reopens_index_with_identical_tfidf_revision(tmp_path: Path) -> None
     manager.build(repo.query(limit=100), TfidfEmbedder())
     client.disconnect()
 
-    reopened, reopened_repo, vector, embedder = _open_stack(
+    reopened, reopened_repo, vector, embedder, meta = _open_stack(
         argparse.Namespace(v2_path=str(path)),
         with_vector=True,
     )
     try:
         assert vector is not None
+        assert meta["vector_source"] == "sqlite_tfidf"
+        assert "score_semantics" in meta
         EmbeddingIndexManager(reopened, vector).check_query_embedder(embedder)
         results = MemoryRetriever(
             reopened_repo,
@@ -74,3 +80,119 @@ def test_cli_reopens_index_with_identical_tfidf_revision(tmp_path: Path) -> None
         assert results[0].vector_score is not None
     finally:
         _close(reopened)
+
+
+pyseekdb = pytest.importorskip("pyseekdb", reason="native SeekDB engine not installed")
+
+
+def _native_stack_args(path: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        v2_path=path,
+        backend="seekdb_embedded",
+        seekdb_url=None,
+        no_vector=False,
+    )
+
+
+def test_open_stack_native_seekdb_backend(shared_embedded_seekdb_target) -> None:
+    """P0-3: --backend seekdb_embedded routes via StorageFactory, not SQLite."""
+    client, repo, vector, embedder, meta = _open_stack(
+        _native_stack_args(shared_embedded_seekdb_target["path"]), with_vector=True
+    )
+    try:
+        from rosclaw.storage.seekdb_native import SeekDBNativeStore
+
+        assert isinstance(client, SeekDBNativeStore)
+        assert meta["backend"] == "SeekDBEmbeddedStore"
+        assert meta["vector_source"] == "seekdb_native"
+        assert "SeekDB" in meta["score_semantics"]
+        # The native adapter must NOT be a SQLite TF-IDF stack.
+        assert not isinstance(vector, SQLiteVectorStore)
+        assert not isinstance(embedder, TfidfEmbedder)
+    finally:
+        _close(client)
+
+
+def test_query_native_discloses_backend_and_score_semantics(
+    shared_embedded_seekdb_target, capsys
+) -> None:
+    """P0-3: query output never presents scores without backend semantics."""
+    path = shared_embedded_seekdb_target["path"]
+    client, repo, _, _, _ = _open_stack(_native_stack_args(path), with_vector=False)
+    client.delete_where("memory_items", {})
+    item = MemoryItem(
+        memory_type="episodic",
+        robot_id="r1",
+        title="native calibration note",
+        document="native seekdb retrieval path completed successfully",
+        evidence_refs=["evt_native_1"],
+    )
+    repo.store(item)
+    client.refresh_index("memory_items")
+    _close(client)
+
+    args = argparse.Namespace(
+        **{
+            **vars(_native_stack_args(path)),
+            "query": "native calibration",
+            "limit": 5,
+            "type": None,
+            "tenant_id": None,
+            "project_id": None,
+            "site_id": None,
+            "robot_id": None,
+            "body_id": None,
+            "task_id": None,
+            "safety_filter": False,
+        }
+    )
+    try:
+        assert cmd_memory_v2_query(args) == 0
+    finally:
+        cleanup, _, _, _, _ = _open_stack(_native_stack_args(path), with_vector=False)
+        cleanup.delete_where("memory_items", {})
+        _close(cleanup)
+    output = json.loads(capsys.readouterr().out)
+    assert output["retrieval"]["backend"] == "SeekDBEmbeddedStore"
+    assert output["retrieval"]["vector_source"] == "seekdb_native"
+    assert "1 - distance" in output["retrieval"]["score_semantics"]
+    assert output["results"], "expected at least one native result"
+    assert output["results"][0]["memory_id"] == item.memory_id
+
+
+def test_explain_native_includes_retrieval_block(shared_embedded_seekdb_target, capsys) -> None:
+    """P0-3: explain shows the retrieval backend + score semantics."""
+    path = shared_embedded_seekdb_target["path"]
+    client, repo, _, _, _ = _open_stack(_native_stack_args(path), with_vector=False)
+    client.delete_where("memory_items", {})
+    item = MemoryItem(
+        memory_type="episodic",
+        robot_id="r1",
+        title="explain target",
+        document="explain retrieval disclosure check",
+        evidence_refs=["evt_explain_1"],
+    )
+    repo.store(item)
+    client.refresh_index("memory_items")
+    _close(client)
+
+    args = argparse.Namespace(
+        **{
+            **vars(_native_stack_args(path)),
+            "memory_id": item.memory_id,
+            "text": "explain target",
+            "tenant_id": None,
+            "project_id": None,
+            "site_id": None,
+            "robot_id": None,
+        }
+    )
+    try:
+        assert cmd_memory_v2_explain(args) == 0
+    finally:
+        cleanup, _, _, _, _ = _open_stack(_native_stack_args(path), with_vector=False)
+        cleanup.delete_where("memory_items", {})
+        _close(cleanup)
+    output = json.loads(capsys.readouterr().out)
+    assert output["retrieval"]["vector_source"] == "seekdb_native"
+    assert "score_semantics" in output["retrieval"]

--- a/tests/memory/v2/test_retrieval_index.py
+++ b/tests/memory/v2/test_retrieval_index.py
@@ -208,9 +208,7 @@ def test_index_rebuild_replaces_stale_corpus(sqlite_stack) -> None:
     second = manager.build(kept, TfidfEmbedder())
     assert second["record_count"] == 1
     assert vector.count("memory_items") == 1
-    assert {row["record_id"] for row in vector._all_rows("memory_items")} == {
-        kept[0].memory_id
-    }
+    assert {row["record_id"] for row in vector._all_rows("memory_items")} == {kept[0].memory_id}
 
 
 def test_index_manager_fits_tfidf_over_full_corpus(sqlite_stack) -> None:
@@ -309,3 +307,44 @@ def test_dimension_guard(sqlite_stack) -> None:
 
     with pytest.raises(IndexModelMismatchError):
         manager.build(repo.query(limit=100), _BadDimEmbedder())
+
+
+def test_retrieval_tie_break_prefers_more_specific_document() -> None:
+    """MEM-02 acceptance regression: a saturated fusion cap must not rank the
+    wrong joint first — the uncapped lexical score breaks same-batch ties."""
+    from rosclaw.memory.seekdb_client import SQLiteKnowledgeStore
+    from rosclaw.memory.v2.models import MemoryItem
+    from rosclaw.memory.v2.repository import MemoryRepository
+    from rosclaw.memory.v2.retrieval import MemoryQuery, MemoryRetriever
+
+    client = SQLiteKnowledgeStore(":memory:")
+    client.connect()
+    repo = MemoryRepository(client)
+    repo.store(
+        MemoryItem(
+            memory_type="failure",
+            robot_id="r1",
+            body_id="rh56_left_01",
+            title="左手拇指旋转不到位 thumb_rot joint_not_reached",
+            document="thumb_rot evidence",
+            tags=["thumb_rot"],
+            evidence_refs=["e1"],
+        )
+    )
+    repo.store(
+        MemoryItem(
+            memory_type="failure",
+            robot_id="r1",
+            body_id="rh56_left_01",
+            title="左手中指不到位 middle joint_not_reached",
+            document="middle evidence",
+            tags=["middle"],
+            evidence_refs=["e2"],
+        )
+    )
+    hits = MemoryRetriever(repo).retrieve(
+        MemoryQuery(text="左手中指不到位", body_id="rh56_left_01", limit=2)
+    )
+    assert hits[0].memory.tags == ["middle"]
+    assert hits[1].memory.tags == ["thumb_rot"]
+    client.disconnect()

--- a/tests/storage/test_db_doctor_native.py
+++ b/tests/storage/test_db_doctor_native.py
@@ -1,0 +1,137 @@
+"""db doctor acceptance tests for native SeekDB backends (P0-4).
+
+Uses the real embedded engine (no mocks) and, when reachable, the live
+SeekDB server container.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+pyseekdb = pytest.importorskip(  # noqa: E402
+    "pyseekdb", reason="native SeekDB engine not installed"
+)
+
+from rosclaw.storage.cli import cmd_db_doctor  # noqa: E402
+from rosclaw.storage.seekdb_native import SeekDBEmbeddedStore  # noqa: E402
+
+
+def _args(path: str, **overrides) -> argparse.Namespace:
+    base = {
+        "json": True,
+        "fix": False,
+        "backend": "seekdb_embedded",
+        "url": None,
+        "path": path,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _doctor_payload(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def test_doctor_embedded_full_check_set(shared_embedded_seekdb_target, capsys) -> None:
+    """P0-4: doctor accepts seekdb_embedded with the full native check set."""
+    path = shared_embedded_seekdb_target["path"]
+    store = SeekDBEmbeddedStore(path=path, database=shared_embedded_seekdb_target["database"])
+    store.connect()
+    store.delete_where("memory_items", {})
+    store.insert("memory_items", {"id": "seed-1", "title": "doctor seed", "document": "x"})
+    store.disconnect()
+
+    try:
+        rc = cmd_db_doctor(_args(path))
+        payload = _doctor_payload(capsys)
+    finally:
+        cleanup = SeekDBEmbeddedStore(path=path, database=shared_embedded_seekdb_target["database"])
+        cleanup.connect()
+        cleanup.delete_where("memory_items", {})
+        cleanup.disconnect()
+
+    assert rc == 0, payload["issues"]
+    by_name = {check["name"]: check for check in payload["checks"]}
+    assert by_name["backend"]["value"] == "seekdb_embedded"
+    assert by_name["engine ready"]["ok"]
+    assert by_name["collections"]["ok"]
+    assert by_name["vector dimension"]["ok"]
+    assert by_name["embedder model"]["ok"]
+    assert by_name["collection counts"]["ok"]
+    # Restart persistence: reopen must see the same collections (the shared
+    # engine accumulates collections across test files, so only ok matters).
+    assert by_name["restart persistence"]["ok"]
+    # schema_migrations must be n/a (not "missing") for native backends.
+    assert by_name["schema_migrations table"]["ok"]
+    assert by_name["schema_migrations table"]["value"] == "n/a"
+    # Structured seekdb block with embedder + dimension per collection.
+    seekdb = payload["seekdb"]
+    assert seekdb["deployment"]["mode"] == "embedded"
+    assert seekdb["deployment"]["path"] == path
+    assert seekdb["collections"]["memory_items"]["count"] == 1
+    assert seekdb["collections"]["memory_items"]["dimension"] == 384
+
+
+def test_doctor_embedded_dimension_mismatch_flagged(shared_embedded_seekdb_target, capsys) -> None:
+    """Consistent vector dimensions across collections must not be flagged."""
+    path = shared_embedded_seekdb_target["path"]
+    store = SeekDBEmbeddedStore(path=path, database=shared_embedded_seekdb_target["database"])
+    store.connect()
+    store.delete_where("memory_items", {})
+    store.insert("memory_items", {"id": "a", "title": "t", "document": "d"})
+    store.disconnect()
+
+    try:
+        rc = cmd_db_doctor(_args(path))
+        payload = _doctor_payload(capsys)
+    finally:
+        cleanup = SeekDBEmbeddedStore(path=path, database=shared_embedded_seekdb_target["database"])
+        cleanup.connect()
+        cleanup.delete_where("memory_items", {})
+        cleanup.disconnect()
+    # Single-engine run: dimensions consistent → no dimension issue.
+    assert rc == 0
+    assert not any("dimension" in issue.lower() for issue in payload["issues"])
+
+
+def _server_reachable(host: str = "127.0.0.1", port: int = 2881) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=1.0):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(not _server_reachable(), reason="SeekDB server not reachable on :2881")
+def test_doctor_server_dsn_auth_and_counts(capsys) -> None:
+    """P0-4: server backend reports dsn auth and per-collection counts."""
+    rc = cmd_db_doctor(
+        _args(
+            "",
+            backend="seekdb_server",
+            url="seekdb://root@127.0.0.1:2881/rosclaw",
+        )
+    )
+    payload = _doctor_payload(capsys)
+    assert rc == 0, payload["issues"]
+    by_name = {check["name"]: check for check in payload["checks"]}
+    assert by_name["dsn auth"]["ok"]
+    assert "root@127.0.0.1:2881/rosclaw" in by_name["dsn auth"]["value"]
+    assert by_name["engine ready"]["ok"]
+    seekdb = payload["seekdb"]
+    assert seekdb["deployment"]["mode"] == "server"
+    assert "password" not in json.dumps(seekdb["deployment"])
+    assert seekdb["collections"], "expected at least one collection"
+
+
+def test_doctor_rejects_unknown_backend_still(tmp_path: Path, capsys) -> None:
+    """The pre-existing unknown-backend guard still fires."""
+    rc = cmd_db_doctor(_args(str(tmp_path / "x"), backend="not_a_backend"))
+    payload = _doctor_payload(capsys)
+    assert rc == 1
+    assert any("Unknown backend" in issue for issue in payload["issues"])

--- a/tests/storage/test_seekdb_native.py
+++ b/tests/storage/test_seekdb_native.py
@@ -23,13 +23,17 @@ TEST_PATH = "/tmp/seekdb_native_tests"
 
 
 @pytest.fixture(scope="module")
-def embedded_path(tmp_path_factory):
-    return tmp_path_factory.mktemp("seekdb_native")
+def embedded_path(shared_embedded_seekdb_target):
+    # One embedded target per process — shared via tests/conftest.py.
+    return shared_embedded_seekdb_target["path"]
 
 
 @pytest.fixture
-def store(embedded_path):
-    store = SeekDBEmbeddedStore(path=str(embedded_path), database="test_db")
+def store(shared_embedded_seekdb_target):
+    store = SeekDBEmbeddedStore(
+        path=shared_embedded_seekdb_target["path"],
+        database=shared_embedded_seekdb_target["database"],
+    )
     store.connect()
     store.delete_where("memory_items", {})
     try:

--- a/tests/test_bench_realsense_metric_semantics.py
+++ b/tests/test_bench_realsense_metric_semantics.py
@@ -89,3 +89,31 @@ class TestBenchRealSenseMetricSemantics:
         assert report["streams"]["depth"]["frame_count"] == 0
         assert "aggregate" in report
         assert report["aggregate"]["total_frame_count"] == 0
+
+
+def test_interval_stats_reports_acceptance_fields() -> None:
+    """RS-01 acceptance fields: drop rate, P99, max gap, jitter."""
+    from rosclaw.bench.realsense import _interval_stats
+
+    # 10 frames at perfect 30 fps over 0.3 s -> no drops, ~33.3 ms intervals.
+    arrivals = [i / 30.0 for i in range(10)]
+    stats = _interval_stats(arrivals, elapsed=0.3)
+    assert stats["frame_count"] == 10
+    assert stats["drop_rate"] == 0.0
+    assert 33.0 <= stats["inter_frame_p99_ms"] <= 34.0
+    assert 33.0 <= stats["max_gap_ms"] <= 34.0
+    assert stats["jitter_ms"] < 1.0
+
+    # One 1.2 s hole: max_gap surfaces the >1 s no-frame violation and the
+    # missing frames count into the drop rate.
+    gapped = [0.0, 0.033, 0.066, 1.266, 1.3, 1.333]
+    stats = _interval_stats(gapped, elapsed=1.333)
+    assert stats["max_gap_ms"] >= 1200.0
+    assert stats["drop_rate"] > 0.5
+
+
+def test_interval_stats_degenerate_inputs() -> None:
+    from rosclaw.bench.realsense import _interval_stats
+
+    assert _interval_stats([], 1.0)["max_gap_ms"] is None
+    assert _interval_stats([0.5], 1.0)["drop_rate"] is None


### PR DESCRIPTION
## Why

The real-hardware acceptance plan (`rosclaw_真机测试大纲v1.md`) gates formal scoring on five prerequisite fixes (P0-1..P0-5): without them, right-hand identity could be falsely verified as the left hand, the native SeekDB backend could not be exercised from the CLI, and REAL execution had no robot-level trace spans.

## Changes

**P0-1 — exp3/exp4 parameterization** (`scripts/experiments/`)
- `--body-id/--robot-id` (+ `--hand`, `--practice-root` on exp3); permits, envelopes, recorder, and practice finalize all derive from the selected body.
- Per-hand OK contact geometry table (left = measured on this rig; right = promoted v2 pose). Geometry is never shared across hands.

**P0-2 — portable RPS demo launchers** (`examples/rh56_rps/`)
- Removed private absolute paths; `RPS_PYTHON`/`RPS_ROSCLAW_SRC`/`RPS_RH56_SRC` env overrides → venv discovery preferring `rosclaw+cv2+serial` → import-based src resolution → sibling checkouts → loud error. Resolved paths printed at startup.
- Fixed a pre-existing break hidden by the old paths: the bundled skill.yaml uses the skill-PACKAGE schema and crashed `SkillManifest.from_yaml`; `_load_demo_skill_manifest` translates it and registers a `SkillEntry` under the demo's local skill id (what `SkillExecutor` and the runtime plugin are wired to), keeping the canonical package id in metadata. CLI prints error/message/reason on non-success.

**P0-3 — memory v2 CLI via StorageFactory** (`src/rosclaw/memory/v2/cli.py`)
- All v2 subcommands accept `--backend` + `--seekdb-url` (or `ROSCLAW_SEEKDB_URL`), including `seekdb_embedded` / `seekdb_server`.
- Native vector leg runs through the engine's server-side embedder; query/explain/status output discloses backend, `vector_source`, `score_semantics`, and embedder model/dimension — a local TF-IDF cosine is never shown as a native SeekDB score.
- index status/rebuild/forget branch honestly for native backends.

**P0-4 — db doctor native backends** (`src/rosclaw/storage/cli.py`, `seekdb_native.py`)
- `db doctor` accepts seekdb_embedded/seekdb_server: engine-ready probe, collections, embedder model, uniform dimension, per-collection counts, restart persistence (embedded reopen), DSN/auth (server, password never printed).
- `SeekDBNativeStore.list_collections()` / `deployment_info()`; `db status` reports native vector capability.

**P0-5 — REAL robot spans** (`src/rosclaw/kernel/action_gateway.py`)
- Explicit `ROBOT_ACTION` (`physical_actuation=true`, bounded command summary + dispatch_result + driver_ack) and `ROBOT_STATE` (`physical_observation=true` only for REAL + PHYSICALLY_OBSERVED/TASK_VERIFIED; positions/forces/currents/temps/status bits) child spans under SKILL. FIXTURE keeps both flags false; blocked-before-dispatch produces no ROBOT_STATE. exp3/exp4 persist spans to `.spans.jsonl` for the acceptance trace gate.

**Bonus fix (found during verification)**: the embedded SeekDB engine's teardown can bypass Python's stdio flush — block-buffered stdout (pipe/redirect) was silently lost with exit 0. memory v2 handlers emit through a flushing helper; db commands are wrapped in a flush decorator.

## Test plan

- [x] `pytest tests/kernel tests/memory/v2 tests/storage` — all green (shared single embedded target per process, real engine, no mocks)
- [x] Live server container: memory insert → native query (score 0.6226) → explain → forget; `db doctor` all-green on both embedded and server backends
- [x] RPS demo mock mode 3 rounds + 36 demo tests
- [x] `ruff check src tests` + `mypy src/rosclaw` clean
- [ ] Full suite: one pre-existing failure on main — `tests/feedback/test_firstboot_integration.py::test_firstboot_creates_telemetry_and_feedback_dirs` fails on origin/main **without** this branch's changes (introduced by one of the recent runtime/firstboot commits). Left for the owning team; flagging here rather than silently fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)