### PR TITLE
fix(exp4): per-hand S4 phantom slave validity + format (acceptance follow-up)

### DIFF
--- a/scripts/experiments/exp4_fault_injection.py
+++ b/scripts/experiments/exp4_fault_injection.py
@@ -358,7 +358,13 @@ def s4_slave_no_response(
     """A silent slave (no unit answers) must escalate to COMMUNICATION_LOST."""
     kwargs = dict(harness_kwargs or {})
     kwargs.pop("sysfs_id", None)
-    h = FaultHarness(profile_path, calibration_path, slave_id=2, sysfs_id=sysfs_id, **kwargs)
+    # The phantom slave must be an id that does NOT exist on this bus:
+    # left bus has slave 1 (real) so phantom is 2; right bus has slave 2
+    # (real) so phantom is 1.  Deriving it keeps the scenario valid for
+    # either hand (P0-1 parameterization).
+    real_slave = int(load_transport_profile(profile_path).transport.slave_id)
+    phantom_slave = 2 if real_slave == 1 else 1
+    h = FaultHarness(profile_path, calibration_path, slave_id=phantom_slave, sysfs_id=sysfs_id, **kwargs)
     outcome: dict[str, Any] = {"scenario": "S4 slave_no_response"}
     try:
         h.arm()

--- a/scripts/experiments/exp4_fault_injection.py
+++ b/scripts/experiments/exp4_fault_injection.py
@@ -364,7 +364,9 @@ def s4_slave_no_response(
     # either hand (P0-1 parameterization).
     real_slave = int(load_transport_profile(profile_path).transport.slave_id)
     phantom_slave = 2 if real_slave == 1 else 1
-    h = FaultHarness(profile_path, calibration_path, slave_id=phantom_slave, sysfs_id=sysfs_id, **kwargs)
+    h = FaultHarness(
+        profile_path, calibration_path, slave_id=phantom_slave, sysfs_id=sysfs_id, **kwargs
+    )
     outcome: dict[str, Any] = {"scenario": "S4 slave_no_response"}
     try:
         h.arm()


### PR DESCRIPTION
Follow-up to merged PR #96 — two commits created after its head (1f44200) that did not make the merge:

- **bf9eda4** fix(exp4): derive S4 phantom slave from the profile (per-hand validity) — the Exp 4 S4 slave-no-response scenario now picks the phantom slave id from each hand's own transport profile instead of a hardcoded value, keeping the fault-injection matrix correct when parameterized across left/right bodies (P0-1 follow-on).
- **5979f35** style: ruff format exp4

Validated during the real-hardware acceptance run (boot #4): exp4 S1-S7 all PASS on the right hand with this fix; full acceptance report at acceptance_20260720/验收报告_v2.md (on the Jetson rig).

🤖 Generated with [Claude Code](https://claude.com/claude-code)