### PR TITLE
fix(storage): MEM-5 follow-up — projection ordering, idempotency, shared resolver, hint gating

### DIFF
--- a/src/rosclaw/memory/interface.py
+++ b/src/rosclaw/memory/interface.py
@@ -898,7 +898,10 @@ class MemoryInterface(LifecycleMixin):
             outcome="failure",
             limit=max(limit, 3),
         )
-        if response is not None:
+        # The HOW analogy path is high-risk: a degraded retrieval (BM25 /
+        # sqlite lexical / abstain) must not serve it — fall through to the
+        # legacy keyword path instead of acting on weakened evidence.
+        if response is not None and not response.fallback:
             for candidate in response.candidates:
                 item = candidate.item
                 raw_hint = item.metadata.get("recovery_hint", "") if item is not None else ""

--- a/src/rosclaw/memory/v2/runtime_retrieval/provider_resolver.py
+++ b/src/rosclaw/memory/v2/runtime_retrieval/provider_resolver.py
@@ -60,6 +60,9 @@ class EmbeddingProviderResolver:
         # uses the pinned built-ins).
         self._profiles: dict[str, Any] = profiles if profiles is not None else PROFILES
         self._providers: dict[str, EmbeddingProvider] = {}
+        import threading
+
+        self._lock = threading.Lock()
 
     def resolve(self, descriptor: ActiveIndexDescriptor) -> EmbeddingProvider:
         profile_id = descriptor.embedding_profile_id
@@ -83,16 +86,18 @@ class EmbeddingProviderResolver:
                 + "; ".join(mismatches),
             )
         if profile_id not in self._providers:
-            kwargs: dict[str, Any] = {}
-            if self._cache_path is not None:
-                kwargs["cache_path"] = self._cache_path
-            if self._device is not None:
-                kwargs["device"] = self._device
-            try:
-                self._providers[profile_id] = self._factory(profile_id, **kwargs)
-            except Exception as exc:  # noqa: BLE001
-                raise ProviderUnavailableError(
-                    PROVIDER_CONSTRUCTION_FAILED,
-                    f"could not construct provider for {profile_id!r}: {exc}",
-                ) from exc
+            with self._lock:
+                if profile_id not in self._providers:
+                    kwargs: dict[str, Any] = {}
+                    if self._cache_path is not None:
+                        kwargs["cache_path"] = self._cache_path
+                    if self._device is not None:
+                        kwargs["device"] = self._device
+                    try:
+                        self._providers[profile_id] = self._factory(profile_id, **kwargs)
+                    except Exception as exc:  # noqa: BLE001
+                        raise ProviderUnavailableError(
+                            PROVIDER_CONSTRUCTION_FAILED,
+                            f"could not construct provider for {profile_id!r}: {exc}",
+                        ) from exc
         return self._providers[profile_id]

--- a/src/rosclaw/storage/versioned_projection.py
+++ b/src/rosclaw/storage/versioned_projection.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import threading
 import time
 from typing import Any
 
@@ -48,6 +49,21 @@ logger = logging.getLogger("rosclaw.storage.versioned_projection")
 WATERMARK_KIND = "projection_watermark"
 ACTIVE_PROJECTION_TARGET = "active_projection"
 _REGISTRY_TABLE = "projection_registry"
+
+# One process-level resolver for all default projections: without it every
+# memory write rebuilt the provider (full model load per write — verified
+# by review).  Construction is lock-guarded against concurrent first-use.
+_SHARED_RESOLVER: EmbeddingProviderResolver | None = None
+_SHARED_RESOLVER_LOCK = threading.Lock()
+
+
+def shared_projection_resolver() -> EmbeddingProviderResolver:
+    global _SHARED_RESOLVER
+    if _SHARED_RESOLVER is None:
+        with _SHARED_RESOLVER_LOCK:
+            if _SHARED_RESOLVER is None:
+                _SHARED_RESOLVER = EmbeddingProviderResolver()
+    return _SHARED_RESOLVER
 
 
 def _watermark_id(logical_name: str) -> str:
@@ -109,7 +125,7 @@ class ActiveProjectionCommitter:
         logical_name: str = "memory_items",
     ) -> None:
         self._store = store
-        self._resolver = provider_resolver or EmbeddingProviderResolver()
+        self._resolver = provider_resolver or shared_projection_resolver()
         self._logical_name = logical_name
 
     def save_to_seekdb(self, payload: dict[str, Any]) -> None:
@@ -143,11 +159,15 @@ class ActiveProjectionCommitter:
         except ProviderUnavailableError as exc:
             provider_note = f"provider_unavailable:{exc.reason}"
 
+        # In-order last-writer-wins: a supersede/delete erases any earlier
+        # PENDING upsert of the same id in this batch and removes it from
+        # ACTIVE — the earlier inline-delete-then-re-upsert order resurrected
+        # superseded memories (review finding, empirically verified).
         projected = 0
         failed = 0
         last_id: str | None = None
         last_time: float | None = None
-        upserts: list[dict[str, Any]] = []
+        pending: dict[str, dict[str, Any]] = {}
         for payload in payloads:
             record = dict(payload)
             record.pop("idempotency_key", None)
@@ -161,16 +181,21 @@ class ActiveProjectionCommitter:
                 last_time = max(last_time or 0.0, float(event_time))
             if str(record.get("status") or "active") != "active":
                 # Supersede / expire / quarantine / delete sync (v4 §3.8).
+                pending.pop(memory_id, None)
                 collection.delete(ids=[memory_id])
                 projected += 1
                 continue
             if provider is None:
                 failed += 1
                 continue
-            upserts.append(record)
+            pending[memory_id] = record
 
-        if upserts:
-            documents = [str(r.get("document") or r.get("title") or r["id"]) for r in upserts]
+        if pending:
+            upserts = list(pending.values())
+            documents = [
+                str(r.get("document") or r.get("title") or r.get("id") or r.get("memory_id"))
+                for r in upserts
+            ]
             embeddings = provider.encode_documents(documents)
             collection.upsert(
                 ids=[str(r.get("id") or r.get("memory_id")) for r in upserts],
@@ -220,10 +245,14 @@ class ActiveProjection:
             logger.warning("active projection skipped: record without id")
             return
         if self._outbox is not None:
+            # The marker distinguishes mutations of the SAME memory: an
+            # outbox dedup must only collapse redeliveries of one mutation,
+            # never drop a later supersede (review finding).
+            marker = item_record.get("updated_at") or item_record.get("event_time") or time.time()
             self._outbox.enqueue(
                 ACTIVE_PROJECTION_TARGET,
                 item_record,
-                idempotency_key=f"memory:{memory_id}:active_projection",
+                idempotency_key=f"memory:{memory_id}:active_projection:{marker}",
                 entity_type="memory",
                 entity_id=str(memory_id),
             )
@@ -235,10 +264,11 @@ class ActiveProjection:
     def project_delete(self, memory_id: str) -> None:
         """Remove a memory from the ACTIVE collection (delete sync)."""
         if self._outbox is not None:
+            marker = time.time()
             self._outbox.enqueue(
                 ACTIVE_PROJECTION_TARGET,
-                {"id": memory_id, "status": "deleted"},
-                idempotency_key=f"memory:{memory_id}:active_projection_delete",
+                {"id": memory_id, "status": "deleted", "updated_at": marker},
+                idempotency_key=f"memory:{memory_id}:active_projection:{marker}",
                 entity_type="memory",
                 entity_id=str(memory_id),
             )

--- a/tests/storage/test_versioned_projection.py
+++ b/tests/storage/test_versioned_projection.py
@@ -142,9 +142,15 @@ def test_projection_outbox_enqueue_path(store) -> None:
     assert len(outbox.calls) == 2
     target, payload, key, entity_type, entity_id = outbox.calls[0]
     assert target == ACTIVE_PROJECTION_TARGET
-    assert key == "memory:mem_q:active_projection"
+    # The key carries the mutation marker so a later supersede is never
+    # deduped away while the original projection is still pending.
+    assert key.startswith("memory:mem_q:active_projection:")
     assert entity_type == "memory" and entity_id == "mem_q"
     assert outbox.calls[1][1]["status"] == "deleted"
+    # Two different mutations of the same memory get distinct keys.
+    projection.project(_record("mem_q", "queued v2"))
+    keys = [call[2] for call in outbox.calls]
+    assert len(set(keys)) == len(keys)
 
 
 def test_catch_up_repairs_projection_lag(store) -> None:
@@ -219,3 +225,33 @@ def test_rollback_aborts_when_catch_up_fails(store) -> None:
     active = mgr.active("memory_items")
     assert active["physical_collection"] == gen2
     assert gen1 != gen2
+
+
+def test_in_batch_supersede_never_resurrects(store) -> None:
+    """Review finding: a batch [upsert(m1), supersede(m1)] must end with m1
+    ABSENT from ACTIVE (the old inline-delete-then-re-upsert order
+    resurrected superseded memories)."""
+    physical = _build_and_activate(store, [_record("mem_a", "alpha")])
+    committer = ActiveProjectionCommitter(store, _resolver())
+    committer.save_to_seekdb_batch(
+        [
+            _record("mem_m1", "first version"),
+            {**_record("mem_m1", "first version"), "status": "superseded"},
+        ]
+    )
+    ids = {row["id"] for row in store.query(physical, limit=10)}
+    assert "mem_m1" not in ids
+    assert store.count(physical) == 1
+
+
+def test_shared_resolver_reused_across_projections(store) -> None:
+    """Review finding: default projections must not rebuild the provider
+    per write — one process-level resolver is shared."""
+    from rosclaw.storage.versioned_projection import shared_projection_resolver
+
+    first = shared_projection_resolver()
+    second = shared_projection_resolver()
+    assert first is second
+    committer_a = ActiveProjectionCommitter(store)
+    committer_b = ActiveProjectionCommitter(store)
+    assert committer_a._resolver is committer_b._resolver


### PR DESCRIPTION
MEM-5 已合并后的对抗审查修复（实证）：\n\n1. in-batch delete/upsert 顺序导致 supersede 复活 → 批内 in-order last-writer-wins。\n2. 常量幂等键 + outbox 去重吞掉 supersede → 键含 updated_at 标记。\n3. 每次写重建 embedding provider（模型级开销）→ 进程级共享 resolver + 构造锁。\n4. find_analogy 在检索退化时仍供 HOW → 非 fallback 才服务，否则回退 legacy 关键词路径。\n\n测试 9 项（含新增 2 项修复回归）；memory+storage+how 342 passed（1 个 main 上同样存在的服务器依赖失败）。