### PR TITLE
style(safety): SIM108 ternary in choreography validator (CI lint)

### DIFF
--- a/src/rosclaw/how/choreography/validator.py
+++ b/src/rosclaw/how/choreography/validator.py
@@ -124,10 +124,7 @@ class ChoreographyValidator:
             for v in violations
             if v.startswith((V_FORBIDDEN_PARAMETER, V_UNKNOWN_PARAMETER, V_OUT_OF_RANGE))
         ]
-        if parameter_violations:
-            patched = model
-        else:
-            patched = apply_patch(model, patch, contract)
+        patched = model if parameter_violations else apply_patch(model, patch, contract)
 
         # 3) Reveal window: the patched reveal offset must stay inside the
         #    contract window (between-round patches never move it; any


### PR DESCRIPTION
main-push CI 的 ruff 报 SIM108（SAFE-2 修复引入的 if/else）。改为三元式。本地 67 how tests 通过。