### PR TITLE
fix: demo-driven hardening — doctor profiles, verify path, intervention retrieval

### DIFF
--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -3124,12 +3124,25 @@ def _print_practice_validate(args: argparse.Namespace, result: dict[str, Any]) -
     print("=" * 60)
 
 
+def normalize_practice_id(practice_id: str) -> str:
+    """Accept a session directory path as well as a bare practice id.
+
+    The catalog keys on the id (the directory name), so an existing
+    directory path must normalize to its basename; anything else passes
+    through unchanged.
+    """
+    candidate = Path(practice_id).expanduser()
+    if candidate.is_dir():
+        return candidate.resolve().name
+    return practice_id
+
+
 def cmd_practice_verify(args: argparse.Namespace) -> int:
     """Verify closed-loop integrity of a practice session."""
     from rosclaw.practice.verifier import PracticeVerifier, format_report
 
     data_root = resolve_practice_data_root(getattr(args, "data_root", None))
-    practice_id = args.practice_id
+    practice_id = normalize_practice_id(args.practice_id)
     strict = getattr(args, "strict", False)
 
     verifier = PracticeVerifier(data_root)

--- a/src/rosclaw/memory/v2/runtime_retrieval/native_retriever.py
+++ b/src/rosclaw/memory/v2/runtime_retrieval/native_retriever.py
@@ -21,6 +21,7 @@ experience.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -36,6 +37,7 @@ from .result import (
     CROSS_BODY_FORBID,
     PurposePolicy,
     RetrievalCandidate,
+    RetrievalPurpose,
 )
 
 logger = logging.getLogger("rosclaw.memory.v2.runtime_retrieval.native_retriever")
@@ -108,6 +110,36 @@ def _entity_matches(row: dict[str, Any], exact: dict[str, list[str]]) -> dict[st
     }
 
 
+INTERVENTION_WINDOW_MIN = 50
+INTERVENTION_ACTIONABILITY_BOOST = 3.0
+
+
+def _actionability_multiplier(row: dict[str, Any], policy: PurposePolicy) -> float:
+    """HOW_INTERVENTION actionability boost (v4 §7.2).
+
+    Only memories carrying recovery guidance can drive a patch — the
+    selective pipeline reads ``metadata.recovery_hint``.  A ranking that
+    fills the intervention path's candidates with unactionable near-
+    duplicate failure records while recovery-bearing memories starve
+    defeats the path's purpose (observed live in the EVO-3 Exp1 pilot and
+    the self-evolution demo, 2026-07-24: ~50 near-identical session
+    memories crowded out every seeded campaign memory).  The boost only
+    re-orders; applicability is still decided downstream by the regime
+    matcher, so safety semantics are unchanged.
+    """
+    if policy.purpose is not RetrievalPurpose.HOW_INTERVENTION:
+        return 1.0
+    metadata = row.get("metadata")
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except (json.JSONDecodeError, ValueError):
+            metadata = {}
+    if isinstance(metadata, dict) and str(metadata.get("recovery_hint") or "").strip():
+        return INTERVENTION_ACTIONABILITY_BOOST
+    return 1.0
+
+
 class VersionedNativeRetriever:
     """Hybrid retrieval against one ACTIVE physical collection."""
 
@@ -128,14 +160,26 @@ class VersionedNativeRetriever:
         exact = extract_exact_terms(text)
         filters = _hard_filters(query)
         limit = max(1, query.limit)
-        window = max(20, limit * 4)
+        # The intervention path scans a wider pool so recovery-bearing
+        # memories reach the actionability re-ranking below even when the
+        # corpus holds many near-duplicate failure records.
+        window = (
+            max(INTERVENTION_WINDOW_MIN, limit * 10)
+            if policy.purpose is RetrievalPurpose.HOW_INTERVENTION
+            else max(20, limit * 4)
+        )
         hands = exact.get("hands") or []
 
         notes: dict[str, Any] = {
             "vector": provider is not None,
             "cross_body_retry": "not_needed",
             "reranker_applied": False,
+            "candidate_window": window,
         }
+        if policy.purpose is RetrievalPurpose.HOW_INTERVENTION:
+            notes["intervention_actionability_boost"] = (
+                f"recovery_hint x{INTERVENTION_ACTIONABILITY_BOOST}"
+            )
 
         constrained = False
         if len(hands) == 1 and "body_id" not in filters:
@@ -212,10 +256,17 @@ class VersionedNativeRetriever:
         policy: PurposePolicy,
     ) -> list[RetrievalCandidate]:
         semantics = SCORE_SEMANTICS_HYBRID if provider is not None else SCORE_SEMANTICS_BM25
-        if exact:
+        # Exact-entity multipliers (§6.3) and, on the intervention path, the
+        # actionability boost re-order the fused pool; original rank breaks
+        # ties so the fusion order is preserved within equal multipliers.
+        if exact or policy.purpose is RetrievalPurpose.HOW_INTERVENTION:
             rows = sorted(
                 enumerate(rows),
-                key=lambda pair: (_exact_row_multiplier(pair[1], exact), -pair[0]),
+                key=lambda pair: (
+                    _exact_row_multiplier(pair[1], exact)
+                    * _actionability_multiplier(pair[1], policy),
+                    -pair[0],
+                ),
                 reverse=True,
             )
             ordered = [row for _, row in rows]

--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -373,6 +373,29 @@ def cmd_db_status(args: argparse.Namespace) -> int:
     return 0 if ping.get("connected") else 1
 
 
+def _versioned_dimension_faults(dimensions: dict[str, Any]) -> dict[str, tuple[Any, int]]:
+    """Collections whose actual vector dimension contradicts the embedding
+    profile encoded in their versioned name (``<logical>__<profile>__<analyzer>``).
+
+    Mixed dimensions ACROSS profiles are by design (PR-SDB-2/MEM-5); only a
+    mismatch with the collection's own declared profile is a fault.  Legacy
+    (non-versioned) collections carry no per-collection expectation.
+    """
+    from rosclaw.embedding.profile import PROFILES
+
+    faults: dict[str, tuple[Any, int]] = {}
+    for name, dim in dimensions.items():
+        if dim is None:
+            continue
+        parts = str(name).split("__")
+        if len(parts) < 3:
+            continue
+        profile = PROFILES.get(parts[1])
+        if profile is not None and dim != profile.dimension:
+            faults[str(name)] = (dim, profile.dimension)
+    return faults
+
+
 def _native_seekdb_checks(
     client: Any,
     backend: str,
@@ -423,6 +446,15 @@ def _native_seekdb_checks(
             dimensions[name] = None
             models[name] = None
             issues.append(f"embedding_info({name}) failed: {exc}")
+        # Versioned collections carry their profile in the name; the store's
+        # global embedder label is stale for them (PR-SDB-2).
+        parts = name.split("__")
+        if len(parts) >= 3:
+            from rosclaw.embedding.profile import PROFILES
+
+            profile = PROFILES.get(parts[1])
+            if profile is not None:
+                models[name] = profile.profile_id
     result["seekdb"]["collections"] = {
         name: {
             "count": counts.get(name),
@@ -432,16 +464,39 @@ def _native_seekdb_checks(
         for name in collections
     }
     dim_set = {d for d in dimensions.values() if d is not None}
-    dim_ok = len(dim_set) <= 1
+    # Versioned physical collections (<logical>__<profile>__<analyzer>) are
+    # validated against their declared embedding profile — mixed dimensions
+    # ACROSS profiles are by design (PR-SDB-2/MEM-5); only a mismatch with
+    # the collection's own profile, or with the ACTIVE descriptor, is a fault.
+    mismatched = _versioned_dimension_faults(dimensions)
+    active_dim_fault: str | None = None
+    try:
+        from rosclaw.memory.v2.runtime_retrieval.active_resolver import (
+            ActiveCollectionResolver,
+        )
+
+        descriptor = ActiveCollectionResolver(client).resolve("memory_items")
+        active_dim = dimensions.get(descriptor.physical_collection)
+        if active_dim is not None and active_dim != descriptor.dimension:
+            active_dim_fault = (
+                f"ACTIVE {descriptor.physical_collection} dim {active_dim} "
+                f"!= descriptor {descriptor.dimension}"
+            )
+    except Exception:  # noqa: BLE001 - no ACTIVE pointer is a state, not a fault
+        descriptor = None
+    dim_ok = not mismatched and active_dim_fault is None
     checks.append(
         (
             "vector dimension",
-            f"{sorted(dim_set) if dim_set else 'n/a'} across {len(dimensions)} collections",
+            f"{sorted(dim_set) if dim_set else 'n/a'} across {len(dimensions)} collections"
+            + ("" if dim_ok else f" mismatched={mismatched}"),
             dim_ok,
         )
     )
-    if not dim_ok:
-        issues.append(f"Mixed vector dimensions across collections: {dimensions}")
+    for name, (dim, expected) in mismatched.items():
+        issues.append(f"Collection {name} dimension {dim} != profile dimension {expected}")
+    if active_dim_fault:
+        issues.append(active_dim_fault)
     model_set = {m for m in models.values() if m}
     checks.append(
         (

--- a/tests/memory/v2/runtime_retrieval/test_facade.py
+++ b/tests/memory/v2/runtime_retrieval/test_facade.py
@@ -332,3 +332,52 @@ def test_memory_interface_falls_back_to_legacy_when_facade_empty() -> None:
     results = memory.find_similar_experiences("legacytag calibration", limit=3)
     assert results  # legacy experience_graph path still serves
     assert results[0].get("source") != "memory_v2_active"
+
+
+def test_how_intervention_boosts_recovery_hint_memories() -> None:
+    """v4 §7.2 actionability: on the intervention path, memories carrying
+    recovery guidance outrank unactionable near-duplicates — they are the
+    only candidates the selective pipeline can turn into a patch (live
+    finding, EVO-3 Exp1 pilot / self-evolution demo 2026-07-24)."""
+    rows = [_failure_row(f"mem_dup_{i}", "rh56_right_01", "middle") for i in range(3)]
+    hinted = _failure_row("mem_recovery", "rh56_right_01", "middle")
+    hinted["metadata"] = '{"recovery_hint": "增加回合间冷却"}'
+    rows.append(hinted)  # hinted LAST in fusion order
+    store = FakeNativeStore(
+        collections={PHYSICAL: rows},
+        registry_rows=_pointer_and_build_rows(physical=PHYSICAL),
+    )
+    facade = build_retrieval_facade(native_store=store, provider_resolver=_resolver())
+    response = facade.retrieve(
+        MemoryQuery(text="右手 middle joint_not_reached 失败 恢复", limit=5),
+        purpose=RetrievalPurpose.HOW_INTERVENTION,
+    )
+    assert response.candidates[0].memory_id == "mem_recovery"
+    # HUMAN_SEARCH: no boost — fusion order preserved (hinted stays last).
+    response2 = facade.retrieve(
+        MemoryQuery(text="右手 middle joint_not_reached 失败 恢复", limit=5),
+        purpose=RetrievalPurpose.HUMAN_SEARCH,
+    )
+    assert response2.candidates[-1].memory_id == "mem_recovery"
+
+
+def test_how_intervention_widens_candidate_window() -> None:
+    """The intervention path scans a wider pool so recovery-bearing memories
+    reach re-ranking even inside corpora full of near-duplicate failures."""
+    store = FakeNativeStore(
+        collections={PHYSICAL: [_failure_row("m1", "rh56_right_01", "middle")]},
+        registry_rows=_pointer_and_build_rows(physical=PHYSICAL),
+    )
+    facade = build_retrieval_facade(native_store=store, provider_resolver=_resolver())
+    facade.retrieve(
+        MemoryQuery(text="右手 middle joint_not_reached", limit=5),
+        purpose=RetrievalPurpose.HOW_INTERVENTION,
+    )
+    facade.retrieve(
+        MemoryQuery(text="右手 middle joint_not_reached", limit=5),
+        purpose=RetrievalPurpose.HUMAN_SEARCH,
+    )
+    assert store.hybrid_calls[0]["limit"] >= 50
+    assert store.hybrid_calls[0]["candidate_window"] >= 50
+    assert store.hybrid_calls[1]["limit"] == 20
+    assert store.hybrid_calls[1]["candidate_window"] == 20

--- a/tests/memory/v2/runtime_retrieval/test_resolvers.py
+++ b/tests/memory/v2/runtime_retrieval/test_resolvers.py
@@ -130,7 +130,13 @@ class FakeNativeStore:
         if self.search_error is not None:
             raise self.search_error
         self.hybrid_calls.append(
-            {"table": table, "filters": filters, "query_embedding": query_embedding}
+            {
+                "table": table,
+                "filters": filters,
+                "query_embedding": query_embedding,
+                "limit": limit,
+                "candidate_window": candidate_window,
+            }
         )
         return self._filtered(table, filters, limit)
 

--- a/tests/storage/test_db_doctor_native.py
+++ b/tests/storage/test_db_doctor_native.py
@@ -135,3 +135,24 @@ def test_doctor_rejects_unknown_backend_still(tmp_path: Path, capsys) -> None:
     payload = _doctor_payload(capsys)
     assert rc == 1
     assert any("Unknown backend" in issue for issue in payload["issues"])
+
+
+def test_versioned_dimension_faults_only_on_profile_mismatch() -> None:
+    """Mixed dimensions across versioned profiles are by design; only a
+    mismatch with the collection's OWN profile is a fault (PR-SDB-2/MEM-5)."""
+    from rosclaw.storage.cli import _versioned_dimension_faults
+
+    # The live server layout: each versioned collection matches its profile.
+    healthy = {
+        "memory_items": 384,
+        "memory_items__qwen3_06b_1024_v1__ik": 1024,
+        "memory_bench__qwen3_06b_512_v1__ngram": 512,
+        "memory_bench__gte_multi_768_v1__ngram": 768,
+    }
+    assert _versioned_dimension_faults(healthy) == {}
+    # A collection whose dimension contradicts its declared profile is faulted.
+    broken = {**healthy, "memory_items__qwen3_06b_1024_v1__ik": 384}
+    faults = _versioned_dimension_faults(broken)
+    assert faults == {"memory_items__qwen3_06b_1024_v1__ik": (384, 1024)}
+    # Unknown profiles and non-versioned names carry no expectation.
+    assert _versioned_dimension_faults({"legacy__unknown_profile__xx": 128, "plain": 96}) == {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -809,3 +809,16 @@ class TestBodyUpdateStateFromProviderHealth:
         captured = capsys.readouterr()
         assert code == 0
         assert "Updated body state" in captured.out
+
+
+def test_normalize_practice_id_accepts_dir_path(tmp_path):
+    """practice verify must accept a session directory path as well as an id."""
+    from rosclaw.cli import normalize_practice_id
+
+    session = tmp_path / "sessions" / "prac_20260724T000000Z_abc123"
+    session.mkdir(parents=True)
+    assert normalize_practice_id(str(session)) == "prac_20260724T000000Z_abc123"
+    # Bare ids and non-existent paths pass through unchanged.
+    assert normalize_practice_id("prac_20260724T000000Z_abc123") == "prac_20260724T000000Z_abc123"
+    missing = tmp_path / "sessions" / "prac_missing"
+    assert normalize_practice_id(str(missing)) == str(missing)


### PR DESCRIPTION
## Summary

Three small hardening fixes + one retrieval optimization, all found by running the **all-module real-hardware self-evolution demo** (RH56 hands, SeekDB server, Memory v4 stack) — evidence in `/tmp/self_evolution_demo/report.json` and `reports/EVO3_EXP1_PILOT_REPORT.md`.

1. **`fix(storage)`: db doctor validates versioned collections against their embedding profile.** The "vector dimension" check failed any deployment with mixed dimensions — but per-profile dimensions are the PR-SDB-2/MEM-5 design (1024d ACTIVE alongside 384/512/768 collections). Doctor now faults only a mismatch with the collection's OWN profile or the ACTIVE descriptor, and reports per-collection profile ids instead of the stale global embedder label. A healthy production server previously failed this gate.
2. **`fix(cli)`: `practice verify` accepts a session directory path** (catalog keys on the id = directory name; a full path used to fail with "not found in catalog").
3. **`feat(memory)`: HOW_INTERVENTION actionability boost + wider candidate window.** Live finding (EVO-3 Exp1 pilot + this demo): ~50 near-identical session memories crowded every recovery-bearing memory out of the intervention path's candidate window (20), so the v4 envelope gate never saw an actionable candidate live. The intervention path now scans `max(50, limit*10)` and re-orders with a `recovery_hint ×3` multiplier (both disclosed in retrieval notes). Ranking only — applicability is still decided downstream by the RegimeMatcher.

## Validation

- New unit tests: profile-dimension faults, path normalization, boost ordering, window widening — **all pass** (retriever 27/27, doctor 5/5, cli 47/47 scoped).
- **Regime benchmark identical before/after the boost**: abstention 1.0, apply_precision 1.0 (17 APPLYs), regime_confusion 0.0, recall@5 0.907.
- exp3/exp4 offline validations pass; ruff + mypy clean on touched files.
- Live on the SeekDB server (440-row corpus): `HOW_INTERVENTION` now surfaces `mem_run2_hot_cooldown` #0 and `mem_run1_hot_slowdown` #1; healthy regime still ABSTAINs via `contraindicated_envelope_hit`; hot regime ABSTAINs via `conflicting_memories`.
- Full demo: 10/10 stages green (runtime/db doctor, real-hands practice + strict verify, distill → 19 memories → ACTIVE, regime + session-derived envelope, KNOW via facade, HOW decide + run1-patch replay BLOCKED, MuJoCo sandbox, 22-tool MCP surface, dashboard, second-session flywheel selecting an S1-distilled memory with the gate keeping ABSTAIN).

## Safety / boundary

- The boost changes **ranking only**; APPLY/ABSTAIN semantics unchanged (matcher + envelopes + choreography still gate everything).
- No hardware behavior change; demo hardware evidence collected with camera mocked (D435i physically absent since 2026-07-23, disclosed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
