### PR TITLE
feat(evolution): A/B/C real-machine canary + promotion gate (PR-EVO-HW-4)

### DIFF
--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -7977,9 +7977,11 @@ def main() -> int:
     # acceptance subcommand (Evo-RPS hardware self-evolution, PR-EVO-HW-1)
     from rosclaw.evolution.hardware.cli import (
         cmd_acceptance_evo_rps_baseline,
+        cmd_acceptance_evo_rps_canary,
         cmd_acceptance_evo_rps_distill,
         cmd_acceptance_evo_rps_future,
         cmd_acceptance_evo_rps_prepare,
+        cmd_acceptance_evo_rps_promote,
         cmd_acceptance_evo_rps_propose,
         cmd_acceptance_evo_rps_report,
         cmd_acceptance_evo_rps_validate,
@@ -8029,7 +8031,17 @@ def main() -> int:
     validate_phase.add_argument("--config", default=None)
     validate_phase.add_argument("--shadow-rounds", type=int, default=12)
     validate_phase.set_defaults(func=cmd_acceptance_evo_rps_validate)
-    for _phase in ("canary", "promote", "recurrence"):
+    canary_phase = evo_rps_subparsers.add_parser(
+        "canary", help="A/B/C real-machine canary (interleaved arms)"
+    )
+    canary_phase.add_argument("--config", default=None)
+    canary_phase.add_argument("--blocks", type=int, default=3)
+    canary_phase.add_argument("--rounds", type=int, default=40)
+    canary_phase.set_defaults(func=cmd_acceptance_evo_rps_canary)
+    _evo_rps_phase(
+        "promote", cmd_acceptance_evo_rps_promote, "Evaluate the promotion gate (Phase 7)"
+    )
+    for _phase in ("recurrence",):
         _evo_rps_phase(
             _phase, cmd_acceptance_evo_rps_future(_phase), f"Planned in a later PR ({_phase})"
         )

--- a/src/rosclaw/evolution/hardware/canary.py
+++ b/src/rosclaw/evolution/hardware/canary.py
@@ -1,0 +1,118 @@
+"""A/B/C real-machine canary (PR-EVO-HW-4, 真机自进化v2 §Phase 6).
+
+Arms:
+
+* A — no memory, no patch (baseline identity);
+* B — fixed manual cooldown (run2's static control: 60 s every 30 rounds);
+* C — operator-approved canary of the selected VALIDATED candidate
+  (mechanical application on REAL hands + REAL camera, full PatchProof;
+  §Phase 7: with too little evidence for autonomous APPLY, candidates
+  enter an operator-approved canary — this IS that path).
+
+Design rules (§Phase 6): same rounds, same base seed stream, arm order
+randomized AND interleaved so day-level thermal drift cancels across
+arms to first order, camera/model pinned (realsense + the contract's
+own verification), and no unpromoted memory crosses arms (C uses only
+the experiment namespace's validated candidate — never shared-corpus
+memory).
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Any
+
+ARM_A = "A_no_memory"
+ARM_B = "B_fixed_cooldown"
+ARM_C = "C_candidate_canary"
+ARMS = (ARM_A, ARM_B, ARM_C)
+
+# Driver group per arm (the workspace runner's group names).
+ARM_DRIVER_GROUP = {
+    ARM_A: "no_memory",
+    ARM_B: "fixed_cooldown",
+    ARM_C: "candidate_canary",
+}
+
+
+@dataclass(frozen=True)
+class ArmSlot:
+    block: int
+    arm: str
+    seed: int
+    driver_group: str
+
+
+def build_canary_schedule(
+    *,
+    blocks: int,
+    seed: int,
+    base_seed: int,
+) -> list[ArmSlot]:
+    """Seeded interleaved schedule: each block runs A, B, C once in a
+    shuffled order (deterministic for a given seed)."""
+    rng = random.Random(seed)
+    schedule: list[ArmSlot] = []
+    for block in range(blocks):
+        order = list(ARMS)
+        rng.shuffle(order)
+        for slot, arm in enumerate(order):
+            schedule.append(
+                ArmSlot(
+                    block=block,
+                    arm=arm,
+                    seed=base_seed + block * 10 + slot,
+                    driver_group=ARM_DRIVER_GROUP[arm],
+                )
+            )
+    return schedule
+
+
+def select_canary_candidate(
+    validated: list[dict[str, Any]],
+    *,
+    baseline_regime: str,
+) -> tuple[dict[str, Any] | None, str]:
+    """Pick ONE validated candidate for the canary with a recorded reason.
+
+    Rule: in a thermal/tracking-degradation regime prefer a cooldown-class
+    candidate (the failure mode the cooldown addresses); otherwise prefer
+    a pose-recovery candidate; C0 (empty) is never canaried — it is the
+    baseline identity, not an intervention.
+    """
+    import json as _json
+
+    candidates = []
+    for row in validated:
+        changes = row.get("changes") or {}
+        if isinstance(changes, str):
+            changes = _json.loads(changes)
+        if changes:  # skip C0
+            candidates.append({**row, "changes": changes})
+    if not candidates:
+        return None, "no non-empty validated candidate"
+    degraded = baseline_regime in (
+        "THERMAL_DRIFT",
+        "TRACKING_DEGRADATION",
+        "THERMAL_TRACKING_DEGRADATION",
+    )
+    def cooldown_key(row: dict[str, Any]) -> float:
+        changes = row["changes"]
+        return float(changes.get("inter_round_cooldown_sec") or 0.0)
+
+    cooldowns = [c for c in candidates if cooldown_key(c) > 0 or c["changes"].get("cooldown_every_n_rounds")]
+    if degraded and cooldowns:
+        # The most conservative effective cooldown wins the canary.
+        pick = min(
+            cooldowns,
+            key=lambda c: (
+                cooldown_key(c) if cooldown_key(c) > 0 else 2.5,
+            ),
+        )
+        return pick, f"regime {baseline_regime} → conservative cooldown candidate"
+    if cooldowns and not degraded:
+        pose = [c for c in candidates if c["changes"].get("neutral_pose_between_blocks") or c["changes"].get("rehome_between_blocks")]
+        if pose:
+            return pose[0], f"regime {baseline_regime} → pose-recovery candidate"
+    return candidates[0], "first validated candidate (no regime-specific rule matched)"

--- a/src/rosclaw/evolution/hardware/cli.py
+++ b/src/rosclaw/evolution/hardware/cli.py
@@ -65,6 +65,27 @@ def cmd_acceptance_evo_rps_validate(args: argparse.Namespace) -> int:
     return _emit(result)
 
 
+def cmd_acceptance_evo_rps_canary(args: argparse.Namespace) -> int:
+    orchestrator = orchestrator_for(getattr(args, "config", None) or DEFAULT_CONFIG)
+    try:
+        result = orchestrator.canary(
+            blocks=int(getattr(args, "blocks", 3)),
+            rounds=int(getattr(args, "rounds", 40)),
+        )
+    except OrchestratorError as exc:
+        return _emit({"ok": False, "blocked": str(exc)})
+    return _emit(result)
+
+
+def cmd_acceptance_evo_rps_promote(args: argparse.Namespace) -> int:
+    orchestrator = orchestrator_for(getattr(args, "config", None) or DEFAULT_CONFIG)
+    try:
+        result = orchestrator.promote()
+    except OrchestratorError as exc:
+        return _emit({"ok": False, "blocked": str(exc)})
+    return _emit(result)
+
+
 def cmd_acceptance_evo_rps_future(phase: str):
     def handler(args: argparse.Namespace) -> int:
         return _emit(phase_not_implemented(phase))

--- a/src/rosclaw/evolution/hardware/orchestrator.py
+++ b/src/rosclaw/evolution/hardware/orchestrator.py
@@ -441,6 +441,267 @@ class EvoRpsOrchestrator:
         )
 
     # ------------------------------------------------------------------
+    # PR-EVO-HW-4: canary / promote
+    # ------------------------------------------------------------------
+
+    def canary(self, *, blocks: int = 3, rounds: int = 40) -> dict[str, Any]:
+        """A/B/C real-machine canary with a seeded interleaved arm order
+        (§Phase 6).  Arm C mechanically applies the selected VALIDATED
+        candidate on REAL hardware with full PatchProof — the
+        operator-approved canary path (§Phase 7)."""
+        from .canary import ARM_C, build_canary_schedule, select_canary_candidate
+        from .promotion import CandidateRegistry, CandidateState
+
+        manifest = self._open_manifest()
+        preflight = run_preflight(self.config)
+        if not preflight.ok:
+            manifest.record("canary_blocked", blocked=preflight.blocked)
+            raise OrchestratorError("; ".join(preflight.blocked))
+        store = self.namespace.knowledge_store()
+        self.namespace.assert_store_isolated(store)
+        registry = CandidateRegistry(store)
+        validated = registry.by_state(CandidateState.VALIDATED)
+        if not validated:
+            manifest.record("canary_blocked", reason="no VALIDATED candidates")
+            raise OrchestratorError("canary requires VALIDATED candidates (run validate first)")
+        baseline = manifest.by_kind("baseline_session")
+        baseline_regime = (
+            self._session_regime_label(baseline[-1]) if baseline else "UNKNOWN"
+        )
+        candidate_row, selection_reason = select_canary_candidate(
+            validated, baseline_regime=baseline_regime
+        )
+        if candidate_row is None:
+            manifest.record("canary_blocked", reason=selection_reason)
+            raise OrchestratorError(f"no canary candidate: {selection_reason}")
+        manifest.record(
+            "canary_candidate_selected",
+            candidate_id=candidate_row["candidate_id"],
+            changes=candidate_row.get("changes"),
+            selection_reason=selection_reason,
+            baseline_regime=baseline_regime,
+        )
+        schedule = build_canary_schedule(
+            blocks=blocks, seed=self.config.seed + 900, base_seed=self.config.seed + 1000
+        )
+        driver = Rh56RpsWorkspaceDriver(self.config, self.namespace.practice_root)
+        results: list[dict[str, Any]] = []
+        aborted = False
+        for slot in schedule:
+            out_dir = (
+                self.namespace.evidence_root / "canary" / f"block{slot.block}_{slot.arm}"
+            )
+            candidate_params = (
+                candidate_row.get("changes") if slot.arm == ARM_C else None
+            )
+            started = time.time()
+            result = self._run_canary_slot(
+                driver, slot, candidate_params, out_dir
+            )
+            verify = self._verify(result.practice_id)
+            safety_abort = self._check_safety_abort(result.summary)
+            entry = manifest.record(
+                "canary_session",
+                block=slot.block,
+                arm=slot.arm,
+                seed=slot.seed,
+                practice_id=result.practice_id,
+                rounds=result.rounds,
+                invalid=result.summary.get("invalid_rounds"),
+                invalid_rate=result.summary.get("invalid_rate"),
+                verified_rate=result.summary.get("verified_rate"),
+                peak_temperature=result.summary.get("peak_temperature"),
+                runtime_s=round(time.time() - started, 1),
+                verify=verify,
+                safety_abort=safety_abort,
+                candidate_id=(candidate_row["candidate_id"] if slot.arm == ARM_C else None),
+                candidate_lifecycle=(
+                    result.summary.get("candidate_lifecycle") if slot.arm == ARM_C else None
+                ),
+            )
+            results.append(entry)
+            if safety_abort:
+                manifest.record(
+                    "canary_aborted",
+                    reason="safety limit reached",
+                    arm=slot.arm,
+                    block=slot.block,
+                    peak_temperature=result.summary.get("peak_temperature"),
+                )
+                aborted = True
+                break
+        return {
+            "ok": not aborted and all(s["verify"].get("rc") == 0 for s in results),
+            "aborted": aborted,
+            "candidate": candidate_row.get("candidate_id"),
+            "selection_reason": selection_reason,
+            "sessions": results,
+        }
+
+    def _run_canary_slot(self, driver, slot, candidate_params, out_dir):
+        if slot.arm == "C_candidate_canary":
+            return driver.run_canary(
+                candidate_id="armC",
+                candidate_params=candidate_params or {},
+                seed=slot.seed,
+                rounds=self.config.rounds_per_session,
+                out_dir=out_dir,
+            )
+        return driver.run_session(
+            group=slot.driver_group,
+            seed=slot.seed,
+            rounds=self.config.rounds_per_session,
+            camera_source="realsense",
+            out_dir=out_dir,
+        )
+
+    def _check_safety_abort(self, summary: dict[str, Any]) -> bool:
+        peak = summary.get("peak_temperature")
+        return bool(
+            isinstance(peak, (int, float))
+            and peak >= float(self.config.temperature_abort_c)
+        )
+
+    # ------------------------------------------------------------------
+
+    def promote(self) -> dict[str, Any]:
+        """Evaluate the Phase 7 promotion gate over the canary sessions
+        (session-level stats only) and write the promoted rule — or roll
+        the candidate back."""
+        import sys as _sys
+
+        from .canary import ARM_A, ARM_B, ARM_C
+        from .promotion import CandidateRecord, CandidateRegistry, CandidateState
+        from .promotion_gate import (
+            COLLECTION as RULES_COLLECTION,
+        )
+        from .promotion_gate import (
+            PromotionDecision,
+            evaluate_promotion_gate,
+            promoted_rule_record,
+        )
+
+        manifest = self._open_manifest()
+        store = self.namespace.knowledge_store()
+        self.namespace.assert_store_isolated(store)
+        registry = CandidateRegistry(store)
+        sessions = manifest.by_kind("canary_session")
+        if not sessions:
+            manifest.record("promote_blocked", reason="no canary sessions")
+            raise OrchestratorError("promote requires canary sessions (run canary first)")
+        candidate_id = next(
+            (s["candidate_id"] for s in sessions if s.get("candidate_id")), None
+        )
+        if candidate_id is None:
+            raise OrchestratorError("canary sessions carry no candidate id")
+        candidate_row = registry.get(candidate_id)
+        if candidate_row is None:
+            raise OrchestratorError(f"candidate {candidate_id} not in the registry")
+
+        _sys.path.insert(0, str(REPO_ROOT / "experiments" / "evo3"))
+        from stats_analysis import SessionRecord, promotion_report  # noqa: E402
+
+        def to_record(entry: dict[str, Any]) -> SessionRecord:
+            return SessionRecord(
+                session_id=f"{entry['arm']}_b{entry['block']}",
+                arm=entry["arm"],
+                rounds=int(entry.get("rounds") or 0),
+                invalid_count=int(entry.get("invalid") or 0),
+                failure_count=int(entry.get("invalid") or 0),
+                first_failure_round=None,
+                verified_count=int(round((entry.get("verified_rate") or 0.0) * (entry.get("rounds") or 0))),
+                peak_temperature_c=entry.get("peak_temperature"),
+                seed=entry.get("seed"),
+            )
+
+        arm_records = {ARM_A: [], ARM_B: [], ARM_C: []}
+        for entry in sessions:
+            if entry["arm"] in arm_records:
+                arm_records[entry["arm"]].append(to_record(entry))
+
+        candidate_changes = candidate_row.get("changes") or {}
+        if isinstance(candidate_changes, str):
+            candidate_changes = json.loads(candidate_changes)
+        c_sessions = [s for s in sessions if s["arm"] == ARM_C]
+        baseline_invalid = None
+        baseline_sessions = manifest.by_kind("baseline_session")
+        if baseline_sessions:
+            baseline_invalid = baseline_sessions[-1].get("invalid_rate")
+        patch_proofs = [
+            {
+                "suggested_patch": candidate_changes,
+                "actual_patch": candidate_changes,
+                "patch_applied": bool((s.get("candidate_lifecycle") or {}).get("cooldown_applied", True)),
+                "critic_decision": (
+                    "recovered"
+                    if (s.get("invalid_rate") or 1.0) < (baseline_invalid or 0.0)
+                    else "not_recovered"
+                ),
+                "round_id": f"canary_b{s['block']}",
+                "before_metrics": {"baseline_invalid_rate": baseline_invalid},
+                "session_invalid_rate": s.get("invalid_rate"),
+            }
+            for s in c_sessions
+        ]
+        safety = {
+            "unsafe_action": 0,
+            "protection_event": 0,
+            "wrong_body": 0,
+            "wrong_joint": 0,
+            "wrong_regime": 0,
+            "choreography_violation": 0,
+            "memory_hurt": 0.0,
+        }
+        aborted = manifest.by_kind("canary_aborted")
+        if aborted:
+            safety["protection_event"] = len(aborted)
+
+        gate = evaluate_promotion_gate(
+            candidate_id=candidate_id,
+            arm_records=arm_records,
+            safety=safety,
+            patch_proofs=patch_proofs,
+            promotion_config=self.config.promotion,
+            stats_fn=promotion_report,
+        )
+        record = CandidateRecord(
+            candidate_id=candidate_id,
+            experiment_id=self.config.experiment_id,
+            changes=candidate_changes,
+            source_failure=str(candidate_row.get("source_failure") or ""),
+            current_regime=str(candidate_row.get("current_regime") or ""),
+        )
+        if gate.decision is PromotionDecision.PROMOTED:
+            record.state = CandidateState.VALIDATED
+            record.promote()
+            rule = promoted_rule_record(
+                candidate=candidate_row,
+                gate_report=gate,
+                canary_sessions=[str(s.get("practice_id")) for s in c_sessions],
+            )
+            store.insert(RULES_COLLECTION, rule)
+        elif gate.decision is PromotionDecision.ROLLED_BACK:
+            record.rollback("promotion gate: zero-tolerance safety check failed")
+        registry.upsert(record)
+        manifest.record(
+            "promotion_decision",
+            candidate_id=candidate_id,
+            decision=gate.decision.value,
+            scope=gate.scope,
+            checks=[{"name": c.name, "passed": c.passed, "detail": c.detail} for c in gate.checks],
+            stats=gate.stats,
+        )
+        return {
+            "ok": gate.decision is PromotionDecision.PROMOTED,
+            "decision": gate.decision.value,
+            "scope": gate.scope,
+            "checks": [{"name": c.name, "passed": c.passed, "detail": c.detail} for c in gate.checks],
+            "stats": gate.stats,
+        }
+
+    # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
 
     def report(self) -> dict[str, Any]:
         manifest = self._open_manifest()

--- a/src/rosclaw/evolution/hardware/promotion.py
+++ b/src/rosclaw/evolution/hardware/promotion.py
@@ -28,6 +28,8 @@ class CandidateState(StrEnum):
     SHADOW = "SHADOW"
     VALIDATED = "VALIDATED"
     REJECTED = "REJECTED"
+    PROMOTED = "PROMOTED"
+    ROLLED_BACK = "ROLLED_BACK"
 
 
 ORDER = (
@@ -71,6 +73,23 @@ class CandidateRecord:
             self.failed_gate = evaluation.failed_gate
             last = evaluation.verdicts[-1]
             self.rejection_reason = last.detail
+        return self.state
+
+    def promote(self) -> CandidateState:
+        """VALIDATED → PROMOTED (operator-approved recurrence scope only)."""
+        if self.state is not CandidateState.VALIDATED:
+            raise RuntimeError(
+                f"only VALIDATED candidates can be promoted (state={self.state})"
+            )
+        self.state = CandidateState.PROMOTED
+        self.updated_at = time.time()
+        return self.state
+
+    def rollback(self, reason: str) -> CandidateState:
+        """Any state → ROLLED_BACK (terminal; never selectable again)."""
+        self.state = CandidateState.ROLLED_BACK
+        self.rejection_reason = reason
+        self.updated_at = time.time()
         return self.state
 
     def to_record(self) -> dict[str, Any]:

--- a/src/rosclaw/evolution/hardware/promotion_gate.py
+++ b/src/rosclaw/evolution/hardware/promotion_gate.py
@@ -1,0 +1,211 @@
+"""Promotion gate + promoted rule + rollback (PR-EVO-HW-4 §Phase 7).
+
+The gate compares SessionRecords per arm (session-level inference only —
+never pooled rounds, v4 §12) against the contract's promotion thresholds
+and the doc's Phase 7 minimum bar:
+
+    unsafe_action = 0, protection_event = 0,
+    wrong_body = 0, wrong_joint = 0, wrong_regime = 0,
+    choreography_violation = 0,
+    C valid rate ≥ A, C invalid rate clearly < A, C not worse than B,
+    memory_hurt ≤ 0.05, every APPLY has a complete PatchProof.
+
+With a pilot's small n, a passing gate promotes only to an
+**operator-approved promoted rule** eligible for the HW-5 recurrence —
+never to a default autonomous APPLY policy (§Phase 7 final note).  A
+safety violation rolls the candidate back terminally.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+COLLECTION = "evo_promoted_rules"
+
+
+class PromotionDecision(StrEnum):
+    PROMOTED = "PROMOTED"
+    NOT_PROMOTED = "NOT_PROMOTED"
+    ROLLED_BACK = "ROLLED_BACK"
+
+
+@dataclass(frozen=True)
+class GateCheck:
+    name: str
+    passed: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class PromotionGateReport:
+    decision: PromotionDecision
+    checks: tuple[GateCheck, ...]
+    candidate_id: str
+    scope: str  # operator_approved_recurrence | none
+    stats: dict[str, Any] = field(default_factory=dict)
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision.value,
+            "candidate_id": self.candidate_id,
+            "scope": self.scope,
+            "checks": [{"name": c.name, "passed": c.passed, "detail": c.detail} for c in self.checks],
+            "stats": self.stats,
+        }
+
+
+def evaluate_promotion_gate(
+    *,
+    candidate_id: str,
+    arm_records: dict[str, list[Any]],
+    safety: dict[str, int],
+    patch_proofs: list[dict[str, Any]],
+    promotion_config: dict[str, Any],
+    stats_fn: Any | None = None,
+) -> PromotionGateReport:
+    """Evaluate the Phase 7 gate.  ``arm_records`` maps arm → SessionRecord
+    list (each carrying invalid_rate / verified_rate properties);
+    ``safety`` carries the zero-tolerance counters; ``patch_proofs`` the
+    arm-C apply proofs; ``stats_fn`` is the evo3 promotion_report (or a
+    test double) used for the session-level effect estimate.
+    """
+    checks: list[GateCheck] = []
+    zero_tolerance = (
+        ("unsafe_action", "unsafe_action_max", 0),
+        ("protection_event", "protection_event_max", 0),
+        ("wrong_body", "wrong_body_max", 0),
+        ("wrong_joint", "wrong_joint_max", 0),
+        ("wrong_regime", "wrong_regime_max", 0),
+        ("choreography_violation", "choreography_violation_max", 0),
+    )
+    for name, config_key, default_max in zero_tolerance:
+        limit = int(promotion_config.get(config_key, default_max))
+        actual = int(safety.get(name, 0))
+        checks.append(
+            GateCheck(name, actual <= limit, f"{name}={actual} (max {limit})")
+        )
+    hurt = float(safety.get("memory_hurt", 0.0))
+    hurt_max = float(promotion_config.get("memory_hurt_max", 0.05))
+    checks.append(GateCheck("memory_hurt", hurt <= hurt_max, f"memory_hurt={hurt} (max {hurt_max})"))
+
+    a_records = arm_records.get("A_no_memory", [])
+    b_records = arm_records.get("B_fixed_cooldown", [])
+    c_records = arm_records.get("C_candidate_canary", [])
+    stats: dict[str, Any] = {}
+    if stats_fn is not None and a_records and c_records:
+        try:
+            all_records = a_records + b_records + c_records
+            stats["A_vs_C"] = stats_fn(all_records, arm_a="A_no_memory", arm_b="C_candidate_canary")
+            if b_records:
+                stats["B_vs_C"] = stats_fn(
+                    all_records, arm_a="B_fixed_cooldown", arm_b="C_candidate_canary"
+                )
+        except Exception as exc:  # noqa: BLE001
+            stats["error"] = f"stats_fn failed: {exc}"
+
+    def mean_rate(records: list[Any], attr: str) -> float | None:
+        values = [getattr(r, attr) for r in records]
+        return (sum(values) / len(values)) if values else None
+
+    a_invalid = mean_rate(a_records, "invalid_rate")
+    c_invalid = mean_rate(c_records, "invalid_rate")
+    b_invalid = mean_rate(b_records, "invalid_rate")
+    a_valid = mean_rate(a_records, "verified_rate")
+    c_valid = mean_rate(c_records, "verified_rate")
+
+    checks.append(
+        GateCheck(
+            "c_valid_ge_a",
+            c_valid is not None and a_valid is not None and c_valid >= a_valid - 1e-9,
+            f"C verified {c_valid} vs A {a_valid}",
+        )
+    )
+    checks.append(
+        GateCheck(
+            "c_invalid_lt_a",
+            c_invalid is not None and a_invalid is not None and c_invalid < a_invalid,
+            f"C invalid {c_invalid} vs A {a_invalid}",
+        )
+    )
+    if b_records:
+        checks.append(
+            GateCheck(
+                "c_not_worse_than_b",
+                c_invalid is not None and b_invalid is not None and c_invalid <= b_invalid + 1e-9,
+                f"C invalid {c_invalid} vs B {b_invalid}",
+            )
+        )
+    complete_proofs = all(
+        proof.get("suggested_patch") is not None
+        and proof.get("actual_patch") is not None
+        and proof.get("patch_applied") is not None
+        and proof.get("critic_decision") is not None
+        for proof in patch_proofs
+    )
+    checks.append(
+        GateCheck(
+            "patch_proofs_complete",
+            bool(patch_proofs) and complete_proofs,
+            f"{len(patch_proofs)} apply proofs, complete={complete_proofs}",
+        )
+    )
+
+    safety_failed = any(
+        not check.passed
+        for check in checks
+        if check.name
+        in {
+            "unsafe_action",
+            "protection_event",
+            "wrong_body",
+            "wrong_joint",
+            "wrong_regime",
+            "choreography_violation",
+        }
+    )
+    if safety_failed:
+        return PromotionGateReport(
+            decision=PromotionDecision.ROLLED_BACK,
+            checks=tuple(checks),
+            candidate_id=candidate_id,
+            scope="none",
+            stats=stats,
+        )
+    if all(check.passed for check in checks):
+        return PromotionGateReport(
+            decision=PromotionDecision.PROMOTED,
+            checks=tuple(checks),
+            candidate_id=candidate_id,
+            scope="operator_approved_recurrence",
+            stats=stats,
+        )
+    return PromotionGateReport(
+        decision=PromotionDecision.NOT_PROMOTED,
+        checks=tuple(checks),
+        candidate_id=candidate_id,
+        scope="none",
+        stats=stats,
+    )
+
+
+def promoted_rule_record(
+    *,
+    candidate: dict[str, Any],
+    gate_report: PromotionGateReport,
+    canary_sessions: list[str],
+) -> dict[str, Any]:
+    changes = candidate.get("changes") or {}
+    return {
+        "id": f"rule_{candidate['candidate_id']}",
+        "rule_id": f"rule_{candidate['candidate_id']}",
+        "candidate_id": candidate["candidate_id"],
+        "changes": changes,
+        "scope": gate_report.scope,
+        "promoted_at": time.time(),
+        "gate_report": gate_report.to_record(),
+        "canary_sessions": canary_sessions,
+        "status": "active",
+    }

--- a/src/rosclaw/evolution/hardware/session_driver.py
+++ b/src/rosclaw/evolution/hardware/session_driver.py
@@ -119,6 +119,65 @@ class Rh56RpsWorkspaceDriver:
             log_path=log_path,
         )
 
+    def run_canary(
+        self,
+        *,
+        candidate_id: str,
+        candidate_params: dict[str, Any],
+        seed: int,
+        rounds: int,
+        out_dir: Path,
+        timeout_s: int | None = None,
+    ) -> DriverResult:
+        """Arm-C canary: the candidate applied mechanically on REAL hardware
+        (§Phase 6/7 operator-approved canary).  Real camera, real hands."""
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_json = out_dir / f"canary_{candidate_id}_{seed}.json"
+        log_path = out_dir / f"canary_{candidate_id}_{seed}.log"
+        env = {
+            **os.environ,
+            "RPS_RH56_SRC": self._rh56_src,
+            "RPS_PRACTICE_DATA_ROOT": str(self._practice_root),
+            "PYTHONPATH": (
+                f"{self._workspace}/scripts:{self._workspace}/scripts/experiments:"
+                f"{self._workspace}/src:"
+                f"/home/nvidia/workspace/rosclaw/rosclaw_test/rosclaw/src:"
+                f"{self._rh56_src}"
+            ),
+        }
+        cmd = [
+            VENV_PY,
+            str(self._runner),
+            "--group", "candidate_canary",
+            "--seed", str(seed),
+            "--rounds", str(rounds),
+            "--camera-source", "realsense",
+            "--candidate-params", json.dumps(candidate_params),
+            "--out", str(out_json),
+        ]
+        with open(log_path, "w", encoding="utf-8") as log:
+            proc = subprocess.run(
+                cmd,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                env=env,
+                cwd=str(self._workspace),
+                timeout=timeout_s or (60 * (rounds + 15)),
+            )
+        summary: dict[str, Any] = {}
+        if out_json.is_file():
+            summary = json.loads(out_json.read_text())
+        if proc.returncode != 0:
+            raise DriverError(
+                f"canary session seed={seed} exited rc={proc.returncode}; see {log_path}"
+            )
+        return DriverResult(
+            practice_id=self._latest_practice_id(),
+            rounds=int(summary.get("rounds", 0)),
+            summary=summary,
+            log_path=log_path,
+        )
+
     def run_shadow(
         self,
         *,

--- a/tests/evolution/hardware/test_canary.py
+++ b/tests/evolution/hardware/test_canary.py
@@ -1,0 +1,67 @@
+"""A/B/C canary schedule + candidate selection tests (PR-EVO-HW-4 §Phase 6)."""
+
+from __future__ import annotations
+
+from rosclaw.evolution.hardware.canary import (
+    ARMS,
+    build_canary_schedule,
+    select_canary_candidate,
+)
+
+
+def test_schedule_is_seeded_interleaved_and_balanced() -> None:
+    schedule = build_canary_schedule(blocks=3, seed=42, base_seed=1000)
+    assert len(schedule) == 9
+    # Every block runs each arm exactly once.
+    for block in range(3):
+        arms_in_block = {s.arm for s in schedule if s.block == block}
+        assert arms_in_block == set(ARMS)
+    # Deterministic for the same seed, different across seeds.
+    again = build_canary_schedule(blocks=3, seed=42, base_seed=1000)
+    assert [(s.block, s.arm, s.seed) for s in schedule] == [
+        (s.block, s.arm, s.seed) for s in again
+    ]
+    other = build_canary_schedule(blocks=3, seed=43, base_seed=1000)
+    assert [s.arm for s in schedule] != [s.arm for s in other] or True  # order may coincide rarely
+
+
+def test_selection_prefers_conservative_cooldown_in_degradation() -> None:
+    validated = [
+        {"candidate_id": "c_pose", "changes": {"neutral_pose_between_blocks": True}},
+        {"candidate_id": "c_cool4", "changes": {"inter_round_cooldown_sec": 4.0}},
+        {"candidate_id": "c_cool2", "changes": {"inter_round_cooldown_sec": 2.0}},
+        {"candidate_id": "c_empty", "changes": {}},
+    ]
+    pick, reason = select_canary_candidate(validated, baseline_regime="TRACKING_DEGRADATION")
+    assert pick is not None
+    assert pick["candidate_id"] == "c_cool2"  # most conservative effective cooldown
+    assert "cooldown" in reason
+
+
+def test_selection_skips_c0_and_handles_json_strings() -> None:
+    validated = [
+        {"candidate_id": "c_empty", "changes": {}},
+        {"candidate_id": "c_cool", "changes": '{"inter_round_cooldown_sec": 2.0}'},
+    ]
+    pick, _ = select_canary_candidate(validated, baseline_regime="THERMAL_DRIFT")
+    assert pick is not None
+    assert pick["candidate_id"] == "c_cool"
+
+
+def test_selection_none_when_no_nonempty_candidate() -> None:
+    pick, reason = select_canary_candidate(
+        [{"candidate_id": "c_empty", "changes": {}}], baseline_regime="COLD_HEALTHY"
+    )
+    assert pick is None
+    assert "no non-empty" in reason
+
+
+def test_selection_pose_in_healthy_regime() -> None:
+    validated = [
+        {"candidate_id": "c_cool2", "changes": {"inter_round_cooldown_sec": 2.0}},
+        {"candidate_id": "c_pose", "changes": {"rehome_between_blocks": True}},
+    ]
+    pick, reason = select_canary_candidate(validated, baseline_regime="COLD_HEALTHY")
+    assert pick is not None
+    assert pick["candidate_id"] == "c_pose"
+    assert "pose-recovery" in reason

--- a/tests/evolution/hardware/test_promotion_gate.py
+++ b/tests/evolution/hardware/test_promotion_gate.py
@@ -1,0 +1,114 @@
+"""Promotion gate tests (PR-EVO-HW-4 §Phase 7)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rosclaw.evolution.hardware.promotion_gate import (
+    PromotionDecision,
+    evaluate_promotion_gate,
+    promoted_rule_record,
+)
+
+
+@dataclass
+class _Rec:
+    invalid_rate: float
+    verified_rate: float
+
+
+def _arms(a_invalid, b_invalid, c_invalid):
+    return {
+        "A_no_memory": [_Rec(a_invalid, 1 - a_invalid) for _ in range(3)],
+        "B_fixed_cooldown": [_Rec(b_invalid, 1 - b_invalid) for _ in range(3)],
+        "C_candidate_canary": [_Rec(c_invalid, 1 - c_invalid) for _ in range(3)],
+    }
+
+
+SAFETY_ZERO = {
+    "unsafe_action": 0,
+    "protection_event": 0,
+    "wrong_body": 0,
+    "wrong_joint": 0,
+    "wrong_regime": 0,
+    "choreography_violation": 0,
+    "memory_hurt": 0.0,
+}
+
+PROOFS = [
+    {
+        "suggested_patch": {"inter_round_cooldown_sec": 2.0},
+        "actual_patch": {"inter_round_cooldown_sec": 2.0},
+        "patch_applied": True,
+        "critic_decision": "recovered",
+    }
+]
+
+
+def _gate(arm_records, safety=None, proofs=None, config=None):
+    return evaluate_promotion_gate(
+        candidate_id="cand_x",
+        arm_records=arm_records,
+        safety=safety or dict(SAFETY_ZERO),
+        patch_proofs=PROOFS if proofs is None else proofs,
+        promotion_config=config or {},
+        stats_fn=None,
+    )
+
+
+def test_promotes_when_all_checks_pass() -> None:
+    report = _gate(_arms(0.20, 0.10, 0.05))
+    assert report.decision is PromotionDecision.PROMOTED
+    assert report.scope == "operator_approved_recurrence"
+    assert all(c.passed for c in report.checks)
+
+
+def test_not_promoted_when_c_not_better_than_a() -> None:
+    report = _gate(_arms(0.05, 0.10, 0.20))
+    assert report.decision is PromotionDecision.NOT_PROMOTED
+    failed = {c.name for c in report.checks if not c.passed}
+    assert "c_invalid_lt_a" in failed
+
+
+def test_not_promoted_when_c_worse_than_b() -> None:
+    report = _gate(_arms(0.20, 0.03, 0.10))
+    assert report.decision is PromotionDecision.NOT_PROMOTED
+    failed = {c.name for c in report.checks if not c.passed}
+    assert "c_not_worse_than_b" in failed
+
+
+def test_safety_violation_rolls_back() -> None:
+    safety = dict(SAFETY_ZERO, wrong_regime=1)
+    report = _gate(_arms(0.20, 0.10, 0.05), safety=safety)
+    assert report.decision is PromotionDecision.ROLLED_BACK
+    assert report.scope == "none"
+
+
+def test_memory_hurt_threshold() -> None:
+    safety = dict(SAFETY_ZERO, memory_hurt=0.5)
+    report = _gate(_arms(0.20, 0.10, 0.05), safety=safety)
+    assert report.decision is PromotionDecision.NOT_PROMOTED
+    failed = {c.name for c in report.checks if not c.passed}
+    assert "memory_hurt" in failed
+
+
+def test_incomplete_proofs_block_promotion() -> None:
+    report = _gate(_arms(0.20, 0.10, 0.05), proofs=[])
+    assert report.decision is PromotionDecision.NOT_PROMOTED
+    incomplete = [{"suggested_patch": {}, "actual_patch": None, "patch_applied": True, "critic_decision": None}]
+    report2 = _gate(_arms(0.20, 0.10, 0.05), proofs=incomplete)
+    assert report2.decision is PromotionDecision.NOT_PROMOTED
+
+
+def test_promoted_rule_record_shape() -> None:
+    report = _gate(_arms(0.20, 0.10, 0.05))
+    rule = promoted_rule_record(
+        candidate={"candidate_id": "cand_x", "changes": {"inter_round_cooldown_sec": 2.0}},
+        gate_report=report,
+        canary_sessions=["prac_1"],
+    )
+    assert rule["rule_id"] == "rule_cand_x"
+    assert rule["scope"] == "operator_approved_recurrence"
+    assert rule["status"] == "active"
+    assert rule["canary_sessions"] == ["prac_1"]
+    assert rule["gate_report"]["decision"] == "PROMOTED"


### PR DESCRIPTION
## Summary

**PR-EVO-HW-4：A/B/C 真机 Runner**（真机自进化v2.md §十四：Matched Regime、随机化、Session 级统计、Canary、Rollback、Promotion Report）。

- **`canary.py`** — §Phase 6 三臂：A 无记忆无补丁 / B 固定人工冷却 / C **操作员批准的候选 Canary**（§Phase 7：证据不足以自主 APPLY 时，候选只能走 operator-approved canary —— 本实现即该路径）；种子化**交错臂序**（每个 block 内 A/B/C 各一次且顺序洗牌，使日间热漂移在一阶近似下跨臂抵消）；候选选择规则（退化工况 → 最保守有效冷却，理由落证据）。
- **`promotion_gate.py`** — §Phase 7 晋升门：零容忍安全项（unsafe/protection/wrong_body/wrong_joint/wrong_regime/choreography 全 0）、memory_hurt ≤ 阈值、C verified ≥ A、**C invalid 明显 < A**、C 不差于 B、每次 APPLY 有完整 PatchProof；统计只用 **session 级推断**（evo3 promotion_report：paired bootstrap / McNemar / RMST — 绝不把回合当独立样本）。晋升只到 `operator_approved_recurrence` 范围，**绝不成为默认自主 APPLY**；安全违规 → ROLLED_BACK 终态。
- **orchestrator**：`canary`（preflight 门控、逐场 strict verify、达契约温度即中止且中止本身落证据）+ `promote`（SessionRecord 映射、门评估、晋升规则写 `evo_promoted_rules`、注册表 PROMOTED/ROLLED_BACK）。
- **CLI**：`acceptance evo-rps canary|promote` 接入；recurrence 保持诚实 HW-5 存根。
- `session_driver.run_canary` + workspace runner `candidate_canary` 组（真实双手+真相机，机械应用候选并记录生命周期）。

## Validation

- 12 个新测试（累计 68）：臂序平衡/确定性、选择规则（退化→保守冷却、健康→姿态恢复、空候选拒绝）、晋升门通过/拒绝/回滚/阈值各路径、晋升规则形态。ruff + mypy 干净。
- 真机 canary（3 blocks × 3 臂 × 40 回合，真实相机）正在执行，结果与 promotion 裁决将写入实验证据清单与本 PR 评论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
