### PR TITLE
Add Phase 7 continual RL and embodied self foundation

### DIFF
--- a/docs/validation/ROSCLAW_PHASE7_SELFCORE_RL_FOUNDATION.md
+++ b/docs/validation/ROSCLAW_PHASE7_SELFCORE_RL_FOUNDATION.md
@@ -6,7 +6,7 @@
 
 基线：Phase 6 分支提交 `d43c49c2fa40e54a4024e6d40a5625445b462ac8`
 
-证据域：MuJoCo `SIM` 与四卡 `CUDA_SCREENING`；没有真实机器人执行或授权
+证据域：MuJoCo `SIM`、四卡 `CUDA_SCREENING` 与 `SIM_TRAINING_FOUNDATION`；没有真实机器人执行或授权
 
 ## 1. 结论先行
 
@@ -28,7 +28,7 @@
 
 - 不能声称 ROSClaw 或 G1 具有主观意识；
 - 不能声称已经发现功能性 SelfCore；目前只生成“persistent subnetwork candidate”；
-- 不能声称四卡筛查已经改善 G1 动作；四卡输入仍是版本合同夹具，不是 MuJoCo rollout；
+- 不能声称四卡学习候选已经改善 G1 动作；真实 MuJoCo rollout 已进入四卡 learner，但候选尚未执行多种子动作评测；
 - 不能声称 L2 相位、瞄准和恢复调制已经晋级；探索性物理测试发现回归，因此默认关闭；
 - 不能声称达到 Phase 7 最终验收；多技能、多种子、移动球、身体变化、Agency 校准和真实 rollout 在线训练仍未完成。
 
@@ -102,6 +102,11 @@ Recent / Anchor / Boundary / Self replay
   - Recent 50%、Anchor 25%、Boundary 15%、Self 10%；
   - Anchor 必须绑定 champion；Boundary 必须有安全事件或近失效；Self 必须绑定身体变化；
   - 未来版本拒绝，过旧版本不能进入 actor。
+- `src/rosclaw/continual/g1_goalforge.py` 与 `serde.py`
+  - 将真实 MuJoCo trace 转成单一 policy version 下的连续运动片段；
+  - 明确记录 torso、COM、支撑脚滑移、球相对位置、policy phase、能量余量和传感质量；
+  - 每个片段绑定由本体状态构建的 `SelfStateSnapshot` 哈希；
+  - 完整 trajectory 去重传输，并逐层验证 trajectory、record 和 batch 内容哈希；JSON key 重排不会改变 observation/action 合同顺序。
 - `src/rosclaw/continual/learner.py`
   - 有界 Gaussian residual actor；
   - twin reward critic、twin fall critic、twin constraint critic；
@@ -190,7 +195,35 @@ Recent / Anchor / Boundary / Self replay
 
 汇总证据 SHA-256：`c1a58d73e2598a8449fc1a18eb7b736db30a64ae79364bfa04f2549740cb8963`
 
-### 5.3 软件验证
+### 5.3 真实 MuJoCo → 四卡 learner → 安全拒绝闭环
+
+正式命令：
+
+```bash
+.venv/bin/python -m rosclaw.entrypoint simforge validate g1-goalforge \
+  --profile continual-physical-foundation \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy \
+  --output /code/rosclaw/phase7_evidence/physical-continual-v2
+```
+
+四个 replay 分区都来自真实 MuJoCo stepping，而非合成 transition：
+
+| 分区 | 工况 | 结果 | policy version | 物理步 | 严格重放 |
+|---|---|---|---:|---:|---|
+| Recent | 35N 横向扰动 | `SUCCESS` | 2 | 6520 | 通过 |
+| Anchor | nominal | `SUCCESS` | 0 | 6520 | 通过 |
+| Boundary | 80N 横向扰动 | `JOINT_LIMIT_EXCEEDED` | 2 | 6520 | 通过 |
+| Self | 0.02rad joint-zero bias | `SUCCESS` | 2 | 6520 | 通过 |
+
+四张 A6000 分别读取一个经完整序列化/反序列化验证的 batch。每卡 critic 使用 8384 条真实物理 transition；actor 只使用 6288 条 policy lag ≤ 1 的 transition；2096 条 v0 Anchor transition 只进入 critic/Self 路径。每卡完成 3 次 SAC 更新，loss 与 hidden activation 均为有限值，动作保持在 residual 上限内，CUDA 峰值分配约 21.25MB，四个 GPU UUID 均不同。
+
+GPU2 生成的 v3 candidate artifact 通过 checksum、body、parent 和 immutable safety identity 校验并进入候选槽。由于候选本身尚未完成 matched SIM rollout，门禁没有把“零个已知回归”伪装成安全通过，而是把 safety、historical retention、critical skill 和 anchor drift 明确标为 `MISSING`；plasticity 与 causal SelfCore 同样缺失。最终决定为 `NEED_MORE_EVIDENCE`，在 `PREPARE` 安全边界发起的激活仍被拒绝，slot 进入 `FROZEN`，active v2 未变化。
+
+这里的闭环成功标准是“真实物理经验可训练，而且不完整候选无法自我晋级”，不是“训练 loss 有限就算动作进步”。`g1_motion_effect_proven=false`、`candidate_activated=false`、`hardware_authorized=false` 均写入机器证据。
+
+汇总证据 SHA-256：`0e1ab01effe2b06f37d16bda32631981eedcb96f48fbab54cba96823abe14e0b`
+
+### 5.4 软件验证
 
 阶段性验证已经覆盖：
 
@@ -207,6 +240,8 @@ Recent / Anchor / Boundary / Self replay
 - 全仓首轮：5274 passed、67 skipped、27 deselected，4 个 LeRobot 集成失败；
 - 失败定位为测试隔离 home 中没有继承外部 LeRobot 路径；显式使用已安装的 `/code/rosclaw/phase6_runtime/lerobot-0.6.1/bin/python` 后，4 项全部通过；
 - 显式设置 `ROSCLAW_TEST_LEROBOT_PYTHON` 后最终全仓复跑：5286 passed、59 skipped、27 deselected、26 warnings，耗时 17m03s，无失败。
+- 本次真实物理 ingest 增量复跑 `tests/feedback tests/simforge tests/continual tests/self_model`：184 passed、1 skipped、3 deselected；原合成四卡 profile 也在四张 A6000 上再次通过，确认新增真实数据入口没有破坏旧诊断路径。
+- 本次最终全仓复跑：5294 passed、59 skipped、27 deselected、26 warnings，耗时 17m52s，无失败。
 
 ## 6. Stability-Plasticity 的实际解决方式
 
@@ -229,10 +264,10 @@ Recent / Anchor / Boundary / Self replay
 | Gate 0 / PR-0B phase clock | 接线完成、校准未完成 | 真实影响 policy frame，默认关闭 |
 | Gate 0 / PR-0C Phase 6 main | 未完成 | 当前 Phase 7 仍堆叠在 Phase 6 分支基线上 |
 | PR-1 RL Trajectory | 基础完成 | 版本、log-prob、body/regime、reward/cost 均已实现 |
-| PR-2 Experience Service | 内核完成 | 当前为进程内 store，尚未服务化 |
+| PR-2 Experience Service | 内核与跨进程 codec 完成 | 当前 store 仍为进程内，尚未长期服务化 |
 | PR-3 Inference Service | 未完成 | 只有 learner inference API |
-| PR-4 Learner Service | 算法内核完成 | SAC 已跑通，尚未形成长期服务 |
-| PR-5 Weight Update | 参考状态机完成 | SIM-only，未接 Registry |
+| PR-4 Learner Service | 算法与真实物理 ingest 完成 | 四卡 SAC 已消费 MuJoCo 轨迹，尚未形成长期服务 |
+| PR-5 Weight Update | 暂存/拒绝闭环完成 | 未评测候选会冻结；SIM-only，未接 Registry |
 | PR-6 AReaL Adapter | 设计映射完成 | 尚未服务编排 |
 | PR-7/8 Anchor/Churn | learner 与 gate 基础完成 | 真实多技能 benchmark 尚缺 |
 | PR-9/10 Rejuvenation/Experts | 未完成 | 下一阶段重点 |
@@ -246,13 +281,14 @@ Recent / Anchor / Boundary / Self replay
 
 ## 8. 下一阶段优先顺序
 
-1. 先把真实 MuJoCo trajectory 转为 `ControlSegment`，替换四卡 smoke 的合成 transition；
-2. 建立 rollout actor、versioned inference、experience、learner、weight-update 五个可恢复服务，并把最大 policy lag 固定为 1；
-3. 用站立、抗扰恢复、静止球、移动球组成交替 curriculum，先跑不少于 8 个 continual seeds 与 8 个 single-task controls；
-4. 实现 dead-unit、effective-rank、fresh-network-gap 和梯度冲突监测，再实现仅限 Plastic Expert 的低效单元重生；
-5. 实现 forward self model，做 payload、friction、latency、motor gain/zero bias 变化检测，再训练和校准 Agency；
-6. 在共同参考状态库上做 SelfCore 多阈值、多种子发现，并执行同规模 matched freeze/lesion/plastic-control/body-change；
-7. 用 Boundary 反例重新学习接触时机估计器；在 holdout 证明无回归前，L2 phase/aim/recovery 保持关闭；
-8. 只有历史平均下降 <3%、关键技能下降 ≤5%、critical regression=0、样本效率提升 ≥30% 且 Self 证据完整，才允许 SIM champion 晋级。
+1. 为 residual SAC artifact 增加只读 inference loader，把候选动作接入新的 MuJoCo evaluation worker；不得接硬件或 active Registry；
+2. 对候选运行 matched multi-seed Recent/Anchor/Boundary/Self 对照，实际计算 retention、安全回归与 anchor action drift；只有这些从 `MISSING` 变成真实观测值后才重新过门；
+3. 建立 rollout actor、versioned inference、experience、learner、weight-update 五个可恢复服务，并把最大 policy lag 固定为 1；
+4. 用站立、抗扰恢复、静止球、移动球组成交替 curriculum，先跑不少于 8 个 continual seeds 与 8 个 single-task controls；
+5. 实现 dead-unit、effective-rank、fresh-network-gap 和梯度冲突监测，再实现仅限 Plastic Expert 的低效单元重生；
+6. 实现 forward self model，做 payload、friction、latency、motor gain/zero bias 变化检测，再训练和校准 Agency；
+7. 在共同参考状态库上做 SelfCore 多阈值、多种子发现，并执行同规模 matched freeze/lesion/plastic-control/body-change；
+8. 用 Boundary 反例重新学习接触时机估计器；在 holdout 证明无回归前，L2 phase/aim/recovery 保持关闭；
+9. 只有历史平均下降 <3%、关键技能下降 ≤5%、critical regression=0、样本效率提升 ≥30% 且 Self 证据完整，才允许 SIM champion 晋级。
 
 真正的下一里程碑不是“训练 loss 下降”，而是：真实 G1 MuJoCo rollout 在四卡异步闭环里持续产生新经验；移动球能力上升；站立、恢复和静止球不遗忘；候选失败时机器门主动拒绝并回滚。

--- a/docs/validation/ROSCLAW_PHASE7_SELFCORE_RL_FOUNDATION.md
+++ b/docs/validation/ROSCLAW_PHASE7_SELFCORE_RL_FOUNDATION.md
@@ -1,0 +1,258 @@
+# ROSClaw Phase 7：SelfCore-RL 基础实施与验证报告
+
+日期：2026-07-27
+
+分支：`phase7-selfcore-rl-foundation`
+
+基线：Phase 6 分支提交 `d43c49c2fa40e54a4024e6d40a5625445b462ac8`
+
+证据域：MuJoCo `SIM` 与四卡 `CUDA_SCREENING`；没有真实机器人执行或授权
+
+## 1. 结论先行
+
+本轮不是把 RoboNaldo 整网直接在线微调，而是建立了一个可继续扩展的安全基础：冻结原踢球策略与安全内核，只学习有界 residual；每条经验绑定策略、控制器、身体和工况版本；陈旧经验不能进入 actor；新权重只能在安全动作边界切换；任何稳定性、可塑性、自我核心或因果证据缺失都会阻止晋级。
+
+已经真实完成并验证的内容包括：
+
+- 版本化运动经验、四时间尺度回放和陈旧度路由；
+- Constrained Residual SAC 学习内核，包括双 reward critic、独立 fall/constraint cost critic、熵、两个拉格朗日乘子、Anchor 蒸馏和父策略输出 churn 约束；
+- 双缓冲、校验和、父子谱系、安全动作边界切换与回滚状态机；
+- Stability-Plasticity 机器门，能区分 `REJECT` 与 `NEED_MORE_EVIDENCE`；
+- 具身自我 Identity、Self State、Capability、Agency 证据合同；
+- permutation-aware 的 SelfCore 候选发现、阈值敏感性分析和严格的因果证据门；
+- G1 L1 平衡与 L2 踢球技能的组合“小脑”接口，以及真正连接 MuJoCo policy clock 的 `kick_phase_rate`；
+- 80N 相同场景 feedback-off/on 因果窗口验证与严格重放；
+- 四张实体 A6000 上并行执行 residual SAC 更新。
+
+当前不能声称的内容：
+
+- 不能声称 ROSClaw 或 G1 具有主观意识；
+- 不能声称已经发现功能性 SelfCore；目前只生成“persistent subnetwork candidate”；
+- 不能声称四卡筛查已经改善 G1 动作；四卡输入仍是版本合同夹具，不是 MuJoCo rollout；
+- 不能声称 L2 相位、瞄准和恢复调制已经晋级；探索性物理测试发现回归，因此默认关闭；
+- 不能声称达到 Phase 7 最终验收；多技能、多种子、移动球、身体变化、Agency 校准和真实 rollout 在线训练仍未完成。
+
+## 2. 对参考工作的判断
+
+### 2.1 AReaL 2.0
+
+[AReaL 2.0](https://github.com/areal-project/AReaL/releases/tag/v2.0.0) 值得复用的是 rollout、训练、推理和权重更新解耦，以及数据携带权重版本、限制 off-policyness 的系统思想。它面向 LLM/Agent RL，不能直接照搬到高动态机器人控制。
+
+ROSClaw 采用了更严格的映射：
+
+| AReaL 概念 | ROSClaw 映射 | G1 额外约束 |
+|---|---|---|
+| token/trajectory version | control segment / episode policy version | 一次高动态动作只允许一个 policy version |
+| rollout staleness | `permitted_use()` | lag ≤ 1 才可进入 actor；更旧数据只用于 critic/Self 分析 |
+| weight update service | residual double-buffer slot | 摆腿、触球、恢复中禁止切换 |
+| async learner | Feedback Plane 外的 SAC learner | 不得写 Registry、DDS 或硬件 transport |
+
+### 2.2 Stability-Plasticity
+
+[Loss of plasticity in deep continual learning](https://www.nature.com/articles/s41586-024-07711-7) 表明长期持续训练会丢失可塑性，普通梯度下降本身不够；低效单元重生是后续要实现的机制，而不是本轮已经完成的能力。
+
+[C-CHAIN](https://arxiv.org/abs/2506.00592) 将持续 RL 的输出 churn 与表示/核秩退化联系起来。本轮据此加入父策略共享参考状态输出约束，并修复了一处“模型与同一时刻的自己比较、梯度恒为零”的实现陷阱。现在训练 penalty 对齐固定父策略参考网络，单步 churn 另行计量。
+
+### 2.3 Self 论文
+
+[Emergent Self in Continual Learning Robots](https://arxiv.org/abs/2603.24350) 的工程启发是：在共同参考状态上，经过持续多行为训练后，寻找跨任务稳定的网络子结构，再用 matched freeze/lesion 验证它是否有功能价值。
+
+这里必须避免循环论证：先人工指定一块网络叫 SelfCore、冻结它，再观察它稳定，不能证明“自我核心涌现”。ROSClaw 因而分成两个不同对象：
+
+1. `Embodied Self Model`：工程上明确设计的身份、状态、预测、Agency 和能力信念；
+2. `SelfCore candidate`：训练完成后才做的统计发现，只有通过持续学习对照、阈值敏感性、多种子、freeze/lesion、身体预测和身体变化测试后，才可晋级为 self-like core。
+
+论文讨论的是可测量的 self-like 不变子网络，不是主观意识的证明。ROSClaw 同样只使用“操作性具身自我认知”这一可测试表述。
+
+## 3. 当前闭环架构
+
+```text
+MuJoCo / future shadow robot
+        │  version-pinned episode
+        ▼
+Recent / Anchor / Boundary / Self replay
+        │  fresh rows ───────────────► Actor
+        └─ fresh + stale rows ───────► Reward/Cost Critics + Self analysis
+                                      │
+                                      ▼
+                         Residual SAC candidate artifact
+                                      │
+                Stability + Plasticity + Self + Safety Gate
+                                      │
+                         checksum + double-buffer stage
+                                      │
+                     STAND / PREPARE / COMPLETE atomic swap
+                                      │
+                         bounded residual + Safety Projector
+                                      │
+                          frozen RoboNaldo kick prior
+```
+
+核心原则是：快速环更新当前状态并救动作，慢速环只改变未来回合的候选参数。一次摆腿不能同时使用两个脑版本。
+
+## 4. 实现清单
+
+### 4.1 Continual RL
+
+- `src/rosclaw/continual/contracts.py`
+  - `PolicyVersion` 使用内容寻址 artifact、父版本、控制器、body 和 safety kernel；
+  - `ControlSegment` 记录 observation/action/next observation、behavior log-prob、Reward 和 Cost；
+  - `VersionedTrajectory` 禁止高动态 episode 跨版本并要求 phase 单调。
+- `src/rosclaw/continual/experience.py`
+  - Recent 50%、Anchor 25%、Boundary 15%、Self 10%；
+  - Anchor 必须绑定 champion；Boundary 必须有安全事件或近失效；Self 必须绑定身体变化；
+  - 未来版本拒绝，过旧版本不能进入 actor。
+- `src/rosclaw/continual/learner.py`
+  - 有界 Gaussian residual actor；
+  - twin reward critic、twin fall critic、twin constraint critic；
+  - Anchor distillation、父策略 churn、熵和 cost Lagrangian；
+  - 只输出候选 artifact，不激活 runtime。
+- `src/rosclaw/continual/stability.py`
+  - 历史平均下降 ≤ 3%，关键技能下降 ≤ 5%；
+  - critical safety regression、stale execution、old-version replay 必须为零；
+  - 新技能样本效率、fresh-network gap、dead unit、effective rank、churn 均有门；
+  - SelfCore 证据缺失返回 `NEED_MORE_EVIDENCE`，安全失败返回 `REJECT`。
+- `src/rosclaw/continual/weight_update.py`
+  - artifact checksum、父子版本、body/safety identity；
+  - 双缓冲、只在安全 phase 原子切换；
+  - 中途切换直接冻结；所有 receipt 的 `hardware_authorized=False`。
+
+### 4.2 具身自我与 SelfCore
+
+- `src/rosclaw/self_model/contracts.py`
+  - S0 `SelfIdentity`；
+  - S1 `SelfStateSnapshot`，包含关节健康、motor gain/zero bias、时延、摩擦、负载、平衡、能量和传感质量信念；
+  - S3 `AgencyAssessment` 的 self/external/sensor-fault 概率合同；
+  - S4 `CapabilityBelief`。
+- `src/rosclaw/self_model/self_core.py`
+  - 共同参考状态 activation；
+  - dead-unit 过滤；
+  - absolute co-activation graph；
+  - Hungarian 神经元排列对齐；
+  - activation/connectivity persistence；
+  - 多阈值敏感性分析；
+  - 输出只能叫 candidate，模块本身禁止把 `causal_validated` 设为真。
+
+尚未完成 S2 forward self model、Agency 估计器、Capability 在线校准器和 S5 autobiographical continuity。现有 Agency 是严格证据合同，不是已经达到 95% 准确率的分类器。
+
+### 4.3 G1 小脑
+
+- `G1CerebellumController` 在一次 Safety Projection 前组合 L1 balance 与 L2 skill residual；
+- MuJoCo backend 已让 `skill:kick_phase_rate` 影响真实 policy frame，而不是只写日志；
+- policy clock 只能前进或短暂停帧，不能倒放动作；
+- 未校准的 phase、lateral aim 和 recovery 三个 L2 通道全部默认关闭；
+- 原 Phase 6 L1 balance phase 语义保持不变，避免新 backend 破坏既有冠军行为。
+
+探索性物理 A/B 显示，固定 `expected_contact_phase=0.48` 与本场景真实触球 policy phase（约 0.416）不一致；相位调制在部分 offset 改善目标误差，在 nominal 和另一 offset 反而恶化。lateral/recovery 也出现 nominal 目标误差约增加 4.7cm 的反例。因此这些数据进入 Boundary 思路，而不是作为晋级证据。
+
+## 5. 实际验证结果
+
+### 5.1 80N feedback 因果窗口
+
+正式命令：
+
+```bash
+.venv/bin/python -m rosclaw.entrypoint simforge validate g1-goalforge \
+  --profile feedback-causal \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy \
+  --output /code/rosclaw/phase7_evidence/causal-feedback-v1.json
+```
+
+结果：
+
+| 指标 | Feedback OFF | Feedback ON | 变化 |
+|---|---:|---:|---:|
+| Episode 状态 | `JOINT_LIMIT_EXCEEDED` | `SUCCESS` | 救援成功 |
+| 扰动后姿态误差积分 | 2.78149 rad·s | 2.47131 rad·s | 改善 11.15% |
+| 扰动后姿态误差峰值 | 0.65877 rad | 0.50815 rad | 改善 22.86% |
+| 最后 0.5s 平均姿态误差 | 0.60136 rad | 0.35207 rad | 改善 41.46% |
+| 严格重放 | — | 通过 | trajectory/result 一致 |
+
+控制器在 5.64s 激活、7.82s 结束；激活前 joint/torso/ball 前缀逐值一致，激活后 counterfactual 发生分叉，因此可以把本场景的救援归因到反馈，而不是随机初态差异。
+
+限制同样被保留：激活早期姿态误差积分由 0.47058 上升到 0.50383 rad·s，存在短暂退化；这解释了原 receipt 的 `tracking_improved=false`。该结果只支持一个固定 SIM 场景中的局部因果主张，仍为 `NEED_MORE_EVIDENCE`。
+
+证据 SHA-256：`0e46ba7ac6d3b11e148f867faa250b5754608502f502f3fc9c3a6b81a35ff06c`
+
+### 5.2 四卡 A6000 residual SAC 系统筛查
+
+正式命令：
+
+```bash
+.venv/bin/python -m rosclaw.entrypoint simforge validate g1-goalforge \
+  --profile continual-four-gpu-smoke \
+  --output /code/rosclaw/phase7_evidence/continual-four-gpu-v2
+```
+
+结果：4 个不同 GPU UUID 全部参与；每卡完成 3 次 SAC 更新；loss、hidden activation 均为有限值；residual action 全部在边界内；每卡 critic 使用 128 条 transition，actor 只使用 96 条 fresh transition，32 条 stale transition 被排除出 actor；每卡约分配 17.99MB CUDA 内存，未停止或修改机器上的其他 GPU 进程。
+
+这项测试的输入是 G1 命名的合成版本合同 transition，只验证系统路径，不证明动作性能。四个候选均未 stage、未 activate、未写 Registry。
+
+汇总证据 SHA-256：`c1a58d73e2598a8449fc1a18eb7b736db30a64ae79364bfa04f2549740cb8963`
+
+### 5.3 软件验证
+
+阶段性验证已经覆盖：
+
+- continual/self/cerebellum/phase-clock/causal/GPU smoke 定向测试；
+- Ruff；
+- Mypy；
+- Python compileall；
+- MuJoCo 真实 physics step 和严格 replay；
+- 四张实体 A6000 的 CUDA kernel 与 optimizer update。
+
+最终测试结果：
+
+- 最终 `tests/feedback tests/simforge`：160 passed、1 skipped、3 deselected；
+- 全仓首轮：5274 passed、67 skipped、27 deselected，4 个 LeRobot 集成失败；
+- 失败定位为测试隔离 home 中没有继承外部 LeRobot 路径；显式使用已安装的 `/code/rosclaw/phase6_runtime/lerobot-0.6.1/bin/python` 后，4 项全部通过；
+- 显式设置 `ROSCLAW_TEST_LEROBOT_PYTHON` 后最终全仓复跑：5286 passed、59 skipped、27 deselected、26 warnings，耗时 17m03s，无失败。
+
+## 6. Stability-Plasticity 的实际解决方式
+
+这不是靠一个正则项解决，而是六道不同失效面的防线：
+
+1. 冻结 RoboNaldo prior、安全 projector、hard limits、permit/lease 和 freshness；
+2. 只训练低维、有界 residual；
+3. 四类回放每个 batch 都出现，旧技能和边界反例不能被新数据挤掉；
+4. actor 只吃新鲜数据，critic/Self 分析可以利用更旧数据；
+5. Anchor distillation 与固定父策略 churn 同时约束“学新动作时乱改其他状态输出”；
+6. 候选必须同时通过 Stability、Plasticity、Self 和 Safety gate，且只在动作安全边界切换。
+
+本轮尚未实现 plastic-unit rejuvenation 和 dynamic expert allocation，所以只能说“建立了可执行门和 learner foundation”，不能说已经彻底解决长期可塑性丢失。
+
+## 7. Phase 7 文档 PR 对照
+
+| v7 项目 | 当前状态 | 说明 |
+|---|---|---|
+| Gate 0 / PR-0A F6 attribution | 部分完成 | 新因果窗口能归因救援，也如实暴露早期退化；广分布仍缺 |
+| Gate 0 / PR-0B phase clock | 接线完成、校准未完成 | 真实影响 policy frame，默认关闭 |
+| Gate 0 / PR-0C Phase 6 main | 未完成 | 当前 Phase 7 仍堆叠在 Phase 6 分支基线上 |
+| PR-1 RL Trajectory | 基础完成 | 版本、log-prob、body/regime、reward/cost 均已实现 |
+| PR-2 Experience Service | 内核完成 | 当前为进程内 store，尚未服务化 |
+| PR-3 Inference Service | 未完成 | 只有 learner inference API |
+| PR-4 Learner Service | 算法内核完成 | SAC 已跑通，尚未形成长期服务 |
+| PR-5 Weight Update | 参考状态机完成 | SIM-only，未接 Registry |
+| PR-6 AReaL Adapter | 设计映射完成 | 尚未服务编排 |
+| PR-7/8 Anchor/Churn | learner 与 gate 基础完成 | 真实多技能 benchmark 尚缺 |
+| PR-9/10 Rejuvenation/Experts | 未完成 | 下一阶段重点 |
+| PR-11 SelfState | 合同基础完成 | 在线估计器未完成 |
+| PR-12 Forward Self Model | 未完成 | Agency 的必要前置 |
+| PR-13 Agency | 证据合同完成 | 分类器和校准实验未完成 |
+| PR-14 Capability | belief 合同完成 | 在线 Bayesian/校准更新未完成 |
+| PR-15 SelfCore Analyzer | 非因果分析基础完成 | 不允许自证 causal |
+| PR-16 SelfCore Protection | 未完成 | 必须等候选通过因果实验 |
+| PR-18 Residual Cerebellum | 接口与物理接线完成 | L2 因回归而 fail-closed |
+
+## 8. 下一阶段优先顺序
+
+1. 先把真实 MuJoCo trajectory 转为 `ControlSegment`，替换四卡 smoke 的合成 transition；
+2. 建立 rollout actor、versioned inference、experience、learner、weight-update 五个可恢复服务，并把最大 policy lag 固定为 1；
+3. 用站立、抗扰恢复、静止球、移动球组成交替 curriculum，先跑不少于 8 个 continual seeds 与 8 个 single-task controls；
+4. 实现 dead-unit、effective-rank、fresh-network-gap 和梯度冲突监测，再实现仅限 Plastic Expert 的低效单元重生；
+5. 实现 forward self model，做 payload、friction、latency、motor gain/zero bias 变化检测，再训练和校准 Agency；
+6. 在共同参考状态库上做 SelfCore 多阈值、多种子发现，并执行同规模 matched freeze/lesion/plastic-control/body-change；
+7. 用 Boundary 反例重新学习接触时机估计器；在 holdout 证明无回归前，L2 phase/aim/recovery 保持关闭；
+8. 只有历史平均下降 <3%、关键技能下降 ≤5%、critical regression=0、样本效率提升 ≥30% 且 Self 证据完整，才允许 SIM champion 晋级。
+
+真正的下一里程碑不是“训练 loss 下降”，而是：真实 G1 MuJoCo rollout 在四卡异步闭环里持续产生新经验；移动球能力上升；站立、恢复和静止球不遗忘；候选失败时机器门主动拒绝并回滚。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,11 @@ knowledge = [
 lerobot = [
     "lerobot>=0.6,<0.7",
 ]
+rl = [
+    # Phase 7 continual residual learning is optional and never imported by
+    # the synchronous control plane.
+    "torch>=2.7,<3",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",

--- a/scripts/simforge/g1_continual_gpu_worker.py
+++ b/scripts/simforge/g1_continual_gpu_worker.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""One isolated CUDA worker for the Phase 7 residual-SAC systems smoke."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from rosclaw.continual.contracts import (
+    ControlSegment,
+    CostVector,
+    ExperiencePartition,
+    PolicyVersion,
+    RewardVector,
+    SkillPhase,
+    VersionedTrajectory,
+)
+from rosclaw.continual.experience import ContinualExperienceStore, ExperienceRecord
+from rosclaw.continual.learner import ConstrainedResidualSAC, ResidualSACConfig
+
+OBSERVATIONS = (
+    "torso_roll",
+    "torso_pitch",
+    "com_y_relative",
+    "support_slip_m",
+    "ball_lateral_error_m",
+    "contact_phase",
+    "energy_margin",
+    "sensor_quality",
+)
+ACTIONS = (
+    "waist_roll_residual",
+    "right_hip_roll_residual",
+    "right_hip_yaw_residual",
+    "kick_phase_rate",
+)
+ACTION_LIMITS = (0.04, 0.08, 0.035, 0.08)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--physical-gpu", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--updates", type=int, default=3)
+    args = parser.parse_args()
+    if args.physical_gpu not in range(4) or not 1 <= args.updates <= 20:
+        raise SystemExit("invalid continual CUDA worker request")
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible != str(args.physical_gpu):
+        raise SystemExit(f"CUDA identity mismatch: expected {args.physical_gpu}, visible={visible}")
+    if not torch.cuda.is_available() or torch.cuda.device_count() != 1:
+        raise SystemExit("continual CUDA worker requires exactly one visible GPU")
+
+    gpu_uuid, pci_bus_id = _gpu_identity(args.physical_gpu)
+    parent, batch = _screening_batch(args.physical_gpu)
+    learner = ConstrainedResidualSAC(
+        ResidualSACConfig(
+            observation_names=OBSERVATIONS,
+            action_names=ACTIONS,
+            action_limits=ACTION_LIMITS,
+            hidden_dims=(64, 64),
+            batch_size=32,
+            device="cuda:0",
+            seed=7001 + args.physical_gpu,
+        )
+    )
+    started = time.perf_counter()
+    updates = [learner.update(batch) for _ in range(args.updates)]
+    action = learner.action(
+        {
+            "torso_roll": 0.2,
+            "torso_pitch": -0.1,
+            "com_y_relative": 0.03,
+            "support_slip_m": 0.01,
+            "ball_lateral_error_m": 0.04,
+            "contact_phase": 0.4,
+            "energy_margin": 0.8,
+            "sensor_quality": 0.95,
+        }
+    )
+    reference = np.linspace(-0.2, 0.2, 64 * len(OBSERVATIONS), dtype=np.float32).reshape(
+        64, len(OBSERVATIONS)
+    )
+    hidden = learner.hidden_activations(reference)
+    candidate, artifact = learner.candidate_policy(parent=parent)
+    torch.cuda.synchronize()
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    bounded = all(
+        abs(action[name]) <= limit + 1e-7
+        for name, limit in zip(ACTIONS, ACTION_LIMITS, strict=True)
+    )
+    value = {
+        "schema_version": "rosclaw.continual.cuda_worker.v1",
+        "physical_gpu": args.physical_gpu,
+        "cuda_visible_devices": visible,
+        "gpu_uuid": gpu_uuid,
+        "pci_bus_id": pci_bus_id,
+        "gpu_name": torch.cuda.get_device_name(0),
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+        "batch_hash": batch.batch_hash,
+        "parent_policy_hash": parent.version_hash,
+        "candidate_policy_hash": candidate.version_hash,
+        "candidate_artifact_hash": candidate.artifact_hash,
+        "candidate_version": candidate.version,
+        "artifact_bytes": len(artifact),
+        "update_count": len(updates),
+        "updates_finite": all(update.finite for update in updates),
+        "critic_transition_count": updates[-1].critic_transition_count,
+        "actor_transition_count": updates[-1].actor_transition_count,
+        "stale_actor_transition_count": updates[-1].stale_actor_transition_count,
+        "final_losses": {
+            "critic": updates[-1].critic_loss,
+            "fall_critic": updates[-1].fall_critic_loss,
+            "constraint_critic": updates[-1].constraint_critic_loss,
+            "actor": updates[-1].actor_loss,
+            "anchor": updates[-1].anchor_loss,
+            "churn": updates[-1].churn_loss,
+            "step_churn": updates[-1].step_churn,
+        },
+        "action_bounded": bounded,
+        "hidden_activations_finite": all(np.isfinite(item).all() for item in hidden),
+        "hidden_activation_shapes": [list(item.shape) for item in hidden],
+        "elapsed_ms": elapsed_ms,
+        "max_memory_allocated_bytes": torch.cuda.max_memory_allocated(),
+        "claims": {
+            "synthetic_versioned_transition_screening": True,
+            "g1_motion_effect_proven": False,
+            "promotion_eligible": False,
+            "hardware_authorized": False,
+        },
+    }
+    args.output.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+def _screening_batch(gpu: int):
+    v0 = _policy(0, artifact=f"g1-parent-v0-gpu{gpu}".encode())
+    v1 = _policy(1, artifact=f"g1-parent-v1-gpu{gpu}".encode(), parent=v0)
+    v2 = _policy(2, artifact=f"g1-parent-v2-gpu{gpu}".encode(), parent=v1)
+    store = ContinualExperienceStore()
+    store.append(
+        ExperienceRecord(
+            _trajectory(v2, episode=f"gpu{gpu}-recent", delta=0.01 * gpu),
+            ExperiencePartition.RECENT,
+        )
+    )
+    store.append(
+        ExperienceRecord(
+            _trajectory(v0, episode=f"gpu{gpu}-anchor", delta=-0.01),
+            ExperiencePartition.ANCHOR,
+            anchor_policy_hash=v0.artifact_hash,
+        )
+    )
+    store.append(
+        ExperienceRecord(
+            _trajectory(
+                v2,
+                episode=f"gpu{gpu}-boundary",
+                delta=0.03,
+                critical=True,
+            ),
+            ExperiencePartition.BOUNDARY,
+            boundary_reason="synthetic-fall-boundary-screen",
+        )
+    )
+    store.append(
+        ExperienceRecord(
+            _trajectory(v2, episode=f"gpu{gpu}-self", delta=0.02),
+            ExperiencePartition.SELF,
+            self_change_hash=_digest(f"gpu{gpu}-payload-change".encode()),
+        )
+    )
+    return v2, store.sample(batch_size=64, learner_version=v2.version, seed=9001 + gpu)
+
+
+def _policy(
+    version: int,
+    *,
+    artifact: bytes,
+    parent: PolicyVersion | None = None,
+) -> PolicyVersion:
+    return PolicyVersion(
+        version=version,
+        artifact_hash=_digest(artifact),
+        parent_version_hash=parent.version_hash if parent else None,
+        controller_snapshot_hash=_digest(b"g1-cerebellum-controller-v1"),
+        body_hash=_digest(b"qualified-g1-screening-body"),
+        safety_kernel_hash=_digest(b"immutable-g1-safety-kernel"),
+        observation_names=OBSERVATIONS,
+        residual_action_names=ACTIONS,
+    )
+
+
+def _trajectory(
+    policy: PolicyVersion,
+    *,
+    episode: str,
+    delta: float,
+    critical: bool = False,
+) -> VersionedTrajectory:
+    segments = (
+        _segment(policy, episode=episode, start=0, phase=SkillPhase.PREPARE, delta=delta),
+        _segment(
+            policy,
+            episode=episode,
+            start=1,
+            phase=SkillPhase.RECOVERY,
+            delta=delta + 0.01,
+            critical=critical,
+            terminal=True,
+        ),
+    )
+    return VersionedTrajectory(segments=segments, strict_replay=True)
+
+
+def _segment(
+    policy: PolicyVersion,
+    *,
+    episode: str,
+    start: int,
+    phase: SkillPhase,
+    delta: float,
+    critical: bool = False,
+    terminal: bool = False,
+) -> ControlSegment:
+    observation = {
+        "torso_roll": 0.10 + delta,
+        "torso_pitch": -0.08 + delta,
+        "com_y_relative": 0.02 + delta,
+        "support_slip_m": max(0.0, 0.01 + delta),
+        "ball_lateral_error_m": 0.04 - delta,
+        "contact_phase": 0.35 + 0.1 * start,
+        "energy_margin": 0.8 - delta,
+        "sensor_quality": 0.95,
+    }
+    next_observation = dict(observation)
+    next_observation["torso_roll"] *= 0.9
+    next_observation["torso_pitch"] *= 0.9
+    action = {
+        "waist_roll_residual": -0.01,
+        "right_hip_roll_residual": -0.02,
+        "right_hip_yaw_residual": 0.005,
+        "kick_phase_rate": 0.01,
+    }
+    return ControlSegment(
+        segment_id=f"{episode}:{start}",
+        episode_id=episode,
+        task_id="g1_penalty_kick",
+        phase=phase,
+        start_step=start,
+        end_step=start + 1,
+        policy=policy,
+        controller_snapshot_hash=policy.controller_snapshot_hash,
+        body_hash=policy.body_hash,
+        regime_hash=_digest(b"cuda-screen-regime"),
+        self_state_hash=_digest(f"{episode}-self-state".encode()),
+        observation=observation,
+        residual_action=action,
+        next_observation=next_observation,
+        behavior_logprob=-0.5,
+        reward=RewardVector(task=1.0, tracking=0.2, balance=0.3, learning=0.1),
+        cost=CostVector(
+            fall=1.0 if critical else 0.0,
+            joint_limit=0.25 if critical else 0.0,
+            energy=0.1,
+        ),
+        terminal=terminal,
+    )
+
+
+def _gpu_identity(index: int) -> tuple[str, str]:
+    output = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "-i",
+            str(index),
+            "--query-gpu=uuid,pci.bus_id",
+            "--format=csv,noheader,nounits",
+        ],
+        text=True,
+    ).strip()
+    uuid, pci_bus_id = (item.strip() for item in output.split(",", maxsplit=1))
+    return uuid, pci_bus_id
+
+
+def _digest(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/simforge/g1_continual_gpu_worker.py
+++ b/scripts/simforge/g1_continual_gpu_worker.py
@@ -24,31 +24,30 @@ from rosclaw.continual.contracts import (
     VersionedTrajectory,
 )
 from rosclaw.continual.experience import ContinualExperienceStore, ExperienceRecord
+from rosclaw.continual.g1_goalforge import (
+    G1_CONTINUAL_ACTION_LIMITS,
+    G1_CONTINUAL_ACTIONS,
+    G1_CONTINUAL_OBSERVATIONS,
+)
 from rosclaw.continual.learner import ConstrainedResidualSAC, ResidualSACConfig
+from rosclaw.continual.serde import experience_batch_from_dict
 
-OBSERVATIONS = (
-    "torso_roll",
-    "torso_pitch",
-    "com_y_relative",
-    "support_slip_m",
-    "ball_lateral_error_m",
-    "contact_phase",
-    "energy_margin",
-    "sensor_quality",
-)
-ACTIONS = (
-    "waist_roll_residual",
-    "right_hip_roll_residual",
-    "right_hip_yaw_residual",
-    "kick_phase_rate",
-)
-ACTION_LIMITS = (0.04, 0.08, 0.035, 0.08)
+OBSERVATIONS = G1_CONTINUAL_OBSERVATIONS
+ACTIONS = G1_CONTINUAL_ACTIONS
+ACTION_LIMITS = G1_CONTINUAL_ACTION_LIMITS
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--physical-gpu", type=int, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--experience-batch", type=Path)
+    parser.add_argument("--artifact-output", type=Path)
+    parser.add_argument(
+        "--input-domain",
+        choices=("synthetic_contract_fixture", "mujoco_goalforge"),
+        default="synthetic_contract_fixture",
+    )
     parser.add_argument("--updates", type=int, default=3)
     args = parser.parse_args()
     if args.physical_gpu not in range(4) or not 1 <= args.updates <= 20:
@@ -59,8 +58,16 @@ def main() -> int:
     if not torch.cuda.is_available() or torch.cuda.device_count() != 1:
         raise SystemExit("continual CUDA worker requires exactly one visible GPU")
 
+    if args.input_domain == "mujoco_goalforge" and args.experience_batch is None:
+        raise SystemExit("MuJoCo worker input requires --experience-batch")
+    if args.experience_batch is not None:
+        batch = experience_batch_from_dict(
+            json.loads(args.experience_batch.read_text(encoding="utf-8"))
+        )
+        parent = _learner_parent(batch)
+    else:
+        parent, batch = _screening_batch(args.physical_gpu)
     gpu_uuid, pci_bus_id = _gpu_identity(args.physical_gpu)
-    parent, batch = _screening_batch(args.physical_gpu)
     learner = ConstrainedResidualSAC(
         ResidualSACConfig(
             observation_names=OBSERVATIONS,
@@ -74,23 +81,12 @@ def main() -> int:
     )
     started = time.perf_counter()
     updates = [learner.update(batch) for _ in range(args.updates)]
-    action = learner.action(
-        {
-            "torso_roll": 0.2,
-            "torso_pitch": -0.1,
-            "com_y_relative": 0.03,
-            "support_slip_m": 0.01,
-            "ball_lateral_error_m": 0.04,
-            "contact_phase": 0.4,
-            "energy_margin": 0.8,
-            "sensor_quality": 0.95,
-        }
-    )
-    reference = np.linspace(-0.2, 0.2, 64 * len(OBSERVATIONS), dtype=np.float32).reshape(
-        64, len(OBSERVATIONS)
-    )
+    action = learner.action(dict(batch.actor_records[0].trajectory.segments[0].observation))
+    reference = _reference_observations(batch)
     hidden = learner.hidden_activations(reference)
     candidate, artifact = learner.candidate_policy(parent=parent)
+    if args.artifact_output is not None:
+        args.artifact_output.write_bytes(artifact)
     torch.cuda.synchronize()
     elapsed_ms = (time.perf_counter() - started) * 1000.0
     bounded = all(
@@ -110,6 +106,7 @@ def main() -> int:
         "parent_policy_hash": parent.version_hash,
         "candidate_policy_hash": candidate.version_hash,
         "candidate_artifact_hash": candidate.artifact_hash,
+        "candidate_policy": candidate.to_dict(),
         "candidate_version": candidate.version,
         "artifact_bytes": len(artifact),
         "update_count": len(updates),
@@ -132,7 +129,11 @@ def main() -> int:
         "elapsed_ms": elapsed_ms,
         "max_memory_allocated_bytes": torch.cuda.max_memory_allocated(),
         "claims": {
-            "synthetic_versioned_transition_screening": True,
+            "input_domain": args.input_domain,
+            "synthetic_versioned_transition_screening": (
+                args.input_domain == "synthetic_contract_fixture"
+            ),
+            "mujoco_physics_transitions": args.input_domain == "mujoco_goalforge",
             "g1_motion_effect_proven": False,
             "promotion_eligible": False,
             "hardware_authorized": False,
@@ -140,6 +141,31 @@ def main() -> int:
     }
     args.output.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 0
+
+
+def _learner_parent(batch):
+    matches = {
+        record.trajectory.policy.version_hash: record.trajectory.policy
+        for record in batch.records
+        if record.trajectory.policy.version == batch.learner_version
+    }
+    if len(matches) != 1:
+        raise ValueError("physical replay must identify exactly one current learner parent")
+    return next(iter(matches.values()))
+
+
+def _reference_observations(batch) -> np.ndarray:
+    rows = [
+        [segment.observation[name] for name in OBSERVATIONS]
+        for record in batch.records
+        for segment in record.trajectory.segments
+    ]
+    if not rows:
+        raise ValueError("experience batch does not contain reference observations")
+    value = np.asarray(rows, dtype=np.float32)
+    if len(value) >= 64:
+        return value[:64]
+    return np.resize(value, (64, len(OBSERVATIONS)))
 
 
 def _screening_batch(gpu: int):

--- a/src/rosclaw/continual/__init__.py
+++ b/src/rosclaw/continual/__init__.py
@@ -1,0 +1,55 @@
+"""Versioned continual-learning substrate for ROSClaw simulation."""
+
+from rosclaw.continual.contracts import (
+    ControlSegment,
+    CostVector,
+    ExperiencePartition,
+    ExperienceUse,
+    PolicyVersion,
+    RewardVector,
+    SkillPhase,
+    VersionedTrajectory,
+)
+from rosclaw.continual.experience import (
+    ContinualExperienceStore,
+    ExperienceBatch,
+    ExperienceBufferConfig,
+    ExperienceRecord,
+    ReplayMix,
+)
+from rosclaw.continual.stability import (
+    ContinualCandidateEvidence,
+    ContinualDecision,
+    ContinualGateReport,
+    PlasticityEvidence,
+    SelfCoreEvidence,
+    StabilityPlasticityGate,
+    TaskRetention,
+)
+from rosclaw.continual.weight_update import ResidualWeightSlot, WeightSlotReceipt, WeightSlotState
+
+__all__ = [
+    "ControlSegment",
+    "CostVector",
+    "ExperiencePartition",
+    "ExperienceUse",
+    "PolicyVersion",
+    "RewardVector",
+    "SkillPhase",
+    "VersionedTrajectory",
+    "ContinualCandidateEvidence",
+    "ContinualDecision",
+    "ContinualExperienceStore",
+    "ContinualGateReport",
+    "ExperienceBatch",
+    "ExperienceBufferConfig",
+    "ExperienceRecord",
+    "PlasticityEvidence",
+    "ReplayMix",
+    "ResidualWeightSlot",
+    "SelfCoreEvidence",
+    "StabilityPlasticityGate",
+    "TaskRetention",
+    "WeightSlotReceipt",
+    "WeightSlotState",
+]

--- a/src/rosclaw/continual/__init__.py
+++ b/src/rosclaw/continual/__init__.py
@@ -17,6 +17,7 @@ from rosclaw.continual.experience import (
     ExperienceRecord,
     ReplayMix,
 )
+from rosclaw.continual.serde import experience_batch_from_dict, experience_batch_to_dict
 from rosclaw.continual.stability import (
     ContinualCandidateEvidence,
     ContinualDecision,
@@ -52,4 +53,6 @@ __all__ = [
     "TaskRetention",
     "WeightSlotReceipt",
     "WeightSlotState",
+    "experience_batch_from_dict",
+    "experience_batch_to_dict",
 ]

--- a/src/rosclaw/continual/contracts.py
+++ b/src/rosclaw/continual/contracts.py
@@ -1,0 +1,358 @@
+"""Immutable contracts for continual residual control.
+
+The contracts deliberately keep learning outside the synchronous Feedback
+Plane.  A rollout may be consumed asynchronously, but one high-dynamic G1
+episode is bound to exactly one policy version and one body/controller
+snapshot.  This is the robot-control analogue of AReaL's per-sample version
+tracking with a stricter no-mid-motion-switch rule.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _require_hash(label: str, value: str) -> None:
+    if not _SHA256.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+def _finite_mapping(value: Mapping[str, float], *, label: str) -> Mapping[str, float]:
+    normalized = {str(key): float(item) for key, item in value.items()}
+    if not normalized:
+        raise ValueError(f"{label} must not be empty")
+    if any(not math.isfinite(item) for item in normalized.values()):
+        raise ValueError(f"{label} must contain only finite values")
+    return MappingProxyType(normalized)
+
+
+class SkillPhase(StrEnum):
+    """Motion boundaries used to prohibit unsafe weight changes."""
+
+    STAND = "stand"
+    PREPARE = "prepare"
+    WEIGHT_TRANSFER = "weight_transfer"
+    SWING = "swing"
+    CONTACT = "contact"
+    RECOVERY = "recovery"
+    COMPLETE = "complete"
+
+
+class ExperiencePartition(StrEnum):
+    RECENT = "recent"
+    ANCHOR = "anchor"
+    BOUNDARY = "boundary"
+    SELF = "self"
+
+
+class ExperienceUse(StrEnum):
+    """Permitted use of a trajectory relative to the learner version."""
+
+    ACTOR_CRITIC_SELF = "actor_critic_self"
+    CRITIC_SELF_ONLY = "critic_self_only"
+    REJECT = "reject"
+
+
+@dataclass(frozen=True)
+class RewardVector:
+    """Task and motion quality rewards; never hides safety costs."""
+
+    task: float = 0.0
+    tracking: float = 0.0
+    balance: float = 0.0
+    contact: float = 0.0
+    learning: float = 0.0
+    style: float = 0.0
+
+    def __post_init__(self) -> None:
+        if any(not math.isfinite(value) for value in self.to_dict().values()):
+            raise ValueError("reward vector must contain only finite values")
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "task": self.task,
+            "tracking": self.tracking,
+            "balance": self.balance,
+            "contact": self.contact,
+            "learning": self.learning,
+            "style": self.style,
+        }
+
+
+@dataclass(frozen=True)
+class CostVector:
+    """Independent non-negative safety and resource costs."""
+
+    fall: float = 0.0
+    joint_limit: float = 0.0
+    torque: float = 0.0
+    slip: float = 0.0
+    energy: float = 0.0
+    stale: float = 0.0
+    collision: float = 0.0
+    feedback_saturation: float = 0.0
+
+    def __post_init__(self) -> None:
+        values = self.to_dict().values()
+        if any(not math.isfinite(value) or value < 0.0 for value in values):
+            raise ValueError("cost vector must contain finite non-negative values")
+
+    @property
+    def critical(self) -> bool:
+        return any(
+            value > 0.0
+            for value in (
+                self.fall,
+                self.joint_limit,
+                self.torque,
+                self.stale,
+                self.collision,
+            )
+        )
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "fall": self.fall,
+            "joint_limit": self.joint_limit,
+            "torque": self.torque,
+            "slip": self.slip,
+            "energy": self.energy,
+            "stale": self.stale,
+            "collision": self.collision,
+            "feedback_saturation": self.feedback_saturation,
+        }
+
+
+@dataclass(frozen=True)
+class PolicyVersion:
+    """Content-addressed residual policy identity and rollback lineage."""
+
+    version: int
+    artifact_hash: str
+    controller_snapshot_hash: str
+    body_hash: str
+    safety_kernel_hash: str
+    observation_names: tuple[str, ...]
+    residual_action_names: tuple[str, ...]
+    parent_version_hash: str | None = None
+    schema_version: str = "rosclaw.continual.policy_version.v1"
+
+    def __post_init__(self) -> None:
+        if self.version < 0:
+            raise ValueError("policy version must be non-negative")
+        for label, value in (
+            ("artifact_hash", self.artifact_hash),
+            ("controller_snapshot_hash", self.controller_snapshot_hash),
+            ("body_hash", self.body_hash),
+            ("safety_kernel_hash", self.safety_kernel_hash),
+        ):
+            _require_hash(label, value)
+        if self.version == 0 and self.parent_version_hash is not None:
+            raise ValueError("policy version zero cannot have a parent")
+        if self.version > 0:
+            if self.parent_version_hash is None:
+                raise ValueError("non-zero policy versions require a parent")
+            _require_hash("parent_version_hash", self.parent_version_hash)
+        for label, names in (
+            ("observation_names", self.observation_names),
+            ("residual_action_names", self.residual_action_names),
+        ):
+            if (
+                not names
+                or len(names) != len(set(names))
+                or any(not name.strip() for name in names)
+            ):
+                raise ValueError(f"{label} must be non-empty, unique names")
+        if len(self.residual_action_names) > 32:
+            raise ValueError("residual policy action dimension must not exceed 32")
+
+    @property
+    def version_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "version": self.version,
+            "artifact_hash": self.artifact_hash,
+            "parent_version_hash": self.parent_version_hash,
+            "controller_snapshot_hash": self.controller_snapshot_hash,
+            "body_hash": self.body_hash,
+            "safety_kernel_hash": self.safety_kernel_hash,
+            "observation_names": list(self.observation_names),
+            "residual_action_names": list(self.residual_action_names),
+        }
+
+
+@dataclass(frozen=True)
+class ControlSegment:
+    """One version-pinned transition segment emitted by a rollout worker."""
+
+    segment_id: str
+    episode_id: str
+    task_id: str
+    phase: SkillPhase
+    start_step: int
+    end_step: int
+    policy: PolicyVersion
+    controller_snapshot_hash: str
+    body_hash: str
+    regime_hash: str
+    self_state_hash: str
+    observation: Mapping[str, float]
+    residual_action: Mapping[str, float]
+    next_observation: Mapping[str, float]
+    behavior_logprob: float
+    reward: RewardVector
+    cost: CostVector
+    terminal: bool = False
+    schema_version: str = "rosclaw.continual.control_segment.v1"
+
+    def __post_init__(self) -> None:
+        if not self.segment_id.strip() or not self.episode_id.strip() or not self.task_id.strip():
+            raise ValueError("segment, episode, and task identifiers must not be empty")
+        if self.start_step < 0 or self.end_step <= self.start_step:
+            raise ValueError("control segment steps must define a positive interval")
+        for label, value in (
+            ("controller_snapshot_hash", self.controller_snapshot_hash),
+            ("body_hash", self.body_hash),
+            ("regime_hash", self.regime_hash),
+            ("self_state_hash", self.self_state_hash),
+        ):
+            _require_hash(label, value)
+        if self.controller_snapshot_hash != self.policy.controller_snapshot_hash:
+            raise ValueError("segment controller snapshot does not match its policy")
+        if self.body_hash != self.policy.body_hash:
+            raise ValueError("segment body does not match its policy")
+        if not math.isfinite(self.behavior_logprob):
+            raise ValueError("behavior_logprob must be finite")
+        observation = _finite_mapping(self.observation, label="observation")
+        next_observation = _finite_mapping(self.next_observation, label="next_observation")
+        action = _finite_mapping(self.residual_action, label="residual_action")
+        if tuple(observation) != self.policy.observation_names:
+            raise ValueError("observation order must match the policy contract")
+        if tuple(next_observation) != self.policy.observation_names:
+            raise ValueError("next observation order must match the policy contract")
+        if tuple(action) != self.policy.residual_action_names:
+            raise ValueError("residual action order must match the policy contract")
+        object.__setattr__(self, "observation", observation)
+        object.__setattr__(self, "next_observation", next_observation)
+        object.__setattr__(self, "residual_action", action)
+
+    @property
+    def segment_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "segment_id": self.segment_id,
+            "episode_id": self.episode_id,
+            "task_id": self.task_id,
+            "phase": self.phase.value,
+            "start_step": self.start_step,
+            "end_step": self.end_step,
+            "policy": self.policy.to_dict(),
+            "policy_version_hash": self.policy.version_hash,
+            "controller_snapshot_hash": self.controller_snapshot_hash,
+            "body_hash": self.body_hash,
+            "regime_hash": self.regime_hash,
+            "self_state_hash": self.self_state_hash,
+            "observation": dict(self.observation),
+            "residual_action": dict(self.residual_action),
+            "next_observation": dict(self.next_observation),
+            "behavior_logprob": self.behavior_logprob,
+            "reward": self.reward.to_dict(),
+            "cost": self.cost.to_dict(),
+            "terminal": self.terminal,
+        }
+
+
+@dataclass(frozen=True)
+class VersionedTrajectory:
+    """A complete episode that cannot straddle residual policy versions."""
+
+    segments: tuple[ControlSegment, ...]
+    strict_replay: bool
+    schema_version: str = "rosclaw.continual.versioned_trajectory.v1"
+
+    def __post_init__(self) -> None:
+        if not self.segments:
+            raise ValueError("versioned trajectory must contain at least one segment")
+        first = self.segments[0]
+        if self.segments[-1].terminal is not True:
+            raise ValueError("versioned trajectory must end in a terminal segment")
+        expected_start = first.start_step
+        phase_order = {phase: index for index, phase in enumerate(SkillPhase)}
+        previous_phase = -1
+        for segment in self.segments:
+            if segment.start_step != expected_start:
+                raise ValueError("trajectory segments must be contiguous")
+            expected_start = segment.end_step
+            if (
+                segment.episode_id != first.episode_id
+                or segment.task_id != first.task_id
+                or segment.body_hash != first.body_hash
+                or segment.regime_hash != first.regime_hash
+                or segment.controller_snapshot_hash != first.controller_snapshot_hash
+            ):
+                raise ValueError("trajectory identity cannot change within an episode")
+            if segment.policy.version_hash != first.policy.version_hash:
+                raise ValueError("a high-dynamic episode cannot cross policy versions")
+            current_phase = phase_order[segment.phase]
+            if current_phase < previous_phase:
+                raise ValueError("skill phases must not move backwards")
+            previous_phase = current_phase
+        if any(segment.terminal for segment in self.segments[:-1]):
+            raise ValueError("only the final trajectory segment may be terminal")
+
+    @property
+    def policy(self) -> PolicyVersion:
+        return self.segments[0].policy
+
+    @property
+    def trajectory_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def has_critical_cost(self) -> bool:
+        return any(segment.cost.critical for segment in self.segments)
+
+    def permitted_use(self, *, learner_version: int, max_policy_lag: int = 1) -> ExperienceUse:
+        if max_policy_lag < 0:
+            raise ValueError("max_policy_lag must be non-negative")
+        lag = learner_version - self.policy.version
+        if lag < 0:
+            return ExperienceUse.REJECT
+        if lag <= max_policy_lag:
+            return ExperienceUse.ACTOR_CRITIC_SELF
+        return ExperienceUse.CRITIC_SELF_ONLY
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "segments": [segment.to_dict() for segment in self.segments],
+            "strict_replay": self.strict_replay,
+        }
+
+
+__all__ = [
+    "ControlSegment",
+    "CostVector",
+    "ExperiencePartition",
+    "ExperienceUse",
+    "PolicyVersion",
+    "RewardVector",
+    "SkillPhase",
+    "VersionedTrajectory",
+]

--- a/src/rosclaw/continual/experience.py
+++ b/src/rosclaw/continual/experience.py
@@ -1,0 +1,238 @@
+"""Four-timescale replay with explicit provenance and staleness routing."""
+
+from __future__ import annotations
+
+import math
+import random
+import re
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.continual.contracts import (
+    ExperiencePartition,
+    ExperienceUse,
+    VersionedTrajectory,
+)
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class ReplayMix:
+    recent: float = 0.50
+    anchor: float = 0.25
+    boundary: float = 0.15
+    self_: float = 0.10
+
+    def __post_init__(self) -> None:
+        values = self.to_dict()
+        if any(not math.isfinite(value) or value <= 0.0 for value in values.values()):
+            raise ValueError("all replay partitions require a finite positive sampling weight")
+        if not math.isclose(sum(values.values()), 1.0, abs_tol=1e-12):
+            raise ValueError("replay sampling weights must sum to one")
+
+    def to_dict(self) -> dict[ExperiencePartition, float]:
+        return {
+            ExperiencePartition.RECENT: self.recent,
+            ExperiencePartition.ANCHOR: self.anchor,
+            ExperiencePartition.BOUNDARY: self.boundary,
+            ExperiencePartition.SELF: self.self_,
+        }
+
+
+@dataclass(frozen=True)
+class ExperienceBufferConfig:
+    capacity_per_partition: int = 4096
+    max_policy_lag: int = 1
+    mix: ReplayMix = ReplayMix()
+
+    def __post_init__(self) -> None:
+        if self.capacity_per_partition <= 0:
+            raise ValueError("replay capacity must be positive")
+        if self.max_policy_lag < 0:
+            raise ValueError("max_policy_lag must be non-negative")
+
+
+@dataclass(frozen=True)
+class ExperienceRecord:
+    trajectory: VersionedTrajectory
+    partition: ExperiencePartition
+    anchor_policy_hash: str | None = None
+    boundary_reason: str | None = None
+    self_change_hash: str | None = None
+    near_boundary_score: float = 0.0
+    schema_version: str = "rosclaw.continual.experience_record.v1"
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.near_boundary_score <= 1.0:
+            raise ValueError("near_boundary_score must be in [0, 1]")
+        if self.partition is ExperiencePartition.ANCHOR and not self.anchor_policy_hash:
+            raise ValueError("anchor experience requires its champion policy hash")
+        if self.partition is ExperiencePartition.BOUNDARY:
+            if not self.boundary_reason:
+                raise ValueError("boundary experience requires a reason")
+            if not self.trajectory.has_critical_cost and self.near_boundary_score < 0.80:
+                raise ValueError("boundary experience requires a safety event or near miss")
+        if self.partition is ExperiencePartition.SELF and not self.self_change_hash:
+            raise ValueError("self experience requires a body-change commitment")
+        for label, value in (
+            ("anchor_policy_hash", self.anchor_policy_hash),
+            ("self_change_hash", self.self_change_hash),
+        ):
+            if value is not None and not _SHA256.fullmatch(value):
+                raise ValueError(f"{label} must be a sha256: content hash")
+
+    @property
+    def record_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "trajectory_hash": self.trajectory.trajectory_hash,
+            "partition": self.partition.value,
+            "anchor_policy_hash": self.anchor_policy_hash,
+            "boundary_reason": self.boundary_reason,
+            "self_change_hash": self.self_change_hash,
+            "near_boundary_score": self.near_boundary_score,
+        }
+
+
+@dataclass(frozen=True)
+class ExperienceBatch:
+    records: tuple[ExperienceRecord, ...]
+    permitted_uses: tuple[ExperienceUse, ...]
+    requested_counts: Mapping[ExperiencePartition, int]
+    learner_version: int
+    schema_version: str = "rosclaw.continual.experience_batch.v1"
+
+    def __post_init__(self) -> None:
+        if not self.records or len(self.records) != len(self.permitted_uses):
+            raise ValueError("experience batch records and uses must be non-empty and aligned")
+        object.__setattr__(self, "requested_counts", MappingProxyType(dict(self.requested_counts)))
+
+    @property
+    def actor_records(self) -> tuple[ExperienceRecord, ...]:
+        return tuple(
+            record
+            for record, use in zip(self.records, self.permitted_uses, strict=True)
+            if use is ExperienceUse.ACTOR_CRITIC_SELF
+        )
+
+    @property
+    def critic_self_only_records(self) -> tuple[ExperienceRecord, ...]:
+        return tuple(
+            record
+            for record, use in zip(self.records, self.permitted_uses, strict=True)
+            if use is ExperienceUse.CRITIC_SELF_ONLY
+        )
+
+    @property
+    def batch_hash(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": self.schema_version,
+                "record_hashes": [record.record_hash for record in self.records],
+                "permitted_uses": [use.value for use in self.permitted_uses],
+                "requested_counts": {
+                    key.value: value for key, value in sorted(self.requested_counts.items())
+                },
+                "learner_version": self.learner_version,
+            }
+        )
+
+
+class ContinualExperienceStore:
+    """Bounded replay memory; its evidence identity remains content-addressed."""
+
+    def __init__(self, config: ExperienceBufferConfig | None = None) -> None:
+        self.config = config or ExperienceBufferConfig()
+        self._buffers = {
+            partition: deque[ExperienceRecord](maxlen=self.config.capacity_per_partition)
+            for partition in ExperiencePartition
+        }
+        self._seen: set[str] = set()
+
+    def append(self, record: ExperienceRecord) -> None:
+        record_hash = record.record_hash
+        if record_hash in self._seen:
+            raise ValueError("experience record is already present in this lineage")
+        self._buffers[record.partition].append(record)
+        self._seen.add(record_hash)
+
+    def counts(self) -> Mapping[ExperiencePartition, int]:
+        return MappingProxyType(
+            {partition: len(records) for partition, records in self._buffers.items()}
+        )
+
+    @property
+    def ready(self) -> bool:
+        return all(self._buffers[partition] for partition in ExperiencePartition)
+
+    def sample(self, *, batch_size: int, learner_version: int, seed: int) -> ExperienceBatch:
+        if batch_size < len(ExperiencePartition):
+            raise ValueError("batch_size must allow every replay partition to be represented")
+        if learner_version < 0:
+            raise ValueError("learner_version must be non-negative")
+        missing = [partition.value for partition, records in self._buffers.items() if not records]
+        if missing:
+            raise RuntimeError(f"continual replay is not ready; empty partitions: {missing}")
+        counts = _apportion(batch_size, self.config.mix.to_dict())
+        rng = random.Random(seed)
+        sampled: list[ExperienceRecord] = []
+        for partition in ExperiencePartition:
+            records = tuple(self._buffers[partition])
+            sampled.extend(rng.choice(records) for _ in range(counts[partition]))
+        rng.shuffle(sampled)
+        uses = tuple(
+            record.trajectory.permitted_use(
+                learner_version=learner_version,
+                max_policy_lag=self.config.max_policy_lag,
+            )
+            for record in sampled
+        )
+        if ExperienceUse.REJECT in uses:
+            raise RuntimeError("replay contains a future policy version")
+        return ExperienceBatch(
+            records=tuple(sampled),
+            permitted_uses=uses,
+            requested_counts=counts,
+            learner_version=learner_version,
+        )
+
+
+def _apportion(
+    batch_size: int,
+    weights: Mapping[ExperiencePartition, float],
+) -> Mapping[ExperiencePartition, int]:
+    raw = {partition: batch_size * weight for partition, weight in weights.items()}
+    counts = {partition: max(1, int(math.floor(value))) for partition, value in raw.items()}
+    while sum(counts.values()) > batch_size:
+        eligible = [partition for partition, count in counts.items() if count > 1]
+        if not eligible:
+            raise ValueError("batch_size is too small for the configured replay mix")
+        selected = min(eligible, key=lambda partition: raw[partition] - counts[partition])
+        counts[selected] -= 1
+    while sum(counts.values()) < batch_size:
+        selected = max(
+            counts,
+            key=lambda partition: (
+                raw[partition] - counts[partition],
+                -list(weights).index(partition),
+            ),
+        )
+        counts[selected] += 1
+    return MappingProxyType(counts)
+
+
+__all__ = [
+    "ContinualExperienceStore",
+    "ExperienceBatch",
+    "ExperienceBufferConfig",
+    "ExperienceRecord",
+    "ReplayMix",
+]

--- a/src/rosclaw/continual/g1_goalforge.py
+++ b/src/rosclaw/continual/g1_goalforge.py
@@ -1,0 +1,464 @@
+"""Adapters from real GoalForge MuJoCo rollouts to continual-RL contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+from rosclaw.continual.contracts import (
+    ControlSegment,
+    CostVector,
+    PolicyVersion,
+    RewardVector,
+    SkillPhase,
+    VersionedTrajectory,
+)
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.self_model.contracts import (
+    CapabilityBelief,
+    ScalarBelief,
+    SelfIdentity,
+    SelfStateSnapshot,
+)
+from rosclaw.simforge.backends.unitree_mujoco_backend import GoalForgeEpisode
+from rosclaw.simforge.tasks.g1_goalforge.concepts import (
+    G1_DDS_JOINT_NAMES,
+    G1_HARD_TORQUE_LIMITS,
+    GOALFORGE_TASK_ID,
+    GoalForgeStatus,
+)
+
+G1_CONTINUAL_OBSERVATIONS = (
+    "torso_roll",
+    "torso_pitch",
+    "com_y_relative",
+    "support_slip_m",
+    "ball_lateral_error_m",
+    "contact_phase",
+    "energy_margin",
+    "sensor_quality",
+)
+G1_CONTINUAL_ACTIONS = (
+    "waist_roll_residual",
+    "right_hip_roll_residual",
+    "right_hip_yaw_residual",
+    "kick_phase_rate",
+)
+G1_CONTINUAL_ACTION_LIMITS = (0.04, 0.08, 0.035, 0.08)
+
+_ACTION_JOINT_INDICES = (13, 7, 8)
+
+
+@dataclass(frozen=True)
+class G1PolicyLineage:
+    policies: tuple[PolicyVersion, ...]
+    artifacts: tuple[bytes, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.policies) != len(self.artifacts) or not self.policies:
+            raise ValueError("policy lineage policies and artifacts must align")
+        for policy, artifact in zip(self.policies, self.artifacts, strict=True):
+            if _digest(artifact) != policy.artifact_hash:
+                raise ValueError("policy lineage artifact hash mismatch")
+
+    def policy(self, version: int) -> PolicyVersion:
+        try:
+            return next(item for item in self.policies if item.version == version)
+        except StopIteration as exc:
+            raise KeyError(f"policy version {version} is absent") from exc
+
+    def artifact(self, version: int) -> bytes:
+        for policy, artifact in zip(self.policies, self.artifacts, strict=True):
+            if policy.version == version:
+                return artifact
+        raise KeyError(f"policy artifact version {version} is absent")
+
+
+@dataclass(frozen=True)
+class G1TrajectoryAdaptation:
+    trajectory: VersionedTrajectory
+    self_identity_hash: str
+    self_state_hashes: tuple[str, ...]
+    source_trajectory_hash: str
+    schema_version: str = "rosclaw.continual.g1_goalforge_adaptation.v1"
+
+
+def build_g1_policy_lineage(
+    *,
+    body_hash: str,
+    kick_prior_hash: str,
+    motion_hash: str,
+    backend_commit: str,
+    torque_guard_scale: float,
+    through_version: int = 2,
+) -> G1PolicyLineage:
+    """Build deterministic zero-residual parent identities for a qualified body."""
+
+    if through_version < 0:
+        raise ValueError("through_version must be non-negative")
+    controller_hash = canonical_hash(
+        {
+            "kick_prior_hash": kick_prior_hash,
+            "motion_hash": motion_hash,
+            "backend_commit": backend_commit,
+            "adapter": "rosclaw.g1_goalforge.fixed_prior.v1",
+        }
+    )
+    safety_hash = canonical_hash(
+        {
+            "hard_torque_limits": list(G1_HARD_TORQUE_LIMITS),
+            "torque_guard_scale": torque_guard_scale,
+            "immutable": [
+                "body_identity",
+                "hard_torque_limits",
+                "joint_limits",
+                "permit",
+                "lease",
+                "evidence_semantics",
+            ],
+        }
+    )
+    policies: list[PolicyVersion] = []
+    artifacts: list[bytes] = []
+    parent: PolicyVersion | None = None
+    for version in range(through_version + 1):
+        artifact = json.dumps(
+            {
+                "schema_version": "rosclaw.continual.zero_residual_artifact.v1",
+                "version": version,
+                "parent_version_hash": parent.version_hash if parent else None,
+                "observation_names": list(G1_CONTINUAL_OBSERVATIONS),
+                "action_names": list(G1_CONTINUAL_ACTIONS),
+                "action_limits": list(G1_CONTINUAL_ACTION_LIMITS),
+                "semantics": "deterministic zero residual over frozen RoboNaldo prior",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        policy = PolicyVersion(
+            version=version,
+            artifact_hash=_digest(artifact),
+            parent_version_hash=parent.version_hash if parent else None,
+            controller_snapshot_hash=controller_hash,
+            body_hash=body_hash,
+            safety_kernel_hash=safety_hash,
+            observation_names=G1_CONTINUAL_OBSERVATIONS,
+            residual_action_names=G1_CONTINUAL_ACTIONS,
+        )
+        policies.append(policy)
+        artifacts.append(artifact)
+        parent = policy
+    return G1PolicyLineage(tuple(policies), tuple(artifacts))
+
+
+def adapt_goalforge_episode(
+    episode: GoalForgeEpisode,
+    *,
+    policy: PolicyVersion,
+    strict_replay: bool,
+) -> G1TrajectoryAdaptation:
+    """Convert a stepped MuJoCo trajectory into immutable control segments."""
+
+    if not episode.result.physics_executed:
+        raise ValueError("continual adaptation requires an executed physics episode")
+    trace = episode.trajectory
+    required = {
+        "time",
+        "joint_torque",
+        "torso_quaternion",
+        "com_y_relative",
+        "support_foot_slip",
+        "ball_lateral_error_m",
+        "policy_phase",
+        "contact_impulse",
+    }
+    missing = sorted(required - set(trace))
+    if missing:
+        raise ValueError("GoalForge trajectory lacks continual signals: " + ", ".join(missing))
+    lengths = {len(np.asarray(trace[name])) for name in required}
+    if len(lengths) != 1 or next(iter(lengths)) < 2:
+        raise ValueError("GoalForge continual signals must be aligned with at least two samples")
+    sample_count = next(iter(lengths))
+    source_hash = _trajectory_hash(trace)
+    identity = _self_identity(policy)
+    phases = _monotonic_phases(trace, sample_count)
+    segments: list[ControlSegment] = []
+    snapshots: list[str] = []
+    for index in range(sample_count - 1):
+        observation = _observation(trace, index)
+        next_observation = _observation(trace, index + 1)
+        action = _action(trace, index)
+        snapshot = _self_snapshot(
+            episode=episode,
+            identity=identity,
+            policy=policy,
+            sequence=index,
+            observation=observation,
+            timestamp_sec=float(np.asarray(trace["time"])[index]),
+        )
+        snapshot_hash = snapshot.snapshot_hash
+        snapshots.append(snapshot_hash)
+        terminal = index == sample_count - 2
+        segments.append(
+            ControlSegment(
+                segment_id=f"{episode.scenario.scenario_id}:{index:05d}",
+                episode_id=episode.scenario.scenario_id,
+                task_id=GOALFORGE_TASK_ID,
+                phase=SkillPhase.COMPLETE if terminal else phases[index],
+                start_step=index,
+                end_step=index + 1,
+                policy=policy,
+                controller_snapshot_hash=policy.controller_snapshot_hash,
+                body_hash=policy.body_hash,
+                regime_hash=episode.scenario.scenario_commitment,
+                self_state_hash=snapshot_hash,
+                observation=observation,
+                residual_action=action,
+                next_observation=next_observation,
+                behavior_logprob=0.0,
+                reward=_reward(episode, trace, index, terminal, observation, action),
+                cost=_cost(episode, trace, index, terminal, observation),
+                terminal=terminal,
+            )
+        )
+    trajectory = VersionedTrajectory(segments=tuple(segments), strict_replay=strict_replay)
+    return G1TrajectoryAdaptation(
+        trajectory=trajectory,
+        self_identity_hash=identity.identity_hash,
+        self_state_hashes=tuple(snapshots),
+        source_trajectory_hash=source_hash,
+    )
+
+
+def _self_identity(policy: PolicyVersion) -> SelfIdentity:
+    return SelfIdentity(
+        body_hash=policy.body_hash,
+        sensor_layout_hash=canonical_hash({"signals": list(G1_CONTINUAL_OBSERVATIONS)}),
+        actuator_layout_hash=canonical_hash({"residuals": list(G1_CONTINUAL_ACTIONS)}),
+        safety_kernel_hash=policy.safety_kernel_hash,
+        controller_lineage=(policy.controller_snapshot_hash, policy.version_hash),
+        current_policy_versions={GOALFORGE_TASK_ID: policy.version},
+    )
+
+
+def _self_snapshot(
+    *,
+    episode: GoalForgeEpisode,
+    identity: SelfIdentity,
+    policy: PolicyVersion,
+    sequence: int,
+    observation: dict[str, float],
+    timestamp_sec: float,
+) -> SelfStateSnapshot:
+    joint_health = dict.fromkeys(G1_DDS_JOINT_NAMES, 1.0)
+    motor = {name: ScalarBelief(1.0, 0.05, 0.80, "scale") for name in G1_DDS_JOINT_NAMES}
+    zero = {
+        name: ScalarBelief(
+            episode.scenario.joint_zero_bias_rad,
+            0.005,
+            0.95,
+            "rad",
+        )
+        for name in G1_DDS_JOINT_NAMES
+    }
+    return SelfStateSnapshot(
+        identity_hash=identity.identity_hash,
+        body_hash=policy.body_hash,
+        sequence=sequence,
+        timestamp_ns=max(0, int(round(timestamp_sec * 1_000_000_000.0))),
+        joint_health=joint_health,
+        motor_gain_beliefs=motor,
+        joint_zero_bias_beliefs=zero,
+        latency_belief=ScalarBelief(
+            episode.scenario.control_latency_ms,
+            1.0,
+            0.95,
+            "ms",
+        ),
+        friction_belief=ScalarBelief(
+            episode.scenario.support_ground_friction,
+            0.05,
+            0.90,
+            "coefficient",
+        ),
+        payload_belief=ScalarBelief(0.0, 1.0, 0.0, "kg"),
+        balance_margin=0.11 - abs(observation["com_y_relative"]),
+        energy_state=observation["energy_margin"],
+        sensor_quality={"mujoco_state": observation["sensor_quality"]},
+        capabilities={
+            GOALFORGE_TASK_ID: CapabilityBelief(
+                success_probability=0.5,
+                uncertainty=1.0,
+                evidence_count=0,
+                policy_version=policy.version,
+            )
+        },
+    )
+
+
+def _observation(trace: dict[str, np.ndarray], index: int) -> dict[str, float]:
+    quaternion = np.asarray(trace["torso_quaternion"][index], dtype=np.float64)
+    roll, pitch = _roll_pitch(quaternion)
+    torque = np.asarray(trace["joint_torque"][index], dtype=np.float64)
+    limits = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float64)
+    ratio = float(np.max(np.abs(torque) / limits))
+    finite = all(
+        np.all(np.isfinite(value))
+        for value in (
+            quaternion,
+            torque,
+            trace["com_y_relative"][index],
+            trace["support_foot_slip"][index],
+            trace["ball_lateral_error_m"][index],
+            trace["policy_phase"][index],
+        )
+    )
+    return {
+        "torso_roll": roll,
+        "torso_pitch": pitch,
+        "com_y_relative": float(trace["com_y_relative"][index]),
+        "support_slip_m": max(0.0, float(trace["support_foot_slip"][index])),
+        "ball_lateral_error_m": float(trace["ball_lateral_error_m"][index]),
+        "contact_phase": float(np.clip(trace["policy_phase"][index], 0.0, 1.0)),
+        "energy_margin": float(np.clip(1.0 - ratio, 0.0, 1.0)),
+        "sensor_quality": 1.0 if finite else 0.0,
+    }
+
+
+def _action(trace: dict[str, np.ndarray], index: int) -> dict[str, float]:
+    residual = trace.get("combined_residual", trace.get("feedback_residual"))
+    if residual is None:
+        joint_values = np.zeros(3, dtype=np.float64)
+    else:
+        joint_values = np.asarray(residual[index], dtype=np.float64)[list(_ACTION_JOINT_INDICES)]
+    phase_rate = (
+        float(trace["feedback_phase_rate"][index]) if "feedback_phase_rate" in trace else 0.0
+    )
+    raw = (*map(float, joint_values), phase_rate)
+    return {
+        name: float(np.clip(value, -limit, limit))
+        for name, value, limit in zip(
+            G1_CONTINUAL_ACTIONS,
+            raw,
+            G1_CONTINUAL_ACTION_LIMITS,
+            strict=True,
+        )
+    }
+
+
+def _monotonic_phases(trace: dict[str, np.ndarray], count: int) -> tuple[SkillPhase, ...]:
+    phases: list[SkillPhase] = []
+    contact = np.asarray(trace["contact_impulse"], dtype=np.float64)
+    for index in range(count):
+        phase = float(np.clip(trace["policy_phase"][index], 0.0, 1.0))
+        if phase < 0.05:
+            value = SkillPhase.STAND
+        elif phase < 0.25:
+            value = SkillPhase.PREPARE
+        elif phase < 0.38:
+            value = SkillPhase.WEIGHT_TRANSFER
+        elif contact[index] <= 0.0 and phase < 0.58:
+            value = SkillPhase.SWING
+        elif contact[index] > 0.0 and phase < 0.62:
+            value = SkillPhase.CONTACT
+        elif phase < 0.95:
+            value = SkillPhase.RECOVERY
+        else:
+            value = SkillPhase.COMPLETE
+        if phases and list(SkillPhase).index(value) < list(SkillPhase).index(phases[-1]):
+            value = phases[-1]
+        phases.append(value)
+    return tuple(phases)
+
+
+def _reward(
+    episode: GoalForgeEpisode,
+    trace: dict[str, np.ndarray],
+    index: int,
+    terminal: bool,
+    observation: dict[str, float],
+    action: dict[str, float],
+) -> RewardVector:
+    impulse = np.asarray(trace["contact_impulse"], dtype=np.float64)
+    new_contact = impulse[index + 1] > impulse[index] + 1e-12
+    attitude = math.hypot(observation["torso_roll"], observation["torso_pitch"])
+    balance = float(np.clip((0.11 - abs(observation["com_y_relative"])) / 0.11, -1.0, 1.0))
+    style = -sum(
+        (action[name] / limit) ** 2
+        for name, limit in zip(G1_CONTINUAL_ACTIONS, G1_CONTINUAL_ACTION_LIMITS, strict=True)
+    ) / len(G1_CONTINUAL_ACTIONS)
+    return RewardVector(
+        task=1.0 if terminal and episode.result.success else 0.0,
+        tracking=-attitude,
+        balance=balance,
+        contact=1.0 if new_contact else 0.0,
+        learning=0.0,
+        style=style,
+    )
+
+
+def _cost(
+    episode: GoalForgeEpisode,
+    trace: dict[str, np.ndarray],
+    index: int,
+    terminal: bool,
+    observation: dict[str, float],
+) -> CostVector:
+    saturation = 0.0
+    if "combined_residual_saturation" in trace:
+        values = np.asarray(trace["combined_residual_saturation"], dtype=np.float64)
+        saturation = max(0.0, float(values[index + 1] - values[index]))
+    result = episode.result
+    return CostVector(
+        fall=1.0 if terminal and result.post_kick_fall else 0.0,
+        joint_limit=1.0 if terminal and result.joint_limit_violation else 0.0,
+        torque=(
+            1.0
+            if terminal and (result.torque_limit_violation or result.actuator_saturation)
+            else 0.0
+        ),
+        slip=observation["support_slip_m"],
+        energy=1.0 - observation["energy_margin"],
+        stale=0.0,
+        collision=(
+            1.0 if terminal and result.status is GoalForgeStatus.WRONG_FOOT_CONTACT else 0.0
+        ),
+        feedback_saturation=saturation,
+    )
+
+
+def _roll_pitch(quaternion_wxyz: np.ndarray) -> tuple[float, float]:
+    w, x, y, z = map(float, quaternion_wxyz)
+    roll = math.atan2(2.0 * (w * x + y * z), 1.0 - 2.0 * (x * x + y * y))
+    pitch = math.asin(max(-1.0, min(1.0, 2.0 * (w * y - z * x))))
+    return roll, pitch
+
+
+def _trajectory_hash(trajectory: dict[str, np.ndarray]) -> str:
+    digest = hashlib.sha256()
+    for name in sorted(trajectory):
+        value = np.ascontiguousarray(trajectory[name])
+        digest.update(name.encode("utf-8"))
+        digest.update(str(value.dtype).encode("utf-8"))
+        digest.update(str(value.shape).encode("utf-8"))
+        digest.update(value.tobytes())
+    return "sha256:" + digest.hexdigest()
+
+
+def _digest(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+__all__ = [
+    "G1_CONTINUAL_ACTIONS",
+    "G1_CONTINUAL_ACTION_LIMITS",
+    "G1_CONTINUAL_OBSERVATIONS",
+    "G1PolicyLineage",
+    "G1TrajectoryAdaptation",
+    "adapt_goalforge_episode",
+    "build_g1_policy_lineage",
+]

--- a/src/rosclaw/continual/learner.py
+++ b/src/rosclaw/continual/learner.py
@@ -1,0 +1,507 @@
+"""Optional PyTorch Constrained Residual SAC learner.
+
+The learner consumes immutable versioned experience and emits a candidate
+artifact.  It never mutates the Feedback Plane, active policy slot, Registry,
+or hardware transport.  Import this module only in an environment installed
+with ``rosclaw[rl]``.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import struct
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import numpy as np
+import torch  # type: ignore[import-not-found]
+from torch import nn  # type: ignore[import-not-found]
+
+from rosclaw.continual.contracts import ExperiencePartition, PolicyVersion
+from rosclaw.continual.experience import ExperienceBatch, ExperienceRecord
+
+
+@dataclass(frozen=True)
+class ResidualSACConfig:
+    observation_names: tuple[str, ...]
+    action_names: tuple[str, ...]
+    action_limits: tuple[float, ...]
+    hidden_dims: tuple[int, int] = (128, 128)
+    gamma: float = 0.99
+    tau: float = 0.005
+    actor_lr: float = 3e-4
+    critic_lr: float = 3e-4
+    alpha_lr: float = 3e-4
+    batch_size: int = 256
+    anchor_weight: float = 1.0
+    churn_weight: float = 0.25
+    fall_cost_limit: float = 0.0
+    constraint_cost_limit: float = 0.0
+    lagrange_lr: float = 1e-3
+    max_lagrange: float = 100.0
+    log_std_min: float = -5.0
+    log_std_max: float = 1.0
+    reward_weights: tuple[float, ...] = (1.0, 0.2, 0.3, 0.2, 0.1, 0.1)
+    device: str = "cpu"
+    seed: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.observation_names or len(set(self.observation_names)) != len(
+            self.observation_names
+        ):
+            raise ValueError("SAC observation names must be non-empty and unique")
+        if not self.action_names or len(set(self.action_names)) != len(self.action_names):
+            raise ValueError("SAC action names must be non-empty and unique")
+        if len(self.action_limits) != len(self.action_names) or any(
+            not math.isfinite(value) or value <= 0.0 for value in self.action_limits
+        ):
+            raise ValueError("SAC action limits must match action names and be positive")
+        if len(self.hidden_dims) != 2 or any(value <= 0 for value in self.hidden_dims):
+            raise ValueError("SAC reference actor requires two positive hidden dimensions")
+        if not 0.0 < self.gamma <= 1.0 or not 0.0 < self.tau <= 1.0:
+            raise ValueError("SAC gamma and tau must be in (0, 1]")
+        if min(self.actor_lr, self.critic_lr, self.alpha_lr, self.lagrange_lr) <= 0.0:
+            raise ValueError("SAC learning rates must be positive")
+        if self.batch_size <= 0:
+            raise ValueError("SAC batch size must be positive")
+        if (
+            min(
+                self.anchor_weight,
+                self.churn_weight,
+                self.fall_cost_limit,
+                self.constraint_cost_limit,
+                self.max_lagrange,
+            )
+            < 0.0
+        ):
+            raise ValueError("SAC regularization and cost limits must be non-negative")
+        if self.log_std_min >= self.log_std_max:
+            raise ValueError("SAC log standard-deviation bounds are invalid")
+        if len(self.reward_weights) != 6 or any(
+            not math.isfinite(value) for value in self.reward_weights
+        ):
+            raise ValueError("SAC reward weights must contain six finite values")
+
+
+@dataclass(frozen=True)
+class ResidualSACUpdate:
+    update_index: int
+    critic_loss: float
+    fall_critic_loss: float
+    constraint_critic_loss: float
+    actor_loss: float
+    alpha: float
+    fall_lagrange: float
+    constraint_lagrange: float
+    anchor_loss: float
+    churn_loss: float
+    step_churn: float
+    actor_transition_count: int
+    critic_transition_count: int
+    stale_actor_transition_count: int
+    finite: bool
+    schema_version: str = "rosclaw.continual.residual_sac_update.v1"
+
+
+class _MLP(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, hidden: tuple[int, int]) -> None:
+        super().__init__()
+        self.hidden0 = nn.Linear(input_dim, hidden[0])
+        self.hidden1 = nn.Linear(hidden[0], hidden[1])
+        self.output = nn.Linear(hidden[1], output_dim)
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        value = torch.relu(self.hidden0(value))
+        value = torch.relu(self.hidden1(value))
+        return self.output(value)
+
+    def activations(self, value: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        first = torch.relu(self.hidden0(value))
+        second = torch.relu(self.hidden1(first))
+        return first, second
+
+
+class _GaussianActor(nn.Module):
+    def __init__(self, config: ResidualSACConfig) -> None:
+        super().__init__()
+        observation_dim = len(config.observation_names)
+        action_dim = len(config.action_names)
+        self.backbone = _MLP(observation_dim, 2 * action_dim, config.hidden_dims)
+        self.register_buffer(
+            "action_limits",
+            torch.as_tensor(config.action_limits, dtype=torch.float32),
+        )
+        self.log_std_min = config.log_std_min
+        self.log_std_max = config.log_std_max
+
+    def sample(self, observation: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mean, log_std = self.backbone(observation).chunk(2, dim=-1)
+        log_std = torch.clamp(log_std, self.log_std_min, self.log_std_max)
+        distribution = torch.distributions.Normal(mean, log_std.exp())
+        latent = distribution.rsample()
+        unit_action = torch.tanh(latent)
+        action = unit_action * self.action_limits
+        jacobian = self.action_limits * (1.0 - unit_action.square())
+        log_probability = (distribution.log_prob(latent) - torch.log(jacobian.clamp_min(1e-6))).sum(
+            dim=-1, keepdim=True
+        )
+        return action, log_probability
+
+    def deterministic(self, observation: torch.Tensor) -> torch.Tensor:
+        mean, _ = self.backbone(observation).chunk(2, dim=-1)
+        return torch.tanh(mean) * self.action_limits
+
+
+class _TwinCritic(nn.Module):
+    def __init__(self, config: ResidualSACConfig) -> None:
+        super().__init__()
+        input_dim = len(config.observation_names) + len(config.action_names)
+        self.q1 = _MLP(input_dim, 1, config.hidden_dims)
+        self.q2 = _MLP(input_dim, 1, config.hidden_dims)
+
+    def forward(
+        self,
+        observation: torch.Tensor,
+        action: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        value = torch.cat((observation, action), dim=-1)
+        return self.q1(value), self.q2(value)
+
+
+class ConstrainedResidualSAC:
+    """Low-dimensional off-policy learner with two independent cost critics."""
+
+    def __init__(self, config: ResidualSACConfig) -> None:
+        self.config = config
+        torch.manual_seed(config.seed)
+        if config.device.startswith("cuda") and not torch.cuda.is_available():
+            raise RuntimeError("CUDA residual SAC requested but torch reports no CUDA device")
+        self.device = torch.device(config.device)
+        self.actor = _GaussianActor(config).to(self.device)
+        # This frozen reference represents the parent policy for out-of-batch
+        # output stability.  Comparing the actor with itself immediately
+        # before an optimizer step would produce a zero-gradient penalty.
+        self.churn_reference = copy.deepcopy(self.actor).eval()
+        for parameter in self.churn_reference.parameters():
+            parameter.requires_grad_(False)
+        self.reward_critic = _TwinCritic(config).to(self.device)
+        self.fall_critic = _TwinCritic(config).to(self.device)
+        self.constraint_critic = _TwinCritic(config).to(self.device)
+        self.reward_target = copy.deepcopy(self.reward_critic).eval()
+        self.fall_target = copy.deepcopy(self.fall_critic).eval()
+        self.constraint_target = copy.deepcopy(self.constraint_critic).eval()
+        self.actor_optimizer = torch.optim.Adam(self.actor.parameters(), lr=config.actor_lr)
+        critic_parameters = (
+            list(self.reward_critic.parameters())
+            + list(self.fall_critic.parameters())
+            + list(self.constraint_critic.parameters())
+        )
+        self.critic_optimizer = torch.optim.Adam(critic_parameters, lr=config.critic_lr)
+        self.log_alpha = torch.zeros((), device=self.device, requires_grad=True)
+        self.alpha_optimizer = torch.optim.Adam((self.log_alpha,), lr=config.alpha_lr)
+        self.target_entropy = -float(len(config.action_names))
+        self.fall_lagrange = 0.0
+        self.constraint_lagrange = 0.0
+        self.update_index = 0
+
+    def update(self, batch: ExperienceBatch) -> ResidualSACUpdate:
+        critic_rows = _rows(batch.records, self.config)
+        actor_rows = _rows(batch.actor_records, self.config)
+        if len(critic_rows[0]) < self.config.batch_size:
+            raise ValueError("critic replay batch has fewer transitions than SAC batch_size")
+        if len(actor_rows[0]) < self.config.batch_size:
+            raise ValueError("fresh actor replay batch has fewer transitions than SAC batch_size")
+        critic_tensors = self._sample_rows(critic_rows, self.config.batch_size, self.update_index)
+        actor_tensors = self._sample_rows(actor_rows, self.config.batch_size, self.update_index + 1)
+        (
+            observations,
+            actions,
+            next_observations,
+            rewards,
+            fall_costs,
+            constraint_costs,
+            terminals,
+        ) = critic_tensors
+        alpha = self.log_alpha.exp().detach()
+        with torch.no_grad():
+            next_actions, next_log_probability = self.actor.sample(next_observations)
+            reward_target = rewards + self.config.gamma * (1.0 - terminals) * (
+                torch.minimum(*self.reward_target(next_observations, next_actions))
+                - alpha * next_log_probability
+            )
+            fall_target = fall_costs + self.config.gamma * (1.0 - terminals) * torch.maximum(
+                *self.fall_target(next_observations, next_actions)
+            )
+            constraint_target = constraint_costs + self.config.gamma * (
+                1.0 - terminals
+            ) * torch.maximum(*self.constraint_target(next_observations, next_actions))
+        reward_q = self.reward_critic(observations, actions)
+        fall_q = self.fall_critic(observations, actions)
+        constraint_q = self.constraint_critic(observations, actions)
+        reward_loss = sum(torch.nn.functional.mse_loss(value, reward_target) for value in reward_q)
+        fall_loss = sum(torch.nn.functional.mse_loss(value, fall_target) for value in fall_q)
+        constraint_loss = sum(
+            torch.nn.functional.mse_loss(value, constraint_target) for value in constraint_q
+        )
+        self.critic_optimizer.zero_grad(set_to_none=True)
+        (reward_loss + fall_loss + constraint_loss).backward()
+        torch.nn.utils.clip_grad_norm_(
+            list(self.reward_critic.parameters())
+            + list(self.fall_critic.parameters())
+            + list(self.constraint_critic.parameters()),
+            max_norm=10.0,
+        )
+        self.critic_optimizer.step()
+
+        actor_observations = actor_tensors[0]
+        reference_observations, reference_actions = self._reference_rows(batch)
+        with torch.no_grad():
+            pre_update_reference = self.actor.deterministic(reference_observations)
+            parent_reference = self.churn_reference.deterministic(reference_observations)
+        sampled_actions, log_probability = self.actor.sample(actor_observations)
+        reward_actor_q = torch.minimum(*self.reward_critic(actor_observations, sampled_actions))
+        fall_actor_q = torch.maximum(*self.fall_critic(actor_observations, sampled_actions))
+        constraint_actor_q = torch.maximum(
+            *self.constraint_critic(actor_observations, sampled_actions)
+        )
+        anchor_prediction = self.actor.deterministic(reference_observations)
+        anchor_loss = torch.nn.functional.mse_loss(anchor_prediction, reference_actions)
+        churn_loss = torch.nn.functional.mse_loss(anchor_prediction, parent_reference)
+        actor_loss = (
+            (
+                self.log_alpha.exp().detach() * log_probability
+                - reward_actor_q
+                + self.fall_lagrange * fall_actor_q
+                + self.constraint_lagrange * constraint_actor_q
+            ).mean()
+            + self.config.anchor_weight * anchor_loss
+            + self.config.churn_weight * churn_loss
+        )
+        self.actor_optimizer.zero_grad(set_to_none=True)
+        actor_loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.actor.parameters(), max_norm=10.0)
+        self.actor_optimizer.step()
+
+        alpha_loss = -(self.log_alpha * (log_probability.detach() + self.target_entropy)).mean()
+        self.alpha_optimizer.zero_grad(set_to_none=True)
+        alpha_loss.backward()
+        self.alpha_optimizer.step()
+        self.fall_lagrange = _lagrange_update(
+            self.fall_lagrange,
+            float(fall_costs.mean().item()) - self.config.fall_cost_limit,
+            self.config,
+        )
+        self.constraint_lagrange = _lagrange_update(
+            self.constraint_lagrange,
+            float(constraint_costs.mean().item()) - self.config.constraint_cost_limit,
+            self.config,
+        )
+        _soft_update(self.reward_target, self.reward_critic, self.config.tau)
+        _soft_update(self.fall_target, self.fall_critic, self.config.tau)
+        _soft_update(self.constraint_target, self.constraint_critic, self.config.tau)
+        with torch.no_grad():
+            post_update_reference = self.actor.deterministic(reference_observations)
+            measured_churn = torch.nn.functional.mse_loss(
+                post_update_reference, pre_update_reference
+            )
+            cumulative_churn = torch.nn.functional.mse_loss(post_update_reference, parent_reference)
+        values = (
+            reward_loss,
+            fall_loss,
+            constraint_loss,
+            actor_loss,
+            self.log_alpha.exp(),
+            anchor_loss,
+            measured_churn,
+        )
+        finite = all(bool(torch.isfinite(value).all().item()) for value in values)
+        update = ResidualSACUpdate(
+            update_index=self.update_index,
+            critic_loss=float(reward_loss.detach().item()),
+            fall_critic_loss=float(fall_loss.detach().item()),
+            constraint_critic_loss=float(constraint_loss.detach().item()),
+            actor_loss=float(actor_loss.detach().item()),
+            alpha=float(self.log_alpha.exp().detach().item()),
+            fall_lagrange=self.fall_lagrange,
+            constraint_lagrange=self.constraint_lagrange,
+            anchor_loss=float(anchor_loss.detach().item()),
+            churn_loss=float(cumulative_churn.detach().item()),
+            step_churn=float(measured_churn.detach().item()),
+            actor_transition_count=len(actor_rows[0]),
+            critic_transition_count=len(critic_rows[0]),
+            stale_actor_transition_count=len(critic_rows[0]) - len(actor_rows[0]),
+            finite=finite,
+        )
+        self.update_index += 1
+        return update
+
+    def action(self, observation: Mapping[str, float]) -> Mapping[str, float]:
+        if tuple(observation) != self.config.observation_names:
+            raise ValueError("inference observation order does not match SAC config")
+        tensor = torch.as_tensor(
+            [[observation[name] for name in self.config.observation_names]],
+            dtype=torch.float32,
+            device=self.device,
+        )
+        with torch.no_grad():
+            value = self.actor.deterministic(tensor)[0].cpu().numpy()
+        return dict(zip(self.config.action_names, map(float, value), strict=True))
+
+    def hidden_activations(self, observations: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        value = np.asarray(observations, dtype=np.float32)
+        if value.ndim != 2 or value.shape[1] != len(self.config.observation_names):
+            raise ValueError("activation observations have the wrong shape")
+        tensor = torch.as_tensor(value, device=self.device)
+        with torch.no_grad():
+            first, second = self.actor.backbone.activations(tensor)
+        return first.cpu().numpy(), second.cpu().numpy()
+
+    def artifact_bytes(self) -> bytes:
+        """Return a deterministic tensor serialization for content addressing."""
+
+        metadata = {
+            "schema_version": "rosclaw.continual.residual_sac_artifact.v1",
+            "observation_names": list(self.config.observation_names),
+            "action_names": list(self.config.action_names),
+            "action_limits": list(self.config.action_limits),
+            "hidden_dims": list(self.config.hidden_dims),
+            "update_index": self.update_index,
+        }
+        chunks = [json.dumps(metadata, sort_keys=True, separators=(",", ":")).encode()]
+        for name, tensor in sorted(self.actor.state_dict().items()):
+            array = tensor.detach().cpu().numpy()
+            name_bytes = name.encode()
+            dtype_bytes = str(array.dtype).encode()
+            chunks.extend(
+                (
+                    struct.pack("!I", len(name_bytes)),
+                    name_bytes,
+                    struct.pack("!I", len(dtype_bytes)),
+                    dtype_bytes,
+                    struct.pack("!I", array.ndim),
+                    struct.pack("!" + "Q" * array.ndim, *array.shape),
+                    np.ascontiguousarray(array).tobytes(),
+                )
+            )
+        return b"".join(chunks)
+
+    def candidate_policy(self, *, parent: PolicyVersion) -> tuple[PolicyVersion, bytes]:
+        if parent.observation_names != self.config.observation_names:
+            raise ValueError("parent observation contract does not match the SAC learner")
+        if parent.residual_action_names != self.config.action_names:
+            raise ValueError("parent action contract does not match the SAC learner")
+        artifact = self.artifact_bytes()
+        candidate = PolicyVersion(
+            version=parent.version + 1,
+            artifact_hash="sha256:" + hashlib.sha256(artifact).hexdigest(),
+            parent_version_hash=parent.version_hash,
+            controller_snapshot_hash=parent.controller_snapshot_hash,
+            body_hash=parent.body_hash,
+            safety_kernel_hash=parent.safety_kernel_hash,
+            observation_names=parent.observation_names,
+            residual_action_names=parent.residual_action_names,
+        )
+        return candidate, artifact
+
+    def _sample_rows(
+        self,
+        rows: tuple[np.ndarray, ...],
+        count: int,
+        seed_offset: int,
+    ) -> tuple[torch.Tensor, ...]:
+        rng = np.random.default_rng(self.config.seed + seed_offset)
+        indices = rng.choice(len(rows[0]), size=count, replace=len(rows[0]) < count)
+        return tuple(
+            torch.as_tensor(value[indices], dtype=torch.float32, device=self.device)
+            for value in rows
+        )
+
+    def _reference_rows(self, batch: ExperienceBatch) -> tuple[torch.Tensor, torch.Tensor]:
+        reference = tuple(
+            record
+            for record in batch.records
+            if record.partition in {ExperiencePartition.ANCHOR, ExperiencePartition.SELF}
+        )
+        if not reference:
+            raise ValueError("SAC update requires Anchor or Self reference transitions")
+        rows = _rows(reference, self.config)
+        observations = torch.as_tensor(rows[0], dtype=torch.float32, device=self.device)
+        actions = torch.as_tensor(rows[1], dtype=torch.float32, device=self.device)
+        return observations, actions
+
+
+def _rows(
+    records: tuple[ExperienceRecord, ...],
+    config: ResidualSACConfig,
+) -> tuple[np.ndarray, ...]:
+    observations: list[list[float]] = []
+    actions: list[list[float]] = []
+    next_observations: list[list[float]] = []
+    rewards: list[list[float]] = []
+    fall_costs: list[list[float]] = []
+    constraint_costs: list[list[float]] = []
+    terminals: list[list[float]] = []
+    for record in records:
+        for segment in record.trajectory.segments:
+            if segment.policy.observation_names != config.observation_names:
+                raise ValueError("experience observation contract does not match SAC config")
+            if segment.policy.residual_action_names != config.action_names:
+                raise ValueError("experience action contract does not match SAC config")
+            observations.append([segment.observation[name] for name in config.observation_names])
+            actions.append([segment.residual_action[name] for name in config.action_names])
+            next_observations.append(
+                [segment.next_observation[name] for name in config.observation_names]
+            )
+            reward_vector = tuple(segment.reward.to_dict().values())
+            rewards.append(
+                [
+                    sum(
+                        weight * value
+                        for weight, value in zip(config.reward_weights, reward_vector, strict=True)
+                    )
+                ]
+            )
+            fall_costs.append([segment.cost.fall])
+            constraint_costs.append(
+                [
+                    segment.cost.joint_limit
+                    + segment.cost.torque
+                    + segment.cost.slip
+                    + segment.cost.stale
+                    + segment.cost.collision
+                    + segment.cost.feedback_saturation
+                ]
+            )
+            terminals.append([float(segment.terminal)])
+    if not observations:
+        raise ValueError("SAC experience rows must not be empty")
+    return tuple(
+        np.asarray(value, dtype=np.float32)
+        for value in (
+            observations,
+            actions,
+            next_observations,
+            rewards,
+            fall_costs,
+            constraint_costs,
+            terminals,
+        )
+    )
+
+
+def _lagrange_update(value: float, violation: float, config: ResidualSACConfig) -> float:
+    return min(config.max_lagrange, max(0.0, value + config.lagrange_lr * violation))
+
+
+def _soft_update(target: nn.Module, source: nn.Module, tau: float) -> None:
+    with torch.no_grad():
+        for target_value, source_value in zip(
+            target.parameters(), source.parameters(), strict=True
+        ):
+            target_value.mul_(1.0 - tau).add_(source_value, alpha=tau)
+
+
+__all__ = ["ConstrainedResidualSAC", "ResidualSACConfig", "ResidualSACUpdate"]

--- a/src/rosclaw/continual/serde.py
+++ b/src/rosclaw/continual/serde.py
@@ -1,0 +1,210 @@
+"""Lossless, hash-checked serialization for versioned continual experience."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from rosclaw.continual.contracts import (
+    ControlSegment,
+    CostVector,
+    ExperiencePartition,
+    ExperienceUse,
+    PolicyVersion,
+    RewardVector,
+    SkillPhase,
+    VersionedTrajectory,
+)
+from rosclaw.continual.experience import ExperienceBatch, ExperienceRecord
+
+_ENVELOPE_SCHEMA = "rosclaw.continual.experience_batch_envelope.v1"
+
+
+def experience_batch_to_dict(batch: ExperienceBatch) -> dict[str, Any]:
+    """Return a complete transport envelope, not the abbreviated audit view."""
+
+    trajectories = {
+        record.trajectory.trajectory_hash: record.trajectory.to_dict() for record in batch.records
+    }
+    return {
+        "schema_version": _ENVELOPE_SCHEMA,
+        "batch_schema_version": batch.schema_version,
+        "learner_version": batch.learner_version,
+        "requested_counts": {
+            partition.value: count
+            for partition, count in sorted(
+                batch.requested_counts.items(), key=lambda item: item[0].value
+            )
+        },
+        "permitted_uses": [item.value for item in batch.permitted_uses],
+        "trajectories": dict(sorted(trajectories.items())),
+        "records": [
+            {
+                "schema_version": record.schema_version,
+                "partition": record.partition.value,
+                "anchor_policy_hash": record.anchor_policy_hash,
+                "boundary_reason": record.boundary_reason,
+                "self_change_hash": record.self_change_hash,
+                "near_boundary_score": record.near_boundary_score,
+                "trajectory_hash": record.trajectory.trajectory_hash,
+                "record_hash": record.record_hash,
+            }
+            for record in batch.records
+        ],
+        "batch_hash": batch.batch_hash,
+    }
+
+
+def experience_batch_from_dict(value: Mapping[str, Any]) -> ExperienceBatch:
+    """Rebuild immutable contracts and reject any identity or payload tampering."""
+
+    _schema(value, "schema_version", _ENVELOPE_SCHEMA)
+    records_raw = _list(value, "records")
+    uses_raw = _list(value, "permitted_uses")
+    counts_raw = _mapping(value, "requested_counts")
+    trajectories_raw = _mapping(value, "trajectories")
+    trajectories = {
+        str(expected_hash): _trajectory(_as_mapping(raw, "trajectory"))
+        for expected_hash, raw in trajectories_raw.items()
+    }
+    if any(
+        expected_hash != trajectory.trajectory_hash
+        for expected_hash, trajectory in trajectories.items()
+    ):
+        raise ValueError("versioned trajectory hash mismatch")
+    records: list[ExperienceRecord] = []
+    for raw in records_raw:
+        item = _as_mapping(raw, "record")
+        _schema(item, "schema_version", "rosclaw.continual.experience_record.v1")
+        trajectory_hash = str(item["trajectory_hash"])
+        if trajectory_hash not in trajectories:
+            raise ValueError("experience record references an absent trajectory")
+        record = ExperienceRecord(
+            trajectory=trajectories[trajectory_hash],
+            partition=ExperiencePartition(str(item["partition"])),
+            anchor_policy_hash=_optional_string(item.get("anchor_policy_hash")),
+            boundary_reason=_optional_string(item.get("boundary_reason")),
+            self_change_hash=_optional_string(item.get("self_change_hash")),
+            near_boundary_score=float(item["near_boundary_score"]),
+        )
+        if item.get("record_hash") != record.record_hash:
+            raise ValueError("experience record hash mismatch")
+        records.append(record)
+    batch = ExperienceBatch(
+        records=tuple(records),
+        permitted_uses=tuple(ExperienceUse(str(item)) for item in uses_raw),
+        requested_counts={
+            ExperiencePartition(str(partition)): int(count)
+            for partition, count in counts_raw.items()
+        },
+        learner_version=int(value["learner_version"]),
+    )
+    if value.get("batch_schema_version") != batch.schema_version:
+        raise ValueError("experience batch schema mismatch")
+    if value.get("batch_hash") != batch.batch_hash:
+        raise ValueError("experience batch hash mismatch")
+    return batch
+
+
+def _trajectory(value: Mapping[str, Any]) -> VersionedTrajectory:
+    _schema(value, "schema_version", "rosclaw.continual.versioned_trajectory.v1")
+    return VersionedTrajectory(
+        segments=tuple(_segment(_as_mapping(item, "segment")) for item in _list(value, "segments")),
+        strict_replay=bool(value["strict_replay"]),
+    )
+
+
+def _segment(value: Mapping[str, Any]) -> ControlSegment:
+    _schema(value, "schema_version", "rosclaw.continual.control_segment.v1")
+    policy = _policy(_mapping(value, "policy"))
+    if value.get("policy_version_hash") != policy.version_hash:
+        raise ValueError("control segment policy hash mismatch")
+    return ControlSegment(
+        segment_id=str(value["segment_id"]),
+        episode_id=str(value["episode_id"]),
+        task_id=str(value["task_id"]),
+        phase=SkillPhase(str(value["phase"])),
+        start_step=int(value["start_step"]),
+        end_step=int(value["end_step"]),
+        policy=policy,
+        controller_snapshot_hash=str(value["controller_snapshot_hash"]),
+        body_hash=str(value["body_hash"]),
+        regime_hash=str(value["regime_hash"]),
+        self_state_hash=str(value["self_state_hash"]),
+        observation=_ordered_numeric(
+            _mapping(value, "observation"),
+            policy.observation_names,
+            "observation",
+        ),
+        residual_action=_ordered_numeric(
+            _mapping(value, "residual_action"),
+            policy.residual_action_names,
+            "residual_action",
+        ),
+        next_observation=_ordered_numeric(
+            _mapping(value, "next_observation"),
+            policy.observation_names,
+            "next_observation",
+        ),
+        behavior_logprob=float(value["behavior_logprob"]),
+        reward=RewardVector(**_numeric_kwargs(_mapping(value, "reward"))),
+        cost=CostVector(**_numeric_kwargs(_mapping(value, "cost"))),
+        terminal=bool(value["terminal"]),
+    )
+
+
+def _policy(value: Mapping[str, Any]) -> PolicyVersion:
+    _schema(value, "schema_version", "rosclaw.continual.policy_version.v1")
+    return PolicyVersion(
+        version=int(value["version"]),
+        artifact_hash=str(value["artifact_hash"]),
+        parent_version_hash=_optional_string(value.get("parent_version_hash")),
+        controller_snapshot_hash=str(value["controller_snapshot_hash"]),
+        body_hash=str(value["body_hash"]),
+        safety_kernel_hash=str(value["safety_kernel_hash"]),
+        observation_names=tuple(str(item) for item in _list(value, "observation_names")),
+        residual_action_names=tuple(str(item) for item in _list(value, "residual_action_names")),
+    )
+
+
+def _schema(value: Mapping[str, Any], key: str, expected: str) -> None:
+    if value.get(key) != expected:
+        raise ValueError(f"unsupported {key}: {value.get(key)!r}")
+
+
+def _mapping(value: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    return _as_mapping(value.get(key), key)
+
+
+def _as_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be a mapping")
+    return value
+
+
+def _list(value: Mapping[str, Any], key: str) -> list[Any]:
+    result = value.get(key)
+    if not isinstance(result, list):
+        raise ValueError(f"{key} must be a list")
+    return result
+
+
+def _optional_string(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _numeric_kwargs(value: Mapping[str, Any]) -> dict[str, float]:
+    return {str(key): float(item) for key, item in value.items()}
+
+
+def _ordered_numeric(
+    value: Mapping[str, Any],
+    names: tuple[str, ...],
+    label: str,
+) -> dict[str, float]:
+    if set(value) != set(names):
+        raise ValueError(f"{label} keys do not match the policy contract")
+    return {name: float(value[name]) for name in names}
+
+
+__all__ = ["experience_batch_from_dict", "experience_batch_to_dict"]

--- a/src/rosclaw/continual/stability.py
+++ b/src/rosclaw/continual/stability.py
@@ -1,0 +1,360 @@
+"""Machine gates for the stability--plasticity dilemma."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class ContinualDecision(StrEnum):
+    PROMOTE_SIM = "PROMOTE_SIM"
+    NEED_MORE_EVIDENCE = "NEED_MORE_EVIDENCE"
+    REJECT = "REJECT"
+
+
+class CheckStatus(StrEnum):
+    PASS = "PASS"
+    MISSING = "MISSING"
+    FAIL = "FAIL"
+
+
+@dataclass(frozen=True)
+class TaskRetention:
+    task_id: str
+    parent_score: float
+    candidate_score: float
+    critical: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.task_id.strip():
+            raise ValueError("task_id must not be empty")
+        if any(
+            not math.isfinite(value) or not 0.0 <= value <= 1.0
+            for value in (self.parent_score, self.candidate_score)
+        ):
+            raise ValueError("task retention scores must be normalized to [0, 1]")
+
+    @property
+    def drop(self) -> float:
+        return max(0.0, self.parent_score - self.candidate_score)
+
+
+@dataclass(frozen=True)
+class PlasticityEvidence:
+    fine_tune_steps_to_threshold: int
+    candidate_steps_to_threshold: int
+    fresh_network_gap_start: float
+    fresh_network_gap_end: float
+    dead_unit_ratio_start: float
+    dead_unit_ratio_end: float
+    effective_rank_start: float
+    effective_rank_end: float
+    output_churn: float
+
+    def __post_init__(self) -> None:
+        if self.fine_tune_steps_to_threshold <= 0 or self.candidate_steps_to_threshold <= 0:
+            raise ValueError("steps-to-threshold values must be positive")
+        values = (
+            self.fresh_network_gap_start,
+            self.fresh_network_gap_end,
+            self.dead_unit_ratio_start,
+            self.dead_unit_ratio_end,
+            self.effective_rank_start,
+            self.effective_rank_end,
+            self.output_churn,
+        )
+        if any(not math.isfinite(value) or value < 0.0 for value in values):
+            raise ValueError("plasticity evidence must be finite and non-negative")
+        if self.dead_unit_ratio_start > 1.0 or self.dead_unit_ratio_end > 1.0:
+            raise ValueError("dead-unit ratios must be in [0, 1]")
+        if self.effective_rank_start <= 0.0 or self.effective_rank_end <= 0.0:
+            raise ValueError("effective rank must be positive")
+
+    @property
+    def sample_efficiency_gain(self) -> float:
+        return 1.0 - self.candidate_steps_to_threshold / self.fine_tune_steps_to_threshold
+
+
+@dataclass(frozen=True)
+class SelfCoreEvidence:
+    """Post-hoc, causal evidence for a self-like persistent subnetwork."""
+
+    shared_reference_hash: str
+    continual_seed_count: int
+    single_task_seed_count: int
+    threshold_sweep_count: int
+    persistence_gap: float
+    bootstrap_support: float
+    freeze_matched_pairs: int
+    freeze_advantage: float
+    lesion_matched_pairs: int
+    lesion_disadvantage: float
+    body_prediction_improved: bool
+    body_change_update_passed: bool
+
+    def __post_init__(self) -> None:
+        if not _SHA256.fullmatch(self.shared_reference_hash):
+            raise ValueError("shared_reference_hash must be a sha256: content hash")
+        if (
+            min(
+                self.continual_seed_count,
+                self.single_task_seed_count,
+                self.threshold_sweep_count,
+                self.freeze_matched_pairs,
+                self.lesion_matched_pairs,
+            )
+            < 0
+        ):
+            raise ValueError("SelfCore evidence counts must be non-negative")
+        for value in (
+            self.persistence_gap,
+            self.bootstrap_support,
+            self.freeze_advantage,
+            self.lesion_disadvantage,
+        ):
+            if not math.isfinite(value):
+                raise ValueError("SelfCore evidence metrics must be finite")
+
+    @property
+    def passed(self) -> bool:
+        return bool(
+            self.continual_seed_count >= 8
+            and self.single_task_seed_count >= 8
+            and self.threshold_sweep_count >= 5
+            and self.persistence_gap >= 0.05
+            and self.bootstrap_support >= 0.95
+            and self.freeze_matched_pairs >= 100
+            and self.freeze_advantage > 0.0
+            and self.lesion_matched_pairs >= 100
+            and self.lesion_disadvantage > 0.0
+            and self.body_prediction_improved
+            and self.body_change_update_passed
+        )
+
+
+@dataclass(frozen=True)
+class ContinualCandidateEvidence:
+    parent_policy_hash: str
+    candidate_policy_hash: str
+    body_hash: str
+    parent_body_hash: str
+    safety_kernel_hash: str
+    parent_safety_kernel_hash: str
+    task_retention: tuple[TaskRetention, ...]
+    plasticity: PlasticityEvidence | None
+    self_core: SelfCoreEvidence | None
+    replay_recent_count: int
+    replay_anchor_count: int
+    replay_boundary_count: int
+    replay_self_count: int
+    anchor_action_drift_rms: float
+    critical_safety_regressions: int
+    stale_action_executions: int
+    old_version_replays: int
+
+    def __post_init__(self) -> None:
+        hashes = (
+            self.parent_policy_hash,
+            self.candidate_policy_hash,
+            self.body_hash,
+            self.parent_body_hash,
+            self.safety_kernel_hash,
+            self.parent_safety_kernel_hash,
+        )
+        if any(not _SHA256.fullmatch(value) for value in hashes):
+            raise ValueError("candidate evidence identities must be sha256: content hashes")
+        if not self.task_retention:
+            raise ValueError("candidate evidence requires historical task retention")
+        counts = (
+            self.replay_recent_count,
+            self.replay_anchor_count,
+            self.replay_boundary_count,
+            self.replay_self_count,
+            self.critical_safety_regressions,
+            self.stale_action_executions,
+            self.old_version_replays,
+        )
+        if any(value < 0 for value in counts):
+            raise ValueError("candidate evidence counts must be non-negative")
+        if not math.isfinite(self.anchor_action_drift_rms) or self.anchor_action_drift_rms < 0.0:
+            raise ValueError("anchor_action_drift_rms must be finite and non-negative")
+
+    @property
+    def mean_historical_drop(self) -> float:
+        return sum(item.drop for item in self.task_retention) / len(self.task_retention)
+
+    @property
+    def worst_critical_drop(self) -> float:
+        values = [item.drop for item in self.task_retention if item.critical]
+        return max(values, default=0.0)
+
+
+@dataclass(frozen=True)
+class GateCheck:
+    name: str
+    status: CheckStatus
+    detail: str
+
+
+@dataclass(frozen=True)
+class ContinualGateReport:
+    decision: ContinualDecision
+    checks: tuple[GateCheck, ...]
+    parent_policy_hash: str
+    candidate_policy_hash: str
+    rollback_target_hash: str
+    activation_allowed: bool
+    evidence_domain: str = "SIM"
+    schema_version: str = "rosclaw.continual.stability_plasticity_gate.v1"
+
+    @property
+    def report_hash(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": self.schema_version,
+                "decision": self.decision.value,
+                "checks": [
+                    {"name": check.name, "status": check.status.value, "detail": check.detail}
+                    for check in self.checks
+                ],
+                "parent_policy_hash": self.parent_policy_hash,
+                "candidate_policy_hash": self.candidate_policy_hash,
+                "rollback_target_hash": self.rollback_target_hash,
+                "activation_allowed": self.activation_allowed,
+                "evidence_domain": self.evidence_domain,
+            }
+        )
+
+
+class StabilityPlasticityGate:
+    """Zero-tolerance safety gate with explicit missing-evidence semantics."""
+
+    def __init__(
+        self,
+        *,
+        max_mean_historical_drop: float = 0.03,
+        max_critical_task_drop: float = 0.05,
+        max_anchor_action_drift_rms: float = 0.03,
+        max_output_churn: float = 0.05,
+        min_sample_efficiency_gain: float = 0.30,
+    ) -> None:
+        self.max_mean_historical_drop = max_mean_historical_drop
+        self.max_critical_task_drop = max_critical_task_drop
+        self.max_anchor_action_drift_rms = max_anchor_action_drift_rms
+        self.max_output_churn = max_output_churn
+        self.min_sample_efficiency_gain = min_sample_efficiency_gain
+
+    def evaluate(self, evidence: ContinualCandidateEvidence) -> ContinualGateReport:
+        checks = (
+            _check(
+                "identity",
+                evidence.body_hash == evidence.parent_body_hash
+                and evidence.safety_kernel_hash == evidence.parent_safety_kernel_hash,
+                "body and immutable safety kernel remain bound to the parent",
+            ),
+            _check(
+                "safety",
+                evidence.critical_safety_regressions == 0,
+                "critical fall/torque/joint/stale/collision regression count is zero",
+            ),
+            _check(
+                "version_execution",
+                evidence.stale_action_executions == 0 and evidence.old_version_replays == 0,
+                "no stale action execution or old-version replay",
+            ),
+            _check(
+                "historical_mean",
+                evidence.mean_historical_drop <= self.max_mean_historical_drop,
+                f"mean historical drop={evidence.mean_historical_drop:.6f}",
+            ),
+            _check(
+                "critical_skill",
+                evidence.worst_critical_drop <= self.max_critical_task_drop,
+                f"worst critical-task drop={evidence.worst_critical_drop:.6f}",
+            ),
+            _check(
+                "anchor_drift",
+                evidence.anchor_action_drift_rms <= self.max_anchor_action_drift_rms,
+                f"anchor action drift RMS={evidence.anchor_action_drift_rms:.6f}",
+            ),
+            _check(
+                "replay_coverage",
+                min(
+                    evidence.replay_recent_count,
+                    evidence.replay_anchor_count,
+                    evidence.replay_boundary_count,
+                    evidence.replay_self_count,
+                )
+                > 0,
+                "Recent, Anchor, Boundary, and Self replay are all represented",
+            ),
+            self._plasticity_check(evidence.plasticity),
+            self._self_core_check(evidence.self_core),
+        )
+        if any(check.status is CheckStatus.FAIL for check in checks):
+            decision = ContinualDecision.REJECT
+        elif any(check.status is CheckStatus.MISSING for check in checks):
+            decision = ContinualDecision.NEED_MORE_EVIDENCE
+        else:
+            decision = ContinualDecision.PROMOTE_SIM
+        return ContinualGateReport(
+            decision=decision,
+            checks=checks,
+            parent_policy_hash=evidence.parent_policy_hash,
+            candidate_policy_hash=evidence.candidate_policy_hash,
+            rollback_target_hash=evidence.parent_policy_hash,
+            activation_allowed=decision is ContinualDecision.PROMOTE_SIM,
+        )
+
+    def _plasticity_check(self, value: PlasticityEvidence | None) -> GateCheck:
+        if value is None:
+            return GateCheck("plasticity", CheckStatus.MISSING, "plasticity evidence is absent")
+        passed = bool(
+            value.sample_efficiency_gain >= self.min_sample_efficiency_gain
+            and value.fresh_network_gap_end <= value.fresh_network_gap_start + 1e-12
+            and value.dead_unit_ratio_end <= value.dead_unit_ratio_start + 0.01
+            and value.effective_rank_end >= value.effective_rank_start * 0.90
+            and value.output_churn <= self.max_output_churn
+        )
+        return _check(
+            "plasticity",
+            passed,
+            "sample-efficiency, fresh-network gap, dead units, rank, and churn are bounded",
+        )
+
+    @staticmethod
+    def _self_core_check(value: SelfCoreEvidence | None) -> GateCheck:
+        if value is None:
+            return GateCheck(
+                "self_core",
+                CheckStatus.MISSING,
+                "no post-hoc persistence plus matched causal intervention evidence",
+            )
+        return _check(
+            "self_core",
+            value.passed,
+            "persistent subnetwork passes controls, freeze/lesion, and body-change tests",
+        )
+
+
+def _check(name: str, passed: bool, detail: str) -> GateCheck:
+    return GateCheck(name, CheckStatus.PASS if passed else CheckStatus.FAIL, detail)
+
+
+__all__ = [
+    "CheckStatus",
+    "ContinualCandidateEvidence",
+    "ContinualDecision",
+    "ContinualGateReport",
+    "GateCheck",
+    "PlasticityEvidence",
+    "SelfCoreEvidence",
+    "StabilityPlasticityGate",
+    "TaskRetention",
+]

--- a/src/rosclaw/continual/stability.py
+++ b/src/rosclaw/continual/stability.py
@@ -157,6 +157,7 @@ class ContinualCandidateEvidence:
     critical_safety_regressions: int
     stale_action_executions: int
     old_version_replays: int
+    candidate_evaluation_complete: bool = True
 
     def __post_init__(self) -> None:
         hashes = (
@@ -169,7 +170,7 @@ class ContinualCandidateEvidence:
         )
         if any(not _SHA256.fullmatch(value) for value in hashes):
             raise ValueError("candidate evidence identities must be sha256: content hashes")
-        if not self.task_retention:
+        if not self.task_retention and self.candidate_evaluation_complete:
             raise ValueError("candidate evidence requires historical task retention")
         counts = (
             self.replay_recent_count,
@@ -187,6 +188,8 @@ class ContinualCandidateEvidence:
 
     @property
     def mean_historical_drop(self) -> float:
+        if not self.task_retention:
+            return 0.0
         return sum(item.drop for item in self.task_retention) / len(self.task_retention)
 
     @property
@@ -258,30 +261,34 @@ class StabilityPlasticityGate:
                 and evidence.safety_kernel_hash == evidence.parent_safety_kernel_hash,
                 "body and immutable safety kernel remain bound to the parent",
             ),
-            _check(
+            self._candidate_evaluation_check(
                 "safety",
                 evidence.critical_safety_regressions == 0,
                 "critical fall/torque/joint/stale/collision regression count is zero",
+                evidence,
             ),
             _check(
                 "version_execution",
                 evidence.stale_action_executions == 0 and evidence.old_version_replays == 0,
                 "no stale action execution or old-version replay",
             ),
-            _check(
+            self._candidate_evaluation_check(
                 "historical_mean",
                 evidence.mean_historical_drop <= self.max_mean_historical_drop,
                 f"mean historical drop={evidence.mean_historical_drop:.6f}",
+                evidence,
             ),
-            _check(
+            self._candidate_evaluation_check(
                 "critical_skill",
                 evidence.worst_critical_drop <= self.max_critical_task_drop,
                 f"worst critical-task drop={evidence.worst_critical_drop:.6f}",
+                evidence,
             ),
-            _check(
+            self._candidate_evaluation_check(
                 "anchor_drift",
                 evidence.anchor_action_drift_rms <= self.max_anchor_action_drift_rms,
                 f"anchor action drift RMS={evidence.anchor_action_drift_rms:.6f}",
+                evidence,
             ),
             _check(
                 "replay_coverage",
@@ -311,6 +318,21 @@ class StabilityPlasticityGate:
             rollback_target_hash=evidence.parent_policy_hash,
             activation_allowed=decision is ContinualDecision.PROMOTE_SIM,
         )
+
+    @staticmethod
+    def _candidate_evaluation_check(
+        name: str,
+        passed: bool,
+        detail: str,
+        evidence: ContinualCandidateEvidence,
+    ) -> GateCheck:
+        if not evidence.candidate_evaluation_complete:
+            return GateCheck(
+                name,
+                CheckStatus.MISSING,
+                "candidate behavior has not completed matched SIM evaluation",
+            )
+        return _check(name, passed, detail)
 
     def _plasticity_check(self, value: PlasticityEvidence | None) -> GateCheck:
         if value is None:

--- a/src/rosclaw/continual/weight_update.py
+++ b/src/rosclaw/continual/weight_update.py
@@ -1,0 +1,119 @@
+"""Double-buffered residual-policy staging with atomic safe-boundary swaps."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import StrEnum
+
+from rosclaw.continual.contracts import PolicyVersion, SkillPhase
+from rosclaw.continual.stability import ContinualDecision, ContinualGateReport
+
+
+class WeightSlotState(StrEnum):
+    ACTIVE = "ACTIVE"
+    CANDIDATE_STAGED = "CANDIDATE_STAGED"
+    FROZEN = "FROZEN"
+    ROLLED_BACK = "ROLLED_BACK"
+
+
+@dataclass(frozen=True)
+class WeightSlotReceipt:
+    state: WeightSlotState
+    active_version_hash: str
+    candidate_version_hash: str | None
+    rollback_version_hash: str | None
+    reason: str
+    hardware_authorized: bool = False
+    schema_version: str = "rosclaw.continual.weight_slot_receipt.v1"
+
+
+class ResidualWeightSlot:
+    """In-memory reference state machine; never writes the active Registry."""
+
+    _SAFE_SWAP_PHASES = {SkillPhase.STAND, SkillPhase.PREPARE, SkillPhase.COMPLETE}
+
+    def __init__(self, active: PolicyVersion, *, active_artifact: bytes) -> None:
+        self._verify_artifact(active, active_artifact)
+        self.active = active
+        self.candidate: PolicyVersion | None = None
+        self.rollback_target: PolicyVersion | None = None
+        self.state = WeightSlotState.ACTIVE
+
+    def stage(self, candidate: PolicyVersion, *, artifact: bytes) -> WeightSlotReceipt:
+        if self.state is WeightSlotState.FROZEN:
+            raise RuntimeError("weight slot is frozen")
+        if self.candidate is not None:
+            raise RuntimeError("a candidate is already staged")
+        self._verify_artifact(candidate, artifact)
+        if candidate.version != self.active.version + 1:
+            raise ValueError("candidate policy version must increment active version by one")
+        if candidate.parent_version_hash != self.active.version_hash:
+            raise ValueError("candidate parent does not match the active policy")
+        if candidate.body_hash != self.active.body_hash:
+            raise ValueError("candidate cannot change body identity")
+        if candidate.safety_kernel_hash != self.active.safety_kernel_hash:
+            raise ValueError("candidate cannot change the immutable safety kernel")
+        self.candidate = candidate
+        self.state = WeightSlotState.CANDIDATE_STAGED
+        return self._receipt("candidate checksum verified and staged")
+
+    def activate(
+        self,
+        *,
+        phase: SkillPhase,
+        gate_report: ContinualGateReport,
+    ) -> WeightSlotReceipt:
+        if self.candidate is None or self.state is not WeightSlotState.CANDIDATE_STAGED:
+            raise RuntimeError("no candidate is staged")
+        if phase not in self._SAFE_SWAP_PHASES:
+            self.state = WeightSlotState.FROZEN
+            return self._receipt(f"unsafe mid-motion swap requested during {phase.value}")
+        if (
+            gate_report.decision is not ContinualDecision.PROMOTE_SIM
+            or not gate_report.activation_allowed
+            or gate_report.evidence_domain != "SIM"
+            or gate_report.parent_policy_hash != self.active.artifact_hash
+            or gate_report.candidate_policy_hash != self.candidate.artifact_hash
+        ):
+            self.state = WeightSlotState.FROZEN
+            return self._receipt("promotion evidence is missing, rejected, or identity-mismatched")
+        self.rollback_target = self.active
+        self.active = self.candidate
+        self.candidate = None
+        self.state = WeightSlotState.ACTIVE
+        return self._receipt("SIM-only candidate atomically activated at a safe boundary")
+
+    def rollback(self, *, reason: str) -> WeightSlotReceipt:
+        if not reason.strip():
+            raise ValueError("rollback reason must not be empty")
+        if self.rollback_target is None:
+            raise RuntimeError("no rollback target is available")
+        failed = self.active
+        self.active = self.rollback_target
+        self.rollback_target = failed
+        self.candidate = None
+        self.state = WeightSlotState.ROLLED_BACK
+        return self._receipt(reason)
+
+    def _receipt(self, reason: str) -> WeightSlotReceipt:
+        return WeightSlotReceipt(
+            state=self.state,
+            active_version_hash=self.active.version_hash,
+            candidate_version_hash=(self.candidate.version_hash if self.candidate else None),
+            rollback_version_hash=(
+                self.rollback_target.version_hash if self.rollback_target else None
+            ),
+            reason=reason,
+        )
+
+    @staticmethod
+    def _verify_artifact(policy: PolicyVersion, artifact: bytes) -> None:
+        if not artifact:
+            raise ValueError("policy artifact must not be empty")
+        actual = "sha256:" + hashlib.sha256(artifact).hexdigest()
+        if actual != policy.artifact_hash:
+            raise ValueError("policy artifact checksum does not match its version contract")
+
+
+__all__ = ["ResidualWeightSlot", "WeightSlotReceipt", "WeightSlotState"]

--- a/src/rosclaw/feedback/controllers/__init__.py
+++ b/src/rosclaw/feedback/controllers/__init__.py
@@ -2,6 +2,10 @@
 
 from rosclaw.feedback.controllers.balance import G1BalanceReflexConfig, G1BalanceReflexController
 from rosclaw.feedback.controllers.base import FeedbackController, ZeroResidualController
+from rosclaw.feedback.controllers.cerebellum import (
+    G1CerebellumConfig,
+    G1CerebellumController,
+)
 from rosclaw.feedback.controllers.kick_skill import (
     G1KickSkillFeedbackConfig,
     G1KickSkillFeedbackController,
@@ -13,6 +17,8 @@ __all__ = [
     "FeedbackController",
     "G1BalanceReflexConfig",
     "G1BalanceReflexController",
+    "G1CerebellumConfig",
+    "G1CerebellumController",
     "G1KickSkillFeedbackConfig",
     "G1KickSkillFeedbackController",
     "LatchedPhaseGate",

--- a/src/rosclaw/feedback/controllers/cerebellum.py
+++ b/src/rosclaw/feedback/controllers/cerebellum.py
@@ -1,0 +1,78 @@
+"""Composite G1 balance and kick-timing residual controller."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+
+from rosclaw.feedback.contracts import FeedbackFrame, canonical_hash
+from rosclaw.feedback.controllers.balance import G1BalanceReflexConfig, G1BalanceReflexController
+from rosclaw.feedback.controllers.kick_skill import (
+    G1KickSkillFeedbackConfig,
+    G1KickSkillFeedbackController,
+)
+
+
+@dataclass(frozen=True)
+class G1CerebellumConfig:
+    balance: G1BalanceReflexConfig = G1BalanceReflexConfig()
+    kick_skill: G1KickSkillFeedbackConfig = G1KickSkillFeedbackConfig()
+    phase_modulation_enabled: bool = False
+    lateral_modulation_enabled: bool = False
+    recovery_modulation_enabled: bool = False
+
+
+class G1CerebellumController:
+    """Sum L1 balance and L2 skill corrections before one safety projection."""
+
+    def __init__(self, config: G1CerebellumConfig | None = None) -> None:
+        self.config = config or G1CerebellumConfig()
+        self.balance = G1BalanceReflexController(self.config.balance)
+        self.kick_skill = G1KickSkillFeedbackController(self.config.kick_skill)
+
+    @property
+    def controller_hash(self) -> str:
+        return canonical_hash(self.config_dict())
+
+    def reset(self) -> None:
+        self.balance.reset()
+        self.kick_skill.reset()
+
+    def compute(
+        self,
+        frame: FeedbackFrame,
+        base_action: Mapping[str, float],
+    ) -> Mapping[str, float]:
+        combined: dict[str, float] = {}
+        balance_output = self.balance.compute(frame, base_action)
+        skill_output = dict(self.kick_skill.compute(frame, base_action))
+        if not self.config.phase_modulation_enabled:
+            skill_output.pop("skill:kick_phase_rate", None)
+        if not self.config.lateral_modulation_enabled:
+            skill_output.pop("joint:right_hip_yaw_joint", None)
+            skill_output.pop("joint:right_ankle_roll_joint", None)
+        if not self.config.recovery_modulation_enabled:
+            for name in (
+                "joint:waist_roll_joint",
+                "joint:left_hip_roll_joint",
+                "joint:right_hip_roll_joint",
+                "joint:waist_pitch_joint",
+                "joint:left_hip_pitch_joint",
+                "joint:right_hip_pitch_joint",
+            ):
+                skill_output.pop(name, None)
+        for output in (balance_output, skill_output):
+            for name, value in output.items():
+                combined[name] = combined.get(name, 0.0) + float(value)
+        return combined
+
+    def config_dict(self) -> dict[str, object]:
+        return {
+            "controller_type": "g1_goalforge_cerebellum",
+            "version": 1,
+            "config": asdict(self.config),
+            "composition": "balance_plus_kick_skill_before_safety_projection",
+        }
+
+
+__all__ = ["G1CerebellumConfig", "G1CerebellumController"]

--- a/src/rosclaw/feedback/controllers/kick_skill.py
+++ b/src/rosclaw/feedback/controllers/kick_skill.py
@@ -67,7 +67,9 @@ class G1KickSkillFeedbackController:
         if frame.phase < cfg.precontact_start or frame.phase > cfg.recovery_end:
             return {}
         if not self._contact_latched and frame.phase <= cfg.precontact_end:
-            contact_phase_error = float(frame.error.value.get("contact_phase", 0.0))
+            contact_phase_error = cfg.expected_contact_phase - float(
+                frame.actual.get("contact_phase", frame.phase)
+            )
             lateral_error = float(frame.actual.get("ball_lateral_error_m", 0.0))
             lateral_correction = -cfg.ball_lateral_kp * lateral_error
             return {

--- a/src/rosclaw/feedback/profiles/__init__.py
+++ b/src/rosclaw/feedback/profiles/__init__.py
@@ -1,6 +1,11 @@
 """Qualified Feedback Plane profiles for supported simulated bodies."""
 
 from rosclaw.feedback.profiles.g1 import build_g1_balance_runtime
+from rosclaw.feedback.profiles.g1_cerebellum import build_g1_cerebellum_runtime
 from rosclaw.feedback.profiles.g1_skill import build_g1_kick_skill_runtime
 
-__all__ = ["build_g1_balance_runtime", "build_g1_kick_skill_runtime"]
+__all__ = [
+    "build_g1_balance_runtime",
+    "build_g1_cerebellum_runtime",
+    "build_g1_kick_skill_runtime",
+]

--- a/src/rosclaw/feedback/profiles/g1_cerebellum.py
+++ b/src/rosclaw/feedback/profiles/g1_cerebellum.py
@@ -1,0 +1,81 @@
+"""Pinned Phase 7 G1 residual-cerebellum profile."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import MappingProxyType
+
+from rosclaw.feedback.contracts import FallbackMode, FeedbackLoopSpec
+from rosclaw.feedback.controllers.cerebellum import G1CerebellumConfig, G1CerebellumController
+from rosclaw.feedback.profiles.g1 import G1_BALANCE_OUTPUT_LIMITS
+from rosclaw.feedback.profiles.g1_skill import G1_SKILL_OUTPUT_LIMITS
+from rosclaw.feedback.runtime import FeedbackRuntime
+
+G1_CEREBELLUM_OUTPUT_LIMITS = MappingProxyType(
+    {
+        name: max(
+            G1_BALANCE_OUTPUT_LIMITS.get(name, 0.0),
+            G1_SKILL_OUTPUT_LIMITS.get(name, 0.0),
+        )
+        for name in set(G1_BALANCE_OUTPUT_LIMITS) | set(G1_SKILL_OUTPUT_LIMITS)
+    }
+)
+
+
+def build_g1_cerebellum_runtime(
+    *,
+    body_hash: str,
+    config: G1CerebellumConfig | None = None,
+    rate_hz: float = 250.0,
+    compute_clock_ns: Callable[[], int] | None = None,
+) -> FeedbackRuntime:
+    resolved = config or G1CerebellumConfig()
+    controller = G1CerebellumController(resolved)
+    output_limits = dict(G1_BALANCE_OUTPUT_LIMITS)
+    reference_signals = ["torso_roll", "torso_pitch", "com_y_relative"]
+    observation_signals = [
+        "torso_roll",
+        "torso_pitch",
+        "com_y_relative",
+        "support_slip_m",
+    ]
+    skill_enabled = bool(
+        resolved.phase_modulation_enabled
+        or resolved.lateral_modulation_enabled
+        or resolved.recovery_modulation_enabled
+    )
+    if skill_enabled:
+        observation_signals.extend(("contact_phase", "contact_detected"))
+    if resolved.phase_modulation_enabled:
+        reference_signals.append("contact_phase")
+        output_limits["skill:kick_phase_rate"] = G1_SKILL_OUTPUT_LIMITS["skill:kick_phase_rate"]
+    if resolved.lateral_modulation_enabled:
+        reference_signals.append("ball_lateral_error_m")
+        observation_signals.append("ball_lateral_error_m")
+        for name in ("joint:right_hip_yaw_joint", "joint:right_ankle_roll_joint"):
+            output_limits[name] = max(
+                output_limits.get(name, 0.0),
+                G1_SKILL_OUTPUT_LIMITS[name],
+            )
+    spec = FeedbackLoopSpec(
+        loop_id="g1/goalforge-cerebellum/v1",
+        body_hash=body_hash,
+        controller_hash=controller.controller_hash,
+        reference_signals=tuple(reference_signals),
+        observation_signals=tuple(observation_signals),
+        output_limits=output_limits,
+        rate_hz=rate_hz,
+        deadline_ms=1000.0 / rate_hz,
+        max_observation_age_ms=2.0 * 1000.0 / rate_hz,
+        fallback_deadline_miss=FallbackMode.FREEZE_AND_STABILIZE,
+    )
+    if compute_clock_ns is None:
+        return FeedbackRuntime(spec=spec, controller=controller)
+    return FeedbackRuntime(
+        spec=spec,
+        controller=controller,
+        compute_clock_ns=compute_clock_ns,
+    )
+
+
+__all__ = ["G1_CEREBELLUM_OUTPUT_LIMITS", "build_g1_cerebellum_runtime"]

--- a/src/rosclaw/self_model/__init__.py
+++ b/src/rosclaw/self_model/__init__.py
@@ -1,0 +1,27 @@
+"""Measurable embodied self-model contracts for ROSClaw."""
+
+from rosclaw.self_model.contracts import (
+    AgencyAssessment,
+    CapabilityBelief,
+    ScalarBelief,
+    SelfIdentity,
+    SelfStateSnapshot,
+)
+from rosclaw.self_model.self_core import (
+    PersistentSubnetworkCandidate,
+    ThresholdSensitivity,
+    discover_persistent_subnetwork,
+    sweep_thresholds,
+)
+
+__all__ = [
+    "AgencyAssessment",
+    "CapabilityBelief",
+    "ScalarBelief",
+    "SelfIdentity",
+    "SelfStateSnapshot",
+    "PersistentSubnetworkCandidate",
+    "ThresholdSensitivity",
+    "discover_persistent_subnetwork",
+    "sweep_thresholds",
+]

--- a/src/rosclaw/self_model/contracts.py
+++ b/src/rosclaw/self_model/contracts.py
@@ -1,0 +1,274 @@
+"""Operational embodied-self contracts without consciousness claims."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _hash(label: str, value: str) -> None:
+    if not _SHA256.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+@dataclass(frozen=True)
+class ScalarBelief:
+    mean: float
+    standard_deviation: float
+    confidence: float
+    unit: str
+
+    def __post_init__(self) -> None:
+        if any(
+            not math.isfinite(value)
+            for value in (self.mean, self.standard_deviation, self.confidence)
+        ):
+            raise ValueError("belief values must be finite")
+        if self.standard_deviation < 0.0:
+            raise ValueError("belief standard deviation must be non-negative")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("belief confidence must be in [0, 1]")
+        if not self.unit.strip():
+            raise ValueError("belief unit must not be empty")
+
+    def to_dict(self) -> dict[str, float | str]:
+        return {
+            "mean": self.mean,
+            "standard_deviation": self.standard_deviation,
+            "confidence": self.confidence,
+            "unit": self.unit,
+        }
+
+
+@dataclass(frozen=True)
+class CapabilityBelief:
+    success_probability: float
+    uncertainty: float
+    evidence_count: int
+    policy_version: int
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.success_probability <= 1.0:
+            raise ValueError("capability success probability must be in [0, 1]")
+        if not 0.0 <= self.uncertainty <= 1.0:
+            raise ValueError("capability uncertainty must be in [0, 1]")
+        if self.evidence_count < 0 or self.policy_version < 0:
+            raise ValueError("capability evidence count and policy version must be non-negative")
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "success_probability": self.success_probability,
+            "uncertainty": self.uncertainty,
+            "evidence_count": self.evidence_count,
+            "policy_version": self.policy_version,
+        }
+
+
+@dataclass(frozen=True)
+class SelfIdentity:
+    """S0: immutable body/layout identity plus versioned control lineage."""
+
+    body_hash: str
+    sensor_layout_hash: str
+    actuator_layout_hash: str
+    safety_kernel_hash: str
+    controller_lineage: tuple[str, ...]
+    current_policy_versions: Mapping[str, int]
+    discovered_self_core_hash: str | None = None
+    self_core_evidence_hash: str | None = None
+    schema_version: str = "rosclaw.self.identity.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("body_hash", self.body_hash),
+            ("sensor_layout_hash", self.sensor_layout_hash),
+            ("actuator_layout_hash", self.actuator_layout_hash),
+            ("safety_kernel_hash", self.safety_kernel_hash),
+        ):
+            _hash(label, value)
+        if not self.controller_lineage:
+            raise ValueError("controller lineage must not be empty")
+        for value in self.controller_lineage:
+            _hash("controller_lineage", value)
+        versions = {str(key): int(value) for key, value in self.current_policy_versions.items()}
+        if not versions or any(not key.strip() or value < 0 for key, value in versions.items()):
+            raise ValueError("current policy versions must be non-empty and non-negative")
+        paired = (self.discovered_self_core_hash, self.self_core_evidence_hash)
+        if (paired[0] is None) != (paired[1] is None):
+            raise ValueError("a discovered SelfCore requires its causal evidence hash")
+        for value in paired:
+            if value is not None:
+                _hash("SelfCore identity", value)
+        object.__setattr__(self, "current_policy_versions", MappingProxyType(versions))
+
+    @property
+    def identity_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "body_hash": self.body_hash,
+            "sensor_layout_hash": self.sensor_layout_hash,
+            "actuator_layout_hash": self.actuator_layout_hash,
+            "safety_kernel_hash": self.safety_kernel_hash,
+            "controller_lineage": list(self.controller_lineage),
+            "current_policy_versions": dict(sorted(self.current_policy_versions.items())),
+            "discovered_self_core_hash": self.discovered_self_core_hash,
+            "self_core_evidence_hash": self.self_core_evidence_hash,
+        }
+
+
+@dataclass(frozen=True)
+class SelfStateSnapshot:
+    """S1/S4: current body beliefs and calibrated capability estimates."""
+
+    identity_hash: str
+    body_hash: str
+    sequence: int
+    timestamp_ns: int
+    joint_health: Mapping[str, float]
+    motor_gain_beliefs: Mapping[str, ScalarBelief]
+    joint_zero_bias_beliefs: Mapping[str, ScalarBelief]
+    latency_belief: ScalarBelief
+    friction_belief: ScalarBelief
+    payload_belief: ScalarBelief
+    balance_margin: float
+    energy_state: float
+    sensor_quality: Mapping[str, float]
+    capabilities: Mapping[str, CapabilityBelief]
+    schema_version: str = "rosclaw.self.state_snapshot.v1"
+
+    def __post_init__(self) -> None:
+        _hash("identity_hash", self.identity_hash)
+        _hash("body_hash", self.body_hash)
+        if self.sequence < 0 or self.timestamp_ns < 0:
+            raise ValueError("self-state sequence and timestamp must be non-negative")
+        if not math.isfinite(self.balance_margin):
+            raise ValueError("balance margin must be finite")
+        if not math.isfinite(self.energy_state) or not 0.0 <= self.energy_state <= 1.0:
+            raise ValueError("energy state must be finite and normalized to [0, 1]")
+        joint_health = _probability_mapping(self.joint_health, label="joint_health")
+        sensor_quality = _probability_mapping(self.sensor_quality, label="sensor_quality")
+        if set(self.motor_gain_beliefs) != set(joint_health):
+            raise ValueError("motor gain beliefs must cover every joint-health entry")
+        if set(self.joint_zero_bias_beliefs) != set(joint_health):
+            raise ValueError("joint zero-bias beliefs must cover every joint-health entry")
+        if not self.capabilities:
+            raise ValueError("self state must include capability beliefs")
+        object.__setattr__(self, "joint_health", joint_health)
+        object.__setattr__(self, "sensor_quality", sensor_quality)
+        object.__setattr__(
+            self,
+            "motor_gain_beliefs",
+            MappingProxyType(dict(self.motor_gain_beliefs)),
+        )
+        object.__setattr__(
+            self,
+            "joint_zero_bias_beliefs",
+            MappingProxyType(dict(self.joint_zero_bias_beliefs)),
+        )
+        object.__setattr__(self, "capabilities", MappingProxyType(dict(self.capabilities)))
+
+    @property
+    def snapshot_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "identity_hash": self.identity_hash,
+            "body_hash": self.body_hash,
+            "sequence": self.sequence,
+            "timestamp_ns": self.timestamp_ns,
+            "joint_health": dict(self.joint_health),
+            "motor_gain_beliefs": {
+                key: value.to_dict() for key, value in sorted(self.motor_gain_beliefs.items())
+            },
+            "joint_zero_bias_beliefs": {
+                key: value.to_dict() for key, value in sorted(self.joint_zero_bias_beliefs.items())
+            },
+            "latency_belief": self.latency_belief.to_dict(),
+            "friction_belief": self.friction_belief.to_dict(),
+            "payload_belief": self.payload_belief.to_dict(),
+            "balance_margin": self.balance_margin,
+            "energy_state": self.energy_state,
+            "sensor_quality": dict(self.sensor_quality),
+            "capabilities": {
+                key: value.to_dict() for key, value in sorted(self.capabilities.items())
+            },
+        }
+
+
+@dataclass(frozen=True)
+class AgencyAssessment:
+    """S3: action-conditioned attribution, not a subjective consciousness claim."""
+
+    self_state_hash: str
+    action_hash: str
+    predicted_outcome_hash: str
+    observed_outcome_hash: str
+    self_caused_probability: float
+    external_disturbance_probability: float
+    sensor_fault_probability: float
+    schema_version: str = "rosclaw.self.agency_assessment.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("self_state_hash", self.self_state_hash),
+            ("action_hash", self.action_hash),
+            ("predicted_outcome_hash", self.predicted_outcome_hash),
+            ("observed_outcome_hash", self.observed_outcome_hash),
+        ):
+            _hash(label, value)
+        probabilities = (
+            self.self_caused_probability,
+            self.external_disturbance_probability,
+            self.sensor_fault_probability,
+        )
+        if any(not math.isfinite(value) or not 0.0 <= value <= 1.0 for value in probabilities):
+            raise ValueError("agency probabilities must be finite values in [0, 1]")
+        if not math.isclose(sum(probabilities), 1.0, abs_tol=1e-6):
+            raise ValueError("agency probabilities must sum to one")
+
+    @property
+    def assessment_hash(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": self.schema_version,
+                "self_state_hash": self.self_state_hash,
+                "action_hash": self.action_hash,
+                "predicted_outcome_hash": self.predicted_outcome_hash,
+                "observed_outcome_hash": self.observed_outcome_hash,
+                "self_caused_probability": self.self_caused_probability,
+                "external_disturbance_probability": self.external_disturbance_probability,
+                "sensor_fault_probability": self.sensor_fault_probability,
+            }
+        )
+
+
+def _probability_mapping(value: Mapping[str, float], *, label: str) -> Mapping[str, float]:
+    normalized = {str(key): float(item) for key, item in value.items()}
+    if not normalized or any(
+        not key.strip() or not math.isfinite(item) or not 0.0 <= item <= 1.0
+        for key, item in normalized.items()
+    ):
+        raise ValueError(f"{label} must contain named finite values in [0, 1]")
+    return MappingProxyType(normalized)
+
+
+__all__ = [
+    "AgencyAssessment",
+    "CapabilityBelief",
+    "ScalarBelief",
+    "SelfIdentity",
+    "SelfStateSnapshot",
+]

--- a/src/rosclaw/self_model/self_core.py
+++ b/src/rosclaw/self_model/self_core.py
@@ -1,0 +1,388 @@
+"""Post-hoc persistent-subnetwork discovery on shared reference states.
+
+This module implements the non-causal analysis portion of Jhunjhunwala,
+Goldfeder, and Lipson (2026): dead-unit filtering, co-activation graphs,
+permutation-aware neuron-family alignment, and persistence scoring.  Its output
+is intentionally named a *candidate*.  ROSClaw may call it SelfCore only after
+multi-seed controls and matched freeze/lesion interventions pass the separate
+stability--plasticity gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class PersistentSubnetworkCandidate:
+    source_policy_hash: str
+    target_policy_hash: str
+    shared_reference_hash: str
+    layer_name: str
+    threshold: float
+    alive_unit_count: int
+    dead_unit_count: int
+    source_for_target: tuple[int, ...]
+    components: tuple[tuple[int, ...], ...]
+    persistent_candidate_units: tuple[int, ...]
+    task_candidate_units: tuple[int, ...]
+    persistence_scores: tuple[float, ...]
+    persistent_mean: float
+    task_mean: float
+    persistence_gap: float
+    source_activation_hash: str
+    target_activation_hash: str
+    causal_validated: bool = False
+    schema_version: str = "rosclaw.self.persistent_subnetwork_candidate.v1"
+
+    def __post_init__(self) -> None:
+        if self.causal_validated:
+            raise ValueError("discovery analysis cannot self-assert causal validation")
+        for label, value in (
+            ("source_policy_hash", self.source_policy_hash),
+            ("target_policy_hash", self.target_policy_hash),
+            ("shared_reference_hash", self.shared_reference_hash),
+            ("source_activation_hash", self.source_activation_hash),
+            ("target_activation_hash", self.target_activation_hash),
+        ):
+            if not _SHA256.fullmatch(value):
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not self.layer_name.strip():
+            raise ValueError("layer_name must not be empty")
+        if not 0.0 < self.threshold <= 1.0:
+            raise ValueError("co-activation threshold must be in (0, 1]")
+        if not self.persistent_candidate_units or not self.task_candidate_units:
+            raise ValueError("persistent/task decomposition must be non-degenerate")
+        if self.alive_unit_count <= 0 or self.dead_unit_count < 0:
+            raise ValueError("alive/dead unit counts are invalid")
+        unit_count = self.alive_unit_count + self.dead_unit_count
+        if len(self.source_for_target) != unit_count or len(self.persistence_scores) != unit_count:
+            raise ValueError("alignment and persistence scores must cover every hidden unit")
+        if any(
+            not math.isfinite(value) or not 0.0 <= value <= 1.0 for value in self.persistence_scores
+        ):
+            raise ValueError("persistence scores must be finite values in [0, 1]")
+        if any(
+            not math.isfinite(value)
+            for value in (self.persistent_mean, self.task_mean, self.persistence_gap)
+        ):
+            raise ValueError("persistence summary values must be finite")
+
+    @property
+    def candidate_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source_policy_hash": self.source_policy_hash,
+            "target_policy_hash": self.target_policy_hash,
+            "shared_reference_hash": self.shared_reference_hash,
+            "layer_name": self.layer_name,
+            "threshold": self.threshold,
+            "alive_unit_count": self.alive_unit_count,
+            "dead_unit_count": self.dead_unit_count,
+            "source_for_target": list(self.source_for_target),
+            "components": [list(component) for component in self.components],
+            "persistent_candidate_units": list(self.persistent_candidate_units),
+            "task_candidate_units": list(self.task_candidate_units),
+            "persistence_scores": list(self.persistence_scores),
+            "persistent_mean": self.persistent_mean,
+            "task_mean": self.task_mean,
+            "persistence_gap": self.persistence_gap,
+            "source_activation_hash": self.source_activation_hash,
+            "target_activation_hash": self.target_activation_hash,
+            "causal_validated": self.causal_validated,
+        }
+
+
+@dataclass(frozen=True)
+class ThresholdSensitivity:
+    candidates: tuple[PersistentSubnetworkCandidate, ...]
+    positive_gap_fraction: float
+    median_gap: float
+    stable: bool
+    schema_version: str = "rosclaw.self.threshold_sensitivity.v1"
+
+    def __post_init__(self) -> None:
+        if len(self.candidates) < 3:
+            raise ValueError("threshold sensitivity requires at least three thresholds")
+        if len({candidate.shared_reference_hash for candidate in self.candidates}) != 1:
+            raise ValueError("threshold candidates must share one reference-state bank")
+
+    @property
+    def sweep_hash(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": self.schema_version,
+                "candidate_hashes": [candidate.candidate_hash for candidate in self.candidates],
+                "positive_gap_fraction": self.positive_gap_fraction,
+                "median_gap": self.median_gap,
+                "stable": self.stable,
+            }
+        )
+
+
+def discover_persistent_subnetwork(
+    *,
+    source_activations: np.ndarray,
+    target_activations: np.ndarray,
+    source_policy_hash: str,
+    target_policy_hash: str,
+    shared_reference_hash: str,
+    layer_name: str,
+    threshold: float = 0.70,
+    dead_unit_epsilon: float = 1e-8,
+) -> PersistentSubnetworkCandidate:
+    """Discover a candidate persistent block without making a causal claim."""
+
+    source = _activation_matrix(source_activations, "source_activations")
+    target = _activation_matrix(target_activations, "target_activations")
+    if source.shape != target.shape:
+        raise ValueError("source and target activation matrices must have the same shape")
+    if not 0.0 < threshold <= 1.0:
+        raise ValueError("threshold must be in (0, 1]")
+    if dead_unit_epsilon <= 0.0:
+        raise ValueError("dead_unit_epsilon must be positive")
+
+    source_normalized, source_alive = _normalize_units(source, dead_unit_epsilon)
+    target_normalized, target_alive = _normalize_units(target, dead_unit_epsilon)
+    jointly_alive = source_alive & target_alive
+    alive_indices = np.flatnonzero(jointly_alive)
+    if alive_indices.size < 2:
+        raise ValueError("at least two jointly alive units are required")
+
+    family_similarity = _cosine_columns(source_normalized, target_normalized)
+    source_for_target = _source_for_target(family_similarity)
+    aligned_source = source_normalized[:, source_for_target]
+    aligned_alive = source_alive[source_for_target] & target_alive
+    target_coactivation = np.abs(_cosine_columns(target_normalized, target_normalized))
+    source_coactivation = np.abs(_cosine_columns(aligned_source, aligned_source))
+    components = _components(target_coactivation, aligned_alive, threshold)
+    if len(components) < 2:
+        raise ValueError("co-activation decomposition is degenerate at this threshold")
+    persistent = max(components, key=lambda value: (len(value), tuple(-item for item in value)))
+    task = tuple(sorted(set(map(int, np.flatnonzero(aligned_alive))).difference(persistent)))
+    if not task:
+        raise ValueError("co-activation decomposition has no task-like units")
+
+    activation_similarity = np.asarray(
+        [
+            max(0.0, _cosine_vector(aligned_source[:, unit], target_normalized[:, unit]))
+            if aligned_alive[unit]
+            else 0.0
+            for unit in range(target.shape[1])
+        ],
+        dtype=np.float64,
+    )
+    connectivity_similarity = np.asarray(
+        [
+            max(0.0, _cosine_vector(source_coactivation[unit], target_coactivation[unit]))
+            if aligned_alive[unit]
+            else 0.0
+            for unit in range(target.shape[1])
+        ],
+        dtype=np.float64,
+    )
+    persistence = np.clip(
+        0.5 * (activation_similarity + connectivity_similarity),
+        0.0,
+        1.0,
+    )
+    persistent_mean = float(np.mean(persistence[list(persistent)]))
+    task_mean = float(np.mean(persistence[list(task)]))
+    return PersistentSubnetworkCandidate(
+        source_policy_hash=source_policy_hash,
+        target_policy_hash=target_policy_hash,
+        shared_reference_hash=shared_reference_hash,
+        layer_name=layer_name,
+        threshold=threshold,
+        alive_unit_count=int(np.count_nonzero(aligned_alive)),
+        dead_unit_count=int(target.shape[1] - np.count_nonzero(aligned_alive)),
+        source_for_target=tuple(map(int, source_for_target)),
+        components=components,
+        persistent_candidate_units=persistent,
+        task_candidate_units=task,
+        persistence_scores=tuple(map(float, persistence)),
+        persistent_mean=persistent_mean,
+        task_mean=task_mean,
+        persistence_gap=persistent_mean - task_mean,
+        source_activation_hash=_array_hash(source),
+        target_activation_hash=_array_hash(target),
+    )
+
+
+def sweep_thresholds(
+    *,
+    source_activations: np.ndarray,
+    target_activations: np.ndarray,
+    source_policy_hash: str,
+    target_policy_hash: str,
+    shared_reference_hash: str,
+    layer_name: str,
+    thresholds: tuple[float, ...] = (0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85),
+) -> ThresholdSensitivity:
+    if len(thresholds) < 3 or len(set(thresholds)) != len(thresholds):
+        raise ValueError("threshold sweep must contain at least three unique values")
+    candidates = tuple(
+        discover_persistent_subnetwork(
+            source_activations=source_activations,
+            target_activations=target_activations,
+            source_policy_hash=source_policy_hash,
+            target_policy_hash=target_policy_hash,
+            shared_reference_hash=shared_reference_hash,
+            layer_name=layer_name,
+            threshold=threshold,
+        )
+        for threshold in thresholds
+    )
+    gaps = np.asarray([candidate.persistence_gap for candidate in candidates], dtype=np.float64)
+    fraction = float(np.mean(gaps > 0.0))
+    median = float(np.median(gaps))
+    return ThresholdSensitivity(
+        candidates=candidates,
+        positive_gap_fraction=fraction,
+        median_gap=median,
+        stable=bool(fraction >= 0.80 and median >= 0.05),
+    )
+
+
+def _activation_matrix(value: np.ndarray, label: str) -> np.ndarray:
+    array = np.asarray(value, dtype=np.float64)
+    if array.ndim != 2 or min(array.shape) < 2:
+        raise ValueError(f"{label} must have shape [reference_states, hidden_units]")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{label} must contain only finite values")
+    return np.ascontiguousarray(array)
+
+
+def _normalize_units(value: np.ndarray, epsilon: float) -> tuple[np.ndarray, np.ndarray]:
+    centered = value - np.mean(value, axis=0, keepdims=True)
+    scale = np.std(centered, axis=0)
+    alive = scale > epsilon
+    normalized = np.zeros_like(centered)
+    normalized[:, alive] = centered[:, alive] / scale[alive]
+    return normalized, alive
+
+
+def _cosine_columns(left: np.ndarray, right: np.ndarray) -> np.ndarray:
+    numerator = left.T @ right
+    left_norm = np.linalg.norm(left, axis=0)
+    right_norm = np.linalg.norm(right, axis=0)
+    denominator = np.outer(left_norm, right_norm)
+    return np.divide(
+        numerator,
+        denominator,
+        out=np.zeros_like(numerator),
+        where=denominator > 1e-12,
+    )
+
+
+def _cosine_vector(left: np.ndarray, right: np.ndarray) -> float:
+    denominator = float(np.linalg.norm(left) * np.linalg.norm(right))
+    if denominator <= 1e-12:
+        return 0.0
+    return float(np.dot(left, right) / denominator)
+
+
+def _source_for_target(similarity: np.ndarray) -> np.ndarray:
+    """Maximum-weight one-to-one neuron alignment via Hungarian assignment."""
+
+    if similarity.ndim != 2 or similarity.shape[0] != similarity.shape[1]:
+        raise ValueError("neuron-family similarity must be square")
+    size = similarity.shape[0]
+    cost = float(np.max(similarity)) - similarity
+    u = np.zeros(size + 1, dtype=np.float64)
+    v = np.zeros(size + 1, dtype=np.float64)
+    matched_row = np.zeros(size + 1, dtype=np.int64)
+    way = np.zeros(size + 1, dtype=np.int64)
+    for row in range(1, size + 1):
+        matched_row[0] = row
+        column0 = 0
+        minimum = np.full(size + 1, math.inf, dtype=np.float64)
+        used = np.zeros(size + 1, dtype=bool)
+        while True:
+            used[column0] = True
+            row0 = int(matched_row[column0])
+            delta = math.inf
+            column1 = 0
+            for column in range(1, size + 1):
+                if used[column]:
+                    continue
+                current = cost[row0 - 1, column - 1] - u[row0] - v[column]
+                if current < minimum[column]:
+                    minimum[column] = current
+                    way[column] = column0
+                if minimum[column] < delta:
+                    delta = float(minimum[column])
+                    column1 = column
+            for column in range(size + 1):
+                if used[column]:
+                    u[matched_row[column]] += delta
+                    v[column] -= delta
+                else:
+                    minimum[column] -= delta
+            column0 = column1
+            if matched_row[column0] == 0:
+                break
+        while True:
+            column1 = int(way[column0])
+            matched_row[column0] = matched_row[column1]
+            column0 = column1
+            if column0 == 0:
+                break
+    source_for_target = np.empty(size, dtype=np.int64)
+    for target in range(1, size + 1):
+        source_for_target[target - 1] = matched_row[target] - 1
+    return source_for_target
+
+
+def _components(
+    affinity: np.ndarray,
+    alive: np.ndarray,
+    threshold: float,
+) -> tuple[tuple[int, ...], ...]:
+    remaining = set(map(int, np.flatnonzero(alive)))
+    components: list[tuple[int, ...]] = []
+    while remaining:
+        root = min(remaining)
+        stack = [root]
+        component: set[int] = set()
+        while stack:
+            unit = stack.pop()
+            if unit in component:
+                continue
+            component.add(unit)
+            neighbors = {
+                int(index) for index in np.flatnonzero(affinity[unit] >= threshold) if alive[index]
+            }
+            stack.extend(sorted(neighbors.difference(component), reverse=True))
+        remaining.difference_update(component)
+        components.append(tuple(sorted(component)))
+    return tuple(sorted(components, key=lambda value: (-len(value), value)))
+
+
+def _array_hash(value: np.ndarray) -> str:
+    digest = hashlib.sha256()
+    digest.update(str(value.dtype).encode())
+    digest.update(repr(tuple(value.shape)).encode())
+    digest.update(np.ascontiguousarray(value).tobytes())
+    return "sha256:" + digest.hexdigest()
+
+
+__all__ = [
+    "PersistentSubnetworkCandidate",
+    "ThresholdSensitivity",
+    "discover_persistent_subnetwork",
+    "sweep_thresholds",
+]

--- a/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
+++ b/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
@@ -418,6 +418,9 @@ class G1MuJoCoBackend:
             "right_foot_contact": [],
             "ground_reaction_force": [],
             "support_foot_slip": [],
+            "policy_phase": [],
+            "com_y_relative": [],
+            "ball_lateral_error_m": [],
             "ball_pose": [],
             "ball_velocity": [],
             "ball_angular_velocity": [],
@@ -434,12 +437,7 @@ class G1MuJoCoBackend:
                 }
             )
             if "skill:kick_phase_rate" in feedback_runtime.spec.output_limits:
-                trace.update(
-                    {
-                        "feedback_phase_rate": [],
-                        "policy_phase": [],
-                    }
-                )
+                trace["feedback_phase_rate"] = []
         if feedforward is not None:
             trace.update(
                 {
@@ -1097,6 +1095,11 @@ def _append_trace(
     trace["right_foot_contact"].append(right_contact)
     trace["ground_reaction_force"].append(ground_reaction_force)
     trace["support_foot_slip"].append(support_slip)
+    trace["policy_phase"].append(policy_phase)
+    trace["com_y_relative"].append(float(com[1]) - float(data.xpos[ids.left_ankle][1]))
+    trace["ball_lateral_error_m"].append(
+        float(data.qpos[ids.ball_qpos + 1]) - float(data.xpos[ids.right_ankle][1])
+    )
     trace["ball_pose"].append(data.qpos[ids.ball_qpos : ids.ball_qpos + 7].copy())
     trace["ball_velocity"].append(data.qvel[ids.ball_qvel : ids.ball_qvel + 3].copy())
     trace["ball_angular_velocity"].append(data.qvel[ids.ball_qvel + 3 : ids.ball_qvel + 6].copy())
@@ -1110,7 +1113,6 @@ def _append_trace(
         trace["feedback_active"].append(bool(np.any(np.abs(feedback_residual) > 0.0)))
     if "feedback_phase_rate" in trace:
         trace["feedback_phase_rate"].append(feedback_phase_rate)
-        trace["policy_phase"].append(policy_phase)
     if "feedforward_residual" in trace:
         assert feedforward_residual is not None
         assert combined_residual is not None

--- a/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
+++ b/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
@@ -433,6 +433,13 @@ class G1MuJoCoBackend:
                     "feedback_active": [],
                 }
             )
+            if "skill:kick_phase_rate" in feedback_runtime.spec.output_limits:
+                trace.update(
+                    {
+                        "feedback_phase_rate": [],
+                        "policy_phase": [],
+                    }
+                )
         if feedforward is not None:
             trace.update(
                 {
@@ -485,6 +492,9 @@ class G1MuJoCoBackend:
             dtype=np.float64,
         )
         feedback_error_rms = math.nan
+        feedback_phase_rate = 0.0
+        policy_phase = 0.0
+        phase_repeat_accumulator = 0.0
         next_feedback_time = 0.0
         latest_support_slip = 0.0
 
@@ -515,6 +525,11 @@ class G1MuJoCoBackend:
                     else:
                         repeat += phase_advance
                         phase_adjusted = True
+                repeat, phase_repeat_accumulator = _apply_feedback_phase_rate(
+                    repeat=repeat,
+                    phase_rate=feedback_phase_rate,
+                    accumulator=phase_repeat_accumulator,
+                )
                 if repeat:
                     with contextlib.redirect_stdout(io.StringIO()):
                         for _ in range(repeat):
@@ -537,6 +552,10 @@ class G1MuJoCoBackend:
                     kp = np.asarray(policy.kps, dtype=np.float64)
                     kd = np.asarray(policy.kds, dtype=np.float64)
                     policy_frame = current_policy_frame
+                policy_phase = min(
+                    1.0,
+                    policy_frame / max(1, int(motion["joint_pos"].shape[0]) - 1),
+                )
             target_queue.append(target)
             delayed_target = (
                 target_queue.popleft() if len(target_queue) > latency_frames else last_target.copy()
@@ -550,15 +569,23 @@ class G1MuJoCoBackend:
             ball_contact_point: np.ndarray = np.zeros(3, dtype=np.float64)
             for _ in range(10):
                 if feedback_runtime is not None and data.time + 1e-12 >= next_feedback_time:
-                    feedback_residual = _feedback_residual(
+                    feedback_phase = (
+                        policy_phase
+                        if "contact_phase" in feedback_runtime.spec.observation_signals
+                        else min(1.0, frame / max(1, total_control_frames - 1))
+                    )
+                    feedback_effect = _feedback_effect(
                         runtime=feedback_runtime,
                         timestamp_sec=float(data.time),
-                        phase=min(1.0, frame / max(1, total_control_frames - 1)),
+                        phase=feedback_phase,
                         data=data,
                         ids=ids,
                         base_target=delayed_target,
                         support_slip=latest_support_slip,
+                        contact_detected=contact_observed,
                     )
+                    feedback_residual = feedback_effect.joint_residual
+                    feedback_phase_rate = feedback_effect.kick_phase_rate
                     feedback_error_rms = feedback_runtime.records[-1].error_rms
                     next_feedback_time += 1.0 / feedback_runtime.spec.rate_hz
                 raw_combined_residual = feedback_residual + feedforward_residual
@@ -673,6 +700,8 @@ class G1MuJoCoBackend:
                     goal_crossed=goal_crossed,
                     feedback_residual=feedback_residual,
                     feedback_error_rms=feedback_error_rms,
+                    feedback_phase_rate=feedback_phase_rate,
+                    policy_phase=policy_phase,
                     feedforward_residual=feedforward_residual,
                     combined_residual=combined_residual,
                     combined_residual_saturation=combined_residual_saturation,
@@ -702,6 +731,8 @@ class G1MuJoCoBackend:
                 goal_crossed=goal_crossed,
                 feedback_residual=feedback_residual,
                 feedback_error_rms=feedback_error_rms,
+                feedback_phase_rate=feedback_phase_rate,
+                policy_phase=policy_phase,
                 feedforward_residual=feedforward_residual,
                 combined_residual=combined_residual,
                 combined_residual_saturation=combined_residual_saturation,
@@ -833,6 +864,12 @@ class _Contacts:
     ball_contact_point: tuple[float, float, float]
     left_ground_force_n: float
     right_ground_force_n: float
+
+
+@dataclass(frozen=True)
+class _FeedbackEffect:
+    joint_residual: np.ndarray
+    kick_phase_rate: float
 
 
 def _load_robonaldo(root: Path) -> tuple[Any, Any, Any, np.ndarray]:
@@ -1042,6 +1079,8 @@ def _append_trace(
     goal_crossed: bool,
     feedback_residual: np.ndarray | None = None,
     feedback_error_rms: float = math.nan,
+    feedback_phase_rate: float = 0.0,
+    policy_phase: float = 0.0,
     feedforward_residual: np.ndarray | None = None,
     combined_residual: np.ndarray | None = None,
     combined_residual_saturation: int = 0,
@@ -1069,6 +1108,9 @@ def _append_trace(
         trace["feedback_residual"].append(feedback_residual.copy())
         trace["feedback_error_rms"].append(feedback_error_rms)
         trace["feedback_active"].append(bool(np.any(np.abs(feedback_residual) > 0.0)))
+    if "feedback_phase_rate" in trace:
+        trace["feedback_phase_rate"].append(feedback_phase_rate)
+        trace["policy_phase"].append(policy_phase)
     if "feedforward_residual" in trace:
         assert feedforward_residual is not None
         assert combined_residual is not None
@@ -1077,7 +1119,7 @@ def _append_trace(
         trace["combined_residual_saturation"].append(combined_residual_saturation)
 
 
-def _feedback_residual(
+def _feedback_effect(
     *,
     runtime: FeedbackRuntime,
     timestamp_sec: float,
@@ -1086,7 +1128,8 @@ def _feedback_residual(
     ids: _ModelIds,
     base_target: np.ndarray,
     support_slip: float,
-) -> np.ndarray:
+    contact_detected: bool,
+) -> _FeedbackEffect:
     """Run one feedback tick from MuJoCo state without crossing the EventBus."""
 
     roll, pitch = _roll_pitch(data.xquat[ids.torso])
@@ -1097,6 +1140,10 @@ def _feedback_residual(
         "torso_pitch": pitch,
         "com_y_relative": float(com[1]) - support_y,
         "support_slip_m": support_slip,
+        "contact_phase": phase,
+        "ball_lateral_error_m": float(data.qpos[ids.ball_qpos + 1])
+        - float(data.xpos[ids.right_ankle][1]),
+        "contact_detected": float(contact_detected),
     }
     actual.update(
         {
@@ -1119,12 +1166,46 @@ def _feedback_residual(
         base_action=base_action,
     )
     residual = np.zeros(29, dtype=np.float64)
+    kick_phase_rate = 0.0
     joint_index = {name: index for index, name in enumerate(G1_DDS_JOINT_NAMES)}
     for output, value in command.projected.items():
+        if output == "skill:kick_phase_rate":
+            kick_phase_rate = value
+            continue
         joint_name = output.removeprefix("joint:")
         if joint_name in joint_index:
             residual[joint_index[joint_name]] = value
-    return residual
+    return _FeedbackEffect(
+        joint_residual=residual,
+        kick_phase_rate=kick_phase_rate,
+    )
+
+
+def _apply_feedback_phase_rate(
+    *,
+    repeat: int,
+    phase_rate: float,
+    accumulator: float,
+) -> tuple[int, float]:
+    """Convert a bounded L2 phase-rate directive into discrete policy-clock steps."""
+
+    if repeat < 0:
+        raise ValueError("policy repeat count must be non-negative")
+    if not math.isfinite(phase_rate) or not -1.0 <= phase_rate <= 1.0:
+        raise ValueError("feedback phase rate must be finite and in [-1, 1]")
+    if not math.isfinite(accumulator):
+        raise ValueError("feedback phase accumulator must be finite")
+    accumulator += phase_rate
+    if accumulator >= 1.0:
+        extra = int(math.floor(accumulator))
+        repeat += extra
+        accumulator -= extra
+    elif accumulator <= -1.0 and repeat > 0:
+        held = min(repeat, int(math.floor(-accumulator)))
+        repeat -= held
+        accumulator += held
+    accumulator = min(0.999999, max(-0.999999, accumulator))
+    return repeat, accumulator
 
 
 def _classify(

--- a/src/rosclaw/simforge/g1_causal_feedback_validation.py
+++ b/src/rosclaw/simforge/g1_causal_feedback_validation.py
@@ -1,0 +1,323 @@
+"""Counterfactual causal-window validation for the G1 balance reflex.
+
+This validator is intentionally narrower than a promotion suite.  It pins one
+qualified MuJoCo scenario, compares feedback off/on, proves that the prefix is
+identical before the reflex activates, and measures the post-disturbance
+attitude response.  A pass supports a local simulation causal claim only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.feedback.profiles.g1 import build_g1_balance_runtime
+from rosclaw.feedback.replay import RecordedLatencyClock
+from rosclaw.simforge.backends.unitree_mujoco_backend import (
+    G1MuJoCoBackend,
+    trajectory_digest,
+)
+from rosclaw.simforge.g1_feedback_validation import G1FeedbackMetrics
+from rosclaw.simforge.models import Partition
+from rosclaw.simforge.seed_ledger import SeedLedger
+from rosclaw.simforge.tasks.g1_goalforge.concepts import ShotParameters
+from rosclaw.simforge.tasks.g1_goalforge.scenario import generate_goalforge_scenarios
+
+_CAUSAL_SECRET = b"rosclaw-feedback-phase6-validation"
+_DISTURBANCE_START_SEC = 4.6
+
+
+@dataclass(frozen=True)
+class AttitudeWindowMetrics:
+    start_sec: float
+    end_sec: float
+    integrated_error_rad_sec: float
+    peak_error_rad: float
+    tail_mean_error_rad: float
+
+
+@dataclass(frozen=True)
+class G1CausalFeedbackValidation:
+    body_hash: str
+    kick_prior_hash: str
+    backend_commit: str
+    scenario_id: str
+    scenario_commitment: str
+    disturbance_n: float
+    baseline: G1FeedbackMetrics
+    feedback: G1FeedbackMetrics
+    baseline_window: AttitudeWindowMetrics
+    feedback_window: AttitudeWindowMetrics
+    baseline_early_window: AttitudeWindowMetrics
+    feedback_early_window: AttitudeWindowMetrics
+    activation_start_sec: float
+    activation_end_sec: float
+    active_trace_samples: int
+    max_projected_residual_rad: float
+    identical_pre_activation_prefix: bool
+    counterfactual_diverged_after_activation: bool
+    strict_replay: bool
+    deadline_compliance_rate: float
+    feedback_receipt: dict[str, Any]
+    schema_version: str = "rosclaw.g1_feedback.causal_validation.v1"
+
+    @property
+    def integrated_error_improvement(self) -> float:
+        baseline = self.baseline_window.integrated_error_rad_sec
+        return (baseline - self.feedback_window.integrated_error_rad_sec) / max(baseline, 1e-12)
+
+    @property
+    def peak_error_improvement(self) -> float:
+        baseline = self.baseline_window.peak_error_rad
+        return (baseline - self.feedback_window.peak_error_rad) / max(baseline, 1e-12)
+
+    @property
+    def early_transient_regression(self) -> bool:
+        return (
+            self.feedback_early_window.integrated_error_rad_sec
+            > self.baseline_early_window.integrated_error_rad_sec + 1e-12
+        )
+
+    @property
+    def passed(self) -> bool:
+        return bool(
+            self.feedback.success
+            and not self.feedback.post_kick_fall
+            and not self.feedback.joint_limit_violation
+            and not self.feedback.torque_limit_violation
+            and self.active_trace_samples > 0
+            and self.max_projected_residual_rad > 0.0
+            and self.identical_pre_activation_prefix
+            and self.counterfactual_diverged_after_activation
+            and self.strict_replay
+            and self.deadline_compliance_rate >= 0.999
+            and self.integrated_error_improvement >= 0.05
+            and self.peak_error_improvement >= 0.05
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "body_hash": self.body_hash,
+            "kick_prior_hash": self.kick_prior_hash,
+            "backend_commit": self.backend_commit,
+            "scenario_id": self.scenario_id,
+            "scenario_commitment": self.scenario_commitment,
+            "disturbance_n": self.disturbance_n,
+            "baseline": asdict(self.baseline),
+            "feedback": asdict(self.feedback),
+            "baseline_window": asdict(self.baseline_window),
+            "feedback_window": asdict(self.feedback_window),
+            "baseline_early_window": asdict(self.baseline_early_window),
+            "feedback_early_window": asdict(self.feedback_early_window),
+            "activation_start_sec": self.activation_start_sec,
+            "activation_end_sec": self.activation_end_sec,
+            "active_trace_samples": self.active_trace_samples,
+            "max_projected_residual_rad": self.max_projected_residual_rad,
+            "identical_pre_activation_prefix": self.identical_pre_activation_prefix,
+            "counterfactual_diverged_after_activation": (
+                self.counterfactual_diverged_after_activation
+            ),
+            "strict_replay": self.strict_replay,
+            "deadline_compliance_rate": self.deadline_compliance_rate,
+            "integrated_error_improvement": self.integrated_error_improvement,
+            "peak_error_improvement": self.peak_error_improvement,
+            "early_transient_regression": self.early_transient_regression,
+            "feedback_receipt": self.feedback_receipt,
+            "passed": self.passed,
+            "promotion_assessment": {
+                "status": "NEED_MORE_EVIDENCE",
+                "eligible": False,
+                "blockers": [
+                    "single deterministic SIM scenario is not a disturbance distribution",
+                    "early active-window attitude error is not required to improve monotonically",
+                    "historical Anchor and multi-seed retention gates remain mandatory",
+                    "real-body Canary is not authorized or complete",
+                ],
+            },
+            "claims": {
+                "evidence_domain": "SIM",
+                "causal_scope": "matched feedback-off/on counterfactual in one pinned scenario",
+                "real_hardware": False,
+                "learned_policy": False,
+                "hardware_authorized": False,
+            },
+        }
+
+
+def run_g1_causal_feedback_validation(
+    *,
+    asset_root: Path,
+    output_path: Path,
+    source_checkout: Path,
+    disturbance_n: float = 80.0,
+) -> G1CausalFeedbackValidation:
+    """Run a strict-replay off/on counterfactual and persist external evidence."""
+
+    destination = output_path.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if destination == checkout or checkout in destination.parents:
+        raise ValueError("Causal feedback evidence must be outside the source checkout")
+    if not 0.0 < disturbance_n <= 80.0:
+        raise ValueError("disturbance_n must be in (0, 80]")
+
+    backend = G1MuJoCoBackend(asset_root=asset_root, trace_stride=1)
+    nominal = generate_goalforge_scenarios(
+        ledger=SeedLedger(task_id="g1_penalty_kick", secret=_CAUSAL_SECRET),
+        partition=Partition.VALIDATION,
+        count=1,
+        generation=0,
+    )[0]
+    scenario = replace(
+        nominal,
+        scenario_id=f"g1-feedback-causal-{int(disturbance_n):03d}n",
+        disturbance_n=disturbance_n,
+    )
+    parameters = ShotParameters()
+    baseline = backend.run(scenario, parameters)
+    runtime = build_g1_balance_runtime(body_hash=backend.qualification.body_hash)
+    feedback = backend.run(scenario, parameters, feedback_runtime=runtime)
+    replay_runtime = build_g1_balance_runtime(
+        body_hash=backend.qualification.body_hash,
+        compute_clock_ns=RecordedLatencyClock(
+            tuple(record.latency_ns for record in runtime.records)
+        ),
+    )
+    replay = backend.run(scenario, parameters, feedback_runtime=replay_runtime)
+    strict_replay = bool(
+        replay.result.summary_dict() == feedback.result.summary_dict()
+        and trajectory_digest(replay.trajectory) == trajectory_digest(feedback.trajectory)
+    )
+    receipt = runtime.build_receipt(
+        action_id=scenario.scenario_id,
+        strict_replay=strict_replay,
+        evidence_domain="SIM",
+    )
+
+    time = np.asarray(feedback.trajectory["time"], dtype=np.float64)
+    active = np.asarray(feedback.trajectory["feedback_active"], dtype=bool)
+    active_indices = np.flatnonzero(active)
+    if active_indices.size == 0:
+        raise RuntimeError("Pinned causal scenario did not activate the feedback controller")
+    first_active = int(active_indices[0])
+    last_active = int(active_indices[-1])
+    activation_start = float(time[first_active])
+    activation_end = float(time[last_active])
+    baseline_error = _attitude_error(baseline.trajectory["torso_quaternion"])
+    feedback_error = _attitude_error(feedback.trajectory["torso_quaternion"])
+    window_end = float(time[-1])
+    early_end = min(window_end, activation_end)
+    baseline_window = _window_metrics(time, baseline_error, _DISTURBANCE_START_SEC, window_end)
+    feedback_window = _window_metrics(time, feedback_error, _DISTURBANCE_START_SEC, window_end)
+    baseline_early = _window_metrics(time, baseline_error, activation_start, early_end)
+    feedback_early = _window_metrics(time, feedback_error, activation_start, early_end)
+    prefix_equal = all(
+        np.array_equal(
+            baseline.trajectory[name][:first_active],
+            feedback.trajectory[name][:first_active],
+        )
+        for name in ("joint_position", "torso_quaternion", "ball_pose")
+    )
+    divergence = (
+        float(
+            np.max(
+                np.abs(
+                    baseline.trajectory["torso_quaternion"][first_active:]
+                    - feedback.trajectory["torso_quaternion"][first_active:]
+                )
+            )
+        )
+        > 1e-9
+    )
+    residual = np.asarray(feedback.trajectory["feedback_residual"], dtype=np.float64)
+    result = G1CausalFeedbackValidation(
+        body_hash=backend.qualification.body_hash,
+        kick_prior_hash=backend.qualification.kick_prior_hash,
+        backend_commit=backend.qualification.backend_commit,
+        scenario_id=scenario.scenario_id,
+        scenario_commitment=scenario.scenario_commitment,
+        disturbance_n=disturbance_n,
+        baseline=G1FeedbackMetrics.from_episode(baseline),
+        feedback=G1FeedbackMetrics.from_episode(feedback),
+        baseline_window=baseline_window,
+        feedback_window=feedback_window,
+        baseline_early_window=baseline_early,
+        feedback_early_window=feedback_early,
+        activation_start_sec=activation_start,
+        activation_end_sec=activation_end,
+        active_trace_samples=int(active_indices.size),
+        max_projected_residual_rad=float(np.max(np.abs(residual))),
+        identical_pre_activation_prefix=prefix_equal,
+        counterfactual_diverged_after_activation=divergence,
+        strict_replay=strict_replay,
+        deadline_compliance_rate=(receipt.samples - receipt.deadline_miss_count) / receipt.samples,
+        feedback_receipt=receipt.to_dict(),
+    )
+    _atomic_json(destination, result.to_dict())
+    return result
+
+
+def _attitude_error(quaternion_wxyz: np.ndarray) -> np.ndarray:
+    quaternion = np.asarray(quaternion_wxyz, dtype=np.float64)
+    if quaternion.ndim != 2 or quaternion.shape[1] != 4:
+        raise ValueError("torso quaternion trace must have shape [N, 4]")
+    w, x, y, z = (quaternion[:, index] for index in range(4))
+    roll = np.arctan2(2.0 * (w * x + y * z), 1.0 - 2.0 * (x * x + y * y))
+    pitch = np.arcsin(np.clip(2.0 * (w * y - z * x), -1.0, 1.0))
+    return np.sqrt(roll * roll + pitch * pitch)
+
+
+def _window_metrics(
+    time: np.ndarray,
+    error: np.ndarray,
+    start_sec: float,
+    end_sec: float,
+) -> AttitudeWindowMetrics:
+    selected = (time >= start_sec) & (time <= end_sec)
+    if np.count_nonzero(selected) < 2:
+        raise ValueError("causal attitude window must contain at least two trace samples")
+    window_time = time[selected]
+    window_error = error[selected]
+    tail_start = max(start_sec, end_sec - 0.5)
+    tail = error[(time >= tail_start) & (time <= end_sec)]
+    return AttitudeWindowMetrics(
+        start_sec=float(window_time[0]),
+        end_sec=float(window_time[-1]),
+        integrated_error_rad_sec=_trapezoid(window_error, window_time),
+        peak_error_rad=float(np.max(window_error)),
+        tail_mean_error_rad=float(np.mean(tail)),
+    )
+
+
+def _trapezoid(value: np.ndarray, coordinate: np.ndarray) -> float:
+    """NumPy 1.24-compatible trapezoidal integration without deprecation warnings."""
+
+    return float(np.sum(0.5 * (value[:-1] + value[1:]) * np.diff(coordinate)))
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, sort_keys=True, indent=2, allow_nan=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+__all__ = [
+    "AttitudeWindowMetrics",
+    "G1CausalFeedbackValidation",
+    "run_g1_causal_feedback_validation",
+]

--- a/src/rosclaw/simforge/g1_continual_gpu_smoke.py
+++ b/src/rosclaw/simforge/g1_continual_gpu_smoke.py
@@ -1,0 +1,169 @@
+"""Four-GPU systems smoke for versioned continual residual SAC."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ContinualGPUShard:
+    physical_gpu: int
+    gpu_uuid: str
+    candidate_policy_hash: str
+    updates_finite: bool
+    stale_actor_transition_count: int
+    action_bounded: bool
+    hidden_activations_finite: bool
+    max_memory_allocated_bytes: int
+    evidence_path: str
+
+
+@dataclass(frozen=True)
+class G1ContinualFourGPUSmoke:
+    shards: tuple[ContinualGPUShard, ...]
+    failures: tuple[str, ...]
+    schema_version: str = "rosclaw.continual.four_gpu_smoke.v1"
+
+    @property
+    def passed(self) -> bool:
+        return bool(
+            len(self.shards) == 4
+            and not self.failures
+            and len({shard.gpu_uuid for shard in self.shards}) == 4
+            and all(
+                shard.updates_finite
+                and shard.stale_actor_transition_count > 0
+                and shard.action_bounded
+                and shard.hidden_activations_finite
+                and shard.max_memory_allocated_bytes > 0
+                for shard in self.shards
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "shards": [shard.__dict__ for shard in self.shards],
+            "failures": list(self.failures),
+            "unique_gpu_uuids": len({shard.gpu_uuid for shard in self.shards}),
+            "passed": self.passed,
+            "promotion_assessment": {
+                "status": "NEED_MORE_EVIDENCE",
+                "eligible": False,
+                "blockers": [
+                    "worker transitions are synthetic contract fixtures, not G1 physics rollouts",
+                    "multi-seed retention, plasticity, and SelfCore causal gates are incomplete",
+                    "no candidate is staged or activated by this smoke test",
+                ],
+            },
+            "claims": {
+                "evidence_domain": "CUDA_SCREENING",
+                "four_physical_gpus_exercised": len(self.shards) == 4,
+                "g1_motion_effect_proven": False,
+                "hardware_authorized": False,
+            },
+        }
+
+
+def run_g1_continual_four_gpu_smoke(
+    *,
+    output_dir: Path,
+    source_checkout: Path,
+    updates_per_gpu: int = 3,
+) -> G1ContinualFourGPUSmoke:
+    """Run one isolated learner process per physical GPU and aggregate evidence."""
+
+    root = output_dir.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if root == checkout or checkout in root.parents:
+        raise ValueError("continual four-GPU evidence must be outside source checkout")
+    if not 1 <= updates_per_gpu <= 20:
+        raise ValueError("updates_per_gpu must be in [1, 20]")
+    root.mkdir(parents=True, exist_ok=False)
+    worker = checkout / "scripts/simforge/g1_continual_gpu_worker.py"
+    processes: list[tuple[int, Path, subprocess.Popen[str]]] = []
+    for physical_gpu in range(4):
+        output = root / f"gpu-{physical_gpu}-learner.json"
+        environment = os.environ.copy()
+        environment["CUDA_VISIBLE_DEVICES"] = str(physical_gpu)
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(worker),
+                "--physical-gpu",
+                str(physical_gpu),
+                "--updates",
+                str(updates_per_gpu),
+                "--output",
+                str(output),
+            ],
+            cwd=checkout,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        processes.append((physical_gpu, output, process))
+    shards: list[ContinualGPUShard] = []
+    failures: list[str] = []
+    for physical_gpu, output, process in processes:
+        try:
+            stdout, stderr = process.communicate(timeout=120.0)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+            failures.append(f"gpu{physical_gpu}:timeout:{stdout[-200:]}:{stderr[-400:]}")
+            continue
+        if process.returncode != 0 or not output.is_file():
+            failures.append(
+                f"gpu{physical_gpu}:exit={process.returncode}:{stdout[-200:]}:{stderr[-600:]}"
+            )
+            continue
+        value = json.loads(output.read_text(encoding="utf-8"))
+        shards.append(
+            ContinualGPUShard(
+                physical_gpu=physical_gpu,
+                gpu_uuid=str(value["gpu_uuid"]),
+                candidate_policy_hash=str(value["candidate_policy_hash"]),
+                updates_finite=bool(value["updates_finite"]),
+                stale_actor_transition_count=int(value["stale_actor_transition_count"]),
+                action_bounded=bool(value["action_bounded"]),
+                hidden_activations_finite=bool(value["hidden_activations_finite"]),
+                max_memory_allocated_bytes=int(value["max_memory_allocated_bytes"]),
+                evidence_path=str(output),
+            )
+        )
+    result = G1ContinualFourGPUSmoke(
+        shards=tuple(sorted(shards, key=lambda item: item.physical_gpu)),
+        failures=tuple(failures),
+    )
+    _atomic_json(root / "four-gpu-continual-summary.json", result.to_dict())
+    return result
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True, allow_nan=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+__all__ = [
+    "ContinualGPUShard",
+    "G1ContinualFourGPUSmoke",
+    "run_g1_continual_four_gpu_smoke",
+]

--- a/src/rosclaw/simforge/g1_continual_physical_validation.py
+++ b/src/rosclaw/simforge/g1_continual_physical_validation.py
@@ -1,0 +1,554 @@
+"""Real-MuJoCo to four-CUDA continual learner foundation validation."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.continual.contracts import ExperiencePartition, PolicyVersion, SkillPhase
+from rosclaw.continual.experience import ContinualExperienceStore, ExperienceRecord
+from rosclaw.continual.g1_goalforge import (
+    adapt_goalforge_episode,
+    build_g1_policy_lineage,
+)
+from rosclaw.continual.serde import experience_batch_from_dict, experience_batch_to_dict
+from rosclaw.continual.stability import (
+    ContinualCandidateEvidence,
+    ContinualDecision,
+    StabilityPlasticityGate,
+)
+from rosclaw.continual.weight_update import ResidualWeightSlot, WeightSlotState
+from rosclaw.simforge.backends.unitree_mujoco_backend import (
+    G1MuJoCoBackend,
+    trajectory_digest,
+)
+from rosclaw.simforge.models import Partition
+from rosclaw.simforge.seed_ledger import SeedLedger
+from rosclaw.simforge.tasks.g1_goalforge.concepts import ShotParameters
+from rosclaw.simforge.tasks.g1_goalforge.scenario import generate_goalforge_scenarios
+
+_FOUNDATION_SECRET = b"rosclaw-phase7-physical-continual-foundation-v1"
+
+
+@dataclass(frozen=True)
+class PhysicalRolloutEvidence:
+    replay_partition: str
+    scenario_id: str
+    scenario_commitment: str
+    policy_version: int
+    policy_version_hash: str
+    source_trajectory_hash: str
+    versioned_trajectory_hash: str
+    self_identity_hash: str
+    first_self_state_hash: str
+    last_self_state_hash: str
+    trace_samples: int
+    physics_steps: int
+    status: str
+    critical_cost: bool
+    strict_replay: bool
+    artifact_path: str
+
+
+@dataclass(frozen=True)
+class PhysicalLearnerShard:
+    physical_gpu: int
+    gpu_uuid: str
+    candidate_policy_hash: str
+    candidate_artifact_hash: str
+    batch_hash: str
+    updates_finite: bool
+    actor_transition_count: int
+    critic_transition_count: int
+    stale_actor_transition_count: int
+    action_bounded: bool
+    hidden_activations_finite: bool
+    max_memory_allocated_bytes: int
+    evidence_path: str
+    artifact_path: str
+
+
+@dataclass(frozen=True)
+class G1ContinualPhysicalFoundation:
+    body_hash: str
+    kick_prior_hash: str
+    backend_commit: str
+    rollouts: tuple[PhysicalRolloutEvidence, ...]
+    shards: tuple[PhysicalLearnerShard, ...]
+    failures: tuple[str, ...]
+    gate_report: dict[str, Any]
+    stage_receipt: dict[str, Any]
+    activation_receipt: dict[str, Any]
+    active_policy_unchanged: bool
+    schema_version: str = "rosclaw.continual.g1_physical_foundation.v1"
+
+    @property
+    def passed(self) -> bool:
+        return bool(
+            len(self.rollouts) == 4
+            and len(self.shards) == 4
+            and not self.failures
+            and all(item.physics_steps > 0 and item.strict_replay for item in self.rollouts)
+            and any(
+                item.replay_partition == ExperiencePartition.BOUNDARY.value and item.critical_cost
+                for item in self.rollouts
+            )
+            and len({item.gpu_uuid for item in self.shards}) == 4
+            and all(
+                item.updates_finite
+                and item.actor_transition_count > 0
+                and item.critic_transition_count > item.actor_transition_count
+                and item.stale_actor_transition_count > 0
+                and item.action_bounded
+                and item.hidden_activations_finite
+                and item.max_memory_allocated_bytes > 0
+                for item in self.shards
+            )
+            and self.gate_report["decision"] == ContinualDecision.NEED_MORE_EVIDENCE.value
+            and not self.gate_report["activation_allowed"]
+            and self.activation_receipt["state"] == WeightSlotState.FROZEN.value
+            and self.active_policy_unchanged
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "body_hash": self.body_hash,
+            "kick_prior_hash": self.kick_prior_hash,
+            "backend_commit": self.backend_commit,
+            "rollouts": [asdict(item) for item in self.rollouts],
+            "shards": [asdict(item) for item in self.shards],
+            "failures": list(self.failures),
+            "unique_gpu_uuids": len({item.gpu_uuid for item in self.shards}),
+            "gate_report": self.gate_report,
+            "stage_receipt": self.stage_receipt,
+            "activation_receipt": self.activation_receipt,
+            "active_policy_unchanged": self.active_policy_unchanged,
+            "safe_activation_refusal": bool(
+                self.gate_report["decision"] == ContinualDecision.NEED_MORE_EVIDENCE.value
+                and self.activation_receipt.get("state") == WeightSlotState.FROZEN.value
+                and self.active_policy_unchanged
+            ),
+            "passed": self.passed,
+            "promotion_assessment": {
+                "status": ContinualDecision.NEED_MORE_EVIDENCE.value,
+                "eligible": False,
+                "blockers": [
+                    "the learned candidate has not run matched multi-seed G1 evaluation",
+                    "historical retention and critical-skill regression evidence is absent",
+                    "plasticity and causal SelfCore evidence is absent",
+                    "SIM evidence cannot authorize real hardware",
+                ],
+            },
+            "claims": {
+                "evidence_domain": "SIM_TRAINING_FOUNDATION",
+                "mujoco_physics_transitions": True,
+                "four_physical_gpus_exercised": len(self.shards) == 4,
+                "candidate_staged": bool(self.stage_receipt),
+                "candidate_activated": False,
+                "g1_motion_effect_proven": False,
+                "consciousness_claimed": False,
+                "hardware_authorized": False,
+            },
+        }
+
+
+def run_g1_continual_physical_foundation(
+    *,
+    asset_root: Path,
+    output_dir: Path,
+    source_checkout: Path,
+    updates_per_gpu: int = 3,
+) -> G1ContinualPhysicalFoundation:
+    """Collect physics, ingest on four GPUs, then prove fail-closed activation."""
+
+    root = output_dir.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if root == checkout or checkout in root.parents:
+        raise ValueError("physical continual evidence must be outside the source checkout")
+    if not 1 <= updates_per_gpu <= 20:
+        raise ValueError("updates_per_gpu must be in [1, 20]")
+    root.mkdir(parents=True, exist_ok=False)
+    rollout_root = root / "rollouts"
+    batch_root = root / "batches"
+    learner_root = root / "learners"
+    rollout_root.mkdir()
+    batch_root.mkdir()
+    learner_root.mkdir()
+
+    backend = G1MuJoCoBackend(asset_root=asset_root, trace_stride=5)
+    qualification = backend.qualification
+    lineage = build_g1_policy_lineage(
+        body_hash=qualification.body_hash,
+        kick_prior_hash=qualification.kick_prior_hash,
+        motion_hash=qualification.motion_hash,
+        backend_commit=qualification.backend_commit,
+        torque_guard_scale=backend.torque_guard_scale,
+        through_version=2,
+    )
+    scenarios = _foundation_scenarios()
+    policy_for = {
+        ExperiencePartition.ANCHOR: lineage.policy(0),
+        ExperiencePartition.RECENT: lineage.policy(2),
+        ExperiencePartition.BOUNDARY: lineage.policy(2),
+        ExperiencePartition.SELF: lineage.policy(2),
+    }
+    store = ContinualExperienceStore()
+    rollouts: list[PhysicalRolloutEvidence] = []
+    failures: list[str] = []
+    parameters = ShotParameters()
+    for partition in ExperiencePartition:
+        scenario = scenarios[partition]
+        episode = backend.run(scenario, parameters)
+        replay = backend.run(scenario, parameters)
+        strict_replay = bool(
+            replay.result.summary_dict() == episode.result.summary_dict()
+            and trajectory_digest(replay.trajectory) == trajectory_digest(episode.trajectory)
+        )
+        policy = policy_for[partition]
+        adaptation = adapt_goalforge_episode(
+            episode,
+            policy=policy,
+            strict_replay=strict_replay,
+        )
+        episode_path = rollout_root / f"{partition.value}.npz"
+        np.savez_compressed(episode_path, **episode.trajectory)
+        _atomic_json(
+            rollout_root / f"{partition.value}.json",
+            {
+                "scenario": scenario.to_private_dict(),
+                "result": episode.result.summary_dict(),
+                "source_trajectory_hash": adaptation.source_trajectory_hash,
+                "versioned_trajectory_hash": adaptation.trajectory.trajectory_hash,
+                "strict_replay": strict_replay,
+            },
+        )
+        record = _record(partition, adaptation.trajectory, scenario.scenario_commitment)
+        store.append(record)
+        rollout = PhysicalRolloutEvidence(
+            replay_partition=partition.value,
+            scenario_id=scenario.scenario_id,
+            scenario_commitment=scenario.scenario_commitment,
+            policy_version=policy.version,
+            policy_version_hash=policy.version_hash,
+            source_trajectory_hash=adaptation.source_trajectory_hash,
+            versioned_trajectory_hash=adaptation.trajectory.trajectory_hash,
+            self_identity_hash=adaptation.self_identity_hash,
+            first_self_state_hash=adaptation.self_state_hashes[0],
+            last_self_state_hash=adaptation.self_state_hashes[-1],
+            trace_samples=len(episode.trajectory["time"]),
+            physics_steps=episode.result.physics_steps,
+            status=episode.result.status.value,
+            critical_cost=adaptation.trajectory.has_critical_cost,
+            strict_replay=strict_replay,
+            artifact_path=str(episode_path),
+        )
+        rollouts.append(rollout)
+        if not strict_replay:
+            failures.append(f"{partition.value}:strict replay failed")
+    boundary = next(
+        item for item in rollouts if item.replay_partition == ExperiencePartition.BOUNDARY.value
+    )
+    if not boundary.critical_cost:
+        failures.append("boundary:80N rollout did not produce a critical safety cost")
+
+    batch_paths: list[Path] = []
+    for gpu in range(4):
+        batch = store.sample(batch_size=64, learner_version=2, seed=17001 + gpu)
+        envelope = experience_batch_to_dict(batch)
+        roundtrip = experience_batch_from_dict(envelope)
+        if roundtrip.batch_hash != batch.batch_hash:
+            failures.append(f"gpu{gpu}:experience codec roundtrip mismatch")
+        path = batch_root / f"gpu-{gpu}-experience.json"
+        _atomic_json(path, envelope)
+        batch_paths.append(path)
+
+    shards, worker_failures = _run_workers(
+        checkout=checkout,
+        learner_root=learner_root,
+        batch_paths=batch_paths,
+        updates_per_gpu=updates_per_gpu,
+    )
+    failures.extend(worker_failures)
+    gate_report: dict[str, Any] = {
+        "decision": ContinualDecision.NEED_MORE_EVIDENCE.value,
+        "activation_allowed": False,
+        "checks": [],
+    }
+    stage_receipt: dict[str, Any] = {}
+    activation_receipt: dict[str, Any] = {}
+    active_unchanged = False
+    if shards:
+        selected = next((item for item in shards if item.physical_gpu == 2), shards[0])
+        candidate_value = json.loads(Path(selected.evidence_path).read_text(encoding="utf-8"))
+        candidate = _policy_from_dict(candidate_value["candidate_policy"])
+        artifact = Path(selected.artifact_path).read_bytes()
+        parent = lineage.policy(2)
+        slot = ResidualWeightSlot(parent, active_artifact=lineage.artifact(2))
+        stage = slot.stage(candidate, artifact=artifact)
+        stage_receipt = _weight_receipt(stage)
+        counts = experience_batch_from_dict(
+            json.loads(batch_paths[selected.physical_gpu].read_text(encoding="utf-8"))
+        ).requested_counts
+        evidence = ContinualCandidateEvidence(
+            parent_policy_hash=parent.artifact_hash,
+            candidate_policy_hash=candidate.artifact_hash,
+            body_hash=candidate.body_hash,
+            parent_body_hash=parent.body_hash,
+            safety_kernel_hash=candidate.safety_kernel_hash,
+            parent_safety_kernel_hash=parent.safety_kernel_hash,
+            task_retention=(),
+            plasticity=None,
+            self_core=None,
+            replay_recent_count=counts[ExperiencePartition.RECENT],
+            replay_anchor_count=counts[ExperiencePartition.ANCHOR],
+            replay_boundary_count=counts[ExperiencePartition.BOUNDARY],
+            replay_self_count=counts[ExperiencePartition.SELF],
+            anchor_action_drift_rms=0.0,
+            critical_safety_regressions=0,
+            stale_action_executions=0,
+            old_version_replays=0,
+            candidate_evaluation_complete=False,
+        )
+        report = StabilityPlasticityGate().evaluate(evidence)
+        gate_report = _gate_report(report)
+        activation = slot.activate(phase=SkillPhase.PREPARE, gate_report=report)
+        activation_receipt = _weight_receipt(activation)
+        active_unchanged = slot.active.version_hash == parent.version_hash
+    else:
+        failures.append("no CUDA learner candidate was available for staging")
+
+    result = G1ContinualPhysicalFoundation(
+        body_hash=qualification.body_hash,
+        kick_prior_hash=qualification.kick_prior_hash,
+        backend_commit=qualification.backend_commit,
+        rollouts=tuple(rollouts),
+        shards=tuple(sorted(shards, key=lambda item: item.physical_gpu)),
+        failures=tuple(failures),
+        gate_report=gate_report,
+        stage_receipt=stage_receipt,
+        activation_receipt=activation_receipt,
+        active_policy_unchanged=active_unchanged,
+    )
+    _atomic_json(root / "physical-continual-summary.json", result.to_dict())
+    return result
+
+
+def _foundation_scenarios():
+    ledger = SeedLedger(task_id="g1_penalty_kick", secret=_FOUNDATION_SECRET)
+    generated = {
+        ExperiencePartition.ANCHOR: generate_goalforge_scenarios(
+            ledger=ledger,
+            partition=Partition.VALIDATION,
+            count=1,
+            generation=0,
+        )[0],
+        ExperiencePartition.RECENT: generate_goalforge_scenarios(
+            ledger=ledger,
+            partition=Partition.DEVELOPMENT,
+            count=1,
+            generation=0,
+        )[0],
+        ExperiencePartition.BOUNDARY: generate_goalforge_scenarios(
+            ledger=ledger,
+            partition=Partition.COUNTEREXAMPLE_REGRESSION,
+            count=1,
+            generation=0,
+        )[0],
+        ExperiencePartition.SELF: generate_goalforge_scenarios(
+            ledger=ledger,
+            partition=Partition.STRESS,
+            count=1,
+            generation=0,
+        )[0],
+    }
+    return {
+        ExperiencePartition.ANCHOR: replace(
+            generated[ExperiencePartition.ANCHOR],
+            scenario_id="g1-continual-anchor-nominal",
+        ),
+        ExperiencePartition.RECENT: replace(
+            generated[ExperiencePartition.RECENT],
+            scenario_id="g1-continual-recent-35n",
+            disturbance_n=35.0,
+        ),
+        ExperiencePartition.BOUNDARY: replace(
+            generated[ExperiencePartition.BOUNDARY],
+            scenario_id="g1-continual-boundary-80n",
+            disturbance_n=80.0,
+        ),
+        ExperiencePartition.SELF: replace(
+            generated[ExperiencePartition.SELF],
+            scenario_id="g1-continual-self-zero-bias",
+            joint_zero_bias_rad=0.02,
+        ),
+    }
+
+
+def _record(partition, trajectory, scenario_commitment):
+    if partition is ExperiencePartition.ANCHOR:
+        return ExperienceRecord(
+            trajectory,
+            partition,
+            anchor_policy_hash=trajectory.policy.artifact_hash,
+        )
+    if partition is ExperiencePartition.BOUNDARY:
+        return ExperienceRecord(
+            trajectory,
+            partition,
+            boundary_reason="80N lateral-push critical counterexample",
+            near_boundary_score=1.0 if not trajectory.has_critical_cost else 0.0,
+        )
+    if partition is ExperiencePartition.SELF:
+        return ExperienceRecord(
+            trajectory,
+            partition,
+            self_change_hash=scenario_commitment,
+        )
+    return ExperienceRecord(trajectory, partition)
+
+
+def _run_workers(*, checkout, learner_root, batch_paths, updates_per_gpu):
+    worker = checkout / "scripts/simforge/g1_continual_gpu_worker.py"
+    processes = []
+    for gpu, batch_path in enumerate(batch_paths):
+        output = learner_root / f"gpu-{gpu}-learner.json"
+        artifact = learner_root / f"gpu-{gpu}-candidate.bin"
+        environment = os.environ.copy()
+        environment["CUDA_VISIBLE_DEVICES"] = str(gpu)
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(worker),
+                "--physical-gpu",
+                str(gpu),
+                "--updates",
+                str(updates_per_gpu),
+                "--experience-batch",
+                str(batch_path),
+                "--input-domain",
+                "mujoco_goalforge",
+                "--artifact-output",
+                str(artifact),
+                "--output",
+                str(output),
+            ],
+            cwd=checkout,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        processes.append((gpu, output, artifact, process))
+    shards = []
+    failures = []
+    for gpu, output, artifact, process in processes:
+        try:
+            stdout, stderr = process.communicate(timeout=180.0)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+            failures.append(f"gpu{gpu}:timeout:{stdout[-200:]}:{stderr[-600:]}")
+            continue
+        if process.returncode != 0 or not output.is_file() or not artifact.is_file():
+            (learner_root / f"gpu-{gpu}-failure.log").write_text(
+                f"exit={process.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}\n",
+                encoding="utf-8",
+            )
+            failures.append(f"gpu{gpu}:exit={process.returncode}:{stdout[-200:]}:{stderr[-800:]}")
+            continue
+        value = json.loads(output.read_text(encoding="utf-8"))
+        if not value["claims"]["mujoco_physics_transitions"]:
+            failures.append(f"gpu{gpu}:worker did not bind MuJoCo input domain")
+            continue
+        shards.append(
+            PhysicalLearnerShard(
+                physical_gpu=gpu,
+                gpu_uuid=str(value["gpu_uuid"]),
+                candidate_policy_hash=str(value["candidate_policy_hash"]),
+                candidate_artifact_hash=str(value["candidate_artifact_hash"]),
+                batch_hash=str(value["batch_hash"]),
+                updates_finite=bool(value["updates_finite"]),
+                actor_transition_count=int(value["actor_transition_count"]),
+                critic_transition_count=int(value["critic_transition_count"]),
+                stale_actor_transition_count=int(value["stale_actor_transition_count"]),
+                action_bounded=bool(value["action_bounded"]),
+                hidden_activations_finite=bool(value["hidden_activations_finite"]),
+                max_memory_allocated_bytes=int(value["max_memory_allocated_bytes"]),
+                evidence_path=str(output),
+                artifact_path=str(artifact),
+            )
+        )
+    return shards, failures
+
+
+def _policy_from_dict(value: dict[str, Any]) -> PolicyVersion:
+    return PolicyVersion(
+        version=int(value["version"]),
+        artifact_hash=str(value["artifact_hash"]),
+        parent_version_hash=value.get("parent_version_hash"),
+        controller_snapshot_hash=str(value["controller_snapshot_hash"]),
+        body_hash=str(value["body_hash"]),
+        safety_kernel_hash=str(value["safety_kernel_hash"]),
+        observation_names=tuple(value["observation_names"]),
+        residual_action_names=tuple(value["residual_action_names"]),
+    )
+
+
+def _gate_report(report):
+    return {
+        "schema_version": report.schema_version,
+        "decision": report.decision.value,
+        "checks": [
+            {"name": item.name, "status": item.status.value, "detail": item.detail}
+            for item in report.checks
+        ],
+        "parent_policy_hash": report.parent_policy_hash,
+        "candidate_policy_hash": report.candidate_policy_hash,
+        "rollback_target_hash": report.rollback_target_hash,
+        "activation_allowed": report.activation_allowed,
+        "evidence_domain": report.evidence_domain,
+        "report_hash": report.report_hash,
+    }
+
+
+def _weight_receipt(receipt):
+    return {
+        "schema_version": receipt.schema_version,
+        "state": receipt.state.value,
+        "active_version_hash": receipt.active_version_hash,
+        "candidate_version_hash": receipt.candidate_version_hash,
+        "rollback_version_hash": receipt.rollback_version_hash,
+        "reason": receipt.reason,
+        "hardware_authorized": receipt.hardware_authorized,
+    }
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True, allow_nan=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+__all__ = [
+    "G1ContinualPhysicalFoundation",
+    "PhysicalLearnerShard",
+    "PhysicalRolloutEvidence",
+    "run_g1_continual_physical_foundation",
+]

--- a/src/rosclaw/simforge/phase4_cli.py
+++ b/src/rosclaw/simforge/phase4_cli.py
@@ -17,6 +17,9 @@ from rosclaw.simforge.g1_causal_feedback_validation import (
     run_g1_causal_feedback_validation,
 )
 from rosclaw.simforge.g1_continual_gpu_smoke import run_g1_continual_four_gpu_smoke
+from rosclaw.simforge.g1_continual_physical_validation import (
+    run_g1_continual_physical_foundation,
+)
 from rosclaw.simforge.g1_cpu_gpu_agreement import run_cpu_gpu_label_agreement
 from rosclaw.simforge.g1_doctor import doctor_goalforge, write_doctor_report
 from rosclaw.simforge.g1_feedback_evolution import run_g1_feedback_evolution
@@ -111,6 +114,7 @@ def _recovery_validation(argv: list[str]) -> int:
             "feedback-ilc",
             "feedback-evolution",
             "continual-four-gpu-smoke",
+            "continual-physical-foundation",
         ),
         default="recovery",
     )
@@ -124,6 +128,14 @@ def _recovery_validation(argv: list[str]) -> int:
     parser.add_argument("--chaos-evidence", type=Path)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
+    if args.profile == "continual-physical-foundation":
+        result = run_g1_continual_physical_foundation(
+            asset_root=args.asset_root,
+            output_dir=args.output,
+            source_checkout=_source_checkout(),
+        )
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return 0 if result.passed else 2
     if args.profile == "continual-four-gpu-smoke":
         result = run_g1_continual_four_gpu_smoke(
             output_dir=args.output,

--- a/src/rosclaw/simforge/phase4_cli.py
+++ b/src/rosclaw/simforge/phase4_cli.py
@@ -13,6 +13,10 @@ from rosclaw.auto.g1_kick.continual_runner import (
 from rosclaw.robot_pack.g1.chaos import run_g1_executor_chaos
 from rosclaw.robot_pack.g1.dds_adapter import run_unitree_dds_loopback
 from rosclaw.simforge.backends.unitree_mujoco_backend import qualify_g1_assets
+from rosclaw.simforge.g1_causal_feedback_validation import (
+    run_g1_causal_feedback_validation,
+)
+from rosclaw.simforge.g1_continual_gpu_smoke import run_g1_continual_four_gpu_smoke
 from rosclaw.simforge.g1_cpu_gpu_agreement import run_cpu_gpu_label_agreement
 from rosclaw.simforge.g1_doctor import doctor_goalforge, write_doctor_report
 from rosclaw.simforge.g1_feedback_evolution import run_g1_feedback_evolution
@@ -102,9 +106,11 @@ def _recovery_validation(argv: list[str]) -> int:
             "recovery",
             "nominal-success",
             "feedback-reflex",
+            "feedback-causal",
             "feedback-holdout",
             "feedback-ilc",
             "feedback-evolution",
+            "continual-four-gpu-smoke",
         ),
         default="recovery",
     )
@@ -118,6 +124,21 @@ def _recovery_validation(argv: list[str]) -> int:
     parser.add_argument("--chaos-evidence", type=Path)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
+    if args.profile == "continual-four-gpu-smoke":
+        result = run_g1_continual_four_gpu_smoke(
+            output_dir=args.output,
+            source_checkout=_source_checkout(),
+        )
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return 0 if result.passed else 2
+    if args.profile == "feedback-causal":
+        result = run_g1_causal_feedback_validation(
+            asset_root=args.asset_root,
+            output_path=args.output,
+            source_checkout=_source_checkout(),
+        )
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return 0 if result.passed else 2
     if args.profile == "feedback-evolution":
         evidence_paths = {
             "--feedback-evidence": args.feedback_evidence,

--- a/tests/continual/__init__.py
+++ b/tests/continual/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 7 continual-learning tests."""

--- a/tests/continual/helpers.py
+++ b/tests/continual/helpers.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import hashlib
+
+from rosclaw.continual.contracts import (
+    ControlSegment,
+    CostVector,
+    PolicyVersion,
+    RewardVector,
+    SkillPhase,
+    VersionedTrajectory,
+)
+
+
+def digest(value: bytes | str) -> str:
+    payload = value.encode() if isinstance(value, str) else value
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def policy(version: int, *, parent: PolicyVersion | None = None) -> tuple[PolicyVersion, bytes]:
+    artifact = f"policy-{version}".encode()
+    value = PolicyVersion(
+        version=version,
+        artifact_hash=digest(artifact),
+        parent_version_hash=parent.version_hash if parent else None,
+        controller_snapshot_hash=digest("controller"),
+        body_hash=digest("body"),
+        safety_kernel_hash=digest("safety"),
+        observation_names=("roll", "pitch"),
+        residual_action_names=("pelvis_roll",),
+    )
+    return value, artifact
+
+
+def trajectory(
+    value: PolicyVersion,
+    *,
+    episode: str = "episode-1",
+    critical: bool = False,
+) -> VersionedTrajectory:
+    first = segment(value, episode=episode, start=0, end=1, phase=SkillPhase.PREPARE)
+    final = segment(
+        value,
+        episode=episode,
+        start=1,
+        end=2,
+        phase=SkillPhase.RECOVERY,
+        terminal=True,
+        critical=critical,
+    )
+    return VersionedTrajectory((first, final), strict_replay=True)
+
+
+def segment(
+    value: PolicyVersion,
+    *,
+    episode: str,
+    start: int,
+    end: int,
+    phase: SkillPhase,
+    terminal: bool = False,
+    critical: bool = False,
+) -> ControlSegment:
+    return ControlSegment(
+        segment_id=f"{episode}:{start}",
+        episode_id=episode,
+        task_id="g1_target_kick",
+        phase=phase,
+        start_step=start,
+        end_step=end,
+        policy=value,
+        controller_snapshot_hash=value.controller_snapshot_hash,
+        body_hash=value.body_hash,
+        regime_hash=digest("regime"),
+        self_state_hash=digest("self-state"),
+        observation={"roll": 0.1, "pitch": -0.1},
+        residual_action={"pelvis_roll": -0.01},
+        next_observation={"roll": 0.08, "pitch": -0.09},
+        behavior_logprob=-0.5,
+        reward=RewardVector(task=1.0, balance=0.2),
+        cost=CostVector(fall=1.0 if critical else 0.0, energy=0.1),
+        terminal=terminal,
+    )

--- a/tests/continual/test_contracts.py
+++ b/tests/continual/test_contracts.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.continual.contracts import ExperienceUse, SkillPhase, VersionedTrajectory
+from tests.continual.helpers import policy, segment, trajectory
+
+
+def test_high_dynamic_episode_is_bound_to_one_policy_version() -> None:
+    v0, _ = policy(0)
+    v1, _ = policy(1, parent=v0)
+    segments = (
+        segment(v0, episode="mixed", start=0, end=1, phase=SkillPhase.PREPARE),
+        segment(
+            v1,
+            episode="mixed",
+            start=1,
+            end=2,
+            phase=SkillPhase.SWING,
+            terminal=True,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="cannot cross policy versions"):
+        VersionedTrajectory(segments, strict_replay=True)
+
+
+def test_policy_lag_downgrades_actor_data_without_discarding_self_data() -> None:
+    v0, _ = policy(0)
+    value = trajectory(v0)
+
+    assert value.permitted_use(learner_version=1) is ExperienceUse.ACTOR_CRITIC_SELF
+    assert value.permitted_use(learner_version=2) is ExperienceUse.CRITIC_SELF_ONLY
+    assert value.permitted_use(learner_version=-1) is ExperienceUse.REJECT
+
+
+def test_observation_order_is_part_of_policy_contract() -> None:
+    v0, _ = policy(0)
+    with pytest.raises(ValueError, match="observation order"):
+        type(segment(v0, episode="order", start=0, end=1, phase=SkillPhase.STAND))(
+            segment_id="bad-order",
+            episode_id="order",
+            task_id="stand",
+            phase=SkillPhase.STAND,
+            start_step=0,
+            end_step=1,
+            policy=v0,
+            controller_snapshot_hash=v0.controller_snapshot_hash,
+            body_hash=v0.body_hash,
+            regime_hash="sha256:" + "1" * 64,
+            self_state_hash="sha256:" + "2" * 64,
+            observation={"pitch": 0.0, "roll": 0.0},
+            residual_action={"pelvis_roll": 0.0},
+            next_observation={"roll": 0.0, "pitch": 0.0},
+            behavior_logprob=0.0,
+            reward=segment(v0, episode="source", start=0, end=1, phase=SkillPhase.STAND).reward,
+            cost=segment(v0, episode="source", start=0, end=1, phase=SkillPhase.STAND).cost,
+            terminal=True,
+        )

--- a/tests/continual/test_experience.py
+++ b/tests/continual/test_experience.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.continual.contracts import ExperiencePartition
+from rosclaw.continual.experience import (
+    ContinualExperienceStore,
+    ExperienceRecord,
+)
+from tests.continual.helpers import digest, policy, trajectory
+
+
+def test_four_buffer_mix_is_exact_and_stale_actor_data_is_downgraded() -> None:
+    v0, _ = policy(0)
+    v1, _ = policy(1, parent=v0)
+    v2, _ = policy(2, parent=v1)
+    store = ContinualExperienceStore()
+    store.append(ExperienceRecord(trajectory(v2, episode="recent"), ExperiencePartition.RECENT))
+    store.append(
+        ExperienceRecord(
+            trajectory(v0, episode="anchor"),
+            ExperiencePartition.ANCHOR,
+            anchor_policy_hash=v0.artifact_hash,
+        )
+    )
+    store.append(
+        ExperienceRecord(
+            trajectory(v2, episode="boundary", critical=True),
+            ExperiencePartition.BOUNDARY,
+            boundary_reason="fall counterexample",
+        )
+    )
+    store.append(
+        ExperienceRecord(
+            trajectory(v2, episode="self"),
+            ExperiencePartition.SELF,
+            self_change_hash=digest("right-hip-gain-drop"),
+        )
+    )
+
+    batch = store.sample(batch_size=20, learner_version=2, seed=7)
+
+    assert batch.requested_counts == {
+        ExperiencePartition.RECENT: 10,
+        ExperiencePartition.ANCHOR: 5,
+        ExperiencePartition.BOUNDARY: 3,
+        ExperiencePartition.SELF: 2,
+    }
+    assert len(batch.actor_records) == 15
+    assert len(batch.critic_self_only_records) == 5
+    assert len(batch.batch_hash) == 71
+
+
+def test_boundary_buffer_rejects_ordinary_non_boundary_rollout() -> None:
+    v0, _ = policy(0)
+    with pytest.raises(ValueError, match="safety event or near miss"):
+        ExperienceRecord(
+            trajectory(v0),
+            ExperiencePartition.BOUNDARY,
+            boundary_reason="not actually close",
+        )
+
+
+def test_replay_fails_closed_until_all_partitions_exist() -> None:
+    v0, _ = policy(0)
+    store = ContinualExperienceStore()
+    store.append(ExperienceRecord(trajectory(v0), ExperiencePartition.RECENT))
+
+    with pytest.raises(RuntimeError, match="empty partitions"):
+        store.sample(batch_size=20, learner_version=0, seed=1)

--- a/tests/continual/test_g1_goalforge_adapter.py
+++ b/tests/continual/test_g1_goalforge_adapter.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import numpy as np
+
+from rosclaw.continual.contracts import SkillPhase
+from rosclaw.continual.g1_goalforge import (
+    G1_CONTINUAL_ACTIONS,
+    G1_CONTINUAL_OBSERVATIONS,
+    adapt_goalforge_episode,
+    build_g1_policy_lineage,
+)
+from rosclaw.simforge.backends.unitree_mujoco_backend import GoalForgeEpisode
+from rosclaw.simforge.models import Partition
+from rosclaw.simforge.tasks.g1_goalforge.concepts import (
+    GoalForgeResult,
+    GoalForgeStatus,
+    ShotParameters,
+    hash_json,
+)
+from rosclaw.simforge.tasks.g1_goalforge.scenario import GoalForgeScenario
+from tests.continual.helpers import digest
+
+
+def test_goalforge_adapter_emits_version_pinned_self_bound_transitions() -> None:
+    lineage = build_g1_policy_lineage(
+        body_hash=digest("qualified-body"),
+        kick_prior_hash=digest("kick-prior"),
+        motion_hash=digest("motion"),
+        backend_commit="abc123",
+        torque_guard_scale=0.85,
+    )
+    episode = GoalForgeEpisode(
+        scenario=_scenario(),
+        parameters=ShotParameters(),
+        result=_result(),
+        receipt=None,
+        artifact_root=None,
+        trajectory=_trace(),
+    )
+
+    adapted = adapt_goalforge_episode(
+        episode,
+        policy=lineage.policy(2),
+        strict_replay=True,
+    )
+
+    trajectory = adapted.trajectory
+    assert trajectory.strict_replay
+    assert tuple(trajectory.segments[0].observation) == G1_CONTINUAL_OBSERVATIONS
+    assert tuple(trajectory.segments[0].residual_action) == G1_CONTINUAL_ACTIONS
+    assert [segment.phase for segment in trajectory.segments] == [
+        SkillPhase.STAND,
+        SkillPhase.PREPARE,
+        SkillPhase.WEIGHT_TRANSFER,
+        SkillPhase.SWING,
+        SkillPhase.CONTACT,
+        SkillPhase.COMPLETE,
+    ]
+    assert all(segment.policy.version == 2 for segment in trajectory.segments)
+    assert len(set(adapted.self_state_hashes)) == len(adapted.self_state_hashes)
+    assert trajectory.has_critical_cost
+    assert trajectory.segments[-1].cost.joint_limit == 1.0
+
+
+def _scenario() -> GoalForgeScenario:
+    return GoalForgeScenario(
+        scenario_id="adapter-episode",
+        partition=Partition.DEVELOPMENT,
+        seed=1,
+        seed_commitment=hash_json({"seed": 1}),
+        generation=0,
+        ball_x_m=1.0,
+        ball_y_m=0.0,
+        ball_velocity_x_mps=0.0,
+        ball_velocity_y_mps=0.0,
+        target_y_m=0.0,
+        target_z_m=0.2,
+        ball_mass_kg=0.41,
+        ball_ground_friction=0.05,
+        restitution=0.55,
+        support_ground_friction=1.0,
+        control_latency_ms=0.0,
+        observation_noise_m=0.0,
+        joint_zero_bias_rad=0.02,
+        disturbance_n=35.0,
+    )
+
+
+def _result() -> GoalForgeResult:
+    return GoalForgeResult(
+        status=GoalForgeStatus.JOINT_LIMIT_EXCEEDED,
+        success=False,
+        physics_executed=True,
+        contact_observed=True,
+        kick_foot_contacted=True,
+        goal_crossed=False,
+        target_zone_hit=False,
+        target_error_m=float("inf"),
+        ball_speed_mps=4.0,
+        ball_contact_time_sec=5.0,
+        contact_impulse_ns=2.0,
+        support_foot_slip_m=0.02,
+        com_margin_min_m=0.03,
+        torso_roll_peak_rad=0.3,
+        torso_pitch_peak_rad=0.2,
+        peak_torque_scale=0.8,
+        joint_limit_violation=True,
+        torque_limit_violation=False,
+        actuator_saturation=False,
+        post_kick_fall=False,
+        post_kick_stability_time_sec=1.0,
+        final_pelvis_height_m=0.75,
+        physics_steps=7000,
+        finite_state=True,
+        robustness=-0.1,
+    )
+
+
+def _trace() -> dict[str, np.ndarray]:
+    count = 7
+    torque = np.zeros((count, 29), dtype=np.float64)
+    torque[:, 0] = np.linspace(0.0, 20.0, count)
+    return {
+        "time": np.arange(count, dtype=np.float64) * 0.1,
+        "joint_torque": torque,
+        "torso_quaternion": np.tile([1.0, 0.0, 0.0, 0.0], (count, 1)),
+        "com_y_relative": np.linspace(0.0, 0.04, count),
+        "support_foot_slip": np.linspace(0.0, 0.02, count),
+        "ball_lateral_error_m": np.linspace(0.1, 0.0, count),
+        "policy_phase": np.asarray([0.0, 0.1, 0.3, 0.45, 0.5, 0.7, 1.0]),
+        "contact_impulse": np.asarray([0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0]),
+    }

--- a/tests/continual/test_learner.py
+++ b/tests/continual/test_learner.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+pytest.importorskip("torch")
+
+from rosclaw.continual.contracts import ExperiencePartition
+from rosclaw.continual.experience import ContinualExperienceStore, ExperienceRecord
+from rosclaw.continual.learner import ConstrainedResidualSAC, ResidualSACConfig
+from tests.continual.helpers import digest, policy, trajectory
+
+
+def _batch():
+    v0, _ = policy(0)
+    v1, _ = policy(1, parent=v0)
+    v2, _ = policy(2, parent=v1)
+    store = ContinualExperienceStore()
+    for index in range(8):
+        store.append(
+            ExperienceRecord(trajectory(v2, episode=f"recent-{index}"), ExperiencePartition.RECENT)
+        )
+    for index in range(4):
+        store.append(
+            ExperienceRecord(
+                trajectory(v0, episode=f"anchor-{index}"),
+                ExperiencePartition.ANCHOR,
+                anchor_policy_hash=v0.artifact_hash,
+            )
+        )
+    for index in range(3):
+        store.append(
+            ExperienceRecord(
+                trajectory(v2, episode=f"boundary-{index}", critical=True),
+                ExperiencePartition.BOUNDARY,
+                boundary_reason="fall",
+            )
+        )
+    for index in range(2):
+        store.append(
+            ExperienceRecord(
+                trajectory(v2, episode=f"self-{index}"),
+                ExperiencePartition.SELF,
+                self_change_hash=digest(f"body-change-{index}"),
+            )
+        )
+    return v2, store.sample(batch_size=20, learner_version=2, seed=5)
+
+
+def test_constrained_residual_sac_updates_without_using_stale_anchor_for_actor() -> None:
+    parent, batch = _batch()
+    learner = ConstrainedResidualSAC(
+        ResidualSACConfig(
+            observation_names=parent.observation_names,
+            action_names=parent.residual_action_names,
+            action_limits=(0.04,),
+            hidden_dims=(16, 16),
+            batch_size=16,
+            seed=3,
+        )
+    )
+
+    first_update = learner.update(batch)
+    update = learner.update(batch)
+    candidate, artifact = learner.candidate_policy(parent=parent)
+    action = learner.action({"roll": 0.2, "pitch": -0.1})
+
+    assert update.finite
+    assert first_update.step_churn > 0.0
+    assert update.churn_loss > 0.0
+    assert update.stale_actor_transition_count > 0
+    assert all(math.isfinite(value) for value in (update.actor_loss, update.critic_loss))
+    assert abs(action["pelvis_roll"]) <= 0.04
+    assert candidate.version == parent.version + 1
+    assert candidate.parent_version_hash == parent.version_hash
+    assert artifact
+
+
+def test_actor_exposes_hidden_activations_for_post_hoc_selfcore_analysis() -> None:
+    parent, _ = _batch()
+    learner = ConstrainedResidualSAC(
+        ResidualSACConfig(
+            observation_names=parent.observation_names,
+            action_names=parent.residual_action_names,
+            action_limits=(0.04,),
+            hidden_dims=(8, 6),
+        )
+    )
+
+    first, second = learner.hidden_activations(
+        __import__("numpy").asarray([[0.0, 0.0], [0.1, -0.1]], dtype=float)
+    )
+
+    assert first.shape == (2, 8)
+    assert second.shape == (2, 6)

--- a/tests/continual/test_serde.py
+++ b/tests/continual/test_serde.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+
+import pytest
+
+from rosclaw.continual.contracts import ExperiencePartition
+from rosclaw.continual.experience import ContinualExperienceStore, ExperienceRecord
+from rosclaw.continual.serde import experience_batch_from_dict, experience_batch_to_dict
+from tests.continual.helpers import digest, policy, trajectory
+
+
+def _batch():
+    v0, _ = policy(0)
+    v1, _ = policy(1, parent=v0)
+    v2, _ = policy(2, parent=v1)
+    store = ContinualExperienceStore()
+    store.append(ExperienceRecord(trajectory(v2, episode="recent"), ExperiencePartition.RECENT))
+    store.append(
+        ExperienceRecord(
+            trajectory(v0, episode="anchor"),
+            ExperiencePartition.ANCHOR,
+            anchor_policy_hash=v0.artifact_hash,
+        )
+    )
+    store.append(
+        ExperienceRecord(
+            trajectory(v2, episode="boundary", critical=True),
+            ExperiencePartition.BOUNDARY,
+            boundary_reason="fall",
+        )
+    )
+    store.append(
+        ExperienceRecord(
+            trajectory(v2, episode="self"),
+            ExperiencePartition.SELF,
+            self_change_hash=digest("body-change"),
+        )
+    )
+    return store.sample(batch_size=20, learner_version=2, seed=11)
+
+
+def test_experience_batch_codec_is_lossless_and_deduplicates_trajectories() -> None:
+    batch = _batch()
+    envelope = experience_batch_to_dict(batch)
+
+    restored = experience_batch_from_dict(json.loads(json.dumps(envelope, sort_keys=True)))
+
+    assert restored.batch_hash == batch.batch_hash
+    assert len(envelope["records"]) == 20
+    assert len(envelope["trajectories"]) == 4
+    assert restored.records[0].trajectory.trajectory_hash == (
+        batch.records[0].trajectory.trajectory_hash
+    )
+
+
+def test_experience_batch_codec_rejects_tampered_transition() -> None:
+    envelope = deepcopy(experience_batch_to_dict(_batch()))
+    trajectory = next(iter(envelope["trajectories"].values()))
+    trajectory["segments"][0]["observation"]["roll"] += 0.01
+
+    with pytest.raises(ValueError, match="trajectory hash mismatch"):
+        experience_batch_from_dict(envelope)

--- a/tests/continual/test_stability.py
+++ b/tests/continual/test_stability.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from rosclaw.continual.stability import (
+    ContinualCandidateEvidence,
+    ContinualDecision,
+    PlasticityEvidence,
+    SelfCoreEvidence,
+    StabilityPlasticityGate,
+    TaskRetention,
+)
+from tests.continual.helpers import digest
+
+
+def _passing_evidence() -> ContinualCandidateEvidence:
+    return ContinualCandidateEvidence(
+        parent_policy_hash=digest("parent"),
+        candidate_policy_hash=digest("candidate"),
+        body_hash=digest("body"),
+        parent_body_hash=digest("body"),
+        safety_kernel_hash=digest("safety"),
+        parent_safety_kernel_hash=digest("safety"),
+        task_retention=(
+            TaskRetention("stand", 0.95, 0.94, critical=True),
+            TaskRetention("kick", 0.80, 0.82),
+        ),
+        plasticity=PlasticityEvidence(
+            fine_tune_steps_to_threshold=1000,
+            candidate_steps_to_threshold=650,
+            fresh_network_gap_start=0.20,
+            fresh_network_gap_end=0.18,
+            dead_unit_ratio_start=0.05,
+            dead_unit_ratio_end=0.05,
+            effective_rank_start=40.0,
+            effective_rank_end=39.0,
+            output_churn=0.02,
+        ),
+        self_core=SelfCoreEvidence(
+            shared_reference_hash=digest("reference-bank"),
+            continual_seed_count=10,
+            single_task_seed_count=8,
+            threshold_sweep_count=12,
+            persistence_gap=0.16,
+            bootstrap_support=0.99,
+            freeze_matched_pairs=120,
+            freeze_advantage=0.02,
+            lesion_matched_pairs=120,
+            lesion_disadvantage=0.03,
+            body_prediction_improved=True,
+            body_change_update_passed=True,
+        ),
+        replay_recent_count=100,
+        replay_anchor_count=50,
+        replay_boundary_count=30,
+        replay_self_count=20,
+        anchor_action_drift_rms=0.01,
+        critical_safety_regressions=0,
+        stale_action_executions=0,
+        old_version_replays=0,
+    )
+
+
+def test_gate_promotes_only_complete_stability_and_plasticity_evidence() -> None:
+    report = StabilityPlasticityGate().evaluate(_passing_evidence())
+
+    assert report.decision is ContinualDecision.PROMOTE_SIM
+    assert report.activation_allowed
+    assert all(check.status.value == "PASS" for check in report.checks)
+
+
+def test_gate_distinguishes_missing_self_evidence_from_safety_failure() -> None:
+    gate = StabilityPlasticityGate()
+    missing = gate.evaluate(replace(_passing_evidence(), self_core=None))
+    unsafe = gate.evaluate(replace(_passing_evidence(), critical_safety_regressions=1))
+
+    assert missing.decision is ContinualDecision.NEED_MORE_EVIDENCE
+    assert not missing.activation_allowed
+    assert unsafe.decision is ContinualDecision.REJECT
+    assert not unsafe.activation_allowed
+
+
+def test_gate_rejects_catastrophic_forgetting_even_when_new_task_improves() -> None:
+    evidence = replace(
+        _passing_evidence(),
+        task_retention=(
+            TaskRetention("stand", 0.95, 0.80, critical=True),
+            TaskRetention("moving_ball", 0.20, 0.90),
+        ),
+    )
+
+    report = StabilityPlasticityGate().evaluate(evidence)
+
+    assert report.decision is ContinualDecision.REJECT
+    assert any(
+        check.name == "critical_skill" and check.status.value == "FAIL" for check in report.checks
+    )

--- a/tests/continual/test_stability.py
+++ b/tests/continual/test_stability.py
@@ -95,3 +95,24 @@ def test_gate_rejects_catastrophic_forgetting_even_when_new_task_improves() -> N
     assert any(
         check.name == "critical_skill" and check.status.value == "FAIL" for check in report.checks
     )
+
+
+def test_unevaluated_candidate_is_missing_evidence_not_a_fabricated_pass() -> None:
+    evidence = replace(
+        _passing_evidence(),
+        task_retention=(),
+        plasticity=None,
+        self_core=None,
+        candidate_evaluation_complete=False,
+    )
+
+    report = StabilityPlasticityGate().evaluate(evidence)
+
+    assert report.decision is ContinualDecision.NEED_MORE_EVIDENCE
+    assert not report.activation_allowed
+    assert {check.name for check in report.checks if check.status.value == "MISSING"} >= {
+        "safety",
+        "historical_mean",
+        "critical_skill",
+        "anchor_drift",
+    }

--- a/tests/continual/test_weight_update.py
+++ b/tests/continual/test_weight_update.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from rosclaw.continual.contracts import SkillPhase
+from rosclaw.continual.stability import StabilityPlasticityGate
+from rosclaw.continual.weight_update import ResidualWeightSlot, WeightSlotState
+from tests.continual.helpers import policy
+from tests.continual.test_stability import _passing_evidence
+
+
+def test_weight_update_is_atomic_only_at_safe_motion_boundary() -> None:
+    v0, artifact0 = policy(0)
+    v1, artifact1 = policy(1, parent=v0)
+    slot = ResidualWeightSlot(v0, active_artifact=artifact0)
+    staged = slot.stage(v1, artifact=artifact1)
+    evidence = _passing_evidence()
+    evidence = type(evidence)(
+        **{
+            **evidence.__dict__,
+            "parent_policy_hash": v0.artifact_hash,
+            "candidate_policy_hash": v1.artifact_hash,
+        }
+    )
+    report = StabilityPlasticityGate().evaluate(evidence)
+
+    activated = slot.activate(phase=SkillPhase.PREPARE, gate_report=report)
+
+    assert staged.state is WeightSlotState.CANDIDATE_STAGED
+    assert activated.state is WeightSlotState.ACTIVE
+    assert slot.active == v1
+    assert not activated.hardware_authorized
+
+
+def test_mid_swing_weight_swap_freezes_instead_of_switching() -> None:
+    v0, artifact0 = policy(0)
+    v1, artifact1 = policy(1, parent=v0)
+    slot = ResidualWeightSlot(v0, active_artifact=artifact0)
+    slot.stage(v1, artifact=artifact1)
+    evidence = _passing_evidence()
+    evidence = type(evidence)(
+        **{
+            **evidence.__dict__,
+            "parent_policy_hash": v0.artifact_hash,
+            "candidate_policy_hash": v1.artifact_hash,
+        }
+    )
+    report = StabilityPlasticityGate().evaluate(evidence)
+
+    receipt = slot.activate(phase=SkillPhase.SWING, gate_report=report)
+
+    assert receipt.state is WeightSlotState.FROZEN
+    assert slot.active == v0
+    assert slot.candidate == v1

--- a/tests/feedback/control/test_cerebellum.py
+++ b/tests/feedback/control/test_cerebellum.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from rosclaw.feedback.contracts import ErrorState, FeedbackFrame
+from rosclaw.feedback.controllers.cerebellum import G1CerebellumConfig, G1CerebellumController
+from rosclaw.feedback.profiles.g1_cerebellum import build_g1_cerebellum_runtime
+from rosclaw.feedback.replay import RecordedLatencyClock
+
+
+def _frame() -> FeedbackFrame:
+    signals = {
+        "torso_roll": 0.45,
+        "torso_pitch": -0.10,
+        "com_y_relative": 0.02,
+        "contact_phase": 0.40,
+        "ball_lateral_error_m": 0.10,
+    }
+    return FeedbackFrame(
+        sequence=0,
+        timestamp_ns=1,
+        observation_timestamp_ns=1,
+        phase=0.40,
+        reference=dict.fromkeys(signals, 0.0),
+        actual={**signals, "support_slip_m": 0.0, "contact_detected": 0.0},
+        error=ErrorState(
+            value={name: -value for name, value in signals.items()},
+            derivative=dict.fromkeys(signals, 0.0),
+            integral=dict.fromkeys(signals, 0.0),
+            timestamp_ns=1,
+        ),
+    )
+
+
+def test_cerebellum_combines_balance_and_skill_before_projection() -> None:
+    controller = G1CerebellumController(
+        G1CerebellumConfig(
+            phase_modulation_enabled=True,
+            lateral_modulation_enabled=True,
+            recovery_modulation_enabled=True,
+        )
+    )
+
+    residual = controller.compute(_frame(), {})
+
+    assert residual["joint:left_hip_roll_joint"] < 0.0
+    assert residual["joint:right_hip_yaw_joint"] < 0.0
+    assert residual["skill:kick_phase_rate"] > 0.0
+
+
+def test_cerebellum_keeps_uncalibrated_phase_modulation_transparent_by_default() -> None:
+    residual = G1CerebellumController().compute(_frame(), {})
+
+    assert "skill:kick_phase_rate" not in residual
+    assert "joint:right_hip_yaw_joint" not in residual
+
+
+def test_default_cerebellum_runtime_does_not_advertise_disabled_skill_outputs() -> None:
+    runtime = build_g1_cerebellum_runtime(body_hash="sha256:" + "1" * 64)
+
+    assert "skill:kick_phase_rate" not in runtime.spec.output_limits
+    assert "contact_phase" not in runtime.spec.observation_signals
+
+
+def test_cerebellum_profile_projects_composite_outputs_once() -> None:
+    runtime = build_g1_cerebellum_runtime(
+        body_hash="sha256:" + "1" * 64,
+        config=G1CerebellumConfig(
+            phase_modulation_enabled=True,
+            lateral_modulation_enabled=True,
+            recovery_modulation_enabled=True,
+        ),
+        compute_clock_ns=RecordedLatencyClock((100_000,)),
+    )
+    frame = _frame()
+
+    command = runtime.tick(
+        timestamp_ns=20_000_000,
+        observation_timestamp_ns=20_000_000,
+        phase=frame.phase,
+        reference=frame.reference,
+        actual=frame.actual,
+        base_action={},
+    )
+
+    assert command.deadline_met
+    assert abs(command.projected["skill:kick_phase_rate"]) <= 0.08
+    assert abs(command.projected["joint:left_hip_roll_joint"]) <= 0.08

--- a/tests/feedback/control/test_kick_skill.py
+++ b/tests/feedback/control/test_kick_skill.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
 from rosclaw.feedback.contracts import ErrorState, FeedbackFrame
-from rosclaw.feedback.controllers.kick_skill import G1KickSkillFeedbackController
+from rosclaw.feedback.controllers.kick_skill import (
+    G1KickSkillFeedbackConfig,
+    G1KickSkillFeedbackController,
+)
 from rosclaw.feedback.profiles.g1_skill import build_g1_kick_skill_runtime
 from rosclaw.feedback.replay import RecordedLatencyClock
 
@@ -80,3 +85,13 @@ def test_skill_runtime_projects_phase_and_joint_directives() -> None:
     assert command.projected["joint:right_hip_yaw_joint"] == -0.035
     assert command.saturation_count == 2
     assert command.deadline_met
+
+
+def test_expected_contact_phase_is_owned_by_the_controller_config() -> None:
+    controller = G1KickSkillFeedbackController(
+        G1KickSkillFeedbackConfig(expected_contact_phase=0.50)
+    )
+
+    residual = controller.compute(_frame(phase=0.4, contact=False), {})
+
+    assert residual["skill:kick_phase_rate"] == pytest.approx(-0.01)

--- a/tests/self_model/__init__.py
+++ b/tests/self_model/__init__.py
@@ -1,0 +1,1 @@
+"""Embodied self-model tests."""

--- a/tests/self_model/test_contracts.py
+++ b/tests/self_model/test_contracts.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.self_model import (
+    AgencyAssessment,
+    CapabilityBelief,
+    ScalarBelief,
+    SelfIdentity,
+    SelfStateSnapshot,
+)
+from tests.continual.helpers import digest
+
+
+def _belief(mean: float, unit: str) -> ScalarBelief:
+    return ScalarBelief(mean, 0.01, 0.9, unit)
+
+
+def test_self_state_binds_body_health_uncertainty_and_capabilities() -> None:
+    identity = SelfIdentity(
+        body_hash=digest("body"),
+        sensor_layout_hash=digest("sensors"),
+        actuator_layout_hash=digest("actuators"),
+        safety_kernel_hash=digest("safety"),
+        controller_lineage=(digest("controller-0"),),
+        current_policy_versions={"g1_target_kick": 0},
+    )
+    state = SelfStateSnapshot(
+        identity_hash=identity.identity_hash,
+        body_hash=identity.body_hash,
+        sequence=1,
+        timestamp_ns=10,
+        joint_health={"right_hip": 0.8},
+        motor_gain_beliefs={"right_hip": _belief(0.8, "ratio")},
+        joint_zero_bias_beliefs={"right_hip": _belief(0.01, "rad")},
+        latency_belief=_belief(20.0, "ms"),
+        friction_belief=_belief(0.75, "coefficient"),
+        payload_belief=_belief(0.0, "kg"),
+        balance_margin=0.04,
+        energy_state=0.8,
+        sensor_quality={"imu": 0.95},
+        capabilities={"target_kick": CapabilityBelief(0.7, 0.2, 20, 0)},
+    )
+
+    assert state.body_hash == identity.body_hash
+    assert len(state.snapshot_hash) == 71
+    assert state.to_dict()["capabilities"]["target_kick"]["success_probability"] == 0.7
+
+
+def test_discovered_self_core_cannot_exist_without_causal_evidence() -> None:
+    with pytest.raises(ValueError, match="causal evidence"):
+        SelfIdentity(
+            body_hash=digest("body"),
+            sensor_layout_hash=digest("sensors"),
+            actuator_layout_hash=digest("actuators"),
+            safety_kernel_hash=digest("safety"),
+            controller_lineage=(digest("controller"),),
+            current_policy_versions={"stand": 0},
+            discovered_self_core_hash=digest("cluster"),
+        )
+
+
+def test_agency_is_a_calibrated_attribution_contract() -> None:
+    assessment = AgencyAssessment(
+        self_state_hash=digest("self"),
+        action_hash=digest("action"),
+        predicted_outcome_hash=digest("prediction"),
+        observed_outcome_hash=digest("observation"),
+        self_caused_probability=0.1,
+        external_disturbance_probability=0.8,
+        sensor_fault_probability=0.1,
+    )
+
+    assert len(assessment.assessment_hash) == 71

--- a/tests/self_model/test_self_core.py
+++ b/tests/self_model/test_self_core.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rosclaw.self_model import discover_persistent_subnetwork, sweep_thresholds
+from tests.continual.helpers import digest
+
+
+def _activations() -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(42)
+    states = 256
+    body = rng.normal(size=states)
+    source_task = rng.normal(size=(states, 3))
+    target_task = rng.normal(size=(states, 3))
+    source = np.column_stack(
+        (
+            body,
+            body + rng.normal(scale=0.01, size=states),
+            -body + rng.normal(scale=0.01, size=states),
+            source_task,
+        )
+    )
+    target = np.column_stack(
+        (
+            body + rng.normal(scale=0.01, size=states),
+            body + rng.normal(scale=0.01, size=states),
+            -body,
+            target_task,
+        )
+    )
+    return source, target
+
+
+def test_persistent_subnetwork_discovery_is_permutation_aware_but_not_causal() -> None:
+    source, target = _activations()
+    permutation = np.asarray((3, 0, 4, 1, 5, 2))
+    candidate = discover_persistent_subnetwork(
+        source_activations=source,
+        target_activations=target[:, permutation],
+        source_policy_hash=digest("walk"),
+        target_policy_hash=digest("kick"),
+        shared_reference_hash=digest("shared-reference"),
+        layer_name="actor.hidden.0",
+        threshold=0.90,
+    )
+
+    persistent_original_indices = {
+        int(permutation[index]) for index in candidate.persistent_candidate_units
+    }
+    assert persistent_original_indices == {0, 1, 2}
+    assert candidate.persistence_gap > 0.25
+    assert not candidate.causal_validated
+    assert len(candidate.candidate_hash) == 71
+
+
+def test_threshold_sweep_requires_a_stable_midrange_decomposition() -> None:
+    source, target = _activations()
+    result = sweep_thresholds(
+        source_activations=source,
+        target_activations=target,
+        source_policy_hash=digest("walk"),
+        target_policy_hash=digest("kick"),
+        shared_reference_hash=digest("shared-reference"),
+        layer_name="actor.hidden.0",
+        thresholds=(0.80, 0.85, 0.90, 0.95),
+    )
+
+    assert result.stable
+    assert result.positive_gap_fraction == 1.0
+    assert result.median_gap > 0.25
+
+
+def test_discovery_rejects_degenerate_all_connected_network() -> None:
+    source = np.column_stack([np.arange(20, dtype=float)] * 4)
+    with pytest.raises(ValueError, match="degenerate"):
+        discover_persistent_subnetwork(
+            source_activations=source,
+            target_activations=source,
+            source_policy_hash=digest("a"),
+            target_policy_hash=digest("b"),
+            shared_reference_hash=digest("states"),
+            layer_name="hidden",
+            threshold=0.70,
+        )

--- a/tests/simforge/test_g1_causal_feedback_validation.py
+++ b/tests/simforge/test_g1_causal_feedback_validation.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rosclaw.simforge.g1_causal_feedback_validation import (
+    AttitudeWindowMetrics,
+    G1CausalFeedbackValidation,
+    _attitude_error,
+    run_g1_causal_feedback_validation,
+)
+from rosclaw.simforge.g1_feedback_validation import G1FeedbackMetrics
+
+
+def _episode_metrics(*, success: bool) -> G1FeedbackMetrics:
+    return G1FeedbackMetrics(
+        status="SUCCESS" if success else "POST_KICK_FALL",
+        success=success,
+        target_error_m=0.1,
+        support_foot_slip_m=0.01,
+        com_margin_min_m=0.01,
+        torso_roll_peak_rad=0.4,
+        torso_pitch_peak_rad=0.2,
+        post_kick_fall=not success,
+        joint_limit_violation=not success,
+        torque_limit_violation=False,
+        robustness=0.01,
+    )
+
+
+def _window(area: float, peak: float) -> AttitudeWindowMetrics:
+    return AttitudeWindowMetrics(
+        start_sec=4.6,
+        end_sec=13.0,
+        integrated_error_rad_sec=area,
+        peak_error_rad=peak,
+        tail_mean_error_rad=0.2,
+    )
+
+
+def test_causal_gate_requires_effect_isolation_replay_and_attitude_improvement() -> None:
+    result = G1CausalFeedbackValidation(
+        body_hash="sha256:" + "1" * 64,
+        kick_prior_hash="sha256:" + "2" * 64,
+        backend_commit="abc",
+        scenario_id="causal",
+        scenario_commitment="sha256:" + "3" * 64,
+        disturbance_n=80.0,
+        baseline=_episode_metrics(success=False),
+        feedback=_episode_metrics(success=True),
+        baseline_window=_window(2.8, 0.65),
+        feedback_window=_window(2.4, 0.50),
+        baseline_early_window=_window(0.4, 0.3),
+        feedback_early_window=_window(0.42, 0.31),
+        activation_start_sec=5.6,
+        activation_end_sec=7.8,
+        active_trace_samples=100,
+        max_projected_residual_rad=0.08,
+        identical_pre_activation_prefix=True,
+        counterfactual_diverged_after_activation=True,
+        strict_replay=True,
+        deadline_compliance_rate=1.0,
+        feedback_receipt={},
+    )
+
+    assert result.passed
+    assert result.early_transient_regression
+    assert result.to_dict()["promotion_assessment"]["eligible"] is False
+
+
+def test_attitude_error_uses_roll_pitch_not_quaternion_component_norm() -> None:
+    half = np.pi / 8.0
+    quaternion = np.asarray([[np.cos(half), np.sin(half), 0.0, 0.0]])
+
+    assert _attitude_error(quaternion)[0] == pytest.approx(np.pi / 4.0)
+
+
+def test_causal_validation_rejects_evidence_inside_checkout(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="outside"):
+        run_g1_causal_feedback_validation(
+            asset_root=tmp_path / "missing",
+            output_path=tmp_path / "causal.json",
+            source_checkout=tmp_path,
+        )

--- a/tests/simforge/test_g1_continual_gpu_smoke.py
+++ b/tests/simforge/test_g1_continual_gpu_smoke.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rosclaw.simforge.g1_continual_gpu_smoke import (
+    ContinualGPUShard,
+    G1ContinualFourGPUSmoke,
+    run_g1_continual_four_gpu_smoke,
+)
+
+
+def _shard(gpu: int) -> ContinualGPUShard:
+    return ContinualGPUShard(
+        physical_gpu=gpu,
+        gpu_uuid=f"GPU-{gpu}",
+        candidate_policy_hash="sha256:" + str(gpu) * 64,
+        updates_finite=True,
+        stale_actor_transition_count=16,
+        action_bounded=True,
+        hidden_activations_finite=True,
+        max_memory_allocated_bytes=1024,
+        evidence_path=f"/evidence/gpu-{gpu}.json",
+    )
+
+
+def test_four_gpu_smoke_requires_four_distinct_finite_cuda_shards() -> None:
+    result = G1ContinualFourGPUSmoke(
+        shards=tuple(_shard(gpu) for gpu in range(4)),
+        failures=(),
+    )
+
+    assert result.passed
+    assert result.to_dict()["claims"]["g1_motion_effect_proven"] is False
+    assert result.to_dict()["promotion_assessment"]["eligible"] is False
+
+
+def test_four_gpu_smoke_rejects_evidence_inside_checkout(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="outside"):
+        run_g1_continual_four_gpu_smoke(
+            output_dir=tmp_path / "evidence",
+            source_checkout=tmp_path,
+        )

--- a/tests/simforge/test_g1_continual_physical_validation.py
+++ b/tests/simforge/test_g1_continual_physical_validation.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rosclaw.simforge.g1_continual_physical_validation import (
+    G1ContinualPhysicalFoundation,
+    run_g1_continual_physical_foundation,
+)
+
+
+def test_physical_continual_foundation_rejects_evidence_inside_checkout(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="outside"):
+        run_g1_continual_physical_foundation(
+            asset_root=tmp_path / "missing",
+            output_dir=tmp_path / "evidence",
+            source_checkout=tmp_path,
+        )
+
+
+def test_failed_worker_path_still_emits_a_safe_nonpassing_summary() -> None:
+    result = G1ContinualPhysicalFoundation(
+        body_hash="sha256:" + "1" * 64,
+        kick_prior_hash="sha256:" + "2" * 64,
+        backend_commit="abc",
+        rollouts=(),
+        shards=(),
+        failures=("gpu0:failed",),
+        gate_report={"decision": "NEED_MORE_EVIDENCE", "activation_allowed": False},
+        stage_receipt={},
+        activation_receipt={},
+        active_policy_unchanged=False,
+    )
+
+    summary = result.to_dict()
+
+    assert not result.passed
+    assert not summary["safe_activation_refusal"]
+    assert summary["failures"] == ["gpu0:failed"]

--- a/tests/simforge/test_g1_phase_clock.py
+++ b/tests/simforge/test_g1_phase_clock.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.simforge.backends.unitree_mujoco_backend import _apply_feedback_phase_rate
+
+
+def test_positive_phase_rate_advances_policy_clock_only_after_accumulation() -> None:
+    repeat = 1
+    accumulator = 0.0
+    repeats = []
+    for _ in range(13):
+        value, accumulator = _apply_feedback_phase_rate(
+            repeat=repeat,
+            phase_rate=0.08,
+            accumulator=accumulator,
+        )
+        repeats.append(value)
+
+    assert repeats.count(2) == 1
+    assert all(value in {1, 2} for value in repeats)
+
+
+def test_negative_phase_rate_holds_policy_clock_without_reversing_it() -> None:
+    accumulator = 0.0
+    repeats = []
+    for _ in range(13):
+        value, accumulator = _apply_feedback_phase_rate(
+            repeat=1,
+            phase_rate=-0.08,
+            accumulator=accumulator,
+        )
+        repeats.append(value)
+
+    assert repeats.count(0) == 1
+    assert all(value in {0, 1} for value in repeats)
+
+
+def test_phase_rate_rejects_unbounded_directive() -> None:
+    with pytest.raises(ValueError, match=r"in \[-1, 1\]"):
+        _apply_feedback_phase_rate(repeat=1, phase_rate=1.1, accumulator=0.0)


### PR DESCRIPTION
## Summary

This stacked Phase 7 foundation adds a fail-closed continual residual-learning substrate on top of Phase 6 (#120).

- add content-addressed, version-pinned G1 control trajectories and four replay partitions (Recent/Anchor/Boundary/Self)
- add an optional PyTorch Constrained Residual SAC kernel with independent reward/fall/constraint critics, entropy, Lagrange constraints, Anchor distillation, and fixed-parent output churn
- add stability-plasticity promotion gates plus checksum-verified double-buffer staging, safe-phase activation, and rollback
- add operational embodied-self contracts and a permutation-aware post-hoc persistent-subnetwork analyzer that cannot self-assert causal SelfCore status
- connect experimental G1 kick phase directives to the real MuJoCo policy clock, while leaving uncalibrated L2 phase/aim/recovery channels disabled by default
- add a matched 80N feedback off/on causal-window validator and the original isolated four-A6000 contract smoke
- add a real GoalForge MuJoCo → lossless versioned experience → four-A6000 SAC → candidate stage → fail-closed activation loop
- add the Chinese implementation/research report under `docs/validation/`

## Why

Directly fine-tuning the RoboNaldo policy online would couple safety, old-skill retention, and new-skill plasticity. This change keeps the qualified prior and safety kernel frozen, learns only bounded residual candidates, pins every high-dynamic episode to one policy version, routes stale data away from the actor, and refuses activation when stability, plasticity, SelfCore, or safety evidence is missing.

The engineered Embodied Self Model is deliberately separate from the post-hoc SelfCore hypothesis. The latter remains a candidate until multi-seed continual-vs-single-task controls and matched freeze/lesion/body-change tests pass. This PR makes no consciousness or real-hardware claim.

## Real physical-simulation training loop

The new `continual-physical-foundation` profile collected four actual GoalForge MuJoCo rollouts and replayed every one deterministically:

| Replay partition | Scenario | Result | Policy | Physics steps |
|---|---|---|---:|---:|
| Recent | 35 N lateral disturbance | `SUCCESS` | v2 | 6520 |
| Anchor | nominal | `SUCCESS` | v0 | 6520 |
| Boundary | 80 N lateral disturbance | `JOINT_LIMIT_EXCEEDED` | v2 | 6520 |
| Self | 0.02 rad joint-zero bias | `SUCCESS` | v2 | 6520 |

The transport codec deduplicates full trajectories and verifies trajectory, record, and batch hashes after JSON serialization. Each of four isolated RTX A6000 processes consumed the real physics batch and completed three finite SAC updates:

- 8,384 critic transitions per GPU
- 6,288 fresh actor transitions per GPU
- 2,096 stale Anchor transitions per GPU excluded from actor use
- bounded residual actions, finite hidden activations, and four distinct GPU UUIDs

The GPU2 v3 candidate passed artifact checksum, parent, body, and immutable-safety identity checks and was staged. Candidate behavior had not yet completed matched multi-seed evaluation, so safety, retention, critical-skill, Anchor-drift, plasticity, and causal SelfCore evidence remained explicitly missing. The gate returned `NEED_MORE_EVIDENCE`; activation was refused, the slot became `FROZEN`, and active v2 remained unchanged.

This proves the real SIM training/fail-safe systems loop, not G1 motion improvement. The evidence records `g1_motion_effect_proven=false`, `candidate_activated=false`, and `hardware_authorized=false`.

## Validation

- full repository: **5,294 passed, 59 skipped, 27 deselected** (LeRobot 0.6.1 runtime explicitly configured)
- focused feedback + simforge + continual + self-model suite: **184 passed, 1 skipped, 3 deselected**
- Ruff, format, Mypy, compileall, and `git diff --check`: pass
- real MuJoCo strict replay for all four replay partitions: pass
- four distinct physical RTX A6000 UUIDs on both the legacy synthetic smoke and new real-physics ingest: pass
- 80 N matched feedback counterfactual: baseline `JOINT_LIMIT_EXCEEDED` → feedback `SUCCESS`; integrated attitude error improved 11.15%, peak improved 22.86%; the early transient regression remains recorded
- physical continual summary SHA-256: `0e1ab01effe2b06f37d16bda32631981eedcb96f48fbab54cba96823abe14e0b`

## Scope and dependency

This remains a draft stacked PR targeting `feedback-phase6`; #120 must land first. No real robot, DDS hardware transport, Registry activation, or hardware authorization was performed.
