### PR TITLE
Add Phase 7.1 candidate proof and GoalForge Hat Trick

### DIFF
--- a/docs/validation/ROSCLAW_PHASE7_1_CAPABILITY_PROOF_AND_HAT_TRICK.md
+++ b/docs/validation/ROSCLAW_PHASE7_1_CAPABILITY_PROOF_AND_HAT_TRICK.md
@@ -1,0 +1,272 @@
+# ROSClaw Phase 7.1：Capability Proof 与 GoalForge Hat Trick 实施报告
+
+日期：2026-07-27
+
+分支：`phase7-1-capability-proof-demo`
+
+基线：Phase 7 提交 `556a85f96099b692bf84a0713ca4fee112b36cb0`
+
+证据域：MuJoCo `SIM` 与四卡 `CUDA_SCREENING`；没有真实机器人执行、DDS Hardware、Registry 写入或候选激活
+
+## 1. 结论先行
+
+本轮完成了 Phase 7.1 文档中最优先的 Candidate Motion Effect Proof，并做成了可公开展示的三球仿真 Demo，但没有把“出现改善均值”误报成候选已经晋级。
+
+核心结果如下：
+
+- 实现只读 Candidate Loader、NumPy actor inference、episode 版本锁、推理 receipt 和产品 CLI；真实 seed 17103 的 v3 artifact、parent、Body、动作/观察合同和 tensor 全部通过校验；
+- 在 4 张 A6000 上完成 8 个 learner seed、每个 10 次 residual SAC 更新，8 个候选均保持有限值和有界动作；
+- 对筛选出的 seed 17103 完成 250 个独立 MuJoCo 场景、四个 matched arm、共 1000 条 episode 结果；
+- v3 相对 Parent 的成功率提高 1.6 个百分点，失败惩罚目标误差平均改善 3.43cm，但 95% CI 为 `[1.37cm, 6.10cm]`，下界没有超过预设 2cm 最小改善，而且出现 4 个新的关键安全回归；最终门禁为 `REJECTED`，v3 没有 stage、activate 或获得硬件授权；
+- 新增不确定性感知 `ContactTimingBelief`、延迟发球物理和有界 `MovingBallInterceptAdapter`；低置信度下 kick phase residual 自动归零；
+- `G1 GoalForge Hat Trick` 三球全部在 MuJoCo 真实 stepping 中成功并严格重放：随机九宫格目标重炮、移动球一脚迎射、80N 扰动下 Feedback OFF 失稳而 ON 救回；
+- 生成 1280×720、30fps、18.2s 的证据下游宣传视频。视频绑定输入 report/trajectory 哈希，明确标记 `SIM EVIDENCE REPLAY · VISUALIZATION ONLY`，不产生或修改任务证据。
+
+因此本轮的准确结论是：ROSClaw 已经从“候选能训练”推进到“候选能真实执行、能被 matched suite 证伪、不能自行越过安全门”；G1 的展示能力通过高层拦截适配器和反馈平衡得到可见扩展。当前 residual learner 出现了正向学习信号，但还不是可晋级的运动冠军。
+
+## 2. 闭环架构
+
+```text
+4× A6000 / 8 learner seeds
+          │ immutable candidate artifact
+          ▼
+read-only loader ── hash / parent / Body / contract / tensor validation
+          │ NumPy deterministic actor + episode version lock
+          ▼
+Matched MuJoCo suite
+  Frozen Prior / Parent v2 / Candidate v3 / Fresh Network
+          │
+          ├── Recent 50
+          ├── Anchor 50
+          ├── Boundary 100
+          └── Self 50
+          │  bootstrap CI + safety/retention/replay gates
+          ▼
+      REJECTED v3 ── active v2 unchanged
+
+Verified MuJoCo trajectories
+          │ one-way visualization input
+          ▼
+GoalForge Hat Trick MP4 (never feeds labels back into evaluation)
+```
+
+## 3. ROSClaw 优化与开发内容
+
+### 3.1 Candidate 从 artifact 到动作的只读路径
+
+新增 `src/rosclaw/continual/inference/`：
+
+- `loader.py` 解析现有 residual SAC v1 二进制格式，限制 artifact 大小，只接受 exact float32 actor tensor 集合，并验证 SHA-256、直接父子谱系、Body、controller/safety identity、观察/动作合同、shape 和有限值；
+- `policy_runtime.py` 使用 NumPy 执行确定性 actor，不依赖训练时 PyTorch/CUDA；四个 residual 被显式映射到 waist roll、右髋 roll/yaw 和 kick phase rate；
+- `version_lock.py` 在一次运动段内锁定 version、version hash、artifact 和 Body；
+- `receipt.py` 记录推理次数、动作边界、归一化动作 RMS、最大边界比例、contact timing 统计、零版本切换、零 Registry 写和未打开 DDS；
+- `src/rosclaw/continual/cli.py` 提供 `inspect`、`evaluate` 和可恢复分片 `merge`；CLI 不读写 active slot。
+
+实际检查的 seed 17103：
+
+| 项目 | 值 |
+|---|---|
+| Candidate | v3 `sha256:a0b198a55cda50bb67ac777decf05bd3c23a358f62a09d17226efc4ee773c8e1` |
+| Artifact | `sha256:02160b6e7aac6ca1f3f47b790ea0ecaaa6637ea1111bd34fe66f21cfd5328ba7` |
+| Parent v2 | `sha256:1009007f5b8c37d7c4a8edece96d09504e7806a7d8e8ad3e77f2282a3b06172e` |
+| Body | `sha256:1525aafc953293dd340475e8660b58fae7ea1a22715222ab06331b644340626c` |
+| Actor | 8 observations、`64×64` hidden、4 bounded actions |
+| 状态 | read-only；Registry 0；DDS false；activated false；hardware false |
+
+### 3.2 Matched Candidate Evaluation
+
+新增 `g1_candidate_evaluation.py`，每个场景固定相同 seed、初态、物理参数、扰动和 ShotParameters，只改变四个 arm 的控制策略：
+
+1. Frozen RoboNaldo Prior；
+2. Active Parent v2（显式 zero residual）；
+3. Candidate v3；
+4. 固定 seed 的 Fresh Random Network。
+
+评测记录成功、触球、过门、失败惩罚目标误差、条件目标误差、球速、跌倒、关节/力矩/饱和、COM 裕度、支撑脚滑移、tracking RMS、能量代理、动作漂移、轨迹哈希、推理 receipt 和版本切换。Frozen Prior 与 Parent 的完整运动轨迹必须逐场景一致；每个分区至少对一个 Candidate episode 做严格 replay。
+
+评测支持 disjoint suite shard、逐场景原子 checkpoint 和崩溃续跑。MuJoCo 对“没有可测单支撑窗口”的 COM accumulator 使用 `+inf`；现在只对这一已知哨兵保守编码为 `-1.0m`，所有其他非有限 evidence 仍然硬拒绝，JSON 使用 `allow_nan=False`。
+
+### 3.3 Contact timing 与移动球
+
+新增 `ContactTimingBelief`，融合：
+
+- 球相对右脚的三维位置和速度；
+- 当前 policy phase 与静态先验；
+- 控制时延、sensor quality；
+- 最近预测 phase 的 churn；
+- 已观测触球状态。
+
+只有球确实移动、预测时域有效、拦截误差在界内且 confidence 达标时，Candidate 的 `kick_phase_rate` 才可进入物理控制；静止、已触球、低质量或高不确定状态全部 fail closed 为零。
+
+GoalForge 场景新增 `ball_launch_delay_sec`。Backend 在发球时刻之前保持球静止，到时再施加真实 MuJoCo 速度，解决“球从 t=0 就滚过机器人、踢腿尚未开始”的时序错误。`MovingBallInterceptAdapter` 只接受不超过 0.20m/s、预测接触误差不超过 0.16m 的温和来球，并且只输出已有高层 ShotParameters，不写低层关节。
+
+### 3.4 Hat Trick 与宣传视频
+
+新增：
+
+- `g1_hat_trick.py`：三球执行、严格 replay、trajectory 哈希和结果报告；
+- `g1_hat_trick_cli.py`：`goalforge hat-trick run/export`；
+- `g1_hat_trick_video.py`：MuJoCo evidence replay、慢动作触球、球迹、九宫格目标、进球视角和 Feedback OFF/ON 分屏；
+- 所有 raw trajectory、report、视频和预览图均位于 checkout 外。
+
+视频导出前重新验证 report 已通过、Body 相同、主轨迹和 comparison 轨迹哈希相同；宣传层不会回写评测、经验池或候选状态。
+
+## 4. 实际验证结果
+
+### 4.1 8 个训练 seed / 4 张 A6000
+
+每张物理 GPU 运行两个不同 seed；每个候选完成 10 次更新，CUDA 峰值分配 21,251,584 bytes，hidden activation、loss 和动作均为有限/有界。8 个 candidate hash 全部不同。
+
+四场景初筛结果：
+
+| Seed | GPU | 成功率差 | 目标误差改善 | 新关键回归 | 决定 |
+|---:|---:|---:|---:|---:|---|
+| 17101 | 0 | 0.00 | +0.70cm | 0 | REJECTED |
+| 17102 | 1 | -25.00pp | -44.42cm | 1 | REJECTED |
+| 17103 | 2 | 0.00 | +1.46cm | 0 | REJECTED；进入 250 场景复核 |
+| 17104 | 3 | 0.00 | -0.66cm | 0 | REJECTED |
+| 17105 | 0 | 0.00 | -0.87cm | 0 | REJECTED |
+| 17106 | 1 | 0.00 | +0.42cm | 0 | REJECTED |
+| 17107 | 2 | 0.00 | -0.62cm | 0 | REJECTED |
+| 17108 | 3 | 0.00 | +0.60cm | 0 | REJECTED |
+
+初筛只用于选择更值得花费 250 场景预算的 seed，不作为晋级证据。
+
+### 4.2 250 场景 matched 结果
+
+规模：Recent 50、Anchor 50、Boundary 100、Self 50；每个场景四个 arm，共 1000 个 episode row；四分区 Candidate strict replay 全部通过。
+
+| 指标 | Frozen Prior | Parent v2 | Candidate v3 | Fresh Network |
+|---|---:|---:|---:|---:|
+| 成功率 | 20.4% | 20.4% | 22.0% | 18.8% |
+| 触球率 | 59.2% | 59.2% | 59.6% | 61.2% |
+| 过门率 | 55.6% | 55.6% | 57.6% | 57.6% |
+| 失败惩罚目标误差 | 1.6385m | 1.6385m | 1.6043m | 1.6646m |
+| Fall rate | 67.2% | 67.2% | 64.0% | 68.0% |
+| Joint violation | 69.6% | 69.6% | 67.6% | 68.8% |
+| Torque violation | 0% | 0% | 0% | 0% |
+| 支撑脚滑移 | 0.0409m | 0.0409m | 0.0388m | 0.0381m |
+| Tracking RMS | 0.5795rad | 0.5795rad | 0.5650rad | 0.5757rad |
+| Energy proxy | 41029.0 | 41029.0 | 41043.9 | 41741.3 |
+
+Paired Candidate - Parent：
+
+- 成功率差 `+1.6pp`，95% CI `[+0.4pp, +3.2pp]`；
+- 失败惩罚目标误差改善 `+3.43cm`，95% CI `[+1.37cm, +6.10cm]`；
+- Anchor 成功率差 `0.0pp`，满足历史平均下降小于 3%；
+- 运动段版本切换为 0；四分区 replay 全通过；
+- 出现 4 个新关键回归：3 个 Boundary、1 个 Self，均从 Parent 的非 joint-limit 失败变为 v3 `JOINT_LIMIT_EXCEEDED`，其中 2 个同时被判为 fall。
+
+最终 gate：
+
+| 检查 | 结果 |
+|---|---|
+| 250 场景 | PASS |
+| 8 training seeds | PASS |
+| 四分区 strict replay | PASS |
+| motion version switch = 0 | PASS |
+| Anchor degradation < 3% | PASS |
+| 关键技能成功率下降 ≤ 5% | PASS（实际 +1.6pp） |
+| 95% CI 下界 > 2cm | **FAIL**（1.37cm） |
+| Critical regression = 0 | **FAIL**（4） |
+| 决定 | **REJECTED** |
+
+正式证据：`/code/rosclaw/phase7_1_evidence/seed-17103-matched-250-v2.json`
+
+SHA-256：`bb13ca3b7dd682c248fd284607f611524d7b750acf9116b81a249393e54b969a`
+
+这个结果说明 v3 确实改变了物理运动并出现整体改善信号，但仍不满足稳定性—可塑性门。整体 fall rate 下降不能抵消四个 previously-safe 场景的新关键回归；ROSClaw 必须先把这些反例加入 Boundary replay 再训练，而不是平均数好看就晋级。
+
+### 4.3 G1 GoalForge Hat Trick
+
+| 球 | 场景与规划 | 结果 | 球速 | 目标误差 | 稳定性 |
+|---|---|---|---:|---:|---|
+| 1：九宫格重炮 | seed 202607289 从 3×3 选择右下区 `y=-0.75,z=0.20` | SUCCESS、目标区命中 | 6.98m/s | 0.326m | 不倒；无 joint/torque violation；滑移 0.0021m |
+| 2：移动球迎射 | t=4.0s 发球，初始 x=1.12m，vx=-0.08m/s；预测接触 x=1.0176m | SUCCESS、5.28s 触球并进球 | 6.22m/s | 0.349m | 不倒；无 joint/torque violation；滑移 0.0106m |
+| 3：80N 救援 | 同一 seed/physics，Feedback OFF vs ON | OFF：`JOINT_LIMIT_EXCEEDED` 且 fall；ON：SUCCESS | 4.93m/s | 0.096m | ON 不倒且无 joint/torque violation |
+
+三球每次执行 6520 个 MuJoCo physics step，主轨迹全部严格重放。第三球 receipt 的 `tracking_improved=false` 被原样保留：runtime 自身的整段 RMS 指标受早期瞬态影响，但 matched outcome 明确显示 OFF 发生 joint-limit/fall、ON 保持安全并成功。这只支持该固定 80N SIM 场景的局部救援结论。
+
+Hat Trick 证据：`/code/rosclaw/phase7_1_evidence/hat-trick-v3/goalforge-hat-trick.json`
+
+SHA-256：`98a9899a1a73d7cfa3ac435c049099ee124f312d1d7bc98718bc1453b3ffe99c`
+
+### 4.4 宣传视频
+
+视频：`/code/rosclaw/phase7_1_evidence/hat-trick-v3/rosclaw-g1-goalforge-hat-trick.mp4`
+
+参数：H.264、yuv420p、1280×720、30fps、546 帧、18.2s、1,589,023 bytes。
+
+视频 SHA-256：`8c8ed367ff87ef415894407ac658a482ec853ea399948b733022de610beb5997`
+
+Manifest SHA-256：`21e5a61e564bd79e18a5424b6fd54caebd14e27f89e1e94bead757dcb829c018`
+
+### 4.5 软件验证
+
+- 新增 inference、contact timing、candidate evaluation 和 moving-ball 定向测试：12 passed；
+- Ruff：通过；
+- Mypy：13 个相关 source file 无问题；
+- compileall：通过；
+- 最终完整仓库回归：5306 passed、59 skipped、27 deselected、26 warnings，耗时 17m11s，无失败；
+- 26 个 warning 均来自既有 `pyseekdb.Configuration` 与 `tar.extractall` 弃用提示。
+
+## 5. 复现命令
+
+Candidate 检查：
+
+```bash
+.venv/bin/python -m rosclaw.entrypoint continual candidate inspect \
+  /code/rosclaw/phase7_1_evidence/training-seeds/seed-17103-candidate.bin \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy
+```
+
+单个 matched shard：
+
+```bash
+.venv/bin/python -m rosclaw.entrypoint continual candidate evaluate \
+  /code/rosclaw/phase7_1_evidence/training-seeds/seed-17103-candidate.bin \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy \
+  --recent 50 --anchor 0 --boundary 0 --self-count 0 \
+  --training-seed-count 8 --suite-shard recent-final \
+  --output /code/rosclaw/phase7_1_evidence/seed-17103-recent-50.json
+```
+
+Hat Trick 证据与视频：
+
+```bash
+.venv/bin/python -m rosclaw.entrypoint goalforge hat-trick run \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy \
+  --output-dir /code/rosclaw/phase7_1_evidence/hat-trick-v3
+
+.venv/bin/python -m rosclaw.entrypoint goalforge hat-trick export \
+  /code/rosclaw/phase7_1_evidence/hat-trick-v3/goalforge-hat-trick.json \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy \
+  --output /code/rosclaw/phase7_1_evidence/hat-trick-v3/rosclaw-g1-goalforge-hat-trick.mp4
+```
+
+## 6. 与 RoboNaldo prior 的关系
+
+本轮没有声称重写或全面超过 RoboNaldo。RoboNaldo 仍提供成熟的全身踢球 prior；ROSClaw 增加的是 prior 外层的可校验能力：
+
+- 对 learned residual 做可执行的 hash/lineage/Body/contract 验证；
+- 用 Parent、Candidate、Fresh Control 的 matched 物理实验判断“是否真的变好”；
+- 即便 Candidate 的总体均值更好，只要有新关键回归仍拒绝晋级；
+- 在冻结 prior 的前提下增加移动球发射/拦截高层适配和扰动反馈救援；
+- 把物理证据与宣传可视化单向隔离。
+
+所以当前优势不是“所有射门指标都已超过 RoboNaldo”，而是 ROSClaw 能让 prior 周围的持续学习和新技能扩展变得可证伪、可重放、可拒绝、可展示。
+
+## 7. 没有完成或不能声称的内容
+
+- 250 场景 candidate 没有晋级，active parent 仍是 v2；不能声称 online RL 已经稳定提高 G1；
+- 九宫格本轮是 seed-committed 随机选择并命中一个区域，不是 9 个区域的统计命中率；
+- 移动球成功只覆盖 `vx=-0.08m/s` 的有界来球；当前宣传 shot 由 deterministic intercept adapter 驱动，不是低置信度 Candidate phase residual；
+- 第三球是固定 80N 场景，不是随机时刻、方向和幅值的扰动成功率；
+- 没有球旋转/空气动力插件，因此没有 Magnus 弧线球主张；
+- 没有真实机器人、sim-to-real 或硬件安全授权；
+- Phase 7.1 文档后续的五个可恢复服务、Adaptation Trigger、Forward Self Model、Regime Encoder、Agency estimator、plastic-unit rejuvenation、residual experts 和 Motion Forge 仍是下一批实施，不属于本轮已完成结论；
+- 这里的 Self 仍是可测试的具身状态/证据合同，不是主观意识证明。
+
+## 8. 下一步建议
+
+下一轮不应该放宽门槛，而应把本轮 4 个关键回归自动加入 Boundary replay，扩大真实 rollout 与 learner update 数量，再用同一 250 场景 suite 做 paired freeze。足球侧应先扩展 moving-ball 的速度/方向网格和 80N 扰动时刻/方向随机化，形成成功率而不是单个旗舰 shot；随后再接 Adaptation Trigger、Forward Self Model 和 Regime Encoder，使“什么时候学习、当前身体处于什么工况、学习是否伤害旧技能”进入同一闭环。

--- a/scripts/simforge/g1_continual_gpu_worker.py
+++ b/scripts/simforge/g1_continual_gpu_worker.py
@@ -49,6 +49,7 @@ def main() -> int:
         default="synthetic_contract_fixture",
     )
     parser.add_argument("--updates", type=int, default=3)
+    parser.add_argument("--learner-seed", type=int)
     args = parser.parse_args()
     if args.physical_gpu not in range(4) or not 1 <= args.updates <= 20:
         raise SystemExit("invalid continual CUDA worker request")
@@ -68,6 +69,9 @@ def main() -> int:
     else:
         parent, batch = _screening_batch(args.physical_gpu)
     gpu_uuid, pci_bus_id = _gpu_identity(args.physical_gpu)
+    learner_seed = args.learner_seed if args.learner_seed is not None else 7001 + args.physical_gpu
+    if learner_seed < 0:
+        raise SystemExit("learner seed must be non-negative")
     learner = ConstrainedResidualSAC(
         ResidualSACConfig(
             observation_names=OBSERVATIONS,
@@ -76,7 +80,7 @@ def main() -> int:
             hidden_dims=(64, 64),
             batch_size=32,
             device="cuda:0",
-            seed=7001 + args.physical_gpu,
+            seed=learner_seed,
         )
     )
     started = time.perf_counter()
@@ -110,6 +114,7 @@ def main() -> int:
         "candidate_version": candidate.version,
         "artifact_bytes": len(artifact),
         "update_count": len(updates),
+        "learner_seed": learner_seed,
         "updates_finite": all(update.finite for update in updates),
         "critic_transition_count": updates[-1].critic_transition_count,
         "actor_transition_count": updates[-1].actor_transition_count,

--- a/src/rosclaw/continual/cli.py
+++ b/src/rosclaw/continual/cli.py
@@ -1,0 +1,203 @@
+"""CLI for inspecting and evaluating immutable continual candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from rosclaw.continual.contracts import PolicyVersion
+
+
+def dispatch_continual_argv(argv: list[str]) -> int | None:
+    if len(argv) < 2 or argv[:2] != ["continual", "candidate"]:
+        return None
+    parser = argparse.ArgumentParser(prog="rosclaw continual candidate")
+    commands = parser.add_subparsers(dest="command", required=True)
+    inspect = commands.add_parser("inspect", help="verify a candidate without activating it")
+    _candidate_arguments(inspect)
+    evaluate = commands.add_parser("evaluate", help="run matched G1 MuJoCo evaluation")
+    _candidate_arguments(evaluate)
+    evaluate.add_argument("--backend", choices=("mujoco",), default="mujoco")
+    evaluate.add_argument(
+        "--suite", choices=("g1-goalforge-eval-v1",), default="g1-goalforge-eval-v1"
+    )
+    evaluate.add_argument("--output", type=Path, required=True)
+    evaluate.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    evaluate.add_argument("--recent", type=int, default=50)
+    evaluate.add_argument("--anchor", type=int, default=50)
+    evaluate.add_argument("--boundary", type=int, default=100)
+    evaluate.add_argument("--self-count", type=int, default=50)
+    evaluate.add_argument("--training-seed-count", type=int, default=1)
+    evaluate.add_argument("--suite-shard", default="")
+    merge = commands.add_parser("merge", help="merge disjoint matched-evaluation shards")
+    merge.add_argument("shards", type=Path, nargs="+")
+    merge.add_argument("--output", type=Path, required=True)
+    merge.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv[2:])
+    if args.command == "inspect":
+        return _inspect(args)
+    if args.command == "merge":
+        return _merge(args)
+    return _evaluate(args)
+
+
+def _candidate_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("--metadata", type=Path)
+    parser.add_argument("--asset-root", type=Path, required=True)
+
+
+def _inspect(args: argparse.Namespace) -> int:
+    from rosclaw.continual.g1_goalforge import build_g1_policy_lineage
+    from rosclaw.continual.inference import load_residual_candidate
+    from rosclaw.simforge.backends.unitree_mujoco_backend import G1MuJoCoBackend
+
+    candidate = _candidate_policy(args.candidate, args.metadata)
+    backend = G1MuJoCoBackend(asset_root=args.asset_root, trace_stride=5)
+    qualification = backend.qualification
+    lineage = build_g1_policy_lineage(
+        body_hash=qualification.body_hash,
+        kick_prior_hash=qualification.kick_prior_hash,
+        motion_hash=qualification.motion_hash,
+        backend_commit=qualification.backend_commit,
+        torque_guard_scale=backend.torque_guard_scale,
+        through_version=2,
+    )
+    loaded = load_residual_candidate(
+        args.candidate,
+        policy=candidate,
+        parent=lineage.policy(2),
+        expected_body_hash=qualification.body_hash,
+    )
+    print(
+        json.dumps(
+            {
+                "schema_version": "rosclaw.continual.candidate_inspection.v1",
+                "verified": True,
+                "artifact_hash": loaded.artifact_hash,
+                "policy_version": loaded.policy.version,
+                "policy_version_hash": loaded.policy.version_hash,
+                "parent_version_hash": loaded.parent.version_hash,
+                "body_hash": loaded.policy.body_hash,
+                "observation_names": list(loaded.observation_names),
+                "action_names": list(loaded.action_names),
+                "action_limits": list(loaded.action_limits),
+                "hidden_dims": list(loaded.hidden_dims),
+                "learner_update_index": loaded.update_index,
+                "read_only": True,
+                "registry_mutated": False,
+                "dds_opened": False,
+                "candidate_activated": False,
+                "hardware_authorized": False,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _evaluate(args: argparse.Namespace) -> int:
+    from rosclaw.simforge.g1_candidate_evaluation import (
+        CandidateEvaluationCounts,
+        run_g1_candidate_matched_evaluation,
+    )
+
+    candidate = _candidate_policy(args.candidate, args.metadata)
+    counts = CandidateEvaluationCounts(
+        recent=args.recent,
+        anchor=args.anchor,
+        boundary=args.boundary,
+        self_partition=args.self_count,
+    )
+
+    def progress(completed: int, total: int) -> None:
+        if completed == 1 or completed == total or completed % max(1, total // 20) == 0:
+            print(f"candidate-eval {completed}/{total}", file=sys.stderr, flush=True)
+
+    result = run_g1_candidate_matched_evaluation(
+        asset_root=args.asset_root,
+        candidate_artifact_path=args.candidate,
+        candidate_policy=candidate,
+        output_path=args.output,
+        source_checkout=args.source_checkout,
+        counts=counts,
+        training_seed_count=args.training_seed_count,
+        suite_shard=args.suite_shard,
+        progress=progress,
+    )
+    print(
+        json.dumps(
+            {
+                "output": str(args.output.expanduser().resolve()),
+                "scenario_count": counts.total,
+                "candidate_policy_hash": candidate.version_hash,
+                "paired_statistics": result.paired_statistics,
+                "gate": result.gate,
+                "passed": result.passed,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _merge(args: argparse.Namespace) -> int:
+    from rosclaw.simforge.g1_candidate_evaluation import merge_g1_candidate_evaluations
+
+    result = merge_g1_candidate_evaluations(
+        shard_paths=args.shards,
+        output_path=args.output,
+        source_checkout=args.source_checkout,
+    )
+    print(
+        json.dumps(
+            {
+                "output": str(args.output.expanduser().resolve()),
+                "scenario_count": result.counts["total"],
+                "paired_statistics": result.paired_statistics,
+                "gate": result.gate,
+                "passed": result.passed,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _candidate_policy(candidate_path: Path, metadata_path: Path | None) -> PolicyVersion:
+    metadata = metadata_path or _infer_metadata_path(candidate_path)
+    if not metadata.is_file():
+        raise FileNotFoundError(
+            "candidate learner metadata is missing; provide --metadata: " + str(metadata)
+        )
+    value: Any = json.loads(metadata.read_text(encoding="utf-8"))
+    if isinstance(value, dict) and "candidate_policy" in value:
+        value = value["candidate_policy"]
+    if not isinstance(value, dict):
+        raise ValueError("candidate metadata must contain a candidate_policy object")
+    return PolicyVersion(
+        version=int(value["version"]),
+        artifact_hash=str(value["artifact_hash"]),
+        parent_version_hash=value.get("parent_version_hash"),
+        controller_snapshot_hash=str(value["controller_snapshot_hash"]),
+        body_hash=str(value["body_hash"]),
+        safety_kernel_hash=str(value["safety_kernel_hash"]),
+        observation_names=tuple(value["observation_names"]),
+        residual_action_names=tuple(value["residual_action_names"]),
+    )
+
+
+def _infer_metadata_path(candidate_path: Path) -> Path:
+    name = candidate_path.name
+    if name.endswith("-candidate.bin"):
+        return candidate_path.with_name(name.removesuffix("-candidate.bin") + "-learner.json")
+    return candidate_path.with_suffix(".json")
+
+
+__all__ = ["dispatch_continual_argv"]

--- a/src/rosclaw/continual/inference/__init__.py
+++ b/src/rosclaw/continual/inference/__init__.py
@@ -1,0 +1,23 @@
+"""Read-only execution of versioned continual-learning candidates."""
+
+from rosclaw.continual.inference.loader import (
+    ResidualCandidateArtifact,
+    load_residual_candidate,
+)
+from rosclaw.continual.inference.policy_runtime import (
+    ResidualCandidateController,
+    ResidualCandidatePolicy,
+    build_g1_candidate_runtime,
+)
+from rosclaw.continual.inference.receipt import CandidateInferenceReceipt
+from rosclaw.continual.inference.version_lock import CandidateVersionLock
+
+__all__ = [
+    "CandidateInferenceReceipt",
+    "CandidateVersionLock",
+    "ResidualCandidateArtifact",
+    "ResidualCandidateController",
+    "ResidualCandidatePolicy",
+    "build_g1_candidate_runtime",
+    "load_residual_candidate",
+]

--- a/src/rosclaw/continual/inference/loader.py
+++ b/src/rosclaw/continual/inference/loader.py
@@ -1,0 +1,272 @@
+"""Fail-closed, read-only loader for residual SAC actor artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import struct
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+import numpy as np
+
+from rosclaw.continual.contracts import PolicyVersion
+
+_MAX_ARTIFACT_BYTES = 64 * 1024 * 1024
+_SCHEMA_V1 = "rosclaw.continual.residual_sac_artifact.v1"
+
+
+@dataclass(frozen=True)
+class ResidualCandidateArtifact:
+    """Verified inference-only view of one content-addressed actor."""
+
+    policy: PolicyVersion
+    parent: PolicyVersion
+    artifact_hash: str
+    schema_version: str
+    observation_names: tuple[str, ...]
+    action_names: tuple[str, ...]
+    action_limits: tuple[float, ...]
+    hidden_dims: tuple[int, int]
+    update_index: int
+    tensors: Mapping[str, np.ndarray]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tensors", MappingProxyType(dict(self.tensors)))
+
+
+def load_residual_candidate(
+    artifact_path: Path,
+    *,
+    policy: PolicyVersion,
+    parent: PolicyVersion,
+    expected_body_hash: str | None = None,
+    expected_observation_names: tuple[str, ...] | None = None,
+    expected_action_names: tuple[str, ...] | None = None,
+) -> ResidualCandidateArtifact:
+    """Load and verify a candidate without touching Registry, DDS, or an active slot."""
+
+    path = artifact_path.expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"candidate artifact is missing: {path}")
+    size = path.stat().st_size
+    if size <= 0 or size > _MAX_ARTIFACT_BYTES:
+        raise ValueError("candidate artifact size is outside the read-only loader limit")
+    payload = path.read_bytes()
+    artifact_hash = "sha256:" + hashlib.sha256(payload).hexdigest()
+    if artifact_hash != policy.artifact_hash:
+        raise ValueError("candidate artifact hash does not match PolicyVersion")
+    _verify_lineage(policy=policy, parent=parent, expected_body_hash=expected_body_hash)
+
+    metadata_end = _json_object_end(payload)
+    try:
+        metadata = json.loads(payload[:metadata_end].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("candidate artifact metadata is invalid") from exc
+    if not isinstance(metadata, dict) or metadata.get("schema_version") != _SCHEMA_V1:
+        raise ValueError("unsupported residual candidate artifact schema")
+    observations = _unique_names(metadata, "observation_names")
+    actions = _unique_names(metadata, "action_names")
+    action_limits = _positive_floats(metadata, "action_limits", count=len(actions))
+    hidden_values = _positive_ints(metadata, "hidden_dims", count=2)
+    hidden = (hidden_values[0], hidden_values[1])
+    update_index = metadata.get("update_index")
+    if not isinstance(update_index, int) or isinstance(update_index, bool) or update_index < 0:
+        raise ValueError("candidate update_index must be a non-negative integer")
+    if observations != policy.observation_names:
+        raise ValueError("candidate observation contract does not match PolicyVersion")
+    if actions != policy.residual_action_names:
+        raise ValueError("candidate residual action contract does not match PolicyVersion")
+    if expected_observation_names is not None and observations != expected_observation_names:
+        raise ValueError("candidate observation contract does not match the runtime contract")
+    if expected_action_names is not None and actions != expected_action_names:
+        raise ValueError("candidate action contract does not match the runtime contract")
+
+    tensors = _parse_v1_tensors(payload, metadata_end)
+    _verify_actor_tensors(
+        tensors,
+        observation_count=len(observations),
+        action_count=len(actions),
+        hidden_dims=hidden,
+        action_limits=action_limits,
+    )
+    return ResidualCandidateArtifact(
+        policy=policy,
+        parent=parent,
+        artifact_hash=artifact_hash,
+        schema_version=str(metadata["schema_version"]),
+        observation_names=observations,
+        action_names=actions,
+        action_limits=action_limits,
+        hidden_dims=hidden,
+        update_index=update_index,
+        tensors=tensors,
+    )
+
+
+def _verify_lineage(
+    *,
+    policy: PolicyVersion,
+    parent: PolicyVersion,
+    expected_body_hash: str | None,
+) -> None:
+    if policy.version != parent.version + 1:
+        raise ValueError("candidate version is not the direct successor of the parent")
+    if policy.parent_version_hash != parent.version_hash:
+        raise ValueError("candidate parent version hash does not match the supplied parent")
+    for label in ("body_hash", "safety_kernel_hash", "controller_snapshot_hash"):
+        if getattr(policy, label) != getattr(parent, label):
+            raise ValueError(f"candidate {label} does not match the parent")
+    if policy.observation_names != parent.observation_names:
+        raise ValueError("candidate observation contract does not match the parent")
+    if policy.residual_action_names != parent.residual_action_names:
+        raise ValueError("candidate residual action contract does not match the parent")
+    if expected_body_hash is not None and policy.body_hash != expected_body_hash:
+        raise ValueError("candidate body hash does not match qualified simulation assets")
+
+
+def _json_object_end(payload: bytes) -> int:
+    if not payload or payload[0] != ord("{"):
+        raise ValueError("candidate artifact must begin with JSON metadata")
+    depth = 0
+    in_string = False
+    escaped = False
+    for index, byte in enumerate(payload):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif byte == ord("\\"):
+                escaped = True
+            elif byte == ord('"'):
+                in_string = False
+            continue
+        if byte == ord('"'):
+            in_string = True
+        elif byte == ord("{"):
+            depth += 1
+        elif byte == ord("}"):
+            depth -= 1
+            if depth == 0:
+                return index + 1
+            if depth < 0:
+                break
+    raise ValueError("candidate artifact metadata JSON is incomplete")
+
+
+def _parse_v1_tensors(payload: bytes, offset: int) -> Mapping[str, np.ndarray]:
+    tensors: dict[str, np.ndarray] = {}
+    cursor = offset
+    while cursor < len(payload):
+        name_size, cursor = _read_u32(payload, cursor, "tensor name length")
+        name_bytes, cursor = _read_bytes(payload, cursor, name_size, "tensor name")
+        dtype_size, cursor = _read_u32(payload, cursor, "tensor dtype length")
+        dtype_bytes, cursor = _read_bytes(payload, cursor, dtype_size, "tensor dtype")
+        ndim, cursor = _read_u32(payload, cursor, "tensor rank")
+        if ndim > 4:
+            raise ValueError("candidate tensor rank exceeds the inference limit")
+        shape: tuple[int, ...] = ()
+        if ndim:
+            shape_size = 8 * ndim
+            shape_bytes, cursor = _read_bytes(payload, cursor, shape_size, "tensor shape")
+            shape = tuple(int(value) for value in struct.unpack("!" + "Q" * ndim, shape_bytes))
+        try:
+            name = name_bytes.decode("utf-8")
+            dtype_name = dtype_bytes.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise ValueError("candidate tensor descriptor is not valid text") from exc
+        if not name or name in tensors:
+            raise ValueError("candidate tensor names must be non-empty and unique")
+        if dtype_name != "float32":
+            raise ValueError("candidate inference permits only float32 actor tensors")
+        if any(dimension <= 0 or dimension > 1_000_000 for dimension in shape):
+            raise ValueError("candidate tensor shape is invalid")
+        count = math.prod(shape)
+        raw, cursor = _read_bytes(payload, cursor, count * 4, f"tensor {name}")
+        value = np.frombuffer(raw, dtype=np.float32).reshape(shape).copy()
+        if not np.all(np.isfinite(value)):
+            raise ValueError(f"candidate tensor {name} contains non-finite values")
+        value.flags.writeable = False
+        tensors[name] = value
+    if cursor != len(payload) or not tensors:
+        raise ValueError("candidate artifact tensor payload is empty or truncated")
+    return MappingProxyType(tensors)
+
+
+def _verify_actor_tensors(
+    tensors: Mapping[str, np.ndarray],
+    *,
+    observation_count: int,
+    action_count: int,
+    hidden_dims: tuple[int, int],
+    action_limits: tuple[float, ...],
+) -> None:
+    h0, h1 = hidden_dims
+    expected = {
+        "action_limits": (action_count,),
+        "backbone.hidden0.bias": (h0,),
+        "backbone.hidden0.weight": (h0, observation_count),
+        "backbone.hidden1.bias": (h1,),
+        "backbone.hidden1.weight": (h1, h0),
+        "backbone.output.bias": (2 * action_count,),
+        "backbone.output.weight": (2 * action_count, h1),
+    }
+    if set(tensors) != set(expected):
+        raise ValueError(
+            "candidate artifact does not contain the exact deterministic actor tensors"
+        )
+    for name, shape in expected.items():
+        if tensors[name].shape != shape:
+            raise ValueError(
+                f"candidate tensor {name} has shape {tensors[name].shape}, expected {shape}"
+            )
+    if not np.allclose(tensors["action_limits"], action_limits, rtol=0.0, atol=1e-8):
+        raise ValueError("candidate tensor action limits do not match metadata")
+
+
+def _read_u32(payload: bytes, cursor: int, label: str) -> tuple[int, int]:
+    raw, next_cursor = _read_bytes(payload, cursor, 4, label)
+    return struct.unpack("!I", raw)[0], next_cursor
+
+
+def _read_bytes(payload: bytes, cursor: int, count: int, label: str) -> tuple[bytes, int]:
+    if count < 0 or cursor < 0 or cursor + count > len(payload):
+        raise ValueError(f"candidate artifact is truncated at {label}")
+    return payload[cursor : cursor + count], cursor + count
+
+
+def _unique_names(metadata: Mapping[str, Any], key: str) -> tuple[str, ...]:
+    value = metadata.get(key)
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"candidate {key} must be a non-empty list")
+    names = tuple(item for item in value if isinstance(item, str) and item.strip())
+    if len(names) != len(value) or len(set(names)) != len(names):
+        raise ValueError(f"candidate {key} must contain unique non-empty strings")
+    return names
+
+
+def _positive_floats(metadata: Mapping[str, Any], key: str, *, count: int) -> tuple[float, ...]:
+    value = metadata.get(key)
+    if not isinstance(value, list) or len(value) != count:
+        raise ValueError(f"candidate {key} has the wrong length")
+    normalized = tuple(float(item) for item in value)
+    if any(not math.isfinite(item) or item <= 0.0 for item in normalized):
+        raise ValueError(f"candidate {key} must contain positive finite values")
+    return normalized
+
+
+def _positive_ints(metadata: Mapping[str, Any], key: str, *, count: int) -> tuple[int, ...]:
+    value = metadata.get(key)
+    if (
+        not isinstance(value, list)
+        or len(value) != count
+        or any(not isinstance(item, int) or isinstance(item, bool) or item <= 0 for item in value)
+    ):
+        raise ValueError(f"candidate {key} must contain {count} positive integers")
+    return tuple(value)
+
+
+__all__ = ["ResidualCandidateArtifact", "load_residual_candidate"]

--- a/src/rosclaw/continual/inference/policy_runtime.py
+++ b/src/rosclaw/continual/inference/policy_runtime.py
@@ -1,0 +1,258 @@
+"""NumPy inference runtime binding a residual candidate to the Feedback Plane."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import asdict
+
+import numpy as np
+
+from rosclaw.continual.inference.loader import ResidualCandidateArtifact
+from rosclaw.continual.inference.receipt import CandidateInferenceReceipt
+from rosclaw.continual.inference.version_lock import CandidateVersionLock
+from rosclaw.feedback.contact_timing import ContactTimingBelief, ContactTimingEstimator
+from rosclaw.feedback.contracts import (
+    FallbackMode,
+    FeedbackFrame,
+    FeedbackLoopSpec,
+    canonical_hash,
+)
+from rosclaw.feedback.runtime import FeedbackRuntime
+
+_G1_ACTION_OUTPUTS = {
+    "waist_roll_residual": "joint:waist_roll_joint",
+    "right_hip_roll_residual": "joint:right_hip_roll_joint",
+    "right_hip_yaw_residual": "joint:right_hip_yaw_joint",
+    "kick_phase_rate": "skill:kick_phase_rate",
+}
+
+
+class ResidualCandidatePolicy:
+    """Deterministic, allocation-light inference over immutable NumPy tensors."""
+
+    def __init__(self, artifact: ResidualCandidateArtifact) -> None:
+        self.artifact = artifact
+        self.version_lock = CandidateVersionLock.pin(artifact.policy)
+        self._observations: list[dict[str, float]] = []
+        self._actions: list[dict[str, float]] = []
+        self.contact_timing = ContactTimingEstimator()
+        self._timing_beliefs: list[ContactTimingBelief] = []
+
+    def reset(self) -> None:
+        self.version_lock.verify(self.artifact.policy)
+        self._observations.clear()
+        self._actions.clear()
+        self.contact_timing.reset()
+        self._timing_beliefs.clear()
+
+    def infer(
+        self,
+        observation: Mapping[str, float],
+        *,
+        enforce_contact_timing: bool = False,
+        timestamp_ns: int = 0,
+        policy_phase: float | None = None,
+    ) -> Mapping[str, float]:
+        self.version_lock.verify(self.artifact.policy)
+        missing = set(self.artifact.observation_names).difference(observation)
+        if missing:
+            raise ValueError(f"candidate inference is missing observations: {sorted(missing)}")
+        ordered = np.asarray(
+            [float(observation[name]) for name in self.artifact.observation_names],
+            dtype=np.float32,
+        )
+        if not np.all(np.isfinite(ordered)):
+            raise ValueError("candidate inference observations must be finite")
+        tensors = self.artifact.tensors
+        hidden0 = np.maximum(
+            tensors["backbone.hidden0.weight"] @ ordered + tensors["backbone.hidden0.bias"],
+            0.0,
+        )
+        hidden1 = np.maximum(
+            tensors["backbone.hidden1.weight"] @ hidden0 + tensors["backbone.hidden1.bias"],
+            0.0,
+        )
+        actor_output = tensors["backbone.output.weight"] @ hidden1 + tensors["backbone.output.bias"]
+        mean = actor_output[: len(self.artifact.action_names)]
+        values = np.tanh(mean) * tensors["action_limits"]
+        if not np.all(np.isfinite(values)):
+            raise ValueError("candidate inference produced a non-finite action")
+        result = dict(zip(self.artifact.action_names, map(float, values), strict=True))
+        if enforce_contact_timing:
+            belief = self.contact_timing.update(
+                timestamp_ns=timestamp_ns,
+                policy_phase=(
+                    float(observation["contact_phase"]) if policy_phase is None else policy_phase
+                ),
+                actual=observation,
+            )
+            self._timing_beliefs.append(belief)
+            if "kick_phase_rate" in result and not belief.phase_residual_enabled:
+                result["kick_phase_rate"] = 0.0
+        self._observations.append(
+            dict(zip(self.artifact.observation_names, map(float, ordered), strict=True))
+        )
+        self._actions.append(result)
+        return result
+
+    def build_receipt(self) -> CandidateInferenceReceipt:
+        if not self._actions:
+            raise ValueError("cannot build a candidate inference receipt without samples")
+        bounded = all(
+            abs(action[name]) <= limit + 1e-8
+            for action in self._actions
+            for name, limit in zip(
+                self.artifact.action_names,
+                self.artifact.action_limits,
+                strict=True,
+            )
+        )
+        normalized = [
+            action[name] / limit
+            for action in self._actions
+            for name, limit in zip(
+                self.artifact.action_names,
+                self.artifact.action_limits,
+                strict=True,
+            )
+        ]
+        mean_timing_confidence = (
+            sum(item.confidence for item in self._timing_beliefs) / len(self._timing_beliefs)
+            if self._timing_beliefs
+            else 0.0
+        )
+        return CandidateInferenceReceipt(
+            policy_version=self.artifact.policy.version,
+            policy_version_hash=self.artifact.policy.version_hash,
+            parent_version_hash=self.artifact.parent.version_hash,
+            artifact_hash=self.artifact.artifact_hash,
+            body_hash=self.artifact.policy.body_hash,
+            observation_contract_hash=canonical_hash(
+                {"observation_names": list(self.artifact.observation_names)}
+            ),
+            action_contract_hash=canonical_hash(
+                {
+                    "action_names": list(self.artifact.action_names),
+                    "action_limits": list(self.artifact.action_limits),
+                }
+            ),
+            trace_hash=canonical_hash(
+                {"observations": self._observations, "actions": self._actions}
+            ),
+            inference_count=len(self._actions),
+            actions_bounded=bounded,
+            action_rms=float(np.sqrt(np.mean(np.square(normalized)))),
+            maximum_action_limit_ratio=max(map(abs, normalized)),
+            contact_timing_enabled_count=sum(
+                item.phase_residual_enabled for item in self._timing_beliefs
+            ),
+            contact_timing_mean_confidence=mean_timing_confidence,
+        )
+
+
+class ResidualCandidateController:
+    """Feedback controller adapter with an explicit ROSClaw action mapping."""
+
+    def __init__(self, policy: ResidualCandidatePolicy) -> None:
+        unknown = set(policy.artifact.action_names).difference(_G1_ACTION_OUTPUTS)
+        if unknown:
+            raise ValueError(
+                f"candidate contains unsupported G1 residual actions: {sorted(unknown)}"
+            )
+        self.policy = policy
+
+    @property
+    def controller_hash(self) -> str:
+        return canonical_hash(self.config_dict())
+
+    def reset(self) -> None:
+        self.policy.reset()
+
+    def compute(
+        self,
+        frame: FeedbackFrame,
+        base_action: Mapping[str, float],
+    ) -> Mapping[str, float]:
+        del base_action
+        action = self.policy.infer(
+            frame.actual,
+            enforce_contact_timing=True,
+            timestamp_ns=frame.timestamp_ns,
+            policy_phase=frame.phase,
+        )
+        return {_G1_ACTION_OUTPUTS[name]: value for name, value in action.items()}
+
+    def config_dict(self) -> dict[str, object]:
+        return {
+            "controller_type": "residual_candidate_numpy",
+            "version": 1,
+            "policy_version": self.policy.artifact.policy.version,
+            "policy_version_hash": self.policy.artifact.policy.version_hash,
+            "artifact_hash": self.policy.artifact.artifact_hash,
+            "action_mapping": {
+                name: _G1_ACTION_OUTPUTS[name] for name in self.policy.artifact.action_names
+            },
+            "contact_timing": asdict(self.policy.contact_timing.config),
+        }
+
+
+def build_g1_candidate_runtime(
+    artifact: ResidualCandidateArtifact,
+    *,
+    rate_hz: float = 100.0,
+    compute_clock_ns: Callable[[], int] | None = None,
+) -> tuple[FeedbackRuntime, ResidualCandidatePolicy]:
+    """Build a SIM-only runtime; it has no Registry, network, DDS, or slot dependency."""
+
+    if not math.isfinite(rate_hz) or not 1.0 <= rate_hz <= 500.0:
+        raise ValueError("candidate feedback rate must be in [1, 500] Hz")
+    policy = ResidualCandidatePolicy(artifact)
+    controller = ResidualCandidateController(policy)
+    output_limits = {
+        _G1_ACTION_OUTPUTS[name]: limit
+        for name, limit in zip(artifact.action_names, artifact.action_limits, strict=True)
+    }
+    preferred_references = tuple(
+        name
+        for name in (
+            "torso_roll",
+            "torso_pitch",
+            "com_y_relative",
+            "ball_lateral_error_m",
+        )
+        if name in artifact.observation_names
+    )
+    references = preferred_references or artifact.observation_names[:1]
+    spec = FeedbackLoopSpec(
+        loop_id=f"g1/goalforge-candidate/v{artifact.policy.version}",
+        body_hash=artifact.policy.body_hash,
+        controller_hash=controller.controller_hash,
+        reference_signals=references,
+        observation_signals=tuple(
+            dict.fromkeys(artifact.observation_names + ContactTimingEstimator.required_signals)
+        ),
+        output_limits=output_limits,
+        rate_hz=rate_hz,
+        deadline_ms=1000.0 / rate_hz,
+        max_observation_age_ms=2.0 * 1000.0 / rate_hz,
+        fallback_deadline_miss=FallbackMode.BASE_POLICY_ONLY,
+        fallback_unsafe_projection=FallbackMode.BASE_POLICY_ONLY,
+    )
+    if compute_clock_ns is None:
+        return FeedbackRuntime(spec=spec, controller=controller), policy
+    return (
+        FeedbackRuntime(
+            spec=spec,
+            controller=controller,
+            compute_clock_ns=compute_clock_ns,
+        ),
+        policy,
+    )
+
+
+__all__ = [
+    "ResidualCandidateController",
+    "ResidualCandidatePolicy",
+    "build_g1_candidate_runtime",
+]

--- a/src/rosclaw/continual/inference/receipt.py
+++ b/src/rosclaw/continual/inference/receipt.py
@@ -1,0 +1,41 @@
+"""Evidence receipt for deterministic candidate inference."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+
+@dataclass(frozen=True)
+class CandidateInferenceReceipt:
+    policy_version: int
+    policy_version_hash: str
+    parent_version_hash: str
+    artifact_hash: str
+    body_hash: str
+    observation_contract_hash: str
+    action_contract_hash: str
+    trace_hash: str
+    inference_count: int
+    actions_bounded: bool
+    action_rms: float
+    maximum_action_limit_ratio: float
+    contact_timing_enabled_count: int
+    contact_timing_mean_confidence: float
+    version_switch_count: int = 0
+    registry_write_count: int = 0
+    dds_opened: bool = False
+    evidence_domain: str = "SIM_ONLY"
+    schema_version: str = "rosclaw.continual.candidate_inference_receipt.v1"
+
+    @property
+    def receipt_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+__all__ = ["CandidateInferenceReceipt"]

--- a/src/rosclaw/continual/inference/version_lock.py
+++ b/src/rosclaw/continual/inference/version_lock.py
@@ -1,0 +1,36 @@
+"""Episode-scoped no-switch lock for a continual candidate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rosclaw.continual.contracts import PolicyVersion
+
+
+@dataclass(frozen=True)
+class CandidateVersionLock:
+    policy_version: int
+    policy_version_hash: str
+    artifact_hash: str
+    body_hash: str
+
+    @classmethod
+    def pin(cls, policy: PolicyVersion) -> CandidateVersionLock:
+        return cls(
+            policy_version=policy.version,
+            policy_version_hash=policy.version_hash,
+            artifact_hash=policy.artifact_hash,
+            body_hash=policy.body_hash,
+        )
+
+    def verify(self, policy: PolicyVersion) -> None:
+        if (
+            policy.version != self.policy_version
+            or policy.version_hash != self.policy_version_hash
+            or policy.artifact_hash != self.artifact_hash
+            or policy.body_hash != self.body_hash
+        ):
+            raise RuntimeError("candidate policy version changed inside a locked motion segment")
+
+
+__all__ = ["CandidateVersionLock"]

--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -26,6 +26,18 @@ def main() -> int:
     if result is not None:
         return result
 
+    from rosclaw.continual.cli import dispatch_continual_argv
+
+    result = dispatch_continual_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
+    from rosclaw.simforge.g1_hat_trick_cli import dispatch_hat_trick_argv
+
+    result = dispatch_hat_trick_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
     from rosclaw.simforge.phase4_cli import dispatch_phase4_argv
 
     result = dispatch_phase4_argv(sys.argv[1:])

--- a/src/rosclaw/feedback/contact_timing.py
+++ b/src/rosclaw/feedback/contact_timing.py
@@ -1,0 +1,188 @@
+"""Uncertainty-aware contact timing belief for GoalForge kick control."""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ContactTimingConfig:
+    expected_static_contact_phase: float = 0.416
+    nominal_phase_rate_per_sec: float = 0.0788
+    maximum_horizon_sec: float = 2.5
+    confidence_threshold: float = 0.70
+    maximum_intercept_miss_m: float = 0.24
+    history_size: int = 12
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.expected_static_contact_phase < 1.0:
+            raise ValueError("expected contact phase must be in (0, 1)")
+        if not 0.0 < self.nominal_phase_rate_per_sec <= 1.0:
+            raise ValueError("nominal phase rate must be in (0, 1]")
+        if not 0.0 < self.maximum_horizon_sec <= 10.0:
+            raise ValueError("contact timing horizon must be in (0, 10]")
+        if not 0.0 < self.confidence_threshold < 1.0:
+            raise ValueError("contact timing threshold must be in (0, 1)")
+        if self.maximum_intercept_miss_m <= 0.0 or self.history_size <= 1:
+            raise ValueError("contact timing miss bound and history size must be positive")
+
+
+@dataclass(frozen=True)
+class ContactTimingBelief:
+    timestamp_ns: int
+    predicted_contact_phase: float
+    predicted_time_to_contact_sec: float
+    predicted_contact_position_m: tuple[float, float, float]
+    intercept_miss_m: float
+    uncertainty: float
+    confidence: float
+    phase_residual_enabled: bool
+    contact_observed: bool
+    source: str
+    schema_version: str = "rosclaw.feedback.contact_timing_belief.v1"
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class ContactTimingEstimator:
+    """Fuse relative ball motion, phase prior, latency, and recent prediction churn."""
+
+    required_signals = (
+        "ball_relative_x_m",
+        "ball_relative_y_m",
+        "ball_relative_z_m",
+        "ball_relative_vx_mps",
+        "ball_relative_vy_mps",
+        "ball_relative_vz_mps",
+        "control_latency_ms",
+        "sensor_quality",
+        "contact_detected",
+    )
+
+    def __init__(self, config: ContactTimingConfig | None = None) -> None:
+        self.config = config or ContactTimingConfig()
+        self._phase_predictions: deque[float] = deque(maxlen=self.config.history_size)
+
+    def reset(self) -> None:
+        self._phase_predictions.clear()
+
+    def update(
+        self,
+        *,
+        timestamp_ns: int,
+        policy_phase: float,
+        actual: Mapping[str, float],
+    ) -> ContactTimingBelief:
+        missing = set(self.required_signals).difference(actual)
+        if missing:
+            raise ValueError(f"contact timing is missing signals: {sorted(missing)}")
+        if not 0.0 <= policy_phase <= 1.0:
+            raise ValueError("contact timing policy phase must be in [0, 1]")
+        position = np.asarray(
+            [
+                actual["ball_relative_x_m"],
+                actual["ball_relative_y_m"],
+                actual["ball_relative_z_m"],
+            ],
+            dtype=np.float64,
+        )
+        velocity = np.asarray(
+            [
+                actual["ball_relative_vx_mps"],
+                actual["ball_relative_vy_mps"],
+                actual["ball_relative_vz_mps"],
+            ],
+            dtype=np.float64,
+        )
+        latency_sec = max(0.0, float(actual["control_latency_ms"]) / 1000.0)
+        sensor_quality = float(np.clip(actual["sensor_quality"], 0.0, 1.0))
+        contact = bool(actual["contact_detected"] >= 0.5)
+        if not np.all(np.isfinite(position)) or not np.all(np.isfinite(velocity)):
+            raise ValueError("contact timing state must be finite")
+        speed_squared = float(velocity @ velocity)
+        moving = speed_squared >= 0.0025
+        if contact:
+            time_to_contact = 0.0
+            predicted_position = position
+            source = "observed_contact"
+        elif moving:
+            time_to_contact = float(
+                np.clip(
+                    -(position @ velocity) / speed_squared - latency_sec,
+                    0.0,
+                    self.config.maximum_horizon_sec,
+                )
+            )
+            predicted_position = position + velocity * (time_to_contact + latency_sec)
+            source = "relative_motion_intercept"
+        else:
+            time_to_contact = float(
+                np.clip(
+                    (self.config.expected_static_contact_phase - policy_phase)
+                    / self.config.nominal_phase_rate_per_sec,
+                    0.0,
+                    self.config.maximum_horizon_sec,
+                )
+            )
+            predicted_position = position
+            source = "static_phase_prior"
+        predicted_phase = float(
+            np.clip(
+                policy_phase
+                + self.config.nominal_phase_rate_per_sec * (time_to_contact + latency_sec),
+                0.0,
+                1.0,
+            )
+        )
+        intercept_miss = float(np.linalg.norm(predicted_position))
+        history_churn = (
+            float(np.std(tuple(self._phase_predictions)))
+            if len(self._phase_predictions) >= 3
+            else 0.0
+        )
+        self._phase_predictions.append(predicted_phase)
+        uncertainty = float(
+            np.clip(
+                0.03
+                + 0.55 * min(1.0, intercept_miss / self.config.maximum_intercept_miss_m)
+                + 0.20 * min(1.0, latency_sec / 0.08)
+                + 0.25 * (1.0 - sensor_quality)
+                + 1.5 * history_churn
+                + (0.20 if not moving and not contact else 0.0),
+                0.0,
+                1.0,
+            )
+        )
+        confidence = math.exp(-2.0 * uncertainty)
+        enabled = bool(
+            not contact
+            and moving
+            and 0.0 < time_to_contact < self.config.maximum_horizon_sec
+            and intercept_miss <= self.config.maximum_intercept_miss_m
+            and confidence >= self.config.confidence_threshold
+        )
+        return ContactTimingBelief(
+            timestamp_ns=timestamp_ns,
+            predicted_contact_phase=predicted_phase,
+            predicted_time_to_contact_sec=time_to_contact,
+            predicted_contact_position_m=tuple(map(float, predicted_position)),
+            intercept_miss_m=intercept_miss,
+            uncertainty=uncertainty,
+            confidence=confidence,
+            phase_residual_enabled=enabled,
+            contact_observed=contact,
+            source=source,
+        )
+
+
+__all__ = [
+    "ContactTimingBelief",
+    "ContactTimingConfig",
+    "ContactTimingEstimator",
+]

--- a/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
+++ b/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
@@ -495,6 +495,7 @@ class G1MuJoCoBackend:
         phase_repeat_accumulator = 0.0
         next_feedback_time = 0.0
         latest_support_slip = 0.0
+        moving_ball_launched = scenario.ball_launch_delay_sec <= 0.0
 
         for frame in range(total_control_frames):
             if feedforward is not None:
@@ -566,6 +567,13 @@ class G1MuJoCoBackend:
             right_ground_force = 0.0
             ball_contact_point: np.ndarray = np.zeros(3, dtype=np.float64)
             for _ in range(10):
+                if not moving_ball_launched and data.time + 1e-12 >= scenario.ball_launch_delay_sec:
+                    data.qvel[ids.ball_qvel : ids.ball_qvel + 3] = (
+                        scenario.ball_velocity_x_mps,
+                        scenario.ball_velocity_y_mps,
+                        0.0,
+                    )
+                    moving_ball_launched = True
                 if feedback_runtime is not None and data.time + 1e-12 >= next_feedback_time:
                     feedback_phase = (
                         policy_phase
@@ -581,6 +589,7 @@ class G1MuJoCoBackend:
                         base_target=delayed_target,
                         support_slip=latest_support_slip,
                         contact_detected=contact_observed,
+                        control_latency_ms=scenario.control_latency_ms,
                     )
                     feedback_residual = feedback_effect.joint_residual
                     feedback_phase_rate = feedback_effect.kick_phase_rate
@@ -921,9 +930,13 @@ def _reset_ball(model: Any, data: Any, scenario: GoalForgeScenario) -> None:
     data.qpos[qpos : qpos + 3] = (scenario.ball_x_m, scenario.ball_y_m, 0.115)
     data.qpos[qpos + 3 : qpos + 7] = (1.0, 0.0, 0.0, 0.0)
     data.qvel[qvel : qvel + 3] = (
-        scenario.ball_velocity_x_mps,
-        scenario.ball_velocity_y_mps,
-        0.0,
+        (
+            scenario.ball_velocity_x_mps,
+            scenario.ball_velocity_y_mps,
+            0.0,
+        )
+        if scenario.ball_launch_delay_sec <= 0.0
+        else (0.0, 0.0, 0.0)
     )
     data.qvel[qvel + 3 : qvel + 6] = 0.0
 
@@ -1131,12 +1144,19 @@ def _feedback_effect(
     base_target: np.ndarray,
     support_slip: float,
     contact_detected: bool,
+    control_latency_ms: float,
 ) -> _FeedbackEffect:
     """Run one feedback tick from MuJoCo state without crossing the EventBus."""
 
     roll, pitch = _roll_pitch(data.xquat[ids.torso])
     com = data.subtree_com[ids.pelvis]
     support_y = float(data.xpos[ids.left_ankle][1])
+    ball_position = np.asarray(data.xpos[ids.ball], dtype=np.float64)
+    foot_position = np.asarray(data.xpos[ids.right_ankle], dtype=np.float64)
+    ball_velocity = np.asarray(data.qvel[ids.ball_qvel : ids.ball_qvel + 3], dtype=np.float64)
+    foot_velocity = np.asarray(data.cvel[ids.right_ankle][3:6], dtype=np.float64)
+    relative_position = ball_position - foot_position
+    relative_velocity = ball_velocity - foot_velocity
     actual: dict[str, float] = {
         "torso_roll": roll,
         "torso_pitch": pitch,
@@ -1146,6 +1166,29 @@ def _feedback_effect(
         "ball_lateral_error_m": float(data.qpos[ids.ball_qpos + 1])
         - float(data.xpos[ids.right_ankle][1]),
         "contact_detected": float(contact_detected),
+        "ball_relative_x_m": float(relative_position[0]),
+        "ball_relative_y_m": float(relative_position[1]),
+        "ball_relative_z_m": float(relative_position[2]),
+        "ball_relative_vx_mps": float(relative_velocity[0]),
+        "ball_relative_vy_mps": float(relative_velocity[1]),
+        "ball_relative_vz_mps": float(relative_velocity[2]),
+        "control_latency_ms": control_latency_ms,
+        "energy_margin": float(
+            np.clip(
+                1.0
+                - np.max(
+                    np.abs(np.asarray(data.ctrl, dtype=np.float64))
+                    / np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float64)
+                ),
+                0.0,
+                1.0,
+            )
+        ),
+        "sensor_quality": float(
+            np.all(np.isfinite(data.qpos))
+            and np.all(np.isfinite(data.qvel))
+            and np.all(np.isfinite(data.ctrl))
+        ),
     }
     actual.update(
         {

--- a/src/rosclaw/simforge/g1_candidate_evaluation.py
+++ b/src/rosclaw/simforge/g1_candidate_evaluation.py
@@ -1,0 +1,854 @@
+"""Matched MuJoCo evaluation for a loaded Phase 7 residual candidate."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import tempfile
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.continual.contracts import PolicyVersion
+from rosclaw.continual.g1_goalforge import build_g1_policy_lineage
+from rosclaw.continual.inference import (
+    ResidualCandidateArtifact,
+    build_g1_candidate_runtime,
+    load_residual_candidate,
+)
+from rosclaw.feedback.contracts import FeedbackFrame, FeedbackLoopSpec, canonical_hash
+from rosclaw.feedback.controllers.base import ZeroResidualController
+from rosclaw.feedback.replay import RecordedLatencyClock
+from rosclaw.feedback.runtime import FeedbackRuntime
+from rosclaw.simforge.backends.unitree_mujoco_backend import G1MuJoCoBackend, GoalForgeEpisode
+from rosclaw.simforge.models import Partition
+from rosclaw.simforge.seed_ledger import SeedLedger
+from rosclaw.simforge.tasks.g1_goalforge.concepts import ShotParameters
+from rosclaw.simforge.tasks.g1_goalforge.scenario import (
+    GoalForgeScenario,
+    generate_goalforge_scenarios,
+)
+
+_SUITE_SECRET = b"rosclaw-phase7.1-candidate-evaluation-v1"
+_FAILURE_TARGET_ERROR_M = 2.0
+_LATENCY_NS = 100_000
+_CLOCK_CAPACITY = 5000
+_ACTION_OUTPUTS = {
+    "waist_roll_residual": "joint:waist_roll_joint",
+    "right_hip_roll_residual": "joint:right_hip_roll_joint",
+    "right_hip_yaw_residual": "joint:right_hip_yaw_joint",
+    "kick_phase_rate": "skill:kick_phase_rate",
+}
+
+
+@dataclass(frozen=True)
+class CandidateEvaluationCounts:
+    recent: int = 50
+    anchor: int = 50
+    boundary: int = 100
+    self_partition: int = 50
+
+    def __post_init__(self) -> None:
+        if min(self.recent, self.anchor, self.boundary, self.self_partition) < 0:
+            raise ValueError("candidate evaluation partition counts must be non-negative")
+        if self.total <= 0:
+            raise ValueError("candidate evaluation requires at least one scenario")
+        if self.total > 1000:
+            raise ValueError("candidate evaluation is limited to 1000 matched scenarios")
+
+    @property
+    def total(self) -> int:
+        return self.recent + self.anchor + self.boundary + self.self_partition
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "recent": self.recent,
+            "anchor": self.anchor,
+            "boundary": self.boundary,
+            "self": self.self_partition,
+            "total": self.total,
+        }
+
+
+@dataclass(frozen=True)
+class CandidateEvaluationRow:
+    scenario_id: str
+    scenario_commitment: str
+    replay_partition: str
+    arm: str
+    policy_version: int | None
+    policy_version_hash: str
+    status: str
+    success: bool
+    contact: bool
+    goal_crossed: bool
+    penalized_target_error_m: float
+    conditional_target_error_m: float | None
+    ball_speed_mps: float
+    fall: bool
+    joint_violation: bool
+    torque_violation: bool
+    actuator_saturation: bool
+    com_margin_min_m: float
+    support_slip_m: float
+    tracking_rms_rad: float
+    energy_proxy: float
+    action_drift_rms: float
+    trajectory_hash: str
+    inference_receipt_hash: str | None
+    version_switch_count: int
+
+    def __post_init__(self) -> None:
+        metrics = {
+            "penalized_target_error_m": self.penalized_target_error_m,
+            "ball_speed_mps": self.ball_speed_mps,
+            "com_margin_min_m": self.com_margin_min_m,
+            "support_slip_m": self.support_slip_m,
+            "tracking_rms_rad": self.tracking_rms_rad,
+            "energy_proxy": self.energy_proxy,
+            "action_drift_rms": self.action_drift_rms,
+        }
+        if self.conditional_target_error_m is not None:
+            metrics["conditional_target_error_m"] = self.conditional_target_error_m
+        invalid = [name for name, value in metrics.items() if not math.isfinite(value)]
+        if invalid:
+            raise ValueError(
+                "candidate evaluation row contains non-finite metrics: " + ", ".join(invalid)
+            )
+
+
+@dataclass(frozen=True)
+class CandidateMatchedEvaluation:
+    body_hash: str
+    kick_prior_hash: str
+    backend_commit: str
+    candidate_policy: dict[str, Any]
+    parent_policy: dict[str, Any]
+    counts: dict[str, int]
+    training_seed_count: int
+    rows: tuple[CandidateEvaluationRow, ...]
+    aggregates: dict[str, Any]
+    paired_statistics: dict[str, Any]
+    gate: dict[str, Any]
+    replay_checks: dict[str, bool]
+    schema_version: str = "rosclaw.continual.g1_candidate_matched_evaluation.v1"
+
+    @property
+    def passed(self) -> bool:
+        return bool(self.gate["candidate_motion_effect_proven"])
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "body_hash": self.body_hash,
+            "kick_prior_hash": self.kick_prior_hash,
+            "backend_commit": self.backend_commit,
+            "candidate_policy": self.candidate_policy,
+            "parent_policy": self.parent_policy,
+            "counts": self.counts,
+            "training_seed_count": self.training_seed_count,
+            "arms": [
+                "frozen_prior",
+                "active_parent_v2",
+                "candidate_v3",
+                "fresh_network",
+            ],
+            "rows": [asdict(row) for row in self.rows],
+            "aggregates": self.aggregates,
+            "paired_statistics": self.paired_statistics,
+            "gate": self.gate,
+            "replay_checks": self.replay_checks,
+            "passed": self.passed,
+            "claims": {
+                "evidence_domain": "SIM",
+                "same_scenario_physics": True,
+                "candidate_artifact_executed": True,
+                "candidate_activated": False,
+                "registry_mutated": False,
+                "dds_opened": False,
+                "hardware_authorized": False,
+            },
+        }
+
+
+def run_g1_candidate_matched_evaluation(
+    *,
+    asset_root: Path,
+    candidate_artifact_path: Path,
+    candidate_policy: PolicyVersion,
+    output_path: Path,
+    source_checkout: Path,
+    counts: CandidateEvaluationCounts | None = None,
+    training_seed_count: int = 1,
+    suite_shard: str = "",
+    progress: Callable[[int, int], None] | None = None,
+) -> CandidateMatchedEvaluation:
+    """Run all four arms with identical scenario, physics, and shot parameters."""
+
+    counts = counts or CandidateEvaluationCounts()
+    destination = output_path.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if destination == checkout or checkout in destination.parents:
+        raise ValueError("candidate evaluation evidence must be outside the source checkout")
+    if destination.exists():
+        raise FileExistsError(f"candidate evaluation output already exists: {destination}")
+    if training_seed_count <= 0:
+        raise ValueError("training_seed_count must be positive")
+    backend = G1MuJoCoBackend(asset_root=asset_root, trace_stride=5)
+    qualification = backend.qualification
+    lineage = build_g1_policy_lineage(
+        body_hash=qualification.body_hash,
+        kick_prior_hash=qualification.kick_prior_hash,
+        motion_hash=qualification.motion_hash,
+        backend_commit=qualification.backend_commit,
+        torque_guard_scale=backend.torque_guard_scale,
+        through_version=2,
+    )
+    parent = lineage.policy(2)
+    artifact = load_residual_candidate(
+        candidate_artifact_path,
+        policy=candidate_policy,
+        parent=parent,
+        expected_body_hash=qualification.body_hash,
+    )
+    if any(character not in "abcdefghijklmnopqrstuvwxyz0123456789-_" for character in suite_shard):
+        raise ValueError(
+            "suite shard may contain only lowercase letters, numbers, dash, underscore"
+        )
+    scenarios = _evaluation_scenarios(counts, suite_shard=suite_shard)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    checkpoint_path = destination.with_name(destination.name + ".checkpoint")
+    checkpoint_identity = canonical_hash(
+        {
+            "candidate_policy_hash": candidate_policy.version_hash,
+            "counts": counts.to_dict(),
+            "suite_shard": suite_shard,
+        }
+    )
+    rows, replay_checks = _load_checkpoint(
+        checkpoint_path,
+        expected_identity=checkpoint_identity,
+    )
+    completed = {row.scenario_commitment for row in rows if row.arm == "active_parent_v2"}
+    for index, (partition_name, scenario) in enumerate(scenarios):
+        if scenario.scenario_commitment in completed:
+            if progress is not None:
+                progress(index + 1, len(scenarios))
+            continue
+        scenario_rows, replay = _run_matched_scenario(
+            backend=backend,
+            scenario=scenario,
+            partition_name=partition_name,
+            parent=parent,
+            candidate=artifact,
+            replay_candidate=partition_name not in replay_checks,
+        )
+        rows.extend(scenario_rows)
+        if replay is not None:
+            replay_checks[partition_name] = replay
+        _write_checkpoint(
+            checkpoint_path,
+            identity=checkpoint_identity,
+            rows=rows,
+            replay_checks=replay_checks,
+            complete=False,
+        )
+        if progress is not None:
+            progress(index + 1, len(scenarios))
+    aggregates = _aggregate(rows)
+    paired = _paired_statistics(rows)
+    gate = _gate(
+        rows=rows,
+        paired=paired,
+        replay_checks=replay_checks,
+        counts=counts,
+        training_seed_count=training_seed_count,
+    )
+    result = CandidateMatchedEvaluation(
+        body_hash=qualification.body_hash,
+        kick_prior_hash=qualification.kick_prior_hash,
+        backend_commit=qualification.backend_commit,
+        candidate_policy=candidate_policy.to_dict(),
+        parent_policy=parent.to_dict(),
+        counts=counts.to_dict(),
+        training_seed_count=training_seed_count,
+        rows=tuple(rows),
+        aggregates=aggregates,
+        paired_statistics=paired,
+        gate=gate,
+        replay_checks=replay_checks,
+    )
+    _atomic_json(destination, result.to_dict())
+    _write_checkpoint(
+        checkpoint_path,
+        identity=checkpoint_identity,
+        rows=rows,
+        replay_checks=replay_checks,
+        complete=True,
+    )
+    return result
+
+
+def _evaluation_scenarios(
+    counts: CandidateEvaluationCounts,
+    *,
+    suite_shard: str = "",
+) -> tuple[tuple[str, GoalForgeScenario], ...]:
+    specifications = (
+        ("recent", Partition.DEVELOPMENT, counts.recent, 9),
+        ("anchor", Partition.VALIDATION, counts.anchor, 0),
+        ("boundary", Partition.COUNTEREXAMPLE_REGRESSION, counts.boundary, 10),
+        ("self", Partition.STRESS, counts.self_partition, 8),
+    )
+    result: list[tuple[str, GoalForgeScenario]] = []
+    for name, partition, count, generation in specifications:
+        if count == 0:
+            continue
+        ledger = SeedLedger(
+            task_id="g1_penalty_kick",
+            secret=(
+                _SUITE_SECRET
+                + b":"
+                + name.encode("ascii")
+                + (b":" + suite_shard.encode("ascii") if suite_shard else b"")
+            ),
+        )
+        generated = generate_goalforge_scenarios(
+            ledger=ledger,
+            partition=partition,
+            count=count,
+            generation=generation,
+        )
+        result.extend(
+            (
+                name,
+                replace(
+                    scenario,
+                    scenario_id=(
+                        f"g1-candidate-eval-{name}"
+                        + (f"-{suite_shard}" if suite_shard else "")
+                        + f"-{index:04d}"
+                    ),
+                ),
+            )
+            for index, scenario in enumerate(generated)
+        )
+    return tuple(result)
+
+
+def merge_g1_candidate_evaluations(
+    *,
+    shard_paths: Sequence[Path],
+    output_path: Path,
+    source_checkout: Path,
+) -> CandidateMatchedEvaluation:
+    """Merge resumable disjoint shards and recompute every aggregate and gate."""
+
+    if len(shard_paths) < 2:
+        raise ValueError("candidate evaluation merge requires at least two shards")
+    destination = output_path.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if destination == checkout or checkout in destination.parents:
+        raise ValueError("candidate evaluation evidence must be outside the source checkout")
+    if destination.exists():
+        raise FileExistsError(f"candidate evaluation output already exists: {destination}")
+    values = [
+        json.loads(path.expanduser().resolve().read_text(encoding="utf-8")) for path in shard_paths
+    ]
+    identity_fields = (
+        "body_hash",
+        "kick_prior_hash",
+        "backend_commit",
+        "candidate_policy",
+        "parent_policy",
+    )
+    first = values[0]
+    for value in values[1:]:
+        if any(value[field] != first[field] for field in identity_fields):
+            raise ValueError("candidate evaluation shard identities do not match")
+    rows = tuple(CandidateEvaluationRow(**row) for value in values for row in value["rows"])
+    commitments = [row.scenario_commitment for row in rows if row.arm == "active_parent_v2"]
+    if len(commitments) != len(set(commitments)):
+        raise ValueError("candidate evaluation shards contain duplicate scenarios")
+    counts = CandidateEvaluationCounts(
+        recent=sum(int(value["counts"]["recent"]) for value in values),
+        anchor=sum(int(value["counts"]["anchor"]) for value in values),
+        boundary=sum(int(value["counts"]["boundary"]) for value in values),
+        self_partition=sum(int(value["counts"]["self"]) for value in values),
+    )
+    replay_checks: dict[str, bool] = {}
+    for value in values:
+        replay_checks.update({str(key): bool(item) for key, item in value["replay_checks"].items()})
+    paired = _paired_statistics(rows)
+    training_seed_count = max(int(value["training_seed_count"]) for value in values)
+    result = CandidateMatchedEvaluation(
+        body_hash=str(first["body_hash"]),
+        kick_prior_hash=str(first["kick_prior_hash"]),
+        backend_commit=str(first["backend_commit"]),
+        candidate_policy=dict(first["candidate_policy"]),
+        parent_policy=dict(first["parent_policy"]),
+        counts=counts.to_dict(),
+        training_seed_count=training_seed_count,
+        rows=rows,
+        aggregates=_aggregate(rows),
+        paired_statistics=paired,
+        gate=_gate(
+            rows=rows,
+            paired=paired,
+            replay_checks=replay_checks,
+            counts=counts,
+            training_seed_count=training_seed_count,
+        ),
+        replay_checks=replay_checks,
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_json(destination, result.to_dict())
+    return result
+
+
+def _run_matched_scenario(
+    *,
+    backend: G1MuJoCoBackend,
+    scenario: GoalForgeScenario,
+    partition_name: str,
+    parent: PolicyVersion,
+    candidate: ResidualCandidateArtifact,
+    replay_candidate: bool,
+) -> tuple[tuple[CandidateEvaluationRow, ...], bool | None]:
+    parameters = ShotParameters()
+    prior = backend.run(scenario, parameters)
+    parent_runtime = _zero_runtime(candidate)
+    parent_episode = backend.run(scenario, parameters, feedback_runtime=parent_runtime)
+    candidate_runtime, candidate_policy = build_g1_candidate_runtime(
+        candidate,
+        compute_clock_ns=RecordedLatencyClock((_LATENCY_NS,) * _CLOCK_CAPACITY),
+    )
+    candidate_episode = backend.run(scenario, parameters, feedback_runtime=candidate_runtime)
+    inference_receipt = candidate_policy.build_receipt()
+    fresh_runtime = _fresh_runtime(candidate, seed=scenario.seed ^ 0xF35A71)
+    fresh = backend.run(scenario, parameters, feedback_runtime=fresh_runtime)
+    parent_matches_prior = bool(
+        parent_episode.result.summary_dict() == prior.result.summary_dict()
+        and _motion_hash(parent_episode) == _motion_hash(prior)
+    )
+    candidate_replay: bool | None = None
+    if replay_candidate:
+        replay_runtime, replay_policy = build_g1_candidate_runtime(
+            candidate,
+            compute_clock_ns=RecordedLatencyClock((_LATENCY_NS,) * _CLOCK_CAPACITY),
+        )
+        replay = backend.run(scenario, parameters, feedback_runtime=replay_runtime)
+        candidate_replay = bool(
+            replay.result.summary_dict() == candidate_episode.result.summary_dict()
+            and _motion_hash(replay) == _motion_hash(candidate_episode)
+            and replay_policy.build_receipt().trace_hash == inference_receipt.trace_hash
+        )
+    return (
+        (
+            _row(
+                scenario,
+                partition_name,
+                "frozen_prior",
+                prior,
+                version=0,
+                version_hash=canonical_hash(
+                    {"frozen_robonaldo_prior": candidate.parent.artifact_hash}
+                ),
+            ),
+            _row(
+                scenario,
+                partition_name,
+                "active_parent_v2",
+                parent_episode,
+                version=parent.version,
+                version_hash=parent.version_hash,
+            ),
+            _row(
+                scenario,
+                partition_name,
+                "candidate_v3",
+                candidate_episode,
+                version=candidate.policy.version,
+                version_hash=candidate.policy.version_hash,
+                inference_receipt=inference_receipt.to_dict(),
+                inference_receipt_hash=inference_receipt.receipt_hash,
+            ),
+            _row(
+                scenario,
+                partition_name,
+                "fresh_network",
+                fresh,
+                version=None,
+                version_hash=fresh_runtime.controller.controller_hash,
+            ),
+        ),
+        candidate_replay if parent_matches_prior else False,
+    )
+
+
+def _row(
+    scenario: GoalForgeScenario,
+    partition_name: str,
+    arm: str,
+    episode: GoalForgeEpisode,
+    *,
+    version: int | None,
+    version_hash: str,
+    inference_receipt: Mapping[str, Any] | None = None,
+    inference_receipt_hash: str | None = None,
+) -> CandidateEvaluationRow:
+    result = episode.result
+    target_error = result.target_error_m if math.isfinite(result.target_error_m) else None
+    tracking = np.asarray(episode.trajectory["policy_action"], dtype=np.float64) - np.asarray(
+        episode.trajectory["joint_position"], dtype=np.float64
+    )
+    torque = np.asarray(episode.trajectory["joint_torque"], dtype=np.float64)
+    return CandidateEvaluationRow(
+        scenario_id=scenario.scenario_id,
+        scenario_commitment=scenario.scenario_commitment,
+        replay_partition=partition_name,
+        arm=arm,
+        policy_version=version,
+        policy_version_hash=version_hash,
+        status=result.status.value,
+        success=result.success,
+        contact=result.kick_foot_contacted,
+        goal_crossed=result.goal_crossed,
+        penalized_target_error_m=(
+            target_error if result.success and target_error is not None else _FAILURE_TARGET_ERROR_M
+        ),
+        conditional_target_error_m=target_error,
+        ball_speed_mps=result.ball_speed_mps,
+        fall=result.post_kick_fall,
+        joint_violation=result.joint_limit_violation,
+        torque_violation=result.torque_limit_violation,
+        actuator_saturation=result.actuator_saturation,
+        # The backend leaves this accumulator at +inf when an episode never enters
+        # a measurable single-support window.  Encode that missing safety margin
+        # conservatively instead of leaking a non-JSON IEEE sentinel into evidence.
+        com_margin_min_m=(
+            result.com_margin_min_m if math.isfinite(result.com_margin_min_m) else -1.0
+        ),
+        support_slip_m=result.support_foot_slip_m,
+        tracking_rms_rad=float(np.sqrt(np.mean(np.square(tracking)))),
+        energy_proxy=float(np.sum(np.square(torque)) * 0.02),
+        action_drift_rms=(
+            float(inference_receipt.get("action_rms", 0.0)) if inference_receipt else 0.0
+        ),
+        trajectory_hash=_motion_hash(episode),
+        inference_receipt_hash=inference_receipt_hash,
+        version_switch_count=(
+            int(inference_receipt.get("version_switch_count", 0)) if inference_receipt else 0
+        ),
+    )
+
+
+def _zero_runtime(candidate: ResidualCandidateArtifact) -> FeedbackRuntime:
+    controller = ZeroResidualController()
+    spec = FeedbackLoopSpec(
+        loop_id="g1/goalforge-parent-v2",
+        body_hash=candidate.policy.body_hash,
+        controller_hash=controller.controller_hash,
+        reference_signals=("torso_roll", "torso_pitch", "com_y_relative"),
+        observation_signals=candidate.observation_names,
+        output_limits={
+            _ACTION_OUTPUTS[name]: limit
+            for name, limit in zip(candidate.action_names, candidate.action_limits, strict=True)
+        },
+        rate_hz=100.0,
+        deadline_ms=10.0,
+        max_observation_age_ms=20.0,
+    )
+    return FeedbackRuntime(
+        spec=spec,
+        controller=controller,
+        compute_clock_ns=RecordedLatencyClock((_LATENCY_NS,) * _CLOCK_CAPACITY),
+    )
+
+
+class _FreshResidualController:
+    def __init__(self, candidate: ResidualCandidateArtifact, *, seed: int) -> None:
+        self._candidate = candidate
+        rng = np.random.default_rng(seed)
+        h0, h1 = candidate.hidden_dims
+        self._weights = (
+            rng.normal(0.0, 0.08, (h0, len(candidate.observation_names))),
+            rng.normal(0.0, 0.08, (h1, h0)),
+            rng.normal(0.0, 0.04, (len(candidate.action_names), h1)),
+        )
+        self._biases = (np.zeros(h0), np.zeros(h1), np.zeros(len(candidate.action_names)))
+        self._seed = seed
+
+    @property
+    def controller_hash(self) -> str:
+        return canonical_hash(self.config_dict())
+
+    def reset(self) -> None:
+        return None
+
+    def compute(
+        self, frame: FeedbackFrame, base_action: Mapping[str, float]
+    ) -> Mapping[str, float]:
+        del base_action
+        value = np.asarray(
+            [frame.actual[name] for name in self._candidate.observation_names], dtype=np.float64
+        )
+        value = np.maximum(self._weights[0] @ value + self._biases[0], 0.0)
+        value = np.maximum(self._weights[1] @ value + self._biases[1], 0.0)
+        value = np.tanh(self._weights[2] @ value + self._biases[2]) * np.asarray(
+            self._candidate.action_limits
+        )
+        return {
+            _ACTION_OUTPUTS[name]: float(item)
+            for name, item in zip(self._candidate.action_names, value, strict=True)
+        }
+
+    def config_dict(self) -> dict[str, object]:
+        return {
+            "controller_type": "fresh_untrained_residual_control",
+            "seed": self._seed,
+            "candidate_contract_hash": self._candidate.policy.version_hash,
+        }
+
+
+def _fresh_runtime(candidate: ResidualCandidateArtifact, *, seed: int) -> FeedbackRuntime:
+    controller = _FreshResidualController(candidate, seed=seed)
+    spec = FeedbackLoopSpec(
+        loop_id="g1/goalforge-fresh-network-control",
+        body_hash=candidate.policy.body_hash,
+        controller_hash=controller.controller_hash,
+        reference_signals=("torso_roll", "torso_pitch", "com_y_relative"),
+        observation_signals=candidate.observation_names,
+        output_limits={
+            _ACTION_OUTPUTS[name]: limit
+            for name, limit in zip(candidate.action_names, candidate.action_limits, strict=True)
+        },
+        rate_hz=100.0,
+        deadline_ms=10.0,
+        max_observation_age_ms=20.0,
+    )
+    return FeedbackRuntime(
+        spec=spec,
+        controller=controller,
+        compute_clock_ns=RecordedLatencyClock((_LATENCY_NS,) * _CLOCK_CAPACITY),
+    )
+
+
+def _motion_hash(episode: GoalForgeEpisode) -> str:
+    digest = hashlib.sha256()
+    ignored = {
+        "feedback_residual",
+        "feedback_error_rms",
+        "feedback_active",
+        "feedback_phase_rate",
+    }
+    for name in sorted(set(episode.trajectory).difference(ignored)):
+        value = np.ascontiguousarray(episode.trajectory[name])
+        digest.update(name.encode("utf-8"))
+        digest.update(str(value.dtype).encode("ascii"))
+        digest.update(np.asarray(value.shape, dtype=np.int64).tobytes())
+        digest.update(value.tobytes())
+    return "sha256:" + digest.hexdigest()
+
+
+def _aggregate(rows: Sequence[CandidateEvaluationRow]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    arms = sorted({row.arm for row in rows})
+    partitions = ("all", "recent", "anchor", "boundary", "self")
+    for arm in arms:
+        result[arm] = {}
+        for partition in partitions:
+            selected = [
+                row
+                for row in rows
+                if row.arm == arm and (partition == "all" or row.replay_partition == partition)
+            ]
+            if not selected:
+                continue
+            result[arm][partition] = {
+                "episodes": len(selected),
+                "success_rate": _mean(row.success for row in selected),
+                "contact_rate": _mean(row.contact for row in selected),
+                "goal_crossing_rate": _mean(row.goal_crossed for row in selected),
+                "mean_penalized_target_error_m": _mean(
+                    row.penalized_target_error_m for row in selected
+                ),
+                "mean_ball_speed_mps": _mean(row.ball_speed_mps for row in selected),
+                "fall_rate": _mean(row.fall for row in selected),
+                "joint_violation_rate": _mean(row.joint_violation for row in selected),
+                "torque_violation_rate": _mean(row.torque_violation for row in selected),
+                "actuator_saturation_rate": _mean(row.actuator_saturation for row in selected),
+                "mean_com_margin_min_m": _mean(row.com_margin_min_m for row in selected),
+                "mean_support_slip_m": _mean(row.support_slip_m for row in selected),
+                "mean_tracking_rms_rad": _mean(row.tracking_rms_rad for row in selected),
+                "mean_energy_proxy": _mean(row.energy_proxy for row in selected),
+                "anchor_action_drift_rms": _mean(row.action_drift_rms for row in selected),
+            }
+    return result
+
+
+def _paired_statistics(rows: Sequence[CandidateEvaluationRow]) -> dict[str, Any]:
+    parent = {row.scenario_commitment: row for row in rows if row.arm == "active_parent_v2"}
+    candidate = {row.scenario_commitment: row for row in rows if row.arm == "candidate_v3"}
+    keys = sorted(set(parent) & set(candidate))
+    success_delta = np.asarray(
+        [float(candidate[key].success) - float(parent[key].success) for key in keys]
+    )
+    error_improvement = np.asarray(
+        [
+            parent[key].penalized_target_error_m - candidate[key].penalized_target_error_m
+            for key in keys
+        ]
+    )
+    return {
+        "paired_scenarios": len(keys),
+        "success_rate_delta": float(np.mean(success_delta)),
+        "success_rate_delta_ci95": list(_bootstrap_ci(success_delta, seed=71001)),
+        "target_error_improvement_m": float(np.mean(error_improvement)),
+        "target_error_improvement_ci95": list(_bootstrap_ci(error_improvement, seed=71002)),
+    }
+
+
+def _gate(
+    *,
+    rows: Sequence[CandidateEvaluationRow],
+    paired: Mapping[str, Any],
+    replay_checks: Mapping[str, bool],
+    counts: CandidateEvaluationCounts,
+    training_seed_count: int,
+) -> dict[str, Any]:
+    parent = {row.scenario_commitment: row for row in rows if row.arm == "active_parent_v2"}
+    candidate = {row.scenario_commitment: row for row in rows if row.arm == "candidate_v3"}
+    common = set(parent) & set(candidate)
+    critical_regressions = sum(
+        (candidate[key].fall or candidate[key].joint_violation or candidate[key].torque_violation)
+        and not (parent[key].fall or parent[key].joint_violation or parent[key].torque_violation)
+        for key in common
+    )
+    parent_anchor = [row.success for row in parent.values() if row.replay_partition == "anchor"]
+    candidate_anchor = [
+        row.success for row in candidate.values() if row.replay_partition == "anchor"
+    ]
+    anchor_delta = (
+        _mean(candidate_anchor) - _mean(parent_anchor)
+        if candidate_anchor and parent_anchor
+        else None
+    )
+    target_ci = paired["target_error_improvement_ci95"]
+    checks = {
+        "minimum_250_scenarios": counts.total >= 250,
+        "minimum_8_training_seeds": training_seed_count >= 8,
+        "four_partition_replay": set(replay_checks) == {"recent", "anchor", "boundary", "self"}
+        and all(replay_checks.values()),
+        "motion_version_switches_zero": all(row.version_switch_count == 0 for row in rows),
+        "critical_regression_zero": critical_regressions == 0,
+        "historical_mean_degradation_lt_3pct": bool(
+            anchor_delta is not None and anchor_delta > -0.03
+        ),
+        "critical_skill_degradation_lte_5pct": bool(
+            float(paired.get("success_rate_delta", float("-inf"))) >= -0.05
+        ),
+        "candidate_target_improvement_ci": target_ci[0] > 0.02,
+    }
+    return {
+        "decision": "SIM_CHAMPION" if all(checks.values()) else "REJECTED",
+        "candidate_motion_effect_proven": all(checks.values()),
+        "checks": checks,
+        "critical_safety_regressions": critical_regressions,
+        "anchor_success_delta": anchor_delta,
+        "minimum_target_error_improvement_m": 0.02,
+        "candidate_activated": False,
+        "hardware_authorized": False,
+    }
+
+
+def _bootstrap_ci(values: np.ndarray, *, seed: int) -> tuple[float, float]:
+    if values.size == 0:
+        raise ValueError("paired confidence interval requires values")
+    if values.size == 1:
+        value = float(values[0])
+        return value, value
+    rng = np.random.default_rng(seed)
+    indices = rng.integers(0, values.size, size=(5000, values.size))
+    means = values[indices].mean(axis=1)
+    return float(np.quantile(means, 0.025)), float(np.quantile(means, 0.975))
+
+
+def _mean(values: Iterable[float]) -> float:
+    resolved = tuple(float(value) for value in values)
+    if not resolved:
+        raise ValueError("mean requires at least one value")
+    return float(sum(resolved) / len(resolved))
+
+
+def _atomic_json(path: Path, value: Mapping[str, Any]) -> None:
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True, allow_nan=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def _load_checkpoint(
+    path: Path,
+    *,
+    expected_identity: str,
+) -> tuple[list[CandidateEvaluationRow], dict[str, bool]]:
+    if not path.is_file():
+        return [], {}
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if value.get("identity") != expected_identity:
+        raise ValueError("candidate evaluation checkpoint identity does not match request")
+    rows = []
+    for serialized in value.get("rows", []):
+        row = dict(serialized)
+        # Checkpoints written before the finite-evidence invariant could contain
+        # the backend's +inf sentinel for an unobserved single-support margin.
+        # Migrate only that known field; CandidateEvaluationRow still rejects any
+        # other non-finite value before the checkpoint can be rewritten.
+        if not math.isfinite(float(row["com_margin_min_m"])):
+            row["com_margin_min_m"] = -1.0
+        rows.append(CandidateEvaluationRow(**row))
+    replay = {str(key): bool(item) for key, item in value.get("replay_checks", {}).items()}
+    return rows, replay
+
+
+def _write_checkpoint(
+    path: Path,
+    *,
+    identity: str,
+    rows: Sequence[CandidateEvaluationRow],
+    replay_checks: Mapping[str, bool],
+    complete: bool,
+) -> None:
+    _atomic_json(
+        path,
+        {
+            "schema_version": "rosclaw.continual.g1_candidate_evaluation_checkpoint.v1",
+            "identity": identity,
+            "complete": complete,
+            "completed_scenarios": sum(row.arm == "active_parent_v2" for row in rows),
+            "rows": [asdict(row) for row in rows],
+            "replay_checks": dict(replay_checks),
+        },
+    )
+
+
+__all__ = [
+    "CandidateEvaluationCounts",
+    "CandidateEvaluationRow",
+    "CandidateMatchedEvaluation",
+    "merge_g1_candidate_evaluations",
+    "run_g1_candidate_matched_evaluation",
+]

--- a/src/rosclaw/simforge/g1_hat_trick.py
+++ b/src/rosclaw/simforge/g1_hat_trick.py
@@ -1,0 +1,346 @@
+"""GoalForge Hat Trick: target, moving-ball, and disturbance-rescue evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import random
+import tempfile
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.feedback.profiles.g1 import build_g1_balance_runtime
+from rosclaw.feedback.replay import RecordedLatencyClock
+from rosclaw.simforge.backends.unitree_mujoco_backend import (
+    G1MuJoCoBackend,
+    GoalForgeEpisode,
+    trajectory_digest,
+)
+from rosclaw.simforge.g1_moving_ball import MovingBallInterceptAdapter
+from rosclaw.simforge.models import Partition
+from rosclaw.simforge.seed_ledger import SeedLedger
+from rosclaw.simforge.tasks.g1_goalforge.concepts import ShotParameters
+from rosclaw.simforge.tasks.g1_goalforge.scenario import (
+    GoalForgeScenario,
+    generate_goalforge_scenarios,
+)
+
+_SECRET = b"rosclaw-phase7.1-goalforge-hat-trick-v1"
+_CLOCK_CAPACITY = 5000
+_LATENCY_NS = 100_000
+
+
+@dataclass(frozen=True)
+class HatTrickShot:
+    name: str
+    title: str
+    capability: str
+    scenario: dict[str, Any]
+    parameters: dict[str, Any]
+    result: dict[str, Any]
+    trajectory_path: str
+    trajectory_hash: str
+    strict_replay: bool
+    feedback_receipt: dict[str, Any] | None = None
+    comparison_result: dict[str, Any] | None = None
+    comparison_trajectory_path: str | None = None
+    comparison_trajectory_hash: str | None = None
+    planner_receipt: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class GoalForgeHatTrick:
+    body_hash: str
+    kick_prior_hash: str
+    backend_commit: str
+    shots: tuple[HatTrickShot, ...]
+    schema_version: str = "rosclaw.g1_goalforge.hat_trick.v1"
+
+    @property
+    def passed(self) -> bool:
+        if len(self.shots) != 3:
+            return False
+        target, moving, rescue = self.shots
+        return bool(
+            all(shot.result["success"] and shot.strict_replay for shot in self.shots)
+            and target.result["target_zone_hit"]
+            and target.result["ball_speed_mps"] >= 6.0
+            and moving.scenario["ball_launch_delay_sec"] > 0.0
+            and moving.result["kick_foot_contacted"]
+            and moving.result["ball_contact_time_sec"] is not None
+            and rescue.scenario["disturbance_n"] >= 80.0
+            and rescue.comparison_result is not None
+            and not rescue.comparison_result["success"]
+            and not any(
+                shot.result[name]
+                for shot in self.shots
+                for name in (
+                    "post_kick_fall",
+                    "joint_limit_violation",
+                    "torque_limit_violation",
+                )
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "body_hash": self.body_hash,
+            "kick_prior_hash": self.kick_prior_hash,
+            "backend_commit": self.backend_commit,
+            "shots": [asdict(shot) for shot in self.shots],
+            "passed": self.passed,
+            "visualization_may_consume_evidence": self.passed,
+            "claims": {
+                "evidence_domain": "SIM",
+                "static_nine_grid_shot": self.shots[0].result["success"],
+                "moving_ball_first_time_shot": self.shots[1].result["success"],
+                "disturbance_feedback_rescue": self.shots[2].result["success"],
+                "candidate_v3_promoted": False,
+                "magnus_curve_claimed": False,
+                "real_hardware": False,
+            },
+        }
+
+
+def run_goalforge_hat_trick(
+    *,
+    asset_root: Path,
+    output_dir: Path,
+    source_checkout: Path,
+) -> GoalForgeHatTrick:
+    """Execute and strictly replay all three SIM-only flagship shots."""
+
+    root = output_dir.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if root == checkout or checkout in root.parents:
+        raise ValueError("Hat Trick evidence must be outside the source checkout")
+    root.mkdir(parents=True, exist_ok=False)
+    backend = G1MuJoCoBackend(asset_root=asset_root, trace_stride=1)
+    qualification = backend.qualification
+    base = _base_scenario()
+    selection_seed = 202607289
+    target_y, target_z = random.Random(selection_seed).choice(
+        [(y, z) for y in (-0.75, 0.0, 0.75) for z in (0.20, 0.55, 0.90)]
+    )
+    target_scenario = replace(
+        base,
+        scenario_id="goalforge-hat-trick-nine-grid",
+        generation=4,
+        ball_y_m=0.10,
+        target_y_m=target_y,
+        target_z_m=target_z,
+    )
+    target_parameters = ShotParameters(
+        stance_offset_y=0.12,
+        pelvis_yaw_offset=-0.20,
+        foot_yaw_offset=-0.0595,
+        policy_type="parameter",
+    )
+    target = _run_strict_pair(
+        backend=backend,
+        scenario=target_scenario,
+        parameters=target_parameters,
+    )
+    target_path = _save_trajectory(root / "shot-1-nine-grid.npz", target[0])
+
+    moving_scenario = replace(
+        base,
+        scenario_id="goalforge-hat-trick-moving-ball",
+        ball_x_m=1.12,
+        ball_y_m=0.0,
+        ball_velocity_x_mps=-0.08,
+        ball_velocity_y_mps=0.0,
+        ball_launch_delay_sec=4.0,
+        ball_ground_friction=0.03,
+        target_y_m=0.0,
+        target_z_m=0.20,
+    )
+    moving_plan = MovingBallInterceptAdapter().plan(moving_scenario)
+    if not moving_plan.eligible:
+        raise RuntimeError("Hat Trick moving-ball scenario is outside the adapter envelope")
+    moving_parameters = moving_plan.parameters
+    moving = _run_strict_pair(
+        backend=backend,
+        scenario=moving_scenario,
+        parameters=moving_parameters,
+    )
+    moving_path = _save_trajectory(root / "shot-2-moving-ball.npz", moving[0])
+
+    rescue_scenario = replace(
+        base,
+        scenario_id="goalforge-hat-trick-80n-rescue",
+        disturbance_n=80.0,
+    )
+    rescue_parameters = ShotParameters()
+    rescue_baseline = backend.run(rescue_scenario, rescue_parameters)
+    runtime = build_g1_balance_runtime(
+        body_hash=qualification.body_hash,
+        compute_clock_ns=RecordedLatencyClock((_LATENCY_NS,) * _CLOCK_CAPACITY),
+    )
+    rescue_episode = backend.run(
+        rescue_scenario,
+        rescue_parameters,
+        feedback_runtime=runtime,
+    )
+    replay_runtime = build_g1_balance_runtime(
+        body_hash=qualification.body_hash,
+        compute_clock_ns=RecordedLatencyClock((_LATENCY_NS,) * _CLOCK_CAPACITY),
+    )
+    rescue_replay = backend.run(
+        rescue_scenario,
+        rescue_parameters,
+        feedback_runtime=replay_runtime,
+    )
+    rescue_strict = bool(
+        rescue_replay.result.summary_dict() == rescue_episode.result.summary_dict()
+        and trajectory_digest(rescue_replay.trajectory)
+        == trajectory_digest(rescue_episode.trajectory)
+    )
+    feedback_receipt = runtime.build_receipt(
+        action_id="goalforge-hat-trick-80n-rescue",
+        strict_replay=rescue_strict,
+        evidence_domain="SIM",
+    )
+    rescue_path = _save_trajectory(root / "shot-3-feedback-on.npz", rescue_episode)
+    rescue_off_path = _save_trajectory(root / "shot-3-feedback-off.npz", rescue_baseline)
+
+    shots = (
+        _shot(
+            name="nine_grid_power",
+            title="SHOT 1 · 3×3 TARGET POWER",
+            capability="precision_and_power",
+            scenario=target_scenario,
+            parameters=target_parameters,
+            episode=target[0],
+            path=target_path,
+            strict=target[1],
+            planner_receipt={
+                "schema_version": "rosclaw.g1_goalforge.nine_grid_selection.v1",
+                "selection_seed": selection_seed,
+                "selection_seed_commitment": "sha256:"
+                + hashlib.sha256(str(selection_seed).encode()).hexdigest(),
+                "selected_target_y_m": target_y,
+                "selected_target_z_m": target_z,
+                "candidate_zones": 9,
+            },
+        ),
+        _shot(
+            name="moving_ball_first_time",
+            title="SHOT 2 · MOVING BALL FIRST-TIME",
+            capability="moving_ball_intercept_adapter",
+            scenario=moving_scenario,
+            parameters=moving_parameters,
+            episode=moving[0],
+            path=moving_path,
+            strict=moving[1],
+            planner_receipt=moving_plan.to_dict(),
+        ),
+        _shot(
+            name="disturbance_feedback_rescue",
+            title="SHOT 3 · 80 N FEEDBACK RESCUE",
+            capability="balance_and_disturbance_recovery",
+            scenario=rescue_scenario,
+            parameters=rescue_parameters,
+            episode=rescue_episode,
+            path=rescue_path,
+            strict=rescue_strict,
+            feedback_receipt=feedback_receipt.to_dict(),
+            comparison_result=rescue_baseline.result.summary_dict(),
+            comparison_path=rescue_off_path,
+        ),
+    )
+    result = GoalForgeHatTrick(
+        body_hash=qualification.body_hash,
+        kick_prior_hash=qualification.kick_prior_hash,
+        backend_commit=qualification.backend_commit,
+        shots=shots,
+    )
+    _atomic_json(root / "goalforge-hat-trick.json", result.to_dict())
+    return result
+
+
+def _base_scenario() -> GoalForgeScenario:
+    return generate_goalforge_scenarios(
+        ledger=SeedLedger(task_id="g1_penalty_kick", secret=_SECRET),
+        partition=Partition.VALIDATION,
+        count=1,
+        generation=0,
+    )[0]
+
+
+def _run_strict_pair(
+    *,
+    backend: G1MuJoCoBackend,
+    scenario: GoalForgeScenario,
+    parameters: ShotParameters,
+) -> tuple[GoalForgeEpisode, bool]:
+    episode = backend.run(scenario, parameters)
+    replay = backend.run(scenario, parameters)
+    return episode, bool(
+        replay.result.summary_dict() == episode.result.summary_dict()
+        and trajectory_digest(replay.trajectory) == trajectory_digest(episode.trajectory)
+    )
+
+
+def _save_trajectory(path: Path, episode: GoalForgeEpisode) -> Path:
+    np.savez_compressed(path, **episode.trajectory)
+    return path
+
+
+def _shot(
+    *,
+    name: str,
+    title: str,
+    capability: str,
+    scenario: GoalForgeScenario,
+    parameters: ShotParameters,
+    episode: GoalForgeEpisode,
+    path: Path,
+    strict: bool,
+    feedback_receipt: dict[str, Any] | None = None,
+    comparison_result: dict[str, Any] | None = None,
+    comparison_path: Path | None = None,
+    planner_receipt: dict[str, Any] | None = None,
+) -> HatTrickShot:
+    return HatTrickShot(
+        name=name,
+        title=title,
+        capability=capability,
+        scenario=scenario.to_private_dict(),
+        parameters=parameters.to_dict(),
+        result=episode.result.summary_dict(),
+        trajectory_path=str(path),
+        trajectory_hash=_file_hash(path),
+        strict_replay=strict,
+        feedback_receipt=feedback_receipt,
+        comparison_result=comparison_result,
+        comparison_trajectory_path=str(comparison_path) if comparison_path else None,
+        comparison_trajectory_hash=_file_hash(comparison_path) if comparison_path else None,
+        planner_receipt=planner_receipt,
+    )
+
+
+def _file_hash(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True, allow_nan=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+__all__ = ["GoalForgeHatTrick", "HatTrickShot", "run_goalforge_hat_trick"]

--- a/src/rosclaw/simforge/g1_hat_trick_cli.py
+++ b/src/rosclaw/simforge/g1_hat_trick_cli.py
@@ -1,0 +1,49 @@
+"""Product CLI for GoalForge Hat Trick evidence and visualization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def dispatch_hat_trick_argv(argv: list[str]) -> int | None:
+    if len(argv) < 3 or argv[:2] != ["goalforge", "hat-trick"]:
+        return None
+    parser = argparse.ArgumentParser(prog="rosclaw goalforge hat-trick")
+    commands = parser.add_subparsers(dest="command", required=True)
+    run = commands.add_parser("run", help="execute three strictly replayed MuJoCo shots")
+    run.add_argument("--asset-root", type=Path, required=True)
+    run.add_argument("--output-dir", type=Path, required=True)
+    run.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    export = commands.add_parser("export", help="render a passing Hat Trick report")
+    export.add_argument("evidence", type=Path)
+    export.add_argument("--asset-root", type=Path, required=True)
+    export.add_argument("--output", type=Path, required=True)
+    export.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    export.add_argument("--fps", type=int, default=30)
+    args = parser.parse_args(argv[2:])
+    if args.command == "run":
+        from rosclaw.simforge.g1_hat_trick import run_goalforge_hat_trick
+
+        result = run_goalforge_hat_trick(
+            asset_root=args.asset_root,
+            output_dir=args.output_dir,
+            source_checkout=args.source_checkout,
+        )
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return 0
+    from rosclaw.simforge.g1_hat_trick_video import render_goalforge_hat_trick_video
+
+    result = render_goalforge_hat_trick_video(
+        evidence_path=args.evidence,
+        asset_root=args.asset_root,
+        output_path=args.output,
+        source_checkout=args.source_checkout,
+        fps=args.fps,
+    )
+    print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    return 0
+
+
+__all__ = ["dispatch_hat_trick_argv"]

--- a/src/rosclaw/simforge/g1_hat_trick_video.py
+++ b/src/rosclaw/simforge/g1_hat_trick_video.py
@@ -1,0 +1,527 @@
+"""Cinematic, evidence-downstream video for the GoalForge Hat Trick."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, BinaryIO, cast
+
+import numpy as np
+
+_SCENE_REL = Path("g1_description/scene_with_ball.xml")
+_RENDER_WIDTH = 640
+_RENDER_HEIGHT = 360
+
+
+@dataclass(frozen=True)
+class HatTrickVideoClip:
+    name: str
+    title: str
+    source_trajectory_hash: str
+    playback_start_sec: float
+    playback_duration_sec: float
+    frame_count: int
+    success: bool
+    target_error_m: float
+    ball_speed_mps: float
+
+
+@dataclass(frozen=True)
+class HatTrickVideoResult:
+    output_path: str
+    manifest_path: str
+    video_hash: str
+    evidence_report_hash: str
+    width: int
+    height: int
+    fps: int
+    frame_count: int
+    duration_sec: float
+    clips: tuple[HatTrickVideoClip, ...]
+    visualization_only: bool = True
+    schema_version: str = "rosclaw.g1_goalforge.hat_trick_video.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "clips": [asdict(clip) for clip in self.clips],
+            "label_source": "verified_hat_trick_evidence",
+            "generates_task_evidence": False,
+        }
+
+
+@dataclass(frozen=True)
+class _Source:
+    name: str
+    title: str
+    result: dict[str, Any]
+    scenario: dict[str, Any]
+    trajectory_hash: str
+    trajectory: dict[str, np.ndarray]
+    comparison: dict[str, np.ndarray] | None
+
+
+def render_goalforge_hat_trick_video(
+    *,
+    evidence_path: Path,
+    asset_root: Path,
+    output_path: Path,
+    source_checkout: Path,
+    fps: int = 30,
+) -> HatTrickVideoResult:
+    """Render three verified clips; labels never flow back into evaluation."""
+
+    evidence_file = evidence_path.expanduser().resolve()
+    output = output_path.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if output == checkout or checkout in output.parents:
+        raise ValueError("Hat Trick video output must be outside the source checkout")
+    if output.suffix.lower() != ".mp4":
+        raise ValueError("Hat Trick video output must use .mp4")
+    if not 10 <= fps <= 60:
+        raise ValueError("Hat Trick video fps must be in [10, 60]")
+    if output.exists() or output.with_suffix(".json").exists():
+        raise FileExistsError("Hat Trick video or manifest already exists")
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("ffmpeg is required for Hat Trick video export")
+    report = json.loads(evidence_file.read_text(encoding="utf-8"))
+    if report.get("passed") is not True:
+        raise ValueError("Hat Trick video requires a passing evidence report")
+    sources = _load_sources(report, checkout)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    previous_gl = os.environ.get("MUJOCO_GL")
+    os.environ.setdefault("MUJOCO_GL", "egl")
+    timelines = tuple(_timeline(source, fps=fps) for source in sources)
+    durations = tuple(len(timeline) / fps for timeline in timelines)
+    try:
+        import mujoco
+
+        from rosclaw.simforge.backends.unitree_mujoco_backend import qualify_g1_assets
+
+        qualification = qualify_g1_assets(asset_root)
+        qualification.require_eligible()
+        if qualification.body_hash != report["body_hash"]:
+            raise ValueError("Hat Trick video Body hash does not match evidence")
+        scene = asset_root.expanduser().resolve() / _SCENE_REL
+        model = mujoco.MjModel.from_xml_path(str(scene))
+        data = mujoco.MjData(model)
+        comparison_data = mujoco.MjData(model)
+        renderer = mujoco.Renderer(model, height=_RENDER_HEIGHT, width=_RENDER_WIDTH)
+        try:
+            process = subprocess.Popen(
+                _ffmpeg_command(
+                    ffmpeg=ffmpeg,
+                    output=output,
+                    fps=fps,
+                    sources=sources,
+                    durations=durations,
+                ),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+            if process.stdin is None:
+                raise RuntimeError("ffmpeg raw-video pipe is unavailable")
+            try:
+                _write_frames(
+                    mujoco=mujoco,
+                    model=model,
+                    data=data,
+                    comparison_data=comparison_data,
+                    renderer=renderer,
+                    sources=sources,
+                    timelines=timelines,
+                    stream=cast(BinaryIO, process.stdin),
+                )
+            except BaseException:
+                process.stdin.close()
+                process.kill()
+                process.wait()
+                raise
+            process.stdin.close()
+            stderr = process.stderr.read().decode(errors="replace") if process.stderr else ""
+            code = process.wait()
+            if code:
+                raise RuntimeError(f"Hat Trick ffmpeg failed ({code}): {stderr[-2000:]}")
+        finally:
+            renderer.close()
+    finally:
+        if previous_gl is None:
+            os.environ.pop("MUJOCO_GL", None)
+        else:
+            os.environ["MUJOCO_GL"] = previous_gl
+
+    clips = []
+    offset = 0.0
+    for source, timeline, duration in zip(sources, timelines, durations, strict=True):
+        clips.append(
+            HatTrickVideoClip(
+                name=source.name,
+                title=source.title,
+                source_trajectory_hash=source.trajectory_hash,
+                playback_start_sec=offset,
+                playback_duration_sec=duration,
+                frame_count=len(timeline),
+                success=bool(source.result["success"]),
+                target_error_m=float(source.result["target_error_m"]),
+                ball_speed_mps=float(source.result["ball_speed_mps"]),
+            )
+        )
+        offset += duration
+    manifest = output.with_suffix(".json")
+    result = HatTrickVideoResult(
+        output_path=str(output),
+        manifest_path=str(manifest),
+        video_hash=_hash_file(output),
+        evidence_report_hash=_hash_file(evidence_file),
+        width=1280,
+        height=720,
+        fps=fps,
+        frame_count=sum(len(item) for item in timelines),
+        duration_sec=offset,
+        clips=tuple(clips),
+    )
+    manifest.write_text(
+        json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return result
+
+
+def _load_sources(report: dict[str, Any], checkout: Path) -> tuple[_Source, ...]:
+    shots = report.get("shots")
+    if not isinstance(shots, list) or len(shots) != 3:
+        raise ValueError("Hat Trick evidence must contain exactly three shots")
+    result = []
+    for shot in shots:
+        path = Path(str(shot["trajectory_path"])).expanduser().resolve()
+        if checkout == path or checkout in path.parents:
+            raise ValueError("Hat Trick source trajectory must be outside the checkout")
+        if _hash_file(path) != shot["trajectory_hash"]:
+            raise ValueError("Hat Trick trajectory hash mismatch")
+        trajectory = _load_trajectory(path)
+        comparison = None
+        comparison_path = shot.get("comparison_trajectory_path")
+        if comparison_path:
+            resolved = Path(str(comparison_path)).expanduser().resolve()
+            if checkout == resolved or checkout in resolved.parents:
+                raise ValueError("Hat Trick comparison trajectory must be outside the checkout")
+            if _hash_file(resolved) != shot["comparison_trajectory_hash"]:
+                raise ValueError("Hat Trick comparison trajectory hash mismatch")
+            comparison = _load_trajectory(resolved)
+        result.append(
+            _Source(
+                name=str(shot["name"]),
+                title=str(shot["title"]),
+                result=dict(shot["result"]),
+                scenario=dict(shot["scenario"]),
+                trajectory_hash=str(shot["trajectory_hash"]),
+                trajectory=trajectory,
+                comparison=comparison,
+            )
+        )
+    return tuple(result)
+
+
+def _load_trajectory(path: Path) -> dict[str, np.ndarray]:
+    with np.load(path, allow_pickle=False) as archive:
+        value = {name: archive[name] for name in archive.files}
+    for name, shape in {
+        "time": (),
+        "pelvis_pose": (7,),
+        "joint_position": (29,),
+        "ball_pose": (7,),
+    }.items():
+        array = np.asarray(value.get(name))
+        if array.ndim != len(shape) + 1 or array.shape[1:] != shape:
+            raise ValueError(f"Hat Trick trajectory {name} has invalid shape")
+        if not np.all(np.isfinite(array)):
+            raise ValueError(f"Hat Trick trajectory {name} is non-finite")
+    return value
+
+
+def _timeline(source: _Source, *, fps: int) -> tuple[float, ...]:
+    contact = float(source.result["ball_contact_time_sec"])
+    start = max(float(source.trajectory["time"][0]), contact - 2.7)
+    end = min(float(source.trajectory["time"][-1]), contact + 3.2)
+    segments = (
+        (start, contact - 0.45, 1.35),
+        (contact - 0.45, contact + 0.75, 0.45),
+        (contact + 0.75, end, 1.45),
+    )
+    values = []
+    for segment_start, segment_end, speed in segments:
+        if segment_end <= segment_start:
+            continue
+        count = max(1, int(np.ceil((segment_end - segment_start) / speed * fps)))
+        values.extend(
+            min(segment_end, segment_start + frame / fps * speed) for frame in range(count)
+        )
+    return tuple(values)
+
+
+def _write_frames(
+    *,
+    mujoco: Any,
+    model: Any,
+    data: Any,
+    comparison_data: Any,
+    renderer: Any,
+    sources: tuple[_Source, ...],
+    timelines: tuple[tuple[float, ...], ...],
+    stream: BinaryIO,
+) -> None:
+    ball_joint = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "ball_free")
+    ball_qpos = int(model.jnt_qposadr[ball_joint])
+    camera = mujoco.MjvCamera()
+    camera.type = mujoco.mjtCamera.mjCAMERA_FREE
+    camera.lookat[:] = (1.4, 0.0, 0.72)
+    camera.distance = 3.6
+    camera.azimuth = 92.0
+    camera.elevation = -8.0
+    for source, timeline in zip(sources, timelines, strict=True):
+        for simulation_time in timeline:
+            if source.comparison is None:
+                frame = _render_pose(
+                    mujoco=mujoco,
+                    model=model,
+                    data=data,
+                    renderer=renderer,
+                    camera=camera,
+                    trajectory=source.trajectory,
+                    simulation_time=simulation_time,
+                    ball_qpos=ball_qpos,
+                    scenario=source.scenario,
+                    contact_time=float(source.result["ball_contact_time_sec"]),
+                    show_grid=source.name == "nine_grid_power",
+                    show_push=source.name == "disturbance_feedback_rescue",
+                )
+                canvas = np.repeat(np.repeat(frame, 2, axis=0), 2, axis=1)
+            else:
+                off = _render_pose(
+                    mujoco=mujoco,
+                    model=model,
+                    data=comparison_data,
+                    renderer=renderer,
+                    camera=camera,
+                    trajectory=source.comparison,
+                    simulation_time=simulation_time,
+                    ball_qpos=ball_qpos,
+                    scenario=source.scenario,
+                    contact_time=float(source.result["ball_contact_time_sec"]),
+                    show_grid=False,
+                    show_push=True,
+                )
+                on = _render_pose(
+                    mujoco=mujoco,
+                    model=model,
+                    data=data,
+                    renderer=renderer,
+                    camera=camera,
+                    trajectory=source.trajectory,
+                    simulation_time=simulation_time,
+                    ball_qpos=ball_qpos,
+                    scenario=source.scenario,
+                    contact_time=float(source.result["ball_contact_time_sec"]),
+                    show_grid=False,
+                    show_push=True,
+                )
+                canvas = np.zeros((720, 1280, 3), dtype=np.uint8)
+                canvas[180:540, :640] = off
+                canvas[180:540, 640:] = on
+            stream.write(np.ascontiguousarray(canvas).tobytes())
+
+
+def _render_pose(
+    *,
+    mujoco: Any,
+    model: Any,
+    data: Any,
+    renderer: Any,
+    camera: Any,
+    trajectory: dict[str, np.ndarray],
+    simulation_time: float,
+    ball_qpos: int,
+    scenario: dict[str, Any],
+    contact_time: float,
+    show_grid: bool,
+    show_push: bool,
+) -> np.ndarray:
+    times = trajectory["time"]
+    index = min(int(np.searchsorted(times, simulation_time, side="left")), len(times) - 1)
+    data.qpos[:] = model.qpos0
+    data.qpos[:7] = trajectory["pelvis_pose"][index]
+    data.qpos[7:36] = trajectory["joint_position"][index]
+    data.qpos[ball_qpos : ball_qpos + 7] = trajectory["ball_pose"][index]
+    mujoco.mj_forward(model, data)
+    if simulation_time >= contact_time + 0.12:
+        camera.lookat[:] = (3.0, 0.0, 0.65)
+        camera.distance = 6.1
+        camera.azimuth = 90.0
+        camera.elevation = -7.0
+    else:
+        camera.lookat[:] = (1.4, 0.0, 0.72)
+        camera.distance = 3.6
+        camera.azimuth = 92.0
+        camera.elevation = -8.0
+    renderer.update_scene(data, camera=camera)
+    _add_targets_and_trail(
+        mujoco=mujoco,
+        scene=renderer.scene,
+        scenario=scenario,
+        trajectory=trajectory,
+        index=index,
+        show_grid=show_grid,
+    )
+    if show_push and 4.35 <= simulation_time <= 5.05:
+        pelvis = np.asarray(trajectory["pelvis_pose"][index, :3], dtype=np.float64)
+        for offset in np.linspace(-0.6, -0.15, 6):
+            _append_sphere(
+                mujoco,
+                renderer.scene,
+                pelvis + np.asarray((0.0, offset, 0.10)),
+                0.025 + 0.02 * (offset + 0.6),
+                (1.0, 0.15, 0.12, 0.85),
+            )
+    return renderer.render().copy()
+
+
+def _add_targets_and_trail(
+    *,
+    mujoco: Any,
+    scene: Any,
+    scenario: dict[str, Any],
+    trajectory: dict[str, np.ndarray],
+    index: int,
+    show_grid: bool,
+) -> None:
+    target_y = float(scenario["target_y_m"])
+    target_z = float(scenario["target_z_m"])
+    targets = (
+        [(y, z) for y in (-0.75, 0.0, 0.75) for z in (0.20, 0.55, 0.90)]
+        if show_grid
+        else [(target_y, target_z)]
+    )
+    for y, z in targets:
+        active = abs(y - target_y) < 1e-6 and abs(z - target_z) < 1e-6
+        _append_sphere(
+            mujoco,
+            scene,
+            np.asarray((5.02, y, z)),
+            0.17 if active else 0.08,
+            (0.15, 1.0, 0.35, 0.92) if active else (0.15, 0.45, 0.65, 0.25),
+        )
+    start = max(0, index - 70)
+    indices = np.linspace(start, index, min(14, index - start + 1), dtype=int)
+    for trail_index, alpha in zip(indices, np.linspace(0.05, 0.55, len(indices)), strict=True):
+        _append_sphere(
+            mujoco,
+            scene,
+            np.asarray(trajectory["ball_pose"][trail_index, :3]),
+            0.032,
+            (0.25, 0.78, 1.0, float(alpha)),
+        )
+
+
+def _append_sphere(
+    mujoco: Any,
+    scene: Any,
+    position: np.ndarray,
+    radius: float,
+    rgba: tuple[float, float, float, float],
+) -> None:
+    if scene.ngeom >= scene.maxgeom:
+        return
+    mujoco.mjv_initGeom(
+        scene.geoms[scene.ngeom],
+        mujoco.mjtGeom.mjGEOM_SPHERE,
+        np.asarray((radius,) * 3, dtype=np.float64),
+        position,
+        np.eye(3, dtype=np.float64).reshape(-1),
+        np.asarray(rgba, dtype=np.float32),
+    )
+    scene.ngeom += 1
+
+
+def _ffmpeg_command(
+    *,
+    ffmpeg: str,
+    output: Path,
+    fps: int,
+    sources: tuple[_Source, ...],
+    durations: tuple[float, ...],
+) -> list[str]:
+    font = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf")
+    font_option = f"fontfile={font}:" if font.is_file() else ""
+    filters = [
+        "drawbox=x=0:y=0:w=iw:h=112:color=0x050A12@0.78:t=fill",
+        "drawbox=x=0:y=h-70:w=iw:h=70:color=0x050A12@0.78:t=fill",
+        f"drawtext={font_option}text='ROSClaw GoalForge Hat Trick':x=34:y=18:fontsize=36:fontcolor=white",
+        f"drawtext={font_option}text='SIM EVIDENCE REPLAY · VISUALIZATION ONLY':x=34:y=h-46:fontsize=22:fontcolor=0x8DD8FF",
+    ]
+    offset = 0.0
+    for source, duration in zip(sources, durations, strict=True):
+        end = offset + duration
+        result = source.result
+        metrics = (
+            f"{source.title}  ·  {float(result['ball_speed_mps']):.2f} m/s  ·  "
+            f"error {float(result['target_error_m']):.3f} m  ·  STABLE"
+        )
+        filters.append(
+            f"drawtext={font_option}text='{metrics}':x=34:y=68:fontsize=22:"
+            f"fontcolor=0x65F59A:enable='between(t,{offset:.6f},{end:.6f})'"
+        )
+        if source.comparison is not None:
+            filters.extend(
+                (
+                    f"drawtext={font_option}text='FEEDBACK OFF · FALL / UNSAFE':x=120:y=145:fontsize=22:fontcolor=0xFF6262:enable='between(t,{offset:.6f},{end:.6f})'",
+                    f"drawtext={font_option}text='FEEDBACK ON · RESCUED GOAL':x=760:y=145:fontsize=22:fontcolor=0x65F59A:enable='between(t,{offset:.6f},{end:.6f})'",
+                )
+            )
+        offset = end
+    return [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "rawvideo",
+        "-pixel_format",
+        "rgb24",
+        "-video_size",
+        "1280x720",
+        "-framerate",
+        str(fps),
+        "-i",
+        "pipe:0",
+        "-vf",
+        ",".join(filters),
+        "-an",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "medium",
+        "-crf",
+        "18",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        str(output),
+    ]
+
+
+def _hash_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+__all__ = [
+    "HatTrickVideoClip",
+    "HatTrickVideoResult",
+    "render_goalforge_hat_trick_video",
+]

--- a/src/rosclaw/simforge/g1_moving_ball.py
+++ b/src/rosclaw/simforge/g1_moving_ball.py
@@ -1,0 +1,73 @@
+"""Bounded high-level intercept adapter around the frozen RoboNaldo prior."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+
+from rosclaw.simforge.tasks.g1_goalforge.concepts import ShotParameters
+from rosclaw.simforge.tasks.g1_goalforge.scenario import GoalForgeScenario
+
+
+@dataclass(frozen=True)
+class MovingBallPlan:
+    launch_time_sec: float
+    predicted_contact_time_sec: float
+    predicted_ball_x_m: float
+    predicted_ball_y_m: float
+    nominal_contact_error_m: float
+    eligible: bool
+    reasons: tuple[str, ...]
+    parameters: ShotParameters
+    schema_version: str = "rosclaw.g1_goalforge.moving_ball_plan.v1"
+
+    def to_dict(self) -> dict[str, object]:
+        value = asdict(self)
+        value["parameters"] = self.parameters.to_dict()
+        return value
+
+
+class MovingBallInterceptAdapter:
+    """Plan only gentle, reachable passes; never writes low-level joint targets."""
+
+    nominal_contact_time_sec = 5.28
+    nominal_ball_x_m = 1.0
+    maximum_contact_position_error_m = 0.16
+    maximum_ball_speed_mps = 0.20
+
+    def plan(self, scenario: GoalForgeScenario) -> MovingBallPlan:
+        moving_duration = max(0.0, self.nominal_contact_time_sec - scenario.ball_launch_delay_sec)
+        predicted_x = scenario.ball_x_m + scenario.ball_velocity_x_mps * moving_duration
+        predicted_y = scenario.ball_y_m + scenario.ball_velocity_y_mps * moving_duration
+        error = math.hypot(predicted_x - self.nominal_ball_x_m, predicted_y)
+        speed = math.hypot(scenario.ball_velocity_x_mps, scenario.ball_velocity_y_mps)
+        reasons = []
+        if scenario.ball_launch_delay_sec <= 0.0:
+            reasons.append("launcher_delay_missing")
+        if speed <= 0.0:
+            reasons.append("ball_not_moving")
+        if speed > self.maximum_ball_speed_mps:
+            reasons.append("ball_speed_outside_validated_envelope")
+        if error > self.maximum_contact_position_error_m:
+            reasons.append("predicted_intercept_outside_kick_envelope")
+        eligible = not reasons
+        parameters = ShotParameters(
+            pelvis_yaw_offset=0.1925,
+            com_shift_y=0.015,
+            foot_yaw_offset=0.03025,
+            recovery_step_length=0.055,
+            policy_type="parameter",
+        )
+        return MovingBallPlan(
+            launch_time_sec=scenario.ball_launch_delay_sec,
+            predicted_contact_time_sec=self.nominal_contact_time_sec,
+            predicted_ball_x_m=predicted_x,
+            predicted_ball_y_m=predicted_y,
+            nominal_contact_error_m=error,
+            eligible=eligible,
+            reasons=tuple(reasons),
+            parameters=parameters,
+        )
+
+
+__all__ = ["MovingBallInterceptAdapter", "MovingBallPlan"]

--- a/src/rosclaw/simforge/tasks/g1_goalforge/scenario.py
+++ b/src/rosclaw/simforge/tasks/g1_goalforge/scenario.py
@@ -33,6 +33,7 @@ class GoalForgeScenario:
     observation_noise_m: float
     joint_zero_bias_rad: float
     disturbance_n: float
+    ball_launch_delay_sec: float = 0.0
     reachable: bool = True
 
     def __post_init__(self) -> None:
@@ -57,6 +58,7 @@ class GoalForgeScenario:
             "observation_noise_m": (self.observation_noise_m, 0.0, 0.08),
             "joint_zero_bias_rad": (self.joint_zero_bias_rad, -0.04, 0.04),
             "disturbance_n": (self.disturbance_n, 0.0, 80.0),
+            "ball_launch_delay_sec": (self.ball_launch_delay_sec, 0.0, 5.0),
         }
         for name, (value, minimum, maximum) in bounds.items():
             if not math.isfinite(value) or not minimum <= value <= maximum:
@@ -152,6 +154,7 @@ def generate_goalforge_scenarios(
                 observation_noise_m=(0.0 if generation < 8 else rng.uniform(0.0, 0.06)),
                 joint_zero_bias_rad=(0.0 if generation < 5 else rng.uniform(-0.03, 0.03)),
                 disturbance_n=(0.0 if generation < 7 else rng.uniform(0.0, 65.0)),
+                ball_launch_delay_sec=(rng.uniform(3.2, 4.2) if moving else 0.0),
             )
         )
     ledger.assert_disjoint()

--- a/tests/continual/test_candidate_inference.py
+++ b/tests/continual/test_candidate_inference.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rosclaw.continual.contracts import PolicyVersion
+from rosclaw.continual.inference import (
+    ResidualCandidatePolicy,
+    build_g1_candidate_runtime,
+    load_residual_candidate,
+)
+from rosclaw.continual.inference.version_lock import CandidateVersionLock
+
+OBSERVATIONS = (
+    "torso_roll",
+    "torso_pitch",
+    "com_y_relative",
+    "support_slip_m",
+    "ball_lateral_error_m",
+    "contact_phase",
+    "energy_margin",
+    "sensor_quality",
+)
+ACTIONS = (
+    "waist_roll_residual",
+    "right_hip_roll_residual",
+    "right_hip_yaw_residual",
+    "kick_phase_rate",
+)
+LIMITS = (0.04, 0.08, 0.035, 0.08)
+
+
+def _digest(value: bytes | str) -> str:
+    payload = value.encode() if isinstance(value, str) else value
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _artifact() -> bytes:
+    metadata = {
+        "schema_version": "rosclaw.continual.residual_sac_artifact.v1",
+        "observation_names": list(OBSERVATIONS),
+        "action_names": list(ACTIONS),
+        "action_limits": list(LIMITS),
+        "hidden_dims": [3, 2],
+        "update_index": 7,
+    }
+    tensors = {
+        "action_limits": np.asarray(LIMITS, dtype=np.float32),
+        "backbone.hidden0.bias": np.asarray([0.2, 0.0, 0.0], dtype=np.float32),
+        "backbone.hidden0.weight": np.zeros((3, 8), dtype=np.float32),
+        "backbone.hidden1.bias": np.zeros(2, dtype=np.float32),
+        "backbone.hidden1.weight": np.asarray([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float32),
+        "backbone.output.bias": np.zeros(8, dtype=np.float32),
+        "backbone.output.weight": np.asarray(
+            [
+                [1.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+            ],
+            dtype=np.float32,
+        ),
+    }
+    chunks = [json.dumps(metadata, sort_keys=True, separators=(",", ":")).encode()]
+    for name, value in sorted(tensors.items()):
+        name_bytes = name.encode()
+        dtype_bytes = str(value.dtype).encode()
+        chunks.extend(
+            (
+                struct.pack("!I", len(name_bytes)),
+                name_bytes,
+                struct.pack("!I", len(dtype_bytes)),
+                dtype_bytes,
+                struct.pack("!I", value.ndim),
+                struct.pack("!" + "Q" * value.ndim, *value.shape),
+                value.tobytes(),
+            )
+        )
+    return b"".join(chunks)
+
+
+def _policies(artifact: bytes) -> tuple[PolicyVersion, PolicyVersion]:
+    common = {
+        "controller_snapshot_hash": _digest("controller"),
+        "body_hash": _digest("body"),
+        "safety_kernel_hash": _digest("safety"),
+        "observation_names": OBSERVATIONS,
+        "residual_action_names": ACTIONS,
+    }
+    parent = PolicyVersion(
+        version=2, artifact_hash=_digest("parent"), parent_version_hash=_digest("v1"), **common
+    )
+    candidate = PolicyVersion(
+        version=3,
+        artifact_hash=_digest(artifact),
+        parent_version_hash=parent.version_hash,
+        **common,
+    )
+    return parent, candidate
+
+
+def _write_candidate(tmp_path: Path) -> tuple[Path, PolicyVersion, PolicyVersion]:
+    artifact = _artifact()
+    parent, candidate = _policies(artifact)
+    path = tmp_path / "candidate.bin"
+    path.write_bytes(artifact)
+    return path, parent, candidate
+
+
+def test_read_only_candidate_loader_executes_bounded_numpy_actor(tmp_path: Path) -> None:
+    path, parent, candidate = _write_candidate(tmp_path)
+
+    loaded = load_residual_candidate(
+        path,
+        policy=candidate,
+        parent=parent,
+        expected_body_hash=candidate.body_hash,
+    )
+    runtime = ResidualCandidatePolicy(loaded)
+    action = runtime.infer(dict.fromkeys(OBSERVATIONS, 0.0))
+    receipt = runtime.build_receipt()
+
+    assert action["waist_roll_residual"] == pytest.approx(np.tanh(0.2) * 0.04)
+    assert all(abs(action[name]) <= limit for name, limit in zip(ACTIONS, LIMITS, strict=True))
+    assert loaded.tensors["backbone.output.weight"].flags.writeable is False
+    assert receipt.inference_count == 1
+    assert receipt.actions_bounded
+    assert receipt.action_rms > 0.0
+    assert receipt.maximum_action_limit_ratio <= 1.0
+    assert receipt.contact_timing_enabled_count == 0
+    assert receipt.version_switch_count == 0
+    assert receipt.registry_write_count == 0
+    assert receipt.dds_opened is False
+
+
+def test_candidate_loader_rejects_tampering_and_wrong_parent(tmp_path: Path) -> None:
+    path, parent, candidate = _write_candidate(tmp_path)
+    path.write_bytes(path.read_bytes() + b"tampered")
+
+    with pytest.raises(ValueError, match="artifact hash"):
+        load_residual_candidate(path, policy=candidate, parent=parent)
+
+    artifact = _artifact()
+    path.write_bytes(artifact)
+    wrong_parent = PolicyVersion(
+        version=2,
+        artifact_hash=_digest("wrong-parent"),
+        parent_version_hash=_digest("v1"),
+        controller_snapshot_hash=parent.controller_snapshot_hash,
+        body_hash=parent.body_hash,
+        safety_kernel_hash=parent.safety_kernel_hash,
+        observation_names=OBSERVATIONS,
+        residual_action_names=ACTIONS,
+    )
+    with pytest.raises(ValueError, match="parent version hash"):
+        load_residual_candidate(path, policy=candidate, parent=wrong_parent)
+
+
+def test_g1_candidate_runtime_maps_actions_and_pins_version(tmp_path: Path) -> None:
+    path, parent, candidate = _write_candidate(tmp_path)
+    loaded = load_residual_candidate(path, policy=candidate, parent=parent)
+
+    runtime, policy = build_g1_candidate_runtime(loaded, rate_hz=100.0)
+    lock = CandidateVersionLock.pin(candidate)
+
+    assert runtime.spec.body_hash == candidate.body_hash
+    assert runtime.spec.output_limits["joint:waist_roll_joint"] == LIMITS[0]
+    assert runtime.spec.output_limits["skill:kick_phase_rate"] == LIMITS[-1]
+    lock.verify(policy.artifact.policy)

--- a/tests/feedback/control/test_contact_timing.py
+++ b/tests/feedback/control/test_contact_timing.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.feedback.contact_timing import ContactTimingEstimator
+
+
+def _actual(**changes: float) -> dict[str, float]:
+    value = {
+        "ball_relative_x_m": 0.20,
+        "ball_relative_y_m": 0.0,
+        "ball_relative_z_m": 0.0,
+        "ball_relative_vx_mps": -0.20,
+        "ball_relative_vy_mps": 0.0,
+        "ball_relative_vz_mps": 0.0,
+        "control_latency_ms": 0.0,
+        "sensor_quality": 1.0,
+        "contact_detected": 0.0,
+    }
+    value.update(changes)
+    return value
+
+
+def test_contact_timing_enables_phase_only_for_confident_intercept() -> None:
+    belief = ContactTimingEstimator().update(
+        timestamp_ns=1,
+        policy_phase=0.30,
+        actual=_actual(),
+    )
+
+    assert belief.source == "relative_motion_intercept"
+    assert belief.predicted_time_to_contact_sec == pytest.approx(1.0)
+    assert belief.intercept_miss_m == pytest.approx(0.0)
+    assert belief.confidence >= 0.70
+    assert belief.phase_residual_enabled
+
+
+def test_contact_timing_disables_static_and_uncertain_intercepts() -> None:
+    estimator = ContactTimingEstimator()
+    static = estimator.update(
+        timestamp_ns=1,
+        policy_phase=0.30,
+        actual=_actual(ball_relative_vx_mps=0.0),
+    )
+    uncertain = estimator.update(
+        timestamp_ns=2,
+        policy_phase=0.31,
+        actual=_actual(
+            ball_relative_y_m=0.30,
+            control_latency_ms=80.0,
+            sensor_quality=0.2,
+        ),
+    )
+    observed = estimator.update(
+        timestamp_ns=3,
+        policy_phase=0.41,
+        actual=_actual(contact_detected=1.0),
+    )
+
+    assert static.source == "static_phase_prior"
+    assert not static.phase_residual_enabled
+    assert not uncertain.phase_residual_enabled
+    assert observed.contact_observed
+    assert not observed.phase_residual_enabled

--- a/tests/simforge/test_g1_candidate_evaluation.py
+++ b/tests/simforge/test_g1_candidate_evaluation.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rosclaw.simforge.g1_candidate_evaluation import (
+    CandidateEvaluationCounts,
+    CandidateEvaluationRow,
+    _evaluation_scenarios,
+    _gate,
+    _load_checkpoint,
+)
+
+
+def test_candidate_evaluation_supports_resumable_disjoint_shards() -> None:
+    counts = CandidateEvaluationCounts(recent=2, anchor=0, boundary=0, self_partition=0)
+
+    first = _evaluation_scenarios(counts, suite_shard="recent-a")
+    second = _evaluation_scenarios(counts, suite_shard="recent-b")
+
+    assert len(first) == len(second) == 2
+    assert {scenario.scenario_commitment for _, scenario in first}.isdisjoint(
+        scenario.scenario_commitment for _, scenario in second
+    )
+    assert all(scenario.ball_launch_delay_sec > 0.0 for _, scenario in first + second)
+
+
+def test_candidate_evaluation_rejects_empty_or_negative_counts() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        CandidateEvaluationCounts(0, 0, 0, 0)
+    with pytest.raises(ValueError, match="non-negative"):
+        CandidateEvaluationCounts(-1, 1, 1, 1)
+
+
+def test_partition_shard_gate_defers_anchor_check_instead_of_crashing() -> None:
+    gate = _gate(
+        rows=(),
+        paired={"target_error_improvement_ci95": [0.1, 0.2]},
+        replay_checks={"recent": True},
+        counts=CandidateEvaluationCounts(1, 0, 0, 0),
+        training_seed_count=8,
+    )
+
+    assert gate["anchor_success_delta"] is None
+    assert gate["checks"]["historical_mean_degradation_lt_3pct"] is False
+    assert gate["checks"]["critical_skill_degradation_lte_5pct"] is False
+    assert gate["decision"] == "REJECTED"
+
+
+def test_candidate_evaluation_row_rejects_non_finite_evidence() -> None:
+    values = {
+        "scenario_id": "scenario",
+        "scenario_commitment": "sha256:" + "0" * 64,
+        "replay_partition": "recent",
+        "arm": "candidate_v3",
+        "policy_version": 3,
+        "policy_version_hash": "sha256:" + "1" * 64,
+        "status": "SUCCESS",
+        "success": True,
+        "contact": True,
+        "goal_crossed": True,
+        "penalized_target_error_m": 0.1,
+        "conditional_target_error_m": 0.1,
+        "ball_speed_mps": 5.0,
+        "fall": False,
+        "joint_violation": False,
+        "torque_violation": False,
+        "actuator_saturation": False,
+        "com_margin_min_m": float("inf"),
+        "support_slip_m": 0.01,
+        "tracking_rms_rad": 0.1,
+        "energy_proxy": 1.0,
+        "action_drift_rms": 0.0,
+        "trajectory_hash": "sha256:" + "2" * 64,
+        "inference_receipt_hash": None,
+        "version_switch_count": 0,
+    }
+
+    with pytest.raises(ValueError, match="com_margin_min_m"):
+        CandidateEvaluationRow(**values)
+
+
+def test_checkpoint_migrates_only_legacy_unobserved_com_margin(tmp_path) -> None:
+    path = tmp_path / "legacy.checkpoint"
+    values = {
+        "scenario_id": "scenario",
+        "scenario_commitment": "sha256:" + "0" * 64,
+        "replay_partition": "recent",
+        "arm": "candidate_v3",
+        "policy_version": 3,
+        "policy_version_hash": "sha256:" + "1" * 64,
+        "status": "NO_CONTACT",
+        "success": False,
+        "contact": False,
+        "goal_crossed": False,
+        "penalized_target_error_m": 2.0,
+        "conditional_target_error_m": None,
+        "ball_speed_mps": 0.0,
+        "fall": False,
+        "joint_violation": False,
+        "torque_violation": False,
+        "actuator_saturation": False,
+        "com_margin_min_m": float("inf"),
+        "support_slip_m": 0.0,
+        "tracking_rms_rad": 0.1,
+        "energy_proxy": 1.0,
+        "action_drift_rms": 0.0,
+        "trajectory_hash": "sha256:" + "2" * 64,
+        "inference_receipt_hash": None,
+        "version_switch_count": 0,
+    }
+    path.write_text(
+        json.dumps({"identity": "expected", "rows": [values], "replay_checks": {}}),
+        encoding="utf-8",
+    )
+
+    rows, replay = _load_checkpoint(path, expected_identity="expected")
+
+    assert rows[0].com_margin_min_m == -1.0
+    assert replay == {}

--- a/tests/simforge/test_g1_moving_ball.py
+++ b/tests/simforge/test_g1_moving_ball.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from rosclaw.simforge.g1_moving_ball import MovingBallInterceptAdapter
+from rosclaw.simforge.models import Partition
+from rosclaw.simforge.seed_ledger import SeedLedger
+from rosclaw.simforge.tasks.g1_goalforge.scenario import generate_goalforge_scenarios
+
+
+def _scenario():
+    base = generate_goalforge_scenarios(
+        ledger=SeedLedger(
+            task_id="g1_penalty_kick",
+            secret=b"moving-ball-adapter-unit-test",
+        ),
+        partition=Partition.VALIDATION,
+        count=1,
+        generation=0,
+    )[0]
+    return replace(
+        base,
+        ball_x_m=1.12,
+        ball_velocity_x_mps=-0.08,
+        ball_launch_delay_sec=4.0,
+    )
+
+
+def test_moving_ball_adapter_plans_inside_bounded_intercept_envelope() -> None:
+    plan = MovingBallInterceptAdapter().plan(_scenario())
+
+    assert plan.eligible
+    assert plan.predicted_ball_x_m == pytest.approx(1.0176)
+    assert plan.nominal_contact_error_m < 0.02
+    assert plan.parameters.policy_type == "parameter"
+
+
+def test_moving_ball_adapter_rejects_unvalidated_fast_pass() -> None:
+    scenario = replace(_scenario(), ball_velocity_x_mps=-0.45)
+    plan = MovingBallInterceptAdapter().plan(scenario)
+
+    assert not plan.eligible
+    assert "ball_speed_outside_validated_envelope" in plan.reasons


### PR DESCRIPTION
## Summary

- add a fail-closed, read-only residual candidate loader, deterministic NumPy inference runtime, episode version lock, receipts, and inspect/evaluate/merge CLI
- add resumable four-arm matched MuJoCo evaluation across Recent, Anchor, Boundary, and Self partitions with bootstrap confidence intervals and promotion gates
- add uncertainty-aware contact timing, delayed moving-ball launch physics, and a bounded moving-ball intercept adapter
- add the three-shot GoalForge Hat Trick evidence workflow and an evidence-downstream cinematic MP4 exporter
- add the Phase 7.1 implementation and validation report

## Why

Phase 7 could train residual candidates but could not execute one in MuJoCo and prove whether motion actually improved. It also lacked a physically timed moving-ball demo and a clean separation between task evidence and promotional visualization. This change closes those gaps without granting the candidate Registry, DDS, active-slot, or hardware authority.

## Validation and impact

- 8 learner seeds ran across 4 physical A6000 GPUs; all updates and actions were finite/bounded
- selected seed 17103 ran 250 matched scenarios and 1,000 arm episodes with strict replay in all four partitions
- candidate success increased by 1.6pp and penalized target error improved by 3.43cm, but the 95% CI lower bound was only 1.37cm and 4 new critical safety regressions occurred
- the gate correctly returned `REJECTED`; v3 was not activated and the parent remained unchanged
- Hat Trick strict replay passed for a seeded 3×3 target shot, a delayed moving-ball first-time shot, and an 80N feedback rescue counterfactual
- targeted tests: 12 passed
- Ruff, Mypy, and compileall passed
- full suite: 5306 passed, 59 skipped, 27 deselected, 26 warnings

Raw MuJoCo trajectories, evaluation JSON, training artifacts, previews, and MP4 remain outside the checkout. The committed report records their paths, hashes, metrics, limitations, and reproduction commands.

## Stacked dependency

This draft targets `phase7-selfcore-rl-foundation` and should be reviewed after #121. PR #121 in turn depends on #120.
