### PR TITLE
Add recoverable continual adaptation and embodied self services

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,7 @@ Welcome to the ROSClaw documentation index. This directory contains all project 
 - **[validation/ROSCLAW_PHASE6_IMPLEMENTATION_REPORT.md](validation/ROSCLAW_PHASE6_IMPLEMENTATION_REPORT.md)** — Chinese implementation and evidence report for the first Phase 6 GoalForge Reflex milestone.
 - **[validation/ROSCLAW_PHASE6_SECOND_STAGE_REPORT.md](validation/ROSCLAW_PHASE6_SECOND_STAGE_REPORT.md)** — Phase 6 second-stage Holdout, historical regression, ten-trial ILC, and canonical DDS evidence report.
 - **[validation/ROSCLAW_PHASE6_SELF_EVOLUTION_REPORT.md](validation/ROSCLAW_PHASE6_SELF_EVOLUTION_REPORT.md)** — Phase 6 evidence-to-candidate self-evolution loop, reloadable ILC artifact, F1-F15 gate, and rollback lineage report.
+- **[validation/ROSCLAW_PHASE7_1_RECOVERABLE_SERVICES_AND_SELF_MODEL.md](validation/ROSCLAW_PHASE7_1_RECOVERABLE_SERVICES_AND_SELF_MODEL.md)** — Phase 7.1 recoverable continual services, adaptation trigger, operational embodied-self model, and real-MuJoCo fail-closed validation.
 - **[help/rosclaw-simforge-phase4-implementation-report.md](help/rosclaw-simforge-phase4-implementation-report.md)** — Phase 4 implementation, physical recovery, Practice flywheel, four-GPU screening, DDS chaos, proof hashes, and evidence ceiling.
 - **[INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md)** — Integration guide.
 - **[G1_SENSE_DEMO.md](G1_SENSE_DEMO.md)** — Unitree G1 sense demo.

--- a/docs/validation/ROSCLAW_PHASE7_1_RECOVERABLE_SERVICES_AND_SELF_MODEL.md
+++ b/docs/validation/ROSCLAW_PHASE7_1_RECOVERABLE_SERVICES_AND_SELF_MODEL.md
@@ -1,0 +1,161 @@
+# ROSClaw Phase 7.1：可恢复持续学习服务与本体自我模型
+
+日期：2026-07-27
+
+证据域：`SIM`
+
+硬件：本地 4×NVIDIA RTX A6000；本轮只使用空闲物理 GPU 2，未干扰 GPU 0/1/3 上的既有任务
+
+## 1. 结论
+
+本轮完成了 Phase 7.1 PR-3 至 PR-7 的第一版工程闭环：Rollout、Experience、Inference、Learner、Weight Update 五个可恢复服务已经落地；预测偏差触发器、解析物理加有界神经残差的 Forward Self Model、三时间尺度 Regime Encoder 和四分类 Agency Estimator 已实现。
+
+真实 MuJoCo 服务闭环 11/11 检查通过，但上一轮 Candidate v3 仍然被拒绝，没有被激活：它虽然在 250 个相同场景上把平均目标误差改善了 3.43cm，95% CI 下界只有 1.37cm，低于预设 2cm 门槛，而且相对 Parent 新增 4 个关键安全回归。系统把这 4 个回归自动写入 Boundary 重跑队列，Adaptation 状态机转入 `ROLLBACK`，Inference 保持 Parent v2。
+
+这意味着本轮证明的是“ROSClaw 已能安全地持续收集、学习、检查和拒绝”，不是“新策略已经让 G1 踢得更好”。
+
+## 2. 五个可恢复服务
+
+```text
+MuJoCo Scenario
+  → Rollout Service（场景分配、Body/Policy 绑定、动作内版本锁）
+  → Experience Service（不可变日志、SQLite 目录、四分区缓存）
+  → Learner Service（只训练，不控制机器人；完整优化器检查点）
+  → Weight Update Service（publish → verify → stage → activate/freeze/rollback）
+  → Inference Service（active/candidate/rollback slot；COMPLETE/ABORT 前不换版本）
+```
+
+### Rollout Service
+
+- 一个高动态动作只允许一个 `PolicyVersion`，输出 `VersionedTrajectory`；
+- 服务崩溃后，RUNNING 任务自动转为 ABORTED；
+- 不重放崩溃前的旧动作；
+- 场景 commitment、Body、controller 和 policy lineage 全部校验。
+
+### Experience Service
+
+- 文件级 append-only hash-chain 是事实源；
+- SQLite 只作为可重建目录，启动时逐字段核对 trajectory、partition、policy version、event sequence 和 Boundary 完成状态；
+- 内存层仍是有界 Recent/Anchor/Boundary/Self replay；
+- 原始轨迹和可变服务状态强制放在源码 checkout 外。
+
+### Inference 与 Weight Update Service
+
+- `active`、`candidate`、`rollback` 三个 slot；
+- artifact 采用内容寻址并在原子 link 后 fsync 目录；
+- motion lease 存在时激活请求只会冻结，不能中途换权重；
+- Weight Update 的 REQUESTED 与 Inference 事件做恢复对账：回调已完成时补写 recovered completion，未发生 mutation 时 abort，出现歧义时冻结 Inference。
+
+### Learner Service
+
+- 只消费版本化 batch，没有 Registry、DDS 或硬件权限；
+- actor、三个 critic/target、三个 optimizer、temperature、constraint multipliers、update index、CPU/CUDA RNG 全量检查点；
+- 已完成 batch 幂等返回；不确定的 optimizer update 在恢复时 quarantine，绝不盲目重放。
+
+真实闭环第一次运行正好触发了这个门禁：`ResidualSACUpdate.schema_version` 被误放进只允许数值的 metrics，Learner 将任务隔离而不是继续发布。修复适配器并增加回归测试后，第二次运行通过。这是恢复机制在真实工作流中发现接口错误的直接证据。
+
+## 3. 什么时候才允许学习
+
+`prediction_monitor.py` 实现固定状态机：
+
+```text
+NORMAL → SUSPECTED_SHIFT → CONFIRMED_SHIFT → SHADOW_LEARNING
+       → CANDIDATE_READY → CONSOLIDATED / ROLLBACK
+```
+
+身体、触球结果、接触模式、控制延迟、能量和任务性能六类预测残差必须持续超过阈值，单次噪声不会开启学习。只有 `SHADOW_LEARNING` 状态允许更新神经残差或 learner；Candidate 还必须同时满足样本量、新任务改善、Anchor 保持、收敛和零关键安全回归。
+
+本轮 4 个真实匹配安全回归使 shift 得到确认并打开 shadow learning，但 Candidate gate 最终把状态送入 `ROLLBACK`。
+
+## 4. “本体自我模型”通俗解释
+
+这里的 Self 不是主观意识，也不声称机器人有感受。它是一个可测量、可证伪的控制系统：
+
+- Forward Self Model 回答“我发出这个动作后，下一刻关节、骨盆、质心、脚接触、球、能量和跌倒风险应该怎样变化”；
+- Regime Encoder 回答“现在是不是换了地面、球的摩擦、延迟、电机增益、负载或外部扰动”；
+- Agency Estimator 比较预测和实际后果，回答“这是我自己的动作造成、外力造成、传感器坏了，还是证据不足”。
+
+Forward Model 采用解析动力学作为稳定底座，神经网络只学习幅度受限的 residual，且输出层从零开始。真实 G1 轨迹的 96 个 transition 做 within-trace shadow calibration 后，均方预测误差从 `0.00299398` 降到 `0.00291725`，降低约 2.56%。这个数字只能说明同一轨迹上的有界校准有效，不能当作未见工况泛化成绩。
+
+80N Boundary 场景被 Agency 判为 `EXTERNAL_DISTURBANCE`。这只是一次功能闭环，尚未达到文档要求的多类测试集 `Agency classification ≥ 90%`。
+
+## 5. 真实 MuJoCo 闭环证据
+
+执行命令：
+
+```bash
+CUDA_VISIBLE_DEVICES=2 .venv/bin/python -m rosclaw.entrypoint \
+  continual services validate \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy \
+  --candidate /code/rosclaw/phase7_1_evidence/training-seeds/seed-17103-candidate.bin \
+  --matched-report /code/rosclaw/phase7_1_evidence/seed-17103-matched-250-v2.json \
+  --state-root /code/rosclaw/phase7_1_evidence/service-validation-v2-state \
+  --output /code/rosclaw/phase7_1_evidence/service-validation-v2.json \
+  --source-checkout /code/rosclaw/rosclaw_test \
+  --learner-device cuda:0 \
+  --learner-updates 3
+```
+
+结果：
+
+| 检查 | 结果 |
+| --- | --- |
+| 四个 replay partition 都执行 MuJoCo physics | PASS |
+| 四个轨迹都完成相同场景严格重放 | PASS |
+| motion 内 policy version switch | 0 |
+| Experience SQLite 从 append-only truth 恢复 | PASS |
+| 4 个 matched safety regression 进入 Boundary 队列 | PASS |
+| CUDA Learner 完整 checkpoint 恢复 | PASS |
+| Forward calibration error 下降 | PASS |
+| Rollout crash 注入后旧动作重放 | 0 |
+| Inference crash 注入后旧 motion 恢复 | 0 |
+| 被拒 Candidate 激活 | 0 |
+| Adaptation 最终状态 | ROLLBACK |
+
+主报告：`/code/rosclaw/phase7_1_evidence/service-validation-v2.json`
+
+- 文件 SHA-256：`7dcef1746bd9a77852fbf1f928a78f1c147b8420d76d44f674f55cb7d8c99b64`
+- 内容内 report hash：`sha256:31bd58b930629b19d72662130b14e2b716c1eaf9d54dc2063f1358289dff0f3a`
+- 输入 matched report hash：`sha256:bb13ca3b7dd682c248fd284607f611524d7b750acf9116b81a249393e54b969a`
+- Registry mutation：0；DDS opened：0；hardware authorized：false。
+
+四条原始轨迹：
+
+| Partition | NPZ SHA-256 |
+| --- | --- |
+| Anchor | `ad51435156c874c2081efcd253f589dc350f8e68da7f4504b555658ffe79c69d` |
+| Boundary | `37aee1a81315674b03ab0dd65551bc5b7ca7aedcb6551fcc74ad15cc25eb612b` |
+| Recent | `0b7cf8c4b9609e8fb64beef644c92659a31e70bfdd4faa9d84a43362035a69e3` |
+| Self | `cd7749f578f473dff59ab4c9d690b4ea6a61cd20f225e1887d81897cb8fc432b` |
+
+## 6. 软件回归
+
+- 本轮 continual/self/service 定向 Ruff、format 与 mypy：PASS；
+- 故障注入、服务恢复、SAC checkpoint、自我模型和相关 SimForge 定向测试：PASS；
+- 全仓测试首次运行：`5320 passed, 67 skipped, 27 deselected, 4 failed`；4 个失败均因 pytest 隔离 HOME 未继承已经安装的 LeRobot runtime 路径；
+- 显式绑定现有 LeRobot 0.6.1 解释器后，原 4 个失败用例：`4 passed`；
+- 带同一 runtime 配置重新运行全仓：`5332 passed, 59 skipped, 27 deselected`，26 个既有 warning，耗时 1034.83 秒。
+
+仓库全局 Ruff 仍有 244 个既有问题，集中在本轮范围外的 `examples/rh56_rps`。本轮没有借机修改该并行/用户工作区；本轮变更文件的 Ruff 与 format 均通过。
+
+## 7. 新增代码
+
+- `src/rosclaw/continual/services/`：五个 durable service 与 persistence primitive；
+- `src/rosclaw/continual/boundary_feedback.py`：matched regression → Boundary re-rollout request；
+- `src/rosclaw/continual/service_validation.py` 与 `service_cli.py`：真实 MuJoCo 服务闭环；
+- `src/rosclaw/self_model/prediction_monitor.py`：适应触发和 stop-learning gate；
+- `src/rosclaw/self_model/forward_model.py`：解析预测加有界神经 residual；
+- `src/rosclaw/self_model/regime.py`：Fast/Episode/Persistent latent 与 regime expert reuse；
+- `src/rosclaw/self_model/agency.py`：SELF/EXTERNAL/SENSOR/UNKNOWN 四分类；
+- `src/rosclaw/continual/learner.py`：完整 CPU/CUDA 可恢复检查点；
+- 故障注入、持久化篡改、版本锁、恢复对账、自我模型测试。
+
+## 8. 尚未完成
+
+- 当前 Candidate v3 仍不满足安全与显著性门槛，不能宣传成已自进化成功；
+- Forward Model 需要跨 seed、跨摩擦、跨负载的 holdout benchmark；
+- Agency 需要平衡四类标注数据和准确率/ECE 测试；
+- Regime Expert 目前证明了重复工况复用接口，尚未证明跨 episode 快速恢复收益；
+- Plastic unit rejuvenation、Fresh Network Gap、dead-unit/effective-rank 长期曲线和动态 expert allocation 尚未实现；
+- 下一轮应重跑 4 个 Boundary 场景并训练新 Candidate，再用同一 250 场景冻结 suite 做 matched evaluation；
+- 足球侧仍需移动球速度/方向网格和随机扰动时刻的成功率实验，旗舰 Hat Trick 视频不能替代统计验证。

--- a/src/rosclaw/continual/boundary_feedback.py
+++ b/src/rosclaw/continual/boundary_feedback.py
@@ -1,0 +1,128 @@
+"""Turn matched-evaluation regressions into explicit re-rollout requests."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from rosclaw.continual.serde import policy_version_from_dict
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class BoundaryReplayRequest:
+    scenario_id: str
+    scenario_commitment: str
+    replay_partition: str
+    parent_policy_hash: str
+    candidate_policy_hash: str
+    parent_status: str
+    candidate_status: str
+    critical_signals: tuple[str, ...]
+    source_evidence_hash: str
+    schema_version: str = "rosclaw.continual.boundary_replay_request.v1"
+
+    def __post_init__(self) -> None:
+        if not self.scenario_id.strip() or not self.replay_partition.strip():
+            raise ValueError("boundary replay scenario and partition must not be empty")
+        for label, value in (
+            ("scenario_commitment", self.scenario_commitment),
+            ("parent_policy_hash", self.parent_policy_hash),
+            ("candidate_policy_hash", self.candidate_policy_hash),
+            ("source_evidence_hash", self.source_evidence_hash),
+        ):
+            if not _SHA256.fullmatch(value):
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not self.critical_signals:
+            raise ValueError("boundary replay request requires a critical safety signal")
+
+    @property
+    def request_hash(self) -> str:
+        return canonical_hash(asdict(self))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**asdict(self), "request_hash": self.request_hash}
+
+
+def extract_boundary_replay_requests(
+    report: Mapping[str, Any],
+    *,
+    source_evidence_hash: str,
+) -> tuple[BoundaryReplayRequest, ...]:
+    """Extract only new Candidate safety failures; never fabricate trajectories."""
+
+    if report.get("schema_version") != "rosclaw.continual.g1_candidate_matched_evaluation.v1":
+        raise ValueError("unsupported matched candidate evaluation schema")
+    gate = _mapping(report, "gate")
+    if gate.get("candidate_activated") is not False:
+        raise ValueError("boundary extraction requires a non-activated candidate report")
+    parent = policy_version_from_dict(_mapping(report, "parent_policy"))
+    candidate = policy_version_from_dict(_mapping(report, "candidate_policy"))
+    rows = _sequence(report, "rows")
+    parent_rows = {
+        str(row["scenario_commitment"]): row
+        for raw in rows
+        if (row := _mapping_value(raw, "row")).get("arm") == "active_parent_v2"
+    }
+    candidate_rows = {
+        str(row["scenario_commitment"]): row
+        for raw in rows
+        if (row := _mapping_value(raw, "row")).get("arm") == "candidate_v3"
+    }
+    requests = []
+    for commitment in sorted(set(parent_rows) & set(candidate_rows)):
+        baseline = parent_rows[commitment]
+        changed = candidate_rows[commitment]
+        baseline_critical = _critical_signals(baseline)
+        changed_critical = _critical_signals(changed)
+        if changed_critical and not baseline_critical:
+            requests.append(
+                BoundaryReplayRequest(
+                    scenario_id=str(changed["scenario_id"]),
+                    scenario_commitment=commitment,
+                    replay_partition=str(changed["replay_partition"]),
+                    parent_policy_hash=parent.version_hash,
+                    candidate_policy_hash=candidate.version_hash,
+                    parent_status=str(baseline["status"]),
+                    candidate_status=str(changed["status"]),
+                    critical_signals=changed_critical,
+                    source_evidence_hash=source_evidence_hash,
+                )
+            )
+    expected = int(gate.get("critical_safety_regressions", -1))
+    if expected != len(requests):
+        raise ValueError("matched report critical-regression count does not match its rows")
+    return tuple(requests)
+
+
+def _critical_signals(row: Mapping[str, Any]) -> tuple[str, ...]:
+    names = (
+        ("fall", "fall"),
+        ("joint_violation", "joint_limit"),
+        ("torque_violation", "torque_limit"),
+    )
+    return tuple(label for key, label in names if bool(row.get(key)))
+
+
+def _mapping(value: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    return _mapping_value(value.get(key), key)
+
+
+def _mapping_value(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be a mapping")
+    return value
+
+
+def _sequence(value: Mapping[str, Any], key: str) -> Sequence[Any]:
+    result = value.get(key)
+    if not isinstance(result, Sequence) or isinstance(result, (str, bytes)):
+        raise ValueError(f"{key} must be a sequence")
+    return result
+
+
+__all__ = ["BoundaryReplayRequest", "extract_boundary_replay_requests"]

--- a/src/rosclaw/continual/cli.py
+++ b/src/rosclaw/continual/cli.py
@@ -12,7 +12,13 @@ from rosclaw.continual.contracts import PolicyVersion
 
 
 def dispatch_continual_argv(argv: list[str]) -> int | None:
-    if len(argv) < 2 or argv[:2] != ["continual", "candidate"]:
+    if len(argv) < 2 or argv[0] != "continual":
+        return None
+    if argv[1] == "services":
+        from rosclaw.continual.service_cli import dispatch_continual_service_argv
+
+        return dispatch_continual_service_argv(argv[2:])
+    if argv[1] != "candidate":
         return None
     parser = argparse.ArgumentParser(prog="rosclaw continual candidate")
     commands = parser.add_subparsers(dest="command", required=True)

--- a/src/rosclaw/continual/learner.py
+++ b/src/rosclaw/continual/learner.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import io
 import json
 import math
 import struct
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 import numpy as np
 import torch  # type: ignore[import-not-found]
@@ -22,6 +23,7 @@ from torch import nn  # type: ignore[import-not-found]
 
 from rosclaw.continual.contracts import ExperiencePartition, PolicyVersion
 from rosclaw.continual.experience import ExperienceBatch, ExperienceRecord
+from rosclaw.feedback.contracts import canonical_hash
 
 
 @dataclass(frozen=True)
@@ -387,6 +389,74 @@ class ConstrainedResidualSAC:
                 )
             )
         return b"".join(chunks)
+
+    def checkpoint_bytes(self) -> bytes:
+        """Persist complete learner/optimizer state for crash-safe service recovery."""
+
+        payload = {
+            "schema_version": "rosclaw.continual.residual_sac_checkpoint.v1",
+            "config_hash": canonical_hash(asdict(self.config)),
+            "actor": self.actor.state_dict(),
+            "churn_reference": self.churn_reference.state_dict(),
+            "reward_critic": self.reward_critic.state_dict(),
+            "fall_critic": self.fall_critic.state_dict(),
+            "constraint_critic": self.constraint_critic.state_dict(),
+            "reward_target": self.reward_target.state_dict(),
+            "fall_target": self.fall_target.state_dict(),
+            "constraint_target": self.constraint_target.state_dict(),
+            "actor_optimizer": self.actor_optimizer.state_dict(),
+            "critic_optimizer": self.critic_optimizer.state_dict(),
+            "alpha_optimizer": self.alpha_optimizer.state_dict(),
+            "log_alpha": self.log_alpha.detach(),
+            "fall_lagrange": self.fall_lagrange,
+            "constraint_lagrange": self.constraint_lagrange,
+            "update_index": self.update_index,
+            "torch_rng_state": torch.get_rng_state(),
+            "cuda_rng_state": (
+                torch.cuda.get_rng_state_all() if self.device.type == "cuda" else None
+            ),
+        }
+        buffer = io.BytesIO()
+        torch.save(payload, buffer)
+        return buffer.getvalue()
+
+    def restore_checkpoint(self, checkpoint: bytes) -> None:
+        """Restore a trusted service-owned checkpoint into the same SAC config."""
+
+        if not checkpoint:
+            raise ValueError("SAC checkpoint must not be empty")
+        payload = torch.load(io.BytesIO(checkpoint), map_location=self.device, weights_only=False)
+        if not isinstance(payload, dict):
+            raise ValueError("SAC checkpoint payload must be a mapping")
+        if payload.get("schema_version") != "rosclaw.continual.residual_sac_checkpoint.v1":
+            raise ValueError("unsupported SAC checkpoint schema")
+        if payload.get("config_hash") != canonical_hash(asdict(self.config)):
+            raise ValueError("SAC checkpoint config does not match this learner")
+        for name in (
+            "actor",
+            "churn_reference",
+            "reward_critic",
+            "fall_critic",
+            "constraint_critic",
+            "reward_target",
+            "fall_target",
+            "constraint_target",
+        ):
+            getattr(self, name).load_state_dict(payload[name])
+        self.actor_optimizer.load_state_dict(payload["actor_optimizer"])
+        self.critic_optimizer.load_state_dict(payload["critic_optimizer"])
+        self.alpha_optimizer.load_state_dict(payload["alpha_optimizer"])
+        with torch.no_grad():
+            self.log_alpha.copy_(payload["log_alpha"])
+        self.fall_lagrange = float(payload["fall_lagrange"])
+        self.constraint_lagrange = float(payload["constraint_lagrange"])
+        self.update_index = int(payload["update_index"])
+        torch.set_rng_state(payload["torch_rng_state"].cpu())
+        if self.device.type == "cuda":
+            cuda_rng_state = payload.get("cuda_rng_state")
+            if cuda_rng_state is None:
+                raise ValueError("CUDA SAC checkpoint is missing device RNG state")
+            torch.cuda.set_rng_state_all(cuda_rng_state)
 
     def candidate_policy(self, *, parent: PolicyVersion) -> tuple[PolicyVersion, bytes]:
         if parent.observation_names != self.config.observation_names:

--- a/src/rosclaw/continual/serde.py
+++ b/src/rosclaw/continual/serde.py
@@ -18,6 +18,54 @@ from rosclaw.continual.contracts import (
 from rosclaw.continual.experience import ExperienceBatch, ExperienceRecord
 
 _ENVELOPE_SCHEMA = "rosclaw.continual.experience_batch_envelope.v1"
+_RECORD_ENVELOPE_SCHEMA = "rosclaw.continual.experience_record_envelope.v1"
+
+
+def policy_version_from_dict(value: Mapping[str, Any]) -> PolicyVersion:
+    """Rebuild a policy identity for durable service recovery."""
+
+    return _policy(value)
+
+
+def experience_record_to_dict(record: ExperienceRecord) -> dict[str, Any]:
+    """Serialize one complete record for an append-only experience log."""
+
+    return {
+        "schema_version": _RECORD_ENVELOPE_SCHEMA,
+        "trajectory": record.trajectory.to_dict(),
+        "record": {
+            "schema_version": record.schema_version,
+            "partition": record.partition.value,
+            "anchor_policy_hash": record.anchor_policy_hash,
+            "boundary_reason": record.boundary_reason,
+            "self_change_hash": record.self_change_hash,
+            "near_boundary_score": record.near_boundary_score,
+            "trajectory_hash": record.trajectory.trajectory_hash,
+            "record_hash": record.record_hash,
+        },
+    }
+
+
+def experience_record_from_dict(value: Mapping[str, Any]) -> ExperienceRecord:
+    """Rebuild one record and reject trajectory or record tampering."""
+
+    _schema(value, "schema_version", _RECORD_ENVELOPE_SCHEMA)
+    trajectory = _trajectory(_mapping(value, "trajectory"))
+    item = _mapping(value, "record")
+    _schema(item, "schema_version", "rosclaw.continual.experience_record.v1")
+    if item.get("trajectory_hash") != trajectory.trajectory_hash:
+        raise ValueError("experience record trajectory hash mismatch")
+    record = ExperienceRecord(
+        trajectory=trajectory,
+        partition=ExperiencePartition(str(item["partition"])),
+        anchor_policy_hash=_optional_string(item.get("anchor_policy_hash")),
+        boundary_reason=_optional_string(item.get("boundary_reason")),
+        self_change_hash=_optional_string(item.get("self_change_hash")),
+        near_boundary_score=float(item["near_boundary_score"]),
+    )
+    if item.get("record_hash") != record.record_hash:
+        raise ValueError("experience record hash mismatch")
+    return record
 
 
 def experience_batch_to_dict(batch: ExperienceBatch) -> dict[str, Any]:
@@ -207,4 +255,10 @@ def _ordered_numeric(
     return {name: float(value[name]) for name in names}
 
 
-__all__ = ["experience_batch_from_dict", "experience_batch_to_dict"]
+__all__ = [
+    "experience_batch_from_dict",
+    "experience_batch_to_dict",
+    "experience_record_from_dict",
+    "experience_record_to_dict",
+    "policy_version_from_dict",
+]

--- a/src/rosclaw/continual/service_cli.py
+++ b/src/rosclaw/continual/service_cli.py
@@ -1,0 +1,55 @@
+"""CLI for real-MuJoCo continual service validation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def dispatch_continual_service_argv(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="rosclaw continual services")
+    commands = parser.add_subparsers(dest="command", required=True)
+    validate = commands.add_parser(
+        "validate",
+        help="run the five recoverable services against real G1 MuJoCo evidence",
+    )
+    validate.add_argument("--asset-root", type=Path, required=True)
+    validate.add_argument("--candidate", type=Path, required=True)
+    validate.add_argument("--matched-report", type=Path, required=True)
+    validate.add_argument("--state-root", type=Path, required=True)
+    validate.add_argument("--output", type=Path, required=True)
+    validate.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    validate.add_argument("--learner-device", default="cpu")
+    validate.add_argument("--learner-updates", type=int, default=1)
+    args = parser.parse_args(argv)
+
+    from rosclaw.continual.service_validation import run_g1_service_validation
+
+    result = run_g1_service_validation(
+        asset_root=args.asset_root,
+        candidate_artifact_path=args.candidate,
+        matched_report_path=args.matched_report,
+        state_root=args.state_root,
+        output_path=args.output,
+        source_checkout=args.source_checkout,
+        learner_device=args.learner_device,
+        learner_updates=args.learner_updates,
+    )
+    print(
+        json.dumps(
+            {
+                "output": str(args.output.expanduser().resolve()),
+                "state_root": str(args.state_root.expanduser().resolve()),
+                "passed": result["passed"],
+                "checks": result["checks"],
+                "report_hash": result["report_hash"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if result["passed"] else 1
+
+
+__all__ = ["dispatch_continual_service_argv"]

--- a/src/rosclaw/continual/service_validation.py
+++ b/src/rosclaw/continual/service_validation.py
@@ -1,0 +1,656 @@
+"""Real-MuJoCo closed-loop validation for recoverable continual services."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.continual.boundary_feedback import extract_boundary_replay_requests
+from rosclaw.continual.contracts import ExperiencePartition, PolicyVersion, SkillPhase
+from rosclaw.continual.g1_goalforge import (
+    G1_CONTINUAL_ACTION_LIMITS,
+    adapt_goalforge_episode,
+    build_g1_policy_lineage,
+)
+from rosclaw.continual.learner import ConstrainedResidualSAC, ResidualSACConfig
+from rosclaw.continual.serde import policy_version_from_dict
+from rosclaw.continual.services.experience import ExperienceService
+from rosclaw.continual.services.inference import InferenceService
+from rosclaw.continual.services.learner import (
+    LearnerService,
+    ResidualSACServiceExecutor,
+)
+from rosclaw.continual.services.persistence import (
+    atomic_write_json,
+    require_external_service_root,
+)
+from rosclaw.continual.services.rollout import RolloutService
+from rosclaw.continual.services.weight_update import WeightUpdateService
+from rosclaw.continual.stability import (
+    ContinualCandidateEvidence,
+    StabilityPlasticityGate,
+    TaskRetention,
+)
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.self_model.agency import AgencyEstimator, AgencyEvidence
+from rosclaw.self_model.forward_model import (
+    ForwardAction,
+    ForwardModelInput,
+    ForwardPrediction,
+    ForwardState,
+    HybridForwardSelfModel,
+)
+from rosclaw.self_model.prediction_monitor import (
+    AdaptationState,
+    AdaptationTrigger,
+    PredictionResiduals,
+)
+from rosclaw.self_model.regime import RegimeEncoder, RegimeMemory, RegimeObservation
+from rosclaw.simforge.backends.unitree_mujoco_backend import (
+    G1MuJoCoBackend,
+    trajectory_digest,
+)
+from rosclaw.simforge.g1_continual_physical_validation import (
+    build_foundation_scenarios,
+    record_goalforge_experience,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_DDS_JOINT_NAMES, ShotParameters
+
+
+def run_g1_service_validation(
+    *,
+    asset_root: Path,
+    candidate_artifact_path: Path,
+    matched_report_path: Path,
+    state_root: Path,
+    output_path: Path,
+    source_checkout: Path,
+    learner_device: str = "cpu",
+    learner_updates: int = 1,
+) -> dict[str, Any]:
+    """Exercise all five services against physics and fail-closed candidate evidence."""
+
+    checkout = source_checkout.expanduser().resolve()
+    root = require_external_service_root(state_root, checkout)
+    output = output_path.expanduser().resolve()
+    require_external_service_root(output.parent, checkout)
+    if root.exists():
+        raise FileExistsError(f"service validation state root already exists: {root}")
+    if output.exists():
+        raise FileExistsError(f"service validation output already exists: {output}")
+    if not 1 <= learner_updates <= 20:
+        raise ValueError("service validation learner updates must be in [1, 20]")
+    report_bytes = matched_report_path.expanduser().resolve().read_bytes()
+    source_evidence_hash = _digest(report_bytes)
+    report = json.loads(report_bytes)
+    if not isinstance(report, dict):
+        raise ValueError("matched candidate report must be a JSON object")
+    boundary_requests = extract_boundary_replay_requests(
+        report,
+        source_evidence_hash=source_evidence_hash,
+    )
+    parent_from_report = policy_version_from_dict(_mapping(report, "parent_policy"))
+    candidate = policy_version_from_dict(_mapping(report, "candidate_policy"))
+    candidate_artifact = candidate_artifact_path.expanduser().resolve().read_bytes()
+    if _digest(candidate_artifact) != candidate.artifact_hash:
+        raise ValueError("candidate artifact does not match the matched report")
+
+    backend = G1MuJoCoBackend(asset_root=asset_root, trace_stride=5)
+    qualification = backend.qualification
+    lineage = build_g1_policy_lineage(
+        body_hash=qualification.body_hash,
+        kick_prior_hash=qualification.kick_prior_hash,
+        motion_hash=qualification.motion_hash,
+        backend_commit=qualification.backend_commit,
+        torque_guard_scale=backend.torque_guard_scale,
+        through_version=2,
+    )
+    parent = lineage.policy(2)
+    if parent.version_hash != parent_from_report.version_hash:
+        raise ValueError("matched report parent does not match qualified local G1 assets")
+    if candidate.parent_version_hash != parent.version_hash:
+        raise ValueError("matched candidate is not the direct successor of the local parent")
+
+    root.mkdir(parents=True)
+    trajectory_root = root / "trajectories"
+    trajectory_root.mkdir()
+
+    trigger = _open_shadow_learning(report)
+    rollout = RolloutService(root, source_checkout=checkout)
+    inference = InferenceService(
+        root,
+        source_checkout=checkout,
+        active=parent,
+        active_artifact=lineage.artifact(2),
+    )
+    experience = ExperienceService(root, source_checkout=checkout)
+    regime_encoder = RegimeEncoder(tuple(G1_DDS_JOINT_NAMES))
+    scenarios = build_foundation_scenarios()
+    parameters = ShotParameters()
+    rollout_evidence: list[dict[str, Any]] = []
+    first_trace: dict[str, np.ndarray] | None = None
+    first_episode_hash: str | None = None
+    for partition in ExperiencePartition:
+        scenario = scenarios[partition]
+        assignment = rollout.assign(
+            episode_id=scenario.scenario_id,
+            scenario_commitment=scenario.scenario_commitment,
+            policy=parent,
+        )
+        rollout.start(assignment.assignment_id, worker_id="local-mujoco-worker")
+        lease = inference.begin_motion(
+            episode_id=scenario.scenario_id,
+            phase=SkillPhase.PREPARE,
+        )
+        episode = backend.run(scenario, parameters)
+        replay = backend.run(scenario, parameters)
+        strict_replay = bool(
+            episode.result.summary_dict() == replay.result.summary_dict()
+            and trajectory_digest(episode.trajectory) == trajectory_digest(replay.trajectory)
+        )
+        adaptation = adapt_goalforge_episode(
+            episode,
+            policy=parent,
+            strict_replay=strict_replay,
+        )
+        completed = rollout.complete(
+            assignment.assignment_id,
+            trajectory=adaptation.trajectory,
+        )
+        inference.end_motion(lease.lease_id)
+        record = record_goalforge_experience(
+            partition,
+            adaptation.trajectory,
+            scenario.scenario_commitment,
+        )
+        experience.append(record)
+        path = trajectory_root / f"{partition.value}.npz"
+        np.savez_compressed(path, **episode.trajectory)
+        rollout_evidence.append(
+            {
+                "partition": partition.value,
+                "scenario_id": scenario.scenario_id,
+                "scenario_commitment": scenario.scenario_commitment,
+                "assignment_id": completed.assignment_id,
+                "policy_version_hash": completed.policy.version_hash,
+                "version_switch_count": completed.version_switch_count,
+                "strict_replay": completed.strict_replay,
+                "physics_steps": episode.result.physics_steps,
+                "status": episode.result.status.value,
+                "trajectory_hash": adaptation.trajectory.trajectory_hash,
+                "trajectory_path": str(path),
+                "critical_cost": adaptation.trajectory.has_critical_cost,
+            }
+        )
+        _observe_regime(regime_encoder, scenario)
+        if first_trace is None:
+            first_trace = episode.trajectory
+            first_episode_hash = adaptation.trajectory.trajectory_hash
+
+    for request in boundary_requests:
+        experience.enqueue_boundary(request)
+    experience_before_recovery = experience.audit_receipt()
+    experience.close()
+    with ExperienceService(root, source_checkout=checkout) as recovered_experience:
+        experience_after_recovery = recovered_experience.audit_receipt()
+        batch = recovered_experience.sample(
+            batch_size=64,
+            learner_version=parent.version,
+            seed=7107,
+        )
+
+    if first_trace is None or first_episode_hash is None:
+        raise RuntimeError("service validation did not produce a physical trajectory")
+    forward = _calibrate_forward_model(
+        first_trace, shadow_learning=trigger.state is AdaptationState.SHADOW_LEARNING
+    )
+    regime_estimate = regime_encoder.estimate()
+    regime_assignment = RegimeMemory().assign(regime_estimate.persistent)
+    boundary_scenario = scenarios[ExperiencePartition.BOUNDARY]
+    agency = AgencyEstimator().estimate(
+        AgencyEvidence(
+            action_magnitude=0.7,
+            prediction_error=min(1.0, forward["error_after"] * 100.0),
+            external_force_evidence=min(1.0, boundary_scenario.disturbance_n / 80.0),
+            sensor_inconsistency=min(1.0, boundary_scenario.observation_noise_m / 0.08),
+            action_hash=canonical_hash(asdict(parameters)),
+            predicted_outcome_hash=canonical_hash(
+                {"forward_model_hash": forward["model_hash"], "episode": first_episode_hash}
+            ),
+            observed_outcome_hash=first_episode_hash,
+            timestamp_ns=0,
+        )
+    )
+
+    learner = ConstrainedResidualSAC(
+        ResidualSACConfig(
+            observation_names=parent.observation_names,
+            action_names=parent.residual_action_names,
+            action_limits=G1_CONTINUAL_ACTION_LIMITS,
+            hidden_dims=(64, 64),
+            batch_size=64,
+            seed=7107,
+            device=learner_device,
+        )
+    )
+    learner_service = LearnerService(root, source_checkout=checkout, parent=parent)
+    learned = learner_service.execute(
+        batch,
+        executor=ResidualSACServiceExecutor(
+            learner,
+            parent=parent,
+            updates_per_job=learner_updates,
+        ),
+    )
+    recovered_learner = LearnerService(root, source_checkout=checkout, parent=parent)
+
+    crash_assignment = rollout.assign(
+        episode_id="crash-injection-rollout",
+        scenario_commitment=canonical_hash({"scenario": "SIM crash recovery injection"}),
+        policy=parent,
+    )
+    rollout.start(crash_assignment.assignment_id, worker_id="crash-injection-worker")
+    inference.begin_motion(
+        episode_id="crash-injection-inference",
+        phase=SkillPhase.PREPARE,
+    )
+    recovered_rollout = RolloutService(root, source_checkout=checkout)
+    recovered_inference = InferenceService(root, source_checkout=checkout)
+
+    updater = WeightUpdateService(
+        root,
+        source_checkout=checkout,
+        inference=recovered_inference,
+    )
+    published = updater.publish(candidate, artifact=candidate_artifact)
+    verified = updater.verify()
+    staged = updater.stage()
+    gate_report = StabilityPlasticityGate().evaluate(
+        _matched_gate_evidence(report, parent=parent, candidate=candidate)
+    )
+    activation = updater.activate(phase=SkillPhase.COMPLETE, gate_report=gate_report)
+    active_parent_unchanged = recovered_inference.active.version_hash == parent.version_hash
+
+    candidate_update = trigger.candidate_update(
+        sample_count=int(_mapping(report, "counts")["total"]),
+        target_improvement=float(
+            _mapping(report, "paired_statistics")["target_error_improvement_m"]
+        ),
+        anchor_degradation=max(
+            0.0,
+            _aggregate(report, "active_parent_v2", "anchor", "success_rate")
+            - _aggregate(report, "candidate_v3", "anchor", "success_rate"),
+        ),
+        critical_safety_regressions=int(_mapping(report, "gate")["critical_safety_regressions"]),
+        converged=True,
+    )
+
+    checks = {
+        "four_physics_partitions": len(rollout_evidence) == 4
+        and all(item["physics_steps"] > 0 for item in rollout_evidence),
+        "strict_replay": all(item["strict_replay"] for item in rollout_evidence),
+        "motion_version_switches_zero": all(
+            item["version_switch_count"] == 0 for item in rollout_evidence
+        ),
+        "experience_catalog_recovered": (
+            experience_before_recovery["catalog_counts"]
+            == experience_after_recovery["catalog_counts"]
+        ),
+        "boundary_regressions_enqueued": len(boundary_requests)
+        == int(_mapping(report, "gate")["critical_safety_regressions"]),
+        "learner_checkpoint_recovered": learned.batch_hash
+        in recovered_learner.completed_batch_hashes,
+        "forward_calibration_error_decreased": forward["error_after"] < forward["error_before"],
+        "rollout_crash_aborted_without_replay": recovered_rollout.recovered_abort_count == 1,
+        "inference_crash_aborted_without_replay": recovered_inference.recovered_abort_count == 1,
+        "unsafe_candidate_not_activated": not gate_report.activation_allowed
+        and active_parent_unchanged,
+        "adaptation_rolled_back": candidate_update.state is AdaptationState.ROLLBACK,
+    }
+    result: dict[str, Any] = {
+        "schema_version": "rosclaw.continual.g1_service_validation.v1",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "source": {
+            "matched_report": str(matched_report_path.expanduser().resolve()),
+            "matched_report_hash": source_evidence_hash,
+            "candidate_artifact": str(candidate_artifact_path.expanduser().resolve()),
+            "candidate_artifact_hash": candidate.artifact_hash,
+            "qualified_body_hash": qualification.body_hash,
+            "backend_commit": qualification.backend_commit,
+        },
+        "rollout_service": {
+            "rollouts": rollout_evidence,
+            "event_count": len(recovered_rollout.log.events),
+            "recovered_abort_count": recovered_rollout.recovered_abort_count,
+        },
+        "experience_service": {
+            "before_recovery": experience_before_recovery,
+            "after_recovery": experience_after_recovery,
+            "boundary_requests": [request.to_dict() for request in boundary_requests],
+            "batch_hash": batch.batch_hash,
+        },
+        "learner_service": {
+            **asdict(learned),
+            "checkpoint_recovered": learned.batch_hash in recovered_learner.completed_batch_hashes,
+            "device": learner_device,
+        },
+        "inference_service": {
+            "active_policy_hash": recovered_inference.active.version_hash,
+            "candidate_policy_hash": (
+                recovered_inference.candidate.version_hash
+                if recovered_inference.candidate is not None
+                else None
+            ),
+            "active_parent_unchanged": active_parent_unchanged,
+            "recovered_abort_count": recovered_inference.recovered_abort_count,
+        },
+        "weight_update_service": {
+            "publish": published.to_dict(),
+            "verify": verified.to_dict(),
+            "stage": staged.to_dict(),
+            "activation": activation.to_dict(),
+            "gate": _gate_to_dict(gate_report),
+        },
+        "adaptation": asdict(candidate_update),
+        "forward_self_model": forward,
+        "regime": {
+            "fast": regime_estimate.fast.to_dict(),
+            "episode": regime_estimate.episode.to_dict(),
+            "persistent": regime_estimate.persistent.to_dict(),
+            "expert_assignment": asdict(regime_assignment),
+        },
+        "agency": agency.to_dict(),
+        "claims": {
+            "evidence_domain": "SIM",
+            "real_mujoco_physics": True,
+            "service_state_external_to_checkout": True,
+            "candidate_activated": False,
+            "registry_mutated": False,
+            "dds_opened": False,
+            "hardware_authorized": False,
+            "consciousness_claimed": False,
+            "operational_embodied_self_model": True,
+        },
+    }
+    result["report_hash"] = canonical_hash(result)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(output, result)
+    return result
+
+
+def _open_shadow_learning(report: dict[str, Any]) -> AdaptationTrigger:
+    critical = int(_mapping(report, "gate")["critical_safety_regressions"])
+    if critical <= 0:
+        raise ValueError("this validation requires rejected safety-boundary evidence")
+    trigger = AdaptationTrigger()
+    for index in range(5):
+        trigger.observe(
+            PredictionResiduals(
+                body_state=1.0,
+                contact_outcome=1.0,
+                contact_mode=1.0,
+                control_latency=0.0,
+                energy=0.0,
+                task_performance=min(
+                    1.0,
+                    _aggregate(report, "candidate_v3", "all", "mean_penalized_target_error_m")
+                    / 2.0,
+                ),
+                timestamp_ns=index,
+                episode_id="matched-candidate-safety-shift",
+            )
+        )
+    if trigger.state is not AdaptationState.CONFIRMED_SHIFT:
+        raise RuntimeError("persistent matched safety residual did not confirm adaptation shift")
+    trigger.begin_shadow_learning()
+    return trigger
+
+
+def _observe_regime(regime: RegimeEncoder, scenario: Any) -> None:
+    for index in range(4):
+        regime.observe(
+            RegimeObservation(
+                episode_id=scenario.scenario_id,
+                timestamp_ns=index,
+                support_friction=scenario.support_ground_friction,
+                ball_friction=scenario.ball_ground_friction,
+                control_latency_ms=scenario.control_latency_ms,
+                joint_zero_bias=dict.fromkeys(G1_DDS_JOINT_NAMES, scenario.joint_zero_bias_rad),
+                motor_gain=dict.fromkeys(G1_DDS_JOINT_NAMES, 1.0),
+                payload_kg=max(0.0, scenario.ball_mass_kg - 0.41),
+                disturbance_magnitude=scenario.disturbance_n / 80.0,
+                sensor_confidence=max(0.0, 1.0 - scenario.observation_noise_m / 0.08),
+            )
+        )
+    regime.end_episode(scenario.scenario_id)
+
+
+def _calibrate_forward_model(
+    trace: dict[str, np.ndarray], *, shadow_learning: bool
+) -> dict[str, Any]:
+    sample_count = len(np.asarray(trace["time"]))
+    stride = max(1, (sample_count - 3) // 96)
+    indices = tuple(range(0, sample_count - 3, stride))[:96]
+    if len(indices) < 16:
+        raise ValueError("physical trace is too short for forward-model calibration")
+    pairs = [(_forward_input(trace, index), _forward_state(trace, index + 1)) for index in indices]
+    model = HybridForwardSelfModel(
+        tuple(G1_DDS_JOINT_NAMES),
+        hidden_size=64,
+        residual_limit=0.05,
+        learning_rate=0.2,
+        seed=7107,
+    )
+    before = _mean_prediction_error(model, pairs)
+    learning_receipts = []
+    for _ in range(8):
+        learning_receipts.extend(
+            model.learn_transition(model_input, actual, shadow_learning=shadow_learning)
+            for model_input, actual in pairs
+        )
+    after = _mean_prediction_error(model, pairs)
+    return {
+        "schema_version": "rosclaw.self.forward_model_validation.v1",
+        "trace_samples": sample_count,
+        "calibration_transitions": len(pairs),
+        "shadow_learning": shadow_learning,
+        "trained_updates": sum(receipt.trained for receipt in learning_receipts),
+        "error_before": before,
+        "error_after": after,
+        "error_reduction": before - after,
+        "model_hash": model.model_hash,
+        "bounded_residual_limit": model.residual_limit,
+        "evaluation_semantics": "within-trace shadow calibration; not an unseen-regime benchmark",
+    }
+
+
+def _forward_input(trace: dict[str, np.ndarray], index: int) -> ForwardModelInput:
+    state = _forward_state(trace, index)
+    dt = _dt(trace, index)
+    velocity = np.asarray(trace["joint_velocity"], dtype=float)
+    acceleration = (velocity[index + 1] - velocity[index]) / dt
+    pelvis_velocity = _pelvis_velocity(trace, index)
+    next_pelvis_velocity = _pelvis_velocity(trace, index + 1)
+    pelvis_acceleration = (next_pelvis_velocity - pelvis_velocity) / dt
+    ball_velocity = np.asarray(trace["ball_velocity"], dtype=float)
+    ball_impulse = ball_velocity[index + 1, :3] - ball_velocity[index, :3]
+    contact = (
+        _scalar(trace["left_foot_contact"], index),
+        _scalar(trace["right_foot_contact"], index),
+    )
+    return ForwardModelInput(
+        state=state,
+        action=ForwardAction(
+            joint_acceleration=dict(zip(G1_DDS_JOINT_NAMES, acceleration.tolist(), strict=True)),
+            pelvis_acceleration=tuple(pelvis_acceleration.tolist()),
+            ball_impulse=tuple(ball_impulse.tolist()),
+        ),
+        dt_seconds=dt,
+        phase_progress=float(np.clip(_scalar(trace["policy_phase"], index), 0.0, 1.0)),
+        contact_mode=tuple(float(np.clip(value, 0.0, 1.0)) for value in contact),
+    )
+
+
+def _forward_state(trace: dict[str, np.ndarray], index: int) -> ForwardState:
+    position = np.asarray(trace["joint_position"], dtype=float)[index]
+    velocity = np.asarray(trace["joint_velocity"], dtype=float)[index]
+    pelvis = np.asarray(trace["pelvis_pose"], dtype=float)[index, :3]
+    com = np.asarray(trace["com"], dtype=float)[index, :3]
+    ball = np.asarray(trace["ball_pose"], dtype=float)[index, :3]
+    ball_velocity = np.asarray(trace["ball_velocity"], dtype=float)[index, :3]
+    sample_count = len(np.asarray(trace["time"]))
+    return ForwardState(
+        joint_position=dict(zip(G1_DDS_JOINT_NAMES, position.tolist(), strict=True)),
+        joint_velocity=dict(zip(G1_DDS_JOINT_NAMES, velocity.tolist(), strict=True)),
+        pelvis_position=tuple(pelvis.tolist()),
+        pelvis_velocity=tuple(_pelvis_velocity(trace, index).tolist()),
+        com_position=tuple(com.tolist()),
+        foot_contact=(
+            float(np.clip(_scalar(trace["left_foot_contact"], index), 0.0, 1.0)),
+            float(np.clip(_scalar(trace["right_foot_contact"], index), 0.0, 1.0)),
+        ),
+        ball_position=tuple(ball.tolist()),
+        ball_velocity=tuple(ball_velocity.tolist()),
+        energy_state=max(0.0, 1.0 - index / (2.0 * sample_count)),
+        balance_margin=0.08 - abs(_scalar(trace["com_y_relative"], index)),
+    )
+
+
+def _mean_prediction_error(
+    model: HybridForwardSelfModel,
+    pairs: list[tuple[ForwardModelInput, ForwardState]],
+) -> float:
+    return sum(
+        _prediction_error(model.predict(model_input), actual) for model_input, actual in pairs
+    ) / len(pairs)
+
+
+def _prediction_error(prediction: ForwardPrediction, actual: ForwardState) -> float:
+    predicted = prediction.next_state
+    values = [
+        *(
+            predicted.joint_position[name] - actual.joint_position[name]
+            for name in G1_DDS_JOINT_NAMES
+        ),
+        *(
+            predicted.joint_velocity[name] - actual.joint_velocity[name]
+            for name in G1_DDS_JOINT_NAMES
+        ),
+        *(
+            left - right
+            for left, right in zip(predicted.pelvis_position, actual.pelvis_position, strict=True)
+        ),
+        *(
+            left - right
+            for left, right in zip(predicted.com_position, actual.com_position, strict=True)
+        ),
+        *(
+            left - right
+            for left, right in zip(predicted.ball_position, actual.ball_position, strict=True)
+        ),
+        predicted.energy_state - actual.energy_state,
+        predicted.balance_margin - actual.balance_margin,
+    ]
+    return sum(value * value for value in values) / len(values)
+
+
+def _pelvis_velocity(trace: dict[str, np.ndarray], index: int) -> np.ndarray:
+    pose = np.asarray(trace["pelvis_pose"], dtype=float)
+    return (pose[index + 1, :3] - pose[index, :3]) / _dt(trace, index)
+
+
+def _dt(trace: dict[str, np.ndarray], index: int) -> float:
+    time = np.asarray(trace["time"], dtype=float)
+    return float(np.clip(time[index + 1] - time[index], 1e-6, 0.1))
+
+
+def _scalar(value: np.ndarray, index: int) -> float:
+    return float(np.asarray(value, dtype=float)[index].reshape(-1)[0])
+
+
+def _matched_gate_evidence(
+    report: dict[str, Any], *, parent: PolicyVersion, candidate: PolicyVersion
+) -> ContinualCandidateEvidence:
+    counts = _mapping(report, "counts")
+    return ContinualCandidateEvidence(
+        parent_policy_hash=parent.artifact_hash,
+        candidate_policy_hash=candidate.artifact_hash,
+        body_hash=candidate.body_hash,
+        parent_body_hash=parent.body_hash,
+        safety_kernel_hash=candidate.safety_kernel_hash,
+        parent_safety_kernel_hash=parent.safety_kernel_hash,
+        task_retention=(
+            TaskRetention(
+                "anchor_kick",
+                _aggregate(report, "active_parent_v2", "anchor", "success_rate"),
+                _aggregate(report, "candidate_v3", "anchor", "success_rate"),
+                critical=True,
+            ),
+            TaskRetention(
+                "all_matched_scenarios",
+                _aggregate(report, "active_parent_v2", "all", "success_rate"),
+                _aggregate(report, "candidate_v3", "all", "success_rate"),
+            ),
+        ),
+        plasticity=None,
+        self_core=None,
+        replay_recent_count=int(counts["recent"]),
+        replay_anchor_count=int(counts["anchor"]),
+        replay_boundary_count=int(counts["boundary"]),
+        replay_self_count=int(counts["self"]),
+        anchor_action_drift_rms=_aggregate(
+            report, "candidate_v3", "anchor", "anchor_action_drift_rms"
+        ),
+        critical_safety_regressions=int(_mapping(report, "gate")["critical_safety_regressions"]),
+        stale_action_executions=0,
+        old_version_replays=0,
+        candidate_evaluation_complete=True,
+    )
+
+
+def _gate_to_dict(report: Any) -> dict[str, Any]:
+    return {
+        "schema_version": report.schema_version,
+        "decision": report.decision.value,
+        "checks": [
+            {"name": item.name, "status": item.status.value, "detail": item.detail}
+            for item in report.checks
+        ],
+        "parent_policy_hash": report.parent_policy_hash,
+        "candidate_policy_hash": report.candidate_policy_hash,
+        "rollback_target_hash": report.rollback_target_hash,
+        "activation_allowed": report.activation_allowed,
+        "evidence_domain": report.evidence_domain,
+        "report_hash": report.report_hash,
+    }
+
+
+def _aggregate(report: dict[str, Any], arm: str, partition: str, metric: str) -> float:
+    aggregates = _mapping(report, "aggregates")
+    arm_value = _mapping(aggregates, arm)
+    partition_value = _mapping(arm_value, partition)
+    value = float(partition_value[metric])
+    if not math.isfinite(value):
+        raise ValueError(f"matched report aggregate is not finite: {arm}/{partition}/{metric}")
+    return value
+
+
+def _mapping(value: dict[str, Any], key: str) -> dict[str, Any]:
+    result = value.get(key)
+    if not isinstance(result, dict):
+        raise ValueError(f"{key} must be a JSON object")
+    return result
+
+
+def _digest(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+__all__ = ["run_g1_service_validation"]

--- a/src/rosclaw/continual/services/__init__.py
+++ b/src/rosclaw/continual/services/__init__.py
@@ -1,0 +1,35 @@
+"""Recoverable service boundaries for asynchronous continual learning."""
+
+from rosclaw.continual.services.experience import ExperienceService
+from rosclaw.continual.services.inference import (
+    InferenceService,
+    InferenceSlotReceipt,
+    MotionVersionLease,
+)
+from rosclaw.continual.services.learner import (
+    LearnerProduct,
+    LearnerService,
+    LearnerServiceReceipt,
+    ResidualSACServiceExecutor,
+)
+from rosclaw.continual.services.rollout import RolloutAssignment, RolloutService, RolloutState
+from rosclaw.continual.services.weight_update import (
+    WeightUpdateService,
+    WeightUpdateServiceReceipt,
+)
+
+__all__ = [
+    "ExperienceService",
+    "InferenceService",
+    "InferenceSlotReceipt",
+    "LearnerProduct",
+    "LearnerService",
+    "LearnerServiceReceipt",
+    "MotionVersionLease",
+    "ResidualSACServiceExecutor",
+    "RolloutAssignment",
+    "RolloutService",
+    "RolloutState",
+    "WeightUpdateService",
+    "WeightUpdateServiceReceipt",
+]

--- a/src/rosclaw/continual/services/experience.py
+++ b/src/rosclaw/continual/services/experience.py
@@ -1,0 +1,303 @@
+"""Persistent four-partition experience service with a SQLite catalog."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from rosclaw.continual.boundary_feedback import BoundaryReplayRequest
+from rosclaw.continual.contracts import ExperiencePartition
+from rosclaw.continual.experience import (
+    ContinualExperienceStore,
+    ExperienceBatch,
+    ExperienceBufferConfig,
+    ExperienceRecord,
+)
+from rosclaw.continual.serde import experience_record_from_dict, experience_record_to_dict
+from rosclaw.continual.services.persistence import (
+    DurableEventLog,
+    require_external_service_root,
+)
+
+
+class ExperienceService:
+    """Append-only truth plus recoverable catalog and bounded replay cache."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        source_checkout: Path,
+        config: ExperienceBufferConfig | None = None,
+    ) -> None:
+        self.root = require_external_service_root(root, source_checkout) / "experience"
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.log = DurableEventLog(self.root / "journal", service="experience")
+        self.store = ContinualExperienceStore(config)
+        self._records: dict[str, ExperienceRecord] = {}
+        self._boundary: dict[str, tuple[BoundaryReplayRequest, str | None]] = {}
+        self._database = sqlite3.connect(self.root / "catalog.sqlite3")
+        self._database.execute("PRAGMA journal_mode=WAL")
+        self._database.execute("PRAGMA synchronous=FULL")
+        self._create_schema()
+        for event in self.log.events:
+            self._apply(event.kind, dict(event.payload))
+        self._audit_catalog()
+
+    def close(self) -> None:
+        self._database.close()
+
+    def __enter__(self) -> ExperienceService:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def append(self, record: ExperienceRecord) -> str:
+        if not record.trajectory.strict_replay:
+            raise ValueError("persistent experience requires strict-replay trajectory truth")
+        if record.record_hash in self._records:
+            raise ValueError("experience record is already durably cataloged")
+        event = self.log.append(
+            "EXPERIENCE_APPENDED",
+            {"envelope": experience_record_to_dict(record)},
+        )
+        self._apply(event.kind, dict(event.payload))
+        return record.record_hash
+
+    def sample(self, *, batch_size: int, learner_version: int, seed: int) -> ExperienceBatch:
+        return self.store.sample(
+            batch_size=batch_size,
+            learner_version=learner_version,
+            seed=seed,
+        )
+
+    def enqueue_boundary(self, request: BoundaryReplayRequest) -> str:
+        if request.request_hash in self._boundary:
+            raise ValueError("boundary replay request is already cataloged")
+        event = self.log.append("BOUNDARY_QUEUED", {"request": request.to_dict()})
+        self._apply(event.kind, dict(event.payload))
+        return request.request_hash
+
+    def complete_boundary(self, request_hash: str, *, record: ExperienceRecord) -> None:
+        entry = self._boundary.get(request_hash)
+        if entry is None:
+            raise KeyError("unknown boundary replay request")
+        if entry[1] is not None:
+            raise RuntimeError("boundary replay request is already complete")
+        if record.partition is not ExperiencePartition.BOUNDARY:
+            raise ValueError("boundary completion requires a Boundary experience record")
+        if not record.trajectory.strict_replay:
+            raise ValueError("boundary completion requires strict replay")
+        if record.record_hash not in self._records:
+            self.append(record)
+        event = self.log.append(
+            "BOUNDARY_COMPLETED",
+            {"request_hash": request_hash, "record_hash": record.record_hash},
+        )
+        self._apply(event.kind, dict(event.payload))
+
+    @property
+    def pending_boundary_requests(self) -> tuple[BoundaryReplayRequest, ...]:
+        return tuple(request for request, completed in self._boundary.values() if completed is None)
+
+    def catalog_counts(self) -> Mapping[ExperiencePartition, int]:
+        rows = self._database.execute(
+            "SELECT partition, COUNT(*) FROM experience_records GROUP BY partition"
+        ).fetchall()
+        values = dict.fromkeys(ExperiencePartition, 0)
+        for name, count in rows:
+            values[ExperiencePartition(str(name))] = int(count)
+        return values
+
+    def audit_receipt(self) -> dict[str, Any]:
+        return {
+            "schema_version": "rosclaw.continual.experience_service_receipt.v1",
+            "event_count": len(self.log.events),
+            "last_event_hash": self.log.last_hash,
+            "catalog_counts": {
+                partition.value: count for partition, count in self.catalog_counts().items()
+            },
+            "cache_counts": {
+                partition.value: count for partition, count in self.store.counts().items()
+            },
+            "pending_boundary_count": len(self.pending_boundary_requests),
+            "registry_write_count": 0,
+            "dds_opened": False,
+            "hardware_authorized": False,
+        }
+
+    def _create_schema(self) -> None:
+        self._database.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS experience_records (
+                record_hash TEXT PRIMARY KEY,
+                trajectory_hash TEXT NOT NULL,
+                partition TEXT NOT NULL,
+                policy_version INTEGER NOT NULL,
+                event_sequence INTEGER NOT NULL UNIQUE
+            );
+            CREATE TABLE IF NOT EXISTS boundary_requests (
+                request_hash TEXT PRIMARY KEY,
+                scenario_commitment TEXT NOT NULL,
+                replay_partition TEXT NOT NULL,
+                completed_record_hash TEXT,
+                event_sequence INTEGER NOT NULL UNIQUE
+            );
+            """
+        )
+        self._database.commit()
+
+    def _apply(self, kind: str, payload: dict[str, Any]) -> None:
+        if kind == "EXPERIENCE_APPENDED":
+            record = experience_record_from_dict(_mapping(payload, "envelope"))
+            if record.record_hash in self._records:
+                raise ValueError("append-only experience log contains a duplicate record")
+            event_sequence = _event_sequence_for_payload(self.log, payload)
+            with self._database:
+                self._database.execute(
+                    "INSERT OR IGNORE INTO experience_records VALUES (?, ?, ?, ?, ?)",
+                    (
+                        record.record_hash,
+                        record.trajectory.trajectory_hash,
+                        record.partition.value,
+                        record.trajectory.policy.version,
+                        event_sequence,
+                    ),
+                )
+            self.store.append(record)
+            self._records[record.record_hash] = record
+            return
+        if kind == "BOUNDARY_QUEUED":
+            request = _boundary_request(_mapping(payload, "request"))
+            if request.request_hash in self._boundary:
+                raise ValueError("append-only log contains a duplicate boundary request")
+            event_sequence = _event_sequence_for_payload(self.log, payload)
+            with self._database:
+                self._database.execute(
+                    "INSERT OR IGNORE INTO boundary_requests VALUES (?, ?, ?, NULL, ?)",
+                    (
+                        request.request_hash,
+                        request.scenario_commitment,
+                        request.replay_partition,
+                        event_sequence,
+                    ),
+                )
+            self._boundary[request.request_hash] = (request, None)
+            return
+        if kind == "BOUNDARY_COMPLETED":
+            request_hash = str(payload["request_hash"])
+            record_hash = str(payload["record_hash"])
+            if record_hash not in self._records:
+                raise ValueError("boundary completion references missing durable experience")
+            request, completed = self._boundary[request_hash]
+            if completed is not None:
+                raise ValueError("append-only log completes a boundary request more than once")
+            with self._database:
+                self._database.execute(
+                    "UPDATE boundary_requests SET completed_record_hash=? WHERE request_hash=?",
+                    (record_hash, request_hash),
+                )
+            self._boundary[request_hash] = (request, record_hash)
+            return
+        raise ValueError(f"unsupported experience service event: {kind}")
+
+    def _audit_catalog(self) -> None:
+        records = {
+            str(row[0]): (str(row[1]), str(row[2]), int(row[3]), int(row[4]))
+            for row in self._database.execute(
+                "SELECT record_hash, trajectory_hash, partition, policy_version, "
+                "event_sequence FROM experience_records"
+            )
+        }
+        expected_records = {
+            record.record_hash: (
+                record.trajectory.trajectory_hash,
+                record.partition.value,
+                record.trajectory.policy.version,
+                _record_event_sequence(self.log, record.record_hash),
+            )
+            for record in self._records.values()
+        }
+        if records != expected_records:
+            raise ValueError("experience SQLite catalog diverges from append-only truth")
+        requests = {
+            str(row[0]): (str(row[1]), str(row[2]), row[3], int(row[4]))
+            for row in self._database.execute(
+                "SELECT request_hash, scenario_commitment, replay_partition, "
+                "completed_record_hash, event_sequence FROM boundary_requests"
+            )
+        }
+        expected_requests = {
+            request.request_hash: (
+                request.scenario_commitment,
+                request.replay_partition,
+                completed,
+                _boundary_event_sequence(self.log, request.request_hash),
+            )
+            for request, completed in self._boundary.values()
+        }
+        if requests != expected_requests:
+            raise ValueError("boundary SQLite catalog diverges from append-only truth")
+
+
+def _event_sequence_for_payload(log: DurableEventLog, payload: dict[str, Any]) -> int:
+    for event in reversed(log.events):
+        if dict(event.payload) == payload:
+            return event.sequence
+    raise RuntimeError("service event payload is not present in its durable log")
+
+
+def _record_event_sequence(log: DurableEventLog, record_hash: str) -> int:
+    for event in log.events:
+        envelope = event.payload.get("envelope")
+        if (
+            event.kind == "EXPERIENCE_APPENDED"
+            and isinstance(envelope, Mapping)
+            and isinstance(envelope.get("record"), Mapping)
+            and envelope["record"].get("record_hash") == record_hash
+        ):
+            return event.sequence
+    raise RuntimeError("experience record has no durable append event")
+
+
+def _boundary_event_sequence(log: DurableEventLog, request_hash: str) -> int:
+    for event in log.events:
+        request = event.payload.get("request")
+        if (
+            event.kind == "BOUNDARY_QUEUED"
+            and isinstance(request, Mapping)
+            and request.get("request_hash") == request_hash
+        ):
+            return event.sequence
+    raise RuntimeError("boundary request has no durable queue event")
+
+
+def _mapping(value: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    item = value.get(key)
+    if not isinstance(item, Mapping):
+        raise ValueError(f"{key} must be a mapping")
+    return item
+
+
+def _boundary_request(value: Mapping[str, Any]) -> BoundaryReplayRequest:
+    request = BoundaryReplayRequest(
+        scenario_id=str(value["scenario_id"]),
+        scenario_commitment=str(value["scenario_commitment"]),
+        replay_partition=str(value["replay_partition"]),
+        parent_policy_hash=str(value["parent_policy_hash"]),
+        candidate_policy_hash=str(value["candidate_policy_hash"]),
+        parent_status=str(value["parent_status"]),
+        candidate_status=str(value["candidate_status"]),
+        critical_signals=tuple(str(item) for item in value["critical_signals"]),
+        source_evidence_hash=str(value["source_evidence_hash"]),
+        schema_version=str(value["schema_version"]),
+    )
+    if value.get("request_hash") != request.request_hash:
+        raise ValueError("boundary replay request hash mismatch")
+    return request
+
+
+__all__ = ["ExperienceService"]

--- a/src/rosclaw/continual/services/inference.py
+++ b/src/rosclaw/continual/services/inference.py
@@ -1,0 +1,440 @@
+"""Recoverable active/candidate/rollback slots and motion-scoped version leases."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rosclaw.continual.contracts import PolicyVersion, SkillPhase
+from rosclaw.continual.serde import policy_version_from_dict
+from rosclaw.continual.services.persistence import (
+    DurableEventLog,
+    fsync_directory,
+    require_external_service_root,
+)
+from rosclaw.continual.stability import ContinualGateReport
+from rosclaw.continual.weight_update import ResidualWeightSlot, WeightSlotState
+from rosclaw.feedback.contracts import canonical_hash
+
+
+@dataclass(frozen=True)
+class MotionVersionLease:
+    lease_id: str
+    episode_id: str
+    policy_version: int
+    policy_version_hash: str
+    artifact_hash: str
+    body_hash: str
+    phase_at_start: SkillPhase
+    schema_version: str = "rosclaw.continual.motion_version_lease.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "lease_id": self.lease_id,
+            "episode_id": self.episode_id,
+            "policy_version": self.policy_version,
+            "policy_version_hash": self.policy_version_hash,
+            "artifact_hash": self.artifact_hash,
+            "body_hash": self.body_hash,
+            "phase_at_start": self.phase_at_start.value,
+        }
+
+
+@dataclass(frozen=True)
+class InferenceSlotReceipt:
+    active_version_hash: str
+    candidate_version_hash: str | None
+    rollback_version_hash: str | None
+    published_version_hash: str | None
+    active_motion_count: int
+    frozen: bool
+    reason: str
+    event_hash: str
+    recovered_abort_count: int
+    hardware_authorized: bool = False
+    registry_write_count: int = 0
+    dds_opened: bool = False
+    schema_version: str = "rosclaw.continual.inference_slot_receipt.v1"
+
+
+class InferenceService:
+    """Inference-plane slot owner; weight mutation is exposed only via its service."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        source_checkout: Path,
+        active: PolicyVersion | None = None,
+        active_artifact: bytes | None = None,
+    ) -> None:
+        self.root = require_external_service_root(root, source_checkout) / "inference"
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.blobs = self.root / "blobs"
+        self.blobs.mkdir(parents=True, exist_ok=True)
+        self.log = DurableEventLog(self.root / "journal", service="inference")
+        self._active: PolicyVersion | None = None
+        self._candidate: PolicyVersion | None = None
+        self._rollback: PolicyVersion | None = None
+        self._published: PolicyVersion | None = None
+        self._published_verified = False
+        self._frozen = False
+        self._motions: dict[str, MotionVersionLease] = {}
+        for event in self.log.events:
+            self._apply(event.kind, dict(event.payload))
+        if not self.log.events:
+            if active is None or active_artifact is None:
+                raise ValueError("new inference service requires active policy and artifact")
+            self._store_blob(active, active_artifact)
+            event = self.log.append(
+                "INITIALIZED",
+                {"active": active.to_dict(), "artifact_hash": active.artifact_hash},
+            )
+            self._apply(event.kind, dict(event.payload))
+        elif active is not None and active.version_hash != self.active.version_hash:
+            raise ValueError("supplied active policy does not match recovered inference state")
+        for policy in (self._active, self._candidate, self._rollback, self._published):
+            if policy is not None:
+                self._verify_blob(policy)
+        inflight = tuple(self._motions)
+        for lease_id in inflight:
+            event = self.log.append(
+                "MOTION_ABORTED",
+                {
+                    "lease_id": lease_id,
+                    "reason": "service recovery aborted the in-flight motion; old actions were not replayed",
+                    "recovered": True,
+                },
+            )
+            self._apply(event.kind, dict(event.payload))
+
+    @property
+    def active(self) -> PolicyVersion:
+        if self._active is None:
+            raise RuntimeError("inference service has no active policy")
+        return self._active
+
+    @property
+    def candidate(self) -> PolicyVersion | None:
+        return self._candidate
+
+    @property
+    def rollback(self) -> PolicyVersion | None:
+        return self._rollback
+
+    @property
+    def published(self) -> PolicyVersion | None:
+        return self._published
+
+    @property
+    def active_motion_count(self) -> int:
+        return len(self._motions)
+
+    @property
+    def recovered_abort_count(self) -> int:
+        return sum(
+            event.kind == "MOTION_ABORTED" and bool(event.payload.get("recovered"))
+            for event in self.log.events
+        )
+
+    def begin_motion(self, *, episode_id: str, phase: SkillPhase) -> MotionVersionLease:
+        if self._frozen:
+            raise RuntimeError("inference service is frozen")
+        if not episode_id.strip():
+            raise ValueError("motion episode id must not be empty")
+        if any(lease.episode_id == episode_id for lease in self._motions.values()):
+            raise ValueError("motion episode already has a version lease")
+        policy = self.active
+        lease_id = canonical_hash(
+            {
+                "episode_id": episode_id,
+                "policy_version_hash": policy.version_hash,
+                "next_event_sequence": len(self.log.events) + 1,
+            }
+        )
+        lease = MotionVersionLease(
+            lease_id=lease_id,
+            episode_id=episode_id,
+            policy_version=policy.version,
+            policy_version_hash=policy.version_hash,
+            artifact_hash=policy.artifact_hash,
+            body_hash=policy.body_hash,
+            phase_at_start=phase,
+        )
+        event = self.log.append("MOTION_BEGAN", {"lease": lease.to_dict()})
+        self._apply(event.kind, dict(event.payload))
+        return self._motions[lease_id]
+
+    def end_motion(self, lease_id: str, *, aborted: bool = False, reason: str = "") -> None:
+        if lease_id not in self._motions:
+            raise KeyError("unknown or completed motion lease")
+        if aborted and not reason.strip():
+            raise ValueError("aborted motion requires a reason")
+        event = self.log.append(
+            "MOTION_ABORTED" if aborted else "MOTION_ENDED",
+            {
+                "lease_id": lease_id,
+                "reason": reason if aborted else "motion reached COMPLETE",
+                "recovered": False,
+            },
+        )
+        self._apply(event.kind, dict(event.payload))
+
+    def receipt(self, reason: str) -> InferenceSlotReceipt:
+        return InferenceSlotReceipt(
+            active_version_hash=self.active.version_hash,
+            candidate_version_hash=(self._candidate.version_hash if self._candidate else None),
+            rollback_version_hash=(self._rollback.version_hash if self._rollback else None),
+            published_version_hash=(self._published.version_hash if self._published else None),
+            active_motion_count=len(self._motions),
+            frozen=self._frozen,
+            reason=reason,
+            event_hash=self.log.last_hash,
+            recovered_abort_count=self.recovered_abort_count,
+        )
+
+    def _publish(self, policy: PolicyVersion, artifact: bytes) -> InferenceSlotReceipt:
+        if self._frozen:
+            raise RuntimeError("inference service is frozen")
+        if self._published is not None or self._candidate is not None:
+            raise RuntimeError("a published or staged candidate already exists")
+        self._validate_successor(policy)
+        self._store_blob(policy, artifact)
+        event = self.log.append(
+            "PUBLISHED",
+            {"policy": policy.to_dict(), "artifact_hash": policy.artifact_hash},
+        )
+        self._apply(event.kind, dict(event.payload))
+        return self.receipt("candidate artifact published outside the active slot")
+
+    def _verify_published(self) -> InferenceSlotReceipt:
+        if self._published is None:
+            raise RuntimeError("no published candidate exists")
+        self._validate_successor(self._published)
+        self._verify_blob(self._published)
+        event = self.log.append(
+            "VERIFIED",
+            {"policy_version_hash": self._published.version_hash},
+        )
+        self._apply(event.kind, dict(event.payload))
+        return self.receipt("published candidate checksum and lineage verified")
+
+    def _stage(self) -> InferenceSlotReceipt:
+        if self._published is None or not self._published_verified:
+            raise RuntimeError("candidate must be published and verified before staging")
+        event = self.log.append(
+            "STAGED",
+            {"policy_version_hash": self._published.version_hash},
+        )
+        self._apply(event.kind, dict(event.payload))
+        return self.receipt("verified candidate staged; active policy unchanged")
+
+    def _activate(
+        self,
+        *,
+        phase: SkillPhase,
+        gate_report: ContinualGateReport,
+    ) -> InferenceSlotReceipt:
+        if self._candidate is None:
+            raise RuntimeError("no staged candidate exists")
+        if self._motions:
+            self._freeze("activation requested while a motion version lease was active")
+            return self.receipt("activation blocked by active motion lease")
+        slot = ResidualWeightSlot(self.active, active_artifact=self._read_blob(self.active))
+        slot.stage(self._candidate, artifact=self._read_blob(self._candidate))
+        result = slot.activate(phase=phase, gate_report=gate_report)
+        if result.state is not WeightSlotState.ACTIVE:
+            self._freeze(result.reason)
+            return self.receipt(result.reason)
+        old = self.active
+        new = self._candidate
+        event = self.log.append(
+            "ACTIVATED",
+            {
+                "active": new.to_dict(),
+                "rollback": old.to_dict(),
+                "reason": result.reason,
+                "hardware_authorized": False,
+            },
+        )
+        self._apply(event.kind, dict(event.payload))
+        return self.receipt(result.reason)
+
+    def _freeze(self, reason: str) -> InferenceSlotReceipt:
+        if not reason.strip():
+            raise ValueError("freeze reason must not be empty")
+        event = self.log.append("FROZEN", {"reason": reason})
+        self._apply(event.kind, dict(event.payload))
+        return self.receipt(reason)
+
+    def _rollback_active(self, reason: str) -> InferenceSlotReceipt:
+        if self._motions:
+            raise RuntimeError("rollback is forbidden while a motion lease is active")
+        if self._rollback is None:
+            raise RuntimeError("no rollback policy exists")
+        if not reason.strip():
+            raise ValueError("rollback reason must not be empty")
+        failed = self.active
+        target = self._rollback
+        event = self.log.append(
+            "ROLLED_BACK",
+            {"active": target.to_dict(), "rollback": failed.to_dict(), "reason": reason},
+        )
+        self._apply(event.kind, dict(event.payload))
+        return self.receipt(reason)
+
+    def _validate_successor(self, policy: PolicyVersion) -> None:
+        active = self.active
+        if (
+            policy.version != active.version + 1
+            or policy.parent_version_hash != active.version_hash
+        ):
+            raise ValueError("candidate is not the direct successor of active policy")
+        for name in (
+            "body_hash",
+            "safety_kernel_hash",
+            "controller_snapshot_hash",
+            "observation_names",
+            "residual_action_names",
+        ):
+            if getattr(policy, name) != getattr(active, name):
+                raise ValueError(f"candidate changes immutable inference identity: {name}")
+
+    def _blob_path(self, policy: PolicyVersion) -> Path:
+        return self.blobs / (policy.artifact_hash.removeprefix("sha256:") + ".bin")
+
+    def _store_blob(self, policy: PolicyVersion, artifact: bytes) -> None:
+        _verify_artifact(policy, artifact)
+        destination = self._blob_path(policy)
+        if destination.exists():
+            if destination.read_bytes() != artifact:
+                raise ValueError("content-addressed policy blob collision")
+            return
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=destination.name + ".", suffix=".tmp", dir=self.blobs
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(artifact)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.link(temporary, destination)
+            Path(temporary).unlink()
+            fsync_directory(self.blobs)
+        except BaseException:
+            Path(temporary).unlink(missing_ok=True)
+            raise
+
+    def _read_blob(self, policy: PolicyVersion) -> bytes:
+        value = self._blob_path(policy).read_bytes()
+        _verify_artifact(policy, value)
+        return value
+
+    def _verify_blob(self, policy: PolicyVersion) -> None:
+        self._read_blob(policy)
+
+    def _apply(self, kind: str, payload: dict[str, Any]) -> None:
+        if kind == "INITIALIZED":
+            if self._active is not None:
+                raise ValueError("inference service may be initialized only once")
+            active = policy_version_from_dict(dict(payload["active"]))
+            if payload.get("artifact_hash") != active.artifact_hash:
+                raise ValueError("initialized inference artifact identity mismatch")
+            self._active = active
+        elif kind == "PUBLISHED":
+            if self._published is not None or self._candidate is not None:
+                raise ValueError("inference publish event conflicts with an existing candidate")
+            published = policy_version_from_dict(dict(payload["policy"]))
+            if payload.get("artifact_hash") != published.artifact_hash:
+                raise ValueError("published inference artifact identity mismatch")
+            self._validate_successor(published)
+            self._published = published
+            self._published_verified = False
+        elif kind == "VERIFIED":
+            if (
+                self._published is None
+                or payload["policy_version_hash"] != self._published.version_hash
+            ):
+                raise ValueError("verified inference policy does not match published candidate")
+            self._published_verified = True
+        elif kind == "STAGED":
+            if (
+                self._published is None
+                or payload["policy_version_hash"] != self._published.version_hash
+            ):
+                raise ValueError("staged inference policy does not match published candidate")
+            self._candidate = self._published
+            self._published = None
+            self._published_verified = False
+        elif kind == "ACTIVATED":
+            active = policy_version_from_dict(dict(payload["active"]))
+            rollback = policy_version_from_dict(dict(payload["rollback"]))
+            if (
+                self._candidate is None
+                or active.version_hash != self._candidate.version_hash
+                or rollback.version_hash != self.active.version_hash
+            ):
+                raise ValueError("inference activation event violates candidate lineage")
+            self._active = active
+            self._rollback = rollback
+            self._candidate = None
+            self._frozen = False
+        elif kind == "FROZEN":
+            self._frozen = True
+        elif kind == "ROLLED_BACK":
+            active = policy_version_from_dict(dict(payload["active"]))
+            rollback = policy_version_from_dict(dict(payload["rollback"]))
+            if self._rollback is None or active.version_hash != self._rollback.version_hash:
+                raise ValueError("inference rollback event does not target its rollback slot")
+            if rollback.version_hash != self.active.version_hash:
+                raise ValueError("inference rollback event does not preserve failed policy")
+            self._active = active
+            self._rollback = rollback
+            self._candidate = None
+            self._published = None
+            self._published_verified = False
+            self._frozen = False
+        elif kind == "MOTION_BEGAN":
+            raw = dict(payload["lease"])
+            lease = MotionVersionLease(
+                lease_id=str(raw["lease_id"]),
+                episode_id=str(raw["episode_id"]),
+                policy_version=int(raw["policy_version"]),
+                policy_version_hash=str(raw["policy_version_hash"]),
+                artifact_hash=str(raw["artifact_hash"]),
+                body_hash=str(raw["body_hash"]),
+                phase_at_start=SkillPhase(str(raw["phase_at_start"])),
+            )
+            if lease.policy_version_hash != self.active.version_hash:
+                raise ValueError("motion lease does not pin the active inference policy")
+            if (
+                lease.policy_version != self.active.version
+                or lease.artifact_hash != self.active.artifact_hash
+                or lease.body_hash != self.active.body_hash
+                or any(item.episode_id == lease.episode_id for item in self._motions.values())
+            ):
+                raise ValueError("motion lease identity does not match active inference")
+            self._motions[lease.lease_id] = lease
+        elif kind in {"MOTION_ENDED", "MOTION_ABORTED"}:
+            lease_id = str(payload["lease_id"])
+            if lease_id not in self._motions:
+                raise ValueError("motion completion references an unknown active lease")
+            self._motions.pop(lease_id)
+        else:
+            raise ValueError(f"unsupported inference service event: {kind}")
+
+
+def _verify_artifact(policy: PolicyVersion, artifact: bytes) -> None:
+    if not artifact:
+        raise ValueError("policy artifact must not be empty")
+    actual = "sha256:" + hashlib.sha256(artifact).hexdigest()
+    if actual != policy.artifact_hash:
+        raise ValueError("policy artifact checksum mismatch")
+
+
+__all__ = ["InferenceService", "InferenceSlotReceipt", "MotionVersionLease"]

--- a/src/rosclaw/continual/services/learner.py
+++ b/src/rosclaw/continual/services/learner.py
@@ -1,0 +1,351 @@
+"""Recoverable learner jobs with durable optimizer checkpoints and idempotency."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import tempfile
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from rosclaw.continual.contracts import PolicyVersion
+from rosclaw.continual.experience import ExperienceBatch
+from rosclaw.continual.learner import ConstrainedResidualSAC
+from rosclaw.continual.serde import policy_version_from_dict
+from rosclaw.continual.services.persistence import (
+    DurableEventLog,
+    fsync_directory,
+    require_external_service_root,
+)
+from rosclaw.feedback.contracts import canonical_hash
+
+
+@dataclass(frozen=True)
+class LearnerProduct:
+    candidate: PolicyVersion
+    artifact: bytes
+    checkpoint: bytes
+    metrics: Mapping[str, float | int | bool]
+
+    def __post_init__(self) -> None:
+        if not self.artifact or not self.checkpoint:
+            raise ValueError("learner product requires artifact and full checkpoint bytes")
+        _validate_metrics(self.metrics)
+
+    @property
+    def checkpoint_hash(self) -> str:
+        return "sha256:" + hashlib.sha256(self.checkpoint).hexdigest()
+
+
+@dataclass(frozen=True)
+class LearnerServiceReceipt:
+    job_id: str
+    batch_hash: str
+    parent_policy_hash: str
+    candidate_policy_hash: str
+    artifact_hash: str
+    checkpoint_hash: str
+    metrics: Mapping[str, float | int | bool]
+    event_hash: str
+    registry_write_count: int = 0
+    dds_opened: bool = False
+    hardware_authorized: bool = False
+    schema_version: str = "rosclaw.continual.learner_service_receipt.v1"
+
+
+class ResidualSACServiceExecutor:
+    """Adapter that emits both inference artifact and full SAC checkpoint."""
+
+    def __init__(
+        self,
+        learner: ConstrainedResidualSAC,
+        *,
+        parent: PolicyVersion,
+        updates_per_job: int = 1,
+    ) -> None:
+        if not 1 <= updates_per_job <= 1000:
+            raise ValueError("updates_per_job must be in [1, 1000]")
+        self.learner = learner
+        self.parent = parent
+        self.updates_per_job = updates_per_job
+
+    def __call__(self, batch: ExperienceBatch) -> LearnerProduct:
+        if batch.learner_version != self.parent.version:
+            raise ValueError("learner batch version does not match executor parent")
+        updates = [self.learner.update(batch) for _ in range(self.updates_per_job)]
+        candidate, artifact = self.learner.candidate_policy(parent=self.parent)
+        last = updates[-1]
+        metrics: dict[str, float | int | bool] = {
+            **{key: value for key, value in asdict(last).items() if key != "schema_version"},
+            "job_update_count": len(updates),
+        }
+        return LearnerProduct(
+            candidate=candidate,
+            artifact=artifact,
+            checkpoint=self.learner.checkpoint_bytes(),
+            metrics=metrics,
+        )
+
+
+class LearnerService:
+    """Consumes versioned batches but has no inference or hardware authority."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        source_checkout: Path,
+        parent: PolicyVersion | None = None,
+    ) -> None:
+        self.root = require_external_service_root(root, source_checkout) / "learner"
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.blobs = self.root / "blobs"
+        self.blobs.mkdir(parents=True, exist_ok=True)
+        self.log = DurableEventLog(self.root / "journal", service="learner")
+        self._parent: PolicyVersion | None = None
+        self._completed: dict[str, LearnerServiceReceipt] = {}
+        self._pending: dict[str, str] = {}
+        self._quarantined: set[str] = set()
+        for event in self.log.events:
+            self._apply(event.kind, dict(event.payload), event.event_hash)
+        if not self.log.events:
+            if parent is None:
+                raise ValueError("new learner service requires a parent policy")
+            event = self.log.append("INITIALIZED", {"parent": parent.to_dict()})
+            self._apply(event.kind, dict(event.payload), event.event_hash)
+        elif parent is not None and parent.version_hash != self.parent.version_hash:
+            raise ValueError("supplied learner parent does not match recovered state")
+        for job_id, batch_hash in tuple(self._pending.items()):
+            event = self.log.append(
+                "JOB_QUARANTINED",
+                {
+                    "job_id": job_id,
+                    "batch_hash": batch_hash,
+                    "reason": "service recovery found an incomplete optimizer update",
+                    "recovered": True,
+                },
+            )
+            self._apply(event.kind, dict(event.payload), event.event_hash)
+
+    @property
+    def parent(self) -> PolicyVersion:
+        if self._parent is None:
+            raise RuntimeError("learner service has no parent policy")
+        return self._parent
+
+    @property
+    def completed_batch_hashes(self) -> tuple[str, ...]:
+        return tuple(sorted(self._completed))
+
+    @property
+    def quarantined_batch_hashes(self) -> tuple[str, ...]:
+        return tuple(sorted(self._quarantined))
+
+    def execute(
+        self,
+        batch: ExperienceBatch,
+        *,
+        executor: Callable[[ExperienceBatch], LearnerProduct],
+    ) -> LearnerServiceReceipt:
+        if batch.batch_hash in self._completed:
+            return self._completed[batch.batch_hash]
+        if batch.batch_hash in self._quarantined:
+            raise RuntimeError("batch is quarantined after an uncertain optimizer update")
+        if batch.learner_version != self.parent.version:
+            raise ValueError("experience batch learner version does not match service parent")
+        job_id = canonical_hash(
+            {
+                "batch_hash": batch.batch_hash,
+                "parent_policy_hash": self.parent.version_hash,
+                "next_event_sequence": len(self.log.events) + 1,
+            }
+        )
+        started = self.log.append(
+            "JOB_STARTED",
+            {
+                "job_id": job_id,
+                "batch_hash": batch.batch_hash,
+                "parent_policy_hash": self.parent.version_hash,
+            },
+        )
+        self._apply(started.kind, dict(started.payload), started.event_hash)
+        try:
+            product = executor(batch)
+            self._validate_product(product)
+            self._store_blob(product.candidate.artifact_hash, product.artifact, suffix="artifact")
+            self._store_blob(product.checkpoint_hash, product.checkpoint, suffix="checkpoint")
+        except BaseException as exc:
+            aborted = self.log.append(
+                "JOB_QUARANTINED",
+                {
+                    "job_id": job_id,
+                    "batch_hash": batch.batch_hash,
+                    "reason": f"{type(exc).__name__}: {exc}",
+                    "recovered": False,
+                },
+            )
+            self._apply(aborted.kind, dict(aborted.payload), aborted.event_hash)
+            raise
+        completed = self.log.append(
+            "JOB_COMPLETED",
+            {
+                "job_id": job_id,
+                "batch_hash": batch.batch_hash,
+                "parent_policy_hash": self.parent.version_hash,
+                "candidate": product.candidate.to_dict(),
+                "artifact_hash": product.candidate.artifact_hash,
+                "checkpoint_hash": product.checkpoint_hash,
+                "metrics": dict(product.metrics),
+            },
+        )
+        self._apply(completed.kind, dict(completed.payload), completed.event_hash)
+        return self._completed[batch.batch_hash]
+
+    def checkpoint_bytes(self, checkpoint_hash: str) -> bytes:
+        return self._read_blob(checkpoint_hash, suffix="checkpoint")
+
+    def advance_parent(self, policy: PolicyVersion) -> None:
+        known = {receipt.candidate_policy_hash for receipt in self._completed.values()}
+        if policy.version_hash not in known:
+            raise ValueError("new learner parent is not a completed candidate")
+        event = self.log.append("PARENT_ADVANCED", {"parent": policy.to_dict()})
+        self._apply(event.kind, dict(event.payload), event.event_hash)
+
+    def _validate_product(self, product: LearnerProduct) -> None:
+        candidate = product.candidate
+        if candidate.version != self.parent.version + 1:
+            raise ValueError("learner candidate version does not follow parent")
+        if candidate.parent_version_hash != self.parent.version_hash:
+            raise ValueError("learner candidate parent hash mismatch")
+        for name in (
+            "body_hash",
+            "safety_kernel_hash",
+            "controller_snapshot_hash",
+            "observation_names",
+            "residual_action_names",
+        ):
+            if getattr(candidate, name) != getattr(self.parent, name):
+                raise ValueError(f"learner candidate changes immutable identity: {name}")
+        if "sha256:" + hashlib.sha256(product.artifact).hexdigest() != candidate.artifact_hash:
+            raise ValueError("learner candidate artifact checksum mismatch")
+
+    def _blob_path(self, content_hash: str, *, suffix: str) -> Path:
+        return self.blobs / f"{content_hash.removeprefix('sha256:')}.{suffix}.bin"
+
+    def _store_blob(self, content_hash: str, payload: bytes, *, suffix: str) -> None:
+        if "sha256:" + hashlib.sha256(payload).hexdigest() != content_hash:
+            raise ValueError(f"learner {suffix} content hash mismatch")
+        destination = self._blob_path(content_hash, suffix=suffix)
+        if destination.exists():
+            if destination.read_bytes() != payload:
+                raise ValueError(f"learner {suffix} content-address collision")
+            return
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=destination.name + ".", suffix=".tmp", dir=self.blobs
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.link(temporary, destination)
+            Path(temporary).unlink()
+            fsync_directory(self.blobs)
+        except BaseException:
+            Path(temporary).unlink(missing_ok=True)
+            raise
+
+    def _read_blob(self, content_hash: str, *, suffix: str) -> bytes:
+        payload = self._blob_path(content_hash, suffix=suffix).read_bytes()
+        if "sha256:" + hashlib.sha256(payload).hexdigest() != content_hash:
+            raise ValueError(f"learner {suffix} blob checksum mismatch")
+        return payload
+
+    def _apply(self, kind: str, payload: dict[str, Any], event_hash: str) -> None:
+        if kind == "INITIALIZED":
+            if self._parent is not None:
+                raise ValueError("learner service may be initialized only once")
+            self._parent = policy_version_from_dict(dict(payload["parent"]))
+        elif kind == "PARENT_ADVANCED":
+            parent = policy_version_from_dict(dict(payload["parent"]))
+            known = {receipt.candidate_policy_hash for receipt in self._completed.values()}
+            if parent.version_hash not in known:
+                raise ValueError("learner parent advance does not reference a completed candidate")
+            self._parent = parent
+        elif kind == "JOB_STARTED":
+            batch_hash = str(payload["batch_hash"])
+            if payload["parent_policy_hash"] != self.parent.version_hash:
+                raise ValueError("learner job parent hash mismatch")
+            job_id = str(payload["job_id"])
+            if job_id in self._pending or batch_hash in self._completed:
+                raise ValueError("learner job is duplicated in its durable log")
+            self._pending[job_id] = batch_hash
+        elif kind == "JOB_COMPLETED":
+            job_id = str(payload["job_id"])
+            batch_hash = str(payload["batch_hash"])
+            candidate = policy_version_from_dict(dict(payload["candidate"]))
+            artifact_hash = str(payload["artifact_hash"])
+            checkpoint_hash = str(payload["checkpoint_hash"])
+            if self._pending.get(job_id) != batch_hash:
+                raise ValueError("learner completion does not match a pending job")
+            if (
+                payload["parent_policy_hash"] != self.parent.version_hash
+                or candidate.parent_version_hash != self.parent.version_hash
+                or candidate.version != self.parent.version + 1
+            ):
+                raise ValueError("learner completion candidate lineage mismatch")
+            for name in (
+                "body_hash",
+                "safety_kernel_hash",
+                "controller_snapshot_hash",
+                "observation_names",
+                "residual_action_names",
+            ):
+                if getattr(candidate, name) != getattr(self.parent, name):
+                    raise ValueError(f"learner completion changes immutable identity: {name}")
+            if candidate.artifact_hash != artifact_hash:
+                raise ValueError("learner completion artifact identity mismatch")
+            self._read_blob(artifact_hash, suffix="artifact")
+            self._read_blob(checkpoint_hash, suffix="checkpoint")
+            metrics = dict(payload["metrics"])
+            _validate_metrics(metrics)
+            receipt = LearnerServiceReceipt(
+                job_id=job_id,
+                batch_hash=batch_hash,
+                parent_policy_hash=str(payload["parent_policy_hash"]),
+                candidate_policy_hash=candidate.version_hash,
+                artifact_hash=artifact_hash,
+                checkpoint_hash=checkpoint_hash,
+                metrics=metrics,
+                event_hash=event_hash,
+            )
+            self._completed[batch_hash] = receipt
+            self._pending.pop(job_id, None)
+        elif kind == "JOB_QUARANTINED":
+            job_id = str(payload["job_id"])
+            batch_hash = str(payload["batch_hash"])
+            if self._pending.get(job_id) != batch_hash:
+                raise ValueError("learner quarantine does not match a pending job")
+            self._pending.pop(job_id, None)
+            self._quarantined.add(batch_hash)
+        else:
+            raise ValueError(f"unsupported learner service event: {kind}")
+
+
+def _validate_metrics(metrics: Mapping[str, Any]) -> None:
+    for name, value in metrics.items():
+        if isinstance(value, bool):
+            continue
+        if not isinstance(value, (float, int)) or not math.isfinite(float(value)):
+            raise ValueError(f"learner metric must be finite numeric value: {name}")
+
+
+__all__ = [
+    "LearnerProduct",
+    "LearnerService",
+    "LearnerServiceReceipt",
+    "ResidualSACServiceExecutor",
+]

--- a/src/rosclaw/continual/services/persistence.py
+++ b/src/rosclaw/continual/services/persistence.py
@@ -1,0 +1,185 @@
+"""Crash-safe append-only event storage for continual-learning services."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_GENESIS_HASH = "sha256:" + "0" * 64
+
+
+def require_external_service_root(root: Path, source_checkout: Path) -> Path:
+    """Keep mutable service state and raw experience outside the checkout."""
+
+    resolved = root.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if resolved == Path(resolved.anchor):
+        raise ValueError("continual service state root must not be a filesystem root")
+    if resolved == checkout or checkout in resolved.parents:
+        raise ValueError("continual service state must be outside the source checkout")
+    return resolved
+
+
+@dataclass(frozen=True)
+class DurableServiceEvent:
+    service: str
+    sequence: int
+    timestamp_ns: int
+    kind: str
+    payload: Mapping[str, Any]
+    previous_event_hash: str
+    event_hash: str
+    schema_version: str = "rosclaw.continual.service_event.v1"
+
+    def __post_init__(self) -> None:
+        if not self.service.strip() or not self.kind.strip():
+            raise ValueError("service event names must not be empty")
+        if self.sequence <= 0 or self.timestamp_ns < 0:
+            raise ValueError("service event sequence must be positive and timestamp non-negative")
+        object.__setattr__(self, "payload", MappingProxyType(dict(self.payload)))
+        if self.event_hash != canonical_hash(self.hash_material()):
+            raise ValueError("service event hash mismatch")
+
+    def hash_material(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "service": self.service,
+            "sequence": self.sequence,
+            "timestamp_ns": self.timestamp_ns,
+            "kind": self.kind,
+            "payload": dict(self.payload),
+            "previous_event_hash": self.previous_event_hash,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**self.hash_material(), "event_hash": self.event_hash}
+
+
+class DurableEventLog:
+    """Immutable file-per-event log; recovery never truncates or rewrites history."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        service: str,
+        clock_ns: Callable[[], int] = time.time_ns,
+    ) -> None:
+        if not service.strip():
+            raise ValueError("durable service name must not be empty")
+        self.root = root.expanduser().resolve()
+        self.service = service
+        self.clock_ns = clock_ns
+        self.events_dir = self.root / "events"
+        self.events_dir.mkdir(parents=True, exist_ok=True)
+        self._events = self._read_events()
+
+    @property
+    def events(self) -> tuple[DurableServiceEvent, ...]:
+        return self._events
+
+    @property
+    def last_hash(self) -> str:
+        return self._events[-1].event_hash if self._events else _GENESIS_HASH
+
+    def append(self, kind: str, payload: Mapping[str, Any]) -> DurableServiceEvent:
+        sequence = len(self._events) + 1
+        material = {
+            "schema_version": "rosclaw.continual.service_event.v1",
+            "service": self.service,
+            "sequence": sequence,
+            "timestamp_ns": int(self.clock_ns()),
+            "kind": kind,
+            "payload": dict(payload),
+            "previous_event_hash": self.last_hash,
+        }
+        event = DurableServiceEvent(event_hash=canonical_hash(material), **material)
+        destination = self.events_dir / f"{sequence:020d}.json"
+        _atomic_create_json(destination, event.to_dict())
+        self._events = (*self._events, event)
+        return event
+
+    def _read_events(self) -> tuple[DurableServiceEvent, ...]:
+        result = []
+        previous = _GENESIS_HASH
+        for expected, path in enumerate(sorted(self.events_dir.glob("[0-9]*.json")), start=1):
+            value = json.loads(path.read_text(encoding="utf-8"))
+            event = DurableServiceEvent(
+                service=str(value["service"]),
+                sequence=int(value["sequence"]),
+                timestamp_ns=int(value["timestamp_ns"]),
+                kind=str(value["kind"]),
+                payload=dict(value["payload"]),
+                previous_event_hash=str(value["previous_event_hash"]),
+                event_hash=str(value["event_hash"]),
+                schema_version=str(value["schema_version"]),
+            )
+            if event.service != self.service or event.sequence != expected:
+                raise ValueError("service event sequence or owner mismatch")
+            if event.previous_event_hash != previous:
+                raise ValueError("service event hash chain is broken")
+            previous = event.event_hash
+            result.append(event)
+        return tuple(result)
+
+
+def atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True, allow_nan=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        fsync_directory(path.parent)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def _atomic_create_json(path: Path, value: Mapping[str, Any]) -> None:
+    if path.exists():
+        raise FileExistsError(f"append-only service event already exists: {path}")
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True, allow_nan=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(temporary, path)
+        Path(temporary).unlink()
+        fsync_directory(path.parent)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def fsync_directory(path: Path) -> None:
+    """Persist a directory entry after an atomic link or replacement."""
+
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+__all__ = [
+    "DurableEventLog",
+    "DurableServiceEvent",
+    "atomic_write_json",
+    "fsync_directory",
+    "require_external_service_root",
+]

--- a/src/rosclaw/continual/services/rollout.py
+++ b/src/rosclaw/continual/services/rollout.py
@@ -1,0 +1,260 @@
+"""Recoverable rollout assignment service with motion-version pinning."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from rosclaw.continual.contracts import PolicyVersion, VersionedTrajectory
+from rosclaw.continual.serde import policy_version_from_dict
+from rosclaw.continual.services.persistence import (
+    DurableEventLog,
+    require_external_service_root,
+)
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class RolloutState(StrEnum):
+    ASSIGNED = "ASSIGNED"
+    RUNNING = "RUNNING"
+    COMPLETE = "COMPLETE"
+    ABORTED = "ABORTED"
+
+
+@dataclass(frozen=True)
+class RolloutAssignment:
+    assignment_id: str
+    episode_id: str
+    scenario_commitment: str
+    policy: PolicyVersion
+    body_hash: str
+    state: RolloutState = RolloutState.ASSIGNED
+    worker_id: str | None = None
+    trajectory_hash: str | None = None
+    strict_replay: bool = False
+    abort_reason: str | None = None
+    schema_version: str = "rosclaw.continual.rollout_assignment.v1"
+
+    @property
+    def version_switch_count(self) -> int:
+        return 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "assignment_id": self.assignment_id,
+            "episode_id": self.episode_id,
+            "scenario_commitment": self.scenario_commitment,
+            "policy": self.policy.to_dict(),
+            "policy_version_hash": self.policy.version_hash,
+            "body_hash": self.body_hash,
+            "state": self.state.value,
+            "worker_id": self.worker_id,
+            "trajectory_hash": self.trajectory_hash,
+            "strict_replay": self.strict_replay,
+            "abort_reason": self.abort_reason,
+            "version_switch_count": 0,
+        }
+
+
+class RolloutService:
+    """Assign scenarios and fail closed on crash without replaying old actions."""
+
+    def __init__(self, root: Path, *, source_checkout: Path) -> None:
+        service_root = require_external_service_root(root, source_checkout) / "rollout"
+        self.log = DurableEventLog(service_root, service="rollout")
+        self._assignments: dict[str, RolloutAssignment] = {}
+        for event in self.log.events:
+            self._apply(event.kind, dict(event.payload))
+        running = [
+            item.assignment_id
+            for item in self._assignments.values()
+            if item.state is RolloutState.RUNNING
+        ]
+        for assignment_id in running:
+            event = self.log.append(
+                "ABORTED",
+                {
+                    "assignment_id": assignment_id,
+                    "reason": "service recovery aborted an in-flight motion; old actions were not replayed",
+                    "recovered": True,
+                },
+            )
+            self._apply(event.kind, dict(event.payload))
+
+    @property
+    def assignments(self) -> tuple[RolloutAssignment, ...]:
+        return tuple(self._assignments[key] for key in sorted(self._assignments))
+
+    @property
+    def recovered_abort_count(self) -> int:
+        return sum(
+            event.kind == "ABORTED" and bool(event.payload.get("recovered"))
+            for event in self.log.events
+        )
+
+    def assign(
+        self,
+        *,
+        episode_id: str,
+        scenario_commitment: str,
+        policy: PolicyVersion,
+    ) -> RolloutAssignment:
+        if not episode_id.strip():
+            raise ValueError("rollout episode id must not be empty")
+        if not _SHA256.fullmatch(scenario_commitment):
+            raise ValueError("rollout scenario commitment must be a sha256 hash")
+        assignment_id = canonical_hash(
+            {
+                "episode_id": episode_id,
+                "scenario_commitment": scenario_commitment,
+                "policy_version_hash": policy.version_hash,
+                "body_hash": policy.body_hash,
+            }
+        )
+        if assignment_id in self._assignments:
+            raise ValueError("rollout assignment already exists")
+        item = RolloutAssignment(
+            assignment_id=assignment_id,
+            episode_id=episode_id,
+            scenario_commitment=scenario_commitment,
+            policy=policy,
+            body_hash=policy.body_hash,
+        )
+        event = self.log.append("ASSIGNED", {"assignment": item.to_dict()})
+        self._apply(event.kind, dict(event.payload))
+        return self._assignments[assignment_id]
+
+    def start(self, assignment_id: str, *, worker_id: str) -> RolloutAssignment:
+        item = self._require(assignment_id, RolloutState.ASSIGNED)
+        if not worker_id.strip():
+            raise ValueError("rollout worker id must not be empty")
+        event = self.log.append(
+            "STARTED",
+            {
+                "assignment_id": item.assignment_id,
+                "worker_id": worker_id,
+                "policy_version_hash": item.policy.version_hash,
+            },
+        )
+        self._apply(event.kind, dict(event.payload))
+        return self._assignments[assignment_id]
+
+    def complete(
+        self,
+        assignment_id: str,
+        *,
+        trajectory: VersionedTrajectory,
+    ) -> RolloutAssignment:
+        item = self._require(assignment_id, RolloutState.RUNNING)
+        if trajectory.segments[0].episode_id != item.episode_id:
+            raise ValueError("rollout trajectory episode does not match its assignment")
+        if trajectory.policy.version_hash != item.policy.version_hash:
+            raise ValueError("rollout changed policy version inside a pinned assignment")
+        if trajectory.policy.body_hash != item.body_hash:
+            raise ValueError("rollout trajectory Body does not match its assignment")
+        if not trajectory.strict_replay:
+            raise ValueError("rollout service accepts only strict-replay trajectories")
+        event = self.log.append(
+            "COMPLETED",
+            {
+                "assignment_id": item.assignment_id,
+                "trajectory_hash": trajectory.trajectory_hash,
+                "strict_replay": True,
+                "version_switch_count": 0,
+            },
+        )
+        self._apply(event.kind, dict(event.payload))
+        return self._assignments[assignment_id]
+
+    def abort(self, assignment_id: str, *, reason: str) -> RolloutAssignment:
+        item = self._assignments.get(assignment_id)
+        if item is None or item.state not in {RolloutState.ASSIGNED, RolloutState.RUNNING}:
+            raise RuntimeError("only assigned or running rollout work may be aborted")
+        if not reason.strip():
+            raise ValueError("rollout abort reason must not be empty")
+        event = self.log.append(
+            "ABORTED",
+            {"assignment_id": assignment_id, "reason": reason, "recovered": False},
+        )
+        self._apply(event.kind, dict(event.payload))
+        return self._assignments[assignment_id]
+
+    def _require(self, assignment_id: str, state: RolloutState) -> RolloutAssignment:
+        item = self._assignments.get(assignment_id)
+        if item is None or item.state is not state:
+            raise RuntimeError(f"rollout assignment must be in {state.value}")
+        return item
+
+    def _apply(self, kind: str, payload: dict[str, Any]) -> None:
+        if kind == "ASSIGNED":
+            raw = dict(payload["assignment"])
+            policy = policy_version_from_dict(dict(raw["policy"]))
+            if raw.get("policy_version_hash") != policy.version_hash:
+                raise ValueError("rollout assignment policy hash mismatch")
+            item = RolloutAssignment(
+                assignment_id=str(raw["assignment_id"]),
+                episode_id=str(raw["episode_id"]),
+                scenario_commitment=str(raw["scenario_commitment"]),
+                policy=policy,
+                body_hash=str(raw["body_hash"]),
+            )
+            if item.body_hash != policy.body_hash:
+                raise ValueError("rollout assignment Body hash mismatch")
+            if not _SHA256.fullmatch(item.scenario_commitment):
+                raise ValueError("rollout scenario commitment hash mismatch")
+            expected_id = canonical_hash(
+                {
+                    "episode_id": item.episode_id,
+                    "scenario_commitment": item.scenario_commitment,
+                    "policy_version_hash": policy.version_hash,
+                    "body_hash": item.body_hash,
+                }
+            )
+            if item.assignment_id != expected_id:
+                raise ValueError("rollout assignment identity hash mismatch")
+            if item.assignment_id in self._assignments:
+                raise ValueError("rollout assignment appears more than once")
+            self._assignments[item.assignment_id] = item
+            return
+        assignment_id = str(payload["assignment_id"])
+        item = self._assignments[assignment_id]
+        if kind == "STARTED":
+            if item.state is not RolloutState.ASSIGNED:
+                raise ValueError("rollout start event does not follow assignment")
+            if payload.get("policy_version_hash") != item.policy.version_hash:
+                raise ValueError("rollout start policy hash mismatch")
+            self._assignments[assignment_id] = replace(
+                item,
+                state=RolloutState.RUNNING,
+                worker_id=str(payload["worker_id"]),
+            )
+        elif kind == "COMPLETED":
+            if item.state is not RolloutState.RUNNING:
+                raise ValueError("rollout completion does not follow a running motion")
+            if not payload.get("strict_replay") or payload.get("version_switch_count") != 0:
+                raise ValueError("completed rollout violated strict version replay")
+            self._assignments[assignment_id] = replace(
+                item,
+                state=RolloutState.COMPLETE,
+                trajectory_hash=str(payload["trajectory_hash"]),
+                strict_replay=bool(payload["strict_replay"]),
+            )
+        elif kind == "ABORTED":
+            if item.state not in {RolloutState.ASSIGNED, RolloutState.RUNNING}:
+                raise ValueError("rollout abort does not follow active work")
+            self._assignments[assignment_id] = replace(
+                item,
+                state=RolloutState.ABORTED,
+                abort_reason=str(payload["reason"]),
+            )
+        else:
+            raise ValueError(f"unsupported rollout service event: {kind}")
+
+
+__all__ = ["RolloutAssignment", "RolloutService", "RolloutState"]

--- a/src/rosclaw/continual/services/weight_update.py
+++ b/src/rosclaw/continual/services/weight_update.py
@@ -1,0 +1,236 @@
+"""Recoverable publish/stage/activate/freeze/rollback coordinator."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from rosclaw.continual.contracts import PolicyVersion, SkillPhase
+from rosclaw.continual.services.inference import InferenceService, InferenceSlotReceipt
+from rosclaw.continual.services.persistence import (
+    DurableEventLog,
+    require_external_service_root,
+)
+from rosclaw.continual.stability import ContinualGateReport
+from rosclaw.feedback.contracts import canonical_hash
+
+
+@dataclass(frozen=True)
+class WeightUpdateServiceReceipt:
+    operation_id: str
+    operation: str
+    status: str
+    inference: InferenceSlotReceipt
+    event_hash: str
+    hardware_authorized: bool = False
+    schema_version: str = "rosclaw.continual.weight_update_service_receipt.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**asdict(self), "inference": asdict(self.inference)}
+
+
+class WeightUpdateService:
+    """The sole service API allowed to mutate inference policy slots."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        source_checkout: Path,
+        inference: InferenceService,
+    ) -> None:
+        service_root = require_external_service_root(root, source_checkout) / "weight-update"
+        self.log = DurableEventLog(service_root, service="weight-update")
+        self.inference = inference
+        pending: dict[str, tuple[str, str | None]] = {}
+        for event in self.log.events:
+            operation_id = str(event.payload["operation_id"])
+            if event.kind == "REQUESTED":
+                before = event.payload.get("inference_event_hash_before")
+                pending[operation_id] = (
+                    str(event.payload["operation"]),
+                    str(before) if before is not None else None,
+                )
+            elif event.kind in {"COMPLETED", "ABORTED"}:
+                pending.pop(operation_id, None)
+            else:
+                raise ValueError(f"unsupported weight update service event: {event.kind}")
+        for operation_id, (operation, before) in pending.items():
+            self._recover_pending(operation_id, operation, before)
+
+    def publish(self, policy: PolicyVersion, *, artifact: bytes) -> WeightUpdateServiceReceipt:
+        return self._run(
+            "publish",
+            {"policy_version_hash": policy.version_hash},
+            lambda: self.inference._publish(policy, artifact),
+        )
+
+    def verify(self) -> WeightUpdateServiceReceipt:
+        return self._run("verify", {}, self.inference._verify_published)
+
+    def stage(self) -> WeightUpdateServiceReceipt:
+        return self._run("stage", {}, self.inference._stage)
+
+    def activate(
+        self,
+        *,
+        phase: SkillPhase,
+        gate_report: ContinualGateReport,
+    ) -> WeightUpdateServiceReceipt:
+        return self._run(
+            "activate",
+            {"phase": phase.value, "gate_report_hash": gate_report.report_hash},
+            lambda: self.inference._activate(phase=phase, gate_report=gate_report),
+        )
+
+    def freeze(self, *, reason: str) -> WeightUpdateServiceReceipt:
+        return self._run(
+            "freeze",
+            {"reason": reason},
+            lambda: self.inference._freeze(reason),
+        )
+
+    def rollback(self, *, reason: str) -> WeightUpdateServiceReceipt:
+        return self._run(
+            "rollback",
+            {"reason": reason},
+            lambda: self.inference._rollback_active(reason),
+        )
+
+    @property
+    def recovered_abort_count(self) -> int:
+        return sum(
+            event.kind == "ABORTED" and bool(event.payload.get("recovered"))
+            for event in self.log.events
+        )
+
+    @property
+    def recovered_completion_count(self) -> int:
+        return sum(
+            event.kind == "COMPLETED" and bool(event.payload.get("recovered"))
+            for event in self.log.events
+        )
+
+    def _run(
+        self,
+        operation: str,
+        parameters: Mapping[str, Any],
+        callback: Callable[[], InferenceSlotReceipt],
+    ) -> WeightUpdateServiceReceipt:
+        operation_id = canonical_hash(
+            {
+                "operation": operation,
+                "parameters": dict(parameters),
+                "next_event_sequence": len(self.log.events) + 1,
+                "inference_event_hash": self.inference.log.last_hash,
+            }
+        )
+        self.log.append(
+            "REQUESTED",
+            {
+                "operation_id": operation_id,
+                "operation": operation,
+                "parameters": dict(parameters),
+                "inference_event_hash_before": self.inference.log.last_hash,
+            },
+        )
+        try:
+            inference_receipt = callback()
+        except BaseException as exc:
+            self.log.append(
+                "ABORTED",
+                {
+                    "operation_id": operation_id,
+                    "operation": operation,
+                    "reason": f"{type(exc).__name__}: {exc}",
+                    "recovered": False,
+                },
+            )
+            raise
+        event = self.log.append(
+            "COMPLETED",
+            {
+                "operation_id": operation_id,
+                "operation": operation,
+                "inference_event_hash": inference_receipt.event_hash,
+                "recovered": False,
+            },
+        )
+        return WeightUpdateServiceReceipt(
+            operation_id=operation_id,
+            operation=operation,
+            status="COMPLETED",
+            inference=inference_receipt,
+            event_hash=event.event_hash,
+        )
+
+    def _recover_pending(
+        self,
+        operation_id: str,
+        operation: str,
+        inference_event_hash_before: str | None,
+    ) -> None:
+        expected = {
+            "publish": {"PUBLISHED"},
+            "verify": {"VERIFIED"},
+            "stage": {"STAGED"},
+            "activate": {"ACTIVATED", "FROZEN"},
+            "freeze": {"FROZEN"},
+            "rollback": {"ROLLED_BACK"},
+        }
+        if operation not in expected or inference_event_hash_before is None:
+            self._recovery_abort(
+                operation_id,
+                operation,
+                "legacy or unsupported incomplete weight operation was quarantined",
+            )
+            return
+        events = self.inference.log.events
+        before_indices = [
+            index
+            for index, event in enumerate(events)
+            if event.event_hash == inference_event_hash_before
+        ]
+        if len(before_indices) != 1:
+            self._recovery_abort(
+                operation_id,
+                operation,
+                "weight operation references an unknown inference checkpoint",
+            )
+            return
+        after = events[before_indices[0] + 1 :]
+        if len(after) == 1 and after[0].kind in expected[operation]:
+            self.log.append(
+                "COMPLETED",
+                {
+                    "operation_id": operation_id,
+                    "operation": operation,
+                    "inference_event_hash": after[0].event_hash,
+                    "recovered": True,
+                },
+            )
+            return
+        if after:
+            self.inference._freeze(
+                "ambiguous inference mutations followed an interrupted weight operation"
+            )
+            reason = "ambiguous incomplete weight operation froze inference"
+        else:
+            reason = "incomplete weight request made no inference mutation"
+        self._recovery_abort(operation_id, operation, reason)
+
+    def _recovery_abort(self, operation_id: str, operation: str, reason: str) -> None:
+        self.log.append(
+            "ABORTED",
+            {
+                "operation_id": operation_id,
+                "operation": operation,
+                "reason": reason,
+                "recovered": True,
+            },
+        )
+
+
+__all__ = ["WeightUpdateService", "WeightUpdateServiceReceipt"]

--- a/src/rosclaw/self_model/__init__.py
+++ b/src/rosclaw/self_model/__init__.py
@@ -1,11 +1,40 @@
 """Measurable embodied self-model contracts for ROSClaw."""
 
+from rosclaw.self_model.agency import (
+    AgencyClass,
+    AgencyEstimator,
+    AgencyEvidence,
+    OperationalAgencyEstimate,
+)
 from rosclaw.self_model.contracts import (
     AgencyAssessment,
     CapabilityBelief,
     ScalarBelief,
     SelfIdentity,
     SelfStateSnapshot,
+)
+from rosclaw.self_model.forward_model import (
+    ForwardAction,
+    ForwardLearningReceipt,
+    ForwardModelInput,
+    ForwardPrediction,
+    ForwardState,
+    HybridForwardSelfModel,
+)
+from rosclaw.self_model.prediction_monitor import (
+    AdaptationReceipt,
+    AdaptationState,
+    AdaptationTrigger,
+    AdaptationTriggerConfig,
+    PredictionResiduals,
+)
+from rosclaw.self_model.regime import (
+    RegimeBelief,
+    RegimeEncoder,
+    RegimeEstimate,
+    RegimeExpertAssignment,
+    RegimeMemory,
+    RegimeObservation,
 )
 from rosclaw.self_model.self_core import (
     PersistentSubnetworkCandidate,
@@ -16,6 +45,10 @@ from rosclaw.self_model.self_core import (
 
 __all__ = [
     "AgencyAssessment",
+    "AgencyClass",
+    "AgencyEstimator",
+    "AgencyEvidence",
+    "OperationalAgencyEstimate",
     "CapabilityBelief",
     "ScalarBelief",
     "SelfIdentity",
@@ -24,4 +57,21 @@ __all__ = [
     "ThresholdSensitivity",
     "discover_persistent_subnetwork",
     "sweep_thresholds",
+    "ForwardAction",
+    "ForwardLearningReceipt",
+    "ForwardModelInput",
+    "ForwardPrediction",
+    "ForwardState",
+    "HybridForwardSelfModel",
+    "AdaptationReceipt",
+    "AdaptationState",
+    "AdaptationTrigger",
+    "AdaptationTriggerConfig",
+    "PredictionResiduals",
+    "RegimeBelief",
+    "RegimeEncoder",
+    "RegimeEstimate",
+    "RegimeExpertAssignment",
+    "RegimeMemory",
+    "RegimeObservation",
 ]

--- a/src/rosclaw/self_model/agency.py
+++ b/src/rosclaw/self_model/agency.py
@@ -1,0 +1,150 @@
+"""Operational action attribution built on forward-model evidence."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class AgencyClass(StrEnum):
+    SELF_CAUSED = "SELF_CAUSED"
+    EXTERNAL_DISTURBANCE = "EXTERNAL_DISTURBANCE"
+    SENSOR_FAULT = "SENSOR_FAULT"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class AgencyEvidence:
+    action_magnitude: float
+    prediction_error: float
+    external_force_evidence: float
+    sensor_inconsistency: float
+    action_hash: str
+    predicted_outcome_hash: str
+    observed_outcome_hash: str
+    timestamp_ns: int
+    schema_version: str = "rosclaw.self.agency_evidence.v1"
+
+    def __post_init__(self) -> None:
+        values = (
+            self.action_magnitude,
+            self.prediction_error,
+            self.external_force_evidence,
+            self.sensor_inconsistency,
+        )
+        if any(not math.isfinite(value) or not 0.0 <= value <= 1.0 for value in values):
+            raise ValueError("agency evidence must be normalized to [0, 1]")
+        for value in (
+            self.action_hash,
+            self.predicted_outcome_hash,
+            self.observed_outcome_hash,
+        ):
+            if not _SHA256.fullmatch(value):
+                raise ValueError("agency evidence references must be sha256 hashes")
+        if self.timestamp_ns < 0:
+            raise ValueError("agency evidence timestamp must be non-negative")
+
+
+@dataclass(frozen=True)
+class OperationalAgencyEstimate:
+    classification: AgencyClass
+    probabilities: Mapping[AgencyClass, float]
+    evidence_hash: str
+    confidence: float
+    schema_version: str = "rosclaw.self.operational_agency.v1"
+
+    def __post_init__(self) -> None:
+        if set(self.probabilities) != set(AgencyClass):
+            raise ValueError("agency estimate must contain all four classes")
+        if any(
+            not math.isfinite(value) or not 0.0 <= value <= 1.0
+            for value in self.probabilities.values()
+        ) or not math.isclose(sum(self.probabilities.values()), 1.0, abs_tol=1e-9):
+            raise ValueError("agency probabilities must be normalized")
+        if self.classification is not max(self.probabilities, key=self.probabilities.__getitem__):
+            raise ValueError("agency classification must match maximum probability")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("agency confidence must be in [0, 1]")
+        object.__setattr__(
+            self,
+            "probabilities",
+            MappingProxyType(dict(self.probabilities)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "classification": self.classification.value,
+            "probabilities": {key.value: value for key, value in self.probabilities.items()},
+            "evidence_hash": self.evidence_hash,
+            "confidence": self.confidence,
+        }
+
+
+class AgencyEstimator:
+    """Attribute outcomes without claiming subjective awareness or intent."""
+
+    def __init__(self, *, temperature: float = 0.65) -> None:
+        if not 0.1 <= temperature <= 2.0:
+            raise ValueError("agency temperature must be in [0.1, 2.0]")
+        self.temperature = temperature
+
+    def estimate(self, evidence: AgencyEvidence) -> OperationalAgencyEstimate:
+        action = evidence.action_magnitude
+        error = evidence.prediction_error
+        external = evidence.external_force_evidence
+        sensor = evidence.sensor_inconsistency
+        scores = {
+            AgencyClass.SELF_CAUSED: 3.0 * action * (1.0 - error) + 0.5 * (1.0 - sensor),
+            AgencyClass.EXTERNAL_DISTURBANCE: (3.0 * external * (1.0 - sensor) + 1.5 * error),
+            AgencyClass.SENSOR_FAULT: 4.0 * sensor + 0.5 * error,
+            AgencyClass.UNKNOWN: (
+                1.5 * (1.0 - max(action, external, sensor))
+                + error * (1.0 - external) * (1.0 - sensor)
+            ),
+        }
+        maximum = max(scores.values())
+        exponentials = {
+            key: math.exp((value - maximum) / self.temperature) for key, value in scores.items()
+        }
+        total = sum(exponentials.values())
+        probabilities = {key: value / total for key, value in exponentials.items()}
+        classification = max(probabilities, key=probabilities.__getitem__)
+        ordered = sorted(probabilities.values(), reverse=True)
+        confidence = max(0.0, min(1.0, ordered[0] - ordered[1]))
+        evidence_hash = canonical_hash(
+            {
+                "schema_version": evidence.schema_version,
+                "action_magnitude": action,
+                "prediction_error": error,
+                "external_force_evidence": external,
+                "sensor_inconsistency": sensor,
+                "action_hash": evidence.action_hash,
+                "predicted_outcome_hash": evidence.predicted_outcome_hash,
+                "observed_outcome_hash": evidence.observed_outcome_hash,
+                "timestamp_ns": evidence.timestamp_ns,
+            }
+        )
+        return OperationalAgencyEstimate(
+            classification=classification,
+            probabilities=probabilities,
+            evidence_hash=evidence_hash,
+            confidence=confidence,
+        )
+
+
+__all__ = [
+    "AgencyClass",
+    "AgencyEstimator",
+    "AgencyEvidence",
+    "OperationalAgencyEstimate",
+]

--- a/src/rosclaw/self_model/forward_model.py
+++ b/src/rosclaw/self_model/forward_model.py
@@ -1,0 +1,450 @@
+"""Hybrid analytical and bounded neural forward model for embodied prediction."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+import numpy as np
+
+from rosclaw.feedback.contracts import canonical_hash
+
+
+def _vector3(value: tuple[float, float, float], *, label: str) -> tuple[float, float, float]:
+    normalized = tuple(float(item) for item in value)
+    if len(normalized) != 3 or any(not math.isfinite(item) for item in normalized):
+        raise ValueError(f"{label} must contain three finite values")
+    return normalized
+
+
+def _finite_mapping(value: Mapping[str, float], *, label: str) -> Mapping[str, float]:
+    normalized = {str(key): float(item) for key, item in value.items()}
+    if not normalized or any(
+        not key.strip() or not math.isfinite(item) for key, item in normalized.items()
+    ):
+        raise ValueError(f"{label} must be a non-empty finite mapping")
+    return MappingProxyType(normalized)
+
+
+@dataclass(frozen=True)
+class ForwardState:
+    joint_position: Mapping[str, float]
+    joint_velocity: Mapping[str, float]
+    pelvis_position: tuple[float, float, float]
+    pelvis_velocity: tuple[float, float, float]
+    com_position: tuple[float, float, float]
+    foot_contact: tuple[float, float]
+    ball_position: tuple[float, float, float]
+    ball_velocity: tuple[float, float, float]
+    energy_state: float
+    balance_margin: float
+
+    def __post_init__(self) -> None:
+        position = _finite_mapping(self.joint_position, label="joint position")
+        velocity = _finite_mapping(self.joint_velocity, label="joint velocity")
+        if tuple(position) != tuple(velocity):
+            raise ValueError("joint position and velocity order must match")
+        contact = tuple(float(item) for item in self.foot_contact)
+        if len(contact) != 2 or any(
+            not math.isfinite(item) or not 0.0 <= item <= 1.0 for item in contact
+        ):
+            raise ValueError("foot contact must contain two probabilities")
+        if not math.isfinite(self.energy_state) or not 0.0 <= self.energy_state <= 1.0:
+            raise ValueError("energy state must be in [0, 1]")
+        if not math.isfinite(self.balance_margin):
+            raise ValueError("balance margin must be finite")
+        object.__setattr__(self, "joint_position", position)
+        object.__setattr__(self, "joint_velocity", velocity)
+        object.__setattr__(
+            self, "pelvis_position", _vector3(self.pelvis_position, label="pelvis position")
+        )
+        object.__setattr__(
+            self, "pelvis_velocity", _vector3(self.pelvis_velocity, label="pelvis velocity")
+        )
+        object.__setattr__(self, "com_position", _vector3(self.com_position, label="COM position"))
+        object.__setattr__(self, "foot_contact", contact)
+        object.__setattr__(
+            self, "ball_position", _vector3(self.ball_position, label="ball position")
+        )
+        object.__setattr__(
+            self, "ball_velocity", _vector3(self.ball_velocity, label="ball velocity")
+        )
+
+    @property
+    def joint_names(self) -> tuple[str, ...]:
+        return tuple(self.joint_position)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "joint_position": dict(self.joint_position),
+            "joint_velocity": dict(self.joint_velocity),
+            "pelvis_position": list(self.pelvis_position),
+            "pelvis_velocity": list(self.pelvis_velocity),
+            "com_position": list(self.com_position),
+            "foot_contact": list(self.foot_contact),
+            "ball_position": list(self.ball_position),
+            "ball_velocity": list(self.ball_velocity),
+            "energy_state": self.energy_state,
+            "balance_margin": self.balance_margin,
+        }
+
+
+@dataclass(frozen=True)
+class ForwardAction:
+    joint_acceleration: Mapping[str, float]
+    pelvis_acceleration: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    ball_impulse: tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "joint_acceleration",
+            _finite_mapping(self.joint_acceleration, label="joint acceleration"),
+        )
+        object.__setattr__(
+            self,
+            "pelvis_acceleration",
+            _vector3(self.pelvis_acceleration, label="pelvis acceleration"),
+        )
+        object.__setattr__(
+            self,
+            "ball_impulse",
+            _vector3(self.ball_impulse, label="ball impulse"),
+        )
+
+
+@dataclass(frozen=True)
+class ForwardModelInput:
+    state: ForwardState
+    action: ForwardAction
+    dt_seconds: float
+    phase_progress: float
+    contact_mode: tuple[float, float]
+
+    def __post_init__(self) -> None:
+        if tuple(self.action.joint_acceleration) != self.state.joint_names:
+            raise ValueError("action joint order must match state joint order")
+        if not math.isfinite(self.dt_seconds) or not 0.0 < self.dt_seconds <= 0.1:
+            raise ValueError("forward-model dt must be in (0, 0.1] seconds")
+        if not math.isfinite(self.phase_progress) or not 0.0 <= self.phase_progress <= 1.0:
+            raise ValueError("phase progress must be in [0, 1]")
+        mode = tuple(float(item) for item in self.contact_mode)
+        if len(mode) != 2 or any(
+            not math.isfinite(item) or not 0.0 <= item <= 1.0 for item in mode
+        ):
+            raise ValueError("contact mode must contain two probabilities")
+        object.__setattr__(self, "contact_mode", mode)
+
+
+@dataclass(frozen=True)
+class ForwardPrediction:
+    next_state: ForwardState
+    fall_risk: float
+    analytical_state: ForwardState
+    neural_residual_norm: float
+    model_hash: str
+    schema_version: str = "rosclaw.self.forward_prediction.v1"
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.fall_risk <= 1.0:
+            raise ValueError("fall risk must be in [0, 1]")
+        if not math.isfinite(self.neural_residual_norm) or self.neural_residual_norm < 0.0:
+            raise ValueError("neural residual norm must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class ForwardLearningReceipt:
+    trained: bool
+    error_before: float
+    error_after: float
+    model_hash: str
+    reason: str
+    schema_version: str = "rosclaw.self.forward_learning_receipt.v1"
+
+
+class HybridForwardSelfModel:
+    """Physics prior plus a small bounded residual network.
+
+    The hidden layer is deterministic and fixed; online adaptation updates only
+    the zero-initialized output layer.  This preserves a stable analytical
+    fallback and makes the plastic part bounded and easy to roll back.
+    """
+
+    def __init__(
+        self,
+        joint_names: tuple[str, ...],
+        *,
+        hidden_size: int = 24,
+        residual_limit: float = 0.05,
+        learning_rate: float = 0.02,
+        damping: float = 0.08,
+        seed: int = 7,
+    ) -> None:
+        if not joint_names or len(joint_names) != len(set(joint_names)):
+            raise ValueError("forward model requires unique joint names")
+        if hidden_size <= 0 or not 0.0 < residual_limit <= 0.25:
+            raise ValueError("invalid forward-model hidden size or residual limit")
+        if not 0.0 < learning_rate <= 0.2 or not 0.0 <= damping <= 1.0:
+            raise ValueError("invalid forward-model learning rate or damping")
+        self.joint_names = tuple(joint_names)
+        self.hidden_size = hidden_size
+        self.residual_limit = residual_limit
+        self.learning_rate = learning_rate
+        self.damping = damping
+        self._output_size = 2 * len(joint_names) + 19
+        input_size = 3 * len(joint_names) + 29
+        rng = np.random.default_rng(seed)
+        self._hidden_weight = rng.normal(0.0, 0.12, size=(hidden_size, input_size))
+        self._hidden_bias = rng.normal(0.0, 0.02, size=hidden_size)
+        self._output_weight = np.zeros((self._output_size, hidden_size), dtype=np.float64)
+        self._output_bias = np.zeros(self._output_size, dtype=np.float64)
+
+    @property
+    def model_hash(self) -> str:
+        return canonical_hash(
+            {
+                "joint_names": list(self.joint_names),
+                "hidden_size": self.hidden_size,
+                "residual_limit": self.residual_limit,
+                "learning_rate": self.learning_rate,
+                "damping": self.damping,
+                "hidden_weight_hash": canonical_hash(self._hidden_weight.tolist()),
+                "hidden_bias_hash": canonical_hash(self._hidden_bias.tolist()),
+                "output_weight_hash": canonical_hash(self._output_weight.tolist()),
+                "output_bias_hash": canonical_hash(self._output_bias.tolist()),
+            }
+        )
+
+    def predict(self, model_input: ForwardModelInput) -> ForwardPrediction:
+        self._validate_input(model_input)
+        analytical = self._analytical(model_input)
+        residual, _ = self._residual(model_input)
+        predicted, risk = self._decode(self._encode_state(analytical), residual)
+        return ForwardPrediction(
+            next_state=predicted,
+            fall_risk=risk,
+            analytical_state=analytical,
+            neural_residual_norm=float(np.linalg.norm(residual)),
+            model_hash=self.model_hash,
+        )
+
+    def learn_transition(
+        self,
+        model_input: ForwardModelInput,
+        actual_next_state: ForwardState,
+        *,
+        shadow_learning: bool,
+    ) -> ForwardLearningReceipt:
+        self._validate_input(model_input)
+        self._validate_state(actual_next_state)
+        analytical = self._analytical(model_input)
+        base = self._encode_state(analytical)
+        target = self._encode_state(actual_next_state)
+        residual, hidden = self._residual(model_input)
+        before = float(np.mean(np.square(base + residual - target)))
+        if not shadow_learning:
+            return ForwardLearningReceipt(
+                trained=False,
+                error_before=before,
+                error_after=before,
+                model_hash=self.model_hash,
+                reason="learning gate closed; analytical prediction remained active",
+            )
+        raw = self._output_weight @ hidden + self._output_bias
+        derivative = self.residual_limit * (1.0 - np.square(np.tanh(raw)))
+        gradient = 2.0 * (base + residual - target) / self._output_size
+        raw_gradient = np.clip(gradient * derivative, -1.0, 1.0)
+        self._output_weight -= self.learning_rate * np.outer(raw_gradient, hidden)
+        self._output_bias -= self.learning_rate * raw_gradient
+        after_residual, _ = self._residual(model_input)
+        after = float(np.mean(np.square(base + after_residual - target)))
+        return ForwardLearningReceipt(
+            trained=True,
+            error_before=before,
+            error_after=after,
+            model_hash=self.model_hash,
+            reason="bounded residual output layer updated in shadow mode",
+        )
+
+    def checkpoint(self) -> dict[str, Any]:
+        return {
+            "schema_version": "rosclaw.self.forward_model_checkpoint.v1",
+            "joint_names": list(self.joint_names),
+            "hidden_size": self.hidden_size,
+            "residual_limit": self.residual_limit,
+            "learning_rate": self.learning_rate,
+            "damping": self.damping,
+            "hidden_weight": self._hidden_weight.tolist(),
+            "hidden_bias": self._hidden_bias.tolist(),
+            "output_weight": self._output_weight.tolist(),
+            "output_bias": self._output_bias.tolist(),
+        }
+
+    def restore_checkpoint(self, checkpoint: Mapping[str, Any]) -> None:
+        if checkpoint.get("schema_version") != "rosclaw.self.forward_model_checkpoint.v1":
+            raise ValueError("unsupported forward-model checkpoint")
+        immutable = {
+            "joint_names": list(self.joint_names),
+            "hidden_size": self.hidden_size,
+            "residual_limit": self.residual_limit,
+            "learning_rate": self.learning_rate,
+            "damping": self.damping,
+        }
+        if any(checkpoint.get(key) != value for key, value in immutable.items()):
+            raise ValueError("forward-model checkpoint configuration mismatch")
+        arrays = (
+            ("hidden_weight", self._hidden_weight.shape),
+            ("hidden_bias", self._hidden_bias.shape),
+            ("output_weight", self._output_weight.shape),
+            ("output_bias", self._output_bias.shape),
+        )
+        for name, shape in arrays:
+            value = np.asarray(checkpoint[name], dtype=np.float64)
+            if value.shape != shape or not np.isfinite(value).all():
+                raise ValueError(f"invalid forward-model checkpoint tensor: {name}")
+            setattr(self, f"_{name}", value.copy())
+
+    def _validate_input(self, model_input: ForwardModelInput) -> None:
+        self._validate_state(model_input.state)
+        if tuple(model_input.action.joint_acceleration) != self.joint_names:
+            raise ValueError("forward action does not match model joints")
+
+    def _validate_state(self, state: ForwardState) -> None:
+        if state.joint_names != self.joint_names:
+            raise ValueError("forward state does not match model joints")
+
+    def _analytical(self, model_input: ForwardModelInput) -> ForwardState:
+        state = model_input.state
+        dt = model_input.dt_seconds
+        acceleration = np.array(list(model_input.action.joint_acceleration.values()))
+        velocity = np.array(list(state.joint_velocity.values()))
+        position = np.array(list(state.joint_position.values()))
+        next_velocity = velocity + (acceleration - self.damping * velocity) * dt
+        next_position = position + next_velocity * dt
+        pelvis_acceleration = np.asarray(model_input.action.pelvis_acceleration)
+        pelvis_velocity = np.asarray(state.pelvis_velocity) + pelvis_acceleration * dt
+        pelvis_position = np.asarray(state.pelvis_position) + pelvis_velocity * dt
+        com_position = np.asarray(state.com_position) + pelvis_velocity * dt
+        ball_velocity = np.asarray(state.ball_velocity) + np.asarray(
+            model_input.action.ball_impulse
+        )
+        ball_velocity *= max(0.0, 1.0 - 0.15 * dt)
+        ball_position = np.asarray(state.ball_position) + ball_velocity * dt
+        work = float(np.mean(np.abs(acceleration * next_velocity)))
+        energy = float(np.clip(state.energy_state - 0.002 * work * dt, 0.0, 1.0))
+        contact = tuple(
+            float(np.clip(0.7 * old + 0.3 * mode, 0.0, 1.0))
+            for old, mode in zip(state.foot_contact, model_input.contact_mode, strict=True)
+        )
+        lateral_com = abs(float(com_position[1] - pelvis_position[1]))
+        support = 0.02 + 0.08 * max(contact)
+        balance_margin = support - lateral_com
+        return ForwardState(
+            joint_position=dict(zip(self.joint_names, next_position.tolist(), strict=True)),
+            joint_velocity=dict(zip(self.joint_names, next_velocity.tolist(), strict=True)),
+            pelvis_position=tuple(pelvis_position.tolist()),
+            pelvis_velocity=tuple(pelvis_velocity.tolist()),
+            com_position=tuple(com_position.tolist()),
+            foot_contact=contact,
+            ball_position=tuple(ball_position.tolist()),
+            ball_velocity=tuple(ball_velocity.tolist()),
+            energy_state=energy,
+            balance_margin=balance_margin,
+        )
+
+    def _features(self, model_input: ForwardModelInput) -> np.ndarray:
+        state = model_input.state
+        return np.asarray(
+            [
+                *state.joint_position.values(),
+                *state.joint_velocity.values(),
+                *model_input.action.joint_acceleration.values(),
+                *state.pelvis_position,
+                *state.pelvis_velocity,
+                *state.com_position,
+                *state.foot_contact,
+                *state.ball_position,
+                *state.ball_velocity,
+                state.energy_state,
+                state.balance_margin,
+                *model_input.action.pelvis_acceleration,
+                *model_input.action.ball_impulse,
+                model_input.dt_seconds,
+                model_input.phase_progress,
+                *model_input.contact_mode,
+            ],
+            dtype=np.float64,
+        )
+
+    def _residual(self, model_input: ForwardModelInput) -> tuple[np.ndarray, np.ndarray]:
+        hidden = np.tanh(self._hidden_weight @ self._features(model_input) + self._hidden_bias)
+        raw = self._output_weight @ hidden + self._output_bias
+        return self.residual_limit * np.tanh(raw), hidden
+
+    def _encode_state(self, state: ForwardState) -> np.ndarray:
+        return np.asarray(
+            [
+                *state.joint_position.values(),
+                *state.joint_velocity.values(),
+                *state.pelvis_position,
+                *state.pelvis_velocity,
+                *state.com_position,
+                *state.foot_contact,
+                *state.ball_position,
+                *state.ball_velocity,
+                state.energy_state,
+                state.balance_margin,
+            ],
+            dtype=np.float64,
+        )
+
+    def _decode(self, encoded: np.ndarray, residual: np.ndarray) -> tuple[ForwardState, float]:
+        value = encoded + residual
+        joint_count = len(self.joint_names)
+        cursor = 0
+
+        def take(count: int) -> np.ndarray:
+            nonlocal cursor
+            result = value[cursor : cursor + count]
+            cursor += count
+            return result
+
+        position = take(joint_count)
+        velocity = take(joint_count)
+        pelvis_position = take(3)
+        pelvis_velocity = take(3)
+        com_position = take(3)
+        contact = np.clip(take(2), 0.0, 1.0)
+        ball_position = take(3)
+        ball_velocity = take(3)
+        energy = float(np.clip(take(1)[0], 0.0, 1.0))
+        balance_margin = float(take(1)[0])
+        risk = float(np.clip(1.0 / (1.0 + math.exp(25.0 * balance_margin)), 0.0, 1.0))
+        return (
+            ForwardState(
+                joint_position=dict(zip(self.joint_names, position.tolist(), strict=True)),
+                joint_velocity=dict(zip(self.joint_names, velocity.tolist(), strict=True)),
+                pelvis_position=tuple(pelvis_position.tolist()),
+                pelvis_velocity=tuple(pelvis_velocity.tolist()),
+                com_position=tuple(com_position.tolist()),
+                foot_contact=tuple(contact.tolist()),
+                ball_position=tuple(ball_position.tolist()),
+                ball_velocity=tuple(ball_velocity.tolist()),
+                energy_state=energy,
+                balance_margin=balance_margin,
+            ),
+            risk,
+        )
+
+
+__all__ = [
+    "ForwardAction",
+    "ForwardLearningReceipt",
+    "ForwardModelInput",
+    "ForwardPrediction",
+    "ForwardState",
+    "HybridForwardSelfModel",
+]

--- a/src/rosclaw/self_model/prediction_monitor.py
+++ b/src/rosclaw/self_model/prediction_monitor.py
@@ -1,0 +1,240 @@
+"""Persistent prediction-residual trigger for bounded shadow adaptation."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+
+class AdaptationState(StrEnum):
+    NORMAL = "NORMAL"
+    SUSPECTED_SHIFT = "SUSPECTED_SHIFT"
+    CONFIRMED_SHIFT = "CONFIRMED_SHIFT"
+    SHADOW_LEARNING = "SHADOW_LEARNING"
+    CANDIDATE_READY = "CANDIDATE_READY"
+    CONSOLIDATED = "CONSOLIDATED"
+    ROLLBACK = "ROLLBACK"
+
+
+@dataclass(frozen=True)
+class PredictionResiduals:
+    body_state: float
+    contact_outcome: float
+    contact_mode: float
+    control_latency: float
+    energy: float
+    task_performance: float
+    timestamp_ns: int
+    episode_id: str
+    schema_version: str = "rosclaw.self.prediction_residuals.v1"
+
+    def __post_init__(self) -> None:
+        values = self.components().values()
+        if any(not math.isfinite(value) or value < 0.0 for value in values):
+            raise ValueError("prediction residuals must be finite non-negative values")
+        if self.timestamp_ns < 0 or not self.episode_id.strip():
+            raise ValueError("prediction residual timestamp and episode must be valid")
+
+    def components(self) -> dict[str, float]:
+        return {
+            "body_state": self.body_state,
+            "contact_outcome": self.contact_outcome,
+            "contact_mode": self.contact_mode,
+            "control_latency": self.control_latency,
+            "energy": self.energy,
+            "task_performance": self.task_performance,
+        }
+
+
+@dataclass(frozen=True)
+class AdaptationTriggerConfig:
+    suspected_threshold: float = 0.35
+    confirmed_threshold: float = 0.55
+    suspected_persistence: int = 2
+    confirmed_persistence: int = 3
+    recovery_persistence: int = 3
+    shadow_min_samples: int = 100
+    minimum_improvement: float = 0.02
+    maximum_anchor_degradation: float = 0.03
+    weights: tuple[float, ...] = (0.25, 0.18, 0.12, 0.15, 0.10, 0.20)
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.suspected_threshold < self.confirmed_threshold <= 1.0:
+            raise ValueError("adaptation thresholds must satisfy 0 < suspected < confirmed <= 1")
+        if (
+            min(
+                self.suspected_persistence,
+                self.confirmed_persistence,
+                self.recovery_persistence,
+                self.shadow_min_samples,
+            )
+            <= 0
+        ):
+            raise ValueError("adaptation persistence and sample requirements must be positive")
+        if len(self.weights) != 6 or any(value < 0.0 for value in self.weights):
+            raise ValueError("adaptation trigger requires six non-negative weights")
+        if not math.isclose(sum(self.weights), 1.0, abs_tol=1e-12):
+            raise ValueError("adaptation trigger weights must sum to one")
+        if (
+            not math.isfinite(self.minimum_improvement)
+            or not math.isfinite(self.maximum_anchor_degradation)
+            or self.minimum_improvement < 0.0
+            or self.maximum_anchor_degradation < 0.0
+        ):
+            raise ValueError("adaptation improvement and retention limits must be non-negative")
+
+
+@dataclass(frozen=True)
+class AdaptationReceipt:
+    previous_state: AdaptationState
+    state: AdaptationState
+    score: float
+    learning_enabled: bool
+    reason: str
+    observation_count: int
+    transition_hash: str
+    registry_write_count: int = 0
+    dds_opened: bool = False
+    hardware_authorized: bool = False
+    schema_version: str = "rosclaw.self.adaptation_receipt.v1"
+
+
+class AdaptationTrigger:
+    """Ignore transient noise and enable learning only after persistent shift."""
+
+    def __init__(self, config: AdaptationTriggerConfig | None = None) -> None:
+        self.config = config or AdaptationTriggerConfig()
+        self.state = AdaptationState.NORMAL
+        self.observation_count = 0
+        self._suspected = 0
+        self._confirmed = 0
+        self._recovered = 0
+        self._last_score = 0.0
+
+    def observe(self, residuals: PredictionResiduals) -> AdaptationReceipt:
+        previous = self.state
+        score = self.score(residuals)
+        self._last_score = score
+        self.observation_count += 1
+        reason = "observation recorded without opening adaptation"
+        if self.state is AdaptationState.NORMAL:
+            self._suspected = self._suspected + 1 if score >= self.config.suspected_threshold else 0
+            if self._suspected >= self.config.suspected_persistence:
+                self.state = AdaptationState.SUSPECTED_SHIFT
+                self._confirmed = 0
+                reason = "prediction residual persisted beyond the suspected threshold"
+        elif self.state is AdaptationState.SUSPECTED_SHIFT:
+            if score >= self.config.confirmed_threshold:
+                self._confirmed += 1
+                self._recovered = 0
+                if self._confirmed >= self.config.confirmed_persistence:
+                    self.state = AdaptationState.CONFIRMED_SHIFT
+                    reason = "multi-signal prediction shift persisted and was confirmed"
+            elif score < self.config.suspected_threshold:
+                self._recovered += 1
+                self._confirmed = 0
+                if self._recovered >= self.config.recovery_persistence:
+                    self.state = AdaptationState.NORMAL
+                    self._suspected = 0
+                    reason = "suspected shift decayed as transient noise"
+            else:
+                self._confirmed = 0
+                self._recovered = 0
+        return self._receipt(previous, reason)
+
+    def begin_shadow_learning(self) -> AdaptationReceipt:
+        if self.state is not AdaptationState.CONFIRMED_SHIFT:
+            raise RuntimeError("shadow learning requires a confirmed shift")
+        previous = self.state
+        self.state = AdaptationState.SHADOW_LEARNING
+        return self._receipt(previous, "confirmed shift opened SIM-only shadow learning")
+
+    def candidate_update(
+        self,
+        *,
+        sample_count: int,
+        target_improvement: float,
+        anchor_degradation: float,
+        critical_safety_regressions: int,
+        converged: bool,
+    ) -> AdaptationReceipt:
+        if self.state is not AdaptationState.SHADOW_LEARNING:
+            raise RuntimeError("candidate evidence is accepted only during shadow learning")
+        if sample_count < 0 or critical_safety_regressions < 0:
+            raise ValueError("candidate sample and regression counts must be non-negative")
+        if any(not math.isfinite(value) for value in (target_improvement, anchor_degradation)):
+            raise ValueError("candidate adaptation metrics must be finite")
+        if anchor_degradation < 0.0:
+            raise ValueError("candidate anchor degradation must be non-negative")
+        previous = self.state
+        if critical_safety_regressions > 0:
+            self.state = AdaptationState.ROLLBACK
+            reason = "shadow candidate introduced a critical safety regression"
+        elif (
+            sample_count >= self.config.shadow_min_samples
+            and target_improvement >= self.config.minimum_improvement
+            and anchor_degradation <= self.config.maximum_anchor_degradation
+            and converged
+        ):
+            self.state = AdaptationState.CANDIDATE_READY
+            reason = (
+                "shadow candidate reached sample, improvement, retention, and convergence gates"
+            )
+        else:
+            reason = "shadow learning remains open; candidate evidence is incomplete"
+        return self._receipt(previous, reason)
+
+    def consolidate(self, *, matched_gate_passed: bool) -> AdaptationReceipt:
+        if self.state is not AdaptationState.CANDIDATE_READY:
+            raise RuntimeError("only a ready candidate may be consolidated")
+        previous = self.state
+        self.state = (
+            AdaptationState.CONSOLIDATED if matched_gate_passed else AdaptationState.ROLLBACK
+        )
+        reason = (
+            "matched evaluation consolidated the candidate"
+            if matched_gate_passed
+            else "matched evaluation rejected the candidate"
+        )
+        return self._receipt(previous, reason)
+
+    def score(self, residuals: PredictionResiduals) -> float:
+        values = residuals.components().values()
+        return float(
+            sum(
+                weight * min(1.0, value)
+                for weight, value in zip(self.config.weights, values, strict=True)
+            )
+        )
+
+    def _receipt(self, previous: AdaptationState, reason: str) -> AdaptationReceipt:
+        material: dict[str, Any] = {
+            "previous_state": previous.value,
+            "state": self.state.value,
+            "score": self._last_score,
+            "learning_enabled": self.state is AdaptationState.SHADOW_LEARNING,
+            "reason": reason,
+            "observation_count": self.observation_count,
+        }
+        return AdaptationReceipt(
+            previous_state=previous,
+            state=self.state,
+            score=self._last_score,
+            learning_enabled=self.state is AdaptationState.SHADOW_LEARNING,
+            reason=reason,
+            observation_count=self.observation_count,
+            transition_hash=canonical_hash(material),
+        )
+
+
+__all__ = [
+    "AdaptationReceipt",
+    "AdaptationState",
+    "AdaptationTrigger",
+    "AdaptationTriggerConfig",
+    "PredictionResiduals",
+]

--- a/src/rosclaw/self_model/regime.py
+++ b/src/rosclaw/self_model/regime.py
@@ -1,0 +1,346 @@
+"""Multi-timescale physical-regime inference and reusable regime memory."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.self_model.contracts import ScalarBelief
+
+
+def _finite_mapping(value: Mapping[str, float], *, label: str) -> Mapping[str, float]:
+    normalized = {str(key): float(item) for key, item in value.items()}
+    if not normalized or any(
+        not key.strip() or not math.isfinite(item) for key, item in normalized.items()
+    ):
+        raise ValueError(f"{label} must be a non-empty finite mapping")
+    return MappingProxyType(normalized)
+
+
+@dataclass(frozen=True)
+class RegimeObservation:
+    episode_id: str
+    timestamp_ns: int
+    support_friction: float
+    ball_friction: float
+    control_latency_ms: float
+    joint_zero_bias: Mapping[str, float]
+    motor_gain: Mapping[str, float]
+    payload_kg: float
+    disturbance_magnitude: float
+    sensor_confidence: float = 1.0
+
+    def __post_init__(self) -> None:
+        values = (
+            self.support_friction,
+            self.ball_friction,
+            self.control_latency_ms,
+            self.payload_kg,
+            self.disturbance_magnitude,
+            self.sensor_confidence,
+        )
+        if not self.episode_id.strip() or self.timestamp_ns < 0:
+            raise ValueError("regime observation requires an episode and timestamp")
+        if any(not math.isfinite(value) for value in values):
+            raise ValueError("regime observation values must be finite")
+        if min(values[:-1]) < 0.0 or not 0.0 <= self.sensor_confidence <= 1.0:
+            raise ValueError("regime magnitudes must be non-negative and confidence normalized")
+        zero = _finite_mapping(self.joint_zero_bias, label="joint zero bias")
+        gain = _finite_mapping(self.motor_gain, label="motor gain")
+        if tuple(zero) != tuple(gain):
+            raise ValueError("joint zero-bias and motor-gain order must match")
+        if any(value <= 0.0 for value in gain.values()):
+            raise ValueError("motor gains must be positive")
+        object.__setattr__(self, "joint_zero_bias", zero)
+        object.__setattr__(self, "motor_gain", gain)
+
+
+@dataclass(frozen=True)
+class RegimeBelief:
+    timescale: str
+    observation_count: int
+    support_friction: ScalarBelief
+    ball_friction: ScalarBelief
+    control_latency: ScalarBelief
+    joint_zero_bias: Mapping[str, ScalarBelief]
+    motor_gain: Mapping[str, ScalarBelief]
+    payload: ScalarBelief
+    disturbance: ScalarBelief
+    uncertainty: float
+    schema_version: str = "rosclaw.self.regime_belief.v1"
+
+    def __post_init__(self) -> None:
+        if self.timescale not in {"fast", "episode", "persistent"}:
+            raise ValueError("unsupported regime timescale")
+        if self.observation_count < 0 or not 0.0 <= self.uncertainty <= 1.0:
+            raise ValueError("invalid regime observation count or uncertainty")
+        zero = MappingProxyType(dict(self.joint_zero_bias))
+        gain = MappingProxyType(dict(self.motor_gain))
+        if not zero or tuple(zero) != tuple(gain):
+            raise ValueError("regime joint beliefs must have matching non-empty order")
+        object.__setattr__(self, "joint_zero_bias", zero)
+        object.__setattr__(self, "motor_gain", gain)
+
+    @property
+    def regime_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "timescale": self.timescale,
+            "observation_count": self.observation_count,
+            "support_friction": self.support_friction.to_dict(),
+            "ball_friction": self.ball_friction.to_dict(),
+            "control_latency": self.control_latency.to_dict(),
+            "joint_zero_bias": {
+                key: value.to_dict() for key, value in self.joint_zero_bias.items()
+            },
+            "motor_gain": {key: value.to_dict() for key, value in self.motor_gain.items()},
+            "payload": self.payload.to_dict(),
+            "disturbance": self.disturbance.to_dict(),
+            "uncertainty": self.uncertainty,
+        }
+
+
+@dataclass(frozen=True)
+class RegimeEstimate:
+    fast: RegimeBelief
+    episode: RegimeBelief
+    persistent: RegimeBelief
+    estimate_hash: str
+    schema_version: str = "rosclaw.self.regime_estimate.v1"
+
+
+class _EWMA:
+    def __init__(self, alpha: float) -> None:
+        self.alpha = alpha
+        self.mean = 0.0
+        self.variance = 0.0
+        self.count = 0
+        self.confidence = 0.0
+
+    def update(self, value: float, confidence: float) -> None:
+        if self.count == 0:
+            self.mean = value
+        else:
+            delta = value - self.mean
+            self.mean += self.alpha * delta
+            self.variance = (1.0 - self.alpha) * (self.variance + self.alpha * delta * delta)
+        self.confidence = (1.0 - self.alpha) * self.confidence + self.alpha * confidence
+        self.count += 1
+
+    def belief(self, unit: str) -> ScalarBelief:
+        return ScalarBelief(
+            mean=self.mean,
+            standard_deviation=math.sqrt(max(0.0, self.variance)),
+            confidence=min(1.0, self.confidence * (1.0 - math.exp(-self.count / 4.0))),
+            unit=unit,
+        )
+
+
+class _TimescaleState:
+    def __init__(self, joint_names: tuple[str, ...], alpha: float) -> None:
+        self.support = _EWMA(alpha)
+        self.ball = _EWMA(alpha)
+        self.latency = _EWMA(alpha)
+        self.payload = _EWMA(alpha)
+        self.disturbance = _EWMA(alpha)
+        self.zero = {name: _EWMA(alpha) for name in joint_names}
+        self.gain = {name: _EWMA(alpha) for name in joint_names}
+
+    @property
+    def count(self) -> int:
+        return self.support.count
+
+    def update(self, observation: RegimeObservation) -> None:
+        confidence = observation.sensor_confidence
+        self.support.update(observation.support_friction, confidence)
+        self.ball.update(observation.ball_friction, confidence)
+        self.latency.update(observation.control_latency_ms, confidence)
+        self.payload.update(observation.payload_kg, confidence)
+        self.disturbance.update(observation.disturbance_magnitude, confidence)
+        for name in self.zero:
+            self.zero[name].update(observation.joint_zero_bias[name], confidence)
+            self.gain[name].update(observation.motor_gain[name], confidence)
+
+    def belief(self, timescale: str) -> RegimeBelief:
+        confidence_values = [
+            self.support.belief("coefficient").confidence,
+            self.ball.belief("coefficient").confidence,
+            self.latency.belief("ms").confidence,
+            self.payload.belief("kg").confidence,
+            self.disturbance.belief("normalized").confidence,
+        ]
+        uncertainty = 1.0 - sum(confidence_values) / len(confidence_values)
+        return RegimeBelief(
+            timescale=timescale,
+            observation_count=self.count,
+            support_friction=self.support.belief("coefficient"),
+            ball_friction=self.ball.belief("coefficient"),
+            control_latency=self.latency.belief("ms"),
+            joint_zero_bias={name: value.belief("rad") for name, value in self.zero.items()},
+            motor_gain={name: value.belief("ratio") for name, value in self.gain.items()},
+            payload=self.payload.belief("kg"),
+            disturbance=self.disturbance.belief("normalized"),
+            uncertainty=max(0.0, min(1.0, uncertainty)),
+        )
+
+
+class RegimeEncoder:
+    """Separate quick response, episode context, and persistent identity drift."""
+
+    def __init__(self, joint_names: tuple[str, ...]) -> None:
+        if not joint_names or len(joint_names) != len(set(joint_names)):
+            raise ValueError("regime encoder requires unique joint names")
+        self.joint_names = tuple(joint_names)
+        self._fast = _TimescaleState(self.joint_names, 0.45)
+        self._episode = _TimescaleState(self.joint_names, 0.12)
+        self._persistent = _TimescaleState(self.joint_names, 0.03)
+        self._active_episode: str | None = None
+        self._episode_observations: list[RegimeObservation] = []
+
+    def observe(self, observation: RegimeObservation) -> RegimeEstimate:
+        if tuple(observation.joint_zero_bias) != self.joint_names:
+            raise ValueError("regime observation does not match encoder joints")
+        if self._active_episode not in {None, observation.episode_id}:
+            raise RuntimeError("end the active regime episode before starting another")
+        self._active_episode = observation.episode_id
+        self._episode_observations.append(observation)
+        self._fast.update(observation)
+        self._episode.update(observation)
+        return self.estimate()
+
+    def end_episode(self, episode_id: str) -> RegimeEstimate:
+        if self._active_episode != episode_id or not self._episode_observations:
+            raise RuntimeError("cannot end an inactive regime episode")
+        averaged = self._average_episode(self._episode_observations)
+        self._persistent.update(averaged)
+        self._active_episode = None
+        self._episode_observations = []
+        self._episode = _TimescaleState(self.joint_names, 0.12)
+        return self.estimate()
+
+    def estimate(self) -> RegimeEstimate:
+        fast = self._fast.belief("fast")
+        episode = self._episode.belief("episode")
+        persistent = self._persistent.belief("persistent")
+        material = {
+            "fast_hash": fast.regime_hash,
+            "episode_hash": episode.regime_hash,
+            "persistent_hash": persistent.regime_hash,
+            "active_episode": self._active_episode,
+        }
+        return RegimeEstimate(
+            fast=fast,
+            episode=episode,
+            persistent=persistent,
+            estimate_hash=canonical_hash(material),
+        )
+
+    def _average_episode(self, observations: list[RegimeObservation]) -> RegimeObservation:
+        count = len(observations)
+
+        def mean(values: list[float]) -> float:
+            return sum(values) / count
+
+        return RegimeObservation(
+            episode_id=observations[0].episode_id,
+            timestamp_ns=observations[-1].timestamp_ns,
+            support_friction=mean([item.support_friction for item in observations]),
+            ball_friction=mean([item.ball_friction for item in observations]),
+            control_latency_ms=mean([item.control_latency_ms for item in observations]),
+            joint_zero_bias={
+                name: mean([item.joint_zero_bias[name] for item in observations])
+                for name in self.joint_names
+            },
+            motor_gain={
+                name: mean([item.motor_gain[name] for item in observations])
+                for name in self.joint_names
+            },
+            payload_kg=mean([item.payload_kg for item in observations]),
+            disturbance_magnitude=mean([item.disturbance_magnitude for item in observations]),
+            sensor_confidence=mean([item.sensor_confidence for item in observations]),
+        )
+
+
+@dataclass(frozen=True)
+class RegimeExpertAssignment:
+    expert_id: str
+    reused: bool
+    distance: float
+    regime_hash: str
+    reason: str
+    schema_version: str = "rosclaw.self.regime_expert_assignment.v1"
+
+
+class RegimeMemory:
+    """Content-addressed regime prototypes that avoid relearning known dynamics."""
+
+    def __init__(self, *, reuse_threshold: float = 0.18) -> None:
+        if not 0.0 < reuse_threshold <= 1.0:
+            raise ValueError("regime reuse threshold must be in (0, 1]")
+        self.reuse_threshold = reuse_threshold
+        self._prototypes: dict[str, RegimeBelief] = {}
+
+    def assign(self, belief: RegimeBelief) -> RegimeExpertAssignment:
+        if belief.timescale != "persistent":
+            raise ValueError("only persistent regimes may select durable experts")
+        distances = {
+            expert_id: self._distance(belief, prototype)
+            for expert_id, prototype in self._prototypes.items()
+        }
+        if distances:
+            expert_id = min(distances, key=distances.__getitem__)
+            distance = distances[expert_id]
+            if distance <= self.reuse_threshold:
+                return RegimeExpertAssignment(
+                    expert_id=expert_id,
+                    reused=True,
+                    distance=distance,
+                    regime_hash=belief.regime_hash,
+                    reason="known physical regime reused its existing expert",
+                )
+        expert_id = f"regime-{belief.regime_hash.removeprefix('sha256:')[:16]}"
+        self._prototypes[expert_id] = belief
+        return RegimeExpertAssignment(
+            expert_id=expert_id,
+            reused=False,
+            distance=min(distances.values(), default=1.0),
+            regime_hash=belief.regime_hash,
+            reason="novel persistent regime requires a shadow-trained expert",
+        )
+
+    def _distance(self, left: RegimeBelief, right: RegimeBelief) -> float:
+        if tuple(left.joint_zero_bias) != tuple(right.joint_zero_bias):
+            raise ValueError("regime prototypes must use the same joint order")
+        pairs = (
+            (left.support_friction.mean, right.support_friction.mean, 1.5),
+            (left.ball_friction.mean, right.ball_friction.mean, 1.5),
+            (left.control_latency.mean, right.control_latency.mean, 50.0),
+            (left.payload.mean, right.payload.mean, 10.0),
+            (left.disturbance.mean, right.disturbance.mean, 1.0),
+        )
+        scalar = [min(1.0, abs(a - b) / scale) for a, b, scale in pairs]
+        joints = [
+            min(1.0, abs(left.joint_zero_bias[name].mean - value.mean) / 0.2)
+            for name, value in right.joint_zero_bias.items()
+        ] + [
+            min(1.0, abs(left.motor_gain[name].mean - value.mean) / 0.5)
+            for name, value in right.motor_gain.items()
+        ]
+        return sum([*scalar, *joints]) / len([*scalar, *joints])
+
+
+__all__ = [
+    "RegimeBelief",
+    "RegimeEncoder",
+    "RegimeEstimate",
+    "RegimeExpertAssignment",
+    "RegimeMemory",
+    "RegimeObservation",
+]

--- a/src/rosclaw/simforge/g1_continual_physical_validation.py
+++ b/src/rosclaw/simforge/g1_continual_physical_validation.py
@@ -13,7 +13,12 @@ from typing import Any
 
 import numpy as np
 
-from rosclaw.continual.contracts import ExperiencePartition, PolicyVersion, SkillPhase
+from rosclaw.continual.contracts import (
+    ExperiencePartition,
+    PolicyVersion,
+    SkillPhase,
+    VersionedTrajectory,
+)
 from rosclaw.continual.experience import ContinualExperienceStore, ExperienceRecord
 from rosclaw.continual.g1_goalforge import (
     adapt_goalforge_episode,
@@ -33,7 +38,10 @@ from rosclaw.simforge.backends.unitree_mujoco_backend import (
 from rosclaw.simforge.models import Partition
 from rosclaw.simforge.seed_ledger import SeedLedger
 from rosclaw.simforge.tasks.g1_goalforge.concepts import ShotParameters
-from rosclaw.simforge.tasks.g1_goalforge.scenario import generate_goalforge_scenarios
+from rosclaw.simforge.tasks.g1_goalforge.scenario import (
+    GoalForgeScenario,
+    generate_goalforge_scenarios,
+)
 
 _FOUNDATION_SECRET = b"rosclaw-phase7-physical-continual-foundation-v1"
 
@@ -194,7 +202,7 @@ def run_g1_continual_physical_foundation(
         torque_guard_scale=backend.torque_guard_scale,
         through_version=2,
     )
-    scenarios = _foundation_scenarios()
+    scenarios = build_foundation_scenarios()
     policy_for = {
         ExperiencePartition.ANCHOR: lineage.policy(0),
         ExperiencePartition.RECENT: lineage.policy(2),
@@ -231,7 +239,9 @@ def run_g1_continual_physical_foundation(
                 "strict_replay": strict_replay,
             },
         )
-        record = _record(partition, adaptation.trajectory, scenario.scenario_commitment)
+        record = record_goalforge_experience(
+            partition, adaptation.trajectory, scenario.scenario_commitment
+        )
         store.append(record)
         rollout = PhysicalRolloutEvidence(
             replay_partition=partition.value,
@@ -342,7 +352,8 @@ def run_g1_continual_physical_foundation(
     return result
 
 
-def _foundation_scenarios():
+def build_foundation_scenarios() -> dict[ExperiencePartition, GoalForgeScenario]:
+    """Return deterministic four-partition G1 service-validation scenarios."""
     ledger = SeedLedger(task_id="g1_penalty_kick", secret=_FOUNDATION_SECRET)
     generated = {
         ExperiencePartition.ANCHOR: generate_goalforge_scenarios(
@@ -393,7 +404,12 @@ def _foundation_scenarios():
     }
 
 
-def _record(partition, trajectory, scenario_commitment):
+def record_goalforge_experience(
+    partition: ExperiencePartition,
+    trajectory: VersionedTrajectory,
+    scenario_commitment: str,
+) -> ExperienceRecord:
+    """Bind a physical trajectory to its replay partition and provenance."""
     if partition is ExperiencePartition.ANCHOR:
         return ExperienceRecord(
             trajectory,
@@ -550,5 +566,7 @@ __all__ = [
     "G1ContinualPhysicalFoundation",
     "PhysicalLearnerShard",
     "PhysicalRolloutEvidence",
+    "build_foundation_scenarios",
+    "record_goalforge_experience",
     "run_g1_continual_physical_foundation",
 ]

--- a/tests/continual/test_learner.py
+++ b/tests/continual/test_learner.py
@@ -9,6 +9,7 @@ pytest.importorskip("torch")
 from rosclaw.continual.contracts import ExperiencePartition
 from rosclaw.continual.experience import ContinualExperienceStore, ExperienceRecord
 from rosclaw.continual.learner import ConstrainedResidualSAC, ResidualSACConfig
+from rosclaw.continual.services.learner import ResidualSACServiceExecutor
 from tests.continual.helpers import digest, policy, trajectory
 
 
@@ -94,3 +95,71 @@ def test_actor_exposes_hidden_activations_for_post_hoc_selfcore_analysis() -> No
 
     assert first.shape == (2, 8)
     assert second.shape == (2, 6)
+
+
+def test_full_checkpoint_restores_policy_optimizer_and_update_index() -> None:
+    parent, batch = _batch()
+    config = ResidualSACConfig(
+        observation_names=parent.observation_names,
+        action_names=parent.residual_action_names,
+        action_limits=(0.04,),
+        hidden_dims=(16, 16),
+        batch_size=16,
+        seed=17,
+    )
+    source = ConstrainedResidualSAC(config)
+    source.update(batch)
+    checkpoint = source.checkpoint_bytes()
+    expected_artifact = source.artifact_bytes()
+    expected_action = source.action({"roll": 0.2, "pitch": -0.1})
+
+    recovered = ConstrainedResidualSAC(config)
+    recovered.restore_checkpoint(checkpoint)
+
+    assert recovered.update_index == source.update_index
+    assert recovered.artifact_bytes() == expected_artifact
+    assert recovered.action({"roll": 0.2, "pitch": -0.1}) == expected_action
+    assert recovered.update(batch).finite
+
+
+def test_checkpoint_rejects_different_learner_configuration() -> None:
+    parent, _ = _batch()
+    source = ConstrainedResidualSAC(
+        ResidualSACConfig(
+            observation_names=parent.observation_names,
+            action_names=parent.residual_action_names,
+            action_limits=(0.04,),
+            hidden_dims=(8, 8),
+        )
+    )
+    incompatible = ConstrainedResidualSAC(
+        ResidualSACConfig(
+            observation_names=parent.observation_names,
+            action_names=parent.residual_action_names,
+            action_limits=(0.03,),
+            hidden_dims=(8, 8),
+        )
+    )
+
+    with pytest.raises(ValueError, match="config does not match"):
+        incompatible.restore_checkpoint(source.checkpoint_bytes())
+
+
+def test_service_executor_emits_numeric_metrics_and_full_checkpoint() -> None:
+    parent, batch = _batch()
+    learner = ConstrainedResidualSAC(
+        ResidualSACConfig(
+            observation_names=parent.observation_names,
+            action_names=parent.residual_action_names,
+            action_limits=(0.04,),
+            hidden_dims=(8, 8),
+            batch_size=16,
+        )
+    )
+
+    product = ResidualSACServiceExecutor(learner, parent=parent)(batch)
+
+    assert product.checkpoint
+    assert product.artifact
+    assert "schema_version" not in product.metrics
+    assert all(isinstance(value, (bool, int, float)) for value in product.metrics.values())

--- a/tests/continual/test_service_cli.py
+++ b/tests/continual/test_service_cli.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rosclaw.continual import service_validation
+from rosclaw.continual.cli import dispatch_continual_argv
+
+
+def test_continual_services_validate_dispatches_and_reports_result(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    captured = {}
+
+    def fake_validation(**kwargs):
+        captured.update(kwargs)
+        return {
+            "passed": True,
+            "checks": {"strict_replay": True},
+            "report_hash": "sha256:" + "1" * 64,
+        }
+
+    monkeypatch.setattr(service_validation, "run_g1_service_validation", fake_validation)
+    output = tmp_path / "report.json"
+    exit_code = dispatch_continual_argv(
+        [
+            "continual",
+            "services",
+            "validate",
+            "--asset-root",
+            str(tmp_path / "assets"),
+            "--candidate",
+            str(tmp_path / "candidate.bin"),
+            "--matched-report",
+            str(tmp_path / "matched.json"),
+            "--state-root",
+            str(tmp_path / "state"),
+            "--output",
+            str(output),
+            "--learner-device",
+            "cuda:0",
+            "--learner-updates",
+            "3",
+        ]
+    )
+    printed = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert captured["learner_device"] == "cuda:0"
+    assert captured["learner_updates"] == 3
+    assert captured["output_path"] == output
+    assert printed["passed"] is True
+
+
+def test_continual_dispatch_leaves_unknown_namespace_for_legacy_cli() -> None:
+    assert dispatch_continual_argv(["continual", "unknown"]) is None

--- a/tests/continual/test_services.py
+++ b/tests/continual/test_services.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from rosclaw.continual.boundary_feedback import BoundaryReplayRequest
+from rosclaw.continual.contracts import ExperiencePartition, SkillPhase
+from rosclaw.continual.experience import (
+    ContinualExperienceStore,
+    ExperienceRecord,
+)
+from rosclaw.continual.services.experience import ExperienceService
+from rosclaw.continual.services.inference import InferenceService
+from rosclaw.continual.services.learner import LearnerProduct, LearnerService
+from rosclaw.continual.services.persistence import DurableEventLog, require_external_service_root
+from rosclaw.continual.services.rollout import RolloutService, RolloutState
+from rosclaw.continual.services.weight_update import WeightUpdateService
+from rosclaw.continual.stability import StabilityPlasticityGate
+from tests.continual.helpers import digest, policy, trajectory
+from tests.continual.test_stability import _passing_evidence
+
+
+def _source_checkout() -> Path:
+    return Path(__file__).parents[2]
+
+
+def _four_partition_store():
+    parent, _ = policy(0)
+    store = ContinualExperienceStore()
+    records = (
+        ExperienceRecord(trajectory(parent, episode="recent"), ExperiencePartition.RECENT),
+        ExperienceRecord(
+            trajectory(parent, episode="anchor"),
+            ExperiencePartition.ANCHOR,
+            anchor_policy_hash=parent.artifact_hash,
+        ),
+        ExperienceRecord(
+            trajectory(parent, episode="boundary", critical=True),
+            ExperiencePartition.BOUNDARY,
+            boundary_reason="fall counterexample",
+        ),
+        ExperienceRecord(
+            trajectory(parent, episode="self"),
+            ExperiencePartition.SELF,
+            self_change_hash=digest("motor-gain-shift"),
+        ),
+    )
+    for record in records:
+        store.append(record)
+    return parent, records, store
+
+
+def test_durable_event_log_detects_tampering(tmp_path: Path) -> None:
+    root = tmp_path / "journal"
+    log = DurableEventLog(root, service="test", clock_ns=lambda: 1)
+    log.append("RECORDED", {"value": 1})
+    event_path = next((root / "events").glob("*.json"))
+    payload = json.loads(event_path.read_text(encoding="utf-8"))
+    payload["payload"]["value"] = 2
+    event_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="hash mismatch"):
+        DurableEventLog(root, service="test")
+
+
+def test_service_state_rejects_filesystem_root() -> None:
+    with pytest.raises(ValueError, match="filesystem root"):
+        require_external_service_root(Path("/"), _source_checkout())
+
+
+def test_rollout_recovery_aborts_motion_and_never_replays_actions(tmp_path: Path) -> None:
+    parent, _ = policy(0)
+    service = RolloutService(tmp_path, source_checkout=_source_checkout())
+    assigned = service.assign(
+        episode_id="kick-1",
+        scenario_commitment=digest("scenario-1"),
+        policy=parent,
+    )
+    running = service.start(assigned.assignment_id, worker_id="sim-worker-0")
+    assert running.state is RolloutState.RUNNING
+
+    recovered = RolloutService(tmp_path, source_checkout=_source_checkout())
+
+    assert recovered.assignments[0].state is RolloutState.ABORTED
+    assert recovered.assignments[0].version_switch_count == 0
+    assert recovered.recovered_abort_count == 1
+    assert "not replayed" in recovered.assignments[0].abort_reason
+
+
+def test_rollout_completes_only_matching_strict_versioned_trajectory(tmp_path: Path) -> None:
+    parent, _ = policy(0)
+    service = RolloutService(tmp_path, source_checkout=_source_checkout())
+    assignment = service.assign(
+        episode_id="kick-2",
+        scenario_commitment=digest("scenario-2"),
+        policy=parent,
+    )
+    service.start(assignment.assignment_id, worker_id="sim-worker-0")
+
+    completed = service.complete(
+        assignment.assignment_id,
+        trajectory=trajectory(parent, episode="kick-2"),
+    )
+
+    assert completed.state is RolloutState.COMPLETE
+    assert completed.strict_replay
+    assert completed.version_switch_count == 0
+
+
+def test_experience_service_recovers_catalog_and_boundary_queue(tmp_path: Path) -> None:
+    parent, records, _ = _four_partition_store()
+    request = BoundaryReplayRequest(
+        scenario_id="unsafe-seed-7",
+        scenario_commitment=digest("scenario-7"),
+        replay_partition="boundary",
+        parent_policy_hash=parent.version_hash,
+        candidate_policy_hash=digest("candidate-version"),
+        parent_status="PASS",
+        candidate_status="SAFETY_ABORT",
+        critical_signals=("fall",),
+        source_evidence_hash=digest("matched-evidence"),
+    )
+    with ExperienceService(tmp_path, source_checkout=_source_checkout()) as service:
+        for record in records:
+            service.append(record)
+        service.enqueue_boundary(request)
+        first = service.audit_receipt()
+
+    with ExperienceService(tmp_path, source_checkout=_source_checkout()) as recovered:
+        second = recovered.audit_receipt()
+        batch = recovered.sample(batch_size=20, learner_version=0, seed=4)
+        recovered.complete_boundary(
+            request.request_hash,
+            record=ExperienceRecord(
+                trajectory(parent, episode="boundary-rerollout", critical=True),
+                ExperiencePartition.BOUNDARY,
+                boundary_reason="reproduced matched-evaluation fall",
+            ),
+        )
+
+        assert len(batch.records) == 20
+        assert second["catalog_counts"] == first["catalog_counts"]
+        assert len(recovered.pending_boundary_requests) == 0
+        assert recovered.audit_receipt()["hardware_authorized"] is False
+
+
+def test_experience_recovery_rejects_corrupted_catalog_row(tmp_path: Path) -> None:
+    _, records, _ = _four_partition_store()
+    with ExperienceService(tmp_path, source_checkout=_source_checkout()) as service:
+        service.append(records[0])
+    database = sqlite3.connect(tmp_path / "experience" / "catalog.sqlite3")
+    with database:
+        database.execute(
+            "UPDATE experience_records SET partition='anchor' WHERE record_hash=?",
+            (records[0].record_hash,),
+        )
+    database.close()
+
+    with pytest.raises(ValueError, match="catalog diverges"):
+        ExperienceService(tmp_path, source_checkout=_source_checkout())
+
+
+def _matching_gate(parent, candidate):
+    evidence = replace(
+        _passing_evidence(),
+        parent_policy_hash=parent.artifact_hash,
+        candidate_policy_hash=candidate.artifact_hash,
+    )
+    return StabilityPlasticityGate().evaluate(evidence)
+
+
+def test_inference_slot_blocks_mid_motion_switch_then_activates_safely(tmp_path: Path) -> None:
+    parent, parent_artifact = policy(0)
+    candidate, candidate_artifact = policy(1, parent=parent)
+    inference = InferenceService(
+        tmp_path,
+        source_checkout=_source_checkout(),
+        active=parent,
+        active_artifact=parent_artifact,
+    )
+    updater = WeightUpdateService(
+        tmp_path,
+        source_checkout=_source_checkout(),
+        inference=inference,
+    )
+    updater.publish(candidate, artifact=candidate_artifact)
+    updater.verify()
+    updater.stage()
+    lease = inference.begin_motion(episode_id="kick-live", phase=SkillPhase.SWING)
+
+    blocked = updater.activate(
+        phase=SkillPhase.COMPLETE,
+        gate_report=_matching_gate(parent, candidate),
+    )
+    inference.end_motion(lease.lease_id, aborted=True, reason="candidate swap was blocked")
+    activated = updater.activate(
+        phase=SkillPhase.COMPLETE,
+        gate_report=_matching_gate(parent, candidate),
+    )
+
+    assert blocked.inference.active_version_hash == parent.version_hash
+    assert blocked.inference.frozen
+    assert activated.inference.active_version_hash == candidate.version_hash
+    assert not activated.inference.frozen
+    assert inference.rollback == parent
+
+
+def test_inference_recovery_aborts_inflight_version_lease(tmp_path: Path) -> None:
+    parent, artifact = policy(0)
+    service = InferenceService(
+        tmp_path,
+        source_checkout=_source_checkout(),
+        active=parent,
+        active_artifact=artifact,
+    )
+    service.begin_motion(episode_id="interrupted", phase=SkillPhase.CONTACT)
+
+    recovered = InferenceService(tmp_path, source_checkout=_source_checkout())
+
+    assert recovered.active_motion_count == 0
+    assert recovered.active.version_hash == parent.version_hash
+    assert recovered.recovered_abort_count == 1
+
+
+def test_weight_update_recovery_commits_completed_inference_mutation(tmp_path: Path) -> None:
+    parent, parent_artifact = policy(0)
+    candidate, candidate_artifact = policy(1, parent=parent)
+    inference = InferenceService(
+        tmp_path,
+        source_checkout=_source_checkout(),
+        active=parent,
+        active_artifact=parent_artifact,
+    )
+    updater = WeightUpdateService(
+        tmp_path,
+        source_checkout=_source_checkout(),
+        inference=inference,
+    )
+    operation_id = digest("interrupted-publish")
+    updater.log.append(
+        "REQUESTED",
+        {
+            "operation_id": operation_id,
+            "operation": "publish",
+            "parameters": {"policy_version_hash": candidate.version_hash},
+            "inference_event_hash_before": inference.log.last_hash,
+        },
+    )
+    inference._publish(candidate, candidate_artifact)
+
+    recovered = WeightUpdateService(
+        tmp_path,
+        source_checkout=_source_checkout(),
+        inference=inference,
+    )
+
+    assert recovered.recovered_completion_count == 1
+    assert recovered.recovered_abort_count == 0
+    assert inference.published == candidate
+
+
+def test_weight_update_recovery_aborts_request_without_mutation(tmp_path: Path) -> None:
+    parent, artifact = policy(0)
+    inference = InferenceService(
+        tmp_path,
+        source_checkout=_source_checkout(),
+        active=parent,
+        active_artifact=artifact,
+    )
+    updater = WeightUpdateService(
+        tmp_path,
+        source_checkout=_source_checkout(),
+        inference=inference,
+    )
+    updater.log.append(
+        "REQUESTED",
+        {
+            "operation_id": digest("interrupted-verify"),
+            "operation": "verify",
+            "parameters": {},
+            "inference_event_hash_before": inference.log.last_hash,
+        },
+    )
+
+    recovered = WeightUpdateService(
+        tmp_path,
+        source_checkout=_source_checkout(),
+        inference=inference,
+    )
+
+    assert recovered.recovered_abort_count == 1
+    assert recovered.recovered_completion_count == 0
+
+
+def test_learner_service_is_idempotent_and_recovers_artifacts(tmp_path: Path) -> None:
+    parent, _, store = _four_partition_store()
+    batch = store.sample(batch_size=20, learner_version=0, seed=3)
+    candidate, artifact = policy(1, parent=parent)
+    calls = 0
+
+    def executor(_batch):
+        nonlocal calls
+        calls += 1
+        return LearnerProduct(
+            candidate=candidate,
+            artifact=artifact,
+            checkpoint=b"trusted-optimizer-checkpoint",
+            metrics={"loss": 0.1, "converged": True},
+        )
+
+    service = LearnerService(tmp_path, source_checkout=_source_checkout(), parent=parent)
+    first = service.execute(batch, executor=executor)
+    repeated = service.execute(batch, executor=executor)
+    recovered = LearnerService(tmp_path, source_checkout=_source_checkout(), parent=parent)
+
+    assert first == repeated
+    assert calls == 1
+    assert recovered.completed_batch_hashes == (batch.batch_hash,)
+    assert recovered.checkpoint_bytes(first.checkpoint_hash) == b"trusted-optimizer-checkpoint"
+    assert first.hardware_authorized is False
+
+
+def test_learner_recovery_quarantines_uncertain_optimizer_job(tmp_path: Path) -> None:
+    parent, _, store = _four_partition_store()
+    batch = store.sample(batch_size=20, learner_version=0, seed=8)
+    service = LearnerService(tmp_path, source_checkout=_source_checkout(), parent=parent)
+    job_id = digest("unfinished-job")
+    service.log.append(
+        "JOB_STARTED",
+        {
+            "job_id": job_id,
+            "batch_hash": batch.batch_hash,
+            "parent_policy_hash": parent.version_hash,
+        },
+    )
+
+    recovered = LearnerService(tmp_path, source_checkout=_source_checkout(), parent=parent)
+
+    assert recovered.quarantined_batch_hashes == (batch.batch_hash,)
+    with pytest.raises(RuntimeError, match="quarantined"):
+        recovered.execute(batch, executor=lambda _: pytest.fail("must not replay update"))

--- a/tests/self_model/test_operational_self.py
+++ b/tests/self_model/test_operational_self.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from rosclaw.self_model.agency import (
+    AgencyClass,
+    AgencyEstimator,
+    AgencyEvidence,
+)
+from rosclaw.self_model.forward_model import (
+    ForwardAction,
+    ForwardModelInput,
+    ForwardState,
+    HybridForwardSelfModel,
+)
+from rosclaw.self_model.prediction_monitor import (
+    AdaptationState,
+    AdaptationTrigger,
+    AdaptationTriggerConfig,
+    PredictionResiduals,
+)
+from rosclaw.self_model.regime import (
+    RegimeEncoder,
+    RegimeMemory,
+    RegimeObservation,
+)
+from tests.continual.helpers import digest
+
+
+def _forward_state(*, joint_offset: float = 0.0) -> ForwardState:
+    return ForwardState(
+        joint_position={"hip": 0.1 + joint_offset, "knee": -0.2},
+        joint_velocity={"hip": 0.05, "knee": -0.02},
+        pelvis_position=(0.0, 0.0, 0.78),
+        pelvis_velocity=(0.1, 0.0, 0.0),
+        com_position=(0.0, 0.01, 0.72),
+        foot_contact=(1.0, 0.2),
+        ball_position=(0.3, 0.0, 0.05),
+        ball_velocity=(0.0, 0.0, 0.0),
+        energy_state=0.9,
+        balance_margin=0.04,
+    )
+
+
+def _forward_input() -> ForwardModelInput:
+    return ForwardModelInput(
+        state=_forward_state(),
+        action=ForwardAction(
+            joint_acceleration={"hip": 0.2, "knee": -0.1},
+            ball_impulse=(0.4, 0.0, 0.05),
+        ),
+        dt_seconds=0.02,
+        phase_progress=0.5,
+        contact_mode=(1.0, 0.0),
+    )
+
+
+def test_forward_model_starts_analytical_and_learns_only_behind_shadow_gate() -> None:
+    model = HybridForwardSelfModel(("hip", "knee"), learning_rate=0.1)
+    model_input = _forward_input()
+    analytical = model.predict(model_input).analytical_state
+    actual = replace(
+        analytical,
+        joint_position={
+            "hip": analytical.joint_position["hip"] + 0.03,
+            "knee": analytical.joint_position["knee"],
+        },
+    )
+    original_hash = model.model_hash
+
+    blocked = model.learn_transition(model_input, actual, shadow_learning=False)
+    updates = [model.learn_transition(model_input, actual, shadow_learning=True) for _ in range(80)]
+    prediction = model.predict(model_input)
+
+    assert not blocked.trained
+    assert blocked.error_before == blocked.error_after
+    assert updates[-1].error_after < updates[0].error_before
+    assert model.model_hash != original_hash
+    assert prediction.neural_residual_norm <= model.residual_limit * (model._output_size**0.5)
+    assert 0.0 <= prediction.fall_risk <= 1.0
+
+
+def test_forward_model_checkpoint_is_exact_and_configuration_bound() -> None:
+    source = HybridForwardSelfModel(("hip", "knee"))
+    source.learn_transition(
+        _forward_input(),
+        replace(source.predict(_forward_input()).next_state, balance_margin=0.02),
+        shadow_learning=True,
+    )
+    checkpoint = source.checkpoint()
+    recovered = HybridForwardSelfModel(("hip", "knee"))
+
+    recovered.restore_checkpoint(checkpoint)
+
+    assert recovered.model_hash == source.model_hash
+    assert (
+        recovered.predict(_forward_input()).next_state.to_dict()
+        == source.predict(_forward_input()).next_state.to_dict()
+    )
+    with pytest.raises(ValueError, match="configuration mismatch"):
+        HybridForwardSelfModel(("ankle",)).restore_checkpoint(checkpoint)
+
+
+def _residual(value: float, *, episode: str = "episode") -> PredictionResiduals:
+    return PredictionResiduals(
+        body_state=value,
+        contact_outcome=value,
+        contact_mode=value,
+        control_latency=value,
+        energy=value,
+        task_performance=value,
+        timestamp_ns=1,
+        episode_id=episode,
+    )
+
+
+def test_adaptation_trigger_ignores_noise_and_enforces_shadow_safety_gate() -> None:
+    config = AdaptationTriggerConfig(
+        suspected_persistence=2,
+        confirmed_persistence=2,
+        recovery_persistence=2,
+        shadow_min_samples=10,
+    )
+    transient = AdaptationTrigger(config)
+    transient.observe(_residual(0.4))
+    receipt = transient.observe(_residual(0.1))
+    assert receipt.state is AdaptationState.NORMAL
+
+    trigger = AdaptationTrigger(config)
+    trigger.observe(_residual(0.6))
+    trigger.observe(_residual(0.6))
+    trigger.observe(_residual(0.8))
+    confirmed = trigger.observe(_residual(0.8))
+    assert confirmed.state is AdaptationState.CONFIRMED_SHIFT
+    shadow = trigger.begin_shadow_learning()
+    rejected = trigger.candidate_update(
+        sample_count=100,
+        target_improvement=0.2,
+        anchor_degradation=0.0,
+        critical_safety_regressions=1,
+        converged=True,
+    )
+
+    assert shadow.learning_enabled
+    assert rejected.state is AdaptationState.ROLLBACK
+    assert not rejected.learning_enabled
+
+
+def test_adaptation_trigger_requires_retention_before_consolidation() -> None:
+    trigger = AdaptationTrigger(
+        AdaptationTriggerConfig(
+            suspected_persistence=1,
+            confirmed_persistence=1,
+            shadow_min_samples=10,
+        )
+    )
+    trigger.observe(_residual(0.6))
+    trigger.observe(_residual(0.8))
+    trigger.begin_shadow_learning()
+    incomplete = trigger.candidate_update(
+        sample_count=100,
+        target_improvement=0.2,
+        anchor_degradation=0.2,
+        critical_safety_regressions=0,
+        converged=True,
+    )
+    ready = trigger.candidate_update(
+        sample_count=100,
+        target_improvement=0.2,
+        anchor_degradation=0.01,
+        critical_safety_regressions=0,
+        converged=True,
+    )
+    consolidated = trigger.consolidate(matched_gate_passed=True)
+
+    assert incomplete.state is AdaptationState.SHADOW_LEARNING
+    assert ready.state is AdaptationState.CANDIDATE_READY
+    assert consolidated.state is AdaptationState.CONSOLIDATED
+
+
+def _regime_observation(
+    episode_id: str,
+    support_friction: float,
+    *,
+    timestamp_ns: int,
+) -> RegimeObservation:
+    return RegimeObservation(
+        episode_id=episode_id,
+        timestamp_ns=timestamp_ns,
+        support_friction=support_friction,
+        ball_friction=0.4,
+        control_latency_ms=8.0,
+        joint_zero_bias={"hip": 0.01, "knee": -0.02},
+        motor_gain={"hip": 0.98, "knee": 1.02},
+        payload_kg=0.2,
+        disturbance_magnitude=0.1,
+        sensor_confidence=0.95,
+    )
+
+
+def test_regime_encoder_separates_timescales_and_reuses_known_regime() -> None:
+    encoder = RegimeEncoder(("hip", "knee"))
+    for index in range(5):
+        encoder.observe(_regime_observation("episode-a", 0.7 + index * 0.01, timestamp_ns=index))
+    first = encoder.end_episode("episode-a")
+    assert first.persistent.observation_count == 1
+    assert first.episode.observation_count == 0
+    assert first.fast.observation_count == 5
+
+    memory = RegimeMemory()
+    created = memory.assign(first.persistent)
+    reused = memory.assign(first.persistent)
+
+    assert not created.reused
+    assert reused.reused
+    assert reused.expert_id == created.expert_id
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ((0.95, 0.05, 0.0, 0.0), AgencyClass.SELF_CAUSED),
+        ((0.2, 0.8, 0.95, 0.0), AgencyClass.EXTERNAL_DISTURBANCE),
+        ((0.2, 0.8, 0.0, 0.95), AgencyClass.SENSOR_FAULT),
+        ((0.0, 0.1, 0.0, 0.0), AgencyClass.UNKNOWN),
+    ],
+)
+def test_agency_estimator_distinguishes_operational_causes(
+    values: tuple[float, float, float, float], expected: AgencyClass
+) -> None:
+    action, error, external, sensor = values
+    evidence = AgencyEvidence(
+        action_magnitude=action,
+        prediction_error=error,
+        external_force_evidence=external,
+        sensor_inconsistency=sensor,
+        action_hash=digest("action"),
+        predicted_outcome_hash=digest("predicted"),
+        observed_outcome_hash=digest("observed"),
+        timestamp_ns=1,
+    )
+
+    estimate = AgencyEstimator().estimate(evidence)
+
+    assert estimate.classification is expected
+    assert sum(estimate.probabilities.values()) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

- add recoverable Rollout, Experience, Inference, Learner, and Weight Update services with append-only hash-chain journals, SQLite catalog recovery, content-addressed artifacts, full optimizer/RNG checkpoints, and motion-scoped policy leases
- feed matched Candidate safety regressions into the Boundary replay queue and add a persistent adaptation trigger that enables learning only after confirmed prediction shift
- add an analytical-plus-bounded-neural Forward Self Model, Fast/Episode/Persistent Regime Encoder with expert reuse, and four-class operational Agency estimator
- add `rosclaw continual services validate` to exercise the service loop with real G1 MuJoCo trajectories and fail-closed candidate evidence
- document the implementation, evidence hashes, limitations, and next work

## Why

Phase 7.1 had Candidate execution and matched evaluation, but the continual loop was still mostly in-process. This change gives ROSClaw explicit recoverable service boundaries and an operational embodied-self feedback loop while preserving the stricter rule that one high-dynamic G1 motion may never cross policy versions.

The evaluated Candidate remains rejected: four new critical safety regressions are queued for Boundary replay, activation is blocked, and Parent v2 remains active. This PR does not claim consciousness, real-hardware authorization, or a promoted football policy.

## Validation

- real G1 MuJoCo service validation: 11/11 checks passed; four replay partitions strictly replayed; motion version switches = 0; Rollout and Inference crash injections replayed no old action; Candidate activation = 0
- service report: `/code/rosclaw/phase7_1_evidence/service-validation-v2.json`
  - file SHA-256: `7dcef1746bd9a77852fbf1f928a78f1c147b8420d76d44f674f55cb7d8c99b64`
  - report hash: `sha256:31bd58b930629b19d72662130b14e2b716c1eaf9d54dc2063f1358289dff0f3a`
- scoped Ruff, format, and mypy: passed
- focused recovery/self-model regression: 30 passed
- full repository suite with the installed LeRobot runtime explicitly configured: 5332 passed, 59 skipped, 27 deselected

## Stack

Depends on #123. The PR base is `phase7-1-capability-proof-demo` so reviewers see only the recoverable-services and self-model delta.
