### PR TITLE
fix(evolution): thermal start gate + promotion gate attribution/generation/state fixes

### DIFF
--- a/src/rosclaw/evolution/hardware/orchestrator.py
+++ b/src/rosclaw/evolution/hardware/orchestrator.py
@@ -615,15 +615,25 @@ class EvoRpsOrchestrator:
         store = self.namespace.knowledge_store()
         self.namespace.assert_store_isolated(store)
         registry = CandidateRegistry(store)
-        sessions = manifest.by_kind("canary_session")
+        # The gate evaluates the LATEST canary generation only: the candidate
+        # named by the newest canary_candidate_selected entry and the sessions
+        # recorded after it.  Mixing generations (yesterday's rolled-back
+        # candidate's sessions with today's selection) would be a second
+        # attribution error (found 2026-07-26).
+        selections = manifest.by_kind("canary_candidate_selected")
+        if not selections:
+            manifest.record("promote_blocked", reason="no canary candidate selection")
+            raise OrchestratorError("promote requires a canary run (run canary first)")
+        generation_start = float(selections[-1].get("recorded_at") or 0.0)
+        candidate_id = str(selections[-1].get("candidate_id"))
+        sessions = [
+            entry
+            for entry in manifest.by_kind("canary_session")
+            if float(entry.get("recorded_at") or 0.0) >= generation_start
+        ]
         if not sessions:
             manifest.record("promote_blocked", reason="no canary sessions")
             raise OrchestratorError("promote requires canary sessions (run canary first)")
-        candidate_id = next(
-            (s["candidate_id"] for s in sessions if s.get("candidate_id")), None
-        )
-        if candidate_id is None:
-            raise OrchestratorError("canary sessions carry no candidate id")
         candidate_row = registry.get(candidate_id)
         if candidate_row is None:
             raise OrchestratorError(f"candidate {candidate_id} not in the registry")
@@ -683,13 +693,24 @@ class EvoRpsOrchestrator:
             "memory_hurt": 0.0,
         }
         aborted = manifest.by_kind("canary_aborted")
-        if aborted:
-            safety["protection_event"] = len(aborted)
+        # Attribution matters: only an abort in the CANDIDATE's OWN arm is a
+        # candidate protection event.  An abort in arm A/B is an experiment-
+        # condition signal (the hardware is heat-soaked), never evidence
+        # against the candidate — rolling back C for B's overheat would be a
+        # false verdict (found + fixed 2026-07-26).
+        candidate_aborts = [a for a in aborted if a.get("arm") == ARM_C]
+        other_aborts = [a for a in aborted if a.get("arm") != ARM_C]
+        if candidate_aborts:
+            safety["protection_event"] = len(candidate_aborts)
 
         gate = evaluate_promotion_gate(
             candidate_id=candidate_id,
             arm_records=arm_records,
             safety=safety,
+            min_sessions_c=int(
+                (self.config.raw.get("canary") or {}).get("min_sessions_per_arm", 3)
+            ),
+            other_arm_aborts=len(other_aborts),
             patch_proofs=patch_proofs,
             promotion_config=self.config.promotion,
             stats_fn=promotion_report,
@@ -701,14 +722,19 @@ class EvoRpsOrchestrator:
             source_failure=str(candidate_row.get("source_failure") or ""),
             current_regime=str(candidate_row.get("current_regime") or ""),
         )
-        # Preserve the validate-phase gate verdicts from the existing row —
-        # upsert replaces the row, and the registry must keep the full
-        # evaluation history, not just the terminal state.
+        # Preserve the validate-phase gate verdicts AND the existing state —
+        # upsert replaces the row.  A NOT_PROMOTED verdict changes nothing
+        # about the candidate's state (VALIDATED stays VALIDATED, terminal
+        # ROLLED_BACK stays terminal); only PROMOTED/ROLLED_BACK transition
+        # (found 2026-07-26: a fresh default record silently reset states).
         prior_verdicts = candidate_row.get("gate_verdicts")
         if isinstance(prior_verdicts, str):
             prior_verdicts = json.loads(prior_verdicts)
         if prior_verdicts:
             record.gate_verdicts = list(prior_verdicts)
+        prior_state = candidate_row.get("state")
+        if prior_state:
+            record.state = CandidateState(str(prior_state))
         if gate.decision is PromotionDecision.PROMOTED:
             record.state = CandidateState.VALIDATED
             record.promote()

--- a/src/rosclaw/evolution/hardware/orchestrator.py
+++ b/src/rosclaw/evolution/hardware/orchestrator.py
@@ -485,9 +485,39 @@ class EvoRpsOrchestrator:
             blocks=blocks, seed=self.config.seed + 900, base_seed=self.config.seed + 1000
         )
         driver = Rh56RpsWorkspaceDriver(self.config, self.namespace.practice_root)
+        canary_cfg = self.config.raw.get("canary") or {}
+        start_max_temp = float(canary_cfg.get("start_max_temp_c", 46.0))
+        max_thermal_wait = float(canary_cfg.get("max_thermal_wait_s", 900.0))
         results: list[dict[str, Any]] = []
         aborted = False
         for slot in schedule:
+            # §Phase 6 相同初始温度区间: every slot starts inside the same
+            # thermal window — waiting is recorded, a timeout blocks the
+            # matrix honestly rather than running mismatched sessions.
+            from .thermal import wait_for_thermal_window
+
+            window = wait_for_thermal_window(
+                start_max_temp_c=start_max_temp,
+                max_wait_s=max_thermal_wait,
+            )
+            manifest.record(
+                "canary_thermal_gate",
+                block=slot.block,
+                arm=slot.arm,
+                ok=window.ok,
+                waited_s=round(window.waited_s, 1),
+                temps=window.temps,
+                reason=window.reason,
+            )
+            if not window.ok:
+                manifest.record(
+                    "canary_thermal_block",
+                    reason="start temperature window not reachable",
+                    waited_s=round(window.waited_s, 1),
+                    temps=window.temps,
+                )
+                aborted = True
+                break
             out_dir = (
                 self.namespace.evidence_root / "canary" / f"block{slot.block}_{slot.arm}"
             )

--- a/src/rosclaw/evolution/hardware/promotion_gate.py
+++ b/src/rosclaw/evolution/hardware/promotion_gate.py
@@ -65,12 +65,16 @@ def evaluate_promotion_gate(
     patch_proofs: list[dict[str, Any]],
     promotion_config: dict[str, Any],
     stats_fn: Any | None = None,
+    min_sessions_c: int = 3,
+    other_arm_aborts: int = 0,
 ) -> PromotionGateReport:
     """Evaluate the Phase 7 gate.  ``arm_records`` maps arm → SessionRecord
     list (each carrying invalid_rate / verified_rate properties);
     ``safety`` carries the zero-tolerance counters; ``patch_proofs`` the
     arm-C apply proofs; ``stats_fn`` is the evo3 promotion_report (or a
     test double) used for the session-level effect estimate.
+    ``min_sessions_c`` is the promotion floor (§Phase 6 pilot: 3 sessions
+    per arm) — a single lucky session never promotes.
     """
     checks: list[GateCheck] = []
     zero_tolerance = (
@@ -116,6 +120,18 @@ def evaluate_promotion_gate(
     a_valid = mean_rate(a_records, "verified_rate")
     c_valid = mean_rate(c_records, "verified_rate")
 
+    checks.append(
+        GateCheck(
+            "min_sessions_c",
+            len(c_records) >= min_sessions_c,
+            f"{len(c_records)}/{min_sessions_c} arm-C sessions"
+            + (
+                f" (matrix incomplete: {other_arm_aborts} abort(s) in other arms)"
+                if other_arm_aborts
+                else ""
+            ),
+        )
+    )
     checks.append(
         GateCheck(
             "c_valid_ge_a",

--- a/src/rosclaw/evolution/hardware/thermal.py
+++ b/src/rosclaw/evolution/hardware/thermal.py
@@ -1,0 +1,111 @@
+"""Thermal window gate for matched-regime canary starts (§Phase 6).
+
+The protocol demands 相同初始温度区间: every canary slot must start in
+the same temperature band.  Before each slot the gate reads the hand
+temperatures; above ``start_max_temp_c`` it waits (recorded) until the
+hands cool into the window, or — past ``max_wait_s`` — blocks the matrix
+honestly rather than running a mismatched experiment.
+
+The probe runs in the camera/hand-capable task env (the repo venv has no
+pyserial), mirroring the camera probe pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+TASK_ENV_PY = "/home/nvidia/workspace/rosclaw/rosclaw_test/.venv/bin/python"
+RPS_ROOT = "/home/nvidia/workspace/rosclaw/rosclaw_test/examples/rh56_rps"
+RH56_SRC = "/home/nvidia/workspace/rosclaw_rh56_real/rosclaw-rh56-runtime/src"
+
+_PROBE_CODE = (
+    "import json\n"
+    "from rosclaw_rps.hand.rh56_controller import build_hand_controller\n"
+    "out = {}\n"
+    "for cfg, side in (({'controller': 'rh56', 'port': '/dev/ttyUSB0', 'device_id': 2}, 'right'),"
+    " ({'controller': 'rh56', 'port': '/dev/ttyUSB1', 'device_id': 1}, 'left')):\n"
+    "    hand = build_hand_controller(cfg)\n"
+    "    try:\n"
+    "        tel = hand.read_telemetry()\n"
+    "        vals = [v for v in (tel.temperature_c or {}).values() if isinstance(v, (int, float)) and v > 0]\n"
+    "        out[side] = max(vals) if vals else None\n"
+    "    except Exception:\n"
+    "        out[side] = None\n"
+    "    finally:\n"
+    "        try: hand.close()\n"
+    "        except Exception: pass\n"
+    "print(json.dumps(out))\n"
+)
+
+TempProbe = Callable[[], dict[str, float | None]]
+
+
+def default_temp_probe() -> dict[str, float | None]:
+    import os
+
+    env = {
+        **os.environ,
+        "PYTHONPATH": f"{RPS_ROOT}/scripts:{RPS_ROOT}/src:{RH56_SRC}:/home/nvidia/workspace/rosclaw/rosclaw_test/rosclaw/src",
+    }
+    proc = subprocess.run(
+        [TASK_ENV_PY, "-c", _PROBE_CODE],
+        capture_output=True,
+        text=True,
+        timeout=90,
+        env=env,
+        cwd=RPS_ROOT,
+    )
+    if proc.returncode != 0:
+        return {"right": None, "left": None, "error": proc.stderr.strip()[-160:]}
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            return json.loads(line)
+    return {"right": None, "left": None, "error": "probe returned no temps"}
+
+
+@dataclass
+class ThermalWindowResult:
+    ok: bool
+    waited_s: float = 0.0
+    temps: dict[str, Any] = field(default_factory=dict)
+    reason: str = ""
+
+
+def wait_for_thermal_window(
+    *,
+    probe: TempProbe = default_temp_probe,
+    start_max_temp_c: float = 46.0,
+    max_wait_s: float = 900.0,
+    poll_s: float = 60.0,
+) -> ThermalWindowResult:
+    """Wait until both hands read at or below start_max_temp_c (missing
+    readings never count as cool — unknown is not cold)."""
+    started = time.monotonic()
+    while True:
+        temps = probe()
+        values = [v for k, v in temps.items() if k in ("right", "left") and v is not None]
+        if values and max(values) <= start_max_temp_c:
+            return ThermalWindowResult(
+                ok=True,
+                waited_s=time.monotonic() - started,
+                temps=temps,
+                reason=f"in window (max {max(values):.0f}°C ≤ {start_max_temp_c}°C)",
+            )
+        waited = time.monotonic() - started
+        if waited >= max_wait_s:
+            return ThermalWindowResult(
+                ok=False,
+                waited_s=waited,
+                temps=temps,
+                reason=(
+                    f"thermal window not reached within {max_wait_s:.0f}s "
+                    f"(last temps {temps})"
+                ),
+            )
+        time.sleep(poll_s)

--- a/tests/evolution/hardware/test_promotion_gate.py
+++ b/tests/evolution/hardware/test_promotion_gate.py
@@ -112,3 +112,38 @@ def test_promoted_rule_record_shape() -> None:
     assert rule["status"] == "active"
     assert rule["canary_sessions"] == ["prac_1"]
     assert rule["gate_report"]["decision"] == "PROMOTED"
+
+
+def test_min_sessions_floor_blocks_single_lucky_session() -> None:
+    """One lucky session never promotes (§Phase 6 pilot: 3/arm)."""
+    records = {
+        "A_no_memory": [_Rec(0.20, 0.80)],
+        "B_fixed_cooldown": [_Rec(0.25, 0.75)],
+        "C_candidate_canary": [_Rec(0.175, 0.825)],
+    }
+    report = _gate(records)
+    assert report.decision is PromotionDecision.NOT_PROMOTED
+    failed = {c.name for c in report.checks if not c.passed}
+    assert "min_sessions_c" in failed
+    # With 3 sessions per arm the same metrics promote.
+    full = _arms(0.20, 0.25, 0.175)
+    report2 = _gate(full)
+    assert report2.decision is PromotionDecision.PROMOTED
+
+
+def test_other_arm_abort_is_disclosed_not_candidate_fault() -> None:
+    """An abort in arm B is an experiment-condition note, never a
+    protection_event against the candidate (found 2026-07-26)."""
+    report = evaluate_promotion_gate(
+        candidate_id="cand_x",
+        arm_records=_arms(0.20, 0.25, 0.175),
+        safety=dict(SAFETY_ZERO),
+        patch_proofs=PROOFS,
+        promotion_config={},
+        stats_fn=None,
+        other_arm_aborts=1,
+    )
+    # Metrics pass; the other-arm abort appears only as disclosure.
+    assert report.decision is PromotionDecision.PROMOTED
+    detail = next(c.detail for c in report.checks if c.name == "min_sessions_c")
+    assert "matrix incomplete" in detail

--- a/tests/evolution/hardware/test_thermal_gate.py
+++ b/tests/evolution/hardware/test_thermal_gate.py
@@ -1,0 +1,56 @@
+"""Thermal window gate tests (§Phase 6 matched start temperature)."""
+
+from __future__ import annotations
+
+from rosclaw.evolution.hardware.thermal import wait_for_thermal_window
+
+
+def test_in_window_passes_immediately() -> None:
+    result = wait_for_thermal_window(
+        probe=lambda: {"right": 42.0, "left": 43.0},
+        start_max_temp_c=46.0,
+        max_wait_s=10.0,
+        poll_s=0.01,
+    )
+    assert result.ok
+    assert result.waited_s < 1.0
+
+
+def test_hot_hands_wait_then_pass() -> None:
+    readings = iter(
+        [
+            {"right": 50.0, "left": 49.0},
+            {"right": 47.0, "left": 46.5},
+            {"right": 44.0, "left": 43.0},
+        ]
+    )
+    result = wait_for_thermal_window(
+        probe=lambda: next(readings),
+        start_max_temp_c=46.0,
+        max_wait_s=10.0,
+        poll_s=0.01,
+    )
+    assert result.ok
+    assert result.temps["right"] == 44.0
+
+
+def test_timeout_blocks_honestly() -> None:
+    result = wait_for_thermal_window(
+        probe=lambda: {"right": 52.0, "left": 51.0},
+        start_max_temp_c=46.0,
+        max_wait_s=0.05,
+        poll_s=0.01,
+    )
+    assert not result.ok
+    assert "not reached" in result.reason
+    assert result.temps["right"] == 52.0
+
+
+def test_missing_reading_never_counts_as_cold() -> None:
+    result = wait_for_thermal_window(
+        probe=lambda: {"right": None, "left": None, "error": "probe failed"},
+        start_max_temp_c=46.0,
+        max_wait_s=0.05,
+        poll_s=0.01,
+    )
+    assert not result.ok


### PR DESCRIPTION
## Summary

**HW-4 后续硬化：热启动门 + 晋升门三处正确性修复**（全部由真机 canary 实战暴露）。

1. **匹配起始温度门（§Phase 6 相同初始温度区间）**：每个 canary slot 前等待双手进入同一温度窗口（默认 ≤46°C，最长等 900s）；等待本身落证据 `canary_thermal_gate`，超时诚实阻断 `canary_thermal_block`，绝不跑失配实验。探针在手部能力环境运行（repo venv 无 pyserial）；读数缺失永远不算"凉"。
2. **protection_event 归属**：A/B 臂的中止此前计为候选的安全事件（昨天的 ROLLED_BACK 实为 B 臂过热误伤）。修复：只计候选本臂中止；他臂中止仅作为 "matrix incomplete" 披露。
3. **代际混淆**：promote 此前取清单中第一个候选评估，混用昨天已回滚候选与今天选择的会话。修复：只评估最近一次 `canary_candidate_selected` 之后的代际。
4. **状态覆盖**：NOT_PROMOTED 裁决此前 upsert 默认 PROPOSED 新记录，静默重置 ROLLED_BACK/VALIDATED 终态（检查时发现；两行已按证据链恢复并落披露式修正）。修复：NOT_PROMOTED 不改状态，仅 PROMOTED/ROLLED_BACK 迁移。
5. **min_sessions_c 晋升下限**（pilot 协议 3 场/臂）：单场幸运绝不晋升。

## 真机验证

- 完整 3×3 canary 第二次运行：b0 A 20% / C(冷却每5轮，35s) 17.5% / B 25%——B 臂再触 52°C 中止；热门工作（C 场前等 233s 进窗）。
- 修复后晋升门：protection_event=0（归属正确）、"1/3 arm-C sessions (matrix incomplete: 2 abort(s) in other arms)" → **NOT_PROMOTED**（场数不足，诚实）；cand_001 保持 ROLLED_BACK 终态、cand_003 保持 VALIDATED。
- 83/83 测试（新增温度门 4 项 + 晋升下限/归属 2 项），ruff + mypy 干净。

## 边界

- 两次矩阵均在 B 臂（固定冷却）触发 52°C 契约中止：当前环境热包络下 B 的静态策略在 40 回合内无法完成——这本身是 B 臂的实验信号；完整矩阵需要更低的起始热状态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
