### PR TITLE
Improve G1 two-stage post-kick body recovery

### DIFF
--- a/docs/validation/ROSCLAW_PHASE7_1_TWO_STAGE_BODY_RECOVERY.md
+++ b/docs/validation/ROSCLAW_PHASE7_1_TWO_STAGE_BODY_RECOVERY.md
@@ -1,0 +1,209 @@
+# ROSClaw Phase 7.1：G1 踢球后退与抖动分析及两阶段身体恢复
+
+## 1. 结论
+
+G1 踢球后出现“先向前晃、随后后退、最后轻微抽动”，不是单一关节增益过大，而是三个动作阶段没有正确衔接：
+
+1. 触球时骨盆仍带有明显的前向、侧向和竖直速度；
+2. 踢球先验在右脚重新落地后仍继续播放较长的 recovery 片段；
+3. ROSClaw 原恢复器直到动量已经反向后才开始向站立姿态混合，只能把机器人停住，无法阻止先前发生的后退。
+
+本阶段把恢复改成接触与落脚双门控的两阶段动作：
+
+- 第一阶段提前卸力，逐步退出踢球先验；
+- 第二阶段增加站立权重、减小侧倾，并仅用腰俯仰做缓慢回正；
+- 上肢目标同步低通，避免手臂和躯干在策略帧之间抽动；
+- 新增以后续球飞行方向为坐标轴的后退与侧摆指标，候选必须相对直接上一版 parent 通过严格重放 A/B 门禁。
+
+最终三球 Hat Trick 闭环通过。第三球在相同种子、相同 80 N 干扰、相同球速和落点下，后退回撤降低 13.2%，侧向峰值回摆降低 29.3%，尾段 wobble 降低 10.3%。
+
+## 2. 为什么踢完会后退和抖动
+
+### 2.1 触球后仍有未卸掉的身体动量
+
+上一版轨迹的第一次球接触发生在约 5.28 s。此时骨盆速度约为：
+
+- 前向：0.190 m/s；
+- 侧向：0.425 m/s；
+- 竖直：0.317 m/s。
+
+右脚约在触球后 0.30 s 再次落地。落脚只代表获得了支撑，并不代表动量已经消失。机器人仍需要通过迈步、髋踝协调、摆臂和躯干姿态把这些动量安全地导入地面。
+
+### 2.2 恢复开始太晚
+
+上一版上肢平滑在策略帧 400 才启动，约为触球后 2.92 s；站立姿态混合在策略帧 421 后才真正激活，约为触球后 3.40 s。此时骨盆已先向前、向侧方运动，随后踢球先验的剩余恢复动作又把身体带回相反方向。
+
+轨迹表现为：
+
+- 骨盆先走到前向峰值；
+- 然后反向回撤约 0.543 m；
+- 侧向峰值到最终位置的回摆约 0.881 m；
+- 晚启动的站立混合只负责最后“刹住”，不能消除已经发生的往返运动。
+
+### 2.3 “抖动”和“姿态不正”必须分开看
+
+搜索中曾出现一种候选：关节 jerk 和骨盆速度都下降，但 wobble 指数反而上升。分解后发现其原因不是继续乱动，而是机器人以较大的后倾姿态安静地停住。wobble 指数同时包含：
+
+- 躯干角速度；
+- 骨盆平面速度；
+- 躯干倾角；
+- 全身关节速度。
+
+因此仅做动作低通，或者仅看视频是否“抽动”，都会漏掉停姿不正的问题。
+
+## 3. 实施内容
+
+### 3.1 两阶段小脑恢复器
+
+`G1CerebellarRecoveryConfig` 新增第二阶段参数：
+
+- `settling_start_policy_frame`；
+- `settling_blend_frames`；
+- `settling_standing_pose_blend`；
+- `settling_roll_posture_bias_rad`；
+- `settling_waist_pitch_bias_rad`。
+
+两个阶段都使用 smoothstep，不产生瞬时目标跳变。控制器仍保持以下因果边界：
+
+- 未观察到球接触时透明；
+- 未观察到踢球脚重新落地时透明；
+- 超出已校准摩擦、延迟和扰动力范围时 fail closed；
+- 只修改 MuJoCo SIM 中的关节目标，不发送力矩，也不开启机器人传输。
+
+最终候选参数为：
+
+```text
+第一阶段：frame 300，100 帧混合，站立权重 0.30，roll bias -0.05 rad
+第二阶段：frame 400，100 帧混合，站立权重增至 0.45，roll bias 收至 -0.02 rad
+腰部回正：waist pitch +0.09 rad
+上肢平滑：alpha 0.60，从 frame 300 开始
+```
+
+只对腰俯仰施加回正，而不使用髋、踝共同硬顶，是因为局部搜索显示后者容易把姿态修正变成新的步态振荡，甚至触发关节限制。
+
+### 3.2 可审计的第二阶段证据
+
+恢复 receipt 升级为 v3，增加：
+
+- 第二阶段首次激活的策略帧与仿真时间；
+- 第二阶段峰值比例；
+- 完整两阶段配置；
+- 控制器、Body、motion 和 regime 哈希。
+
+轨迹增加 `recovery_settling_fraction`。最终证据中：
+
+- 第一阶段激活：policy frame 300，约 6.18 s；
+- 第二阶段激活：policy frame 401，约 8.20 s；
+- 两阶段峰值比例均为 1.0；
+- candidate 与 parent 均严格重放一致。
+
+### 3.3 身体效果指标与晋级门禁
+
+恢复质量 schema 升级为 v4，新增：
+
+- `post_contact_forward_peak_advance_m`；
+- `post_contact_backward_reversal_m`；
+- `post_contact_lateral_peak_return_m`。
+
+坐标轴使用球离脚后的平面飞行方向，而不是机器人触球瞬间已经旋转的骨盆方向。这样“向球门前进”和“向后撤”在不同站姿下仍有一致含义。
+
+侧向回摆取轨迹中任一侧向峰值到最终位置的最大距离。它能覆盖“先向一侧卸力、再越过中线停到另一侧”的情形，不会因为最终点恰好是最大绝对值而误报为零。
+
+自然度门禁 schema 升级为 v2。除原有成功、安全、严格重放、全身/腿/腰/手臂/tail jerk、路径和稳定时间约束外，新增最低要求：
+
+- tail wobble 至少降低 5%；
+- 后退回撤至少降低 10%；
+- 侧向峰值回摆至少降低 15%。
+
+## 4. 匹配 A/B 结果
+
+第三球的 parent 是上一阶段已经晋级的 V6 自然跟随动作，不是更弱的早期基线。
+
+| 指标 | V6 parent | V7 candidate | 改善 |
+|---|---:|---:|---:|
+| 球速 | 5.6011 m/s | 5.6011 m/s | 保持 |
+| 目标误差 | 0.1352 m | 0.1352 m | 保持 |
+| 骨盆总路径 | 1.8787 m | 1.6200 m | 13.8% |
+| 最终平面位移 | 0.5220 m | 0.2645 m | 49.3% |
+| 前进后反向回撤 | 0.5429 m | 0.4711 m | 13.2% |
+| 侧向峰值回摆 | 0.8814 m | 0.6229 m | 29.3% |
+| 支撑切换次数 | 49 | 37 | 24.5% |
+| 稳定时间 | 4.30 s | 4.18 s | 2.8% |
+| 全身 joint jerk RMS | 729.00 | 635.93 | 12.8% |
+| 手臂 joint jerk RMS | 366.26 | 252.98 | 30.9% |
+| 腰部 joint jerk RMS | 661.39 | 507.36 | 23.3% |
+| tail joint jerk RMS | 1.0287 | 0.8411 | 18.2% |
+| tail wobble index | 0.12166 | 0.10907 | 10.3% |
+
+安全结果：
+
+- `SUCCESS`；
+- 无跌倒；
+- 无关节限制越界；
+- 无力矩限制越界；
+- 无执行器饱和；
+- 末端双脚支撑；
+- 支撑脚滑移 0.0266 m；
+- 三球及各自重放全部通过。
+
+## 5. 被数据拒绝的方案
+
+以下方案没有进入正式代码路径：
+
+1. 直接冻结落脚后的策略目标：造成长时间单脚支撑、漂移或关节限制越界；
+2. 按骨盆速度持续施加髋踝阻尼：能减少少量后退，但放大 tail jerk；
+3. 只调整 recovery step length/yaw：最好仅减少约 8% 后退，且 wobble 有回归；
+4. 单阶段提前切站立：可明显减小路径和后退，但把能量变成末段小抖动；
+5. 髋、踝、腰联合俯仰回正：对符号和幅值敏感，部分组合触发关节限制。
+
+这些搜索结果说明，动作自然度不能靠一个更强的阻尼或更大的站立权重解决。正确结构是“先卸动量，再独立收姿”。
+
+## 6. 最终证据与复现
+
+最终证据目录：
+
+```text
+/code/rosclaw/phase7_1_evidence/hat-trick-v7-body-effect-final/
+```
+
+最终视频：
+
+```text
+/code/rosclaw/phase7_1_evidence/hat-trick-v7-body-effect-final.mp4
+```
+
+内容哈希：
+
+```text
+report sha256: 9ff1d6ff0951214a9d4b10cd27c5bd06a4c596b17649f2747107304ca6357569
+video  sha256: f66ada799e9d1507413c00a54ee219a950d22de6035f66523549f9f5bfbdc8cd
+manifest sha256: a4b18f5aff522f2d59ee0a96f445a6c763b91c37031e5a1318e4ad95243aee93
+```
+
+复现命令：
+
+```bash
+.venv/bin/python -m rosclaw.entrypoint goalforge hat-trick run \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy \
+  --output-dir /code/rosclaw/phase7_1_evidence/hat-trick-v7-body-effect-final \
+  --source-checkout /code/rosclaw/rosclaw_test
+
+.venv/bin/python -m rosclaw.entrypoint goalforge hat-trick export \
+  /code/rosclaw/phase7_1_evidence/hat-trick-v7-body-effect-final/goalforge-hat-trick.json \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy \
+  --output /code/rosclaw/phase7_1_evidence/hat-trick-v7-body-effect-final.mp4 \
+  --source-checkout /code/rosclaw/rosclaw_test \
+  --fps 50
+```
+
+## 7. 边界与下一步
+
+本报告只证明 SIM 中、已校准的相同 Body/motion/regime 下改善成立，不声明真实 G1 已验证。当前控制仍是确定性的动作整形，不是完整的在线学习策略。
+
+下一步应在保留本阶段门禁的前提下：
+
+1. 把两阶段参数放入受约束的 continual-learning 候选空间；
+2. 在摩擦、延迟、球位、扰动方向和扰动力 holdout 上做域随机化；
+3. 学习接触后捕获步，而不是只使用固定策略帧；
+4. 将后退、侧摆、wobble、jerk 和落点共同作为多目标 replay buffer；
+5. 只有在严格 parent/candidate A/B、回滚和稳定性门禁同时通过后才晋级。

--- a/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
+++ b/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
@@ -499,6 +499,7 @@ class G1MuJoCoBackend:
                 {
                     "recovery_active": [],
                     "recovery_blend_fraction": [],
+                    "recovery_settling_fraction": [],
                     "recovery_smoothing_active": [],
                     "recovery_smoothing_residual_rms_rad": [],
                 }
@@ -557,6 +558,7 @@ class G1MuJoCoBackend:
         moving_ball_launched = scenario.ball_launch_delay_sec <= 0.0
         recovery_active = False
         recovery_blend_fraction = 0.0
+        recovery_settling_fraction = 0.0
         recovery_smoothing_active = False
         recovery_smoothing_residual_rms_rad = 0.0
 
@@ -621,6 +623,7 @@ class G1MuJoCoBackend:
                         target = recovery_effect.target
                         recovery_active = recovery_effect.active
                         recovery_blend_fraction = recovery_effect.blend_fraction
+                        recovery_settling_fraction = recovery_effect.settling_fraction
                         recovery_smoothing_active = recovery_effect.smoothing_active
                         recovery_smoothing_residual_rms_rad = (
                             recovery_effect.smoothing_residual_rms_rad
@@ -795,6 +798,7 @@ class G1MuJoCoBackend:
                     combined_residual_saturation=combined_residual_saturation,
                     recovery_active=recovery_active,
                     recovery_blend_fraction=recovery_blend_fraction,
+                    recovery_settling_fraction=recovery_settling_fraction,
                     recovery_smoothing_active=recovery_smoothing_active,
                     recovery_smoothing_residual_rms_rad=(recovery_smoothing_residual_rms_rad),
                 )
@@ -830,6 +834,7 @@ class G1MuJoCoBackend:
                 combined_residual_saturation=combined_residual_saturation,
                 recovery_active=recovery_active,
                 recovery_blend_fraction=recovery_blend_fraction,
+                recovery_settling_fraction=recovery_settling_fraction,
                 recovery_smoothing_active=recovery_smoothing_active,
                 recovery_smoothing_residual_rms_rad=recovery_smoothing_residual_rms_rad,
             )
@@ -1192,6 +1197,7 @@ def _append_trace(
     combined_residual_saturation: int = 0,
     recovery_active: bool = False,
     recovery_blend_fraction: float = 0.0,
+    recovery_settling_fraction: float = 0.0,
     recovery_smoothing_active: bool = False,
     recovery_smoothing_residual_rms_rad: float = 0.0,
 ) -> None:
@@ -1234,6 +1240,7 @@ def _append_trace(
     if "recovery_active" in trace:
         trace["recovery_active"].append(recovery_active)
         trace["recovery_blend_fraction"].append(recovery_blend_fraction)
+        trace["recovery_settling_fraction"].append(recovery_settling_fraction)
         trace["recovery_smoothing_active"].append(recovery_smoothing_active)
         trace["recovery_smoothing_residual_rms_rad"].append(recovery_smoothing_residual_rms_rad)
 

--- a/src/rosclaw/simforge/g1_cerebellar_recovery.py
+++ b/src/rosclaw/simforge/g1_cerebellar_recovery.py
@@ -27,15 +27,20 @@ _SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
 class G1CerebellarRecoveryConfig:
     """Bounded target-space recovery segment discovered by matched SIM A/B.
 
-    ``start_policy_frame=420`` begins after the original contact and recovery
-    step.  A smooth 100-frame blend avoids the unstable discontinuity produced
-    by immediately switching the whole-body policy to a standing pose.
+    The first smoothstep unloads the kick while the second, optional smoothstep
+    settles into a more upright terminal posture.  Both are contact- and
+    landing-gated, so the kick itself is never modified.
     """
 
     start_policy_frame: int = 420
     blend_frames: int = 100
     standing_pose_blend: float = 0.30
     roll_posture_bias_rad: float = -0.05
+    settling_start_policy_frame: int | None = None
+    settling_blend_frames: int = 80
+    settling_standing_pose_blend: float | None = None
+    settling_roll_posture_bias_rad: float | None = None
+    settling_waist_pitch_bias_rad: float = 0.0
     target_smoothing_alpha: float = 1.0
     target_smoothing_start_policy_frame: int = 400
     target_smoothing_joint_group: str = "upper_body"
@@ -57,6 +62,35 @@ class G1CerebellarRecoveryConfig:
             -0.08 <= self.roll_posture_bias_rad <= 0.08
         ):
             raise ValueError("roll_posture_bias_rad must be finite and in [-0.08, 0.08]")
+        settling_values = (
+            self.settling_start_policy_frame,
+            self.settling_standing_pose_blend,
+            self.settling_roll_posture_bias_rad,
+        )
+        if any(value is None for value in settling_values) and not all(
+            value is None for value in settling_values
+        ):
+            raise ValueError("settling recovery parameters must be all set or all disabled")
+        if self.settling_blend_frames <= 0:
+            raise ValueError("settling_blend_frames must be positive")
+        if self.settling_start_policy_frame is not None:
+            if self.settling_start_policy_frame < self.start_policy_frame + self.blend_frames:
+                raise ValueError("settling recovery cannot overlap the unloading blend")
+            if not 0.0 <= float(self.settling_standing_pose_blend) <= 0.50:
+                raise ValueError("settling_standing_pose_blend must be in [0, 0.50]")
+            settling_roll = float(self.settling_roll_posture_bias_rad)
+            if not math.isfinite(settling_roll) or not -0.08 <= settling_roll <= 0.08:
+                raise ValueError(
+                    "settling_roll_posture_bias_rad must be finite and in [-0.08, 0.08]"
+                )
+        if not math.isfinite(self.settling_waist_pitch_bias_rad) or not (
+            -0.12 <= self.settling_waist_pitch_bias_rad <= 0.12
+        ):
+            raise ValueError(
+                "settling_waist_pitch_bias_rad must be finite and in [-0.12, 0.12]"
+            )
+        if self.settling_start_policy_frame is None and self.settling_waist_pitch_bias_rad != 0.0:
+            raise ValueError("settling waist pitch bias requires settling recovery")
         if not 0.25 <= self.target_smoothing_alpha <= 1.0:
             raise ValueError("target_smoothing_alpha must be in [0.25, 1.0]")
         if self.target_smoothing_start_policy_frame < 0:
@@ -78,6 +112,7 @@ class G1CerebellarRecoveryEffect:
     target: np.ndarray
     active: bool
     blend_fraction: float
+    settling_fraction: float
     contact_latched: bool
     kick_foot_landing_latched: bool
     smoothing_active: bool
@@ -99,12 +134,15 @@ class G1CerebellarRecoveryReceipt:
     activation_time_sec: float | None
     smoothing_activation_policy_frame: int | None
     smoothing_activation_time_sec: float | None
+    settling_activation_policy_frame: int | None
+    settling_activation_time_sec: float | None
     peak_blend_fraction: float
+    peak_settling_fraction: float
     peak_smoothing_residual_rms_rad: float
     strict_replay: bool
     evidence_domain: str
     config: dict[str, Any]
-    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v2"
+    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v3"
 
     def to_dict(self) -> dict[str, Any]:
         value = asdict(self)
@@ -154,6 +192,7 @@ class G1CerebellarRecoveryController:
         self.standing_pose_hash = hash_bytes(np.ascontiguousarray(pose).tobytes())
         self.config = config or G1CerebellarRecoveryConfig()
         self._roll_pattern = _roll_posture_pattern()
+        self._waist_pitch_pattern = _waist_pitch_pattern()
         self.reset()
 
     @property
@@ -161,7 +200,7 @@ class G1CerebellarRecoveryController:
         return hash_json(
             {
                 "controller_type": "g1_cerebellar_post_kick_recovery",
-                "version": 2,
+                "version": 3,
                 "body_hash": self.body_hash,
                 "motion_hash": self.motion_hash,
                 "standing_pose_hash": self.standing_pose_hash,
@@ -193,8 +232,11 @@ class G1CerebellarRecoveryController:
         self._activation_time_sec: float | None = None
         self._smoothing_activation_policy_frame: int | None = None
         self._smoothing_activation_time_sec: float | None = None
+        self._settling_activation_policy_frame: int | None = None
+        self._settling_activation_time_sec: float | None = None
         self._smoothed_target: np.ndarray | None = None
         self._peak_blend_fraction = 0.0
+        self._peak_settling_fraction = 0.0
         self._peak_smoothing_residual_rms_rad = 0.0
 
     def adapt_target(
@@ -231,14 +273,44 @@ class G1CerebellarRecoveryController:
                 ),
             )
             fraction = linear * linear * (3.0 - 2.0 * linear)
-            standing_weight = fraction * self.config.standing_pose_blend
+            settling_fraction = 0.0
+            standing_pose_blend = self.config.standing_pose_blend
+            roll_posture_bias = self.config.roll_posture_bias_rad
+            if (
+                self.config.settling_start_policy_frame is not None
+                and policy_frame >= self.config.settling_start_policy_frame
+            ):
+                settling_linear = min(
+                    1.0,
+                    max(
+                        0.0,
+                        (policy_frame - self.config.settling_start_policy_frame)
+                        / self.config.settling_blend_frames,
+                    ),
+                )
+                settling_fraction = settling_linear * settling_linear * (
+                    3.0 - 2.0 * settling_linear
+                )
+                standing_pose_blend += settling_fraction * (
+                    float(self.config.settling_standing_pose_blend)
+                    - standing_pose_blend
+                )
+                roll_posture_bias += settling_fraction * (
+                    float(self.config.settling_roll_posture_bias_rad)
+                    - roll_posture_bias
+                )
+            standing_weight = fraction * standing_pose_blend
             adapted = (
                 (1.0 - standing_weight) * value
                 + standing_weight * self.standing_pose
-                + fraction * self.config.roll_posture_bias_rad * self._roll_pattern
+                + fraction * roll_posture_bias * self._roll_pattern
+                + settling_fraction
+                * self.config.settling_waist_pitch_bias_rad
+                * self._waist_pitch_pattern
             )
         else:
             fraction = 0.0
+            settling_fraction = 0.0
             adapted = value.copy()
         smoothing_active = bool(
             causal_gate
@@ -272,11 +344,16 @@ class G1CerebellarRecoveryController:
         if active and self._activation_policy_frame is None:
             self._activation_policy_frame = policy_frame
             self._activation_time_sec = timestamp_sec
+        if settling_fraction > 0.0 and self._settling_activation_policy_frame is None:
+            self._settling_activation_policy_frame = policy_frame
+            self._settling_activation_time_sec = timestamp_sec
         self._peak_blend_fraction = max(self._peak_blend_fraction, fraction)
+        self._peak_settling_fraction = max(self._peak_settling_fraction, settling_fraction)
         return G1CerebellarRecoveryEffect(
             target=adapted,
             active=active,
             blend_fraction=fraction,
+            settling_fraction=settling_fraction,
             contact_latched=self._contact_latched,
             kick_foot_landing_latched=self._landing_latched,
             smoothing_active=smoothing_active,
@@ -303,7 +380,10 @@ class G1CerebellarRecoveryController:
             activation_time_sec=self._activation_time_sec,
             smoothing_activation_policy_frame=self._smoothing_activation_policy_frame,
             smoothing_activation_time_sec=self._smoothing_activation_time_sec,
+            settling_activation_policy_frame=self._settling_activation_policy_frame,
+            settling_activation_time_sec=self._settling_activation_time_sec,
             peak_blend_fraction=self._peak_blend_fraction,
+            peak_settling_fraction=self._peak_settling_fraction,
             peak_smoothing_residual_rms_rad=self._peak_smoothing_residual_rms_rad,
             strict_replay=strict_replay,
             evidence_domain=evidence_domain,
@@ -344,6 +424,14 @@ def _roll_posture_pattern() -> np.ndarray:
     for name in ("left_ankle_roll_joint", "right_ankle_roll_joint"):
         pattern[index[name]] = -0.65
     pattern[index["waist_roll_joint"]] = 0.45
+    pattern.setflags(write=False)
+    return pattern
+
+
+def _waist_pitch_pattern() -> np.ndarray:
+    index = {name: position for position, name in enumerate(G1_DDS_JOINT_NAMES)}
+    pattern: np.ndarray = np.zeros(len(G1_DDS_JOINT_NAMES), dtype=np.float64)
+    pattern[index["waist_pitch_joint"]] = 1.0
     pattern.setflags(write=False)
     return pattern
 

--- a/src/rosclaw/simforge/g1_hat_trick.py
+++ b/src/rosclaw/simforge/g1_hat_trick.py
@@ -92,7 +92,7 @@ class GoalForgeHatTrick:
     kick_prior_hash: str
     backend_commit: str
     shots: tuple[HatTrickShot, ...]
-    schema_version: str = "rosclaw.g1_goalforge.hat_trick.v4"
+    schema_version: str = "rosclaw.g1_goalforge.hat_trick.v5"
 
     @property
     def passed(self) -> bool:
@@ -121,6 +121,8 @@ class GoalForgeHatTrick:
             and rescue.naturalness_parent_strict_replay
             and rescue.naturalness_comparison is not None
             and rescue.naturalness_comparison["passed"]
+            and rescue.recovery_receipt is not None
+            and rescue.recovery_receipt["peak_settling_fraction"] == 1.0
             and all(
                 shot.recovery_receipt is not None
                 and shot.recovery_receipt["strict_replay"]
@@ -176,6 +178,17 @@ class GoalForgeHatTrick:
                 "natural_upper_body_follow_through": bool(
                     self.shots[2].naturalness_comparison
                     and self.shots[2].naturalness_comparison["passed"]
+                ),
+                "two_stage_upright_body_recovery": bool(
+                    self.shots[2].recovery_receipt
+                    and self.shots[2].recovery_receipt["peak_settling_fraction"] == 1.0
+                ),
+                "backward_and_lateral_reversal_reduced": bool(
+                    self.shots[2].naturalness_comparison
+                    and self.shots[2].naturalness_comparison["backward_reversal_reduction"]
+                    >= 0.10
+                    and self.shots[2].naturalness_comparison["lateral_peak_return_reduction"]
+                    >= 0.15
                 ),
                 "candidate_v3_promoted": False,
                 "magnus_curve_claimed": False,
@@ -381,8 +394,8 @@ def run_goalforge_hat_trick(
         ),
         _shot(
             name="disturbance_feedback_rescue",
-            title="SHOT 3 · 80 N EVOLVED RECOVERY",
-            capability="balance_momentum_unloading_and_disturbance_recovery",
+            title="SHOT 3 · 80 N TWO-STAGE BODY RECOVERY",
+            capability="balance_unloading_upright_settling_and_disturbance_recovery",
             scenario=rescue_scenario,
             parameters=rescue_parameters,
             episode=rescue.candidate,
@@ -419,7 +432,26 @@ def _base_scenario() -> GoalForgeScenario:
 
 
 def _natural_recovery_config() -> G1CerebellarRecoveryConfig:
-    """Evolved post-contact coordination bound to the Hat Trick evidence."""
+    """Two-stage unloading and upright settling bound to matched SIM evidence."""
+
+    return G1CerebellarRecoveryConfig(
+        start_policy_frame=300,
+        blend_frames=100,
+        standing_pose_blend=0.30,
+        roll_posture_bias_rad=-0.05,
+        settling_start_policy_frame=400,
+        settling_blend_frames=100,
+        settling_standing_pose_blend=0.45,
+        settling_roll_posture_bias_rad=-0.02,
+        settling_waist_pitch_bias_rad=0.09,
+        target_smoothing_alpha=0.60,
+        target_smoothing_start_policy_frame=300,
+        target_smoothing_joint_group="upper_body",
+    )
+
+
+def _retained_natural_recovery_config() -> G1CerebellarRecoveryConfig:
+    """Immediate Phase 7.1 parent used by the body-effect promotion gate."""
 
     return G1CerebellarRecoveryConfig(
         target_smoothing_alpha=0.70,
@@ -577,9 +609,9 @@ def _run_naturalness_comparison(
     parameters: ShotParameters,
     candidate_pair: _RecoveryPair,
 ) -> _NaturalnessPair:
-    """Gate upper-body follow-through against the retained unsmoothed action."""
+    """Gate two-stage body recovery against the retained natural action."""
 
-    parent_config = G1CerebellarRecoveryConfig()
+    parent_config = _retained_natural_recovery_config()
     parent = backend.run(
         scenario,
         parameters,

--- a/src/rosclaw/simforge/g1_hat_trick_video.py
+++ b/src/rosclaw/simforge/g1_hat_trick_video.py
@@ -35,6 +35,8 @@ class HatTrickVideoClip:
     joint_jerk_reduction: float
     arm_jerk_reduction: float
     tail_joint_jerk_reduction: float
+    backward_reversal_reduction: float
+    lateral_peak_return_reduction: float
 
 
 @dataclass(frozen=True)
@@ -50,7 +52,7 @@ class HatTrickVideoResult:
     duration_sec: float
     clips: tuple[HatTrickVideoClip, ...]
     visualization_only: bool = True
-    schema_version: str = "rosclaw.g1_goalforge.hat_trick_video.v3"
+    schema_version: str = "rosclaw.g1_goalforge.hat_trick_video.v4"
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -183,16 +185,23 @@ def render_goalforge_hat_trick_video(
                 target_error_m=float(source.result["target_error_m"]),
                 ball_speed_mps=float(source.result["ball_speed_mps"]),
                 tail_wobble_reduction=float(
-                    source.momentum_comparison.get(
+                    source.naturalness_comparison.get(
                         "tail_wobble_reduction",
-                        source.recovery_comparison.get("tail_wobble_reduction", 0.0),
+                        source.momentum_comparison.get(
+                            "tail_wobble_reduction",
+                            source.recovery_comparison.get("tail_wobble_reduction", 0.0),
+                        ),
                     )
                 ),
                 pelvis_path_reduction=float(
-                    source.momentum_comparison.get("pelvis_path_reduction", 0.0)
+                    -source.naturalness_comparison["pelvis_path_regression"]
+                    if source.naturalness_comparison
+                    else source.momentum_comparison.get("pelvis_path_reduction", 0.0)
                 ),
                 pelvis_displacement_reduction=float(
-                    source.momentum_comparison.get("pelvis_displacement_reduction", 0.0)
+                    -source.naturalness_comparison["pelvis_displacement_regression"]
+                    if source.naturalness_comparison
+                    else source.momentum_comparison.get("pelvis_displacement_reduction", 0.0)
                 ),
                 joint_jerk_reduction=float(
                     source.naturalness_comparison.get("joint_jerk_reduction", 0.0)
@@ -202,6 +211,12 @@ def render_goalforge_hat_trick_video(
                 ),
                 tail_joint_jerk_reduction=float(
                     source.naturalness_comparison.get("tail_joint_jerk_reduction", 0.0)
+                ),
+                backward_reversal_reduction=float(
+                    source.naturalness_comparison.get("backward_reversal_reduction", 0.0)
+                ),
+                lateral_peak_return_reduction=float(
+                    source.naturalness_comparison.get("lateral_peak_return_reduction", 0.0)
                 ),
             )
         )
@@ -605,18 +620,19 @@ def _ffmpeg_command(
     for source, duration in zip(sources, durations, strict=True):
         end = offset + duration
         result = source.result
-        if source.momentum_comparison:
-            path_reduction = 100.0 * float(source.momentum_comparison["pelvis_path_reduction"])
-            arm_jerk_reduction = 100.0 * float(
-                source.naturalness_comparison.get("arm_joint_jerk_reduction", 0.0)
+        if source.naturalness_comparison:
+            backward_reduction = 100.0 * float(
+                source.naturalness_comparison["backward_reversal_reduction"]
             )
-            tail_jerk_reduction = 100.0 * float(
-                source.naturalness_comparison.get("tail_joint_jerk_reduction", 0.0)
+            lateral_reduction = 100.0 * float(
+                source.naturalness_comparison["lateral_peak_return_reduction"]
+            )
+            wobble_reduction = 100.0 * float(
+                source.naturalness_comparison["tail_wobble_reduction"]
             )
             metrics = (
-                f"SHOT 3 · NATURAL FOLLOW-THROUGH  ·  PATH -{path_reduction:.0f}pct  ·  "
-                f"ARM JERK -{arm_jerk_reduction:.0f}pct  ·  "
-                f"TAIL JERK -{tail_jerk_reduction:.0f}pct"
+                f"SHOT 3 · TWO-STAGE BODY RECOVERY  ·  BACKSTEP -{backward_reduction:.0f}pct  ·  "
+                f"SIDE SWAY -{lateral_reduction:.0f}pct  ·  WOBBLE -{wobble_reduction:.0f}pct"
             )
         elif float(source.scenario["target_z_m"]) >= 0.55:
             metrics = (
@@ -639,12 +655,12 @@ def _ffmpeg_command(
         )
         if source.comparison is not None:
             left_label = (
-                "V5 CONTROL · UNSMOOTHED UPPER BODY"
+                "V6 PARENT · LATE RECOVERY"
                 if source.comparison_kind == "naturalness_parent"
                 else "PARENT · LONG DRIFT / UNSAFE"
             )
             right_label = (
-                "V6 · COORDINATED FOLLOW-THROUGH"
+                "V7 · UNLOAD + UPRIGHT SETTLE"
                 if source.comparison_kind == "naturalness_parent"
                 else "EVOLVED UNLOAD · SHORT STEP + SETTLED"
             )

--- a/src/rosclaw/simforge/g1_recovery_quality.py
+++ b/src/rosclaw/simforge/g1_recovery_quality.py
@@ -37,13 +37,16 @@ class G1RecoveryQuality:
     post_contact_pelvis_path_length_m: float
     post_contact_pelvis_displacement_m: float
     post_contact_pelvis_max_excursion_m: float
+    post_contact_forward_peak_advance_m: float
+    post_contact_backward_reversal_m: float
+    post_contact_lateral_peak_return_m: float
     post_contact_support_transition_count: int
     post_contact_single_support_duration_sec: float
     bilateral_support_fraction: float
     terminal_bilateral_support: bool
     terminal_stable_duration_sec: float
     settling_time_sec: float | None
-    schema_version: str = "rosclaw.g1_goalforge.recovery_quality.v3"
+    schema_version: str = "rosclaw.g1_goalforge.recovery_quality.v4"
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -109,10 +112,12 @@ class G1NaturalnessComparison:
     pelvis_path_regression: float
     pelvis_displacement_regression: float
     tail_wobble_reduction: float
+    backward_reversal_reduction: float
+    lateral_peak_return_reduction: float
     settling_time_regression: float
     support_transition_regression: float
     reasons: tuple[str, ...]
-    schema_version: str = "rosclaw.g1_goalforge.naturalness_comparison.v1"
+    schema_version: str = "rosclaw.g1_goalforge.naturalness_comparison.v2"
 
     def to_dict(self) -> dict[str, Any]:
         value = asdict(self)
@@ -145,6 +150,7 @@ def measure_g1_recovery_quality(
         "left_foot_contact",
         "right_foot_contact",
         "contact_impulse",
+        "ball_velocity",
     }
     missing = required.difference(trajectory)
     if missing:
@@ -157,6 +163,7 @@ def measure_g1_recovery_quality(
     left_support = np.asarray(trajectory["left_foot_contact"], dtype=bool)
     right_support = np.asarray(trajectory["right_foot_contact"], dtype=bool)
     impulse = np.asarray(trajectory["contact_impulse"], dtype=np.float64)
+    ball_velocity = np.asarray(trajectory["ball_velocity"], dtype=np.float64)
     count = len(time)
     expected = {
         "torso_quaternion": (count, 4),
@@ -166,6 +173,7 @@ def measure_g1_recovery_quality(
         "left_foot_contact": (count,),
         "right_foot_contact": (count,),
         "contact_impulse": (count,),
+        "ball_velocity": (count, 3),
     }
     actual_shapes = {
         "torso_quaternion": quaternion.shape,
@@ -175,6 +183,7 @@ def measure_g1_recovery_quality(
         "left_foot_contact": left_support.shape,
         "right_foot_contact": right_support.shape,
         "contact_impulse": impulse.shape,
+        "ball_velocity": ball_velocity.shape,
     }
     invalid = [name for name, shape in expected.items() if actual_shapes[name] != shape]
     if count < 3 or time.ndim != 1 or invalid:
@@ -183,7 +192,7 @@ def measure_g1_recovery_quality(
         raise ValueError("recovery trajectory time must be strictly increasing")
     if not all(
         np.all(np.isfinite(value))
-        for value in (time, quaternion, pelvis, joint_velocity, com_y, impulse)
+        for value in (time, quaternion, pelvis, joint_velocity, com_y, impulse, ball_velocity)
     ):
         raise ValueError("recovery trajectory must contain only finite values")
     contact_indices = np.flatnonzero(np.diff(impulse, prepend=0.0) > 1e-9)
@@ -217,6 +226,17 @@ def measure_g1_recovery_quality(
     support_state = left_support.astype(np.uint8) + 2 * right_support.astype(np.uint8)
     post_xy = pelvis[contact_index:, :2]
     post_excursion = np.linalg.norm(post_xy - post_xy[0], axis=1)
+    post_relative_xy = post_xy - post_xy[0]
+    forward_axis = _planar_unit_axis(ball_velocity[contact_index, :2])
+    lateral_axis = np.asarray((-forward_axis[1], forward_axis[0]), dtype=np.float64)
+    forward_progress = post_relative_xy @ forward_axis
+    lateral_progress = post_relative_xy @ lateral_axis
+    forward_peak = float(np.max(forward_progress))
+    backward_reversal = max(0.0, forward_peak - float(forward_progress[-1]))
+    lateral_peak_return = max(
+        float(np.max(lateral_progress) - lateral_progress[-1]),
+        float(lateral_progress[-1] - np.min(lateral_progress)),
+    )
     post_path = float(np.linalg.norm(np.diff(post_xy, axis=0), axis=1).sum())
     post_displacement = float(np.linalg.norm(post_xy[-1] - post_xy[0]))
     post_support = support_state[contact_index:]
@@ -274,6 +294,9 @@ def measure_g1_recovery_quality(
         post_contact_pelvis_path_length_m=post_path,
         post_contact_pelvis_displacement_m=post_displacement,
         post_contact_pelvis_max_excursion_m=float(np.max(post_excursion)),
+        post_contact_forward_peak_advance_m=forward_peak,
+        post_contact_backward_reversal_m=backward_reversal,
+        post_contact_lateral_peak_return_m=lateral_peak_return,
         post_contact_support_transition_count=int(np.count_nonzero(np.diff(post_support))),
         post_contact_single_support_duration_sec=float(np.sum(post_dt * post_single_support[:-1])),
         bilateral_support_fraction=float(np.mean(bilateral[evaluation])),
@@ -421,6 +444,9 @@ def compare_g1_naturalness(
     minimum_waist_jerk_reduction: float = 0.02,
     minimum_arm_jerk_reduction: float = 0.05,
     minimum_tail_jerk_reduction: float = 0.10,
+    minimum_tail_wobble_reduction: float = 0.05,
+    minimum_backward_reversal_reduction: float = 0.10,
+    minimum_lateral_peak_return_reduction: float = 0.15,
     maximum_path_regression: float = 0.02,
     maximum_displacement_regression: float = 0.05,
     maximum_settling_time_regression: float = 0.02,
@@ -429,8 +455,9 @@ def compare_g1_naturalness(
 
     Jerk is derived from recorded physical joint velocity and starts one
     second after ball contact, so impact itself cannot dominate the score.
-    Small path/time allowances cover the extra body coordination, while
-    wobble and support chatter may not regress at all.
+    The immediate retained parent must be beaten on tail wobble, backward
+    reversal, and lateral peak return.  Path, settling time, and support
+    chatter retain fail-closed non-regression bounds.
     """
 
     thresholds = (
@@ -440,6 +467,9 @@ def compare_g1_naturalness(
         minimum_waist_jerk_reduction,
         minimum_arm_jerk_reduction,
         minimum_tail_jerk_reduction,
+        minimum_tail_wobble_reduction,
+        minimum_backward_reversal_reduction,
+        minimum_lateral_peak_return_reduction,
         maximum_path_regression,
         maximum_displacement_regression,
         maximum_settling_time_regression,
@@ -499,6 +529,14 @@ def compare_g1_naturalness(
         candidate.post_contact_pelvis_displacement_m,
     )
     wobble_reduction = _reduction(parent.tail_wobble_index, candidate.tail_wobble_index)
+    backward_reversal_reduction = _reduction(
+        parent.post_contact_backward_reversal_m,
+        candidate.post_contact_backward_reversal_m,
+    )
+    lateral_peak_return_reduction = _reduction(
+        parent.post_contact_lateral_peak_return_m,
+        candidate.post_contact_lateral_peak_return_m,
+    )
     settling_regression = _optional_time_regression(
         parent.settling_time_sec,
         candidate.settling_time_sec,
@@ -529,6 +567,21 @@ def compare_g1_naturalness(
         ),
         (arm_reduction, minimum_arm_jerk_reduction, "arm_jerk_reduction_below_gate"),
         (tail_reduction, minimum_tail_jerk_reduction, "tail_jerk_reduction_below_gate"),
+        (
+            wobble_reduction,
+            minimum_tail_wobble_reduction,
+            "tail_wobble_reduction_below_gate",
+        ),
+        (
+            backward_reversal_reduction,
+            minimum_backward_reversal_reduction,
+            "backward_reversal_reduction_below_gate",
+        ),
+        (
+            lateral_peak_return_reduction,
+            minimum_lateral_peak_return_reduction,
+            "lateral_peak_return_reduction_below_gate",
+        ),
     ):
         if actual < threshold:
             reasons.append(reason)
@@ -548,8 +601,6 @@ def compare_g1_naturalness(
     ):
         if actual > maximum + 1e-12:
             reasons.append(reason)
-    if wobble_reduction < 0.0:
-        reasons.append("tail_wobble_regressed")
     return G1NaturalnessComparison(
         passed=not reasons,
         goal_outcome_preserved=goal_preserved,
@@ -564,6 +615,8 @@ def compare_g1_naturalness(
         pelvis_path_regression=path_regression,
         pelvis_displacement_regression=displacement_regression,
         tail_wobble_reduction=wobble_reduction,
+        backward_reversal_reduction=backward_reversal_reduction,
+        lateral_peak_return_reduction=lateral_peak_return_reduction,
         settling_time_regression=settling_regression,
         support_transition_regression=transition_regression,
         reasons=tuple(reasons),
@@ -655,6 +708,16 @@ def _roll_pitch(quaternion_wxyz: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     roll = np.arctan2(2.0 * (w * x + y * z), 1.0 - 2.0 * (x * x + y * y))
     pitch = np.arcsin(np.clip(2.0 * (w * y - z * x), -1.0, 1.0))
     return roll, pitch
+
+
+def _planar_unit_axis(value: np.ndarray) -> np.ndarray:
+    """Normalize the observed ball travel direction into the field XY plane."""
+
+    axis = np.asarray(value, dtype=np.float64)
+    norm = float(np.linalg.norm(axis))
+    if norm <= 1e-9:
+        raise ValueError("ball contact velocity has no finite planar travel direction")
+    return axis / norm
 
 
 def _rms(value: np.ndarray) -> float:

--- a/tests/simforge/test_g1_cerebellar_recovery.py
+++ b/tests/simforge/test_g1_cerebellar_recovery.py
@@ -99,6 +99,7 @@ def test_recovery_smoothly_blends_qualified_pose_after_landing() -> None:
     assert halfway.active
     assert halfway.blend_fraction == 0.5
     assert complete.blend_fraction == 1.0
+    assert complete.settling_fraction == 0.0
     # Non-roll joints receive only the 30% standing-pose blend.
     assert complete.target[0] == 0.7
     # Left hip roll also receives the bounded -0.05 rad posture bias.
@@ -109,6 +110,40 @@ def test_recovery_smoothly_blends_qualified_pose_after_landing() -> None:
     assert receipt.activation_policy_frame == 470
     assert receipt.peak_blend_fraction == 1.0
     assert receipt.strict_replay
+
+
+def test_recovery_uses_a_second_smoothstep_for_upright_settling() -> None:
+    controller = _controller(
+        G1CerebellarRecoveryConfig(
+            start_policy_frame=100,
+            blend_frames=100,
+            standing_pose_blend=0.20,
+            roll_posture_bias_rad=0.0,
+            settling_start_policy_frame=200,
+            settling_blend_frames=100,
+            settling_standing_pose_blend=0.40,
+            settling_roll_posture_bias_rad=0.0,
+            settling_waist_pitch_bias_rad=0.09,
+        )
+    )
+    target = np.ones(29, dtype=np.float64)
+
+    halfway = controller.adapt_target(
+        target=target,
+        policy_frame=250,
+        timestamp_sec=5.0,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+    )
+
+    assert halfway.blend_fraction == 1.0
+    assert halfway.settling_fraction == 0.5
+    assert halfway.target[0] == pytest.approx(0.70)
+    assert halfway.target[14] == pytest.approx(0.745)
+    receipt = controller.build_receipt(strict_replay=True)
+    assert receipt.settling_activation_policy_frame == 250
+    assert receipt.peak_settling_fraction == 0.5
 
 
 def test_recovery_causally_smooths_only_upper_body_after_landing() -> None:
@@ -179,6 +214,30 @@ def test_recovery_quality_detects_lower_wobble_and_preserved_goal() -> None:
     assert candidate.settling_time_sec is not None
     assert candidate.post_contact_pelvis_path_length_m > 0.0
     assert candidate.post_contact_pelvis_displacement_m >= 0.0
+    assert candidate.post_contact_backward_reversal_m >= 0.0
+    assert candidate.post_contact_lateral_peak_return_m >= 0.0
+
+
+def test_recovery_quality_measures_reversal_in_the_ball_travel_frame() -> None:
+    trajectory = _trajectory(wobble_scale=0.35)
+    contact = int(np.flatnonzero(trajectory["contact_impulse"] > 0.0)[0])
+    progress = np.linspace(0.0, 1.0, len(trajectory["time"]) - contact)
+    trajectory["pelvis_pose"][contact:, 0] = np.where(
+        progress <= 0.5,
+        progress,
+        0.5 - 0.8 * (progress - 0.5),
+    )
+    trajectory["pelvis_pose"][contact:, 1] = np.where(
+        progress <= 0.5,
+        1.2 * progress,
+        0.6 - 1.6 * (progress - 0.5),
+    )
+
+    quality = measure_g1_recovery_quality(trajectory)
+
+    assert quality.post_contact_forward_peak_advance_m == pytest.approx(0.5, abs=0.01)
+    assert quality.post_contact_backward_reversal_m == pytest.approx(0.4, abs=0.01)
+    assert quality.post_contact_lateral_peak_return_m == pytest.approx(0.8, abs=0.01)
 
 
 def test_momentum_unloading_gate_requires_measured_motion_and_replay_gains() -> None:
@@ -259,6 +318,8 @@ def test_naturalness_gate_requires_jerk_gains_without_stability_regression() -> 
         post_contact_pelvis_path_length_m=1.86,
         post_contact_pelvis_displacement_m=0.50,
         post_contact_support_transition_count=49,
+        post_contact_backward_reversal_m=0.60,
+        post_contact_lateral_peak_return_m=0.85,
         tail_wobble_index=0.124,
         settling_time_sec=4.26,
     )
@@ -272,7 +333,9 @@ def test_naturalness_gate_requires_jerk_gains_without_stability_regression() -> 
         tail_joint_jerk_rms_rad_s3=1.04,
         post_contact_pelvis_path_length_m=1.875,
         post_contact_pelvis_displacement_m=0.52,
-        tail_wobble_index=0.122,
+        post_contact_backward_reversal_m=0.49,
+        post_contact_lateral_peak_return_m=0.61,
+        tail_wobble_index=0.115,
         settling_time_sec=4.30,
     )
     result = _successful_result(target_error_m=0.13, ball_speed_mps=5.6)
@@ -297,6 +360,8 @@ def test_naturalness_gate_requires_jerk_gains_without_stability_regression() -> 
     assert promoted.passed
     assert promoted.arm_joint_jerk_reduction == pytest.approx(0.0875)
     assert promoted.tail_joint_jerk_reduction > 0.15
+    assert promoted.backward_reversal_reduction > 0.15
+    assert promoted.lateral_peak_return_reduction > 0.25
     assert not rejected.passed
     assert "arm_jerk_reduction_below_gate" in rejected.reasons
 
@@ -381,6 +446,8 @@ def _trajectory(*, wobble_scale: float) -> dict[str, np.ndarray]:
     )
     impulse = np.zeros(count, dtype=np.float64)
     impulse[contact_index:] = 1.0
+    ball_velocity = np.zeros((count, 3), dtype=np.float64)
+    ball_velocity[contact_index:, 0] = 1.0
     return {
         "time": time,
         "torso_quaternion": quaternion,
@@ -390,6 +457,7 @@ def _trajectory(*, wobble_scale: float) -> dict[str, np.ndarray]:
         "left_foot_contact": np.ones(count, dtype=bool),
         "right_foot_contact": np.ones(count, dtype=bool),
         "contact_impulse": impulse,
+        "ball_velocity": ball_velocity,
     }
 
 


### PR DESCRIPTION
## What changed

- replace the late single-stage G1 recovery with contact/landing-gated unloading plus upright settling
- record the second-stage fraction and receipt activation evidence
- measure backward reversal and lateral peak return in the observed ball-travel frame
- require matched parent/candidate gains in wobble, backward motion, lateral sway, jerk, safety, and strict replay
- update Hat Trick evidence/video schemas and add a detailed validation report

## Root cause

The retained kick prior kept driving recovery after the kick foot landed, while the standing blend started only after the pelvis had already reversed. Earlier starts reduced drift but could convert momentum into tail jitter or a quiet backward lean. The selected controller first unloads the kick, then gradually increases standing authority and applies a bounded waist-pitch correction.

## Verified impact (80 N matched SIM A/B)

- backward reversal: -13.2%
- lateral peak return: -29.3%
- pelvis path: -13.8%
- final pelvis displacement: -49.3%
- support transitions: -24.5%
- whole-body jerk: -12.8%
- arm jerk: -30.9%
- tail jerk: -18.2%
- tail wobble: -10.3%
- ball speed and target error unchanged; no fall or limit violation; strict replay passed

## Checks

- `python -m pytest -q tests/simforge -m 'not integration and not gpu'` — 103 passed, 1 skipped, 3 deselected
- `python -m ruff check src/rosclaw/simforge tests/simforge`
- focused mypy on the five changed SimForge source modules
- full three-shot GoalForge Hat Trick run and 50 fps evidence video export

Evidence remains SIM-only; this PR makes no real-hardware claim.
