### PR TITLE
Harden continual evidence and G1 recovery proofs

### DIFF
--- a/src/rosclaw/continual/experience.py
+++ b/src/rosclaw/continual/experience.py
@@ -63,6 +63,7 @@ class ExperienceRecord:
     partition: ExperiencePartition
     anchor_policy_hash: str | None = None
     boundary_reason: str | None = None
+    boundary_request_hash: str | None = None
     self_change_hash: str | None = None
     near_boundary_score: float = 0.0
     schema_version: str = "rosclaw.continual.experience_record.v1"
@@ -77,10 +78,13 @@ class ExperienceRecord:
                 raise ValueError("boundary experience requires a reason")
             if not self.trajectory.has_critical_cost and self.near_boundary_score < 0.80:
                 raise ValueError("boundary experience requires a safety event or near miss")
+        elif self.boundary_request_hash is not None:
+            raise ValueError("only boundary experience may bind a boundary replay request")
         if self.partition is ExperiencePartition.SELF and not self.self_change_hash:
             raise ValueError("self experience requires a body-change commitment")
         for label, value in (
             ("anchor_policy_hash", self.anchor_policy_hash),
+            ("boundary_request_hash", self.boundary_request_hash),
             ("self_change_hash", self.self_change_hash),
         ):
             if value is not None and not _SHA256.fullmatch(value):
@@ -91,7 +95,7 @@ class ExperienceRecord:
         return canonical_hash(self.to_dict())
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        value = {
             "schema_version": self.schema_version,
             "trajectory_hash": self.trajectory.trajectory_hash,
             "partition": self.partition.value,
@@ -100,6 +104,11 @@ class ExperienceRecord:
             "self_change_hash": self.self_change_hash,
             "near_boundary_score": self.near_boundary_score,
         }
+        # Preserve hashes of legacy v1 records while binding queue-backed
+        # completions to the exact request commitment when one is present.
+        if self.boundary_request_hash is not None:
+            value["boundary_request_hash"] = self.boundary_request_hash
+        return value
 
 
 @dataclass(frozen=True)

--- a/src/rosclaw/continual/serde.py
+++ b/src/rosclaw/continual/serde.py
@@ -33,16 +33,7 @@ def experience_record_to_dict(record: ExperienceRecord) -> dict[str, Any]:
     return {
         "schema_version": _RECORD_ENVELOPE_SCHEMA,
         "trajectory": record.trajectory.to_dict(),
-        "record": {
-            "schema_version": record.schema_version,
-            "partition": record.partition.value,
-            "anchor_policy_hash": record.anchor_policy_hash,
-            "boundary_reason": record.boundary_reason,
-            "self_change_hash": record.self_change_hash,
-            "near_boundary_score": record.near_boundary_score,
-            "trajectory_hash": record.trajectory.trajectory_hash,
-            "record_hash": record.record_hash,
-        },
+        "record": _record_summary(record),
     }
 
 
@@ -60,6 +51,7 @@ def experience_record_from_dict(value: Mapping[str, Any]) -> ExperienceRecord:
         partition=ExperiencePartition(str(item["partition"])),
         anchor_policy_hash=_optional_string(item.get("anchor_policy_hash")),
         boundary_reason=_optional_string(item.get("boundary_reason")),
+        boundary_request_hash=_optional_string(item.get("boundary_request_hash")),
         self_change_hash=_optional_string(item.get("self_change_hash")),
         near_boundary_score=float(item["near_boundary_score"]),
     )
@@ -86,19 +78,7 @@ def experience_batch_to_dict(batch: ExperienceBatch) -> dict[str, Any]:
         },
         "permitted_uses": [item.value for item in batch.permitted_uses],
         "trajectories": dict(sorted(trajectories.items())),
-        "records": [
-            {
-                "schema_version": record.schema_version,
-                "partition": record.partition.value,
-                "anchor_policy_hash": record.anchor_policy_hash,
-                "boundary_reason": record.boundary_reason,
-                "self_change_hash": record.self_change_hash,
-                "near_boundary_score": record.near_boundary_score,
-                "trajectory_hash": record.trajectory.trajectory_hash,
-                "record_hash": record.record_hash,
-            }
-            for record in batch.records
-        ],
+        "records": [_record_summary(record) for record in batch.records],
         "batch_hash": batch.batch_hash,
     }
 
@@ -132,6 +112,7 @@ def experience_batch_from_dict(value: Mapping[str, Any]) -> ExperienceBatch:
             partition=ExperiencePartition(str(item["partition"])),
             anchor_policy_hash=_optional_string(item.get("anchor_policy_hash")),
             boundary_reason=_optional_string(item.get("boundary_reason")),
+            boundary_request_hash=_optional_string(item.get("boundary_request_hash")),
             self_change_hash=_optional_string(item.get("self_change_hash")),
             near_boundary_score=float(item["near_boundary_score"]),
         )
@@ -152,6 +133,22 @@ def experience_batch_from_dict(value: Mapping[str, Any]) -> ExperienceBatch:
     if value.get("batch_hash") != batch.batch_hash:
         raise ValueError("experience batch hash mismatch")
     return batch
+
+
+def _record_summary(record: ExperienceRecord) -> dict[str, Any]:
+    value = {
+        "schema_version": record.schema_version,
+        "partition": record.partition.value,
+        "anchor_policy_hash": record.anchor_policy_hash,
+        "boundary_reason": record.boundary_reason,
+        "self_change_hash": record.self_change_hash,
+        "near_boundary_score": record.near_boundary_score,
+        "trajectory_hash": record.trajectory.trajectory_hash,
+        "record_hash": record.record_hash,
+    }
+    if record.boundary_request_hash is not None:
+        value["boundary_request_hash"] = record.boundary_request_hash
+    return value
 
 
 def _trajectory(value: Mapping[str, Any]) -> VersionedTrajectory:

--- a/src/rosclaw/continual/services/experience.py
+++ b/src/rosclaw/continual/services/experience.py
@@ -20,6 +20,7 @@ from rosclaw.continual.services.persistence import (
     DurableEventLog,
     require_external_service_root,
 )
+from rosclaw.feedback.contracts import canonical_hash
 
 
 class ExperienceService:
@@ -38,6 +39,7 @@ class ExperienceService:
         self.store = ContinualExperienceStore(config)
         self._records: dict[str, ExperienceRecord] = {}
         self._boundary: dict[str, tuple[BoundaryReplayRequest, str | None]] = {}
+        self._legacy_completion_quarantine_count = 0
         self._database = sqlite3.connect(self.root / "catalog.sqlite3")
         self._database.execute("PRAGMA journal_mode=WAL")
         self._database.execute("PRAGMA synchronous=FULL")
@@ -91,11 +93,24 @@ class ExperienceService:
             raise ValueError("boundary completion requires a Boundary experience record")
         if not record.trajectory.strict_replay:
             raise ValueError("boundary completion requires strict replay")
+        _validate_boundary_completion(
+            request_hash=request_hash,
+            request=entry[0],
+            record=record,
+        )
         if record.record_hash not in self._records:
             self.append(record)
         event = self.log.append(
             "BOUNDARY_COMPLETED",
-            {"request_hash": request_hash, "record_hash": record.record_hash},
+            {
+                "request_hash": request_hash,
+                "request_commitment": entry[0].request_hash,
+                "record_hash": record.record_hash,
+                "completion_commitment": _boundary_completion_commitment(
+                    request_hash=request_hash,
+                    record_hash=record.record_hash,
+                ),
+            },
         )
         self._apply(event.kind, dict(event.payload))
 
@@ -124,6 +139,7 @@ class ExperienceService:
                 partition.value: count for partition, count in self.store.counts().items()
             },
             "pending_boundary_count": len(self.pending_boundary_requests),
+            "legacy_completion_quarantine_count": self._legacy_completion_quarantine_count,
             "registry_write_count": 0,
             "dds_opened": False,
             "hardware_authorized": False,
@@ -195,6 +211,30 @@ class ExperienceService:
             request, completed = self._boundary[request_hash]
             if completed is not None:
                 raise ValueError("append-only log completes a boundary request more than once")
+            expected_completion = _boundary_completion_commitment(
+                request_hash=request_hash,
+                record_hash=record_hash,
+            )
+            if (
+                payload.get("request_commitment") != request.request_hash
+                or payload.get("completion_commitment") != expected_completion
+            ):
+                # Pre-hardening completions cannot prove which queued request
+                # their record satisfied.  Keep the request pending and repair
+                # only the derived SQLite cache; immutable log truth is retained.
+                with self._database:
+                    self._database.execute(
+                        "UPDATE boundary_requests SET completed_record_hash=NULL "
+                        "WHERE request_hash=?",
+                        (request_hash,),
+                    )
+                self._legacy_completion_quarantine_count += 1
+                return
+            _validate_boundary_completion(
+                request_hash=request_hash,
+                request=request,
+                record=self._records[record_hash],
+            )
             with self._database:
                 self._database.execute(
                     "UPDATE boundary_requests SET completed_record_hash=? WHERE request_hash=?",
@@ -298,6 +338,45 @@ def _boundary_request(value: Mapping[str, Any]) -> BoundaryReplayRequest:
     if value.get("request_hash") != request.request_hash:
         raise ValueError("boundary replay request hash mismatch")
     return request
+
+
+def _validate_boundary_completion(
+    *,
+    request_hash: str,
+    request: BoundaryReplayRequest,
+    record: ExperienceRecord,
+) -> None:
+    if record.boundary_request_hash != request_hash:
+        raise ValueError("boundary completion record does not bind its request commitment")
+    trajectory = record.trajectory
+    first = trajectory.segments[0]
+    if first.episode_id != request.scenario_id:
+        raise ValueError("boundary completion episode does not match its request")
+    if first.regime_hash != request.scenario_commitment:
+        raise ValueError("boundary completion scenario commitment does not match its request")
+    if trajectory.policy.version_hash != request.candidate_policy_hash:
+        raise ValueError("boundary completion must replay the request's candidate policy")
+    cost_names = {
+        "fall": "fall",
+        "joint_limit": "joint_limit",
+        "torque_limit": "torque",
+    }
+    for signal in request.critical_signals:
+        cost_name = cost_names.get(signal)
+        if cost_name is None or not any(
+            getattr(segment.cost, cost_name) > 0.0 for segment in trajectory.segments
+        ):
+            raise ValueError(f"boundary completion does not reproduce critical signal: {signal}")
+
+
+def _boundary_completion_commitment(*, request_hash: str, record_hash: str) -> str:
+    return canonical_hash(
+        {
+            "schema_version": "rosclaw.continual.boundary_completion.v2",
+            "request_hash": request_hash,
+            "record_hash": record_hash,
+        }
+    )
 
 
 __all__ = ["ExperienceService"]

--- a/src/rosclaw/continual/services/rollout.py
+++ b/src/rosclaw/continual/services/rollout.py
@@ -158,6 +158,8 @@ class RolloutService:
             raise ValueError("rollout changed policy version inside a pinned assignment")
         if trajectory.policy.body_hash != item.body_hash:
             raise ValueError("rollout trajectory Body does not match its assignment")
+        if trajectory.segments[0].regime_hash != item.scenario_commitment:
+            raise ValueError("rollout trajectory scenario does not match its assignment")
         if not trajectory.strict_replay:
             raise ValueError("rollout service accepts only strict-replay trajectories")
         event = self.log.append(

--- a/src/rosclaw/self_model/prediction_monitor.py
+++ b/src/rosclaw/self_model/prediction_monitor.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import math
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
 from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 class AdaptationState(StrEnum):
@@ -201,6 +204,32 @@ class AdaptationTrigger:
             else "matched evaluation rejected the candidate"
         )
         return self._receipt(previous, reason)
+
+    def close_cycle(self, *, completion_evidence_hash: str) -> AdaptationReceipt:
+        """Leave a terminal state only after content-addressed completion evidence.
+
+        ROLLBACK and CONSOLIDATED remain fail-closed terminal states until the
+        caller supplies the immutable receipt proving that rollback or champion
+        consolidation actually completed.  Closing a cycle resets only the
+        persistence counters; the lifetime observation count remains auditable.
+        """
+
+        if self.state not in {AdaptationState.CONSOLIDATED, AdaptationState.ROLLBACK}:
+            raise RuntimeError("only a terminal adaptation cycle may be closed")
+        if not _SHA256.fullmatch(completion_evidence_hash):
+            raise ValueError("adaptation completion evidence must be a sha256 content hash")
+        previous = self.state
+        outcome = "consolidation" if previous is AdaptationState.CONSOLIDATED else "rollback"
+        self.state = AdaptationState.NORMAL
+        receipt = self._receipt(
+            previous,
+            f"verified {outcome} closed the adaptation cycle: {completion_evidence_hash}",
+        )
+        self._suspected = 0
+        self._confirmed = 0
+        self._recovered = 0
+        self._last_score = 0.0
+        return receipt
 
     def score(self, residuals: PredictionResiduals) -> float:
         values = residuals.components().values()

--- a/src/rosclaw/simforge/g1_cerebellar_recovery.py
+++ b/src/rosclaw/simforge/g1_cerebellar_recovery.py
@@ -74,11 +74,16 @@ class G1CerebellarRecoveryConfig:
         if self.settling_blend_frames <= 0:
             raise ValueError("settling_blend_frames must be positive")
         if self.settling_start_policy_frame is not None:
+            if (
+                self.settling_standing_pose_blend is None
+                or self.settling_roll_posture_bias_rad is None
+            ):
+                raise ValueError("enabled settling recovery requires complete parameters")
             if self.settling_start_policy_frame < self.start_policy_frame + self.blend_frames:
                 raise ValueError("settling recovery cannot overlap the unloading blend")
-            if not 0.0 <= float(self.settling_standing_pose_blend) <= 0.50:
+            if not 0.0 <= self.settling_standing_pose_blend <= 0.50:
                 raise ValueError("settling_standing_pose_blend must be in [0, 0.50]")
-            settling_roll = float(self.settling_roll_posture_bias_rad)
+            settling_roll = self.settling_roll_posture_bias_rad
             if not math.isfinite(settling_roll) or not -0.08 <= settling_roll <= 0.08:
                 raise ValueError(
                     "settling_roll_posture_bias_rad must be finite and in [-0.08, 0.08]"
@@ -86,9 +91,7 @@ class G1CerebellarRecoveryConfig:
         if not math.isfinite(self.settling_waist_pitch_bias_rad) or not (
             -0.12 <= self.settling_waist_pitch_bias_rad <= 0.12
         ):
-            raise ValueError(
-                "settling_waist_pitch_bias_rad must be finite and in [-0.12, 0.12]"
-            )
+            raise ValueError("settling_waist_pitch_bias_rad must be finite and in [-0.12, 0.12]")
         if self.settling_start_policy_frame is None and self.settling_waist_pitch_bias_rad != 0.0:
             raise ValueError("settling waist pitch bias requires settling recovery")
         if not 0.25 <= self.target_smoothing_alpha <= 1.0:
@@ -122,6 +125,7 @@ class G1CerebellarRecoveryEffect:
 @dataclass(frozen=True)
 class G1CerebellarRecoveryReceipt:
     controller_hash: str
+    config_hash: str
     body_hash: str
     motion_hash: str
     standing_pose_hash: str
@@ -142,7 +146,7 @@ class G1CerebellarRecoveryReceipt:
     strict_replay: bool
     evidence_domain: str
     config: dict[str, Any]
-    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v3"
+    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v4"
 
     def to_dict(self) -> dict[str, Any]:
         value = asdict(self)
@@ -194,6 +198,15 @@ class G1CerebellarRecoveryController:
         self._roll_pattern = _roll_posture_pattern()
         self._waist_pitch_pattern = _waist_pitch_pattern()
         self.reset()
+
+    @property
+    def config_hash(self) -> str:
+        return hash_json(
+            {
+                "schema_version": "rosclaw.g1_goalforge.cerebellar_recovery_config.v1",
+                "config": asdict(self.config),
+            }
+        )
 
     @property
     def controller_hash(self) -> str:
@@ -280,6 +293,10 @@ class G1CerebellarRecoveryController:
                 self.config.settling_start_policy_frame is not None
                 and policy_frame >= self.config.settling_start_policy_frame
             ):
+                settling_standing_pose_blend = self.config.settling_standing_pose_blend
+                settling_roll_posture_bias = self.config.settling_roll_posture_bias_rad
+                if settling_standing_pose_blend is None or settling_roll_posture_bias is None:
+                    raise RuntimeError("validated settling recovery config became incomplete")
                 settling_linear = min(
                     1.0,
                     max(
@@ -288,16 +305,14 @@ class G1CerebellarRecoveryController:
                         / self.config.settling_blend_frames,
                     ),
                 )
-                settling_fraction = settling_linear * settling_linear * (
-                    3.0 - 2.0 * settling_linear
+                settling_fraction = (
+                    settling_linear * settling_linear * (3.0 - 2.0 * settling_linear)
                 )
                 standing_pose_blend += settling_fraction * (
-                    float(self.config.settling_standing_pose_blend)
-                    - standing_pose_blend
+                    settling_standing_pose_blend - standing_pose_blend
                 )
                 roll_posture_bias += settling_fraction * (
-                    float(self.config.settling_roll_posture_bias_rad)
-                    - roll_posture_bias
+                    settling_roll_posture_bias - roll_posture_bias
                 )
             standing_weight = fraction * standing_pose_blend
             adapted = (
@@ -368,6 +383,7 @@ class G1CerebellarRecoveryController:
     ) -> G1CerebellarRecoveryReceipt:
         return G1CerebellarRecoveryReceipt(
             controller_hash=self.controller_hash,
+            config_hash=self.config_hash,
             body_hash=self.body_hash,
             motion_hash=self.motion_hash,
             standing_pose_hash=self.standing_pose_hash,

--- a/src/rosclaw/simforge/g1_hat_trick.py
+++ b/src/rosclaw/simforge/g1_hat_trick.py
@@ -123,6 +123,14 @@ class GoalForgeHatTrick:
             and rescue.naturalness_comparison["passed"]
             and rescue.recovery_receipt is not None
             and rescue.recovery_receipt["peak_settling_fraction"] == 1.0
+            and rescue.momentum_evolution.get("recovery_controller_hash")
+            == rescue.recovery_receipt.get("controller_hash")
+            and rescue.momentum_evolution.get("recovery_config_hash")
+            == rescue.recovery_receipt.get("config_hash")
+            and rescue.momentum_route_receipt.get("recovery_controller_hash")
+            == rescue.recovery_receipt.get("controller_hash")
+            and rescue.momentum_route_receipt.get("recovery_config_hash")
+            == rescue.recovery_receipt.get("config_hash")
             and all(
                 shot.recovery_receipt is not None
                 and shot.recovery_receipt["strict_replay"]
@@ -185,8 +193,7 @@ class GoalForgeHatTrick:
                 ),
                 "backward_and_lateral_reversal_reduced": bool(
                     self.shots[2].naturalness_comparison
-                    and self.shots[2].naturalness_comparison["backward_reversal_reduction"]
-                    >= 0.10
+                    and self.shots[2].naturalness_comparison["backward_reversal_reduction"] >= 0.10
                     and self.shots[2].naturalness_comparison["lateral_peak_return_reduction"]
                     >= 0.15
                 ),
@@ -579,9 +586,17 @@ def _run_momentum_evolution(
         parent_strict_replay=parent_strict,
         candidate_strict_replay=candidate_pair.candidate_strict_replay,
     )
+    candidate_controller_hash = str(candidate_pair.recovery_receipt["controller_hash"])
+    candidate_config_hash = str(candidate_pair.recovery_receipt["config_hash"])
+    if candidate_controller_hash != parent_recovery.controller_hash:
+        raise RuntimeError("momentum evolution recovery controller hash mismatch")
+    if candidate_config_hash != parent_recovery.config_hash:
+        raise RuntimeError("momentum evolution recovery config hash mismatch")
     evolution = G1MomentumUnloadingEvolution.evaluate(
         body_hash=backend.qualification.body_hash,
         kick_prior_hash=backend.qualification.kick_prior_hash,
+        recovery_controller_hash=candidate_controller_hash,
+        recovery_config_hash=candidate_config_hash,
         regime_commitment=scenario.scenario_commitment,
         parent=parent_parameters,
         candidate=candidate_parameters,

--- a/src/rosclaw/simforge/g1_hat_trick_video.py
+++ b/src/rosclaw/simforge/g1_hat_trick_video.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 import subprocess
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, BinaryIO, cast
@@ -127,41 +128,44 @@ def render_goalforge_hat_trick_video(
         comparison_data = mujoco.MjData(model)
         renderer = mujoco.Renderer(model, height=_RENDER_HEIGHT, width=_RENDER_WIDTH)
         try:
-            process = subprocess.Popen(
-                _ffmpeg_command(
-                    ffmpeg=ffmpeg,
-                    output=output,
-                    fps=fps,
-                    sources=sources,
-                    durations=durations,
-                ),
-                stdin=subprocess.PIPE,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-            )
-            if process.stdin is None:
-                raise RuntimeError("ffmpeg raw-video pipe is unavailable")
-            try:
-                _write_frames(
-                    mujoco=mujoco,
-                    model=model,
-                    data=data,
-                    comparison_data=comparison_data,
-                    renderer=renderer,
-                    sources=sources,
-                    timelines=timelines,
-                    stream=cast(BinaryIO, process.stdin),
+            with tempfile.TemporaryDirectory(prefix="rosclaw-hat-trick-drawtext-") as text_root:
+                metric_files = _write_metric_text_files(Path(text_root), sources)
+                process = subprocess.Popen(
+                    _ffmpeg_command(
+                        ffmpeg=ffmpeg,
+                        output=output,
+                        fps=fps,
+                        sources=sources,
+                        durations=durations,
+                        metric_files=metric_files,
+                    ),
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
                 )
-            except BaseException:
+                if process.stdin is None:
+                    raise RuntimeError("ffmpeg raw-video pipe is unavailable")
+                try:
+                    _write_frames(
+                        mujoco=mujoco,
+                        model=model,
+                        data=data,
+                        comparison_data=comparison_data,
+                        renderer=renderer,
+                        sources=sources,
+                        timelines=timelines,
+                        stream=cast(BinaryIO, process.stdin),
+                    )
+                except BaseException:
+                    process.stdin.close()
+                    process.kill()
+                    process.wait()
+                    raise
                 process.stdin.close()
-                process.kill()
-                process.wait()
-                raise
-            process.stdin.close()
-            stderr = process.stderr.read().decode(errors="replace") if process.stderr else ""
-            code = process.wait()
-            if code:
-                raise RuntimeError(f"Hat Trick ffmpeg failed ({code}): {stderr[-2000:]}")
+                stderr = process.stderr.read().decode(errors="replace") if process.stderr else ""
+                code = process.wait()
+                if code:
+                    raise RuntimeError(f"Hat Trick ffmpeg failed ({code}): {stderr[-2000:]}")
         finally:
             renderer.close()
     finally:
@@ -513,7 +517,7 @@ def _sample_trajectory(
 
 
 def _interpolate_pose(left: np.ndarray, right: np.ndarray, ratio: float) -> np.ndarray:
-    result = np.empty(7, dtype=np.float64)
+    result: np.ndarray = np.empty(7, dtype=np.float64)
     result[:3] = _lerp(left[:3], right[:3], ratio)
     result[3:] = _slerp_wxyz(left[3:], right[3:], ratio)
     return result
@@ -607,50 +611,26 @@ def _ffmpeg_command(
     fps: int,
     sources: tuple[_Source, ...],
     durations: tuple[float, ...],
+    metric_files: tuple[Path, ...],
 ) -> list[str]:
+    if len(metric_files) != len(sources):
+        raise ValueError("Hat Trick drawtext files must align with video sources")
     font = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf")
-    font_option = f"fontfile={font}:" if font.is_file() else ""
+    font_option = f"fontfile={_escape_filtergraph_option(str(font))}:" if font.is_file() else ""
     filters = [
         "drawbox=x=0:y=0:w=iw:h=112:color=0x050A12@0.78:t=fill",
         "drawbox=x=0:y=h-70:w=iw:h=70:color=0x050A12@0.78:t=fill",
-        f"drawtext={font_option}text='ROSClaw GoalForge Hat Trick':x=34:y=18:fontsize=36:fontcolor=white",
-        f"drawtext={font_option}text='SIM EVIDENCE REPLAY · VISUALIZATION ONLY':x=34:y=h-46:fontsize=22:fontcolor=0x8DD8FF",
+        f"drawtext={font_option}text={_escape_filtergraph_option('ROSClaw GoalForge Hat Trick')}:"
+        "expansion=none:x=34:y=18:fontsize=36:fontcolor=white",
+        f"drawtext={font_option}text={_escape_filtergraph_option('SIM EVIDENCE REPLAY · VISUALIZATION ONLY')}:"
+        "expansion=none:x=34:y=h-46:fontsize=22:fontcolor=0x8DD8FF",
     ]
     offset = 0.0
-    for source, duration in zip(sources, durations, strict=True):
+    for source, duration, metric_file in zip(sources, durations, metric_files, strict=True):
         end = offset + duration
-        result = source.result
-        if source.naturalness_comparison:
-            backward_reduction = 100.0 * float(
-                source.naturalness_comparison["backward_reversal_reduction"]
-            )
-            lateral_reduction = 100.0 * float(
-                source.naturalness_comparison["lateral_peak_return_reduction"]
-            )
-            wobble_reduction = 100.0 * float(
-                source.naturalness_comparison["tail_wobble_reduction"]
-            )
-            metrics = (
-                f"SHOT 3 · TWO-STAGE BODY RECOVERY  ·  BACKSTEP -{backward_reduction:.0f}pct  ·  "
-                f"SIDE SWAY -{lateral_reduction:.0f}pct  ·  WOBBLE -{wobble_reduction:.0f}pct"
-            )
-        elif float(source.scenario["target_z_m"]) >= 0.55:
-            metrics = (
-                f"{source.title}  ·  HIGH TARGET {float(source.scenario['target_z_m']):.2f} m  ·  "
-                f"{float(result['ball_speed_mps']):.2f} m/s  ·  "
-                f"error {float(result['target_error_m']):.3f} m"
-            )
-        else:
-            wobble_reduction = 100.0 * float(
-                source.recovery_comparison.get("tail_wobble_reduction", 0.0)
-            )
-            metrics = (
-                f"{source.title}  ·  {float(result['ball_speed_mps']):.2f} m/s  ·  "
-                f"error {float(result['target_error_m']):.3f} m  ·  "
-                f"RECOVERY WOBBLE -{wobble_reduction:.0f} pct"
-            )
         filters.append(
-            f"drawtext={font_option}text='{metrics}':x=34:y=68:fontsize=22:"
+            f"drawtext={font_option}textfile={_escape_filtergraph_option(str(metric_file))}:"
+            "expansion=none:x=34:y=68:fontsize=22:"
             f"fontcolor=0x65F59A:enable='between(t,{offset:.6f},{end:.6f})'"
         )
         if source.comparison is not None:
@@ -666,8 +646,10 @@ def _ffmpeg_command(
             )
             filters.extend(
                 (
-                    f"drawtext={font_option}text='{left_label}':x=105:y=145:fontsize=20:fontcolor=0xFFB45F:enable='between(t,{offset:.6f},{end:.6f})'",
-                    f"drawtext={font_option}text='{right_label}':x=735:y=145:fontsize=20:fontcolor=0x65F59A:enable='between(t,{offset:.6f},{end:.6f})'",
+                    f"drawtext={font_option}text={_escape_filtergraph_option(left_label)}:"
+                    f"expansion=none:x=105:y=145:fontsize=20:fontcolor=0xFFB45F:enable='between(t,{offset:.6f},{end:.6f})'",
+                    f"drawtext={font_option}text={_escape_filtergraph_option(right_label)}:"
+                    f"expansion=none:x=735:y=145:fontsize=20:fontcolor=0x65F59A:enable='between(t,{offset:.6f},{end:.6f})'",
                 )
             )
         offset = end
@@ -701,6 +683,57 @@ def _ffmpeg_command(
         "+faststart",
         str(output),
     ]
+
+
+def _write_metric_text_files(root: Path, sources: tuple[_Source, ...]) -> tuple[Path, ...]:
+    root.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for index, source in enumerate(sources):
+        path = root / f"metrics-{index}.txt"
+        path.write_text(_metric_text(source), encoding="utf-8")
+        paths.append(path)
+    return tuple(paths)
+
+
+def _metric_text(source: _Source) -> str:
+    result = source.result
+    if source.naturalness_comparison:
+        backward_reduction = 100.0 * float(
+            source.naturalness_comparison["backward_reversal_reduction"]
+        )
+        lateral_reduction = 100.0 * float(
+            source.naturalness_comparison["lateral_peak_return_reduction"]
+        )
+        wobble_reduction = 100.0 * float(source.naturalness_comparison["tail_wobble_reduction"])
+        return (
+            f"SHOT 3 · TWO-STAGE BODY RECOVERY  ·  BACKSTEP -{backward_reduction:.0f}pct  ·  "
+            f"SIDE SWAY -{lateral_reduction:.0f}pct  ·  WOBBLE -{wobble_reduction:.0f}pct"
+        )
+    if float(source.scenario["target_z_m"]) >= 0.55:
+        return (
+            f"{source.title}  ·  HIGH TARGET {float(source.scenario['target_z_m']):.2f} m  ·  "
+            f"{float(result['ball_speed_mps']):.2f} m/s  ·  "
+            f"error {float(result['target_error_m']):.3f} m"
+        )
+    wobble_reduction = 100.0 * float(source.recovery_comparison.get("tail_wobble_reduction", 0.0))
+    return (
+        f"{source.title}  ·  {float(result['ball_speed_mps']):.2f} m/s  ·  "
+        f"error {float(result['target_error_m']):.3f} m  ·  "
+        f"RECOVERY WOBBLE -{wobble_reduction:.0f} pct"
+    )
+
+
+def _escape_filtergraph_option(value: str) -> str:
+    """Apply FFmpeg's option-value and filtergraph escaping layers.
+
+    The command is passed as an argv sequence, so shell escaping is neither
+    necessary nor desirable here.
+    """
+
+    def escape_level(text: str, special: str) -> str:
+        return "".join(("\\" + char) if char in special else char for char in text)
+
+    return escape_level(escape_level(value, "\\':"), "\\'[],;")
 
 
 def _hash_file(path: Path) -> str:

--- a/src/rosclaw/simforge/g1_recovery_evolution.py
+++ b/src/rosclaw/simforge/g1_recovery_evolution.py
@@ -31,6 +31,8 @@ class G1RecoveryEvolutionDecision(StrEnum):
 @dataclass(frozen=True)
 class G1RecoveryRouteReceipt:
     candidate_hash: str
+    recovery_controller_hash: str
+    recovery_config_hash: str
     evaluated_regime_commitment: str
     promoted_regime_commitment: str
     selected_policy_hash: str
@@ -39,7 +41,7 @@ class G1RecoveryRouteReceipt:
     fallback_reason: str | None
     evidence_domain: str = "SIM"
     hardware_command_sent: bool = False
-    schema_version: str = "rosclaw.g1_goalforge.recovery_route_receipt.v1"
+    schema_version: str = "rosclaw.g1_goalforge.recovery_route_receipt.v2"
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -49,6 +51,8 @@ class G1RecoveryRouteReceipt:
 class G1MomentumUnloadingEvolution:
     body_hash: str
     kick_prior_hash: str
+    recovery_controller_hash: str
+    recovery_config_hash: str
     regime_commitment: str
     parent: ShotParameters
     candidate: ShotParameters
@@ -57,12 +61,14 @@ class G1MomentumUnloadingEvolution:
     comparison: G1MomentumUnloadingComparison
     decision: G1RecoveryEvolutionDecision
     activation_ceiling: str = "SIM_ONLY"
-    schema_version: str = "rosclaw.g1_goalforge.momentum_unloading_evolution.v1"
+    schema_version: str = "rosclaw.g1_goalforge.momentum_unloading_evolution.v2"
 
     def __post_init__(self) -> None:
         for label, value in (
             ("body_hash", self.body_hash),
             ("kick_prior_hash", self.kick_prior_hash),
+            ("recovery_controller_hash", self.recovery_controller_hash),
+            ("recovery_config_hash", self.recovery_config_hash),
             ("regime_commitment", self.regime_commitment),
         ):
             if not _SHA256.fullmatch(value):
@@ -85,6 +91,8 @@ class G1MomentumUnloadingEvolution:
         *,
         body_hash: str,
         kick_prior_hash: str,
+        recovery_controller_hash: str,
+        recovery_config_hash: str,
         regime_commitment: str,
         parent: ShotParameters,
         candidate: ShotParameters,
@@ -100,6 +108,8 @@ class G1MomentumUnloadingEvolution:
         return cls(
             body_hash=body_hash,
             kick_prior_hash=kick_prior_hash,
+            recovery_controller_hash=recovery_controller_hash,
+            recovery_config_hash=recovery_config_hash,
             regime_commitment=regime_commitment,
             parent=parent,
             candidate=candidate,
@@ -133,6 +143,8 @@ class G1MomentumUnloadingEvolution:
         )
         receipt = G1RecoveryRouteReceipt(
             candidate_hash=self.candidate_hash,
+            recovery_controller_hash=self.recovery_controller_hash,
+            recovery_config_hash=self.recovery_config_hash,
             evaluated_regime_commitment=regime_commitment,
             promoted_regime_commitment=self.regime_commitment,
             selected_policy_hash=selected.policy_hash,
@@ -147,6 +159,8 @@ class G1MomentumUnloadingEvolution:
             "schema_version": self.schema_version,
             "body_hash": self.body_hash,
             "kick_prior_hash": self.kick_prior_hash,
+            "recovery_controller_hash": self.recovery_controller_hash,
+            "recovery_config_hash": self.recovery_config_hash,
             "regime_commitment": self.regime_commitment,
             "parent": self.parent.to_dict(),
             "candidate": self.candidate.to_dict(),

--- a/tests/continual/helpers.py
+++ b/tests/continual/helpers.py
@@ -37,8 +37,16 @@ def trajectory(
     *,
     episode: str = "episode-1",
     critical: bool = False,
+    regime_hash: str | None = None,
 ) -> VersionedTrajectory:
-    first = segment(value, episode=episode, start=0, end=1, phase=SkillPhase.PREPARE)
+    first = segment(
+        value,
+        episode=episode,
+        start=0,
+        end=1,
+        phase=SkillPhase.PREPARE,
+        regime_hash=regime_hash,
+    )
     final = segment(
         value,
         episode=episode,
@@ -47,6 +55,7 @@ def trajectory(
         phase=SkillPhase.RECOVERY,
         terminal=True,
         critical=critical,
+        regime_hash=regime_hash,
     )
     return VersionedTrajectory((first, final), strict_replay=True)
 
@@ -60,6 +69,7 @@ def segment(
     phase: SkillPhase,
     terminal: bool = False,
     critical: bool = False,
+    regime_hash: str | None = None,
 ) -> ControlSegment:
     return ControlSegment(
         segment_id=f"{episode}:{start}",
@@ -71,7 +81,7 @@ def segment(
         policy=value,
         controller_snapshot_hash=value.controller_snapshot_hash,
         body_hash=value.body_hash,
-        regime_hash=digest("regime"),
+        regime_hash=regime_hash or digest("regime"),
         self_state_hash=digest("self-state"),
         observation={"roll": 0.1, "pitch": -0.1},
         residual_action={"pelvis_roll": -0.01},

--- a/tests/continual/test_experience.py
+++ b/tests/continual/test_experience.py
@@ -61,6 +61,16 @@ def test_boundary_buffer_rejects_ordinary_non_boundary_rollout() -> None:
         )
 
 
+def test_non_boundary_record_rejects_boundary_request_commitment() -> None:
+    v0, _ = policy(0)
+    with pytest.raises(ValueError, match="only boundary"):
+        ExperienceRecord(
+            trajectory(v0),
+            ExperiencePartition.RECENT,
+            boundary_request_hash=digest("boundary-request"),
+        )
+
+
 def test_replay_fails_closed_until_all_partitions_exist() -> None:
     v0, _ = policy(0)
     store = ContinualExperienceStore()

--- a/tests/continual/test_serde.py
+++ b/tests/continual/test_serde.py
@@ -7,7 +7,12 @@ import pytest
 
 from rosclaw.continual.contracts import ExperiencePartition
 from rosclaw.continual.experience import ContinualExperienceStore, ExperienceRecord
-from rosclaw.continual.serde import experience_batch_from_dict, experience_batch_to_dict
+from rosclaw.continual.serde import (
+    experience_batch_from_dict,
+    experience_batch_to_dict,
+    experience_record_from_dict,
+    experience_record_to_dict,
+)
 from tests.continual.helpers import digest, policy, trajectory
 
 
@@ -62,3 +67,19 @@ def test_experience_batch_codec_rejects_tampered_transition() -> None:
 
     with pytest.raises(ValueError, match="trajectory hash mismatch"):
         experience_batch_from_dict(envelope)
+
+
+def test_boundary_request_commitment_survives_record_codec() -> None:
+    v0, _ = policy(0)
+    request_hash = digest("boundary-request")
+    record = ExperienceRecord(
+        trajectory(v0, episode="boundary-bound", critical=True),
+        ExperiencePartition.BOUNDARY,
+        boundary_reason="fall replay",
+        boundary_request_hash=request_hash,
+    )
+
+    restored = experience_record_from_dict(experience_record_to_dict(record))
+
+    assert restored.record_hash == record.record_hash
+    assert restored.boundary_request_hash == request_hash

--- a/tests/continual/test_services.py
+++ b/tests/continual/test_services.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from rosclaw.continual.boundary_feedback import BoundaryReplayRequest
-from rosclaw.continual.contracts import ExperiencePartition, SkillPhase
+from rosclaw.continual.contracts import ExperiencePartition, PolicyVersion, SkillPhase
 from rosclaw.continual.experience import (
     ContinualExperienceStore,
     ExperienceRecord,
@@ -93,17 +93,18 @@ def test_rollout_recovery_aborts_motion_and_never_replays_actions(tmp_path: Path
 
 def test_rollout_completes_only_matching_strict_versioned_trajectory(tmp_path: Path) -> None:
     parent, _ = policy(0)
+    scenario_commitment = digest("scenario-2")
     service = RolloutService(tmp_path, source_checkout=_source_checkout())
     assignment = service.assign(
         episode_id="kick-2",
-        scenario_commitment=digest("scenario-2"),
+        scenario_commitment=scenario_commitment,
         policy=parent,
     )
     service.start(assignment.assignment_id, worker_id="sim-worker-0")
 
     completed = service.complete(
         assignment.assignment_id,
-        trajectory=trajectory(parent, episode="kick-2"),
+        trajectory=trajectory(parent, episode="kick-2", regime_hash=scenario_commitment),
     )
 
     assert completed.state is RolloutState.COMPLETE
@@ -113,12 +114,13 @@ def test_rollout_completes_only_matching_strict_versioned_trajectory(tmp_path: P
 
 def test_experience_service_recovers_catalog_and_boundary_queue(tmp_path: Path) -> None:
     parent, records, _ = _four_partition_store()
+    candidate, _ = policy(1, parent=parent)
     request = BoundaryReplayRequest(
         scenario_id="unsafe-seed-7",
         scenario_commitment=digest("scenario-7"),
         replay_partition="boundary",
         parent_policy_hash=parent.version_hash,
-        candidate_policy_hash=digest("candidate-version"),
+        candidate_policy_hash=candidate.version_hash,
         parent_status="PASS",
         candidate_status="SAFETY_ABORT",
         critical_signals=("fall",),
@@ -136,9 +138,15 @@ def test_experience_service_recovers_catalog_and_boundary_queue(tmp_path: Path) 
         recovered.complete_boundary(
             request.request_hash,
             record=ExperienceRecord(
-                trajectory(parent, episode="boundary-rerollout", critical=True),
+                trajectory(
+                    candidate,
+                    episode=request.scenario_id,
+                    critical=True,
+                    regime_hash=request.scenario_commitment,
+                ),
                 ExperiencePartition.BOUNDARY,
                 boundary_reason="reproduced matched-evaluation fall",
+                boundary_request_hash=request.request_hash,
             ),
         )
 
@@ -146,6 +154,138 @@ def test_experience_service_recovers_catalog_and_boundary_queue(tmp_path: Path) 
         assert second["catalog_counts"] == first["catalog_counts"]
         assert len(recovered.pending_boundary_requests) == 0
         assert recovered.audit_receipt()["hardware_authorized"] is False
+
+
+def test_boundary_completion_rejects_unbound_or_mismatched_evidence(tmp_path: Path) -> None:
+    parent, _ = policy(0)
+    candidate, _ = policy(1, parent=parent)
+    request = BoundaryReplayRequest(
+        scenario_id="unsafe-seed-9",
+        scenario_commitment=digest("scenario-9"),
+        replay_partition="recent",
+        parent_policy_hash=parent.version_hash,
+        candidate_policy_hash=candidate.version_hash,
+        parent_status="PASS",
+        candidate_status="SAFETY_ABORT",
+        critical_signals=("fall",),
+        source_evidence_hash=digest("matched-evidence-9"),
+    )
+    service = ExperienceService(tmp_path, source_checkout=_source_checkout())
+    service.enqueue_boundary(request)
+
+    def record(
+        *,
+        policy_value: PolicyVersion = candidate,
+        episode: str = request.scenario_id,
+        regime_hash: str = request.scenario_commitment,
+        request_hash: str | None = request.request_hash,
+        critical: bool = True,
+    ) -> ExperienceRecord:
+        return ExperienceRecord(
+            trajectory(
+                policy_value,
+                episode=episode,
+                critical=critical,
+                regime_hash=regime_hash,
+            ),
+            ExperiencePartition.BOUNDARY,
+            boundary_reason="candidate fall replay",
+            boundary_request_hash=request_hash,
+            near_boundary_score=0.9 if not critical else 0.0,
+        )
+
+    with pytest.raises(ValueError, match="request commitment"):
+        service.complete_boundary(request.request_hash, record=record(request_hash=None))
+    with pytest.raises(ValueError, match="episode"):
+        service.complete_boundary(request.request_hash, record=record(episode="wrong-seed"))
+    with pytest.raises(ValueError, match="scenario commitment"):
+        service.complete_boundary(request.request_hash, record=record(regime_hash=digest("wrong")))
+    with pytest.raises(ValueError, match="candidate policy"):
+        service.complete_boundary(request.request_hash, record=record(policy_value=parent))
+    with pytest.raises(ValueError, match="critical signal"):
+        service.complete_boundary(request.request_hash, record=record(critical=False))
+
+    assert service.pending_boundary_requests == (request,)
+    service.close()
+
+
+def test_legacy_unbound_boundary_completion_is_quarantined_and_requeued(
+    tmp_path: Path,
+) -> None:
+    parent, _ = policy(0)
+    candidate, _ = policy(1, parent=parent)
+    request = BoundaryReplayRequest(
+        scenario_id="legacy-unsafe-seed",
+        scenario_commitment=digest("legacy-scenario"),
+        replay_partition="boundary",
+        parent_policy_hash=parent.version_hash,
+        candidate_policy_hash=candidate.version_hash,
+        parent_status="PASS",
+        candidate_status="SAFETY_ABORT",
+        critical_signals=("fall",),
+        source_evidence_hash=digest("legacy-source-evidence"),
+    )
+    legacy_record = ExperienceRecord(
+        trajectory(
+            candidate,
+            episode=request.scenario_id,
+            critical=True,
+            regime_hash=request.scenario_commitment,
+        ),
+        ExperiencePartition.BOUNDARY,
+        boundary_reason="legacy candidate fall replay",
+    )
+    with ExperienceService(tmp_path, source_checkout=_source_checkout()) as service:
+        service.enqueue_boundary(request)
+        service.append(legacy_record)
+
+    log = DurableEventLog(tmp_path / "experience" / "journal", service="experience")
+    log.append(
+        "BOUNDARY_COMPLETED",
+        {"request_hash": request.request_hash, "record_hash": legacy_record.record_hash},
+    )
+    database = sqlite3.connect(tmp_path / "experience" / "catalog.sqlite3")
+    with database:
+        database.execute(
+            "UPDATE boundary_requests SET completed_record_hash=? WHERE request_hash=?",
+            (legacy_record.record_hash, request.request_hash),
+        )
+    database.close()
+
+    with ExperienceService(tmp_path, source_checkout=_source_checkout()) as recovered:
+        receipt = recovered.audit_receipt()
+        assert recovered.pending_boundary_requests == (request,)
+        assert receipt["legacy_completion_quarantine_count"] == 1
+        recovered.complete_boundary(
+            request.request_hash,
+            record=ExperienceRecord(
+                legacy_record.trajectory,
+                ExperiencePartition.BOUNDARY,
+                boundary_reason="bound candidate fall replay",
+                boundary_request_hash=request.request_hash,
+            ),
+        )
+
+    with ExperienceService(tmp_path, source_checkout=_source_checkout()) as recovered_again:
+        assert recovered_again.pending_boundary_requests == ()
+        assert recovered_again.audit_receipt()["legacy_completion_quarantine_count"] == 1
+
+
+def test_rollout_rejects_trajectory_from_another_scenario(tmp_path: Path) -> None:
+    parent, _ = policy(0)
+    service = RolloutService(tmp_path, source_checkout=_source_checkout())
+    assignment = service.assign(
+        episode_id="kick-scenario-boundary",
+        scenario_commitment=digest("assigned-scenario"),
+        policy=parent,
+    )
+    service.start(assignment.assignment_id, worker_id="sim-worker-0")
+
+    with pytest.raises(ValueError, match="scenario"):
+        service.complete(
+            assignment.assignment_id,
+            trajectory=trajectory(parent, episode=assignment.episode_id),
+        )
 
 
 def test_experience_recovery_rejects_corrupted_catalog_row(tmp_path: Path) -> None:

--- a/tests/self_model/test_operational_self.py
+++ b/tests/self_model/test_operational_self.py
@@ -180,6 +180,68 @@ def test_adaptation_trigger_requires_retention_before_consolidation() -> None:
     assert consolidated.state is AdaptationState.CONSOLIDATED
 
 
+def test_adaptation_terminal_cycles_require_evidence_before_reopening() -> None:
+    completion_hash = "sha256:" + "a" * 64
+    trigger = AdaptationTrigger(
+        AdaptationTriggerConfig(
+            suspected_persistence=1,
+            confirmed_persistence=1,
+            shadow_min_samples=1,
+        )
+    )
+    with pytest.raises(RuntimeError, match="terminal"):
+        trigger.close_cycle(completion_evidence_hash=completion_hash)
+
+    trigger.observe(_residual(0.6))
+    trigger.observe(_residual(0.8))
+    trigger.begin_shadow_learning()
+    trigger.candidate_update(
+        sample_count=1,
+        target_improvement=0.2,
+        anchor_degradation=0.0,
+        critical_safety_regressions=0,
+        converged=True,
+    )
+    trigger.consolidate(matched_gate_passed=False)
+    with pytest.raises(ValueError, match="sha256"):
+        trigger.close_cycle(completion_evidence_hash="operator said rollback completed")
+
+    receipt = trigger.close_cycle(completion_evidence_hash=completion_hash)
+
+    assert receipt.previous_state is AdaptationState.ROLLBACK
+    assert receipt.state is AdaptationState.NORMAL
+    assert completion_hash in receipt.reason
+    assert trigger.state is AdaptationState.NORMAL
+    trigger.observe(_residual(0.6))
+    assert trigger.state is AdaptationState.SUSPECTED_SHIFT
+
+
+def test_consolidated_cycle_can_close_with_champion_commitment() -> None:
+    trigger = AdaptationTrigger(
+        AdaptationTriggerConfig(
+            suspected_persistence=1,
+            confirmed_persistence=1,
+            shadow_min_samples=1,
+        )
+    )
+    trigger.observe(_residual(0.6))
+    trigger.observe(_residual(0.8))
+    trigger.begin_shadow_learning()
+    trigger.candidate_update(
+        sample_count=1,
+        target_improvement=0.2,
+        anchor_degradation=0.0,
+        critical_safety_regressions=0,
+        converged=True,
+    )
+    trigger.consolidate(matched_gate_passed=True)
+
+    receipt = trigger.close_cycle(completion_evidence_hash="sha256:" + "b" * 64)
+
+    assert receipt.previous_state is AdaptationState.CONSOLIDATED
+    assert receipt.state is AdaptationState.NORMAL
+
+
 def _regime_observation(
     episode_id: str,
     support_friction: float,

--- a/tests/simforge/test_g1_cerebellar_recovery.py
+++ b/tests/simforge/test_g1_cerebellar_recovery.py
@@ -105,6 +105,8 @@ def test_recovery_smoothly_blends_qualified_pose_after_landing() -> None:
     # Left hip roll also receives the bounded -0.05 rad posture bias.
     assert complete.target[1] == pytest.approx(0.65)
     receipt = controller.build_receipt(strict_replay=True)
+    assert receipt.controller_hash == controller.controller_hash
+    assert receipt.config_hash == controller.config_hash
     assert receipt.contact_latched
     assert receipt.kick_foot_landing_latched
     assert receipt.activation_policy_frame == 470
@@ -287,6 +289,8 @@ def test_momentum_unloading_gate_requires_measured_motion_and_replay_gains() -> 
     evolution = G1MomentumUnloadingEvolution.evaluate(
         body_hash=_HASH_A,
         kick_prior_hash=_HASH_B,
+        recovery_controller_hash="sha256:" + "6" * 64,
+        recovery_config_hash="sha256:" + "7" * 64,
         regime_commitment="sha256:" + "4" * 64,
         parent=ShotParameters(),
         candidate=ShotParameters(stance_offset_y=-0.08, swing_amplitude=1.125),
@@ -300,10 +304,15 @@ def test_momentum_unloading_gate_requires_measured_motion_and_replay_gains() -> 
     assert evolution.decision is G1RecoveryEvolutionDecision.SIM_CHAMPION
     assert selected.policy_hash == evolution.candidate.policy_hash
     assert selected_receipt.used_candidate
+    assert selected_receipt.recovery_controller_hash == evolution.recovery_controller_hash
+    assert selected_receipt.recovery_config_hash == evolution.recovery_config_hash
     assert fallback.policy_hash == evolution.parent.policy_hash
     assert not fallback_receipt.used_candidate
     assert fallback_receipt.fallback_reason == "out_of_evidence_regime"
     assert fallback_receipt.rollback_target_hash == evolution.parent.policy_hash
+    assert replace(evolution, recovery_config_hash="sha256:" + "8" * 64).candidate_hash != (
+        evolution.candidate_hash
+    )
 
 
 def test_naturalness_gate_requires_jerk_gains_without_stability_regression() -> None:

--- a/tests/simforge/test_g1_hat_trick_video.py
+++ b/tests/simforge/test_g1_hat_trick_video.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import shutil
+import subprocess
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 from rosclaw.simforge.g1_hat_trick_video import (
+    _escape_filtergraph_option,
+    _ffmpeg_command,
     _load_trajectory,
     _sample_trajectory,
     _slerp_wxyz,
+    _Source,
+    _write_metric_text_files,
 )
 
 
@@ -57,3 +63,57 @@ def test_hat_trick_video_rejects_non_monotonic_evidence_time(tmp_path: Path) -> 
 
     with pytest.raises(ValueError, match="strictly increasing"):
         _load_trajectory(path)
+
+
+def test_filtergraph_option_escaping_matches_ffmpeg_two_level_rules() -> None:
+    assert (
+        _escape_filtergraph_option("this is a 'string': may contain one, or more")
+        == r"this is a \\\'string\\\'\\: may contain one\, or more"
+    )
+
+
+def test_hat_trick_video_uses_textfile_for_untrusted_titles(tmp_path: Path) -> None:
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        pytest.skip("ffmpeg is unavailable")
+    dangerous_title = "A:B,C;D[E]'F\\G%{n}\nSECOND LINE"
+    source = _Source(
+        name="escaping",
+        title=dangerous_title,
+        result={"ball_speed_mps": 6.2, "target_error_m": 0.1},
+        scenario={"target_z_m": 0.6},
+        trajectory_hash="sha256:" + "1" * 64,
+        trajectory={},
+        comparison=None,
+        recovery_metrics={},
+        recovery_comparison={},
+        momentum_comparison={},
+        naturalness_comparison={},
+        comparison_kind=None,
+    )
+    metric_files = _write_metric_text_files(tmp_path / "drawtext", (source,))
+    output = tmp_path / "escaped-title.mp4"
+    command = _ffmpeg_command(
+        ffmpeg=ffmpeg,
+        output=output,
+        fps=10,
+        sources=(source,),
+        durations=(0.1,),
+        metric_files=metric_files,
+    )
+    filtergraph = command[command.index("-vf") + 1]
+
+    assert dangerous_title not in filtergraph
+    assert "textfile=" in filtergraph
+    assert "expansion=none" in filtergraph
+    assert dangerous_title in metric_files[0].read_text(encoding="utf-8")
+
+    completed = subprocess.run(
+        command,
+        input=np.zeros((720, 1280, 3), dtype=np.uint8).tobytes(),
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    assert output.is_file() and output.stat().st_size > 0


### PR DESCRIPTION
## Outcome

Closes the four post-merge hardening follow-ups without opening any hardware or DDS path.

## Hardening

- add evidence-bound exits from terminal continual-adaptation states
- bind boundary replay completions to the exact request, scenario, policy, episode, and reproduced safety signals
- quarantine legacy unbound completion events while preserving immutable logs and re-queueing derived state
- bind rollout trajectories to their assigned scenario commitment
- bind G1 recovery evolution and route receipts to the exact controller and full configuration hashes
- move dynamic FFmpeg drawtext content to UTF-8 text files with expansion disabled and apply both documented filter escaping layers to static values

## Validation

- 5353 passed, 71 skipped, 28 deselected in a clean HOME environment
- 166 passed, 1 skipped, 3 deselected across simforge, continual, and self-model suites
- 75 focused tests passed
- Ruff check and format check passed
- strict mypy passed for all 9 changed source modules
- compileall and diff checks passed
- actual local FFmpeg malicious-title regression passed

## Safety

SIM/test only. No real robot, DDS, registry write, or hardware command was enabled.