### PR TITLE
feat(memory): session envelope backfill closes distill→RegimeMatcher link

### DIFF
--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -8912,7 +8912,7 @@ def main() -> int:
             handler = getattr(args, "handler", None)
             if handler is not None:
                 return handler(args)
-            print("regime requires a subcommand: status|explain|replay|transitions")
+            print("regime requires a subcommand: status|explain|replay|transitions|build-envelopes")
             return 1
         elif args.command == "memory":
             v2_handler = getattr(args, "v2_handler", None)

--- a/src/rosclaw/memory/v2/regime/cli.py
+++ b/src/rosclaw/memory/v2/regime/cli.py
@@ -140,6 +140,35 @@ def cmd_regime_transitions(args: argparse.Namespace) -> int:
     return cmd_regime_replay(args)
 
 
+def cmd_regime_build_envelopes(args: argparse.Namespace) -> int:
+    """Backfill OBSERVED applicability envelopes for the memories
+    distilled from one practice session (v4 §5 — closes the
+    distill → matcher link on real corpora)."""
+    from rosclaw.storage.factory import StorageFactory
+
+    from .session_envelopes import build_session_envelopes
+
+    backend = getattr(args, "backend", None) or None
+    url = getattr(args, "seekdb_url", None) or None
+    store = StorageFactory.create_knowledge_store(
+        backend=backend or ("seekdb_server" if url else "sqlite"),
+        url=url,
+        path=getattr(args, "v2_path", None),
+    )
+    try:
+        result = build_session_envelopes(
+            args.session_dir,
+            store,
+            hand=getattr(args, "hand", "right"),
+        )
+    finally:
+        close = getattr(store, "close", None)
+        if callable(close):
+            close()
+    _emit(result)
+    return 0 if result.get("ok") else 1
+
+
 def register_regime_commands(subparsers: Any) -> None:
     """Register the ``rosclaw regime`` command group."""
     parser = subparsers.add_parser("regime", help="Operating regime inspection (v4, PR-MEM-6)")
@@ -170,3 +199,14 @@ def register_regime_commands(subparsers: Any) -> None:
     _common(p)
     p.add_argument("--practice-id", default=None)
     p.set_defaults(handler=cmd_regime_transitions)
+
+    p = regime_sub.add_parser(
+        "build-envelopes",
+        help="Backfill OBSERVED applicability envelopes from one session's telemetry",
+    )
+    p.add_argument("session_dir", help="Practice session directory (contains raw/events.jsonl)")
+    p.add_argument("--hand", choices=["left", "right"], default="right")
+    p.add_argument("--backend", default=None, help="Knowledge-store backend (default: sqlite)")
+    p.add_argument("--seekdb-url", default=None, help="SeekDB server DSN (implies seekdb_server)")
+    p.add_argument("--v2-path", default=None, help="SQLite knowledge store path")
+    p.set_defaults(handler=cmd_regime_build_envelopes)

--- a/src/rosclaw/memory/v2/regime/matcher.py
+++ b/src/rosclaw/memory/v2/regime/matcher.py
@@ -131,14 +131,17 @@ def interval_distance(
 ) -> float | None:
     """Normalized distance to an interval (v4 §6.2).
 
-    ``None`` value → ``None`` (unknown is not a match, never a zero).
-    Unbounded interval → 0.  Inside → 0.  Outside → distance to the
-    nearest boundary, normalized by ``scale``.
+    Unbounded interval → 0 (no constraint — neutral even when the regime
+    value is unknown; an unconstrained feature must never block
+    applicability on bodies whose telemetry never reports it, e.g. RH56
+    has no position_error_p95).  Bounded with unknown value → ``None``
+    (unknown is not a match, never a zero).  Inside → 0.  Outside →
+    distance to the nearest boundary, normalized by ``scale``.
     """
-    if value is None:
-        return None
     if low is None and high is None:
         return 0.0
+    if value is None:
+        return None
     if low is not None and value < low:
         return (low - value) / scale
     if high is not None and value > high:

--- a/src/rosclaw/memory/v2/regime/session_envelopes.py
+++ b/src/rosclaw/memory/v2/regime/session_envelopes.py
@@ -1,0 +1,317 @@
+"""Session-aggregated OBSERVED applicability envelopes (v4 §5 backfill).
+
+The distill pipeline stores memories carrying regime metadata
+(``metadata.temperature_c`` …), but until this module nothing ever wrote
+the ``memory_applicability`` rows the :class:`RegimeMatcher` matches
+against — so on real corpora every intervention candidate had zero
+envelopes and the matcher answered "not applicable" for all of them.  The
+self-loop was inert: the system recorded its thermal regime everywhere
+except the one table that gates regime-aware intervention.
+
+This module closes that link honestly:
+
+* per session, extract only the regime features the hardware ACTUALLY
+  measured (temperature from ``health_check`` events via
+  :mod:`.session_samples`, invalid rate + action count from resolved
+  rounds, elapsed time from round timestamps).  Features the session
+  never recorded stay unbounded and never enter ``required_features`` —
+  unknown is not wildcard, and a zero-width invented interval would be
+  worse than no constraint;
+* per memory distilled from that session, merge the session into ONE
+  aggregated OBSERVED envelope: ranges widen monotonically,
+  ``evidence_count`` grows once per DISTINCT session (``evidence_refs``
+  carry the practice_id, so re-running the same session is a no-op),
+  ``required_features`` is the intersection of what every merged session
+  measured.
+
+OBSERVED envelopes can never reach the APPLY rung on their own — the
+matcher's ``type_factor`` (0.8) caps them below the validated band.
+They make memories *addressable* by the regime matcher without
+self-certifying them.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .envelope import ApplicabilityEnvelope, EnvelopeType
+from .persistence import ApplicabilityStore
+from .session_samples import extract_samples, load_session_events
+
+BUILDER_TAG = "session_envelope_backfill"
+
+# Matcher regime-feature names this builder can supply (v4 §6.2), mapped
+# to the envelope bounds they feed.
+_MEASURED_FEATURES = (
+    "temperature_c",
+    "temperature_slope_c_per_min",
+    "session_elapsed_sec",
+    "cumulative_action_count",
+    "recent_failure_rate",
+)
+
+
+@dataclass(frozen=True)
+class SessionEnvelopeFeatures:
+    """The regime features one session actually measured."""
+
+    temperature_min: float | None = None
+    temperature_max: float | None = None
+    temperature_slope: float | None = None  # °C per minute, first→last
+    elapsed_sec: float | None = None
+    action_count: int | None = None
+    invalid_rate: float | None = None
+    rounds: int = 0
+    measured: tuple[str, ...] = field(default_factory=tuple)
+
+
+def features_from_samples(samples: list[Any]) -> SessionEnvelopeFeatures:
+    """Aggregate round-level :class:`TelemetrySample` rows into session
+    envelope features.  Missing data stays ``None`` — never invented."""
+    if not samples:
+        return SessionEnvelopeFeatures()
+    temps = [s.temperature_c for s in samples if s.temperature_c is not None]
+    started = samples[0].timestamp
+    ended = samples[-1].timestamp
+    elapsed = max(0.0, ended - started) if ended >= started else None
+    rounds = len(samples)
+    invalid_rate = sum(1 for s in samples if s.invalid) / rounds if rounds else None
+    slope: float | None = None
+    if len(temps) >= 2 and elapsed and elapsed >= 60.0:
+        slope = (temps[-1] - temps[0]) / (elapsed / 60.0)
+
+    measured: list[str] = []
+    if temps:
+        measured.append("temperature_c")
+    if slope is not None:
+        measured.append("temperature_slope_c_per_min")
+    if elapsed is not None:
+        measured.append("session_elapsed_sec")
+    if rounds:
+        measured.append("cumulative_action_count")
+    if invalid_rate is not None:
+        measured.append("recent_failure_rate")
+
+    return SessionEnvelopeFeatures(
+        temperature_min=min(temps) if temps else None,
+        temperature_max=max(temps) if temps else None,
+        temperature_slope=slope,
+        elapsed_sec=elapsed,
+        action_count=rounds or None,
+        invalid_rate=invalid_rate,
+        rounds=rounds,
+        measured=tuple(measured),
+    )
+
+
+def _widen(
+    lo: float | None, hi: float | None, value: float | None
+) -> tuple[float | None, float | None]:
+    """Widen a [lo, hi] interval to include ``value`` (None = no data)."""
+    if value is None:
+        return lo, hi
+    return (
+        value if lo is None else min(lo, value),
+        value if hi is None else max(hi, value),
+    )
+
+
+def envelope_from_session(
+    memory: dict[str, Any],
+    features: SessionEnvelopeFeatures,
+    *,
+    practice_id: str,
+    now: float | None = None,
+) -> ApplicabilityEnvelope:
+    """Create the first aggregated OBSERVED envelope for one memory from
+    one session's measured features."""
+    measured = list(features.measured)
+    return ApplicabilityEnvelope(
+        memory_id=str(memory["id"]),
+        body_ids=[str(memory["body_id"])] if memory.get("body_id") else [],
+        task_ids=[str(memory["task_id"])] if memory.get("task_id") else [],
+        skill_ids=[str(memory["skill_id"])] if memory.get("skill_id") else [],
+        gestures=[str(memory["gesture_name"])] if memory.get("gesture_name") else [],
+        joints=[str(memory["joint_name"])] if memory.get("joint_name") else [],
+        failure_types=[str(memory["failure_type"])] if memory.get("failure_type") else [],
+        temperature_min=features.temperature_min,
+        temperature_max=features.temperature_max,
+        temperature_slope_min=features.temperature_slope,
+        temperature_slope_max=features.temperature_slope,
+        elapsed_sec_min=0.0 if features.elapsed_sec is not None else None,
+        elapsed_sec_max=features.elapsed_sec,
+        action_count_min=0 if features.action_count is not None else None,
+        action_count_max=features.action_count,
+        recent_failure_rate_min=features.invalid_rate,
+        recent_failure_rate_max=features.invalid_rate,
+        envelope_type=EnvelopeType.OBSERVED.value,
+        evidence_count=1,
+        success_count=0 if memory.get("outcome") == "failure" else 1,
+        failure_count=1 if memory.get("outcome") == "failure" else 0,
+        confidence=_confidence(1),
+        required_features=measured,
+        reason=BUILDER_TAG,
+        evidence_refs=[practice_id],
+        created_at=now if now is not None else time.time(),
+        updated_at=now if now is not None else time.time(),
+    )
+
+
+def merge_session_into_envelope(
+    envelope: ApplicabilityEnvelope,
+    features: SessionEnvelopeFeatures,
+    *,
+    practice_id: str,
+    outcome: str | None = None,
+) -> bool:
+    """Merge one more session into an aggregated envelope in place.
+
+    Returns False (no-op) when this session is already counted —
+    idempotency is by practice_id in ``evidence_refs``.
+    """
+    if practice_id in envelope.evidence_refs:
+        return False
+    lo, hi = _widen(envelope.temperature_min, envelope.temperature_max, features.temperature_min)
+    lo, hi = _widen(lo, hi, features.temperature_max)
+    envelope.temperature_min, envelope.temperature_max = lo, hi
+    envelope.temperature_slope_min, envelope.temperature_slope_max = _widen(
+        envelope.temperature_slope_min, envelope.temperature_slope_max, features.temperature_slope
+    )
+    if features.elapsed_sec is not None:
+        envelope.elapsed_sec_min, envelope.elapsed_sec_max = _widen(
+            envelope.elapsed_sec_min, envelope.elapsed_sec_max, features.elapsed_sec
+        )
+    if features.action_count is not None:
+        lo, hi = _widen(
+            float(envelope.action_count_min) if envelope.action_count_min is not None else None,
+            float(envelope.action_count_max) if envelope.action_count_max is not None else None,
+            float(features.action_count),
+        )
+        envelope.action_count_min = int(lo) if lo is not None else None
+        envelope.action_count_max = int(hi) if hi is not None else None
+    envelope.recent_failure_rate_min, envelope.recent_failure_rate_max = _widen(
+        envelope.recent_failure_rate_min, envelope.recent_failure_rate_max, features.invalid_rate
+    )
+    # required_features = what EVERY merged session measured.
+    envelope.required_features = [
+        name for name in envelope.required_features if name in features.measured
+    ]
+    envelope.evidence_count += 1
+    if outcome == "failure":
+        envelope.failure_count += 1
+    else:
+        envelope.success_count += 1
+    envelope.confidence = _confidence(envelope.evidence_count)
+    envelope.evidence_refs = [*envelope.evidence_refs, practice_id]
+    envelope.updated_at = time.time()
+    return True
+
+
+def _confidence(evidence_count: int) -> float:
+    """Single-observation envelopes are weak (0.4); confidence grows with
+    distinct-session evidence and caps below any VALIDATED prior."""
+    return min(0.8, 0.3 + 0.1 * max(1, evidence_count))
+
+
+def build_session_envelopes(
+    session_dir: str | Path,
+    store: Any,
+    *,
+    hand: str = "right",
+    memory_table: str = "memory_items",
+) -> dict[str, Any]:
+    """Build/merge OBSERVED envelopes for every memory distilled from one
+    practice session.
+
+    ``store`` is a knowledge-store client (the same backend the memories
+    live in).  Returns a JSON-able summary; idempotent per session.
+    """
+    events = load_session_events(session_dir)
+    if not events:
+        return {"ok": False, "reason": "no events", "session_dir": str(session_dir)}
+    practice_id = events[0].get("practice_id")
+    if not practice_id:
+        return {"ok": False, "reason": "no practice_id in events", "session_dir": str(session_dir)}
+
+    samples = extract_samples(events, hand=hand)
+    features = features_from_samples(samples)
+
+    # Memories observed in this session: (a) rows whose practice_id IS
+    # this session (first distillation), plus (b) rows re-confirmed here
+    # via the distiller's MERGE path — those keep the originating
+    # session's practice_id, so we discover them through memory_evidence
+    # source_event_ids present in THIS session's event stream.
+    rows = {
+        str(row["id"]): dict(row)
+        for row in store.query(memory_table, filters={"practice_id": practice_id}, limit=1000)
+    }
+    session_event_ids = {e.get("event_id") for e in events if e.get("event_id")}
+    try:
+        evidence_rows = store.query("memory_evidence", limit=50000)
+    except Exception:  # backend without memory_evidence — (a) still works
+        evidence_rows = []
+    reconfirmed_ids = {
+        str(ev["memory_id"])
+        for ev in evidence_rows
+        if ev.get("source_event_id") in session_event_ids and ev.get("memory_id")
+    }
+    missing = [mid for mid in reconfirmed_ids if mid not in rows]
+    for mid in missing:
+        row = store.query(memory_table, filters={"id": mid}, limit=1)
+        if row:
+            rows[mid] = dict(row[0])
+
+    applicability = ApplicabilityStore(store)
+    created = merged = already = 0
+    details: list[dict[str, Any]] = []
+    for row in rows.values():
+        memory = row
+        meta = memory.get("metadata")
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except json.JSONDecodeError:
+                meta = {}
+        if not memory.get("gesture_name"):
+            memory["gesture_name"] = (meta or {}).get("gesture")
+        existing = [
+            env
+            for env in applicability.for_memory(str(memory["id"]))
+            if env.reason == BUILDER_TAG and env.envelope_type == EnvelopeType.OBSERVED.value
+        ]
+        if existing:
+            envelope = existing[0]
+            if merge_session_into_envelope(
+                envelope, features, practice_id=practice_id, outcome=memory.get("outcome")
+            ):
+                applicability.upsert(envelope)
+                merged += 1
+                details.append({"memory_id": memory["id"], "action": "merged"})
+            else:
+                already += 1
+                details.append({"memory_id": memory["id"], "action": "already_counted"})
+        else:
+            envelope = envelope_from_session(memory, features, practice_id=practice_id)
+            applicability.upsert(envelope)
+            created += 1
+            details.append({"memory_id": memory["id"], "action": "created"})
+
+    return {
+        "ok": True,
+        "session_dir": str(session_dir),
+        "practice_id": practice_id,
+        "hand": hand,
+        "rounds": features.rounds,
+        "measured": list(features.measured),
+        "temperature_range": [features.temperature_min, features.temperature_max],
+        "invalid_rate": features.invalid_rate,
+        "memories": len(rows),
+        "envelopes_created": created,
+        "envelopes_merged": merged,
+        "envelopes_already_counted": already,
+        "details": details,
+    }

--- a/tests/memory/v2/regime/test_matcher.py
+++ b/tests/memory/v2/regime/test_matcher.py
@@ -69,9 +69,38 @@ def _thermal_envelope(**overrides) -> ApplicabilityEnvelope:
 def test_interval_distance_semantics() -> None:
     assert interval_distance(None, 1.0, 2.0, scale=1.0) is None  # unknown ≠ match
     assert interval_distance(5.0, None, None, scale=1.0) == 0.0  # unbounded
+    assert interval_distance(None, None, None, scale=1.0) == 0.0  # unbounded unknown is neutral
     assert interval_distance(1.5, 1.0, 2.0, scale=1.0) == 0.0  # inside
     assert interval_distance(0.5, 1.0, 2.0, scale=0.5) == 1.0  # below
     assert interval_distance(3.0, 1.0, 2.0, scale=2.0) == 0.5  # above
+
+
+def test_unconstrained_missing_feature_never_blocks_applicability() -> None:
+    """Real-corpus regression (RH56 evo-rps campaign, 2026-07-29): RH56
+    telemetry never reports position_error_p95, and envelopes built from
+    it leave that feature unbounded.  With the buggy check order
+    (unknown-before-unbounded), EVERY match on the real corpus was
+    blocked as 'missing position_error_p95' — applicability was dead on
+    hardware that doesn't report every feature."""
+    matcher = RegimeMatcher()
+    envelope = ApplicabilityEnvelope(
+        memory_id="mem_real",
+        body_ids=["rh56_right_01"],
+        temperature_min=38.0,
+        temperature_max=52.0,
+        evidence_count=5,
+        confidence=0.8,
+        required_features=["temperature_c"],
+        # position_error_p95 deliberately unbounded + not required
+    )
+    regime = _regime(position_error_p95=None)
+    regime.regime_label = None
+    regime.calibration_hash = None
+    regime.control_profile_hash = None
+    regime.joint_name = None
+    result = matcher.match("mem_real", [envelope], regime)
+    assert "position_error_p95" not in result.missing_required_features
+    assert result.score > 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/memory/v2/regime/test_session_envelopes.py
+++ b/tests/memory/v2/regime/test_session_envelopes.py
@@ -1,0 +1,294 @@
+"""Session envelope backfill tests (distill → RegimeMatcher link).
+
+The gap this covers: distillation stored memories with regime metadata
+but never wrote ``memory_applicability`` rows, so the matcher answered
+"not applicable" for every real memory.  These tests pin the honest
+semantics of the backfill: measured-only features, monotone widening,
+practice_id idempotency, and regime-differentiated matching.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rosclaw.memory.seekdb_client import InMemoryKnowledgeStore
+from rosclaw.memory.v2.regime import (
+    ApplicabilityStore,
+    OperatingRegime,
+    RegimeMatcher,
+    empty_regime,
+)
+from rosclaw.memory.v2.regime.session_envelopes import (
+    BUILDER_TAG,
+    build_session_envelopes,
+    features_from_samples,
+)
+from rosclaw.memory.v2.regime.session_samples import extract_samples
+
+T0 = 1_785_300_000.0
+
+
+def _telemetry_event(temp: float, ts: float) -> dict:
+    return {
+        "event_type": "health_check",
+        "timestamp_ns": int(ts * 1e9),
+        "payload": {"right": {"temperature_c": {"index": temp, "thumb": temp - 1}}},
+    }
+
+
+def _round_event(index: int, ts: float, result: str = "win") -> dict:
+    return {
+        "event_type": "rps.stress.round.resolved",
+        "event_id": f"evt_{index:04d}",
+        "timestamp_ns": int(ts * 1e9),
+        "payload": {
+            "round": {
+                "round_id": f"stress_{index:06d}",
+                "started_at": ts,
+                "ended_at": ts + 1.5,
+                "result": result,
+                "robot_gesture_verified": result != "invalid",
+                "robot_gesture_failure_reason": "joint_not_reached"
+                if result == "invalid"
+                else None,
+            }
+        },
+    }
+
+
+def _write_session(
+    root: Path,
+    practice_id: str,
+    *,
+    temp_start: float,
+    temp_end: float,
+    rounds: int = 10,
+    invalid_every: int = 5,
+) -> Path:
+    session = root / "sessions" / practice_id
+    (session / "raw").mkdir(parents=True)
+    events = [
+        {
+            "event_type": "practice.session_started",
+            "practice_id": practice_id,
+            "session_id": f"sess_{practice_id}",
+            "robot_id": "rh56_rps_robot",
+            "body_id": "rh56_right_01",
+            "timestamp_ns": int(T0 * 1e9),
+            "payload": {},
+        }
+    ]
+    for i in range(rounds):
+        ts = T0 + 60 + i * 8.0
+        temp = temp_start + (temp_end - temp_start) * (i / max(1, rounds - 1))
+        events.append(_telemetry_event(temp, ts))
+        result = "invalid" if (i + 1) % invalid_every == 0 else "win"
+        events.append(_round_event(i + 1, ts, result))
+    with (session / "raw" / "events.jsonl").open("w", encoding="utf-8") as handle:
+        for event in events:
+            handle.write(json.dumps(event) + "\n")
+    return session
+
+
+def _seed_memory(
+    store: InMemoryKnowledgeStore, practice_id: str, *, memory_id: str = "mem_x"
+) -> None:
+    store.insert(
+        "memory_items",
+        {
+            "id": memory_id,
+            "memory_type": "failure",
+            "practice_id": practice_id,
+            "body_id": "rh56_right_01",
+            "task_id": "rh56_rps",
+            "gesture_name": "rock",
+            "failure_type": "joint_not_reached",
+            "outcome": "failure",
+            "status": "active",
+        },
+    )
+
+
+def test_features_from_samples_measured_only() -> None:
+    events = [
+        _telemetry_event(40.0, T0),
+        _round_event(1, T0, "win"),
+        _telemetry_event(46.0, T0 + 120),
+        _round_event(2, T0 + 120, "invalid"),
+    ]
+    samples = extract_samples(events)
+    features = features_from_samples(samples)
+    assert features.temperature_min == 40.0
+    assert features.temperature_max == 46.0
+    assert features.temperature_slope is not None and features.temperature_slope > 0
+    assert features.invalid_rate == 0.5
+    assert features.rounds == 2
+    # position_error_p95 is never invented.
+    assert "position_error_p95" not in features.measured
+
+
+def test_features_missing_temperature_stays_unbounded() -> None:
+    events = [_round_event(1, T0, "win"), _round_event(2, T0 + 8, "win")]
+    features = features_from_samples(extract_samples(events))
+    assert features.temperature_min is None
+    assert "temperature_c" not in features.measured
+
+
+def test_backfill_creates_observed_envelope(tmp_path: Path) -> None:
+    store = InMemoryKnowledgeStore()
+    session = _write_session(tmp_path, "prac_hot", temp_start=46.0, temp_end=52.0)
+    _seed_memory(store, "prac_hot")
+
+    result = build_session_envelopes(session, store)
+    assert result["ok"] and result["envelopes_created"] == 1
+
+    envelopes = ApplicabilityStore(store).for_memory("mem_x")
+    assert len(envelopes) == 1
+    env = envelopes[0]
+    assert env.envelope_type == "observed"
+    assert env.reason == BUILDER_TAG
+    assert env.temperature_min == 46.0
+    assert env.temperature_max == 52.0
+    assert env.evidence_count == 1
+    assert env.failure_count == 1
+    assert env.evidence_refs == ["prac_hot"]
+    assert env.gestures == ["rock"]
+    assert env.failure_types == ["joint_not_reached"]
+    assert "temperature_c" in env.required_features
+
+
+def test_backfill_independent_envelopes_per_memory(tmp_path: Path) -> None:
+    store = InMemoryKnowledgeStore()
+    hot = _write_session(tmp_path, "prac_hot", temp_start=46.0, temp_end=52.0)
+    cold = _write_session(tmp_path, "prac_cold", temp_start=34.0, temp_end=38.0, invalid_every=3)
+    _seed_memory(store, "prac_hot", memory_id="mem_hot")
+    _seed_memory(store, "prac_cold", memory_id="mem_cold")
+
+    build_session_envelopes(hot, store)
+    build_session_envelopes(cold, store)
+
+    hot_env = ApplicabilityStore(store).for_memory("mem_hot")[0]
+    cold_env = ApplicabilityStore(store).for_memory("mem_cold")[0]
+    assert (hot_env.temperature_min, hot_env.temperature_max) == (46.0, 52.0)
+    assert (cold_env.temperature_min, cold_env.temperature_max) == (34.0, 38.0)
+    assert cold_env.evidence_refs == ["prac_cold"]
+
+
+def test_backfill_idempotent_per_session(tmp_path: Path) -> None:
+    store = InMemoryKnowledgeStore()
+    session = _write_session(tmp_path, "prac_hot", temp_start=46.0, temp_end=52.0)
+    _seed_memory(store, "prac_hot")
+    build_session_envelopes(session, store)
+    again = build_session_envelopes(session, store)
+    assert again["envelopes_created"] == 0
+    assert again["envelopes_already_counted"] == 1
+    env = ApplicabilityStore(store).for_memory("mem_x")[0]
+    assert env.evidence_count == 1
+
+
+def _regime(temp: float, failure_rate: float) -> OperatingRegime:
+    regime = empty_regime(
+        robot_id="rh56_rps_robot", body_id="rh56_right_01", task_id="rh56_rps", now=T0
+    )
+    regime.temperature_c = temp
+    regime.temperature_slope_c_per_min = 0.1
+    regime.session_elapsed_sec = 300.0
+    regime.cumulative_action_count = 40
+    regime.recent_failure_rate = failure_rate
+    regime.gesture_name = "rock"
+    return regime
+
+
+def test_backfill_discovers_reconfirmed_memory_via_evidence(tmp_path: Path) -> None:
+    """The distiller's MERGE path keeps the ORIGINATING session's
+    practice_id on the memory row; re-confirmations in later sessions are
+    only visible through memory_evidence.source_event_id.  The backfill
+    must attribute those sessions to the memory's envelope too."""
+    store = InMemoryKnowledgeStore()
+    cold = _write_session(tmp_path, "prac_cold", temp_start=34.0, temp_end=38.0)
+    hot = _write_session(tmp_path, "prac_hot", temp_start=46.0, temp_end=52.0)
+    _seed_memory(store, "prac_cold", memory_id="mem_shared")
+    # The hot session re-confirmed the same memory: distill merged into it
+    # and wrote an evidence row pointing at a HOT-session event.
+    hot_event_ids = [
+        json.loads(line)["event_id"]
+        for line in (hot / "raw" / "events.jsonl").read_text().splitlines()
+        if json.loads(line).get("event_id")
+    ]
+    store.insert(
+        "memory_evidence",
+        {
+            "id": "evd_hot_1",
+            "memory_id": "mem_shared",
+            "evidence_type": "practice_event",
+            "source_event_id": hot_event_ids[-1],
+            "confidence": 1.0,
+        },
+    )
+
+    build_session_envelopes(cold, store)
+    result = build_session_envelopes(hot, store)
+    assert result["envelopes_merged"] == 1
+
+    env = ApplicabilityStore(store).for_memory("mem_shared")[0]
+    assert env.evidence_count == 2
+    assert env.temperature_min == 34.0 and env.temperature_max == 52.0
+    assert set(env.evidence_refs) == {"prac_cold", "prac_hot"}
+
+
+def test_matcher_prefers_regime_matching_envelope(tmp_path: Path) -> None:
+    """The self-loop payoff: one memory observed in BOTH a cold and a hot
+    session must score higher in the regime it was observed in."""
+    store = InMemoryKnowledgeStore()
+    cold = _write_session(tmp_path, "prac_cold", temp_start=34.0, temp_end=38.0)
+    hot = _write_session(tmp_path, "prac_hot", temp_start=46.0, temp_end=52.0)
+    # One memory id observed in both sessions: seed the row once per
+    # practice but with the same id, so the second backfill MERGES.
+    store.insert(
+        "memory_items",
+        {
+            "id": "mem_shared",
+            "memory_type": "failure",
+            "practice_id": "prac_cold",
+            "body_id": "rh56_right_01",
+            "failure_type": "joint_not_reached",
+            "outcome": "failure",
+            "status": "active",
+        },
+    )
+    build_session_envelopes(cold, store)
+    # Simulate the same memory surfacing again in the hot session: the
+    # production distiller keys memories by content hash, so re-distilling
+    # an identical failure UPDATES the same memory id and re-points its
+    # practice_id.  Mirror that here.
+    store.insert(
+        "memory_items",
+        {
+            "id": "mem_shared",
+            "memory_type": "failure",
+            "practice_id": "prac_hot",
+            "body_id": "rh56_right_01",
+            "failure_type": "joint_not_reached",
+            "outcome": "failure",
+            "status": "active",
+        },
+    )
+    result = build_session_envelopes(hot, store)
+    assert result["envelopes_merged"] == 1
+
+    env = ApplicabilityStore(store).for_memory("mem_shared")[0]
+    assert env.evidence_count == 2
+    assert env.temperature_min == 34.0 and env.temperature_max == 52.0
+    assert set(env.evidence_refs) == {"prac_cold", "prac_hot"}
+
+    matcher = RegimeMatcher()
+    envelopes = ApplicabilityStore(store).for_memory("mem_shared")
+    cold_match = matcher.match("mem_shared", envelopes, _regime(36.0, 0.2))
+    hot_match = matcher.match("mem_shared", envelopes, _regime(51.0, 0.2))
+    far_match = matcher.match("mem_shared", envelopes, _regime(70.0, 0.2))
+    assert cold_match.score > 0 and hot_match.score > 0
+    assert far_match.score < cold_match.score  # out-of-envelope penalized
+    # A memory with no envelopes at all stays inert (the pre-fix behavior).
+    no_env = matcher.match("mem_nothing", [], _regime(36.0, 0.2))
+    assert not no_env.applicable


### PR DESCRIPTION
## 真机发现的问题（RH56 evo-rps 战役，31 场会话 484 条 envelope）

在真实战役语料上验证"自我闭环"时发现 **distill → RegimeMatcher 链路断裂**，分两层：

1. **没有 envelope**：distill 写的记忆带 regime 元数据（`metadata.temperature_c`），但整个系统没有任何路径写 `memory_applicability` 表 → 每条真实记忆匹配结果都是 `no_applicability_envelope` → 干预路径在真实语料上完全惰性。
2. **即使有了 envelope 也全部不匹配**：`interval_distance` 把"未知值"判断放在"无界区间"判断**之前**，于是任何缺少某特征的 regime（RH56 遥测根本不报 `position_error_p95`）都会被当作"missing feature"阻断 → applicability 层在不汇报全部特征的本体上是死的。

## 修复内容

- **`regime/session_envelopes.py`**：从会话**实际测量**的特征构建/合并 OBSERVED envelope（温度来自 health_check、invalid 率与动作数来自回合事件、时长来自时间戳）；未测特征保持无界且不进入 `required_features`（unknown is not wildcard）。每条记忆聚合一条 envelope：区间单调扩宽、`evidence_count` 按不同会话增长（`evidence_refs` 中的 practice_id 保证幂等）；distiller MERGE 路径的再确认通过 `memory_evidence.source_event_id` 回溯发现（记忆行只保留起源会话的 practice_id，evidence 表是唯一链接）。
- **`rosclaw regime build-envelopes <session_dir>`** CLI（--backend/--seekdb-url/--v2-path）。
- **matcher 修复**：无界区间先判中性（0.0），有界+未知才是 None。
- 测试 +9（7 个 backfill + 2 个 matcher 回归，含"无界+未要求特征绝不阻断 applicability"的真实语料回归）。

## 真机验证（实验命名空间 rosclaw_evo_rps_2026_01）

- 484 条 envelope（31 场真机会话），1202 次跨场合并，291 条多会话 envelope（最高一条记忆在 20 场、38–52°C 区间被观测）
- 实时温度（44°C）sweep：**38 条 regime 适用记忆**；36°C sweep：**0 条**——语料从未在 38°C 以下观测过自己，系统诚实地不推广（而不是瞎匹配）
- OBSERVED 分数封顶 0.72 < 0.85 SUGGEST 带：不会自我认证到 APPLY
- `pytest tests/memory tests/how` 227 全过；mypy/ruff 干净

## 语义边界

- OBSERVED envelope 永远到不了 APPLY 档（matcher type_factor 0.8 封顶在 validated 带以下）——让记忆可被 regime 寻址，但不自我认证。
- 战役 promotion gate 不读 memory_items（读 manifest/registry），此回填不影响实验裁决；manifest 已记 ops_note 披露。

🤖 Generated with [Claude Code](https://claude.com/claude-code)