### PR TITLE
fix(evolution): parse registry changes in explicit candidate selection

### DIFF
--- a/src/rosclaw/evolution/hardware/canary.py
+++ b/src/rosclaw/evolution/hardware/canary.py
@@ -146,7 +146,16 @@ def select_explicit_candidate(
     """
     for row in validated:
         if str(row.get("candidate_id")) == candidate_id:
-            return row, f"operator-directed top-up: {candidate_id}"
+            # The registry stores changes as JSON text on SQL backends;
+            # the runner must receive a dict (select_canary_candidate
+            # parses too — an unparsed str double-encodes downstream and
+            # crashes the workspace runner, found 2026-07-30).
+            import json as _json
+
+            changes = row.get("changes") or {}
+            if isinstance(changes, str):
+                changes = _json.loads(changes)
+            return {**row, "changes": changes}, f"operator-directed top-up: {candidate_id}"
     return None, (
         f"candidate {candidate_id} is not VALIDATED "
         "(unknown id, rolled back, or already promoted/decided)"

--- a/tests/evolution/hardware/test_canary.py
+++ b/tests/evolution/hardware/test_canary.py
@@ -108,3 +108,18 @@ def test_explicit_candidate_rejects_non_validated() -> None:
     pick, reason = select_explicit_candidate(validated, "c_unknown")
     assert pick is None
     assert "not VALIDATED" in reason
+
+
+def test_explicit_candidate_parses_string_changes() -> None:
+    """Real-hardware regression (2026-07-30): the registry stores changes
+    as JSON text on SQL backends; the explicit path returned the raw row,
+    so json.dumps(string) double-encoded and the workspace runner crashed
+    ('str' object has no attribute 'get'). The ladder's selector parses —
+    the explicit selector must too."""
+    validated = [
+        {"candidate_id": "c_every5", "changes": '{"cooldown_every_n_rounds": 5}'},
+    ]
+    pick, _ = select_explicit_candidate(validated, "c_every5")
+    assert pick is not None
+    assert pick["changes"] == {"cooldown_every_n_rounds": 5}
+    assert isinstance(pick["changes"], dict)


### PR DESCRIPTION
## 真机故障

首次 operator-directed 补场矩阵（cand_003，2026-07-30 02:28）在 block0 C 臂启动 16 秒后崩溃：`'str' object has no attribute 'get'`。

根因：`select_canary_candidate`（阶梯路径）会把注册表的 JSON 文本 `changes` 解析成 dict；#133 新增的 `select_explicit_candidate` 直接返回原始行 → orchestrator `json.dumps(str)` 双重编码 → workspace runner 解析一次后仍是 str → 崩溃。

注：此前所有 C 臂会话都走阶梯路径（有解析），所以该 bug 只在首次使用 `--candidate-id` 时暴露。

## 修复与测试

- 显式选择与阶梯选择同样解析 `changes`（dict 才下行）
- 回归测试：字符串 changes 必须解析为 dict（正是真机崩溃的形态）

9 canary tests 全过。修复后将重跑 cand_003 补场矩阵。

🤖 Generated with [Claude Code](https://claude.com/claude-code)