### PR TITLE
feat: add Phase 8 DreamForge growth and evidence contracts

### DIFF
--- a/src/rosclaw/collective/__init__.py
+++ b/src/rosclaw/collective/__init__.py
@@ -1,0 +1,23 @@
+"""Contracts for governed use of external and collective experience."""
+
+from rosclaw.collective.contracts import (
+    ApplicabilityAssessment,
+    ApplicabilityDecision,
+    CollectiveSourceIdentity,
+    CollectiveUse,
+    ExperienceCapsule,
+    LicenseDecision,
+    LicenseUse,
+    SourceLicenseEvidence,
+)
+
+__all__ = [
+    "ApplicabilityAssessment",
+    "ApplicabilityDecision",
+    "CollectiveSourceIdentity",
+    "CollectiveUse",
+    "ExperienceCapsule",
+    "LicenseDecision",
+    "LicenseUse",
+    "SourceLicenseEvidence",
+]

--- a/src/rosclaw/collective/contracts.py
+++ b/src/rosclaw/collective/contracts.py
@@ -1,0 +1,299 @@
+"""Fail-closed provenance contracts for collective experience.
+
+External data is useful only after its license, body mapping, task semantics
+and learning role are explicit.  These records intentionally separate a motion
+reference from an RL transition dataset.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.growth.contracts import EvidenceUsePolicy, TrainingEligibility
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _require_hash(label: str, value: str) -> None:
+    if not _SHA256.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+def _optional_hash(label: str, value: str | None) -> None:
+    if value is not None:
+        _require_hash(label, value)
+
+
+def _unit_score(label: str, value: float) -> None:
+    if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+        raise ValueError(f"{label} must be finite and in [0, 1]")
+
+
+class LicenseUse(StrEnum):
+    RESEARCH_NONCOMMERCIAL = "research_noncommercial"
+    COMMERCIAL = "commercial"
+    REDISTRIBUTION = "redistribution"
+
+
+class LicenseDecision(StrEnum):
+    PERMITTED = "permitted"
+    PENDING = "pending"
+    DENIED = "denied"
+
+
+@dataclass(frozen=True)
+class SourceLicenseEvidence:
+    """License conclusion for one concrete intended use.
+
+    ``PENDING`` deliberately permits absent terms so an incompletely documented
+    source can be catalogued without becoming trainable.
+    """
+
+    requested_use: LicenseUse
+    decision: LicenseDecision
+    terms_uri: str | None = None
+    terms_hash: str | None = None
+    attribution: str = ""
+    schema_version: str = "rosclaw.collective.source_license.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.requested_use, LicenseUse):
+            raise ValueError("requested_use must be a recognized LicenseUse")
+        if not isinstance(self.decision, LicenseDecision):
+            raise ValueError("decision must be a recognized LicenseDecision")
+        _optional_hash("terms_hash", self.terms_hash)
+        if self.decision is not LicenseDecision.PENDING and (
+            not self.terms_uri or self.terms_hash is None
+        ):
+            raise ValueError("a final license decision requires URI and hashed terms")
+        if self.terms_uri is not None and not self.terms_uri.strip():
+            raise ValueError("terms_uri must be non-empty when supplied")
+
+    @property
+    def evidence_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "requested_use": self.requested_use.value,
+            "decision": self.decision.value,
+            "terms_uri": self.terms_uri,
+            "terms_hash": self.terms_hash,
+            "attribution": self.attribution,
+        }
+
+
+class ApplicabilityDecision(StrEnum):
+    ACCEPT = "accept"
+    PENDING = "pending"
+    REJECT = "reject"
+
+
+@dataclass(frozen=True)
+class ApplicabilityAssessment:
+    """Evidence-backed source-to-target morphology and regime assessment."""
+
+    target_body_hash: str
+    target_mapping_hash: str
+    body_score: float
+    task_score: float
+    regime_score: float
+    confidence: float
+    evidence_hashes: tuple[str, ...]
+    decision: ApplicabilityDecision
+    schema_version: str = "rosclaw.collective.applicability.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.decision, ApplicabilityDecision):
+            raise ValueError("decision must be a recognized ApplicabilityDecision")
+        _require_hash("target_body_hash", self.target_body_hash)
+        _require_hash("target_mapping_hash", self.target_mapping_hash)
+        for label in ("body_score", "task_score", "regime_score", "confidence"):
+            _unit_score(label, getattr(self, label))
+        evidence_hashes = tuple(self.evidence_hashes)
+        if not evidence_hashes or len(evidence_hashes) != len(set(evidence_hashes)):
+            raise ValueError("evidence_hashes must be non-empty and unique")
+        for value in evidence_hashes:
+            _require_hash("evidence_hashes", value)
+        object.__setattr__(self, "evidence_hashes", evidence_hashes)
+        if self.decision is ApplicabilityDecision.ACCEPT:
+            scores = (self.body_score, self.task_score, self.regime_score, self.confidence)
+            if any(score < 0.8 for score in scores):
+                raise ValueError("accepted applicability requires all scores and confidence >= 0.8")
+
+    @property
+    def assessment_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "target_body_hash": self.target_body_hash,
+            "target_mapping_hash": self.target_mapping_hash,
+            "body_score": self.body_score,
+            "task_score": self.task_score,
+            "regime_score": self.regime_score,
+            "confidence": self.confidence,
+            "evidence_hashes": list(self.evidence_hashes),
+            "decision": self.decision.value,
+        }
+
+
+@dataclass(frozen=True)
+class CollectiveSourceIdentity:
+    provider: str
+    dataset: str
+    revision: str
+    file_hashes: Mapping[str, str]
+    license_evidence: SourceLicenseEvidence
+    source_body_id: str
+    source_body_hash: str | None = None
+    schema_version: str = "rosclaw.collective.source_identity.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.license_evidence, SourceLicenseEvidence):
+            raise ValueError("license_evidence must be a SourceLicenseEvidence record")
+        for label in ("provider", "dataset", "revision", "source_body_id"):
+            if not getattr(self, label).strip():
+                raise ValueError(f"{label} must not be empty")
+        _optional_hash("source_body_hash", self.source_body_hash)
+        file_hashes = {str(path): str(value) for path, value in self.file_hashes.items()}
+        if not file_hashes or any(not path.strip() for path in file_hashes):
+            raise ValueError("file_hashes must contain at least one named file")
+        for value in file_hashes.values():
+            _require_hash("file_hashes value", value)
+        object.__setattr__(self, "file_hashes", MappingProxyType(file_hashes))
+
+    @property
+    def source_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "provider": self.provider,
+            "dataset": self.dataset,
+            "revision": self.revision,
+            "file_hashes": dict(sorted(self.file_hashes.items())),
+            "license_evidence": self.license_evidence.to_dict(),
+            "source_body_id": self.source_body_id,
+            "source_body_hash": self.source_body_hash,
+        }
+
+
+class CollectiveUse(StrEnum):
+    MOTION_REFERENCE = "motion_reference"
+    MOTION_TRACKING = "motion_tracking"
+    BEHAVIOR_CLONING = "behavior_cloning"
+    OFFLINE_RL = "offline_rl"
+    WORLD_MODEL = "world_model"
+
+
+@dataclass(frozen=True)
+class ExperienceCapsule:
+    """A governed external experience unit with explicit semantic limits."""
+
+    source: CollectiveSourceIdentity
+    applicability: ApplicabilityAssessment
+    task_semantics_hash: str
+    observation_semantics_hash: str
+    modalities: tuple[str, ...]
+    requested_uses: tuple[CollectiveUse, ...]
+    quality_report_hash: str
+    evidence_policy: EvidenceUsePolicy
+    source_episode_count: int
+    action_semantics_hash: str | None = None
+    transition_semantics_hash: str | None = None
+    reward_semantics_hash: str | None = None
+    schema_version: str = "rosclaw.collective.experience_capsule.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source, CollectiveSourceIdentity):
+            raise ValueError("source must be a CollectiveSourceIdentity record")
+        if not isinstance(self.applicability, ApplicabilityAssessment):
+            raise ValueError("applicability must be an ApplicabilityAssessment record")
+        if not isinstance(self.evidence_policy, EvidenceUsePolicy):
+            raise ValueError("evidence_policy must be an EvidenceUsePolicy record")
+        for label, value in (
+            ("task_semantics_hash", self.task_semantics_hash),
+            ("observation_semantics_hash", self.observation_semantics_hash),
+            ("quality_report_hash", self.quality_report_hash),
+        ):
+            _require_hash(label, value)
+        for label in (
+            "action_semantics_hash",
+            "transition_semantics_hash",
+            "reward_semantics_hash",
+        ):
+            _optional_hash(label, getattr(self, label))
+        modalities = tuple(self.modalities)
+        if not modalities or len(modalities) != len(set(modalities)):
+            raise ValueError("modalities must be non-empty and unique")
+        if any(not modality.strip() for modality in modalities):
+            raise ValueError("modalities must not contain empty values")
+        object.__setattr__(self, "modalities", modalities)
+        requested_uses = tuple(self.requested_uses)
+        if not requested_uses or len(requested_uses) != len(set(requested_uses)):
+            raise ValueError("requested_uses must be non-empty and unique")
+        if any(not isinstance(value, CollectiveUse) for value in requested_uses):
+            raise ValueError("requested_uses must contain recognized CollectiveUse values")
+        object.__setattr__(self, "requested_uses", requested_uses)
+        if self.source_episode_count <= 0:
+            raise ValueError("source_episode_count must be positive")
+        if CollectiveUse.BEHAVIOR_CLONING in requested_uses and self.action_semantics_hash is None:
+            raise ValueError("behavior cloning requires action semantics")
+        if CollectiveUse.WORLD_MODEL in requested_uses and self.transition_semantics_hash is None:
+            raise ValueError("world-model training requires transition semantics")
+        if CollectiveUse.OFFLINE_RL in requested_uses:
+            required = (
+                self.action_semantics_hash,
+                self.transition_semantics_hash,
+                self.reward_semantics_hash,
+            )
+            if any(value is None for value in required):
+                raise ValueError("offline RL requires action, transition and reward semantics")
+
+    @property
+    def training_eligible(self) -> bool:
+        return (
+            self.source.license_evidence.decision is LicenseDecision.PERMITTED
+            and self.applicability.decision is ApplicabilityDecision.ACCEPT
+            and self.evidence_policy.training is not TrainingEligibility.DENIED
+        )
+
+    @property
+    def promotion_truth_allowed(self) -> bool:
+        """Collective data may teach, but cannot independently approve."""
+
+        return False
+
+    @property
+    def capsule_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source": self.source.to_dict(),
+            "applicability": self.applicability.to_dict(),
+            "task_semantics_hash": self.task_semantics_hash,
+            "observation_semantics_hash": self.observation_semantics_hash,
+            "action_semantics_hash": self.action_semantics_hash,
+            "transition_semantics_hash": self.transition_semantics_hash,
+            "reward_semantics_hash": self.reward_semantics_hash,
+            "modalities": list(self.modalities),
+            "requested_uses": [value.value for value in self.requested_uses],
+            "quality_report_hash": self.quality_report_hash,
+            "evidence_policy": self.evidence_policy.to_dict(),
+            "source_episode_count": self.source_episode_count,
+            "training_eligible": self.training_eligible,
+            "promotion_truth_allowed": self.promotion_truth_allowed,
+        }

--- a/src/rosclaw/dream/__init__.py
+++ b/src/rosclaw/dream/__init__.py
@@ -1,0 +1,5 @@
+"""Bounded dream-campaign contracts for offline skill consolidation."""
+
+from rosclaw.dream.contracts import DreamBudget, DreamCampaign, DreamEpisode, DreamType
+
+__all__ = ["DreamBudget", "DreamCampaign", "DreamEpisode", "DreamType"]

--- a/src/rosclaw/dream/contracts.py
+++ b/src/rosclaw/dream/contracts.py
@@ -1,0 +1,302 @@
+"""Immutable contracts for ROSClaw's bounded Dream Plane.
+
+Dreaming is an asynchronous candidate-generation and consolidation activity.
+It cannot write to the synchronous control loop, reveal private holdout rows or
+turn model predictions into promotion evidence.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.growth.contracts import EvidenceLevel, EvidenceUsePolicy, TrainingEligibility
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _require_hash(label: str, value: str) -> None:
+    if not _SHA256.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+def _optional_hash(label: str, value: str | None) -> None:
+    if value is not None:
+        _require_hash(label, value)
+
+
+def _hash_tuple(values: tuple[str, ...], *, label: str, allow_empty: bool = False) -> tuple[str, ...]:
+    normalized = tuple(values)
+    if not allow_empty and not normalized:
+        raise ValueError(f"{label} must not be empty")
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must be unique")
+    for value in normalized:
+        _require_hash(label, value)
+    return normalized
+
+
+def _names(values: tuple[str, ...], *, label: str) -> tuple[str, ...]:
+    normalized = tuple(values)
+    if not normalized or len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must be non-empty and unique")
+    if any(not value.strip() for value in normalized):
+        raise ValueError(f"{label} must not contain empty values")
+    return normalized
+
+
+class DreamType(StrEnum):
+    REPLAY = "replay"
+    COUNTERFACTUAL = "counterfactual"
+    PROSPECTIVE = "prospective"
+    SELF = "self"
+    SOCIAL = "social"
+    NIGHTMARE = "nightmare"
+
+
+@dataclass(frozen=True)
+class DreamBudget:
+    """Hard resource and drift limits for one campaign."""
+
+    max_gpu_seconds: float
+    max_cpu_rollouts: int
+    max_candidates: int
+    max_wall_seconds: float
+    max_policy_change: float
+    max_anchor_drift: float
+    schema_version: str = "rosclaw.dream.budget.v1"
+
+    def __post_init__(self) -> None:
+        for label in ("max_gpu_seconds", "max_wall_seconds", "max_policy_change", "max_anchor_drift"):
+            value = getattr(self, label)
+            if not math.isfinite(value):
+                raise ValueError(f"{label} must be finite")
+        if self.max_gpu_seconds < 0.0:
+            raise ValueError("max_gpu_seconds must be non-negative")
+        if self.max_cpu_rollouts < 0:
+            raise ValueError("max_cpu_rollouts must be non-negative")
+        if self.max_gpu_seconds == 0.0 and self.max_cpu_rollouts == 0:
+            raise ValueError("at least one compute budget must be positive")
+        if self.max_candidates <= 0 or self.max_wall_seconds <= 0.0:
+            raise ValueError("candidate and wall-clock budgets must be positive")
+        if not 0.0 <= self.max_policy_change <= 1.0:
+            raise ValueError("max_policy_change must be in [0, 1]")
+        if not 0.0 <= self.max_anchor_drift <= 1.0:
+            raise ValueError("max_anchor_drift must be in [0, 1]")
+
+    @property
+    def budget_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "max_gpu_seconds": self.max_gpu_seconds,
+            "max_cpu_rollouts": self.max_cpu_rollouts,
+            "max_candidates": self.max_candidates,
+            "max_wall_seconds": self.max_wall_seconds,
+            "max_policy_change": self.max_policy_change,
+            "max_anchor_drift": self.max_anchor_drift,
+        }
+
+
+@dataclass(frozen=True)
+class DreamCampaign:
+    """Content-addressed intent for one bounded offline learning run."""
+
+    skill_growth_spec_hash: str
+    body_hash: str
+    parent_policy_hash: str
+    trigger_kind: str
+    trigger_evidence_hashes: tuple[str, ...]
+    objectives: tuple[str, ...]
+    constraint_hashes: tuple[str, ...]
+    practice_snapshot_hashes: tuple[str, ...]
+    collective_capsule_hashes: tuple[str, ...]
+    historical_anchor_hashes: tuple[str, ...]
+    boundary_suite_hashes: tuple[str, ...]
+    private_holdout_commitment: str
+    dream_types: tuple[DreamType, ...]
+    learner_ids: tuple[str, ...]
+    budget: DreamBudget
+    schema_version: str = "rosclaw.dream.campaign.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.budget, DreamBudget):
+            raise ValueError("budget must be a DreamBudget record")
+        for label, value in (
+            ("skill_growth_spec_hash", self.skill_growth_spec_hash),
+            ("body_hash", self.body_hash),
+            ("parent_policy_hash", self.parent_policy_hash),
+            ("private_holdout_commitment", self.private_holdout_commitment),
+        ):
+            _require_hash(label, value)
+        if not self.trigger_kind.strip():
+            raise ValueError("trigger_kind must not be empty")
+        object.__setattr__(
+            self,
+            "trigger_evidence_hashes",
+            _hash_tuple(self.trigger_evidence_hashes, label="trigger_evidence_hashes"),
+        )
+        for label in ("constraint_hashes", "historical_anchor_hashes", "boundary_suite_hashes"):
+            object.__setattr__(self, label, _hash_tuple(getattr(self, label), label=label))
+        for label in ("practice_snapshot_hashes", "collective_capsule_hashes"):
+            object.__setattr__(
+                self,
+                label,
+                _hash_tuple(getattr(self, label), label=label, allow_empty=True),
+            )
+        object.__setattr__(self, "objectives", _names(self.objectives, label="objectives"))
+        object.__setattr__(self, "learner_ids", _names(self.learner_ids, label="learner_ids"))
+        dream_types = tuple(self.dream_types)
+        if not dream_types or len(dream_types) != len(set(dream_types)):
+            raise ValueError("dream_types must be non-empty and unique")
+        if any(not isinstance(dream_type, DreamType) for dream_type in dream_types):
+            raise ValueError("dream_types must contain recognized DreamType values")
+        object.__setattr__(self, "dream_types", dream_types)
+        if DreamType.SOCIAL in dream_types and not self.collective_capsule_hashes:
+            raise ValueError("social dreaming requires collective experience capsules")
+        if DreamType.REPLAY in dream_types and not (
+            self.practice_snapshot_hashes or self.historical_anchor_hashes
+        ):
+            raise ValueError("replay dreaming requires practice or historical evidence")
+
+    @property
+    def campaign_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def hardware_authorized(self) -> bool:
+        return False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "skill_growth_spec_hash": self.skill_growth_spec_hash,
+            "body_hash": self.body_hash,
+            "parent_policy_hash": self.parent_policy_hash,
+            "trigger_kind": self.trigger_kind,
+            "trigger_evidence_hashes": list(self.trigger_evidence_hashes),
+            "objectives": list(self.objectives),
+            "constraint_hashes": list(self.constraint_hashes),
+            "practice_snapshot_hashes": list(self.practice_snapshot_hashes),
+            "collective_capsule_hashes": list(self.collective_capsule_hashes),
+            "historical_anchor_hashes": list(self.historical_anchor_hashes),
+            "boundary_suite_hashes": list(self.boundary_suite_hashes),
+            "private_holdout_commitment": self.private_holdout_commitment,
+            "dream_types": [dream_type.value for dream_type in self.dream_types],
+            "learner_ids": list(self.learner_ids),
+            "budget": self.budget.to_dict(),
+            "hardware_authorized": self.hardware_authorized,
+        }
+
+
+@dataclass(frozen=True)
+class DreamEpisode:
+    """One dreamed or replayed episode with an immutable evidence label."""
+
+    campaign_hash: str
+    source_episode_hash: str
+    body_hash: str
+    policy_hash: str
+    dream_type: DreamType
+    evidence_policy: EvidenceUsePolicy
+    uncertainty: float
+    self_model_hash: str | None = None
+    world_model_hash: str | None = None
+    counterfactual_changes_hash: str | None = None
+    predicted_outcome_hash: str | None = None
+    simulated_outcome_hash: str | None = None
+    execution_receipt_hash: str | None = None
+    physics_replay_verified: bool = False
+    schema_version: str = "rosclaw.dream.episode.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.dream_type, DreamType):
+            raise ValueError("dream_type must be a recognized DreamType")
+        if not isinstance(self.evidence_policy, EvidenceUsePolicy):
+            raise ValueError("evidence_policy must be an EvidenceUsePolicy record")
+        for label, value in (
+            ("campaign_hash", self.campaign_hash),
+            ("source_episode_hash", self.source_episode_hash),
+            ("body_hash", self.body_hash),
+            ("policy_hash", self.policy_hash),
+        ):
+            _require_hash(label, value)
+        for label in (
+            "self_model_hash",
+            "world_model_hash",
+            "counterfactual_changes_hash",
+            "predicted_outcome_hash",
+            "simulated_outcome_hash",
+            "execution_receipt_hash",
+        ):
+            _optional_hash(label, getattr(self, label))
+        if not math.isfinite(self.uncertainty) or not 0.0 <= self.uncertainty <= 1.0:
+            raise ValueError("uncertainty must be finite and in [0, 1]")
+        if self.evidence_policy.level is EvidenceLevel.WORLD_MODEL and (
+            self.world_model_hash is None or self.predicted_outcome_hash is None
+        ):
+            raise ValueError("world-model evidence requires model and prediction hashes")
+        if self.evidence_policy.level in {
+            EvidenceLevel.PHYSICS_REPLAY,
+            EvidenceLevel.ACCELERATED_SIM,
+        } and self.simulated_outcome_hash is None:
+            raise ValueError("simulation evidence requires a simulated outcome")
+        if (
+            self.evidence_policy.level is EvidenceLevel.EXECUTION_RECEIPT
+            and self.execution_receipt_hash is None
+        ):
+            raise ValueError("execution evidence requires a signed receipt hash")
+        if self.dream_type is DreamType.COUNTERFACTUAL:
+            if self.counterfactual_changes_hash is None:
+                raise ValueError("counterfactual dreams require a change-set hash")
+            if self.predicted_outcome_hash is None and self.simulated_outcome_hash is None:
+                raise ValueError("counterfactual dreams require a predicted or simulated outcome")
+        if self.dream_type is DreamType.PROSPECTIVE and (
+            self.world_model_hash is None or self.predicted_outcome_hash is None
+        ):
+            raise ValueError("prospective dreams require a world model and prediction")
+
+    @property
+    def training_eligible(self) -> bool:
+        return self.evidence_policy.training is not TrainingEligibility.DENIED
+
+    @property
+    def promotion_truth_allowed(self) -> bool:
+        level = self.evidence_policy.level
+        if level is EvidenceLevel.EXECUTION_RECEIPT:
+            return self.execution_receipt_hash is not None
+        if level is EvidenceLevel.PHYSICS_REPLAY:
+            return self.physics_replay_verified and self.simulated_outcome_hash is not None
+        return False
+
+    @property
+    def episode_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "campaign_hash": self.campaign_hash,
+            "source_episode_hash": self.source_episode_hash,
+            "body_hash": self.body_hash,
+            "policy_hash": self.policy_hash,
+            "dream_type": self.dream_type.value,
+            "evidence_policy": self.evidence_policy.to_dict(),
+            "uncertainty": self.uncertainty,
+            "self_model_hash": self.self_model_hash,
+            "world_model_hash": self.world_model_hash,
+            "counterfactual_changes_hash": self.counterfactual_changes_hash,
+            "predicted_outcome_hash": self.predicted_outcome_hash,
+            "simulated_outcome_hash": self.simulated_outcome_hash,
+            "execution_receipt_hash": self.execution_receipt_hash,
+            "physics_replay_verified": self.physics_replay_verified,
+            "training_eligible": self.training_eligible,
+            "promotion_truth_allowed": self.promotion_truth_allowed,
+            "hardware_authorized": False,
+        }

--- a/src/rosclaw/growth/__init__.py
+++ b/src/rosclaw/growth/__init__.py
@@ -1,0 +1,29 @@
+"""Evidence and consolidation contracts for bounded ROSClaw growth."""
+
+from rosclaw.growth.contracts import (
+    ConsolidationDecision,
+    ConsolidationManifest,
+    EvidenceLevel,
+    EvidenceUsePolicy,
+    GateName,
+    GateResult,
+    GateStatus,
+    GrowthMetricSpec,
+    MetricDirection,
+    SkillGrowthSpec,
+    TrainingEligibility,
+)
+
+__all__ = [
+    "ConsolidationDecision",
+    "ConsolidationManifest",
+    "EvidenceLevel",
+    "EvidenceUsePolicy",
+    "GateName",
+    "GateResult",
+    "GateStatus",
+    "GrowthMetricSpec",
+    "MetricDirection",
+    "SkillGrowthSpec",
+    "TrainingEligibility",
+]

--- a/src/rosclaw/growth/contracts.py
+++ b/src/rosclaw/growth/contracts.py
@@ -1,0 +1,419 @@
+"""Immutable, fail-closed contracts for evidence-backed skill growth.
+
+The Growth Plane may propose and evaluate artifacts, but these contracts never
+authorize a physical actuator.  They make evidence provenance, retention and
+rollback lineage explicit so low-trust synthetic data cannot silently become
+promotion truth.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
+
+
+def _require_hash(label: str, value: str) -> None:
+    if not _SHA256.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+def _require_identifier(label: str, value: str) -> None:
+    if not _IDENTIFIER.fullmatch(value):
+        raise ValueError(f"{label} must be a normalized identifier")
+
+
+def _unique_nonempty(values: tuple[str, ...], *, label: str) -> tuple[str, ...]:
+    normalized = tuple(values)
+    if not normalized or len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must be non-empty and unique")
+    if any(not item.strip() for item in normalized):
+        raise ValueError(f"{label} must not contain empty values")
+    return normalized
+
+
+def _hash_tuple(values: tuple[str, ...], *, label: str, allow_empty: bool = False) -> tuple[str, ...]:
+    normalized = tuple(values)
+    if not allow_empty and not normalized:
+        raise ValueError(f"{label} must not be empty")
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must be unique")
+    for item in normalized:
+        _require_hash(label, item)
+    return normalized
+
+
+class EvidenceLevel(StrEnum):
+    """Evidence strength, from executed reality to unverified external data."""
+
+    EXECUTION_RECEIPT = "e0_execution_receipt"
+    PHYSICS_REPLAY = "e1_physics_replay"
+    ACCELERATED_SIM = "e2_accelerated_sim"
+    WORLD_MODEL = "e3_world_model"
+    EXTERNAL_APPLICABLE = "e4_external_applicable"
+    EXTERNAL_UNVERIFIED = "e5_external_unverified"
+
+
+class TrainingEligibility(StrEnum):
+    DENIED = "denied"
+    CONDITIONAL = "conditional"
+    ALLOWED = "allowed"
+
+
+@dataclass(frozen=True)
+class EvidenceUsePolicy:
+    """Canonical capabilities of one evidence level.
+
+    The permissions are computed rather than caller supplied.  In particular,
+    E2--E5 evidence can discover or train candidates but cannot independently
+    approve one.
+    """
+
+    level: EvidenceLevel
+    schema_version: str = "rosclaw.growth.evidence_use_policy.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.level, EvidenceLevel):
+            raise ValueError("level must be a recognized EvidenceLevel")
+
+    @property
+    def training(self) -> TrainingEligibility:
+        if self.level is EvidenceLevel.EXTERNAL_UNVERIFIED:
+            return TrainingEligibility.DENIED
+        if self.level is EvidenceLevel.EXTERNAL_APPLICABLE:
+            return TrainingEligibility.CONDITIONAL
+        return TrainingEligibility.ALLOWED
+
+    @property
+    def candidate_discovery_allowed(self) -> bool:
+        return True
+
+    @property
+    def promotion_truth_allowed(self) -> bool:
+        return self.level in {EvidenceLevel.EXECUTION_RECEIPT, EvidenceLevel.PHYSICS_REPLAY}
+
+    @property
+    def required_replay_level(self) -> EvidenceLevel | None:
+        if self.promotion_truth_allowed:
+            return None
+        return EvidenceLevel.PHYSICS_REPLAY
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "level": self.level.value,
+            "training": self.training.value,
+            "candidate_discovery_allowed": self.candidate_discovery_allowed,
+            "promotion_truth_allowed": self.promotion_truth_allowed,
+            "required_replay_level": (
+                self.required_replay_level.value if self.required_replay_level else None
+            ),
+        }
+
+
+class MetricDirection(StrEnum):
+    MAXIMIZE = "maximize"
+    MINIMIZE = "minimize"
+
+
+@dataclass(frozen=True)
+class GrowthMetricSpec:
+    metric_id: str
+    direction: MetricDirection
+    primary: bool = False
+    minimum_relative_improvement: float = 0.05
+    confidence_level: float = 0.95
+    require_ci_lower_bound_positive: bool = True
+    schema_version: str = "rosclaw.growth.metric_spec.v1"
+
+    def __post_init__(self) -> None:
+        _require_identifier("metric_id", self.metric_id)
+        if not isinstance(self.direction, MetricDirection):
+            raise ValueError("direction must be a recognized MetricDirection")
+        if not math.isfinite(self.minimum_relative_improvement):
+            raise ValueError("minimum_relative_improvement must be finite")
+        if self.minimum_relative_improvement < 0.0:
+            raise ValueError("minimum_relative_improvement must be non-negative")
+        if not math.isfinite(self.confidence_level) or not 0.5 < self.confidence_level < 1.0:
+            raise ValueError("confidence_level must be finite and in (0.5, 1.0)")
+
+    @property
+    def metric_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "metric_id": self.metric_id,
+            "direction": self.direction.value,
+            "primary": self.primary,
+            "minimum_relative_improvement": self.minimum_relative_improvement,
+            "confidence_level": self.confidence_level,
+            "require_ci_lower_bound_positive": self.require_ci_lower_bound_positive,
+        }
+
+
+@dataclass(frozen=True)
+class SkillGrowthSpec:
+    """Task-neutral growth target pinned to semantic and safety contracts."""
+
+    skill_id: str
+    adapter_id: str
+    body_hashes: tuple[str, ...]
+    capability_ids: tuple[str, ...]
+    observation_contract_hash: str
+    action_contract_hash: str
+    reward_contract_hash: str
+    cost_contract_hash: str
+    practice_source_ids: tuple[str, ...]
+    collective_source_ids: tuple[str, ...]
+    allowed_dream_types: tuple[str, ...]
+    allowed_learner_ids: tuple[str, ...]
+    historical_anchor_hashes: tuple[str, ...]
+    boundary_suite_hash: str
+    metrics: tuple[GrowthMetricSpec, ...]
+    promotion_profile_hash: str
+    rollback_policy_hash: str
+    schema_version: str = "rosclaw.growth.skill_spec.v1"
+
+    def __post_init__(self) -> None:
+        _require_identifier("skill_id", self.skill_id)
+        _require_identifier("adapter_id", self.adapter_id)
+        for label, value in (
+            ("observation_contract_hash", self.observation_contract_hash),
+            ("action_contract_hash", self.action_contract_hash),
+            ("reward_contract_hash", self.reward_contract_hash),
+            ("cost_contract_hash", self.cost_contract_hash),
+            ("boundary_suite_hash", self.boundary_suite_hash),
+            ("promotion_profile_hash", self.promotion_profile_hash),
+            ("rollback_policy_hash", self.rollback_policy_hash),
+        ):
+            _require_hash(label, value)
+        object.__setattr__(self, "body_hashes", _hash_tuple(self.body_hashes, label="body_hashes"))
+        object.__setattr__(
+            self,
+            "historical_anchor_hashes",
+            _hash_tuple(self.historical_anchor_hashes, label="historical_anchor_hashes"),
+        )
+        for label in (
+            "capability_ids",
+            "practice_source_ids",
+            "allowed_dream_types",
+            "allowed_learner_ids",
+        ):
+            object.__setattr__(self, label, _unique_nonempty(getattr(self, label), label=label))
+        object.__setattr__(
+            self,
+            "collective_source_ids",
+            tuple(self.collective_source_ids),
+        )
+        if len(self.collective_source_ids) != len(set(self.collective_source_ids)):
+            raise ValueError("collective_source_ids must be unique")
+        metrics = tuple(self.metrics)
+        if any(not isinstance(metric, GrowthMetricSpec) for metric in metrics):
+            raise ValueError("metrics must contain GrowthMetricSpec records")
+        if not metrics or sum(metric.primary for metric in metrics) != 1:
+            raise ValueError("metrics must contain exactly one primary metric")
+        if next(metric for metric in metrics if metric.primary).minimum_relative_improvement <= 0.0:
+            raise ValueError("the primary metric must require a positive relative improvement")
+        if len({metric.metric_id for metric in metrics}) != len(metrics):
+            raise ValueError("metric ids must be unique")
+        object.__setattr__(self, "metrics", metrics)
+
+    @property
+    def spec_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "skill_id": self.skill_id,
+            "adapter_id": self.adapter_id,
+            "body_hashes": list(self.body_hashes),
+            "capability_ids": list(self.capability_ids),
+            "observation_contract_hash": self.observation_contract_hash,
+            "action_contract_hash": self.action_contract_hash,
+            "reward_contract_hash": self.reward_contract_hash,
+            "cost_contract_hash": self.cost_contract_hash,
+            "practice_source_ids": list(self.practice_source_ids),
+            "collective_source_ids": list(self.collective_source_ids),
+            "allowed_dream_types": list(self.allowed_dream_types),
+            "allowed_learner_ids": list(self.allowed_learner_ids),
+            "historical_anchor_hashes": list(self.historical_anchor_hashes),
+            "boundary_suite_hash": self.boundary_suite_hash,
+            "metrics": [metric.to_dict() for metric in self.metrics],
+            "promotion_profile_hash": self.promotion_profile_hash,
+            "rollback_policy_hash": self.rollback_policy_hash,
+        }
+
+
+class GateName(StrEnum):
+    LEARNING = "learning"
+    RETENTION = "retention"
+    SAFETY = "safety"
+    APPLICABILITY = "applicability"
+    DARWIN = "darwin"
+
+
+class GateStatus(StrEnum):
+    PASS = "pass"
+    FAIL = "fail"
+    MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class GateResult:
+    name: GateName
+    status: GateStatus
+    report_hash: str | None = None
+    detail: str = ""
+    schema_version: str = "rosclaw.growth.gate_result.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, GateName):
+            raise ValueError("name must be a recognized GateName")
+        if not isinstance(self.status, GateStatus):
+            raise ValueError("status must be a recognized GateStatus")
+        if self.status is GateStatus.MISSING:
+            if self.report_hash is not None:
+                raise ValueError("a missing gate cannot carry a report hash")
+        elif self.report_hash is None:
+            raise ValueError("a completed gate requires a report hash")
+        else:
+            _require_hash("report_hash", self.report_hash)
+
+    @property
+    def result_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "name": self.name.value,
+            "status": self.status.value,
+            "report_hash": self.report_hash,
+            "detail": self.detail,
+        }
+
+
+class ConsolidationDecision(StrEnum):
+    CONSOLIDATE_SIM = "consolidate_sim"
+    REJECT = "reject"
+    NEED_MORE_EVIDENCE = "need_more_evidence"
+
+
+@dataclass(frozen=True)
+class ConsolidationManifest:
+    """Auditable result of all five growth gates.
+
+    V1 intentionally supports simulation consolidation only.  A separate,
+    operator-mediated mechanism is required for any physical deployment.
+    """
+
+    skill_growth_spec_hash: str
+    candidate_artifact_hash: str
+    parent_artifact_hash: str
+    rollback_artifact_hash: str
+    learned_changes: Mapping[str, str]
+    new_capability_ids: tuple[str, ...]
+    retained_capability_ids: tuple[str, ...]
+    forgotten_capability_ids: tuple[str, ...]
+    gate_results: tuple[GateResult, ...]
+    darwin_report_hash: str
+    decision: ConsolidationDecision
+    schema_version: str = "rosclaw.growth.consolidation_manifest.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.decision, ConsolidationDecision):
+            raise ValueError("decision must be a recognized ConsolidationDecision")
+        for label, value in (
+            ("skill_growth_spec_hash", self.skill_growth_spec_hash),
+            ("candidate_artifact_hash", self.candidate_artifact_hash),
+            ("parent_artifact_hash", self.parent_artifact_hash),
+            ("rollback_artifact_hash", self.rollback_artifact_hash),
+            ("darwin_report_hash", self.darwin_report_hash),
+        ):
+            _require_hash(label, value)
+        if self.candidate_artifact_hash == self.parent_artifact_hash:
+            raise ValueError("candidate artifact must differ from its parent")
+        if self.rollback_artifact_hash != self.parent_artifact_hash:
+            raise ValueError("v1 rollback artifact must be the pinned parent artifact")
+        learned_changes = {str(key): str(value) for key, value in self.learned_changes.items()}
+        if not learned_changes:
+            raise ValueError("learned_changes must not be empty")
+        for value in learned_changes.values():
+            _require_hash("learned_changes value", value)
+        object.__setattr__(self, "learned_changes", MappingProxyType(learned_changes))
+        for label in (
+            "new_capability_ids",
+            "retained_capability_ids",
+            "forgotten_capability_ids",
+        ):
+            values = tuple(getattr(self, label))
+            if len(values) != len(set(values)) or any(not value.strip() for value in values):
+                raise ValueError(f"{label} must contain unique non-empty values")
+            object.__setattr__(self, label, values)
+        gates = tuple(self.gate_results)
+        if any(not isinstance(gate, GateResult) for gate in gates):
+            raise ValueError("gate_results must contain GateResult records")
+        if {gate.name for gate in gates} != set(GateName) or len(gates) != len(GateName):
+            raise ValueError("gate_results must contain each required gate exactly once")
+        object.__setattr__(self, "gate_results", gates)
+        darwin_gate = next(gate for gate in gates if gate.name is GateName.DARWIN)
+        if darwin_gate.report_hash is not None and darwin_gate.report_hash != self.darwin_report_hash:
+            raise ValueError("darwin_report_hash must match the Darwin gate report")
+        expected = self._expected_decision(gates)
+        if self.decision is not expected:
+            raise ValueError(f"decision must be {expected.value} for the supplied gate results")
+        if self.decision is ConsolidationDecision.CONSOLIDATE_SIM:
+            if self.forgotten_capability_ids:
+                raise ValueError("a consolidatable candidate cannot forget declared capabilities")
+            if not self.retained_capability_ids:
+                raise ValueError("a consolidatable candidate must prove retained capabilities")
+
+    @staticmethod
+    def _expected_decision(gates: tuple[GateResult, ...]) -> ConsolidationDecision:
+        if any(gate.status is GateStatus.FAIL for gate in gates):
+            return ConsolidationDecision.REJECT
+        if any(gate.status is GateStatus.MISSING for gate in gates):
+            return ConsolidationDecision.NEED_MORE_EVIDENCE
+        return ConsolidationDecision.CONSOLIDATE_SIM
+
+    @property
+    def evidence_domain(self) -> str:
+        return "SIM_ONLY"
+
+    @property
+    def hardware_authorized(self) -> bool:
+        return False
+
+    @property
+    def manifest_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "skill_growth_spec_hash": self.skill_growth_spec_hash,
+            "candidate_artifact_hash": self.candidate_artifact_hash,
+            "parent_artifact_hash": self.parent_artifact_hash,
+            "rollback_artifact_hash": self.rollback_artifact_hash,
+            "learned_changes": dict(sorted(self.learned_changes.items())),
+            "new_capability_ids": list(self.new_capability_ids),
+            "retained_capability_ids": list(self.retained_capability_ids),
+            "forgotten_capability_ids": list(self.forgotten_capability_ids),
+            "gate_results": [gate.to_dict() for gate in self.gate_results],
+            "darwin_report_hash": self.darwin_report_hash,
+            "decision": self.decision.value,
+            "evidence_domain": self.evidence_domain,
+            "hardware_authorized": self.hardware_authorized,
+        }

--- a/tests/collective/test_contracts.py
+++ b/tests/collective/test_contracts.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from rosclaw.collective import (
+    ApplicabilityAssessment,
+    ApplicabilityDecision,
+    CollectiveSourceIdentity,
+    CollectiveUse,
+    ExperienceCapsule,
+    LicenseDecision,
+    LicenseUse,
+    SourceLicenseEvidence,
+)
+from rosclaw.growth import EvidenceLevel, EvidenceUsePolicy
+
+
+def _hash(label: str) -> str:
+    return "sha256:" + hashlib.sha256(label.encode()).hexdigest()
+
+
+def _license(decision: LicenseDecision) -> SourceLicenseEvidence:
+    if decision is LicenseDecision.PENDING:
+        return SourceLicenseEvidence(
+            requested_use=LicenseUse.RESEARCH_NONCOMMERCIAL,
+            decision=decision,
+        )
+    return SourceLicenseEvidence(
+        requested_use=LicenseUse.RESEARCH_NONCOMMERCIAL,
+        decision=decision,
+        terms_uri="https://example.invalid/dataset-license",
+        terms_hash=_hash("license"),
+        attribution="Example Dataset Authors",
+    )
+
+
+def _source(decision: LicenseDecision = LicenseDecision.PERMITTED) -> CollectiveSourceIdentity:
+    return CollectiveSourceIdentity(
+        provider="CMRobot",
+        dataset="MotionDecode",
+        revision="pinned-revision",
+        file_hashes={"motions/example.csv": _hash("csv")},
+        license_evidence=_license(decision),
+        source_body_id="source-humanoid",
+    )
+
+
+def _applicability(
+    decision: ApplicabilityDecision = ApplicabilityDecision.ACCEPT,
+) -> ApplicabilityAssessment:
+    return ApplicabilityAssessment(
+        target_body_hash=_hash("g1-body"),
+        target_mapping_hash=_hash("mapping"),
+        body_score=0.9,
+        task_score=0.9,
+        regime_score=0.9,
+        confidence=0.9,
+        evidence_hashes=(_hash("applicability-report"),),
+        decision=decision,
+    )
+
+
+def _capsule(
+    *,
+    source: CollectiveSourceIdentity | None = None,
+    requested_uses: tuple[CollectiveUse, ...] = (CollectiveUse.MOTION_REFERENCE,),
+    action: str | None = None,
+    transition: str | None = None,
+    reward: str | None = None,
+) -> ExperienceCapsule:
+    return ExperienceCapsule(
+        source=source or _source(),
+        applicability=_applicability(),
+        task_semantics_hash=_hash("task"),
+        observation_semantics_hash=_hash("observation"),
+        action_semantics_hash=action,
+        transition_semantics_hash=transition,
+        reward_semantics_hash=reward,
+        modalities=("joint_position", "root_pose"),
+        requested_uses=requested_uses,
+        quality_report_hash=_hash("quality"),
+        evidence_policy=EvidenceUsePolicy(EvidenceLevel.EXTERNAL_APPLICABLE),
+        source_episode_count=42,
+    )
+
+
+def test_unknown_license_catalogues_but_never_trains() -> None:
+    capsule = _capsule(source=_source(LicenseDecision.PENDING))
+
+    assert capsule.source.license_evidence.terms_hash is None
+    assert capsule.training_eligible is False
+
+
+def test_motion_reference_can_train_after_license_and_applicability_gates() -> None:
+    capsule = _capsule()
+
+    assert capsule.training_eligible is True
+    assert capsule.promotion_truth_allowed is False
+    assert capsule.to_dict()["requested_uses"] == ["motion_reference"]
+
+
+def test_motion_csv_cannot_be_declared_offline_rl_without_transition_semantics() -> None:
+    with pytest.raises(ValueError, match="offline RL requires"):
+        _capsule(requested_uses=(CollectiveUse.OFFLINE_RL,))
+
+    capsule = _capsule(
+        requested_uses=(CollectiveUse.OFFLINE_RL,),
+        action=_hash("action"),
+        transition=_hash("transition"),
+        reward=_hash("reward"),
+    )
+    assert capsule.training_eligible is True
+
+
+def test_learning_use_cannot_be_spoofed_to_bypass_semantic_requirements() -> None:
+    with pytest.raises(ValueError, match="recognized CollectiveUse"):
+        _capsule(requested_uses=("offline_rl",))  # type: ignore[arg-type]
+
+
+def test_applicability_acceptance_requires_high_confidence_scores() -> None:
+    with pytest.raises(ValueError, match=">= 0.8"):
+        ApplicabilityAssessment(
+            target_body_hash=_hash("g1-body"),
+            target_mapping_hash=_hash("mapping"),
+            body_score=0.79,
+            task_score=0.9,
+            regime_score=0.9,
+            confidence=0.9,
+            evidence_hashes=(_hash("report"),),
+            decision=ApplicabilityDecision.ACCEPT,
+        )
+
+
+def test_source_file_manifest_is_immutable() -> None:
+    source = _source()
+
+    with pytest.raises(TypeError):
+        source.file_hashes["other.csv"] = _hash("other")  # type: ignore[index]

--- a/tests/dream/test_contracts.py
+++ b/tests/dream/test_contracts.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+import math
+
+import pytest
+
+from rosclaw.dream import DreamBudget, DreamCampaign, DreamEpisode, DreamType
+from rosclaw.growth import EvidenceLevel, EvidenceUsePolicy
+
+
+def _hash(label: str) -> str:
+    return "sha256:" + hashlib.sha256(label.encode()).hexdigest()
+
+
+def _budget() -> DreamBudget:
+    return DreamBudget(
+        max_gpu_seconds=3600.0,
+        max_cpu_rollouts=100,
+        max_candidates=8,
+        max_wall_seconds=7200.0,
+        max_policy_change=0.05,
+        max_anchor_drift=0.02,
+    )
+
+
+def _campaign(
+    *,
+    dream_types: tuple[DreamType, ...] = (DreamType.REPLAY, DreamType.COUNTERFACTUAL),
+    collective: tuple[str, ...] = (),
+) -> DreamCampaign:
+    return DreamCampaign(
+        skill_growth_spec_hash=_hash("growth-spec"),
+        body_hash=_hash("body"),
+        parent_policy_hash=_hash("parent-policy"),
+        trigger_kind="post_practice_regression",
+        trigger_evidence_hashes=(_hash("trigger"),),
+        objectives=("improve_recovery", "retain_kick_success"),
+        constraint_hashes=(_hash("constraints"),),
+        practice_snapshot_hashes=(_hash("practice"),),
+        collective_capsule_hashes=collective,
+        historical_anchor_hashes=(_hash("anchor"),),
+        boundary_suite_hashes=(_hash("boundary"),),
+        private_holdout_commitment=_hash("private-holdout-commitment"),
+        dream_types=dream_types,
+        learner_ids=("residual.ppo",),
+        budget=_budget(),
+    )
+
+
+def _episode(
+    level: EvidenceLevel,
+    **kwargs: object,
+) -> DreamEpisode:
+    values: dict[str, object] = {
+        "campaign_hash": _hash("campaign"),
+        "source_episode_hash": _hash("episode"),
+        "body_hash": _hash("body"),
+        "policy_hash": _hash("policy"),
+        "dream_type": DreamType.REPLAY,
+        "evidence_policy": EvidenceUsePolicy(level),
+        "uncertainty": 0.1,
+    }
+    values.update(kwargs)
+    return DreamEpisode(**values)  # type: ignore[arg-type]
+
+
+def test_campaign_exposes_holdout_commitment_but_no_holdout_rows() -> None:
+    campaign = _campaign()
+    payload = campaign.to_dict()
+
+    assert payload["private_holdout_commitment"] == _hash("private-holdout-commitment")
+    assert "holdout_rows" not in str(payload)
+    assert campaign.hardware_authorized is False
+
+
+def test_social_dream_requires_governed_collective_capsules() -> None:
+    with pytest.raises(ValueError, match="social dreaming requires"):
+        _campaign(dream_types=(DreamType.SOCIAL,))
+
+    campaign = _campaign(
+        dream_types=(DreamType.SOCIAL,),
+        collective=(_hash("experience-capsule"),),
+    )
+    assert campaign.collective_capsule_hashes == (_hash("experience-capsule"),)
+
+
+def test_dream_type_cannot_be_spoofed_to_bypass_social_gate() -> None:
+    with pytest.raises(ValueError, match="recognized DreamType"):
+        _campaign(dream_types=("social",))  # type: ignore[arg-type]
+
+
+def test_world_model_dream_can_train_but_never_approve() -> None:
+    episode = _episode(
+        EvidenceLevel.WORLD_MODEL,
+        dream_type=DreamType.PROSPECTIVE,
+        world_model_hash=_hash("world-model"),
+        predicted_outcome_hash=_hash("prediction"),
+    )
+
+    assert episode.training_eligible is True
+    assert episode.promotion_truth_allowed is False
+
+
+def test_physics_replay_requires_verified_outcome_for_promotion_truth() -> None:
+    unverified = _episode(
+        EvidenceLevel.PHYSICS_REPLAY,
+        simulated_outcome_hash=_hash("sim-result"),
+    )
+    verified = _episode(
+        EvidenceLevel.PHYSICS_REPLAY,
+        simulated_outcome_hash=_hash("sim-result"),
+        physics_replay_verified=True,
+    )
+
+    assert unverified.promotion_truth_allowed is False
+    assert verified.promotion_truth_allowed is True
+
+
+def test_execution_truth_requires_receipt_and_external_unverified_cannot_train() -> None:
+    with pytest.raises(ValueError, match="signed receipt"):
+        _episode(EvidenceLevel.EXECUTION_RECEIPT)
+
+    receipt = _episode(
+        EvidenceLevel.EXECUTION_RECEIPT,
+        execution_receipt_hash=_hash("execution-receipt"),
+    )
+    external = _episode(EvidenceLevel.EXTERNAL_UNVERIFIED)
+
+    assert receipt.promotion_truth_allowed is True
+    assert external.training_eligible is False
+    assert external.promotion_truth_allowed is False
+
+
+def test_budget_rejects_nonfinite_or_unbounded_drift() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        DreamBudget(math.inf, 0, 1, 1.0, 0.1, 0.1)
+    with pytest.raises(ValueError, match="max_policy_change"):
+        DreamBudget(1.0, 0, 1, 1.0, 1.1, 0.1)

--- a/tests/growth/test_contracts.py
+++ b/tests/growth/test_contracts.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from rosclaw.growth import (
+    ConsolidationDecision,
+    ConsolidationManifest,
+    EvidenceLevel,
+    EvidenceUsePolicy,
+    GateName,
+    GateResult,
+    GateStatus,
+    GrowthMetricSpec,
+    MetricDirection,
+    SkillGrowthSpec,
+    TrainingEligibility,
+)
+
+
+def _hash(label: str) -> str:
+    return "sha256:" + hashlib.sha256(label.encode()).hexdigest()
+
+
+def _metric(*, primary: bool = True) -> GrowthMetricSpec:
+    return GrowthMetricSpec(
+        metric_id="kick.recovery_stability",
+        direction=MetricDirection.MAXIMIZE,
+        primary=primary,
+    )
+
+
+def _skill_spec(metrics: tuple[GrowthMetricSpec, ...] | None = None) -> SkillGrowthSpec:
+    return SkillGrowthSpec(
+        skill_id="g1.kick",
+        adapter_id="g1.motion_adapter",
+        body_hashes=(_hash("body"),),
+        capability_ids=("kick", "recover"),
+        observation_contract_hash=_hash("observation"),
+        action_contract_hash=_hash("action"),
+        reward_contract_hash=_hash("reward"),
+        cost_contract_hash=_hash("cost"),
+        practice_source_ids=("practice.g1_hat_trick",),
+        collective_source_ids=(),
+        allowed_dream_types=("replay", "counterfactual"),
+        allowed_learner_ids=("residual.ppo",),
+        historical_anchor_hashes=(_hash("anchor"),),
+        boundary_suite_hash=_hash("boundary"),
+        metrics=metrics or (_metric(),),
+        promotion_profile_hash=_hash("promotion"),
+        rollback_policy_hash=_hash("rollback"),
+    )
+
+
+def _gates(statuses: dict[GateName, GateStatus] | None = None) -> tuple[GateResult, ...]:
+    statuses = statuses or {}
+    return tuple(
+        GateResult(
+            name=name,
+            status=statuses.get(name, GateStatus.PASS),
+            report_hash=(
+                None if statuses.get(name) is GateStatus.MISSING else _hash(f"report-{name.value}")
+            ),
+        )
+        for name in GateName
+    )
+
+
+def _manifest(
+    *,
+    gates: tuple[GateResult, ...] | None = None,
+    decision: ConsolidationDecision = ConsolidationDecision.CONSOLIDATE_SIM,
+    rollback: str | None = None,
+    forgotten: tuple[str, ...] = (),
+) -> ConsolidationManifest:
+    return ConsolidationManifest(
+        skill_growth_spec_hash=_hash("growth-spec"),
+        candidate_artifact_hash=_hash("candidate"),
+        parent_artifact_hash=_hash("parent"),
+        rollback_artifact_hash=rollback or _hash("parent"),
+        learned_changes={"residual_policy": _hash("residual-policy")},
+        new_capability_ids=("recover_without_step",),
+        retained_capability_ids=("kick", "recover"),
+        forgotten_capability_ids=forgotten,
+        gate_results=gates or _gates(),
+        darwin_report_hash=_hash("report-darwin"),
+        decision=decision,
+    )
+
+
+@pytest.mark.parametrize(
+    ("level", "training", "promotion"),
+    [
+        (EvidenceLevel.EXECUTION_RECEIPT, TrainingEligibility.ALLOWED, True),
+        (EvidenceLevel.PHYSICS_REPLAY, TrainingEligibility.ALLOWED, True),
+        (EvidenceLevel.ACCELERATED_SIM, TrainingEligibility.ALLOWED, False),
+        (EvidenceLevel.WORLD_MODEL, TrainingEligibility.ALLOWED, False),
+        (EvidenceLevel.EXTERNAL_APPLICABLE, TrainingEligibility.CONDITIONAL, False),
+        (EvidenceLevel.EXTERNAL_UNVERIFIED, TrainingEligibility.DENIED, False),
+    ],
+)
+def test_evidence_permissions_are_canonical(
+    level: EvidenceLevel,
+    training: TrainingEligibility,
+    promotion: bool,
+) -> None:
+    policy = EvidenceUsePolicy(level)
+
+    assert policy.training is training
+    assert policy.promotion_truth_allowed is promotion
+    assert (policy.required_replay_level is None) is promotion
+
+
+def test_evidence_level_cannot_be_spoofed_with_a_string() -> None:
+    with pytest.raises(ValueError, match="recognized EvidenceLevel"):
+        EvidenceUsePolicy("e5_external_unverified")  # type: ignore[arg-type]
+
+
+def test_skill_growth_spec_is_content_addressed_and_task_neutral() -> None:
+    first = _skill_spec()
+    second = _skill_spec()
+
+    assert first.spec_hash == second.spec_hash
+    assert first.to_dict()["skill_id"] == "g1.kick"
+    assert "football" not in first.to_dict()
+
+
+def test_skill_growth_spec_requires_exactly_one_positive_primary_metric() -> None:
+    with pytest.raises(ValueError, match="exactly one primary"):
+        _skill_spec((_metric(primary=False),))
+
+    zero = GrowthMetricSpec(
+        metric_id="kick.success",
+        direction=MetricDirection.MAXIMIZE,
+        primary=True,
+        minimum_relative_improvement=0.0,
+    )
+    with pytest.raises(ValueError, match="positive relative improvement"):
+        _skill_spec((zero,))
+
+
+def test_complete_passed_gates_only_consolidate_in_sim() -> None:
+    manifest = _manifest()
+
+    assert manifest.decision is ConsolidationDecision.CONSOLIDATE_SIM
+    assert manifest.evidence_domain == "SIM_ONLY"
+    assert manifest.hardware_authorized is False
+    assert manifest.to_dict()["rollback_artifact_hash"] == _hash("parent")
+
+
+def test_missing_or_failed_gate_forces_fail_closed_decision() -> None:
+    missing = _gates({GateName.RETENTION: GateStatus.MISSING})
+    manifest = _manifest(gates=missing, decision=ConsolidationDecision.NEED_MORE_EVIDENCE)
+    assert manifest.decision is ConsolidationDecision.NEED_MORE_EVIDENCE
+
+    failed = _gates({GateName.SAFETY: GateStatus.FAIL})
+    rejected = _manifest(gates=failed, decision=ConsolidationDecision.REJECT)
+    assert rejected.decision is ConsolidationDecision.REJECT
+
+    with pytest.raises(ValueError, match="decision must be reject"):
+        _manifest(gates=failed, decision=ConsolidationDecision.CONSOLIDATE_SIM)
+
+
+def test_manifest_pins_rollback_and_rejects_forgetting() -> None:
+    with pytest.raises(ValueError, match="rollback artifact"):
+        _manifest(rollback=_hash("unrelated"))
+    with pytest.raises(ValueError, match="cannot forget"):
+        _manifest(forgotten=("stand",))


### PR DESCRIPTION
## What changed

- Add task-neutral SkillGrowthSpec, metric, evidence-level and five-gate consolidation contracts.
- Add bounded DreamBudget, DreamCampaign and evidence-labelled DreamEpisode contracts.
- Add governed collective-experience contracts for source identity, license evidence, applicability and intended learning use.
- Enforce runtime enum validation so string values cannot bypass offline-RL, social-dream or evidence gates.
- Keep all Phase 8 V1 consolidation SIM-only with no actuator or hardware authorization path.
- Add 25 focused fail-closed tests.

## Why

Phase 8 needs trustworthy contracts before schedulers or learning algorithms. Synthetic/world-model evidence and external datasets may discover or train candidates, but must not silently become promotion truth. Motion-reference CSVs must not be treated as offline-RL transitions without action, transition and reward semantics.

## Validation

- Ruff: passed.
- Mypy on six new source files: passed.
- Focused plus continual, self-model, feedback and evolution regression: 208 passed.
- Full suite: 5384 passed, 67 skipped, 27 deselected; four LeRobot tests initially lacked runtime discovery.
- Explicit existing LeRobot 0.6.1 runtime recheck: remaining 4 passed.
- Git diff check: passed.
- Exact ROSClaw CLI import/help smoke: passed.

## Scope boundaries

- No training algorithm or policy activation in this PR.
- No real robot, ROS/DDS actuation or hardware permit.
- MotionDecode data remains external to the checkout and is not included.