### PR TITLE
Support MCP console entrypoints

### DIFF
--- a/src/rosclaw/mcp/onboarding/source_installer.py
+++ b/src/rosclaw/mcp/onboarding/source_installer.py
@@ -178,8 +178,16 @@ def _normalize_simple_manifest(data: dict[str, Any], source_dir: Path) -> dict[s
     hardware = data.get("hardware", {})
     files = data.get("files", [])
 
-    entrypoint = args[0] if args else "mcp_server.py"
-    if not (source_dir / entrypoint).exists() and files:
+    declared_entrypoint = data.get("entrypoint")
+    has_declared_entrypoint = isinstance(declared_entrypoint, str) and bool(
+        declared_entrypoint.strip()
+    )
+    entrypoint = (
+        declared_entrypoint.strip()
+        if has_declared_entrypoint
+        else (args[0] if args else "mcp_server.py")
+    )
+    if not (source_dir / entrypoint).exists() and files and not has_declared_entrypoint:
         for f in files:
             if "server" in f and (source_dir / f).exists():
                 entrypoint = f
@@ -272,12 +280,19 @@ import sys
 
 SOURCE_DIR = {str(source_dir)!r}
 PYTHON = {python!r}
-ENTRYPOINT = os.path.join(SOURCE_DIR, {entrypoint!r})
+ENTRYPOINT = {entrypoint!r}
 
 env = os.environ.copy()
 env["PYTHONPATH"] = SOURCE_DIR + os.pathsep + env.get("PYTHONPATH", "")
 os.chdir(SOURCE_DIR)
-sys.exit(subprocess.call([PYTHON, ENTRYPOINT] + sys.argv[1:], env=env))
+source_entrypoint = os.path.join(SOURCE_DIR, ENTRYPOINT)
+if os.path.isfile(source_entrypoint):
+    command = [PYTHON, source_entrypoint]
+elif os.path.isabs(ENTRYPOINT):
+    command = [ENTRYPOINT]
+else:
+    command = [os.path.join(os.path.dirname(PYTHON), ENTRYPOINT)]
+sys.exit(subprocess.call(command + sys.argv[1:], env=env))
 """
     wrapper.write_text(script, encoding="utf-8")
     wrapper.chmod(0o755)
@@ -502,7 +517,7 @@ def install_from_git(
             rollback_source()
             return failed_result(commit)
 
-        py = str(Path(python or sys.executable).expanduser().resolve())
+        py = str(Path(python or sys.executable).expanduser().absolute())
         entrypoint = (
             manifest.artifact.entrypoint
             if (manifest.artifact and manifest.artifact.entrypoint)
@@ -614,7 +629,7 @@ def install_from_local_path(
 
     _install_dependencies(source_dir, python, no_install_deps, errors)
 
-    py = str(Path(python or sys.executable).expanduser().resolve())
+    py = str(Path(python or sys.executable).expanduser().absolute())
     entrypoint = (
         manifest.artifact.entrypoint
         if (manifest.artifact and manifest.artifact.entrypoint)

--- a/tests/mcp/test_source_installer_revision.py
+++ b/tests/mcp/test_source_installer_revision.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from rosclaw.mcp.onboarding.installed import InstalledRegistry
-from rosclaw.mcp.onboarding.source_installer import install_from_git
+from rosclaw.mcp.onboarding.source_installer import (
+    install_from_git,
+    install_from_local_path,
+)
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -130,3 +135,51 @@ def test_failed_registry_update_rolls_back_source_and_metadata(
     assert installed.runtime_config_path.read_bytes() == runtime_config
     assert registry_path.read_bytes() == registry
     assert not list(installed.local_path.parent.glob(".source-*"))
+
+
+def test_simple_manifest_console_entrypoint_runs_from_selected_python_bin(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "manifest.json").write_text(
+        json.dumps(
+            {
+                "name": "limo-ros-mcp",
+                "version": "0.5.2",
+                "transport": "stdio",
+                "entrypoint": "limo-ros-mcp",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    selected_bin = tmp_path / "selected-python" / "bin"
+    selected_bin.mkdir(parents=True)
+    selected_python = selected_bin / "python"
+    selected_python.symlink_to(sys.executable)
+    console_script = selected_bin / "limo-ros-mcp"
+    console_script.write_text(
+        f"#!{sys.executable}\nimport sys\nprint('console:' + ','.join(sys.argv[1:]))\n",
+        encoding="utf-8",
+    )
+    console_script.chmod(0o755)
+    home = tmp_path / "home"
+    result = install_from_local_path(
+        source,
+        server_name="limo-ros-mcp",
+        home=home,
+        python=str(selected_python),
+        no_install_deps=True,
+    )
+    assert result.success
+    wrapper = home / "mcp" / "installed" / "limo-ros-mcp" / "run_server.py"
+
+    completed = subprocess.run(
+        [sys.executable, str(wrapper), "probe"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout.strip() == "console:probe"


### PR DESCRIPTION
## What changed

- honor a simple MCP manifest top-level entrypoint declaration
- run declared console entrypoints from the selected Python environment bin directory
- preserve the selected virtual-environment Python path instead of resolving its symlink to the base interpreter
- add an end-to-end local installer regression test covering manifest normalization, venv symlinks, wrapper generation, and console execution

## Root cause

The source installer ignored limo-ros-mcp manifest entrypoint and fell back to a nonexistent mcp_server.py. After honoring the entrypoint, resolving the selected venv Python symlink still pointed the wrapper at the base interpreter bin directory, where the console script was absent.

## Impact

Robot Pack adapter installation now generates a runnable stdio wrapper for packaged MCP servers that expose project console scripts.

## Validation

- console-entrypoint end-to-end regression test passed
- ruff check and format passed
- focused mypy passed
- physical deployment: installed limo-ros-mcp 0.5.2 at ff78d0706ca28eba7e8f75c543244c996fcbb253
- live read-only MCP probe: 66 ROS topics, 16 nodes, required topics present, command_dispatched=false