### PR TITLE
feat(perception): HandCam camera pose contract + marker-free visual hand state (PR-PE-3)

### DIFF
--- a/configs/handcam/front_v1.yaml
+++ b/configs/handcam/front_v1.yaml
@@ -1,0 +1,27 @@
+# HandCam camera pose contracts — Physical Evolution Lab front_v1
+# Measured 2026-07-30 on the dual-RH56 rig (D435i 231122070092, fw 5.17.0.10).
+# Intrinsics are read from the DEVICE at capture time (never hand-edited here);
+# the values below are the measured reference for verification.
+camera_pose_id: front_v1
+camera_id: d435i_231122070092
+intrinsics:
+  width: 640
+  height: 480
+  fx: 384.893
+  fy: 384.893
+  ppx: 324.663
+  ppy: 244.437
+  distortion_model: brown_conrady
+  coeffs: [0.0, 0.0, 0.0, 0.0, 0.0]
+extrinsic:
+  status: unmeasured
+mount:
+  status: unmeasured
+lighting_profile_id: ceiling_fluorescent_v1
+rois:
+  left_hand: {x0: 0, y0: 80, x1: 230, y1: 480}
+  right_hand: {x0: 410, y0: 120, x1: 640, y1: 480}
+notes: >
+  双手在支架上指向镜头（仰视角），指尖距镜头 ~20cm；左右 ROI 依据
+  2026-07-30 实拍画面标定。移动相机必须重测 ROI 并重新生成
+  camera_pose_hash（v3 §4.2）。

--- a/src/rosclaw/perception/__init__.py
+++ b/src/rosclaw/perception/__init__.py
@@ -1,0 +1,1 @@
+"""HandCam perception package (Physical Evolution Lab)."""

--- a/src/rosclaw/perception/handcam/__init__.py
+++ b/src/rosclaw/perception/handcam/__init__.py
@@ -1,0 +1,33 @@
+"""HandCam perception for the Physical Evolution Lab (PR-PE-3)."""
+
+from .calibration import (
+    CONTRACT_VERSION,
+    CameraIntrinsics,
+    CameraPoseContract,
+    intrinsics_from_json,
+    intrinsics_from_pyrealsense,
+)
+from .hand_state import (
+    STATE_VERSION,
+    ClusterQuality,
+    StabilityResult,
+    VisualHandState,
+    contact_distance_m,
+    estimate_hand_state,
+    measure_visual_stability,
+)
+
+__all__ = [
+    "CONTRACT_VERSION",
+    "STATE_VERSION",
+    "CameraIntrinsics",
+    "CameraPoseContract",
+    "ClusterQuality",
+    "StabilityResult",
+    "VisualHandState",
+    "contact_distance_m",
+    "estimate_hand_state",
+    "intrinsics_from_json",
+    "intrinsics_from_pyrealsense",
+    "measure_visual_stability",
+]

--- a/src/rosclaw/perception/handcam/calibration.py
+++ b/src/rosclaw/perception/handcam/calibration.py
@@ -1,0 +1,188 @@
+"""Camera pose contract + intrinsics binding (Physical Evolution Lab §4.2, PR-PE-3).
+
+Every visual conclusion is valid only under one camera pose.  The
+contract binds:
+
+* ``camera_pose_id`` — operator-named pose (e.g. ``front_v1``);
+* ``intrinsic_hash`` — from the DEVICE's real intrinsics (fx/fy/ppx/ppy
+  + distortion model), read off the D435i — never hand-copied;
+* ``extrinsic_hash`` / ``mount_hash`` — "unmeasured" until an operator
+  measures them (disclosed, and still hashed so a changed declaration
+  is a changed hash);
+* ``roi_hash`` / ``lighting_profile_id``.
+
+Moving the camera invalidates the contract: ``camera_pose_hash``
+changes and every visual calibration produced under the old hash stops
+being valid evidence (v3 §4.2: 移动相机后必须重新生成 Camera Pose
+Hash，旧视觉标定不得继续作为有效证据).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from rosclaw.practice.physical_observation import canonical_hash
+
+CONTRACT_VERSION = "rosclaw.camera_pose.v1"
+
+
+@dataclass(frozen=True)
+class CameraIntrinsics:
+    width: int
+    height: int
+    fx: float
+    fy: float
+    ppx: float
+    ppy: float
+    distortion_model: str = "unknown"
+    coeffs: tuple[float, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "width": self.width,
+            "height": self.height,
+            "fx": self.fx,
+            "fy": self.fy,
+            "ppx": self.ppx,
+            "ppy": self.ppy,
+            "distortion_model": self.distortion_model,
+            "coeffs": list(self.coeffs),
+        }
+
+    @property
+    def intrinsic_hash(self) -> str:
+        return canonical_hash(self.to_dict(), prefix="intr")
+
+    def deproject(self, u: float, v: float, depth_m: float) -> tuple[float, float, float]:
+        """Pinhole deprojection (no distortion correction — disclosed;
+        D435i depth is factory-rectified so this is the honest model)."""
+        x = (u - self.ppx) * depth_m / self.fx
+        y = (v - self.ppy) * depth_m / self.fy
+        return (x, y, depth_m)
+
+
+@dataclass(frozen=True)
+class CameraPoseContract:
+    camera_pose_id: str
+    camera_id: str
+    intrinsics: CameraIntrinsics
+    extrinsic: dict[str, Any] = field(default_factory=dict)
+    mount: dict[str, Any] = field(default_factory=dict)
+    roi: dict[str, int] = field(default_factory=dict)  # x0,y0,x1,y1 in pixels
+    lighting_profile_id: str = "unmeasured"
+
+    @property
+    def extrinsic_hash(self) -> str:
+        return canonical_hash(self.extrinsic or {"status": "unmeasured"}, prefix="extr")
+
+    @property
+    def mount_hash(self) -> str:
+        return canonical_hash(self.mount or {"status": "unmeasured"}, prefix="mount")
+
+    @property
+    def roi_hash(self) -> str:
+        return canonical_hash(self.roi or {"status": "full_frame"}, prefix="roi")
+
+    @property
+    def camera_pose_hash(self) -> str:
+        return canonical_hash(
+            {
+                "camera_pose_id": self.camera_pose_id,
+                "camera_id": self.camera_id,
+                "intrinsic_hash": self.intrinsics.intrinsic_hash,
+                "extrinsic_hash": self.extrinsic_hash,
+                "mount_hash": self.mount_hash,
+                "roi_hash": self.roi_hash,
+                "lighting_profile_id": self.lighting_profile_id,
+            },
+            prefix="campose",
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "camera_pose_id": self.camera_pose_id,
+            "camera_id": self.camera_id,
+            "intrinsics": self.intrinsics.to_dict(),
+            "intrinsic_hash": self.intrinsics.intrinsic_hash,
+            "extrinsic": self.extrinsic or {"status": "unmeasured"},
+            "extrinsic_hash": self.extrinsic_hash,
+            "mount": self.mount or {"status": "unmeasured"},
+            "mount_hash": self.mount_hash,
+            "roi": self.roi or {"status": "full_frame"},
+            "roi_hash": self.roi_hash,
+            "lighting_profile_id": self.lighting_profile_id,
+            "camera_pose_hash": self.camera_pose_hash,
+        }
+
+    def validate_against(self, other: CameraPoseContract) -> list[str]:
+        """What changed between two poses (evidence invalidation report)."""
+        changed: list[str] = []
+        if self.intrinsics.intrinsic_hash != other.intrinsics.intrinsic_hash:
+            changed.append("intrinsics")
+        if self.extrinsic_hash != other.extrinsic_hash:
+            changed.append("extrinsic")
+        if self.mount_hash != other.mount_hash:
+            changed.append("mount")
+        if self.roi_hash != other.roi_hash:
+            changed.append("roi")
+        if self.lighting_profile_id != other.lighting_profile_id:
+            changed.append("lighting_profile")
+        return changed
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> CameraPoseContract:
+        intr = raw.get("intrinsics") or {}
+        return cls(
+            camera_pose_id=str(raw.get("camera_pose_id") or ""),
+            camera_id=str(raw.get("camera_id") or ""),
+            intrinsics=CameraIntrinsics(
+                width=int(intr.get("width") or 0),
+                height=int(intr.get("height") or 0),
+                fx=float(intr.get("fx") or 0.0),
+                fy=float(intr.get("fy") or 0.0),
+                ppx=float(intr.get("ppx") or 0.0),
+                ppy=float(intr.get("ppy") or 0.0),
+                distortion_model=str(intr.get("distortion_model") or "unknown"),
+                coeffs=tuple(float(c) for c in (intr.get("coeffs") or ())),
+            ),
+            extrinsic=dict(raw.get("extrinsic") or {}),
+            mount=dict(raw.get("mount") or {}),
+            roi={k: int(v) for k, v in (raw.get("roi") or {}).items()} if raw.get("roi") else {},
+            lighting_profile_id=str(raw.get("lighting_profile_id") or "unmeasured"),
+        )
+
+
+def intrinsics_from_pyrealsense(profile: Any, stream_type: Any) -> CameraIntrinsics:
+    """Read REAL intrinsics off a running pyrealsense2 pipeline profile."""
+    stream = profile.get_stream(stream_type).as_video_stream_profile()
+    intr = stream.get_intrinsics()
+    return CameraIntrinsics(
+        width=int(intr.width),
+        height=int(intr.height),
+        fx=float(intr.fx),
+        fy=float(intr.fy),
+        ppx=float(intr.ppx),
+        ppy=float(intr.ppy),
+        distortion_model=str(intr.model).split(".")[-1],
+        coeffs=tuple(float(c) for c in intr.coeffs),
+    )
+
+
+def intrinsics_from_json(path: str) -> CameraIntrinsics:
+    """Load device intrinsics captured earlier by the camera-env probe
+    (the repo venv has no pyrealsense2 — probes run in the task env)."""
+    with open(path, encoding="utf-8") as handle:
+        raw = json.loads(handle.read())
+    return CameraIntrinsics(
+        width=int(raw["width"]),
+        height=int(raw["height"]),
+        fx=float(raw["fx"]),
+        fy=float(raw["fy"]),
+        ppx=float(raw["ppx"]),
+        ppy=float(raw["ppy"]),
+        distortion_model=str(raw.get("distortion_model") or "unknown"),
+        coeffs=tuple(float(c) for c in (raw.get("coeffs") or ())),
+    )

--- a/src/rosclaw/perception/handcam/hand_state.py
+++ b/src/rosclaw/perception/handcam/hand_state.py
@@ -1,0 +1,296 @@
+"""Marker-free visual hand state from depth (Physical Evolution Lab §7.2, PR-PE-3).
+
+Phase-1 honesty about what this IS and IS NOT:
+
+* it finds the NEAREST depth cluster inside a declared ROI and reports
+  its 3D centroid + a forward-most fingertip CANDIDATE — an external
+  proprioception signal good enough for onset/settle/contact-distance
+  evidence;
+* it is NOT a skeletal hand pose estimator.  When the cluster quality
+  gate fails (too few pixels, too dispersed, validity too low, ROI
+  empty) the result is an honest UNKNOWN — never a guessed pose
+  (v3 §7.5: Unknown/occluded must be rejected, not labeled).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from .calibration import CameraIntrinsics, CameraPoseContract
+
+STATE_VERSION = "rosclaw.handcam_state.v1"
+
+
+def _nearest_depth_mode(
+    valid_mm: np.ndarray, *, min_pixels: int, window_mm: float, bin_mm: int = 25
+) -> tuple[float | None, float | None]:
+    """Nearest depth MODE via histogram — robust to hand size.
+
+    A global quantile silently degrades when the hand occupies less than
+    ``quantile`` of the ROI (test-driven fix: a 1.2%-of-frame blob fell
+    below a 2% quantile, so the 'near cluster' became the whole scene).
+    The nearest bin with ≥ min_pixels is the hand candidate regardless
+    of its frame share; none → (None, None) = honest no-hand.
+    """
+    if len(valid_mm) == 0:
+        return None, None
+    max_depth = int(valid_mm.max()) + bin_mm
+    counts, edges = np.histogram(valid_mm, bins=np.arange(0, max_depth + bin_mm, bin_mm))
+    for index, count in enumerate(counts):
+        if count >= min_pixels:
+            return float(edges[index]), float(edges[index + 1] + window_mm)
+    return None, None
+
+
+@dataclass(frozen=True)
+class ClusterQuality:
+    pixels: int
+    valid_ratio: float
+    spread_m: float
+    ok: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class VisualHandState:
+    state: str  # "ok" | "unknown"
+    reason: str
+    centroid_3d: tuple[float, float, float] | None
+    fingertip_3d: tuple[float, float, float] | None
+    cluster: ClusterQuality | None
+    depth_valid_ratio: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "state_version": STATE_VERSION,
+            "state": self.state,
+            "reason": self.reason,
+            "centroid_3d": self.centroid_3d,
+            "fingertip_3d": self.fingertip_3d,
+            "cluster": None
+            if self.cluster is None
+            else {
+                "pixels": self.cluster.pixels,
+                "valid_ratio": round(self.cluster.valid_ratio, 4),
+                "spread_m": round(self.cluster.spread_m, 4),
+            },
+            "depth_valid_ratio": round(self.depth_valid_ratio, 4),
+        }
+
+
+def _quality_gate(
+    points_m: np.ndarray,
+    *,
+    min_pixels: int,
+    max_spread_m: float,
+    max_extent_m: float,
+    valid_ratio: float,
+    min_valid_ratio: float,
+) -> ClusterQuality:
+    pixels = int(points_m.shape[0])
+    if valid_ratio < min_valid_ratio:
+        return ClusterQuality(
+            pixels, valid_ratio, float("nan"), False, "depth validity too low in ROI"
+        )
+    if pixels < min_pixels:
+        return ClusterQuality(
+            pixels, valid_ratio, float("nan"), False, "cluster too small (no hand?)"
+        )
+    # Physical extent: a hand is ~0.1–0.2 m across; a full-ROI scene at
+    # any depth is not a hand even when its std is modest (test-driven
+    # fix: whole-foreground-at-300 mm passed a pure spread gate).
+    extent = float(np.linalg.norm(np.ptp(points_m, axis=0)))
+    if math.isfinite(extent) and extent > max_extent_m:
+        return ClusterQuality(
+            pixels, valid_ratio, extent, False, "cluster extent larger than a hand (scene)"
+        )
+    spread = float(np.linalg.norm(points_m.std(axis=0)))
+    if not math.isfinite(spread) or spread > max_spread_m:
+        return ClusterQuality(
+            pixels, valid_ratio, spread, False, "cluster too dispersed (scene, not hand)"
+        )
+    return ClusterQuality(pixels, valid_ratio, spread, True, "ok")
+
+
+def estimate_hand_state(
+    depth_mm: np.ndarray,
+    contract: CameraPoseContract,
+    *,
+    near_window_mm: float = 80.0,
+    min_pixels: int = 300,
+    max_spread_m: float = 0.25,
+    max_extent_m: float = 0.30,
+    min_valid_ratio: float = 0.5,
+    fingertip_quantile: float = 1.0,
+) -> VisualHandState:
+    """Estimate one hand's visual state from a depth frame (numpy uint16 mm)."""
+    intr: CameraIntrinsics = contract.intrinsics
+    if depth_mm is None or depth_mm.size == 0:
+        return VisualHandState("unknown", "no depth frame", None, None, None, 0.0)
+
+    roi = contract.roi
+    if roi:
+        x0, y0 = roi.get("x0", 0), roi.get("y0", 0)
+        x1 = roi.get("x1", depth_mm.shape[1])
+        y1 = roi.get("y1", depth_mm.shape[0])
+        region = depth_mm[y0:y1, x0:x1]
+        offset = (x0, y0)
+    else:
+        region = depth_mm
+        offset = (0, 0)
+
+    valid = region[region > 0]
+    valid_ratio = float(len(valid)) / float(region.size) if region.size else 0.0
+    if len(valid) < min_pixels:
+        return VisualHandState(
+            "unknown",
+            f"insufficient valid depth in ROI ({len(valid)} px)",
+            None,
+            None,
+            ClusterQuality(len(valid), valid_ratio, float("nan"), False, "insufficient depth"),
+            valid_ratio,
+        )
+
+    thresh_low, thresh_high = _nearest_depth_mode(
+        valid, min_pixels=min_pixels, window_mm=near_window_mm
+    )
+    if thresh_low is None:
+        return VisualHandState("unknown", "no near cluster", None, None, None, valid_ratio)
+    mask = (region > 0) & (region >= thresh_low) & (region <= thresh_high)
+    ys, xs = np.nonzero(mask)
+    if len(xs) == 0:
+        return VisualHandState("unknown", "no near cluster", None, None, None, valid_ratio)
+
+    depths_m = region[ys, xs].astype(np.float64) / 1000.0
+    us = xs.astype(np.float64) + offset[0]
+    vs = ys.astype(np.float64) + offset[1]
+    points = np.stack(
+        [
+            (us - intr.ppx) * depths_m / intr.fx,
+            (vs - intr.ppy) * depths_m / intr.fy,
+            depths_m,
+        ],
+        axis=1,
+    )
+    quality = _quality_gate(
+        points,
+        min_pixels=min_pixels,
+        max_spread_m=max_spread_m,
+        max_extent_m=max_extent_m,
+        valid_ratio=valid_ratio,
+        min_valid_ratio=min_valid_ratio,
+    )
+    if not quality.ok:
+        return VisualHandState("unknown", quality.reason, None, None, quality, valid_ratio)
+
+    centroid = tuple(float(v) for v in points.mean(axis=0))
+    # Fingertip candidate: mean of the forward-most (nearest-to-camera) points.
+    tip_thresh = float(np.percentile(points[:, 2], fingertip_quantile))
+    tips = points[points[:, 2] <= tip_thresh + 0.01]
+    fingertip = tuple(float(v) for v in tips.mean(axis=0)) if len(tips) else centroid
+    return VisualHandState("ok", "ok", centroid, fingertip, quality, valid_ratio)
+
+
+@dataclass(frozen=True)
+class StabilityResult:
+    settled: bool
+    settle_time_s: float | None
+    onset_time_s: float | None
+    max_post_settle_displacement_m: float
+    frames: int
+    unknown_frames: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "settled": self.settled,
+            "settle_time_s": self.settle_time_s,
+            "onset_time_s": self.onset_time_s,
+            "max_post_settle_displacement_m": round(self.max_post_settle_displacement_m, 4),
+            "frames": self.frames,
+            "unknown_frames": self.unknown_frames,
+        }
+
+
+def measure_visual_stability(
+    states: list[VisualHandState],
+    timestamps_s: list[float],
+    *,
+    settle_window_s: float = 0.5,
+    settle_threshold_m: float = 0.01,
+) -> StabilityResult:
+    """Onset→settle over a state sequence: the first motion onset and the
+    earliest time after which the centroid stays within
+    ``settle_threshold_m`` for ``settle_window_s``.  Unknown frames are
+    counted and break a settle window (honest UNKNOWN ≠ stable)."""
+    if len(states) != len(timestamps_s):
+        raise ValueError("states and timestamps must align")
+    centroids = [s.centroid_3d if s.state == "ok" else None for s in states]
+    known = [c for c in centroids if c is not None]
+    unknown_frames = len(centroids) - len(known)
+    if len(known) < 2:
+        return StabilityResult(False, None, None, float("nan"), len(states), unknown_frames)
+
+    # Onset: first frame whose centroid moved > 3x settle threshold from
+    # the initial pose.
+    onset_index = None
+    base = known[0]
+    for index, centroid in enumerate(centroids):
+        if centroid is None:
+            continue
+        if math.dist(base, centroid) > 3 * settle_threshold_m:
+            onset_index = index
+            break
+
+    # Settle: earliest index after which consecutive ok frames stay
+    # within threshold for the window.
+    settle_time = None
+    run_start: int | None = None
+    anchor: tuple[float, float, float] | None = None
+    for index, centroid in enumerate(centroids):
+        if centroid is None:
+            run_start = None
+            anchor = None
+            continue
+        if run_start is None:
+            run_start = index
+            anchor = centroid
+            continue
+        assert anchor is not None
+        if math.dist(anchor, centroid) > settle_threshold_m:
+            run_start = index
+            anchor = centroid
+            continue
+        if timestamps_s[index] - timestamps_s[run_start] >= settle_window_s:
+            settle_time = timestamps_s[run_start]
+            break
+
+    post = 0.0
+    if settle_time is not None:
+        settled_points = [
+            c for c, t in zip(centroids, timestamps_s, strict=True) if c is not None and t >= settle_time
+        ]
+        if settled_points:
+            anchor2 = settled_points[0]
+            post = max(math.dist(anchor2, c) for c in settled_points)
+
+    return StabilityResult(
+        settled=settle_time is not None,
+        settle_time_s=settle_time,
+        onset_time_s=timestamps_s[onset_index] if onset_index is not None else None,
+        max_post_settle_displacement_m=post,
+        frames=len(states),
+        unknown_frames=unknown_frames,
+    )
+
+
+def contact_distance_m(a: VisualHandState, b: VisualHandState) -> float | None:
+    """Nearest-cluster distance between two hands' fingertip candidates;
+    None (unknown) unless BOTH hands are ok — a missing hand is not zero
+    distance."""
+    if a.state != "ok" or b.state != "ok" or not a.fingertip_3d or not b.fingertip_3d:
+        return None
+    return math.dist(a.fingertip_3d, b.fingertip_3d)

--- a/tests/perception/handcam/test_handcam.py
+++ b/tests/perception/handcam/test_handcam.py
@@ -1,0 +1,140 @@
+"""PR-PE-3 tests: camera pose contract + marker-free visual hand state."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from rosclaw.perception.handcam import (
+    CameraIntrinsics,
+    CameraPoseContract,
+    VisualHandState,
+    contact_distance_m,
+    estimate_hand_state,
+    measure_visual_stability,
+)
+
+
+def _intrinsics() -> CameraIntrinsics:
+    return CameraIntrinsics(width=640, height=480, fx=600.0, fy=600.0, ppx=320.0, ppy=240.0)
+
+
+def _contract(**kw) -> CameraPoseContract:
+    return CameraPoseContract(
+        camera_pose_id=kw.get("camera_pose_id", "front_v1"),
+        camera_id="d435i_test",
+        intrinsics=_intrinsics(),
+        roi=kw.get("roi", {}),
+    )
+
+
+def _depth_with_blob(
+    center_uv: tuple[int, int], depth_at_blob_mm: int = 350, background_mm: int = 3000
+) -> np.ndarray:
+    depth = np.full((480, 640), background_mm, dtype=np.uint16)
+    u, v = center_uv
+    depth[v - 30 : v + 30, u - 30 : u + 30] = depth_at_blob_mm
+    return depth
+
+
+def test_pose_hash_changes_on_any_component() -> None:
+    base = _contract()
+    moved = _contract(camera_pose_id="front_v2")
+    assert base.camera_pose_hash != moved.camera_pose_hash
+    changed = base.validate_against(moved)
+    # Same intrinsics/mount/roi/lighting — only the declared id changed.
+    assert changed == []
+
+    roi_changed = _contract(roi={"x0": 0, "y0": 0, "x1": 320, "y1": 480})
+    assert "roi" in base.validate_against(roi_changed)
+    assert base.camera_pose_hash != roi_changed.camera_pose_hash
+
+    other_intr = CameraPoseContract(
+        camera_pose_id="front_v1",
+        camera_id="d435i_test",
+        intrinsics=CameraIntrinsics(
+            width=848, height=480, fx=420.0, fy=420.0, ppx=424.0, ppy=240.0
+        ),
+    )
+    assert "intrinsics" in base.validate_against(other_intr)
+
+
+def test_intrinsics_hash_deterministic_and_deproject() -> None:
+    intr = _intrinsics()
+    assert intr.intrinsic_hash == _intrinsics().intrinsic_hash
+    x, y, z = intr.deproject(320.0, 240.0, 1.0)
+    assert abs(x) < 1e-9 and abs(y) < 1e-9 and z == 1.0
+    x, _, _ = intr.deproject(620.0, 240.0, 0.5)
+    assert abs(x - 0.25) < 1e-9  # (620-320)*0.5/600
+
+
+def test_hand_state_ok_on_clear_blob() -> None:
+    depth = _depth_with_blob((320, 240), depth_at_blob_mm=350)
+    state = estimate_hand_state(depth, _contract())
+    assert state.state == "ok"
+    assert state.centroid_3d is not None
+    cx, cy, cz = state.centroid_3d
+    assert abs(cx) < 0.05 and abs(cy) < 0.05 and 0.3 < cz < 0.45
+    assert state.fingertip_3d is not None
+    assert state.cluster is not None and state.cluster.ok
+
+
+def test_hand_state_unknown_when_no_hand_or_scene() -> None:
+    # No near blob: flat far scene.
+    flat = np.full((480, 640), 3000, dtype=np.uint16)
+    state = estimate_hand_state(flat, _contract())
+    assert state.state == "unknown"
+    assert state.centroid_3d is None
+
+    # Whole-foreground scene (too dispersed → not a hand).
+    near_scene = np.full((480, 640), 300, dtype=np.uint16)
+    state2 = estimate_hand_state(near_scene, _contract())
+    assert state2.state == "unknown"
+    assert (
+        "dispersed" in state2.reason or "too small" in state2.reason or state2.cluster is not None
+    )
+
+    # Empty depth.
+    empty = np.zeros((480, 640), dtype=np.uint16)
+    state3 = estimate_hand_state(empty, _contract())
+    assert state3.state == "unknown"
+
+
+def test_hand_state_respects_roi() -> None:
+    depth = _depth_with_blob((500, 240), depth_at_blob_mm=350)
+    roi_left = {"x0": 0, "y0": 0, "x1": 320, "y1": 480}
+    state = estimate_hand_state(depth, _contract(roi=roi_left))
+    # Blob is in the RIGHT half; left ROI must honestly see nothing.
+    assert state.state == "unknown"
+    roi_right = {"x0": 320, "y0": 0, "x1": 640, "y1": 480}
+    state2 = estimate_hand_state(depth, _contract(roi=roi_right))
+    assert state2.state == "ok"
+    assert state2.centroid_3d[0] > 0  # right of principal point
+
+
+def test_visual_stability_onset_and_settle() -> None:
+    moving = [(0.01 * i, 0.0, 0.35) for i in range(10)]  # moving away in x
+    still = [(0.1, 0.0, 0.35)] * 20
+    trajectory = moving + still
+    states = [
+        VisualHandState("ok", "ok", c, c, None, 0.9)  # type: ignore[arg-type]
+        for c in trajectory
+    ]
+    ts = [i * 0.033 for i in range(len(states))]
+    result = measure_visual_stability(states, ts, settle_window_s=0.2, settle_threshold_m=0.005)
+    assert result.settled
+    assert result.onset_time_s is not None
+    assert result.max_post_settle_displacement_m < 0.005
+
+    # Unknown frames break settle.
+    states_broken = states[:15]
+    states_broken[12] = VisualHandState("unknown", "no cluster", None, None, None, 0.0)
+    result2 = measure_visual_stability(states_broken, ts[:15], settle_window_s=0.2)
+    assert result2.unknown_frames == 1
+
+
+def test_contact_distance_requires_both_hands() -> None:
+    a = VisualHandState("ok", "ok", (0.0, 0.0, 0.35), (0.0, 0.0, 0.30), None, 0.9)  # type: ignore[arg-type]
+    b = VisualHandState("ok", "ok", (0.1, 0.0, 0.35), (0.08, 0.0, 0.30), None, 0.9)  # type: ignore[arg-type]
+    assert abs(contact_distance_m(a, b) - 0.08) < 1e-9  # type: ignore[operator]
+    unknown = VisualHandState("unknown", "no cluster", None, None, None, 0.0)
+    assert contact_distance_m(a, unknown) is None


### PR DESCRIPTION
Physical Evolution Lab v3 §4.2/§7.2——外部手部状态与视觉标定。

## 交付

- **CameraPoseContract**（`rosclaw.camera_pose.v1`）：camera_pose_id + 从**设备真实读取**的 intrinsic_hash（D435i 在线读取，绝不手抄）+ extrinsic/mount/roi/lighting hash（未测量如实披露但仍参与 hash）。移动相机 → camera_pose_hash 变化 → 旧视觉标定自动失效；`validate_against` 报告具体变化分量。针孔反投影（出厂校正深度，披露）
- **estimate_hand_state**：声明 ROI 内最近深度**众数**（直方图）→ 3D 质心 + 最前指尖候选。质量门：像素数、深度有效率、**物理包络**（整幅前景不是手——测试驱动发现）、离散度。失败=诚实 UNKNOWN，绝不猜姿态
- **measure_visual_stability**：onset→settle（质心序列）；unknown 帧打破 settle 窗口（UNKNOWN ≠ 稳定）
- **contact_distance_m**：双手都 ok 才给距离（缺一手 ≠ 零距离）
- `configs/handcam/front_v1.yaml`：实测设备契约（含双手 ROI）

## 测试驱动修复（§16.12 先写复现测试）

1. 全局分位数近聚类对小占比手部 blob 退化为整幅场景 → 直方图众数
2. 纯离散度门放行了 300mm 全幅前景 → 物理包络门

## Independent Hardware 验证（在线 D435i，真实内参 640×480 fx 384.9）

- 全帧 → 诚实 UNKNOWN（场景包络超出手）
- 双手 ROI → 左 (-0.10, 0.10, 0.20m) / 右 (0.10, 0.11, 0.21m)，指尖间距 **0.201m** 跨帧稳定——与实拍布置物理一致（双手支架上指向镜头，间距 ~20cm）

## 验证级别（§16.13）

Component Test（7 测试）+ Independent Hardware（在线，只读）。无 Shadow/REAL 声明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)