### PR TITLE
feat(self_model): generic operational self protocols + RH56/dual/D435i adapters (PR-PE-4)

### DIFF
--- a/src/rosclaw/self_model/adapters/__init__.py
+++ b/src/rosclaw/self_model/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Self adapters for the Operational Self Model (PR-PE-4)."""

--- a/src/rosclaw/self_model/adapters/dual_rh56.py
+++ b/src/rosclaw/self_model/adapters/dual_rh56.py
@@ -1,0 +1,155 @@
+"""Dual-hand and D435i self adapters (v3 §8.2, PR-PE-4)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rosclaw.practice.physical_observation import canonical_hash
+
+from ..protocols import SelfStateAdapter
+from .rh56 import RH56HandSelfAdapter
+
+
+class DualHandSelfAdapter(SelfStateAdapter):
+    """Both RH56 hands as ONE operational body (bimanual tasks: sync,
+    leader-follower, near-contact).  Identity includes BOTH hand hashes
+    plus the pairing — swapping one hand changes the body."""
+
+    def __init__(
+        self, left: RH56HandSelfAdapter, right: RH56HandSelfAdapter, *, body_id: str
+    ) -> None:
+        self._left = left
+        self._right = right
+        self._body_id = body_id
+
+    def body_id(self) -> str:
+        return self._body_id
+
+    @property
+    def left(self) -> RH56HandSelfAdapter:
+        return self._left
+
+    @property
+    def right(self) -> RH56HandSelfAdapter:
+        return self._right
+
+    def body_hash(self) -> str:
+        return canonical_hash(
+            {
+                "kind": "dual_rh56",
+                "body_id": self._body_id,
+                "left": self._left.body_hash(),
+                "right": self._right.body_hash(),
+            },
+            prefix="body",
+        )
+
+    def current_state(self) -> dict[str, Any]:
+        return {
+            "body_id": self._body_id,
+            "left": self._left.current_state(),
+            "right": self._right.current_state(),
+        }
+
+    def health_channels(self) -> dict[str, float]:
+        return {}
+
+    def skew_channels(
+        self,
+        left_telemetry: dict[str, Any],
+        right_telemetry: dict[str, Any],
+    ) -> dict[str, float]:
+        """Bimanual supervision channels (§10 T2): per-joint state skew
+        between hands for mirrored gestures + temperature asymmetry."""
+        channels: dict[str, float] = {}
+        left_angles = left_telemetry.get("angle_actual") or {}
+        right_angles = right_telemetry.get("angle_actual") or {}
+        for joint in set(left_angles) & set(right_angles):
+            channels[f"mirror_skew_{joint}"] = abs(
+                float(left_angles[joint]) - float(right_angles[joint])
+            )
+        left_temps = [
+            v
+            for v in (left_telemetry.get("temperature_c") or {}).values()
+            if isinstance(v, (int, float)) and v > 0
+        ]
+        right_temps = [
+            v
+            for v in (right_telemetry.get("temperature_c") or {}).values()
+            if isinstance(v, (int, float)) and v > 0
+        ]
+        if left_temps and right_temps:
+            channels["temperature_asymmetry"] = abs(max(left_temps) - max(right_temps))
+        return channels
+
+
+class D435iSensorSelfAdapter(SelfStateAdapter):
+    """The D435i as a sensor-body: freshness state machine + observation
+    reliability belief (v3 §8.4 camera freshness state machine)."""
+
+    def __init__(self, camera_id: str, *, camera_pose_hash: str = "unmeasured") -> None:
+        self._camera_id = camera_id
+        self._pose_hash = camera_pose_hash
+
+    def body_id(self) -> str:
+        return self._camera_id
+
+    def body_hash(self) -> str:
+        return canonical_hash(
+            {
+                "kind": "d435i_sensor",
+                "camera_id": self._camera_id,
+                "camera_pose_hash": self._pose_hash,
+            },
+            prefix="body",
+        )
+
+    def current_state(self) -> dict[str, Any]:
+        return {"camera_id": self._camera_id, "camera_pose_hash": self._pose_hash}
+
+    def health_channels(self) -> dict[str, float]:
+        return {}
+
+    def freshness_state(
+        self,
+        *,
+        frame_age_ms: float | None,
+        rgb_depth_skew_ms: float | None,
+        consecutive_missing: int,
+        max_frame_age_ms: float = 500.0,
+        max_rgb_depth_skew_ms: float = 50.0,
+    ) -> dict[str, Any]:
+        """Camera freshness state machine → reliability belief in [0, 1].
+
+        Unknown inputs DEGRADE the belief (unknown ≠ fresh), and three
+        consecutive missing frames flip the state to STALE regardless of
+        the last measured age."""
+        state = "FRESH"
+        reasons: list[str] = []
+        if consecutive_missing >= 3:
+            state = "STALE"
+            reasons.append(f"{consecutive_missing} consecutive missing frames")
+        if frame_age_ms is None:
+            if state == "FRESH":
+                state = "DEGRADED"
+            reasons.append("frame age unknown")
+        elif frame_age_ms > max_frame_age_ms:
+            state = "STALE"
+            reasons.append(f"frame age {frame_age_ms:.0f}ms > {max_frame_age_ms:.0f}ms")
+        if rgb_depth_skew_ms is None:
+            reasons.append("rgb/depth skew unknown")
+        elif rgb_depth_skew_ms > max_rgb_depth_skew_ms:
+            if state == "FRESH":
+                state = "DEGRADED"
+            reasons.append(
+                f"rgb/depth skew {rgb_depth_skew_ms:.0f}ms > {max_rgb_depth_skew_ms:.0f}ms"
+            )
+        reliability = {"FRESH": 1.0, "DEGRADED": 0.5, "STALE": 0.0}[state]
+        if "rgb/depth skew unknown" in reasons and reliability == 1.0:
+            reliability = 0.8  # honest haircut for unmeasurable skew
+        return {
+            "state": state,
+            "reliability": reliability,
+            "reasons": reasons,
+            "consecutive_missing": consecutive_missing,
+        }

--- a/src/rosclaw/self_model/adapters/rh56.py
+++ b/src/rosclaw/self_model/adapters/rh56.py
@@ -1,0 +1,257 @@
+"""RH56 hand self adapter + analytical forward prior (v3 §8.3/§8.4, PR-PE-4).
+
+The RH56 forward prior predicts what a gesture command does next — NOT a
+pelvis:
+
+* 下一时刻 joint position（一阶位置响应，每关节独立时间常数）
+* tracking error 与 time-to-reach（同模型的直接读出）
+* temperature delta（简化热 RC 模型：动作发热 vs 环境散热）
+
+Bounded residual 只挂 shadow（本适配器内置 analytical_only=True 直到
+shadow 数据足够——v3 §8.4：Analytical Prior + Bounded Residual，
+Residual 只在 Shadow 学习）.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from rosclaw.practice.physical_observation import canonical_hash
+
+from ..protocols import ForwardModelProtocol, SelfPrediction, SelfStateAdapter
+
+JOINTS = ("little", "ring", "middle", "index", "thumb", "thumb_rot")
+
+# Per-joint first-order time constants (seconds) — calibrated from REAL
+# gesture telemetry (session prac_20260730T024004Z_3260ea, 2026-07-30:
+# median per-joint tau over measured motion windows; little/ring share
+# the middle estimate until their own evidence exists).  Recalibrate by
+# residual evidence only — never G1 parameters, never guesses (v3 §8.5).
+DEFAULT_TAU_S: dict[str, float] = {
+    "little": 0.52,
+    "ring": 0.52,
+    "middle": 0.52,
+    "index": 0.28,
+    "thumb": 0.49,
+    "thumb_rot": 0.33,
+}
+
+# Simplified thermal RC: one gesture's holding-current heat input at
+# force_set 300, cooling toward ambient with ~20 min time constant
+# (measured: idle floor 45 °C, coast-recovery minutes–hour).
+THERMAL_HEAT_PER_GESTURE_C = 0.06
+THERMAL_COOL_TAU_S = 1200.0
+
+
+@dataclass(frozen=True)
+class RH56SelfState:
+    """§8.3 RH56SelfState blocks."""
+
+    identity: dict[str, Any]
+    kinematics: dict[str, Any]
+    interaction: dict[str, Any]
+    health: dict[str, Any]
+    perception: dict[str, Any]
+    task: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "identity": self.identity,
+            "kinematics": self.kinematics,
+            "interaction": self.interaction,
+            "health": self.health,
+            "perception": self.perception,
+            "task": self.task,
+        }
+
+
+class RH56HandSelfAdapter(SelfStateAdapter):
+    """One RH56 hand (left or right) as a self-model body."""
+
+    def __init__(
+        self,
+        body_id: str,
+        *,
+        firmware: str = "unmeasured",
+        calibration_hash: str = "unmeasured",
+        tau_s: dict[str, float] | None = None,
+    ) -> None:
+        self._body_id = body_id
+        self._identity = {
+            "body_id": body_id,
+            "firmware": firmware,
+            "calibration_hash": calibration_hash,
+            "transport_profile": "ftdi_serial_460800",
+        }
+        self._tau = dict(tau_s or DEFAULT_TAU_S)
+
+    def body_id(self) -> str:
+        return self._body_id
+
+    def body_hash(self) -> str:
+        return canonical_hash(self._identity, prefix="body")
+
+    def current_state(self) -> dict[str, Any]:
+        return self._identity
+
+    def health_channels(self) -> dict[str, float]:
+        return {}
+
+    def self_state(
+        self,
+        telemetry: dict[str, Any],
+        *,
+        target: dict[str, float] | None = None,
+        task: dict[str, Any] | None = None,
+        perception: dict[str, Any] | None = None,
+    ) -> RH56SelfState:
+        """Build the full §8.3 state from one telemetry reading."""
+        angles = telemetry.get("angle_actual") or {}
+        angle_set = telemetry.get("angle_set") or target or {}
+        tracking = {
+            joint: float(angle_set.get(joint, 0.0)) - float(angles.get(joint, 0.0))
+            for joint in JOINTS
+            if joint in angles or joint in angle_set
+        }
+        temps = telemetry.get("temperature_c") or {}
+        return RH56SelfState(
+            identity=self._identity,
+            kinematics={
+                "joint_position": angles,
+                "target_position": angle_set,
+                "tracking_error": tracking,
+                "joint_velocity_estimate": telemetry.get("velocity_estimate") or {},
+            },
+            interaction={
+                "force": telemetry.get("force_act") or {},
+                "current_ma": telemetry.get("current_ma") or {},
+                "contact_probability": telemetry.get("contact_probability"),
+            },
+            health={
+                "temperature": temps,
+                "temperature_max": max(
+                    (float(v) for v in temps.values() if isinstance(v, (int, float)) and v > 0),
+                    default=None,
+                ),
+                "status": telemetry.get("status"),
+                "transport_latency_ms": telemetry.get("transport_latency_ms"),
+            },
+            perception=perception or {},
+            task=task or {},
+        )
+
+
+class RH56ForwardPrior(ForwardModelProtocol):
+    """Analytical forward prior for one RH56 hand (§8.4).
+
+    predict(state, action):
+      state  = {"pos_<joint>": raw, "temp_max": °C, "ambient_c": °C?}
+      action = {"target_<joint>": raw, "dt_s": seconds, "gestures": n?}
+
+    channels: next joint positions, per-joint |tracking error| after dt,
+    time-to-reach (95% settle), temperature delta."""
+
+    def __init__(
+        self,
+        body_id: str,
+        body_hash: str,
+        *,
+        tau_s: dict[str, float] | None = None,
+        heat_per_gesture_c: float = THERMAL_HEAT_PER_GESTURE_C,
+        cool_tau_s: float = THERMAL_COOL_TAU_S,
+    ) -> None:
+        self._body_id = body_id
+        self._body_hash = body_hash
+        self._tau = dict(tau_s or DEFAULT_TAU_S)
+        self._heat = heat_per_gesture_c
+        self._cool_tau = cool_tau_s
+
+    @property
+    def model_hash(self) -> str:
+        return canonical_hash(
+            {
+                "kind": "rh56_forward_prior",
+                "body_id": self._body_id,
+                "body_hash": self._body_hash,
+                "tau_s": self._tau,
+                "heat_per_gesture_c": self._heat,
+                "cool_tau_s": self._cool_tau,
+            },
+            prefix="fwm",
+        )
+
+    def expected_body_hash(self) -> str:
+        return self._body_hash
+
+    def predict(self, state: dict[str, float], action: dict[str, float]) -> SelfPrediction:
+        dt = float(action.get("dt_s") or 0.1)
+        if dt <= 0 or not math.isfinite(dt):
+            raise ValueError("dt_s must be positive and finite")
+        channels: dict[str, float] = {}
+        uncertainty: dict[str, float] = {}
+        for joint in JOINTS:
+            pos_key = f"pos_{joint}"
+            if pos_key not in state:
+                continue
+            pos = float(state[pos_key])
+            target = float(action.get(f"target_{joint}", pos))
+            tau = self._tau.get(joint, 0.18)
+            velocity = state.get(f"vel_{joint}")
+            # Two-mode prior (real-telemetry driven, 2026-07-30): the RH56
+            # servo approaches its command register ONLY during gesture
+            # execution windows; elsewhere the register holds a STALE
+            # value while the hand holds position.  Predicting toward a
+            # stale register is 5× worse than predicting hold (measured:
+            # RMSE 899 vs 173).  Motion evidence (measured velocity
+            # toward the target) is what separates the modes — never the
+            # register alone.
+            moving_toward = (
+                isinstance(velocity, (int, float))
+                and abs(velocity) > 30.0
+                and (target - pos) * velocity > 0
+            )
+            if moving_toward:
+                residual = (pos - target) * math.exp(-dt / tau)
+                channels[f"next_pos_{joint}"] = target + residual
+                channels[f"tracking_error_{joint}"] = abs(residual)
+                if abs(pos - target) > 1.0:
+                    channels[f"time_to_reach_{joint}"] = tau * math.log(20.0)
+                else:
+                    channels[f"time_to_reach_{joint}"] = 0.0
+            else:
+                channels[f"next_pos_{joint}"] = pos
+                channels[f"tracking_error_{joint}"] = abs(target - pos)
+                channels[f"time_to_reach_{joint}"] = 0.0
+            uncertainty[f"next_pos_{joint}"] = 15.0 if moving_toward else 8.0
+        temp = state.get("temp_max")
+        gestures = float(action.get("gestures", 1.0))
+        if isinstance(temp, (int, float)):
+            ambient = float(state.get("ambient_c", 25.0))
+            heat = self._heat * gestures
+            cool = (float(temp) - ambient) * (1.0 - math.exp(-dt / self._cool_tau))
+            channels["temp_delta"] = heat - cool
+            uncertainty["temp_delta"] = 0.5
+        return SelfPrediction(
+            channels=channels,
+            uncertainty=uncertainty,
+            model_hash=self.model_hash,
+            analytical_only=True,
+        )
+
+
+class BodyHashMismatchError(RuntimeError):
+    """Loading a model against a different body hash (v3 §8.7)."""
+
+
+def bind_model_to_body(
+    model: ForwardModelProtocol, adapter: SelfStateAdapter
+) -> ForwardModelProtocol:
+    """The only honest way to load a forward model: hash must match."""
+    if model.expected_body_hash() != adapter.body_hash():
+        raise BodyHashMismatchError(
+            f"model bound to {model.expected_body_hash()} cannot load on "
+            f"body {adapter.body_id()} ({adapter.body_hash()})"
+        )
+    return model

--- a/src/rosclaw/self_model/protocols.py
+++ b/src/rosclaw/self_model/protocols.py
@@ -1,0 +1,109 @@
+"""Generic Operational Self Model protocols (Physical Evolution Lab §8.2, PR-PE-4).
+
+The v3 Self is NOT personality or consciousness — it is the
+engineering-verifiable estimate of:
+
+> 我当前是什么身体、处于什么状态、执行这个动作后会发生什么、
+> 结果是否由我造成、我还具备哪些可靠能力。
+
+The existing ``self_model`` (HybridForwardSelfModel, PredictionMonitor,
+AgencyEstimator) is G1-shaped (pelvis/COM/foot contact/ball).  These
+protocols are the abstraction layer: bodies provide ADAPTERS; the
+residual/monitor/agency machinery above stays body-agnostic.  RH56 must
+never pretend to be G1 (v3 §8.2).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+PROTOCOLS_VERSION = "rosclaw.self_protocols.v1"
+
+
+@dataclass(frozen=True)
+class SelfPrediction:
+    """One forward prediction in BODY-AGNOSTIC units (§8.4 targets).
+
+    Every value is body-specific in meaning but shared in shape: the
+    residual machinery compares predicted vs measured per channel
+    without knowing what a pelvis is."""
+
+    channels: dict[str, float]  # e.g. next joint positions, ttr, temp delta
+    uncertainty: dict[str, float]  # per-channel std (calibrated separately)
+    model_hash: str
+    analytical_only: bool  # True when the bounded residual contributed nothing
+
+
+@dataclass(frozen=True)
+class SelfObservation:
+    """The measured counterpart of SelfPrediction (same channel names)."""
+
+    channels: dict[str, float]
+    timestamp_ns: int
+    source: str  # "telemetry" | "visual" | "fused"
+
+
+class SelfStateAdapter(ABC):
+    """Body → self-state channels (§8.3)."""
+
+    @abstractmethod
+    def body_id(self) -> str: ...
+
+    @abstractmethod
+    def body_hash(self) -> str:
+        """Binds every prediction/snapshot to THIS body's measured config —
+        a mutated body must fail to load models bound to the old hash."""
+
+    @abstractmethod
+    def current_state(self) -> dict[str, Any]:
+        """The body's self-state blocks (identity/kinematics/interaction/
+        health/perception/task — adapters name their own blocks)."""
+
+    @abstractmethod
+    def health_channels(self) -> dict[str, float]:
+        """Channels used for regime/health reasoning (temperature, slope,
+        error rates, latency)."""
+
+
+class SelfActionAdapter(ABC):
+    """Action → forward-model input channels."""
+
+    @abstractmethod
+    def action_channels(self, action: dict[str, Any]) -> dict[str, float]: ...
+
+
+class ForwardModelProtocol(Protocol):
+    """Analytical prior + bounded residual (§8.4)."""
+
+    @property
+    @abstractmethod
+    def model_hash(self) -> str: ...
+
+    @abstractmethod
+    def predict(self, state: dict[str, float], action: dict[str, float]) -> SelfPrediction: ...
+
+    @abstractmethod
+    def expected_body_hash(self) -> str:
+        """The body hash this model was built for — loading against a
+        different body hash must raise (v3 §8.7/PR-PE-4 acceptance)."""
+
+
+class ResidualEncoder(ABC):
+    """Predicted × measured → named residual channels (§8.5)."""
+
+    @abstractmethod
+    def encode(
+        self, prediction: SelfPrediction, observation: SelfObservation
+    ) -> dict[str, float]: ...
+
+
+@runtime_checkable
+class AgencyEvidenceAdapter(Protocol):
+    """Body → agency evidence (§8.6 four-class attribution)."""
+
+    def agency_channels(self) -> dict[str, float]:
+        """action_magnitude, prediction_error, external_force_evidence,
+        sensor_inconsistency — the AgencyEstimator's four inputs."""
+        ...

--- a/src/rosclaw/self_model/residuals.py
+++ b/src/rosclaw/self_model/residuals.py
@@ -1,0 +1,114 @@
+"""Prediction residual encoding (v3 §8.5, PR-PE-4).
+
+After every action, compare predicted vs measured per channel.  Named
+residual channels:
+
+    joint_state / visual_pose / contact_outcome / force_peak /
+    control_latency / thermal / perception / task_performance
+
+A single residual NEVER triggers learning (v3 §8.5); escalation follows
+the existing PredictionMonitor's persistence thresholds
+(NORMAL → SUSPECTED_SHIFT → CONFIRMED_SHIFT → …), with RH56-recalibrated
+thresholds — never G1 parameters.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from .protocols import ResidualEncoder, SelfObservation, SelfPrediction
+
+RESIDUALS_VERSION = "rosclaw.prediction_residuals.v1"
+
+
+@dataclass(frozen=True)
+class PredictionResiduals:
+    channels: dict[str, float]
+    per_channel: dict[str, dict[str, float]]
+    max_abs: float
+    norm: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "residuals_version": RESIDUALS_VERSION,
+            "channels": self.channels,
+            "per_channel": self.per_channel,
+            "max_abs": round(self.max_abs, 4),
+            "norm": round(self.norm, 4),
+        }
+
+
+# RH56-recalibrated residual thresholds (raw units / physical units),
+# initial values from the evo-rps campaign telemetry — recalibrated by
+# residual evidence, never inherited from G1.
+RH56_SHIFT_THRESHOLDS: dict[str, float] = {
+    "joint_state": 60.0,  # raw units, ~4x typical first-order miss
+    "thermal": 2.0,  # °C prediction miss
+    "control_latency": 100.0,  # ms
+    "visual_pose": 0.05,  # m
+    "force_peak": 80.0,  # raw force units
+    "task_performance": 0.15,  # invalid-rate delta
+}
+
+
+class ChannelResidualEncoder(ResidualEncoder):
+    """Map prediction/observation channel names onto the §8.5 residual
+    families and compute per-family magnitudes."""
+
+    _FAMILY_PREFIX = {
+        "joint_state": ("next_pos_", "tracking_error_"),
+        "thermal": ("temp_",),
+        "control_latency": ("latency_", "time_to_reach_"),
+        "visual_pose": ("visual_",),
+        "force_peak": ("force_",),
+        "task_performance": ("invalid_rate", "task_"),
+        "contact_outcome": ("contact_",),
+        "perception": ("reliability", "confidence"),
+    }
+
+    def encode(self, prediction: SelfPrediction, observation: SelfObservation) -> dict[str, float]:
+        residuals: dict[str, float] = {}
+        for name, measured in observation.channels.items():
+            predicted = prediction.channels.get(name)
+            if predicted is None:
+                continue  # unpredicted channels are disclosed, not zero
+            residuals[name] = measured - predicted
+        return residuals
+
+    def encode_families(
+        self, prediction: SelfPrediction, observation: SelfObservation
+    ) -> PredictionResiduals:
+        flat = self.encode(prediction, observation)
+        families: dict[str, dict[str, float]] = {}
+        for name, value in flat.items():
+            family = "other"
+            for label, prefixes in self._FAMILY_PREFIX.items():
+                if any(name.startswith(prefix) for prefix in prefixes):
+                    family = label
+                    break
+            families.setdefault(family, {})[name] = value
+        channels = {
+            family: max((abs(v) for v in values.values()), default=0.0)
+            for family, values in families.items()
+        }
+        norm = math.sqrt(sum(v * v for v in flat.values())) if flat else 0.0
+        return PredictionResiduals(
+            channels=channels,
+            per_channel=families,
+            max_abs=max((abs(v) for v in flat.values()), default=0.0),
+            norm=norm,
+        )
+
+
+def shift_flags(
+    residuals: PredictionResiduals, thresholds: dict[str, float] | None = None
+) -> dict[str, bool]:
+    """Per-family shift flag (persistence/escalation belongs to the
+    PredictionMonitor — this is only the per-sample signal)."""
+    limits = thresholds or RH56_SHIFT_THRESHOLDS
+    return {
+        family: value > limits.get(family, float("inf"))
+        for family, value in residuals.channels.items()
+    }

--- a/src/rosclaw/self_model/snapshot.py
+++ b/src/rosclaw/self_model/snapshot.py
@@ -1,0 +1,124 @@
+"""SelfSnapshot: immutable pre-action self-state binding (v3 §8.7, PR-PE-4).
+
+Every real action submission binds to a SelfSnapshot: who the body is,
+how healthy it is, what it currently perceives, which regime it is in,
+what it believes it can do, which model predicted for it, and how
+uncertain that prediction was.  ``ActionGateway``'s body_snapshot_hash
+upgrades to this hash — a mutated body/perception/model produces a
+different hash, and stale snapshots stop matching reality (v3 §8.7).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from rosclaw.practice.physical_observation import canonical_hash
+
+SNAPSHOT_VERSION = "rosclaw.self_snapshot.v1"
+
+
+@dataclass(frozen=True)
+class SelfSnapshot:
+    body_id: str
+    body_hash: str
+    health: dict[str, Any]
+    perception_confidence: float | None
+    regime_label: str | None
+    capabilities: dict[str, str]
+    forward_model_hash: str | None
+    prediction_uncertainty: dict[str, float] | None
+    active_policy_hash: str | None
+    agency_summary: dict[str, int]
+    sequence: int
+    timestamp_ns: int = field(default_factory=time.time_ns)
+
+    @property
+    def snapshot_hash(self) -> str:
+        return canonical_hash(self.to_dict(), prefix="selfsnap")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SNAPSHOT_VERSION,
+            "body_id": self.body_id,
+            "body_hash": self.body_hash,
+            "health": self.health,
+            "perception_confidence": self.perception_confidence,
+            "regime_label": self.regime_label,
+            "capabilities": self.capabilities,
+            "forward_model_hash": self.forward_model_hash,
+            "prediction_uncertainty": self.prediction_uncertainty,
+            "active_policy_hash": self.active_policy_hash,
+            "agency_summary": self.agency_summary,
+            "sequence": self.sequence,
+            "timestamp_ns": self.timestamp_ns,
+        }
+
+    def mutation_report(self, other: SelfSnapshot) -> list[str]:
+        """Which binding components changed (v3 §15 self-loop acceptance:
+        body mutation invalidates the old snapshot)."""
+        changed: list[str] = []
+        for name in (
+            "body_hash",
+            "regime_label",
+            "forward_model_hash",
+            "active_policy_hash",
+        ):
+            if getattr(self, name) != getattr(other, name):
+                changed.append(name)
+        if self.snapshot_hash == other.snapshot_hash:
+            return []
+        if not changed and (
+            self.health != other.health or self.perception_confidence != other.perception_confidence
+        ):
+            changed.append("health_or_perception")
+        return changed
+
+
+@dataclass(frozen=True)
+class CalibratedUncertainty:
+    """Prediction uncertainty with calibration bookkeeping (v3 §15:
+    prediction uncertainty 有校准).  calibrated=False is the honest
+    default until enough predicted-vs-measured pairs exist."""
+
+    per_channel_std: dict[str, float]
+    samples: int
+    calibrated: bool
+    coverage: float | None  # fraction of measured residuals inside ±2σ
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "per_channel_std": self.per_channel_std,
+            "samples": self.samples,
+            "calibrated": self.calibrated,
+            "coverage": self.coverage,
+        }
+
+
+def calibrate_uncertainty(
+    residuals: list[dict[str, float]],
+    predicted_std: dict[str, float],
+    *,
+    min_samples: int = 30,
+) -> CalibratedUncertainty:
+    """Coverage calibration: with < min_samples the uncertainty is a
+    declared PRIOR, never a claimed calibration."""
+    coverage: float | None = None
+    if residuals:
+        inside = 0
+        total = 0
+        for residual in residuals:
+            for channel, value in residual.items():
+                std = predicted_std.get(channel)
+                if std is None or std <= 0:
+                    continue
+                total += 1
+                inside += int(abs(value) <= 2 * std)
+        coverage = inside / total if total else None
+    return CalibratedUncertainty(
+        per_channel_std=dict(predicted_std),
+        samples=len(residuals),
+        calibrated=len(residuals) >= min_samples,
+        coverage=coverage,
+    )

--- a/tests/self_model/test_rh56_self_adapters.py
+++ b/tests/self_model/test_rh56_self_adapters.py
@@ -1,0 +1,260 @@
+"""PR-PE-4 tests: self protocols, RH56/dual/D435i adapters, snapshot,
+residuals, uncertainty — plus the real-telemetry replay acceptance."""
+
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.self_model.adapters.dual_rh56 import D435iSensorSelfAdapter, DualHandSelfAdapter
+from rosclaw.self_model.adapters.rh56 import (
+    BodyHashMismatchError,
+    RH56ForwardPrior,
+    RH56HandSelfAdapter,
+    bind_model_to_body,
+)
+from rosclaw.self_model.protocols import SelfObservation
+from rosclaw.self_model.residuals import (
+    ChannelResidualEncoder,
+    shift_flags,
+)
+from rosclaw.self_model.snapshot import SelfSnapshot, calibrate_uncertainty
+
+JOINTS = ("little", "ring", "middle", "index", "thumb", "thumb_rot")
+
+
+def _adapter(body_id: str = "rh56_right_01") -> RH56HandSelfAdapter:
+    return RH56HandSelfAdapter(body_id)
+
+
+def _prior(adapter: RH56HandSelfAdapter) -> RH56ForwardPrior:
+    return RH56ForwardPrior(adapter.body_id(), adapter.body_hash())
+
+
+def test_first_order_position_response() -> None:
+    adapter = _adapter()
+    prior = _prior(adapter)
+    # Motion evidence toward the target → first-order approach.
+    state = {"pos_index": 400.0, "vel_index": 120.0, "temp_max": 44.0}
+    action = {"target_index": 600.0, "dt_s": 0.16, "gestures": 1.0}
+    prediction = prior.predict(state, action)
+    # tau_index=0.28 (session-calibrated), dt=0.16 → exp(-0.571) ≈ 0.565
+    # of the 200-unit gap remains.
+    import math
+
+    remaining = math.exp(-0.16 / 0.28)
+    expected = 600.0 + (400.0 - 600.0) * remaining
+    assert abs(prediction.channels["next_pos_index"] - expected) < 0.5
+    assert prediction.channels["tracking_error_index"] == pytest.approx(
+        abs(400.0 - 600.0) * remaining, abs=0.5
+    )
+    assert prediction.channels["time_to_reach_index"] == pytest.approx(0.28 * 2.9957, abs=0.01)
+    assert prediction.analytical_only
+    # Thermal: heat in minus cooling out.
+    assert "temp_delta" in prediction.channels
+
+
+def test_stale_register_without_motion_predicts_hold() -> None:
+    """Real-telemetry driven: angle_set holds stale values between
+    gestures while the hand holds position — the prior must predict hold
+    (measured: toward-register was 5× worse than hold)."""
+    adapter = _adapter()
+    prior = _prior(adapter)
+    prediction = prior.predict(
+        {"pos_index": 1000.0, "vel_index": 0.0}, {"target_index": 70.0, "dt_s": 0.5}
+    )
+    assert prediction.channels["next_pos_index"] == pytest.approx(1000.0)
+    assert prediction.channels["time_to_reach_index"] == 0.0
+    # No velocity channel at all → also hold (unknown motion ≠ motion).
+    prediction2 = prior.predict({"pos_index": 1000.0}, {"target_index": 70.0, "dt_s": 0.5})
+    assert prediction2.channels["next_pos_index"] == pytest.approx(1000.0)
+
+
+def test_no_target_means_hold_position() -> None:
+    adapter = _adapter()
+    prior = _prior(adapter)
+    prediction = prior.predict({"pos_thumb": 250.0}, {"dt_s": 0.5})
+    assert prediction.channels["next_pos_thumb"] == pytest.approx(250.0)
+    assert prediction.channels["time_to_reach_thumb"] == 0.0
+
+
+def test_body_hash_binding_rejects_mutation() -> None:
+    adapter = _adapter()
+    prior = _prior(adapter)
+    assert bind_model_to_body(prior, adapter) is prior
+    other = RH56HandSelfAdapter("rh56_right_01", firmware="different")
+    with pytest.raises(BodyHashMismatchError):
+        bind_model_to_body(prior, other)
+
+
+def test_dual_hand_skew_channels_and_hash() -> None:
+    dual = DualHandSelfAdapter(_adapter("rh56_left_01"), _adapter(), body_id="rh56_dual_01")
+    skew = dual.skew_channels(
+        {"angle_actual": {"index": 400}, "temperature_c": {"index": 44}},
+        {"angle_actual": {"index": 430}, "temperature_c": {"index": 46}},
+    )
+    assert skew["mirror_skew_index"] == 30.0
+    assert skew["temperature_asymmetry"] == 2.0
+    assert dual.body_hash() != dual.left.body_hash()
+    swapped = DualHandSelfAdapter(
+        RH56HandSelfAdapter("rh56_left_01", firmware="new"), _adapter(), body_id="rh56_dual_01"
+    )
+    assert swapped.body_hash() != dual.body_hash()
+
+
+def test_d435i_freshness_state_machine() -> None:
+    cam = D435iSensorSelfAdapter("d435i_231122070092", camera_pose_hash="campose_x")
+    fresh = cam.freshness_state(frame_age_ms=30.0, rgb_depth_skew_ms=5.0, consecutive_missing=0)
+    assert fresh["state"] == "FRESH" and fresh["reliability"] == 1.0
+    stale = cam.freshness_state(frame_age_ms=600.0, rgb_depth_skew_ms=5.0, consecutive_missing=0)
+    assert stale["state"] == "STALE" and stale["reliability"] == 0.0
+    missing = cam.freshness_state(frame_age_ms=30.0, rgb_depth_skew_ms=5.0, consecutive_missing=3)
+    assert missing["state"] == "STALE"
+    # Unknown skew: honest reliability haircut, never full confidence.
+    unknown = cam.freshness_state(frame_age_ms=30.0, rgb_depth_skew_ms=None, consecutive_missing=0)
+    assert unknown["reliability"] == 0.8
+
+
+def test_residual_encoding_and_shift_flags() -> None:
+    adapter = _adapter()
+    prior = _prior(adapter)
+    prediction = prior.predict(
+        {"pos_index": 400.0, "temp_max": 44.0}, {"target_index": 600.0, "dt_s": 0.16}
+    )
+    observation = SelfObservation(
+        channels={
+            "next_pos_index": prediction.channels["next_pos_index"] + 100.0,  # big miss
+            "temp_delta": prediction.channels["temp_delta"] + 3.0,
+        },
+        timestamp_ns=1,
+        source="telemetry",
+    )
+    encoder = ChannelResidualEncoder()
+    residuals = encoder.encode_families(prediction, observation)
+    assert residuals.channels["joint_state"] == pytest.approx(100.0)
+    flags = shift_flags(residuals)
+    assert flags["joint_state"] is True  # 100 > 60 threshold
+    assert flags.get("thermal", False) is True  # 3.0 > 2.0
+
+
+def test_snapshot_hash_and_mutation_report() -> None:
+    snap = SelfSnapshot(
+        body_id="rh56_right_01",
+        body_hash="body_a",
+        health={"temperature_max": 44},
+        perception_confidence=0.9,
+        regime_label="COLD_HEALTHY",
+        capabilities={"rps": "compatible"},
+        forward_model_hash="fwm_a",
+        prediction_uncertainty={"next_pos_index": 15.0},
+        active_policy_hash="pol_a",
+        agency_summary={"SELF_CAUSED": 3},
+        sequence=1,
+    )
+    mutated = SelfSnapshot(
+        body_id="rh56_right_01",
+        body_hash="body_b",
+        health={"temperature_max": 44},
+        perception_confidence=0.9,
+        regime_label="COLD_HEALTHY",
+        capabilities={"rps": "compatible"},
+        forward_model_hash="fwm_a",
+        prediction_uncertainty={"next_pos_index": 15.0},
+        active_policy_hash="pol_a",
+        agency_summary={"SELF_CAUSED": 3},
+        sequence=2,
+    )
+    assert snap.snapshot_hash != mutated.snapshot_hash
+    assert "body_hash" in snap.mutation_report(mutated)
+
+
+def test_uncertainty_calibration_honest_until_enough_samples() -> None:
+    prior_std = {"next_pos_index": 15.0}
+    few = [{"next_pos_index": 3.0}] * 10
+    result = calibrate_uncertainty(few, prior_std, min_samples=30)
+    assert not result.calibrated
+    assert result.coverage == 1.0
+    many = [{"next_pos_index": 3.0}] * 40
+    result2 = calibrate_uncertainty(many, prior_std, min_samples=30)
+    assert result2.calibrated
+
+
+# ------------------------------------------------ real telemetry replay (read-only)
+
+
+def test_rh56_prior_replay_on_real_session() -> None:
+    """Independent Hardware (read-only): replay the first-order prior over
+    a REAL canary session's telemetry and compare its next-position
+    residuals against the naive 'no motion' baseline.  The prior must be
+    better during gestures — otherwise it is not a model."""
+    import json
+    from pathlib import Path
+
+    session = Path(
+        "/home/nvidia/.rosclaw/acceptance/evo_rps/evo_rps_2026_01/practice/sessions/prac_20260730T024004Z_3260ea"
+    )
+    if not (session / "raw" / "events.jsonl").is_file():
+        pytest.skip("real session not present on this machine")
+    telemetry = []
+    with (session / "raw" / "events.jsonl").open() as handle:
+        for line in handle:
+            event = json.loads(line)
+            if event.get("event_type") == "rps.telemetry":
+                telemetry.append(event["payload"])
+    if len(telemetry) < 50:
+        pytest.skip("not enough telemetry")
+
+    adapter = _adapter()
+    prior = _prior(adapter)
+    joints = ("index", "thumb")
+    prior_sq = 0.0
+    naive_sq = 0.0
+    motion_prior_sq = 0.0
+    motion_naive_sq = 0.0
+    motion_n = 0
+    n = 0
+    prev_prev = None
+    for prev, cur in zip(telemetry, telemetry[1:], strict=False):
+        dt = float(cur["timestamp"]) - float(prev["timestamp"])
+        if not 0.05 < dt < 2.0:
+            prev_prev = prev
+            continue
+        prev_right = prev.get("right") or {}
+        cur_right = cur.get("right") or {}
+        prev_pos = prev_right.get("angle_actual") or {}
+        target = prev_right.get("angle_set") or {}
+        cur_pos = cur_right.get("angle_actual") or {}
+        # Measured velocity from the previous step (motion evidence).
+        old_pos = (prev_prev.get("right") or {}).get("angle_actual") if prev_prev else None
+        dt_prev = float(prev["timestamp"]) - float(prev_prev["timestamp"]) if prev_prev else None
+        state = {f"pos_{j}": float(prev_pos[j]) for j in joints if j in prev_pos}
+        if old_pos and dt_prev and dt_prev > 0.01:
+            for j in joints:
+                if j in old_pos and j in prev_pos:
+                    state[f"vel_{j}"] = (float(prev_pos[j]) - float(old_pos[j])) / dt_prev
+        action = {f"target_{j}": float(target.get(j, prev_pos[j])) for j in joints if j in prev_pos}
+        action["dt_s"] = dt
+        prediction = prior.predict(state, action)
+        for j in joints:
+            if j not in cur_pos or f"next_pos_{j}" not in prediction.channels:
+                continue
+            prior_sq += (float(cur_pos[j]) - prediction.channels[f"next_pos_{j}"]) ** 2
+            naive_sq += (float(cur_pos[j]) - float(prev_pos[j])) ** 2
+            n += 1
+            vel = state.get(f"vel_{j}", 0.0)
+            if abs(vel) > 30.0:
+                motion_prior_sq += (float(cur_pos[j]) - prediction.channels[f"next_pos_{j}"]) ** 2
+                motion_naive_sq += (float(cur_pos[j]) - float(prev_pos[j])) ** 2
+                motion_n += 1
+        prev_prev = prev
+    assert n > 30
+    prior_rmse = (prior_sq / n) ** 0.5
+    naive_rmse = (naive_sq / n) ** 0.5
+    # Overall the two-mode prior must not be worse than hold.
+    assert prior_rmse <= naive_rmse * 1.01, f"prior {prior_rmse:.1f} >> naive {naive_rmse:.1f}"
+    # During measured motion it must be strictly better.
+    assert motion_n > 5
+    motion_prior = (motion_prior_sq / motion_n) ** 0.5
+    motion_naive = (motion_naive_sq / motion_n) ** 0.5
+    assert motion_prior < motion_naive, (
+        f"motion prior {motion_prior:.1f} >= naive {motion_naive:.1f}"
+    )


### PR DESCRIPTION
Physical Evolution Lab v3 §8——Generic Operational Self Model。Self 不是人格/意识，而是可工程验证的持续估计："我当前是什么身体、什么状态、执行动作后会发生什么、结果是否由我造成、我还具备哪些可靠能力"。现有 self_model 是 G1 形（pelvis/COM/ball）——**RH56 绝不伪装 G1**。

## 交付

- **protocols**：SelfStateAdapter / SelfActionAdapter / ForwardModelProtocol / ResidualEncoder / AgencyEvidenceAdapter + 本体无关的 SelfPrediction/SelfObservation 通道契约
- **RH56HandSelfAdapter + RH56ForwardPrior**（§8.3/§8.4）：§8.3 状态块（identity/kinematics/interaction/health/perception/task）+ 解析先验（下一时刻关节位置/tracking error/time-to-reach/温度 delta）——**真实遥测证据驱动的双模式**：伺服只在手势执行窗口内趋向命令寄存器；窗口外寄存器是**陈旧的**而手保持位置（实测：向寄存器预测 RMSE 899 vs 保持 173——差 5 倍；用实测速度作运动证据区分两模式）。**每关节 tau 从真实会话遥测标定**（index 0.28 / thumb 0.49 / middle 0.52 / thumb_rot 0.33s），绝不沿用 G1 参数
- **DualHandSelfAdapter**（双手本体：镜像 skew + 温度不对称；换一只手即改变 body hash）+ **D435iSensorSelfAdapter**（新鲜度状态机；不可测 skew 诚实降置信）
- **SelfSnapshot**（§8.7）：动作前不可变绑定 + 变化报告；对变异身体加载模型抛 BodyHashMismatchError
- **PredictionResiduals**（§8.5 家族通道，RH56 重标定阈值）+ **CalibratedUncertainty**（<30 残差样本时诚实保持"先验"身份）

## 真实回放验收（Independent Hardware, read-only）

双模式先验整体不劣于 hold 基线，且在实测运动窗口内**严格更优**。G1 兼容：全部既有 self_model 测试不退化（25/25）。

## 验证级别（§16.13）

Component Test（10 测试，含真实遥测回放）+ Independent Hardware（read-only）。无 Shadow/REAL 声明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)