### PR TITLE
feat(mcp): add interactive operator confirmation

### DIFF
--- a/docs/ROSCLAWD.md
+++ b/docs/ROSCLAWD.md
@@ -145,6 +145,25 @@ Do not paste Permit IDs into prompts, manifests, source control, or chat logs.
 The Agent submits `authorized_action` with `request-action` or the guarded MCP
 tool and cannot issue or widen its own Permit.
 
+### Interactive host confirmation
+
+`RuntimeClient.prepare_operator_action()` builds an exact REAL proposal and a
+non-secret `rosclaw.operator_confirmation.v1` card containing its intent hash.
+A trusted MCP host may render that card to the operator. After an explicit
+accept response, `confirm_operator_action()` asks rosclawd to issue the exact
+one-shot permit, injects the returned `authorized_action`, and submits it. Its
+public result contains only `permit_injected=true` and
+`permit_exposed=false`; the permit identifier and authorized envelope are not
+returned to the Agent.
+
+The confirmation must carry the same action-intent hash. Decline, cancellation,
+missing elicitation support, hash mismatch, missing operator principal, or any
+daemon precondition fails before submission. This convenience path does not
+weaken the deployment boundary: in production, the MCP/operator host must run
+as the daemon service UID or use an equivalent authenticated operator broker,
+while the Agent remains a different UID. Same-UID development validates only
+the protocol and audit flow.
+
 ## Adapter Worker Isolation
 
 Registered Adapter workers use newline-delimited JSON over private pipes. The

--- a/src/rosclaw/mcp/adapters/runtime_client.py
+++ b/src/rosclaw/mcp/adapters/runtime_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, NoReturn
@@ -20,6 +21,14 @@ from rosclaw.mcp.adapters.skill_registry_client import SkillRegistryClient
 from rosclaw.mcp.schemas.common import MCPError
 
 logger = logging.getLogger("rosclaw.mcp.adapters.runtime_client")
+
+
+@dataclass(frozen=True)
+class PreparedOperatorAction:
+    """Exact REAL action plus the non-secret confirmation card shown by the host."""
+
+    action: Any
+    approval_request: dict[str, Any]
 
 
 class RuntimeClient:
@@ -602,6 +611,172 @@ class RuntimeClient:
     ) -> dict[str, Any]:
         """Submit a structured action request; only rosclawd can authorize REAL."""
 
+        action, mode = self._build_action(
+            capability_id=capability_id,
+            arguments=arguments,
+            execution_mode=execution_mode,
+            body_snapshot_hash=body_snapshot_hash,
+            principal_id=principal_id,
+            approval_id=approval_id,
+            body_id=body_id,
+            action_id=action_id,
+            deadline_at=deadline_at,
+            required_evidence=required_evidence,
+            timeout_sec=timeout_sec,
+        )
+        try:
+            ticket = await asyncio.to_thread(self._daemon_client.request_action, action)
+            result = ticket
+            if wait_timeout_sec > 0:
+                result = await asyncio.to_thread(
+                    self._daemon_client.wait_for_action,
+                    action.action_id,
+                    timeout_sec=wait_timeout_sec,
+                )
+        except MCPError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self._raise_daemon_error("request_action", exc)
+        return self._action_result_metadata(result, mode.value)
+
+    def prepare_operator_action(
+        self,
+        *,
+        capability_id: str,
+        arguments: dict[str, Any],
+        body_snapshot_hash: str,
+        body_id: str | None = None,
+        action_id: str | None = None,
+        deadline_at: str | datetime | None = None,
+        required_evidence: str = "TASK_VERIFIED",
+        timeout_sec: float = 30.0,
+        display: dict[str, Any] | None = None,
+    ) -> PreparedOperatorAction:
+        """Prepare one exact REAL proposal without issuing a permit or dispatching it."""
+
+        from rosclaw.daemon.permits import action_intent_hash
+
+        action, _mode = self._build_action(
+            capability_id=capability_id,
+            arguments=arguments,
+            execution_mode="REAL",
+            body_snapshot_hash=body_snapshot_hash,
+            body_id=body_id,
+            action_id=action_id,
+            session_id=action_id,
+            deadline_at=deadline_at,
+            required_evidence=required_evidence,
+            timeout_sec=timeout_sec,
+        )
+        approval_request = {
+            "schema_version": "rosclaw.operator_confirmation.v1",
+            "action_id": action.action_id,
+            "action_intent_hash": action_intent_hash(action),
+            "body_id": action.body_id,
+            "capability_id": action.capability_id,
+            "execution_mode": "REAL",
+            "risk_class": action.risk_class,
+            "deadline_at": action.to_dict()["deadline_at"],
+            "single_use": True,
+            "display": dict(display or {}),
+            "interaction": {
+                "kind": "mcp_elicitation",
+                "approve_label": "Confirm",
+                "decline_label": "Cancel",
+            },
+        }
+        return PreparedOperatorAction(action=action, approval_request=approval_request)
+
+    async def confirm_operator_action(
+        self,
+        prepared: PreparedOperatorAction,
+        *,
+        principal_id: str,
+        confirmation: dict[str, Any],
+        wait_timeout_sec: float = 2.0,
+        permit_ttl_sec: float = 60.0,
+    ) -> dict[str, Any]:
+        """Exchange a host-confirmed proposal for an opaque permit and submit it once."""
+
+        action = prepared.action
+        expected_hash = prepared.approval_request.get("action_intent_hash")
+        supplied_hash = confirmation.get("action_intent_hash")
+        if confirmation.get("accepted") is not True or supplied_hash != expected_hash:
+            raise MCPError(
+                "OPERATOR_CONFIRMATION_INVALID",
+                "The operator confirmation was not accepted or did not match the exact action.",
+            )
+        if not principal_id.strip():
+            raise MCPError(
+                "OPERATOR_PRINCIPAL_REQUIRED",
+                "A trusted operator principal is required for REAL confirmation.",
+            )
+        reason = str(confirmation.get("reason") or "Accepted through MCP elicitation")
+        try:
+            await asyncio.to_thread(
+                self._daemon_client.create_session,
+                session_id=action.session_id,
+                actor_id=action.actor_id,
+                agent_framework=action.agent_framework,
+                body_scope=[action.body_id],
+                capability_scope=[action.capability_id],
+                ttl_ms=60_000,
+            )
+            issued = await asyncio.to_thread(
+                self._daemon_client.issue_execution_permit,
+                action,
+                principal_id=principal_id,
+                target_peer_uid=os.geteuid(),
+                expires_in_sec=permit_ttl_sec,
+                reason=reason,
+            )
+            authorized_action = issued.get("authorized_action")
+            if not isinstance(authorized_action, dict):
+                raise RuntimeError("rosclawd returned no authorized action")
+            ticket = await asyncio.to_thread(
+                self._daemon_client.request_action,
+                authorized_action,
+            )
+            result = ticket
+            if wait_timeout_sec > 0:
+                result = await asyncio.to_thread(
+                    self._daemon_client.wait_for_action,
+                    action.action_id,
+                    timeout_sec=wait_timeout_sec,
+                )
+        except MCPError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self._raise_daemon_error("confirm_operator_action", exc)
+        return {
+            **self._action_result_metadata(result, "REAL"),
+            "operator_confirmation": {
+                "schema_version": "rosclaw.operator_confirmation_result.v1",
+                "accepted": True,
+                "action_intent_hash": expected_hash,
+                "permit_injected": True,
+                "permit_exposed": False,
+            },
+        }
+
+    def _build_action(
+        self,
+        *,
+        capability_id: str,
+        arguments: dict[str, Any],
+        execution_mode: str,
+        body_snapshot_hash: str,
+        principal_id: str = "",
+        approval_id: str | None = None,
+        body_id: str | None = None,
+        action_id: str | None = None,
+        session_id: str | None = None,
+        deadline_at: str | datetime | None = None,
+        required_evidence: str = "TASK_VERIFIED",
+        timeout_sec: float = 30.0,
+    ) -> tuple[Any, Any]:
+        """Build the immutable action shared by normal and interactive submission paths."""
+
         from rosclaw.kernel import (
             ActionEnvelope,
             AuthorizationContext,
@@ -641,7 +816,7 @@ class RuntimeClient:
         action_kwargs: dict[str, Any] = {
             "actor_id": os.environ.get("ROSCLAW_AGENT_ACTOR", "rosclaw-mcp"),
             "agent_framework": os.environ.get("ROSCLAW_AGENT_CLIENT", "mcp"),
-            "session_id": os.environ.get("ROSCLAW_AGENT_SESSION", "mcp-session"),
+            "session_id": session_id or os.environ.get("ROSCLAW_AGENT_SESSION", "mcp-session"),
             "body_id": body_id or self.robot_id,
             "body_snapshot_hash": body_snapshot_hash,
             "capability_id": capability_id,
@@ -685,21 +860,7 @@ class RuntimeClient:
             action_kwargs["deadline_at"] = parsed_deadline
         if action_id:
             action_kwargs["action_id"] = action_id
-        try:
-            action = ActionEnvelope(**action_kwargs)
-            ticket = await asyncio.to_thread(self._daemon_client.request_action, action)
-            result = ticket
-            if wait_timeout_sec > 0:
-                result = await asyncio.to_thread(
-                    self._daemon_client.wait_for_action,
-                    action.action_id,
-                    timeout_sec=wait_timeout_sec,
-                )
-        except MCPError:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            self._raise_daemon_error("request_action", exc)
-        return self._action_result_metadata(result, mode.value)
+        return ActionEnvelope(**action_kwargs), mode
 
     async def get_action_status(self, action_id: str) -> dict[str, Any]:
         """Read daemon queue state and any terminal ExecutionReceipt."""

--- a/tests/mcp/adapters/test_daemon_boundary.py
+++ b/tests/mcp/adapters/test_daemon_boundary.py
@@ -9,12 +9,14 @@ import pytest
 
 from rosclaw.kernel import ActionEnvelope
 from rosclaw.mcp.adapters.runtime_client import RuntimeClient
+from rosclaw.mcp.schemas.common import MCPError
 
 
 class _FakeDaemonClient:
     def __init__(self) -> None:
         self.actions: list[ActionEnvelope] = []
         self.stop_requests: list[tuple[str, str]] = []
+        self.sessions: list[dict[str, Any]] = []
 
     def get_runtime_status(self) -> dict[str, Any]:
         return {
@@ -25,8 +27,32 @@ class _FakeDaemonClient:
         }
 
     def request_action(self, action: ActionEnvelope) -> dict[str, Any]:
+        if isinstance(action, dict):
+            action = ActionEnvelope.from_dict(action)
         self.actions.append(action)
         return {"action_id": action.action_id, "state": "QUEUED"}
+
+    def issue_execution_permit(
+        self,
+        action: ActionEnvelope,
+        *,
+        principal_id: str,
+        target_peer_uid: int,
+        expires_in_sec: float,
+        reason: str,
+    ) -> dict[str, Any]:
+        payload = action.to_dict()
+        payload["authorization"] = {
+            "principal_id": principal_id,
+            "approved": True,
+            "approval_id": "permit-secret",
+            "scopes": [action.capability_id],
+        }
+        return {"authorized_action": payload, "permit": {"permit_id": "permit-secret"}}
+
+    def create_session(self, **kwargs: Any) -> dict[str, Any]:
+        self.sessions.append(kwargs)
+        return {"session_id": kwargs["session_id"], "state": "ACTIVE"}
 
     def wait_for_action(self, action_id: str, *, timeout_sec: float) -> dict[str, Any]:
         return {
@@ -131,6 +157,59 @@ async def test_request_action_preserves_operator_proposal_deadline(
     )
 
     assert daemon.actions[0].to_dict()["deadline_at"] == "2030-01-02T03:04:05Z"
+
+
+async def test_interactive_confirmation_injects_permit_without_exposing_it(
+    client: tuple[RuntimeClient, _FakeDaemonClient],
+) -> None:
+    runtime_client, daemon = client
+    prepared = runtime_client.prepare_operator_action(
+        capability_id="limo.set_initial_pose",
+        arguments={"target_pose": {"frame_id": "map", "x": 0.75, "y": -1.25}},
+        body_snapshot_hash="sha256:body",
+        action_id="action-interactive",
+        deadline_at="2030-01-02T03:04:05Z",
+        display={"summary": "Set LIMO initial pose"},
+    )
+
+    result = await runtime_client.confirm_operator_action(
+        prepared,
+        principal_id="operator-1",
+        confirmation={
+            "accepted": True,
+            "action_intent_hash": prepared.approval_request["action_intent_hash"],
+        },
+        wait_timeout_sec=0.0,
+    )
+
+    assert result["operator_confirmation"]["permit_injected"] is True
+    assert result["operator_confirmation"]["permit_exposed"] is False
+    assert "permit" not in result
+    assert "permit-secret" not in str(result)
+    assert daemon.actions[-1].authorization.approved is True
+    assert daemon.sessions[-1]["session_id"] == "action-interactive"
+
+
+async def test_interactive_confirmation_rejects_mismatched_intent(
+    client: tuple[RuntimeClient, _FakeDaemonClient],
+) -> None:
+    runtime_client, daemon = client
+    prepared = runtime_client.prepare_operator_action(
+        capability_id="limo.set_initial_pose",
+        arguments={"target_pose": {"frame_id": "map", "x": 0.75, "y": -1.25}},
+        body_snapshot_hash="sha256:body",
+        action_id="action-interactive-mismatch",
+        deadline_at="2030-01-02T03:04:05Z",
+    )
+
+    with pytest.raises(MCPError, match="did not match the exact action"):
+        await runtime_client.confirm_operator_action(
+            prepared,
+            principal_id="operator-1",
+            confirmation={"accepted": True, "action_intent_hash": "sha256:wrong"},
+        )
+
+    assert daemon.actions == []
 
 
 async def test_runtime_status_and_cancel_are_daemon_calls(


### PR DESCRIPTION
## Summary
- add a reusable exact-action operator confirmation card bound to the daemon action-intent hash
- exchange accepted host confirmation for an internally injected one-shot permit without exposing the permit to the Agent
- create a bounded per-action daemon Session and fail closed on confirmation mismatch

## Verification
- `pytest tests/mcp/adapters/test_daemon_boundary.py -q` (6 passed)
- targeted ruff, format, mypy, and compileall passed
- broader daemon/MCP suite: 293 passed, 1 skipped; 3 unrelated failures because the host Git 1.8.3 does not support `git init -b`
