### PR TITLE
feat: qualify MotionDecode sources for Social Dream

### DIFF
--- a/docs/integrations/motiondecode.md
+++ b/docs/integrations/motiondecode.md
@@ -1,0 +1,59 @@
+# MotionDecode source qualification
+
+ROSClaw treats MotionDecode CSVs as external motion references, not as trusted
+robot actions or offline-RL transitions. The adapter does not download data,
+authorize hardware, repair clips, or activate a policy.
+
+## Evidence loop
+
+Use an operator-managed local snapshot and pin a 40-character dataset commit.
+Write all generated evidence outside the source checkout.
+
+```bash
+.venv/bin/python -m rosclaw.entrypoint collective source add motiondecode \
+  --dataset-root /data/MotionDecode \
+  --revision <pinned-commit> \
+  --usage research_noncommercial \
+  --license-decision pending \
+  --terms-file /data/MotionDecode/LICENSE \
+  --terms-uri <revision-pinned-license-url> \
+  --families football,balance,gait,transition_recovery \
+  --limit 400 \
+  --output /evidence/motiondecode-registration.json
+
+.venv/bin/python -m rosclaw.entrypoint collective source inspect motiondecode \
+  --registration /evidence/motiondecode-registration.json
+
+.venv/bin/python -m rosclaw.entrypoint collective ingest motiondecode \
+  --registration /evidence/motiondecode-registration.json \
+  --dataset-root /data/MotionDecode \
+  --target-model e-urdf-zoo/g1/robot.mjcf.xml \
+  --output /evidence/motiondecode-ingest.json
+```
+
+`source add` hashes the catalog and a bounded set of selected CSVs. `inspect`
+replays the content-addressed registration without opening the dataset.
+`ingest` rehashes every registered file before parsing it, checks the exact
+Unitree HG 29-joint mapping, constructs read-only canonical episodes, and
+performs finite-value, quaternion, discontinuity, joint-limit, velocity, and
+acceleration checks.
+
+## Fail-closed rules
+
+- A dataset card or public download does not prove training permission.
+  `PERMITTED` requires a non-empty terms snapshot, revision-pinned URI,
+  attribution, and an explicit legal decision.
+- An empty or absent terms file can only produce `PENDING`.
+- MotionDecode v1 CSVs have no action, reward, transition, contact, or
+  synchronized ball semantics. They cannot be labeled as behavior-cloning,
+  football-contact, or offline-RL data.
+- Kinematic audit stops at Q1. Only later Q3/Q4 MuJoCo qualification may allow
+  motion-tracker training.
+- External evidence may discover candidates but cannot be Promotion truth.
+- Every receipt declares `hardware_authorized=false`; no ROS, DDS, motor, or
+  real-robot path exists in this adapter.
+
+Loop-reset or clip-concatenation boundaries are errors, even if the reset is
+near the end of a file. A future repair stage must emit a separate,
+content-addressed repair manifest, preserve the source hash and semantics, and
+pass the full audit again before MuJoCo qualification.

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -6742,6 +6742,11 @@ def main() -> int:
         help="Plan and schedule bounded SIM-only DreamForge campaigns",
         add_help=False,
     )
+    subparsers.add_parser(
+        "collective",
+        help="Register and audit governed external experience",
+        add_help=False,
+    )
 
     app_parser = subparsers.add_parser("app", help="Install, author, and run Capability Apps")
     app_subparsers = app_parser.add_subparsers(dest="app_command")

--- a/src/rosclaw/collective/cli.py
+++ b/src/rosclaw/collective/cli.py
@@ -1,0 +1,275 @@
+"""CLI for governed external-experience registration and ingestion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from rosclaw.collective.contracts import LicenseDecision, LicenseUse
+from rosclaw.continual.services.persistence import atomic_write_json
+
+if TYPE_CHECKING:
+    from rosclaw.collective.sources.motiondecode.manifest import MotionDecodeRegistration
+    from rosclaw.collective.sources.motiondecode.taxonomy import MotionFamily
+
+
+def dispatch_collective_argv(argv: list[str]) -> int | None:
+    if not argv or argv[0] != "collective":
+        return None
+    args = _parser().parse_args(argv[1:])
+    try:
+        return int(args.handler(args))
+    except (OSError, ValueError, KeyError, PermissionError) as exc:
+        _print(
+            {
+                "schema_version": "rosclaw.collective.cli_error.v1",
+                "ok": False,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+                "training_eligible": False,
+                "activation_authorized": False,
+                "hardware_authorized": False,
+            },
+            stream=sys.stderr,
+        )
+        return 2
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="rosclaw collective",
+        description="Register and audit external experience without authorizing hardware.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    source = commands.add_parser("source", help="manage content-addressed source evidence")
+    source_commands = source.add_subparsers(dest="source_command", required=True)
+
+    add = source_commands.add_parser("add", help="register an operator-managed local snapshot")
+    add.add_argument("adapter", choices=["motiondecode"])
+    add.add_argument("--dataset-root", type=Path, required=True)
+    add.add_argument("--revision", required=True)
+    add.add_argument(
+        "--usage",
+        choices=[item.value for item in LicenseUse],
+        default=LicenseUse.RESEARCH_NONCOMMERCIAL.value,
+    )
+    add.add_argument(
+        "--license-decision",
+        choices=[item.value for item in LicenseDecision],
+        default=LicenseDecision.PENDING.value,
+    )
+    add.add_argument("--terms-file", type=Path)
+    add.add_argument("--terms-uri")
+    add.add_argument("--attribution", default="ChingMu / CMRobot MotionDecode")
+    add.add_argument(
+        "--families",
+        default="",
+        help="comma-separated football,balance,gait,transition_recovery,other",
+    )
+    add.add_argument("--limit", type=int, default=400)
+    add.add_argument("--output", type=Path, required=True)
+    add.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    add.add_argument("--force", action="store_true")
+    add.set_defaults(handler=_source_add)
+
+    inspect = source_commands.add_parser(
+        "inspect", help="replay and summarize a registration artifact"
+    )
+    inspect.add_argument("adapter", choices=["motiondecode"])
+    inspect.add_argument("--registration", type=Path, required=True)
+    inspect.set_defaults(handler=_source_inspect)
+
+    ingest = commands.add_parser(
+        "ingest",
+        help="rehash and kinematically audit a registered local snapshot",
+    )
+    ingest.add_argument("adapter", choices=["motiondecode"])
+    ingest.add_argument("--registration", type=Path, required=True)
+    ingest.add_argument("--dataset-root", type=Path, required=True)
+    ingest.add_argument("--target-model", type=Path, required=True)
+    ingest.add_argument("--output", type=Path, required=True)
+    ingest.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    ingest.add_argument("--force", action="store_true")
+    ingest.set_defaults(handler=_ingest)
+    return parser
+
+
+def _source_add(args: argparse.Namespace) -> int:
+    from rosclaw.collective.sources.motiondecode.manifest import (
+        register_motiondecode_source,
+    )
+
+    output = _output_path(args.output, args.source_checkout, force=args.force)
+    registration = register_motiondecode_source(
+        args.dataset_root,
+        revision=args.revision,
+        requested_use=LicenseUse(args.usage),
+        license_decision=LicenseDecision(args.license_decision),
+        terms_path=args.terms_file,
+        terms_uri=args.terms_uri,
+        attribution_text=args.attribution,
+        families=_families(args.families),
+        limit=args.limit,
+    )
+    artifact = _registration_artifact(registration)
+    atomic_write_json(output, artifact)
+    _print(
+        {
+            "schema_version": "rosclaw.collective.source_add_receipt.v1",
+            "ok": registration.source_registered,
+            "output": str(output),
+            "registration_hash": registration.registration_hash,
+            "source_manifest_hash": registration.manifest.manifest_hash,
+            "catalog_schema_valid": registration.catalog_audit.schema_valid,
+            "selected_sample_count": registration.manifest.selected_sample_count,
+            "license_decision": registration.manifest.license_snapshot.decision.value,
+            "training_eligible": registration.training_eligible,
+            "training_blockers": registration.to_dict()["training_blockers"],
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+    )
+    return 0 if registration.source_registered else 1
+
+
+def _source_inspect(args: argparse.Namespace) -> int:
+    registration = _read_registration(args.registration)
+    _print(
+        {
+            "schema_version": "rosclaw.collective.source_inspection.v1",
+            "ok": registration.source_registered,
+            "registration_hash": registration.registration_hash,
+            "source_manifest_hash": registration.manifest.manifest_hash,
+            "source_identity_hash": registration.manifest.source_identity.source_hash,
+            "revision": registration.manifest.revision,
+            "catalog_audit": registration.catalog_audit.to_dict(),
+            "selected_sample_count": registration.manifest.selected_sample_count,
+            "inventory_scope": "operator_managed_local_snapshot",
+            "upstream_inventory_verified": False,
+            "local_discovered_sample_count": (registration.manifest.local_discovered_sample_count),
+            "local_selection_complete": registration.manifest.local_selection_complete,
+            "requested_families": [
+                family.value for family in registration.manifest.requested_families
+            ],
+            "license_snapshot": registration.manifest.license_snapshot.to_dict(),
+            "attribution": registration.manifest.attribution.to_dict(),
+            "training_eligible": registration.training_eligible,
+            "training_blockers": registration.to_dict()["training_blockers"],
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+    )
+    return 0 if registration.source_registered else 1
+
+
+def _ingest(args: argparse.Namespace) -> int:
+    from rosclaw.collective.sources.motiondecode.audit import (
+        audit_motiondecode_snapshot,
+    )
+
+    output = _output_path(args.output, args.source_checkout, force=args.force)
+    registration = _read_registration(args.registration)
+    report = audit_motiondecode_snapshot(
+        registration,
+        args.dataset_root,
+        target_model_path=args.target_model,
+    )
+    artifact = {
+        "schema_version": "rosclaw.collective.motiondecode_ingest_artifact.v1",
+        "report": report.to_dict(),
+        "report_hash": report.report_hash,
+    }
+    atomic_write_json(output, artifact)
+    _print(
+        {
+            "schema_version": "rosclaw.collective.ingest_receipt.v1",
+            "ok": report.kinematic_valid_count > 0,
+            "output": str(output),
+            "report_hash": report.report_hash,
+            "source_manifest_hash": report.source_manifest_hash,
+            "clip_count": len(report.clips),
+            "kinematic_valid_count": report.kinematic_valid_count,
+            "qualification_counts": report.qualification_counts,
+            "issue_clip_counts": report.issue_clip_counts,
+            "segmentation_repair_candidate_count": (report.segmentation_repair_candidate_count),
+            "experience_capsule_hash": (
+                report.experience_capsule.capsule_hash
+                if report.experience_capsule is not None
+                else None
+            ),
+            "training_eligible": report.training_eligible,
+            "training_blockers": report.training_blockers,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+    )
+    return 0 if report.kinematic_valid_count > 0 else 1
+
+
+def _families(value: str) -> tuple[MotionFamily, ...]:
+    from rosclaw.collective.sources.motiondecode.taxonomy import MotionFamily
+
+    if not value.strip():
+        return ()
+    names = tuple(item.strip() for item in value.split(","))
+    if any(not item for item in names) or len(names) != len(set(names)):
+        raise ValueError("families must contain unique non-empty names")
+    try:
+        return tuple(MotionFamily(item) for item in names)
+    except ValueError as exc:
+        raise ValueError("families contains an unknown MotionDecode family") from exc
+
+
+def _registration_artifact(registration: MotionDecodeRegistration) -> dict[str, Any]:
+    return {
+        "schema_version": "rosclaw.collective.motiondecode_registration_artifact.v1",
+        "registration": registration.to_dict(),
+        "registration_hash": registration.registration_hash,
+    }
+
+
+def _read_registration(path: Path) -> MotionDecodeRegistration:
+    from rosclaw.collective.sources.motiondecode.manifest import (
+        MotionDecodeRegistration,
+    )
+
+    value = _read_object(path)
+    registration_value = value.get("registration")
+    if not isinstance(registration_value, dict):
+        raise ValueError("registration artifact lacks a registration object")
+    registration = MotionDecodeRegistration.from_dict(registration_value)
+    if value.get("registration_hash") != registration.registration_hash:
+        raise ValueError("registration_hash does not replay")
+    return registration
+
+
+def _read_object(path: Path) -> Mapping[str, Any]:
+    value = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    if not isinstance(value, Mapping):
+        raise ValueError("JSON artifact must be an object")
+    return value
+
+
+def _output_path(path: Path, checkout: Path, *, force: bool) -> Path:
+    resolved = path.expanduser().resolve()
+    source = checkout.expanduser().resolve()
+    if resolved == source or source in resolved.parents:
+        raise ValueError("collective evidence output must be outside the source checkout")
+    if resolved.exists() and not force:
+        raise FileExistsError("output already exists; pass --force to replace it")
+    return resolved
+
+
+def _print(value: Mapping[str, Any], *, stream: Any | None = None) -> None:
+    print(
+        json.dumps(dict(value), indent=2, sort_keys=True, allow_nan=False),
+        file=stream if stream is not None else sys.stdout,
+    )
+
+
+__all__ = ["dispatch_collective_argv"]

--- a/src/rosclaw/collective/sources/__init__.py
+++ b/src/rosclaw/collective/sources/__init__.py
@@ -1,0 +1,1 @@
+"""Governed adapters for external collective-experience sources."""

--- a/src/rosclaw/collective/sources/motiondecode/__init__.py
+++ b/src/rosclaw/collective/sources/motiondecode/__init__.py
@@ -1,0 +1,40 @@
+"""Fail-closed MotionDecode source qualification.
+
+The adapter never downloads a dataset and never authorizes hardware.  It turns
+an operator-managed local snapshot into content-addressed source evidence, then
+audits motion CSVs without treating a kinematic reference as an RL transition.
+"""
+
+from rosclaw.collective.sources.motiondecode.audit import (
+    MotionDecodeClipAudit,
+    MotionDecodeIngestReport,
+    MotionQualificationLevel,
+    audit_motiondecode_snapshot,
+)
+from rosclaw.collective.sources.motiondecode.license import (
+    MotionDecodeLicenseSnapshot,
+    snapshot_license,
+)
+from rosclaw.collective.sources.motiondecode.manifest import (
+    MotionDecodeFileRecord,
+    MotionDecodeRegistration,
+    MotionDecodeSourceManifest,
+    register_motiondecode_source,
+)
+from rosclaw.collective.sources.motiondecode.parser import CanonicalMotionEpisode
+from rosclaw.collective.sources.motiondecode.taxonomy import MotionFamily
+
+__all__ = [
+    "CanonicalMotionEpisode",
+    "MotionDecodeClipAudit",
+    "MotionDecodeFileRecord",
+    "MotionDecodeIngestReport",
+    "MotionDecodeLicenseSnapshot",
+    "MotionDecodeRegistration",
+    "MotionDecodeSourceManifest",
+    "MotionFamily",
+    "MotionQualificationLevel",
+    "audit_motiondecode_snapshot",
+    "register_motiondecode_source",
+    "snapshot_license",
+]

--- a/src/rosclaw/collective/sources/motiondecode/attribution.py
+++ b/src/rosclaw/collective/sources/motiondecode/attribution.py
@@ -1,0 +1,60 @@
+"""Attribution manifest for derived MotionDecode artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+
+@dataclass(frozen=True)
+class MotionDecodeAttribution:
+    provider: str
+    dataset: str
+    source_uri: str
+    revision: str
+    attribution_text: str
+    license_snapshot_hash: str
+    schema_version: str = "rosclaw.collective.motiondecode_attribution.v1"
+
+    def __post_init__(self) -> None:
+        for label in (
+            "provider",
+            "dataset",
+            "source_uri",
+            "revision",
+            "attribution_text",
+            "license_snapshot_hash",
+        ):
+            if not getattr(self, label).strip():
+                raise ValueError(f"{label} must not be empty")
+
+    @property
+    def attribution_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "provider": self.provider,
+            "dataset": self.dataset,
+            "source_uri": self.source_uri,
+            "revision": self.revision,
+            "attribution_text": self.attribution_text,
+            "license_snapshot_hash": self.license_snapshot_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> MotionDecodeAttribution:
+        return cls(
+            provider=str(value["provider"]),
+            dataset=str(value["dataset"]),
+            source_uri=str(value["source_uri"]),
+            revision=str(value["revision"]),
+            attribution_text=str(value["attribution_text"]),
+            license_snapshot_hash=str(value["license_snapshot_hash"]),
+        )
+
+
+__all__ = ["MotionDecodeAttribution"]

--- a/src/rosclaw/collective/sources/motiondecode/audit.py
+++ b/src/rosclaw/collective/sources/motiondecode/audit.py
@@ -1,0 +1,633 @@
+"""Kinematic qualification and collective-capsule closure for MotionDecode."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import math
+import xml.etree.ElementTree as ET
+from collections import Counter
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.collective.contracts import (
+    ApplicabilityAssessment,
+    ApplicabilityDecision,
+    CollectiveUse,
+    ExperienceCapsule,
+    LicenseDecision,
+)
+from rosclaw.collective.sources.motiondecode.manifest import (
+    MotionDecodeFileRecord,
+    MotionDecodeRegistration,
+    verify_registered_files,
+)
+from rosclaw.collective.sources.motiondecode.parser import (
+    CanonicalMotionEpisode,
+    parse_motion_csv,
+)
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.growth.contracts import EvidenceLevel, EvidenceUsePolicy
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_DDS_JOINT_NAMES
+
+
+class MotionQualificationLevel(StrEnum):
+    Q0_INVALID = "q0_invalid"
+    Q1_KINEMATIC_ONLY = "q1_kinematic_only"
+    Q2_TRACKABLE_WITH_REPAIR = "q2_trackable_with_repair"
+    Q3_PHYSICS_TRACKABLE = "q3_physics_trackable"
+    Q4_ROBUST_TRACKABLE = "q4_robust_trackable"
+
+
+class AuditSeverity(StrEnum):
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class MotionDecodeAuditThresholds:
+    quaternion_norm_warning: float = 0.005
+    quaternion_norm_error: float = 0.05
+    root_step_warning_m: float = 0.05
+    root_step_error_m: float = 0.10
+    terminal_root_match_m: float = 0.002
+    terminal_quaternion_match: float = 0.01
+    terminal_joint_match_rad: float = 0.05
+    loop_closure_search_frames: int = 64
+    loop_closure_root_speed_error_m_s: float = 2.0
+    loop_closure_joint_speed_error_rad_s: float = 10.0
+    joint_limit_tolerance_rad: float = 0.02
+    joint_velocity_warning_rad_s: float = 30.0
+    joint_acceleration_warning_rad_s2: float = 1000.0
+
+    def __post_init__(self) -> None:
+        values = tuple(vars(self).values())
+        if any(
+            isinstance(value, bool) or not math.isfinite(value) or value <= 0.0 for value in values
+        ):
+            raise ValueError("kinematic audit thresholds must be finite and positive")
+        if not isinstance(self.loop_closure_search_frames, int):
+            raise ValueError("loop_closure_search_frames must be an integer")
+        if self.quaternion_norm_warning >= self.quaternion_norm_error:
+            raise ValueError("quaternion warning threshold must be below error threshold")
+        if self.root_step_warning_m >= self.root_step_error_m:
+            raise ValueError("root-step warning threshold must be below error threshold")
+
+    def to_dict(self) -> dict[str, float | int]:
+        return dict(vars(self))
+
+
+@dataclass(frozen=True)
+class MotionDecodeAuditIssue:
+    code: str
+    severity: AuditSeverity
+    observed: float
+    threshold: float
+    count: int
+
+    def __post_init__(self) -> None:
+        if not self.code.strip():
+            raise ValueError("audit issue code must not be empty")
+        if not isinstance(self.severity, AuditSeverity):
+            raise ValueError("audit issue severity is unknown")
+        if not math.isfinite(self.observed) or not math.isfinite(self.threshold):
+            raise ValueError("audit issue values must be finite")
+        if self.count <= 0:
+            raise ValueError("audit issue count must be positive")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "severity": self.severity.value,
+            "observed": self.observed,
+            "threshold": self.threshold,
+            "count": self.count,
+        }
+
+
+@dataclass(frozen=True)
+class MotionDecodeClipAudit:
+    relative_path: str
+    source_file_hash: str
+    qualification: MotionQualificationLevel
+    issues: tuple[MotionDecodeAuditIssue, ...]
+    episode_summary: dict[str, Any] | None
+    parser_error: str | None = None
+    schema_version: str = "rosclaw.collective.motiondecode_clip_audit.v1"
+
+    @property
+    def kinematic_valid(self) -> bool:
+        return (
+            self.qualification is MotionQualificationLevel.Q1_KINEMATIC_ONLY
+            and self.parser_error is None
+            and not any(issue.severity is AuditSeverity.ERROR for issue in self.issues)
+        )
+
+    @property
+    def physics_training_eligible(self) -> bool:
+        return False
+
+    @property
+    def audit_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "relative_path": self.relative_path,
+            "source_file_hash": self.source_file_hash,
+            "qualification": self.qualification.value,
+            "issues": [issue.to_dict() for issue in self.issues],
+            "episode_summary": self.episode_summary,
+            "parser_error": self.parser_error,
+            "kinematic_valid": self.kinematic_valid,
+            "physics_training_eligible": self.physics_training_eligible,
+            "hardware_authorized": False,
+        }
+
+
+@dataclass(frozen=True)
+class MotionDecodeIngestReport:
+    registration_hash: str
+    source_manifest_hash: str
+    target_body_hash: str
+    target_model_file_hash: str
+    license_decision: LicenseDecision
+    catalog_schema_valid: bool
+    thresholds: MotionDecodeAuditThresholds
+    clips: tuple[MotionDecodeClipAudit, ...]
+    experience_capsule: ExperienceCapsule | None
+    schema_version: str = "rosclaw.collective.motiondecode_ingest_report.v1"
+
+    @property
+    def quality_commitment(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": "rosclaw.collective.motiondecode_quality_commitment.v1",
+                "thresholds": self.thresholds.to_dict(),
+                "clip_audit_hashes": [clip.audit_hash for clip in self.clips],
+            }
+        )
+
+    @property
+    def report_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def kinematic_valid_count(self) -> int:
+        return sum(clip.kinematic_valid for clip in self.clips)
+
+    @property
+    def qualification_counts(self) -> dict[str, int]:
+        counts = Counter(clip.qualification.value for clip in self.clips)
+        return dict(sorted(counts.items()))
+
+    @property
+    def issue_clip_counts(self) -> dict[str, int]:
+        counts = Counter(issue.code for clip in self.clips for issue in clip.issues)
+        return dict(sorted(counts.items()))
+
+    @property
+    def segmentation_repair_candidate_count(self) -> int:
+        repair_codes = {
+            "ROOT_LOOP_CLOSURE_DISCONTINUITY",
+            "JOINT_LOOP_CLOSURE_DISCONTINUITY",
+        }
+        return sum(any(issue.code in repair_codes for issue in clip.issues) for clip in self.clips)
+
+    @property
+    def training_eligible(self) -> bool:
+        return False
+
+    @property
+    def training_blockers(self) -> list[str]:
+        blockers = [
+            "Q3_OR_Q4_PHYSICS_QUALIFICATION_REQUIRED",
+            "SOURCE_COORDINATE_FRAME_UNSPECIFIED",
+            "SYNCHRONIZED_BALL_POSE_ABSENT",
+            "ACTION_REWARD_TRANSITION_SEMANTICS_ABSENT",
+        ]
+        if self.kinematic_valid_count == 0:
+            blockers.insert(0, "NO_KINEMATICALLY_VALID_CLIPS")
+        elif self.kinematic_valid_count != len(self.clips):
+            blockers.insert(0, "KINEMATIC_AUDIT_PARTIAL")
+        if self.license_decision is not LicenseDecision.PERMITTED:
+            blockers.insert(0, "LICENSE_NOT_PERMITTED")
+        if not self.catalog_schema_valid:
+            blockers.insert(0, "CATALOG_SCHEMA_INVALID")
+        return blockers
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "registration_hash": self.registration_hash,
+            "source_manifest_hash": self.source_manifest_hash,
+            "target_body_hash": self.target_body_hash,
+            "target_model_file_hash": self.target_model_file_hash,
+            "license_decision": self.license_decision.value,
+            "catalog_schema_valid": self.catalog_schema_valid,
+            "thresholds": self.thresholds.to_dict(),
+            "clips": [clip.to_dict() for clip in self.clips],
+            "clip_count": len(self.clips),
+            "kinematic_valid_count": self.kinematic_valid_count,
+            "qualification_counts": self.qualification_counts,
+            "issue_clip_counts": self.issue_clip_counts,
+            "segmentation_repair_candidate_count": (self.segmentation_repair_candidate_count),
+            "manual_review_required_count": (
+                len(self.clips) - self.segmentation_repair_candidate_count
+            ),
+            "quality_commitment": self.quality_commitment,
+            "experience_capsule": (
+                self.experience_capsule.to_dict() if self.experience_capsule else None
+            ),
+            "experience_capsule_hash": (
+                self.experience_capsule.capsule_hash if self.experience_capsule else None
+            ),
+            "eligibility": {
+                "motion_reference_discovery": self.kinematic_valid_count > 0,
+                "motion_tracker_training": False,
+                "football_contact_training": False,
+                "behavior_cloning": False,
+                "offline_rl": False,
+                "promotion_truth": False,
+            },
+            "training_eligible": self.training_eligible,
+            "training_blockers": self.training_blockers,
+            "hardware_authorized": False,
+        }
+
+
+def audit_motiondecode_snapshot(
+    registration: MotionDecodeRegistration,
+    dataset_root: Path,
+    *,
+    target_model_path: Path,
+    thresholds: MotionDecodeAuditThresholds | None = None,
+) -> MotionDecodeIngestReport:
+    """Replay source hashes, parse registered clips and stop at Q1."""
+
+    limits, target_body_hash, model_hash = _load_joint_limits(target_model_path)
+    verified = verify_registered_files(registration, dataset_root)
+    selected_thresholds = thresholds or MotionDecodeAuditThresholds()
+    clips: list[MotionDecodeClipAudit] = []
+    for record in registration.manifest.files:
+        if not record.relative_path.startswith("samples/"):
+            continue
+        clips.append(
+            _audit_record(
+                record,
+                verified[record.relative_path],
+                source_manifest_hash=registration.manifest.manifest_hash,
+                target_body_hash=target_body_hash,
+                joint_limits=limits,
+                thresholds=selected_thresholds,
+                sample_rate_hz=registration.manifest.sample_rate_hz,
+            )
+        )
+    quality_commitment = canonical_hash(
+        {
+            "schema_version": "rosclaw.collective.motiondecode_quality_commitment.v1",
+            "thresholds": selected_thresholds.to_dict(),
+            "clip_audit_hashes": [clip.audit_hash for clip in clips],
+        }
+    )
+    capsule = _build_capsule(
+        registration,
+        tuple(clips),
+        target_body_hash=target_body_hash,
+        quality_commitment=quality_commitment,
+    )
+    return MotionDecodeIngestReport(
+        registration_hash=registration.registration_hash,
+        source_manifest_hash=registration.manifest.manifest_hash,
+        target_body_hash=target_body_hash,
+        target_model_file_hash=model_hash,
+        license_decision=registration.manifest.license_snapshot.decision,
+        catalog_schema_valid=registration.catalog_audit.schema_valid,
+        thresholds=selected_thresholds,
+        clips=tuple(clips),
+        experience_capsule=capsule,
+    )
+
+
+def _audit_record(
+    record: MotionDecodeFileRecord,
+    path: Path,
+    *,
+    source_manifest_hash: str,
+    target_body_hash: str,
+    joint_limits: dict[str, tuple[float, float]],
+    thresholds: MotionDecodeAuditThresholds,
+    sample_rate_hz: float,
+) -> MotionDecodeClipAudit:
+    try:
+        episode = parse_motion_csv(
+            path,
+            source_manifest_hash=source_manifest_hash,
+            expected_file_hash=record.content_hash,
+            target_body_hash=target_body_hash,
+            sample_rate_hz=sample_rate_hz,
+        )
+        issues = _kinematic_issues(episode, joint_limits, thresholds)
+    except (OSError, ValueError, csv.Error) as exc:
+        return MotionDecodeClipAudit(
+            relative_path=record.relative_path,
+            source_file_hash=record.content_hash,
+            qualification=MotionQualificationLevel.Q0_INVALID,
+            issues=(),
+            episode_summary=None,
+            parser_error=f"{type(exc).__name__}: {exc}",
+        )
+    qualification = (
+        MotionQualificationLevel.Q0_INVALID
+        if any(issue.severity is AuditSeverity.ERROR for issue in issues)
+        else MotionQualificationLevel.Q1_KINEMATIC_ONLY
+    )
+    return MotionDecodeClipAudit(
+        relative_path=record.relative_path,
+        source_file_hash=record.content_hash,
+        qualification=qualification,
+        issues=tuple(issues),
+        episode_summary=episode.summary(),
+    )
+
+
+def _kinematic_issues(
+    episode: CanonicalMotionEpisode,
+    joint_limits: dict[str, tuple[float, float]],
+    thresholds: MotionDecodeAuditThresholds,
+) -> list[MotionDecodeAuditIssue]:
+    issues: list[MotionDecodeAuditIssue] = []
+    norms = np.linalg.norm(episode.root_quaternion, axis=1)
+    quaternion_error = np.abs(norms - 1.0)
+    maximum_quaternion_error = float(np.max(quaternion_error))
+    if maximum_quaternion_error > thresholds.quaternion_norm_error:
+        issues.append(
+            MotionDecodeAuditIssue(
+                code="QUATERNION_NORM_ERROR",
+                severity=AuditSeverity.ERROR,
+                observed=maximum_quaternion_error,
+                threshold=thresholds.quaternion_norm_error,
+                count=int(np.count_nonzero(quaternion_error > thresholds.quaternion_norm_error)),
+            )
+        )
+    elif maximum_quaternion_error > thresholds.quaternion_norm_warning:
+        issues.append(
+            MotionDecodeAuditIssue(
+                code="QUATERNION_NORM_WARNING",
+                severity=AuditSeverity.WARNING,
+                observed=maximum_quaternion_error,
+                threshold=thresholds.quaternion_norm_warning,
+                count=int(np.count_nonzero(quaternion_error > thresholds.quaternion_norm_warning)),
+            )
+        )
+    root_steps = np.linalg.norm(np.diff(episode.root_position, axis=0), axis=1)
+    maximum_root_step = float(np.max(root_steps))
+    issues.extend(_loop_closure_issues(episode, thresholds))
+    if maximum_root_step > thresholds.root_step_error_m:
+        issues.append(
+            MotionDecodeAuditIssue(
+                code="ROOT_STEP_ERROR",
+                severity=AuditSeverity.ERROR,
+                observed=maximum_root_step,
+                threshold=thresholds.root_step_error_m,
+                count=int(np.count_nonzero(root_steps > thresholds.root_step_error_m)),
+            )
+        )
+    elif maximum_root_step > thresholds.root_step_warning_m:
+        issues.append(
+            MotionDecodeAuditIssue(
+                code="ROOT_STEP_WARNING",
+                severity=AuditSeverity.WARNING,
+                observed=maximum_root_step,
+                threshold=thresholds.root_step_warning_m,
+                count=int(np.count_nonzero(root_steps > thresholds.root_step_warning_m)),
+            )
+        )
+    limit_excesses: list[np.ndarray] = []
+    for index, joint_name in enumerate(episode.mapping.target_joint_names):
+        lower, upper = joint_limits[joint_name]
+        values = episode.joint_position[:, index]
+        limit_excesses.append(np.maximum(lower - values, values - upper))
+    excess = np.maximum(np.column_stack(limit_excesses), 0.0)
+    maximum_excess = float(np.max(excess))
+    if maximum_excess > thresholds.joint_limit_tolerance_rad:
+        issues.append(
+            MotionDecodeAuditIssue(
+                code="JOINT_LIMIT_ERROR",
+                severity=AuditSeverity.ERROR,
+                observed=maximum_excess,
+                threshold=thresholds.joint_limit_tolerance_rad,
+                count=int(np.count_nonzero(excess > thresholds.joint_limit_tolerance_rad)),
+            )
+        )
+    maximum_velocity = float(np.max(np.abs(episode.joint_velocity)))
+    if maximum_velocity > thresholds.joint_velocity_warning_rad_s:
+        issues.append(
+            MotionDecodeAuditIssue(
+                code="JOINT_VELOCITY_WARNING",
+                severity=AuditSeverity.WARNING,
+                observed=maximum_velocity,
+                threshold=thresholds.joint_velocity_warning_rad_s,
+                count=int(
+                    np.count_nonzero(
+                        np.abs(episode.joint_velocity) > thresholds.joint_velocity_warning_rad_s
+                    )
+                ),
+            )
+        )
+    maximum_acceleration = float(np.max(np.abs(episode.joint_acceleration)))
+    if maximum_acceleration > thresholds.joint_acceleration_warning_rad_s2:
+        issues.append(
+            MotionDecodeAuditIssue(
+                code="JOINT_ACCELERATION_WARNING",
+                severity=AuditSeverity.WARNING,
+                observed=maximum_acceleration,
+                threshold=thresholds.joint_acceleration_warning_rad_s2,
+                count=int(
+                    np.count_nonzero(
+                        np.abs(episode.joint_acceleration)
+                        > thresholds.joint_acceleration_warning_rad_s2
+                    )
+                ),
+            )
+        )
+    return issues
+
+
+def _loop_closure_issues(
+    episode: CanonicalMotionEpisode,
+    thresholds: MotionDecodeAuditThresholds,
+) -> list[MotionDecodeAuditIssue]:
+    """Find an appended reset-to-start frame near a non-cyclic clip tail."""
+
+    transition_count = episode.time.shape[0] - 1
+    start = max(0, transition_count - thresholds.loop_closure_search_frames)
+    root_speeds: list[float] = []
+    joint_speeds: list[float] = []
+    for index in range(start, transition_count):
+        post = index + 1
+        if (
+            float(np.linalg.norm(episode.root_position[post] - episode.root_position[0]))
+            > thresholds.terminal_root_match_m
+            or float(np.linalg.norm(episode.root_quaternion[post] - episode.root_quaternion[0]))
+            > thresholds.terminal_quaternion_match
+            or float(np.max(np.abs(episode.joint_position[post] - episode.joint_position[0])))
+            > thresholds.terminal_joint_match_rad
+        ):
+            continue
+        step_seconds = float(episode.time[post] - episode.time[index])
+        root_speed = float(
+            np.linalg.norm(episode.root_position[post] - episode.root_position[index])
+            / step_seconds
+        )
+        joint_speed = float(
+            np.max(np.abs(episode.joint_position[post] - episode.joint_position[index]))
+            / step_seconds
+        )
+        if root_speed > thresholds.loop_closure_root_speed_error_m_s:
+            root_speeds.append(root_speed)
+        if joint_speed > thresholds.loop_closure_joint_speed_error_rad_s:
+            joint_speeds.append(joint_speed)
+    issues: list[MotionDecodeAuditIssue] = []
+    if root_speeds:
+        issues.append(
+            MotionDecodeAuditIssue(
+                code="ROOT_LOOP_CLOSURE_DISCONTINUITY",
+                severity=AuditSeverity.ERROR,
+                observed=max(root_speeds),
+                threshold=thresholds.loop_closure_root_speed_error_m_s,
+                count=len(root_speeds),
+            )
+        )
+    if joint_speeds:
+        issues.append(
+            MotionDecodeAuditIssue(
+                code="JOINT_LOOP_CLOSURE_DISCONTINUITY",
+                severity=AuditSeverity.ERROR,
+                observed=max(joint_speeds),
+                threshold=thresholds.loop_closure_joint_speed_error_rad_s,
+                count=len(joint_speeds),
+            )
+        )
+    return issues
+
+
+def _build_capsule(
+    registration: MotionDecodeRegistration,
+    clips: tuple[MotionDecodeClipAudit, ...],
+    *,
+    target_body_hash: str,
+    quality_commitment: str,
+) -> ExperienceCapsule | None:
+    valid = tuple(clip for clip in clips if clip.kinematic_valid and clip.episode_summary)
+    if not valid:
+        return None
+    mapping_hashes = {
+        str(clip.episode_summary["mapping_hash"])
+        for clip in valid
+        if clip.episode_summary is not None
+    }
+    if len(mapping_hashes) != 1:
+        raise ValueError("kinematically valid clips do not share one target mapping")
+    mapping_hash = next(iter(mapping_hashes))
+    applicability = ApplicabilityAssessment(
+        target_body_hash=target_body_hash,
+        target_mapping_hash=mapping_hash,
+        body_score=1.0,
+        task_score=0.5,
+        regime_score=0.0,
+        confidence=0.5,
+        evidence_hashes=(quality_commitment,),
+        decision=ApplicabilityDecision.PENDING,
+    )
+    valid_paths = {clip.relative_path for clip in valid}
+    observed_families = sorted(
+        {
+            record.family.value
+            for record in registration.manifest.files
+            if record.relative_path in valid_paths
+        }
+    )
+    task_semantics_hash = canonical_hash(
+        {
+            "schema_version": "rosclaw.collective.motiondecode_task_semantics.v1",
+            "families": observed_families,
+            "football_contact_semantics": False,
+        }
+    )
+    observation_semantics_hash = canonical_hash(
+        {
+            "schema_version": "rosclaw.collective.motiondecode_observation_semantics.v1",
+            "root_position": {"unit": "m", "frame": "source_world_unspecified"},
+            "root_quaternion": {"order": "wxyz", "frame": "source_world_unspecified"},
+            "joint_position": {
+                "unit": "rad",
+                "order": list(G1_DDS_JOINT_NAMES),
+            },
+            "sample_rate_hz": registration.manifest.sample_rate_hz,
+        }
+    )
+    return ExperienceCapsule(
+        source=registration.manifest.source_identity,
+        applicability=applicability,
+        task_semantics_hash=task_semantics_hash,
+        observation_semantics_hash=observation_semantics_hash,
+        modalities=("root_pose", "joint_position"),
+        requested_uses=(CollectiveUse.MOTION_REFERENCE,),
+        quality_report_hash=quality_commitment,
+        evidence_policy=EvidenceUsePolicy(EvidenceLevel.EXTERNAL_UNVERIFIED),
+        source_episode_count=len(valid),
+    )
+
+
+def _load_joint_limits(
+    model_path: Path,
+) -> tuple[dict[str, tuple[float, float]], str, str]:
+    resolved = model_path.expanduser().resolve(strict=True)
+    if not resolved.is_file() or resolved.is_symlink():
+        raise ValueError("target model must be a non-symlink regular file")
+    if resolved.stat().st_size > 10 * 1024 * 1024:
+        raise ValueError("target model exceeds the 10 MB parser safety limit")
+    payload = resolved.read_bytes()
+    file_hash = "sha256:" + hashlib.sha256(payload).hexdigest()
+    root = ET.fromstring(payload)
+    limits: dict[str, tuple[float, float]] = {}
+    for joint in root.iter("joint"):
+        name = joint.attrib.get("name")
+        if name is None or name not in G1_DDS_JOINT_NAMES:
+            continue
+        raw_range = joint.attrib.get("range")
+        if raw_range is None:
+            raise ValueError(f"target model joint lacks a range: {name}")
+        values = tuple(float(item) for item in raw_range.split())
+        if len(values) != 2 or not all(math.isfinite(item) for item in values):
+            raise ValueError(f"target model joint has an invalid range: {name}")
+        limits[name] = (values[0], values[1])
+    if set(limits) != set(G1_DDS_JOINT_NAMES):
+        missing = sorted(set(G1_DDS_JOINT_NAMES) - set(limits))
+        raise ValueError(f"target model does not define the full G1 joint contract: {missing}")
+    target_body_hash = canonical_hash(
+        {
+            "schema_version": "rosclaw.body.unitree_g1_joint_contract.v1",
+            "model_file_hash": file_hash,
+            "joint_names": list(G1_DDS_JOINT_NAMES),
+            "joint_limits": {name: list(limits[name]) for name in G1_DDS_JOINT_NAMES},
+        }
+    )
+    return limits, target_body_hash, file_hash
+
+
+__all__ = [
+    "AuditSeverity",
+    "MotionDecodeAuditIssue",
+    "MotionDecodeAuditThresholds",
+    "MotionDecodeClipAudit",
+    "MotionDecodeIngestReport",
+    "MotionQualificationLevel",
+    "audit_motiondecode_snapshot",
+]

--- a/src/rosclaw/collective/sources/motiondecode/joint_mapping.py
+++ b/src/rosclaw/collective/sources/motiondecode/joint_mapping.py
@@ -1,0 +1,120 @@
+"""Exact MotionDecode CSV to ROSClaw Unitree HG joint mapping."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_DDS_JOINT_NAMES
+
+MOTIONDECODE_ROOT_COLUMNS = (
+    "root_pos_x(m)",
+    "root_pos_y(m)",
+    "root_pos_z(m)",
+    "root_rot_w",
+    "root_rot_x",
+    "root_rot_y",
+    "root_rot_z",
+)
+MOTIONDECODE_TIME_COLUMNS = ("time(s)", "time_sec")
+_JOINT_COLUMN = re.compile(r"^dof_([a-z0-9_]+_joint)\(rad\)$")
+
+
+@dataclass(frozen=True)
+class MotionDecodeJointMapping:
+    source_joint_names: tuple[str, ...]
+    target_joint_names: tuple[str, ...]
+    source_indices_by_target: tuple[int, ...]
+    exact_order: bool
+    source_unit: str = "rad"
+    target_contract: str = "unitree_hg_dds_29"
+    schema_version: str = "rosclaw.collective.motiondecode_joint_mapping.v1"
+
+    def __post_init__(self) -> None:
+        source = tuple(self.source_joint_names)
+        target = tuple(self.target_joint_names)
+        indices = tuple(self.source_indices_by_target)
+        if not source or len(source) != len(set(source)):
+            raise ValueError("source_joint_names must be non-empty and unique")
+        if not target or len(target) != len(set(target)):
+            raise ValueError("target_joint_names must be non-empty and unique")
+        if set(source) != set(target):
+            missing = sorted(set(target) - set(source))
+            extra = sorted(set(source) - set(target))
+            raise ValueError(f"joint mapping is incomplete; missing={missing}, extra={extra}")
+        if len(indices) != len(target) or set(indices) != set(range(len(source))):
+            raise ValueError("source_indices_by_target must be a complete permutation")
+        if self.exact_order != (source == target):
+            raise ValueError("exact_order does not match the declared joint sequences")
+        object.__setattr__(self, "source_joint_names", source)
+        object.__setattr__(self, "target_joint_names", target)
+        object.__setattr__(self, "source_indices_by_target", indices)
+
+    @property
+    def mapping_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source_joint_names": list(self.source_joint_names),
+            "target_joint_names": list(self.target_joint_names),
+            "source_indices_by_target": list(self.source_indices_by_target),
+            "exact_order": self.exact_order,
+            "source_unit": self.source_unit,
+            "target_contract": self.target_contract,
+        }
+
+
+def mapping_from_header(
+    header: tuple[str, ...],
+    *,
+    target_joint_names: tuple[str, ...] = G1_DDS_JOINT_NAMES,
+) -> tuple[MotionDecodeJointMapping, str | None]:
+    """Validate the complete CSV header and return an explicit permutation."""
+
+    if not header or len(header) != len(set(header)):
+        raise ValueError("MotionDecode CSV header must be non-empty and unique")
+    offset = 0
+    time_column: str | None = None
+    if header[0] in MOTIONDECODE_TIME_COLUMNS:
+        time_column = header[0]
+        offset = 1
+    root = header[offset : offset + len(MOTIONDECODE_ROOT_COLUMNS)]
+    if root != MOTIONDECODE_ROOT_COLUMNS:
+        raise ValueError(
+            "MotionDecode root schema must declare xyz in metres and quaternion in wxyz order"
+        )
+    joint_columns = header[offset + len(MOTIONDECODE_ROOT_COLUMNS) :]
+    source_names: list[str] = []
+    for column in joint_columns:
+        match = _JOINT_COLUMN.fullmatch(column)
+        if match is None:
+            raise ValueError(f"unexpected MotionDecode CSV column: {column}")
+        source_names.append(match.group(1))
+    source = tuple(source_names)
+    target = tuple(target_joint_names)
+    source_index = {name: index for index, name in enumerate(source)}
+    if set(source) != set(target):
+        missing = sorted(set(target) - set(source))
+        extra = sorted(set(source) - set(target))
+        raise ValueError(
+            f"MotionDecode G1 joint contract mismatch; missing={missing}, extra={extra}"
+        )
+    mapping = MotionDecodeJointMapping(
+        source_joint_names=source,
+        target_joint_names=target,
+        source_indices_by_target=tuple(source_index[name] for name in target),
+        exact_order=source == target,
+    )
+    return mapping, time_column
+
+
+__all__ = [
+    "MOTIONDECODE_ROOT_COLUMNS",
+    "MOTIONDECODE_TIME_COLUMNS",
+    "MotionDecodeJointMapping",
+    "mapping_from_header",
+]

--- a/src/rosclaw/collective/sources/motiondecode/license.py
+++ b/src/rosclaw/collective/sources/motiondecode/license.py
@@ -1,0 +1,156 @@
+"""License evidence for one pinned MotionDecode source revision."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rosclaw.collective.contracts import (
+    LicenseDecision,
+    LicenseUse,
+    SourceLicenseEvidence,
+)
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MAX_TERMS_BYTES = 1_000_000
+
+
+@dataclass(frozen=True)
+class MotionDecodeLicenseSnapshot:
+    """Hashed terms plus a human legal decision.
+
+    A terms file is evidence, not a permission oracle.  A non-empty snapshot
+    may remain ``PENDING``; ``PERMITTED`` and ``DENIED`` require explicit
+    caller input and non-empty terms.  Empty or absent current terms can only
+    produce ``PENDING``.
+    """
+
+    requested_use: LicenseUse
+    decision: LicenseDecision
+    source_revision: str
+    terms_uri: str | None
+    terms_hash: str | None
+    terms_size_bytes: int
+    attribution: str
+    schema_version: str = "rosclaw.collective.motiondecode_license_snapshot.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.requested_use, LicenseUse):
+            raise ValueError("requested_use must be a recognized LicenseUse")
+        if not isinstance(self.decision, LicenseDecision):
+            raise ValueError("decision must be a recognized LicenseDecision")
+        if not self.source_revision.strip():
+            raise ValueError("source_revision must not be empty")
+        if self.terms_size_bytes < 0:
+            raise ValueError("terms_size_bytes must be non-negative")
+        if self.terms_hash is not None and not _SHA256.fullmatch(self.terms_hash):
+            raise ValueError("terms_hash must be a sha256: content hash")
+        if (self.terms_hash is None) != (self.terms_size_bytes == 0):
+            raise ValueError("terms hash and non-zero size must be supplied together")
+        if self.terms_uri is not None and not self.terms_uri.strip():
+            raise ValueError("terms_uri must be non-empty when supplied")
+        if self.decision is not LicenseDecision.PENDING:
+            if self.terms_hash is None or self.terms_uri is None:
+                raise ValueError("a final license decision requires non-empty hashed terms")
+            if not self.attribution.strip():
+                raise ValueError("a final license decision requires attribution")
+
+    @property
+    def evidence(self) -> SourceLicenseEvidence:
+        return SourceLicenseEvidence(
+            requested_use=self.requested_use,
+            decision=self.decision,
+            terms_uri=self.terms_uri,
+            terms_hash=self.terms_hash,
+            attribution=self.attribution,
+        )
+
+    @property
+    def snapshot_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def training_permitted(self) -> bool:
+        return self.decision is LicenseDecision.PERMITTED
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "requested_use": self.requested_use.value,
+            "decision": self.decision.value,
+            "source_revision": self.source_revision,
+            "terms_uri": self.terms_uri,
+            "terms_hash": self.terms_hash,
+            "terms_size_bytes": self.terms_size_bytes,
+            "attribution": self.attribution,
+            "training_permitted": self.training_permitted,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> MotionDecodeLicenseSnapshot:
+        return cls(
+            requested_use=LicenseUse(str(value["requested_use"])),
+            decision=LicenseDecision(str(value["decision"])),
+            source_revision=str(value["source_revision"]),
+            terms_uri=(str(value["terms_uri"]) if value.get("terms_uri") is not None else None),
+            terms_hash=(str(value["terms_hash"]) if value.get("terms_hash") is not None else None),
+            terms_size_bytes=int(value["terms_size_bytes"]),
+            attribution=str(value.get("attribution", "")),
+        )
+
+
+def snapshot_license(
+    *,
+    source_revision: str,
+    requested_use: LicenseUse,
+    decision: LicenseDecision = LicenseDecision.PENDING,
+    terms_path: Path | None = None,
+    terms_uri: str | None = None,
+    attribution: str = "ChingMu / CMRobot MotionDecode",
+) -> MotionDecodeLicenseSnapshot:
+    """Read at most one small terms document and create immutable evidence."""
+
+    terms_hash: str | None = None
+    terms_size = 0
+    if terms_path is not None:
+        resolved = terms_path.expanduser().resolve(strict=True)
+        if not resolved.is_file():
+            raise ValueError("terms_path must name a regular file")
+        with resolved.open("rb") as handle:
+            before = os.fstat(handle.fileno())
+            payload = handle.read(_MAX_TERMS_BYTES + 1)
+            after = os.fstat(handle.fileno())
+        if _changed(before, after):
+            raise ValueError("license terms changed while evidence was captured")
+        if len(payload) > _MAX_TERMS_BYTES:
+            raise ValueError("license terms exceed the 1 MB evidence limit")
+        terms_size = len(payload)
+        if payload:
+            terms_hash = "sha256:" + hashlib.sha256(payload).hexdigest()
+    if decision is not LicenseDecision.PENDING and terms_hash is None:
+        raise ValueError("empty or absent terms cannot receive a final license decision")
+    return MotionDecodeLicenseSnapshot(
+        requested_use=requested_use,
+        decision=decision,
+        source_revision=source_revision,
+        terms_uri=terms_uri,
+        terms_hash=terms_hash,
+        terms_size_bytes=terms_size,
+        attribution=attribution,
+    )
+
+
+def _changed(before: os.stat_result, after: os.stat_result) -> bool:
+    return (
+        before.st_ino != after.st_ino
+        or before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+    )
+
+
+__all__ = ["MotionDecodeLicenseSnapshot", "snapshot_license"]

--- a/src/rosclaw/collective/sources/motiondecode/manifest.py
+++ b/src/rosclaw/collective/sources/motiondecode/manifest.py
@@ -1,0 +1,446 @@
+"""Content-addressed local snapshot manifests for MotionDecode."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rosclaw.collective.contracts import CollectiveSourceIdentity, LicenseDecision, LicenseUse
+from rosclaw.collective.sources.motiondecode.attribution import MotionDecodeAttribution
+from rosclaw.collective.sources.motiondecode.license import (
+    MotionDecodeLicenseSnapshot,
+    snapshot_license,
+)
+from rosclaw.collective.sources.motiondecode.taxonomy import (
+    MotionDecodeCatalogAudit,
+    MotionFamily,
+    classify_motion,
+    parse_catalog,
+)
+from rosclaw.feedback.contracts import canonical_hash
+
+MOTIONDECODE_PROVIDER = "CMRobot"
+MOTIONDECODE_DATASET = "MotionDecode"
+MOTIONDECODE_SOURCE_URI = "https://huggingface.co/datasets/CMRobot/MotionDecode"
+MOTIONDECODE_SOURCE_BODY_ID = "unitree_g1_retargeted_29dof"
+_REVISION = re.compile(r"^[0-9a-f]{40}$")
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MAX_REGISTERED_MOTION_BYTES = 128 * 1024 * 1024
+_MAX_REGISTERED_SAMPLES = 10_000
+
+
+@dataclass(frozen=True)
+class MotionDecodeFileRecord:
+    relative_path: str
+    content_hash: str
+    size_bytes: int
+    media_type: str
+    family: MotionFamily
+    schema_version: str = "rosclaw.collective.motiondecode_file.v1"
+
+    def __post_init__(self) -> None:
+        path = Path(self.relative_path)
+        if (
+            not self.relative_path
+            or path.is_absolute()
+            or ".." in path.parts
+            or self.relative_path.startswith(".")
+        ):
+            raise ValueError("relative_path must be a safe dataset-relative path")
+        if not _SHA256.fullmatch(self.content_hash):
+            raise ValueError("content_hash must be a sha256: content hash")
+        if self.size_bytes < 0:
+            raise ValueError("size_bytes must be non-negative")
+        if not self.media_type.strip():
+            raise ValueError("media_type must not be empty")
+        if not isinstance(self.family, MotionFamily):
+            raise ValueError("family must be a recognized MotionFamily")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "relative_path": self.relative_path,
+            "content_hash": self.content_hash,
+            "size_bytes": self.size_bytes,
+            "media_type": self.media_type,
+            "family": self.family.value,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> MotionDecodeFileRecord:
+        return cls(
+            relative_path=str(value["relative_path"]),
+            content_hash=str(value["content_hash"]),
+            size_bytes=int(value["size_bytes"]),
+            media_type=str(value["media_type"]),
+            family=MotionFamily(str(value["family"])),
+        )
+
+
+@dataclass(frozen=True)
+class MotionDecodeSourceManifest:
+    revision: str
+    files: tuple[MotionDecodeFileRecord, ...]
+    license_snapshot: MotionDecodeLicenseSnapshot
+    attribution: MotionDecodeAttribution
+    catalog_audit_hash: str
+    local_discovered_sample_count: int
+    selected_sample_count: int
+    local_selection_complete: bool
+    requested_families: tuple[MotionFamily, ...]
+    source_uri: str = MOTIONDECODE_SOURCE_URI
+    sample_rate_hz: float = 120.0
+    root_position_unit: str = "header_declared_m"
+    root_quaternion_order: str = "wxyz"
+    schema_version: str = "rosclaw.collective.motiondecode_source_manifest.v1"
+
+    def __post_init__(self) -> None:
+        if not _REVISION.fullmatch(self.revision):
+            raise ValueError("revision must be a pinned 40-character lowercase commit hash")
+        if not self.source_uri.strip():
+            raise ValueError("source_uri must not be empty")
+        files = tuple(self.files)
+        if not files or any(not isinstance(item, MotionDecodeFileRecord) for item in files):
+            raise ValueError("files must contain MotionDecodeFileRecord entries")
+        paths = tuple(item.relative_path for item in files)
+        if len(paths) != len(set(paths)) or paths != tuple(sorted(paths)):
+            raise ValueError("files must be unique and sorted by relative_path")
+        if "metadata/index.csv" not in paths:
+            raise ValueError("files must include metadata/index.csv")
+        object.__setattr__(self, "files", files)
+        if not isinstance(self.license_snapshot, MotionDecodeLicenseSnapshot):
+            raise ValueError("license_snapshot must be MotionDecodeLicenseSnapshot")
+        if self.license_snapshot.source_revision != self.revision:
+            raise ValueError("license snapshot revision does not match source revision")
+        if not isinstance(self.attribution, MotionDecodeAttribution):
+            raise ValueError("attribution must be MotionDecodeAttribution")
+        if self.attribution.revision != self.revision:
+            raise ValueError("attribution revision does not match source revision")
+        if self.attribution.license_snapshot_hash != self.license_snapshot.snapshot_hash:
+            raise ValueError("attribution is not bound to the license snapshot")
+        if not _SHA256.fullmatch(self.catalog_audit_hash):
+            raise ValueError("catalog_audit_hash must be a sha256: content hash")
+        if self.local_discovered_sample_count < 0 or self.selected_sample_count < 0:
+            raise ValueError("sample counts must be non-negative")
+        if self.selected_sample_count > self.local_discovered_sample_count:
+            raise ValueError("selected_sample_count cannot exceed local_discovered_sample_count")
+        sample_records = sum(item.relative_path.startswith("samples/") for item in files)
+        if sample_records != self.selected_sample_count:
+            raise ValueError("selected_sample_count must match sample file records")
+        families = tuple(self.requested_families)
+        if len(families) != len(set(families)):
+            raise ValueError("requested_families must be unique")
+        if any(not isinstance(item, MotionFamily) for item in families):
+            raise ValueError("requested_families contains an unknown family")
+        object.__setattr__(self, "requested_families", families)
+        if self.sample_rate_hz != 120.0:
+            raise ValueError("MotionDecode source manifests currently require declared 120 Hz")
+
+    @property
+    def manifest_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def file_hashes(self) -> dict[str, str]:
+        return {item.relative_path: item.content_hash for item in self.files}
+
+    @property
+    def source_identity(self) -> CollectiveSourceIdentity:
+        return CollectiveSourceIdentity(
+            provider=MOTIONDECODE_PROVIDER,
+            dataset=MOTIONDECODE_DATASET,
+            revision=self.revision,
+            file_hashes=self.file_hashes,
+            license_evidence=self.license_snapshot.evidence,
+            source_body_id=MOTIONDECODE_SOURCE_BODY_ID,
+        )
+
+    @property
+    def hardware_authorized(self) -> bool:
+        return False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "provider": MOTIONDECODE_PROVIDER,
+            "dataset": MOTIONDECODE_DATASET,
+            "source_uri": self.source_uri,
+            "revision": self.revision,
+            "source_body_id": MOTIONDECODE_SOURCE_BODY_ID,
+            "files": [item.to_dict() for item in self.files],
+            "license_snapshot": self.license_snapshot.to_dict(),
+            "attribution": self.attribution.to_dict(),
+            "catalog_audit_hash": self.catalog_audit_hash,
+            "inventory_scope": "operator_managed_local_snapshot",
+            "upstream_inventory_verified": False,
+            "local_discovered_sample_count": self.local_discovered_sample_count,
+            "selected_sample_count": self.selected_sample_count,
+            "local_selection_complete": self.local_selection_complete,
+            "requested_families": [item.value for item in self.requested_families],
+            "sample_rate_hz": self.sample_rate_hz,
+            "root_position_unit": self.root_position_unit,
+            "root_quaternion_order": self.root_quaternion_order,
+            "source_identity_hash": self.source_identity.source_hash,
+            "hardware_authorized": self.hardware_authorized,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> MotionDecodeSourceManifest:
+        if value.get("provider") != MOTIONDECODE_PROVIDER:
+            raise ValueError("unexpected MotionDecode provider")
+        if value.get("dataset") != MOTIONDECODE_DATASET:
+            raise ValueError("unexpected MotionDecode dataset")
+        if value.get("hardware_authorized") not in (None, False):
+            raise ValueError("MotionDecode source evidence cannot authorize hardware")
+        if value.get("inventory_scope") != "operator_managed_local_snapshot":
+            raise ValueError("MotionDecode manifest has an unknown inventory scope")
+        if value.get("upstream_inventory_verified") is not False:
+            raise ValueError("local registration cannot claim a verified upstream inventory")
+        files_value = value["files"]
+        if not isinstance(files_value, list) or any(
+            not isinstance(item, dict) for item in files_value
+        ):
+            raise ValueError("files must be an array")
+        requested_families = value["requested_families"]
+        if not isinstance(requested_families, list):
+            raise ValueError("requested_families must be an array")
+        local_selection_complete = value["local_selection_complete"]
+        if not isinstance(local_selection_complete, bool):
+            raise ValueError("local_selection_complete must be a boolean")
+        license_value = value["license_snapshot"]
+        attribution_value = value["attribution"]
+        if not isinstance(license_value, dict) or not isinstance(attribution_value, dict):
+            raise ValueError("license_snapshot and attribution must be objects")
+        manifest = cls(
+            revision=str(value["revision"]),
+            files=tuple(MotionDecodeFileRecord.from_dict(item) for item in files_value),
+            license_snapshot=MotionDecodeLicenseSnapshot.from_dict(license_value),
+            attribution=MotionDecodeAttribution.from_dict(attribution_value),
+            catalog_audit_hash=str(value["catalog_audit_hash"]),
+            local_discovered_sample_count=int(value["local_discovered_sample_count"]),
+            selected_sample_count=int(value["selected_sample_count"]),
+            local_selection_complete=local_selection_complete,
+            requested_families=tuple(MotionFamily(str(item)) for item in requested_families),
+            source_uri=str(value.get("source_uri", MOTIONDECODE_SOURCE_URI)),
+            sample_rate_hz=float(value["sample_rate_hz"]),
+            root_position_unit=str(value["root_position_unit"]),
+            root_quaternion_order=str(value["root_quaternion_order"]),
+        )
+        claimed = value.get("source_identity_hash")
+        if claimed is not None and claimed != manifest.source_identity.source_hash:
+            raise ValueError("source_identity_hash does not replay")
+        return manifest
+
+
+@dataclass(frozen=True)
+class MotionDecodeRegistration:
+    manifest: MotionDecodeSourceManifest
+    catalog_audit: MotionDecodeCatalogAudit
+    schema_version: str = "rosclaw.collective.motiondecode_registration.v1"
+
+    def __post_init__(self) -> None:
+        if self.manifest.catalog_audit_hash != self.catalog_audit.audit_hash:
+            raise ValueError("catalog audit does not match the source manifest")
+
+    @property
+    def registration_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def source_registered(self) -> bool:
+        return self.catalog_audit.schema_valid
+
+    @property
+    def training_eligible(self) -> bool:
+        return False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "manifest": self.manifest.to_dict(),
+            "catalog_audit": self.catalog_audit.to_dict(),
+            "source_registered": self.source_registered,
+            "training_eligible": self.training_eligible,
+            "training_blockers": _registration_blockers(self),
+            "hardware_authorized": False,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> MotionDecodeRegistration:
+        if value.get("hardware_authorized") not in (None, False):
+            raise ValueError("MotionDecode registration cannot authorize hardware")
+        manifest_value = value["manifest"]
+        audit_value = value["catalog_audit"]
+        if not isinstance(manifest_value, dict) or not isinstance(audit_value, dict):
+            raise ValueError("manifest and catalog_audit must be objects")
+        return cls(
+            manifest=MotionDecodeSourceManifest.from_dict(manifest_value),
+            catalog_audit=MotionDecodeCatalogAudit.from_dict(audit_value),
+        )
+
+
+def register_motiondecode_source(
+    dataset_root: Path,
+    *,
+    revision: str,
+    requested_use: LicenseUse,
+    license_decision: LicenseDecision = LicenseDecision.PENDING,
+    terms_path: Path | None = None,
+    terms_uri: str | None = None,
+    attribution_text: str = "ChingMu / CMRobot MotionDecode",
+    families: tuple[MotionFamily, ...] = (),
+    limit: int = 400,
+) -> MotionDecodeRegistration:
+    """Hash a bounded, operator-managed local snapshot without downloading it."""
+
+    if limit <= 0 or limit > _MAX_REGISTERED_SAMPLES:
+        raise ValueError(f"limit must be in [1, {_MAX_REGISTERED_SAMPLES}]")
+    root = dataset_root.expanduser().resolve(strict=True)
+    if not root.is_dir():
+        raise ValueError("dataset_root must be a directory")
+    catalog_path = _safe_file(root, Path("metadata/index.csv"))
+    _, catalog_audit = parse_catalog(catalog_path)
+    license_snapshot = snapshot_license(
+        source_revision=revision,
+        requested_use=requested_use,
+        decision=license_decision,
+        terms_path=terms_path,
+        terms_uri=terms_uri,
+        attribution=attribution_text,
+    )
+    attribution = MotionDecodeAttribution(
+        provider=MOTIONDECODE_PROVIDER,
+        dataset=MOTIONDECODE_DATASET,
+        source_uri=MOTIONDECODE_SOURCE_URI,
+        revision=revision,
+        attribution_text=attribution_text,
+        license_snapshot_hash=license_snapshot.snapshot_hash,
+    )
+    requested = tuple(families)
+    discovered = _discover_samples(root, requested)
+    selected = discovered[:limit]
+    records = [_file_record(root, catalog_path, MotionFamily.OTHER, "text/csv")]
+    records.extend(
+        _file_record(root, path, classify_motion(path.as_posix()), "text/csv") for path in selected
+    )
+    records.sort(key=lambda item: item.relative_path)
+    manifest = MotionDecodeSourceManifest(
+        revision=revision,
+        files=tuple(records),
+        license_snapshot=license_snapshot,
+        attribution=attribution,
+        catalog_audit_hash=catalog_audit.audit_hash,
+        local_discovered_sample_count=len(discovered),
+        selected_sample_count=len(selected),
+        local_selection_complete=len(selected) == len(discovered),
+        requested_families=requested,
+    )
+    return MotionDecodeRegistration(manifest=manifest, catalog_audit=catalog_audit)
+
+
+def verify_registered_files(
+    registration: MotionDecodeRegistration, dataset_root: Path
+) -> dict[str, Path]:
+    """Replay every registered size/hash against a local root."""
+
+    root = dataset_root.expanduser().resolve(strict=True)
+    verified: dict[str, Path] = {}
+    for record in registration.manifest.files:
+        path = _safe_file(root, Path(record.relative_path))
+        actual_hash, actual_size = _hash_file(path)
+        if actual_size != record.size_bytes:
+            raise ValueError(f"registered file size changed: {record.relative_path}")
+        if actual_hash != record.content_hash:
+            raise ValueError(f"registered file hash changed: {record.relative_path}")
+        verified[record.relative_path] = path
+    return verified
+
+
+def _registration_blockers(registration: MotionDecodeRegistration) -> list[str]:
+    blockers = ["PHYSICS_QUALIFICATION_REQUIRED"]
+    if not registration.catalog_audit.schema_valid:
+        blockers.append("CATALOG_SCHEMA_INVALID")
+    if not registration.manifest.license_snapshot.training_permitted:
+        blockers.append("LICENSE_NOT_PERMITTED")
+    if registration.manifest.selected_sample_count == 0:
+        blockers.append("NO_LOCAL_MOTION_SAMPLES")
+    return blockers
+
+
+def _discover_samples(root: Path, families: tuple[MotionFamily, ...]) -> list[Path]:
+    samples_root = root / "samples"
+    if not samples_root.exists():
+        return []
+    allowed = set(families)
+    paths: list[Path] = []
+    for candidate in samples_root.rglob("*.csv"):
+        if candidate.is_symlink() or not candidate.is_file():
+            continue
+        relative = candidate.relative_to(root)
+        family = classify_motion(relative.as_posix())
+        if allowed and family not in allowed:
+            continue
+        paths.append(relative)
+    return sorted(paths, key=lambda item: item.as_posix())
+
+
+def _safe_file(root: Path, relative: Path) -> Path:
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError("dataset path must stay below dataset_root")
+    unresolved = root / relative
+    if unresolved.is_symlink():
+        raise ValueError(f"dataset evidence cannot be a symlink: {relative.as_posix()}")
+    resolved = unresolved.resolve(strict=True)
+    if root not in resolved.parents or not resolved.is_file():
+        raise ValueError(f"dataset evidence must be a regular file below root: {relative}")
+    return resolved
+
+
+def _file_record(
+    root: Path, path: Path, family: MotionFamily, media_type: str
+) -> MotionDecodeFileRecord:
+    resolved = path if path.is_absolute() else _safe_file(root, path)
+    relative = resolved.relative_to(root).as_posix()
+    if relative.startswith("samples/") and resolved.stat().st_size > _MAX_REGISTERED_MOTION_BYTES:
+        raise ValueError(f"motion CSV exceeds the 128 MB safety limit: {relative}")
+    content_hash, size_bytes = _hash_file(resolved)
+    return MotionDecodeFileRecord(
+        relative_path=relative,
+        content_hash=content_hash,
+        size_bytes=size_bytes,
+        media_type=media_type,
+        family=family,
+    )
+
+
+def _hash_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        before = os.fstat(handle.fileno())
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+        after = os.fstat(handle.fileno())
+    if (
+        before.st_ino != after.st_ino
+        or before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+    ):
+        raise ValueError(f"dataset evidence changed while it was hashed: {path.name}")
+    return "sha256:" + digest.hexdigest(), before.st_size
+
+
+__all__ = [
+    "MOTIONDECODE_DATASET",
+    "MOTIONDECODE_PROVIDER",
+    "MOTIONDECODE_SOURCE_BODY_ID",
+    "MOTIONDECODE_SOURCE_URI",
+    "MotionDecodeFileRecord",
+    "MotionDecodeRegistration",
+    "MotionDecodeSourceManifest",
+    "register_motiondecode_source",
+    "verify_registered_files",
+]

--- a/src/rosclaw/collective/sources/motiondecode/parser.py
+++ b/src/rosclaw/collective/sources/motiondecode/parser.py
@@ -1,0 +1,225 @@
+"""Strict MotionDecode CSV parser and canonical motion episode."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import math
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.collective.sources.motiondecode.joint_mapping import (
+    MOTIONDECODE_ROOT_COLUMNS,
+    MotionDecodeJointMapping,
+    mapping_from_header,
+)
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_DDS_JOINT_NAMES
+
+_MAX_FRAMES = 1_000_000
+_MAX_CSV_BYTES = 128 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class CanonicalMotionEpisode:
+    """One immutable, target-ordered motion reference.
+
+    Arrays are read-only and are not serialized into control-plane receipts.
+    The registered file hash is the commitment to their raw values.
+    """
+
+    source_manifest_hash: str
+    source_file_hash: str
+    target_body_hash: str
+    mapping: MotionDecodeJointMapping
+    sample_rate_hz: float
+    time: np.ndarray
+    root_position: np.ndarray
+    root_quaternion: np.ndarray
+    joint_position: np.ndarray
+    joint_velocity: np.ndarray
+    joint_acceleration: np.ndarray
+    implicit_timeline: bool
+    ball_pose_available: bool = False
+    action_semantics_available: bool = False
+    reward_semantics_available: bool = False
+    transition_semantics_available: bool = False
+    schema_version: str = "rosclaw.collective.canonical_motion_episode.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("source_manifest_hash", self.source_manifest_hash),
+            ("source_file_hash", self.source_file_hash),
+            ("target_body_hash", self.target_body_hash),
+        ):
+            if not value.startswith("sha256:") or len(value) != 71:
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not isinstance(self.mapping, MotionDecodeJointMapping):
+            raise ValueError("mapping must be MotionDecodeJointMapping")
+        if not math.isfinite(self.sample_rate_hz) or self.sample_rate_hz <= 0.0:
+            raise ValueError("sample_rate_hz must be finite and positive")
+        frames = int(self.time.shape[0])
+        expected = {
+            "time": (frames,),
+            "root_position": (frames, 3),
+            "root_quaternion": (frames, 4),
+            "joint_position": (frames, len(self.mapping.target_joint_names)),
+            "joint_velocity": (frames, len(self.mapping.target_joint_names)),
+            "joint_acceleration": (frames, len(self.mapping.target_joint_names)),
+        }
+        if frames < 3:
+            raise ValueError("a canonical motion episode requires at least three frames")
+        for label, shape in expected.items():
+            array = np.asarray(getattr(self, label), dtype=np.float64)
+            if array.shape != shape or not np.all(np.isfinite(array)):
+                raise ValueError(f"{label} must be finite with shape {shape}")
+            array.setflags(write=False)
+            object.__setattr__(self, label, array)
+        if np.any(np.diff(self.time) <= 0.0):
+            raise ValueError("time must be strictly increasing")
+
+    @property
+    def episode_hash(self) -> str:
+        return canonical_hash(self.summary())
+
+    @property
+    def duration_seconds(self) -> float:
+        return float(self.time[-1] - self.time[0])
+
+    @property
+    def hardware_authorized(self) -> bool:
+        return False
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source_manifest_hash": self.source_manifest_hash,
+            "source_file_hash": self.source_file_hash,
+            "target_body_hash": self.target_body_hash,
+            "mapping_hash": self.mapping.mapping_hash,
+            "joint_names": list(self.mapping.target_joint_names),
+            "frame_count": int(self.time.shape[0]),
+            "duration_seconds": self.duration_seconds,
+            "sample_rate_hz": self.sample_rate_hz,
+            "implicit_timeline": self.implicit_timeline,
+            "root_position_unit": "m",
+            "root_quaternion_order": "wxyz",
+            "joint_position_unit": "rad",
+            "ball_pose_available": self.ball_pose_available,
+            "action_semantics_available": self.action_semantics_available,
+            "reward_semantics_available": self.reward_semantics_available,
+            "transition_semantics_available": self.transition_semantics_available,
+            "hardware_authorized": self.hardware_authorized,
+        }
+
+
+def parse_motion_csv(
+    path: Path,
+    *,
+    source_manifest_hash: str,
+    expected_file_hash: str,
+    target_body_hash: str,
+    sample_rate_hz: float = 120.0,
+    target_joint_names: tuple[str, ...] = G1_DDS_JOINT_NAMES,
+    max_frames: int = _MAX_FRAMES,
+) -> CanonicalMotionEpisode:
+    """Parse a full registered CSV without guessing units or joint names."""
+
+    if max_frames <= 0 or max_frames > _MAX_FRAMES:
+        raise ValueError(f"max_frames must be in [1, {_MAX_FRAMES}]")
+    resolved = path.expanduser().resolve(strict=True)
+    if not resolved.is_file() or resolved.is_symlink():
+        raise ValueError("motion CSV must be a non-symlink regular file")
+    if resolved.stat().st_size > _MAX_CSV_BYTES:
+        raise ValueError("motion CSV exceeds the 128 MB parser safety limit")
+    payload = _read_stable_bytes(resolved)
+    actual_hash = "sha256:" + hashlib.sha256(payload).hexdigest()
+    if actual_hash != expected_file_hash:
+        raise ValueError("motion CSV does not match its registered content hash")
+    try:
+        text = payload.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise ValueError("motion CSV must be UTF-8") from exc
+    with io.StringIO(text, newline="") as handle:
+        reader = csv.reader(handle)
+        try:
+            header = tuple(next(reader))
+        except StopIteration as exc:
+            raise ValueError("motion CSV is empty") from exc
+        mapping, time_column = mapping_from_header(
+            header,
+            target_joint_names=target_joint_names,
+        )
+        rows: list[list[float]] = []
+        for line_number, row in enumerate(reader, start=2):
+            if len(rows) >= max_frames:
+                raise ValueError("motion CSV exceeds the bounded frame limit")
+            if len(row) != len(header):
+                raise ValueError(f"motion CSV row {line_number} has the wrong width")
+            try:
+                values = [float(value) for value in row]
+            except ValueError as exc:
+                raise ValueError(f"motion CSV row {line_number} contains non-numeric data") from exc
+            if not all(math.isfinite(value) for value in values):
+                raise ValueError(f"motion CSV row {line_number} contains NaN or Inf")
+            rows.append(values)
+    if len(rows) < 3:
+        raise ValueError("motion CSV requires at least three data rows")
+    matrix = np.asarray(rows, dtype=np.float64)
+    offset = 1 if time_column is not None else 0
+    if time_column is None:
+        time = np.arange(matrix.shape[0], dtype=np.float64) / sample_rate_hz
+        implicit_timeline = True
+    else:
+        time = matrix[:, 0].copy()
+        implicit_timeline = False
+        observed_steps = np.diff(time)
+        inferred_rate = 1.0 / float(np.median(observed_steps))
+        if not math.isclose(inferred_rate, sample_rate_hz, rel_tol=0.02):
+            raise ValueError("explicit MotionDecode timeline is not consistent with declared rate")
+    root_start = offset
+    joint_start = root_start + len(MOTIONDECODE_ROOT_COLUMNS)
+    root_position = matrix[:, root_start : root_start + 3].copy()
+    root_quaternion = matrix[:, root_start + 3 : joint_start].copy()
+    source_joints = matrix[:, joint_start:]
+    joint_position = source_joints[:, mapping.source_indices_by_target].copy()
+    joint_velocity = np.gradient(joint_position, time, axis=0, edge_order=2)
+    joint_acceleration = np.gradient(joint_velocity, time, axis=0, edge_order=2)
+    return CanonicalMotionEpisode(
+        source_manifest_hash=source_manifest_hash,
+        source_file_hash=expected_file_hash,
+        target_body_hash=target_body_hash,
+        mapping=mapping,
+        sample_rate_hz=sample_rate_hz,
+        time=time,
+        root_position=root_position,
+        root_quaternion=root_quaternion,
+        joint_position=joint_position,
+        joint_velocity=joint_velocity,
+        joint_acceleration=joint_acceleration,
+        implicit_timeline=implicit_timeline,
+    )
+
+
+def _read_stable_bytes(path: Path) -> bytes:
+    with path.open("rb") as handle:
+        before = os.fstat(handle.fileno())
+        payload = handle.read(_MAX_CSV_BYTES + 1)
+        after = os.fstat(handle.fileno())
+    if (
+        before.st_ino != after.st_ino
+        or before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+    ):
+        raise ValueError("motion CSV changed while it was read")
+    if len(payload) > _MAX_CSV_BYTES:
+        raise ValueError("motion CSV exceeds the 128 MB parser safety limit")
+    return payload
+
+
+__all__ = ["CanonicalMotionEpisode", "parse_motion_csv"]

--- a/src/rosclaw/collective/sources/motiondecode/taxonomy.py
+++ b/src/rosclaw/collective/sources/motiondecode/taxonomy.py
@@ -1,0 +1,169 @@
+"""Deterministic MotionDecode taxonomy parsing and pilot bucketing."""
+
+from __future__ import annotations
+
+import csv
+import re
+from collections import Counter
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+MOTIONDECODE_INDEX_COLUMNS = (
+    "Label",
+    "Primary class name",
+    "Secondary class name",
+    "Tertiary class name",
+    "Data Format",
+    "Retargeted Model",
+)
+_MAX_CATALOG_BYTES = 10 * 1024 * 1024
+
+
+class MotionFamily(StrEnum):
+    FOOTBALL = "football"
+    BALANCE = "balance"
+    GAIT = "gait"
+    TRANSITION_RECOVERY = "transition_recovery"
+    OTHER = "other"
+
+
+@dataclass(frozen=True)
+class MotionDecodeTaxonomyRow:
+    label: str
+    primary: str
+    secondary: str
+    tertiary: str
+    data_format: str
+    retargeted_model: str
+    family: MotionFamily
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "label": self.label,
+            "primary": self.primary,
+            "secondary": self.secondary,
+            "tertiary": self.tertiary,
+            "data_format": self.data_format,
+            "retargeted_model": self.retargeted_model,
+            "family": self.family.value,
+        }
+
+
+@dataclass(frozen=True)
+class MotionDecodeCatalogAudit:
+    row_count: int
+    duplicate_labels: tuple[str, ...]
+    non_csv_rows: int
+    non_g1_rows: int
+    family_counts: dict[str, int]
+    schema_version: str = "rosclaw.collective.motiondecode_catalog_audit.v1"
+
+    @property
+    def schema_valid(self) -> bool:
+        return not self.duplicate_labels and self.non_csv_rows == 0 and self.non_g1_rows == 0
+
+    @property
+    def audit_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "row_count": self.row_count,
+            "duplicate_labels": list(self.duplicate_labels),
+            "non_csv_rows": self.non_csv_rows,
+            "non_g1_rows": self.non_g1_rows,
+            "family_counts": dict(sorted(self.family_counts.items())),
+            "schema_valid": self.schema_valid,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> MotionDecodeCatalogAudit:
+        counts = value["family_counts"]
+        if not isinstance(counts, dict):
+            raise ValueError("family_counts must be an object")
+        return cls(
+            row_count=int(value["row_count"]),
+            duplicate_labels=tuple(str(item) for item in value["duplicate_labels"]),
+            non_csv_rows=int(value["non_csv_rows"]),
+            non_g1_rows=int(value["non_g1_rows"]),
+            family_counts={str(key): int(count) for key, count in counts.items()},
+        )
+
+
+def parse_catalog(
+    path: Path,
+) -> tuple[tuple[MotionDecodeTaxonomyRow, ...], MotionDecodeCatalogAudit]:
+    resolved = path.expanduser().resolve(strict=True)
+    if resolved.stat().st_size > _MAX_CATALOG_BYTES:
+        raise ValueError("MotionDecode metadata/index.csv exceeds the 10 MB safety limit")
+    with resolved.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if tuple(reader.fieldnames or ()) != MOTIONDECODE_INDEX_COLUMNS:
+            raise ValueError("MotionDecode metadata/index.csv has an unexpected schema")
+        rows = tuple(_taxonomy_row(row) for row in reader)
+    if not rows:
+        raise ValueError("MotionDecode metadata/index.csv is empty")
+    labels = Counter(row.label for row in rows)
+    duplicates = tuple(sorted(label for label, count in labels.items() if count > 1))
+    family_counts = Counter(row.family.value for row in rows)
+    audit = MotionDecodeCatalogAudit(
+        row_count=len(rows),
+        duplicate_labels=duplicates,
+        non_csv_rows=sum(row.data_format.casefold() != "csv" for row in rows),
+        non_g1_rows=sum(_normalized(row.retargeted_model) != "unitree_g1" for row in rows),
+        family_counts=dict(family_counts),
+    )
+    return rows, audit
+
+
+def classify_motion(*parts: str) -> MotionFamily:
+    text = "_".join(_normalized(part) for part in parts)
+    if re.search(r"(football|soccer)", text):
+        return MotionFamily.FOOTBALL
+    if re.search(r"(balance|single_leg|tiptoe|stability|push_recovery)", text):
+        return MotionFamily.BALANCE
+    if re.search(r"(gait|walking|jogging|running|sprint|turning|lateral)", text):
+        return MotionFamily.GAIT
+    if re.search(r"(transition|recovery|stand_to|to_stand|fall|lie_down|get_up)", text):
+        return MotionFamily.TRANSITION_RECOVERY
+    return MotionFamily.OTHER
+
+
+def _taxonomy_row(row: dict[str, str]) -> MotionDecodeTaxonomyRow:
+    values = {key: (row.get(key) or "").strip() for key in MOTIONDECODE_INDEX_COLUMNS}
+    if not values["Label"]:
+        raise ValueError("MotionDecode catalog contains an empty Label")
+    family = classify_motion(
+        values["Primary class name"],
+        values["Secondary class name"],
+        values["Tertiary class name"],
+    )
+    return MotionDecodeTaxonomyRow(
+        label=values["Label"],
+        primary=values["Primary class name"],
+        secondary=values["Secondary class name"],
+        tertiary=values["Tertiary class name"],
+        data_format=values["Data Format"],
+        retargeted_model=values["Retargeted Model"],
+        family=family,
+    )
+
+
+def _normalized(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", value.casefold()).strip("_")
+    return normalized
+
+
+__all__ = [
+    "MOTIONDECODE_INDEX_COLUMNS",
+    "MotionDecodeCatalogAudit",
+    "MotionDecodeTaxonomyRow",
+    "MotionFamily",
+    "classify_motion",
+    "parse_catalog",
+]

--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -26,6 +26,12 @@ def main() -> int:
     if result is not None:
         return result
 
+    from rosclaw.collective.cli import dispatch_collective_argv
+
+    result = dispatch_collective_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
     from rosclaw.dream.cli import dispatch_dream_argv
 
     result = dispatch_dream_argv(sys.argv[1:])

--- a/tests/collective/test_motiondecode_source.py
+++ b/tests/collective/test_motiondecode_source.py
@@ -1,0 +1,481 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rosclaw.collective.cli import dispatch_collective_argv
+from rosclaw.collective.contracts import LicenseDecision, LicenseUse
+from rosclaw.collective.sources.motiondecode.audit import (
+    MotionQualificationLevel,
+    audit_motiondecode_snapshot,
+)
+from rosclaw.collective.sources.motiondecode.joint_mapping import (
+    MOTIONDECODE_ROOT_COLUMNS,
+    mapping_from_header,
+)
+from rosclaw.collective.sources.motiondecode.license import snapshot_license
+from rosclaw.collective.sources.motiondecode.manifest import (
+    MotionDecodeRegistration,
+    register_motiondecode_source,
+    verify_registered_files,
+)
+from rosclaw.collective.sources.motiondecode.parser import parse_motion_csv
+from rosclaw.collective.sources.motiondecode.taxonomy import (
+    MOTIONDECODE_INDEX_COLUMNS,
+    MotionFamily,
+    classify_motion,
+    parse_catalog,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_DDS_JOINT_NAMES
+
+ROOT = Path(__file__).parents[2]
+G1_MODEL = ROOT / "e-urdf-zoo/g1/robot.mjcf.xml"
+REVISION = "c460808e801b35c683eb4cf4c8338ce61481a9bb"
+OFFICIAL_MOTIONDECODE_G1_ORDER = (
+    "left_hip_pitch_joint",
+    "left_hip_roll_joint",
+    "left_hip_yaw_joint",
+    "left_knee_joint",
+    "left_ankle_pitch_joint",
+    "left_ankle_roll_joint",
+    "right_hip_pitch_joint",
+    "right_hip_roll_joint",
+    "right_hip_yaw_joint",
+    "right_knee_joint",
+    "right_ankle_pitch_joint",
+    "right_ankle_roll_joint",
+    "waist_yaw_joint",
+    "waist_roll_joint",
+    "waist_pitch_joint",
+    "left_shoulder_pitch_joint",
+    "left_shoulder_roll_joint",
+    "left_shoulder_yaw_joint",
+    "left_elbow_joint",
+    "left_wrist_roll_joint",
+    "left_wrist_pitch_joint",
+    "left_wrist_yaw_joint",
+    "right_shoulder_pitch_joint",
+    "right_shoulder_roll_joint",
+    "right_shoulder_yaw_joint",
+    "right_elbow_joint",
+    "right_wrist_roll_joint",
+    "right_wrist_pitch_joint",
+    "right_wrist_yaw_joint",
+)
+
+
+def _hash(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _header(
+    joints: tuple[str, ...] = OFFICIAL_MOTIONDECODE_G1_ORDER,
+) -> tuple[str, ...]:
+    return MOTIONDECODE_ROOT_COLUMNS + tuple(f"dof_{name}(rad)" for name in joints)
+
+
+def _dataset(
+    root: Path,
+    *,
+    joint_value: float = 0.0,
+    non_finite: bool = False,
+    sample_name: str = "MD_Football_Kick_00001.csv",
+) -> Path:
+    metadata = root / "metadata"
+    sample_dir = root / "samples/3.3.Ball_Game_Interaction/3.3.1.Football"
+    metadata.mkdir(parents=True)
+    sample_dir.mkdir(parents=True)
+    with (metadata / "index.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(MOTIONDECODE_INDEX_COLUMNS)
+        writer.writerow(
+            (
+                "3.3.1",
+                "Ball_Game_Interaction",
+                "Football",
+                "Instep_Kick",
+                "csv",
+                "Unitree_G1",
+            )
+        )
+    (root / "LICENSE").write_bytes(b"")
+    sample = sample_dir / sample_name
+    with sample.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(_header())
+        for frame in range(5):
+            joints = [0.0] * len(G1_DDS_JOINT_NAMES)
+            joints[0] = joint_value
+            if non_finite and frame == 2:
+                joints[1] = float("nan")
+            writer.writerow(
+                [
+                    0.001 * frame,
+                    0.0,
+                    0.78,
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    *joints,
+                ]
+            )
+    return sample
+
+
+def _register(root: Path) -> MotionDecodeRegistration:
+    return register_motiondecode_source(
+        root,
+        revision=REVISION,
+        requested_use=LicenseUse.RESEARCH_NONCOMMERCIAL,
+        terms_path=root / "LICENSE",
+        terms_uri=(f"https://huggingface.co/datasets/CMRobot/MotionDecode/blob/{REVISION}/LICENSE"),
+        families=(MotionFamily.FOOTBALL,),
+        limit=40,
+    )
+
+
+def test_empty_current_license_is_pending_and_cannot_be_permitted(tmp_path: Path) -> None:
+    terms = tmp_path / "LICENSE"
+    terms.write_bytes(b"")
+
+    pending = snapshot_license(
+        source_revision=REVISION,
+        requested_use=LicenseUse.RESEARCH_NONCOMMERCIAL,
+        terms_path=terms,
+        terms_uri="https://example.invalid/LICENSE",
+    )
+
+    assert pending.decision is LicenseDecision.PENDING
+    assert pending.terms_hash is None
+    assert pending.training_permitted is False
+    with pytest.raises(ValueError, match="empty or absent terms"):
+        snapshot_license(
+            source_revision=REVISION,
+            requested_use=LicenseUse.RESEARCH_NONCOMMERCIAL,
+            decision=LicenseDecision.PERMITTED,
+            terms_path=terms,
+            terms_uri="https://example.invalid/LICENSE",
+        )
+
+
+def test_nonempty_terms_are_hashed_but_permission_remains_explicit(tmp_path: Path) -> None:
+    terms = tmp_path / "LICENSE"
+    terms.write_text("research terms", encoding="utf-8")
+
+    snapshot = snapshot_license(
+        source_revision=REVISION,
+        requested_use=LicenseUse.RESEARCH_NONCOMMERCIAL,
+        decision=LicenseDecision.PENDING,
+        terms_path=terms,
+        terms_uri="https://example.invalid/LICENSE",
+    )
+
+    assert snapshot.terms_hash == _hash(terms)
+    assert snapshot.decision is LicenseDecision.PENDING
+
+
+def test_catalog_and_paths_map_to_the_four_pilot_families(tmp_path: Path) -> None:
+    _dataset(tmp_path)
+
+    rows, audit = parse_catalog(tmp_path / "metadata/index.csv")
+
+    assert audit.schema_valid is True
+    assert rows[0].family is MotionFamily.FOOTBALL
+    assert (
+        classify_motion("1.5.Balance_Control_Actions/Single_Leg_Standing") is MotionFamily.BALANCE
+    )
+    assert classify_motion("1.3.Basic_Gait_Category/Normal_Walking") is MotionFamily.GAIT
+    assert (
+        classify_motion("1.2.State_Transition_Category/Still_Walk_Run_Stop")
+        is MotionFamily.TRANSITION_RECOVERY
+    )
+
+
+def test_official_36_column_header_exactly_matches_rosclaw_g1_order() -> None:
+    assert OFFICIAL_MOTIONDECODE_G1_ORDER == G1_DDS_JOINT_NAMES
+
+    mapping, time_column = mapping_from_header(_header())
+
+    assert time_column is None
+    assert mapping.exact_order is True
+    assert mapping.source_joint_names == G1_DDS_JOINT_NAMES
+    assert mapping.source_indices_by_target == tuple(range(29))
+
+
+def test_explicit_permutation_is_reordered_without_guessing() -> None:
+    source_order = tuple(reversed(G1_DDS_JOINT_NAMES))
+
+    mapping, _ = mapping_from_header(_header(source_order))
+
+    assert mapping.exact_order is False
+    assert mapping.source_indices_by_target == tuple(reversed(range(29)))
+
+
+def test_missing_joint_fails_closed() -> None:
+    with pytest.raises(ValueError, match="contract mismatch"):
+        mapping_from_header(_header(G1_DDS_JOINT_NAMES[:-1]))
+
+
+def test_registration_is_content_addressed_and_replays(tmp_path: Path) -> None:
+    sample = _dataset(tmp_path)
+
+    registration = _register(tmp_path)
+    replayed = MotionDecodeRegistration.from_dict(registration.to_dict())
+
+    assert registration.source_registered is True
+    assert registration.training_eligible is False
+    assert registration.manifest.selected_sample_count == 1
+    assert registration.manifest.files[1].content_hash == _hash(sample)
+    assert replayed.registration_hash == registration.registration_hash
+    assert replayed.manifest.source_identity.source_hash == (
+        registration.manifest.source_identity.source_hash
+    )
+
+
+def test_registered_file_mutation_is_rejected_before_parse(tmp_path: Path) -> None:
+    sample = _dataset(tmp_path)
+    registration = _register(tmp_path)
+    sample.write_text("mutated\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="registered file size changed"):
+        verify_registered_files(registration, tmp_path)
+
+
+def test_registration_rejects_oversized_motion_before_hashing(tmp_path: Path) -> None:
+    sample = _dataset(tmp_path)
+    with sample.open("ab") as handle:
+        handle.truncate(128 * 1024 * 1024 + 1)
+
+    with pytest.raises(ValueError, match="128 MB safety limit"):
+        _register(tmp_path)
+
+
+def test_parser_builds_read_only_canonical_episode_with_implicit_120hz(
+    tmp_path: Path,
+) -> None:
+    sample = _dataset(tmp_path)
+    registration = _register(tmp_path)
+    record = next(
+        item for item in registration.manifest.files if item.relative_path.startswith("samples/")
+    )
+    target_hash = "sha256:" + "1" * 64
+
+    episode = parse_motion_csv(
+        sample,
+        source_manifest_hash=registration.manifest.manifest_hash,
+        expected_file_hash=record.content_hash,
+        target_body_hash=target_hash,
+    )
+
+    assert episode.implicit_timeline is True
+    assert episode.sample_rate_hz == 120.0
+    assert episode.joint_position.shape == (5, 29)
+    assert episode.duration_seconds == pytest.approx(4 / 120)
+    assert np.allclose(episode.root_quaternion[:, 0], 1.0)
+    assert episode.joint_position.flags.writeable is False
+    assert episode.ball_pose_available is False
+    assert episode.action_semantics_available is False
+
+
+def test_nan_is_rejected_before_it_can_reach_training(tmp_path: Path) -> None:
+    sample = _dataset(tmp_path, non_finite=True)
+    registration = _register(tmp_path)
+    record = next(
+        item for item in registration.manifest.files if item.relative_path.startswith("samples/")
+    )
+
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        parse_motion_csv(
+            sample,
+            source_manifest_hash=registration.manifest.manifest_hash,
+            expected_file_hash=record.content_hash,
+            target_body_hash="sha256:" + "1" * 64,
+        )
+
+
+def test_kinematic_audit_closes_to_unverified_capsule_not_training(
+    tmp_path: Path,
+) -> None:
+    _dataset(tmp_path)
+    registration = _register(tmp_path)
+
+    report = audit_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+    )
+
+    assert report.kinematic_valid_count == 1
+    assert report.clips[0].qualification is MotionQualificationLevel.Q1_KINEMATIC_ONLY
+    assert report.clips[0].episode_summary is not None
+    assert report.clips[0].episode_summary["mapping_hash"]
+    assert report.experience_capsule is not None
+    assert report.experience_capsule.training_eligible is False
+    assert report.experience_capsule.promotion_truth_allowed is False
+    assert report.training_eligible is False
+    assert "LICENSE_NOT_PERMITTED" in report.training_blockers
+    assert "Q3_OR_Q4_PHYSICS_QUALIFICATION_REQUIRED" in report.training_blockers
+    assert report.to_dict()["eligibility"]["motion_reference_discovery"] is True
+    assert report.to_dict()["eligibility"]["football_contact_training"] is False
+
+
+def test_joint_limit_violation_is_q0_and_yields_no_capsule(tmp_path: Path) -> None:
+    _dataset(tmp_path, joint_value=99.0)
+    registration = _register(tmp_path)
+
+    report = audit_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+    )
+
+    assert report.kinematic_valid_count == 0
+    assert report.clips[0].qualification is MotionQualificationLevel.Q0_INVALID
+    assert any(issue.code == "JOINT_LIMIT_ERROR" for issue in report.clips[0].issues)
+    assert report.experience_capsule is None
+
+
+def test_terminal_loop_closure_is_detected_as_a_discontinuity(tmp_path: Path) -> None:
+    sample = _dataset(tmp_path)
+    with sample.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.reader(handle))
+    rows[2][0] = "0.04"
+    rows[3][0] = "0.08"
+    rows[4][0] = "0.12"
+    rows[-1] = rows[1]
+    with sample.open("w", encoding="utf-8", newline="") as handle:
+        csv.writer(handle).writerows(rows)
+    registration = _register(tmp_path)
+
+    report = audit_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+    )
+
+    assert report.clips[0].qualification is MotionQualificationLevel.Q0_INVALID
+    assert any(issue.code == "ROOT_LOOP_CLOSURE_DISCONTINUITY" for issue in report.clips[0].issues)
+    assert report.experience_capsule is None
+    assert "NO_KINEMATICALLY_VALID_CLIPS" in report.training_blockers
+    assert report.segmentation_repair_candidate_count == 1
+    assert report.issue_clip_counts["ROOT_LOOP_CLOSURE_DISCONTINUITY"] == 1
+
+
+def test_cli_registration_inspection_and_ingest_are_replayable(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _dataset(tmp_path / "dataset")
+    registration_path = tmp_path / "evidence/registration.json"
+    ingest_path = tmp_path / "evidence/ingest.json"
+
+    assert (
+        dispatch_collective_argv(
+            [
+                "collective",
+                "source",
+                "add",
+                "motiondecode",
+                "--dataset-root",
+                str(tmp_path / "dataset"),
+                "--revision",
+                REVISION,
+                "--terms-file",
+                str(tmp_path / "dataset/LICENSE"),
+                "--terms-uri",
+                (f"https://huggingface.co/datasets/CMRobot/MotionDecode/blob/{REVISION}/LICENSE"),
+                "--families",
+                "football",
+                "--limit",
+                "40",
+                "--output",
+                str(registration_path),
+                "--source-checkout",
+                str(ROOT),
+            ]
+        )
+        == 0
+    )
+    add_receipt = json.loads(capsys.readouterr().out)
+    assert add_receipt["selected_sample_count"] == 1
+    assert add_receipt["license_decision"] == "pending"
+    assert add_receipt["training_eligible"] is False
+
+    assert (
+        dispatch_collective_argv(
+            [
+                "collective",
+                "source",
+                "inspect",
+                "motiondecode",
+                "--registration",
+                str(registration_path),
+            ]
+        )
+        == 0
+    )
+    inspection = json.loads(capsys.readouterr().out)
+    assert inspection["registration_hash"] == add_receipt["registration_hash"]
+
+    assert (
+        dispatch_collective_argv(
+            [
+                "collective",
+                "ingest",
+                "motiondecode",
+                "--registration",
+                str(registration_path),
+                "--dataset-root",
+                str(tmp_path / "dataset"),
+                "--target-model",
+                str(G1_MODEL),
+                "--output",
+                str(ingest_path),
+                "--source-checkout",
+                str(ROOT),
+            ]
+        )
+        == 0
+    )
+    ingest_receipt = json.loads(capsys.readouterr().out)
+    assert ingest_receipt["kinematic_valid_count"] == 1
+    assert ingest_receipt["experience_capsule_hash"]
+    assert ingest_receipt["training_eligible"] is False
+    persisted = json.loads(ingest_path.read_text(encoding="utf-8"))
+    assert persisted["report_hash"] == ingest_receipt["report_hash"]
+
+
+def test_cli_rejects_tampered_registration_commitment(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _dataset(tmp_path / "dataset")
+    registration = _register(tmp_path / "dataset")
+    artifact = {
+        "schema_version": "rosclaw.collective.motiondecode_registration_artifact.v1",
+        "registration": registration.to_dict(),
+        "registration_hash": "sha256:" + "0" * 64,
+    }
+    path = tmp_path / "registration.json"
+    path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    assert (
+        dispatch_collective_argv(
+            [
+                "collective",
+                "source",
+                "inspect",
+                "motiondecode",
+                "--registration",
+                str(path),
+            ]
+        )
+        == 2
+    )
+    error = json.loads(capsys.readouterr().err)
+    assert error["training_eligible"] is False
+    assert "does not replay" in error["error"]


### PR DESCRIPTION
## Summary

- add a fail-closed MotionDecode Source Adapter with pinned revisions,
  content-addressed local manifests, license snapshots, attribution, catalog
  taxonomy, and stable-file hashing
- add strict Unitree HG 29-joint CSV mapping and read-only
  `CanonicalMotionEpisode` parsing with explicit/implicit 120 Hz handling
- add Q0/Q1 kinematic audits for finite values, quaternion norms, root
  discontinuities, loop-reset tails, G1 joint limits, velocity, and acceleration
- close qualified references into governed `ExperienceCapsule` records while
  preserving `EXTERNAL_UNVERIFIED`, `promotion_truth_allowed=false`, and
  `hardware_authorized=false`
- expose `collective source add`, `collective source inspect`, and
  `collective ingest` CLI workflows with evidence outputs outside the checkout
- document the safety and evidence ceiling; no raw MotionDecode data is committed

## Why

Phase 8 Social Dream cannot treat a downloadable retargeted CSV as a trainable
robot transition. The source needs a pinned legal/provenance identity, exact
morphology mapping, immutable bytes, explicit semantics, and a qualification
result before any motion prior can reach learning.

The current official MotionDecode revision
`c460808e801b35c683eb4cf4c8338ce61481a9bb` declares custom `chingmu-terms`,
but its resolved `LICENSE` is empty. The adapter therefore records `PENDING`
and refuses training; a historical license is not silently applied to the
current revision.

## Real 40-clip audit

A separate external evidence snapshot (not committed and not taken from the
user-managed background download) audited the first 40 official
Football/Shooting CSVs:

- catalog: 482 taxonomy rows, no duplicate labels, all CSV / Unitree G1
- exact CSV contract: root xyz `(m)`, quaternion `wxyz`, 29 joint angles
  `(rad)` in the same order as ROSClaw `unitree_hg_dds`
- 36,565 frames / 304.375 seconds
- Q0: 40; Q1: 0; ExperienceCapsule: not emitted
- 36 root loop-reset tails and 36 joint loop-reset tails
- 32 root-step errors, 37 acceleration warnings, 28 velocity warnings,
  1 joint-limit error
- 36 clips are segmentation-repair candidates; 4 require manual review

This catches a systematic reset-to-first-frame boundary that would otherwise
become an artificial velocity/acceleration impulse in a motion tracker. No
repair or training is performed in this PR.

## Safety and semantics

- the runtime adapter performs no download, ROS/DDS publish, simulator
  actuation, or real-robot operation
- source registration is scoped to an operator-managed local snapshot and
  never claims a verified complete upstream inventory
- empty/absent terms can only be `PENDING`; final decisions require non-empty
  hashed terms, pinned URI, attribution, and explicit operator input
- MotionDecode CSVs remain motion references: no synchronized ball pose,
  contact truth, action, reward, or transition semantics are inferred
- the audit stops at Q1; only later Q3/Q4 MuJoCo qualification may permit
  motion-tracker training
- collective evidence can discover candidates but cannot be Promotion truth

## Validation

- `80 passed` — `tests/collective tests/growth tests/dream`
- `5499 passed, 60 skipped, 27 deselected, 0 failed` — full repository pytest
  (26 existing deprecation warnings)
- Ruff check and format check pass for changed scope
- CI mypy passes for `collective`, `growth`, `dream`, and `entrypoint`
- 16 new tests cover license fail-closed behavior, catalog/schema parsing,
  exact/permuted/missing joints, immutable hashes, oversized inputs, NaN/Inf,
  implicit 120 Hz, G1 joint limits, loop resets, CLI replay, and tamper rejection

## Stack

This draft PR targets `agent/phase8-replay-dream` (#150) and depends on:

1. #139 Dream/Growth/Collective contracts
2. #145 Dream campaign control plane
3. #150 Replay Dream consolidation loop

## Follow-up

Build a content-addressed `SegmentationRepairManifest`, trim only proven
reset/tail boundaries, re-run the kinematic audit, infer contacts, and then run
CPU MuJoCo tracking qualification. Training stays blocked until both Q3/Q4
physics evidence and a valid current-revision license decision exist.
