### PR TITLE
fix(robot-pack): verify declared loader contracts

### DIFF
--- a/src/rosclaw/robot_pack/runtime_loader.py
+++ b/src/rosclaw/robot_pack/runtime_loader.py
@@ -32,6 +32,37 @@ class RobotPackRuntimeError(RuntimeError):
     """Raised when daemon startup encounters a configured but unsafe Pack."""
 
 
+_DAEMON_EXECUTOR_CONTRACTS: dict[str, tuple[str, frozenset[str]]] = {
+    "camera.capture_rgbd": ("read_only", frozenset({"REAL"})),
+    "limo.set_initial_pose": ("actuation", frozenset({"SHADOW", "REAL"})),
+}
+
+
+def validate_daemon_loader_contract(
+    manifest: RobotPackManifest,
+) -> tuple[bool, tuple[str, ...]]:
+    """Validate that every declared capability has a matching daemon executor contract."""
+
+    errors: list[str] = []
+    for capability in manifest.capabilities:
+        expected = _DAEMON_EXECUTOR_CONTRACTS.get(capability.id)
+        if expected is None:
+            errors.append(f"no daemon executor is implemented for {capability.id}")
+            continue
+        expected_safety_class, required_modes = expected
+        if capability.safety_class != expected_safety_class:
+            errors.append(
+                f"{capability.id} requires safety_class {expected_safety_class}, "
+                f"got {capability.safety_class}"
+            )
+        missing_modes = required_modes.difference(capability.execution_modes)
+        if missing_modes:
+            errors.append(
+                f"{capability.id} is missing execution modes: {', '.join(sorted(missing_modes))}"
+            )
+    return not errors, tuple(errors)
+
+
 class _ArtifactDirectoryError(RuntimeError):
     def __init__(self, code: str, message: str) -> None:
         self.code = code
@@ -600,17 +631,15 @@ def load_daemon_robot_pack(
             "Configured Robot Pack adapter binding is missing or no longer matches its locked revision"
         )
 
+    loader_contract_ok, loader_contract_errors = validate_daemon_loader_contract(manifest)
+    if not loader_contract_ok:
+        raise RobotPackRuntimeError("; ".join(loader_contract_errors))
+
     registered: list[str] = []
     for capability in manifest.capabilities:
         if capability.id == "camera.capture_rgbd" and capability.safety_class == "read_only":
-            if "REAL" not in capability.execution_modes:
-                raise RobotPackRuntimeError("RealSense capture capability must declare REAL mode")
             executor: Any = RealSenseCaptureExecutor(instance, home=resolved_home)
         elif capability.id == "limo.set_initial_pose" and capability.safety_class == "actuation":
-            if not {"SHADOW", "REAL"}.issubset(capability.execution_modes):
-                raise RobotPackRuntimeError(
-                    "LIMO initial-pose capability must declare SHADOW and REAL modes"
-                )
             record_entry = InstalledRegistry(home=resolved_home).get(current_adapter.server_name)
             if record_entry is None:
                 raise RobotPackRuntimeError("LIMO adapter installation record is missing")

--- a/src/rosclaw/robot_pack/verification.py
+++ b/src/rosclaw/robot_pack/verification.py
@@ -267,37 +267,56 @@ def _contract_checks(
         )
     )
     policy_safe = (
-        manifest.safety.perception_only
-        and manifest.safety.actuation == "forbidden"
-        and manifest.safety.direct_driver_access == "forbidden"
+        manifest.safety.direct_driver_access == "forbidden"
         and manifest.safety.agent_southbound_access == "daemon_only"
-        and all(capability.safety_class == "read_only" for capability in manifest.capabilities)
+        and manifest.adapter.direct_driver_access == "forbidden"
+        and (
+            not manifest.safety.perception_only
+            or (
+                manifest.safety.actuation == "forbidden"
+                and all(
+                    capability.safety_class == "read_only" for capability in manifest.capabilities
+                )
+            )
+        )
     )
+    if manifest.safety.perception_only:
+        policy_check_id = "contract.perception-only-policy"
+        policy_pass_message = (
+            "Pack is perception-only, forbids actuation/direct driver access, and requires rosclawd"
+        )
+    else:
+        policy_check_id = f"contract.{manifest.safety.actuation}-actuation-policy"
+        policy_pass_message = (
+            f"Pack declares {manifest.safety.actuation} actuation, forbids direct driver access, "
+            "and requires rosclawd"
+        )
     checks.append(
         VerificationCheckResult(
-            id="contract.perception-only-policy",
+            id=policy_check_id,
             status="pass" if policy_safe else "fail",
             message=(
-                "Pack is perception-only, forbids actuation/direct driver access, and requires rosclawd"
+                policy_pass_message
                 if policy_safe
-                else "Pack safety declarations do not preserve the read-only boundary"
+                else "Pack safety declarations do not preserve the declared daemon boundary"
             ),
         )
     )
     try:
-        from rosclaw.robot_pack.runtime_loader import RealSenseCaptureExecutor
+        from rosclaw.robot_pack.runtime_loader import validate_daemon_loader_contract
 
-        loader_available = callable(RealSenseCaptureExecutor)
-    except Exception:
+        loader_available, loader_errors = validate_daemon_loader_contract(manifest)
+    except Exception as exc:
         loader_available = False
+        loader_errors = (str(exc),)
     checks.append(
         VerificationCheckResult(
             id="contract.daemon-loader-contract",
             status="pass" if loader_available else "fail",
             message=(
-                "daemon-side camera.capture_rgbd executor is available"
+                "daemon-side executors cover all declared Pack capabilities"
                 if loader_available
-                else "daemon-side Pack executor is unavailable"
+                else "; ".join(loader_errors) or "daemon-side Pack executor is unavailable"
             ),
         )
     )

--- a/tests/robot_pack/test_verification.py
+++ b/tests/robot_pack/test_verification.py
@@ -12,6 +12,7 @@ from rosclaw.robot_pack.discovery import (
     StreamProfile,
 )
 from rosclaw.robot_pack.instance import configure_robot_instance
+from rosclaw.robot_pack.store import RobotPackStore
 from rosclaw.robot_pack.verification import verify_installed_robot_pack
 
 
@@ -151,6 +152,28 @@ def test_contract_verification_persists_h1_evidence(installed_pack) -> None:
     assert report.observed_candidate_tier is None
     assert report.report_path is not None and Path(report.report_path).is_file()
     assert store.list_installed()[0].latest_verification_id == report.evidence_id
+
+
+def test_limo_guarded_contract_verification_is_not_treated_as_perception_only(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "limo-home"
+    store = RobotPackStore(home)
+    store.install("limo")
+
+    report = verify_installed_robot_pack("limo", home=home)
+
+    assert report.passed
+    assert report.support_tier == "H1_CONTRACT_VERIFIED"
+    safety_check = next(
+        check for check in report.checks if check.id == "contract.guarded-actuation-policy"
+    )
+    assert safety_check.status == "pass"
+    loader_check = next(
+        check for check in report.checks if check.id == "contract.daemon-loader-contract"
+    )
+    assert loader_check.status == "pass"
+    assert "all declared Pack capabilities" in loader_check.message
 
 
 def test_full_local_read_only_run_is_candidate_not_canonical_h3(installed_pack) -> None:


### PR DESCRIPTION
## Summary
- validate Robot Pack safety contracts according to their declared perception/actuation mode
- verify every declared capability against the daemon executor contract registry
- reuse the same fail-closed loader validation at daemon startup
- add a LIMO guarded-actuation regression test

## Reproduction
Before this fix, robot verify for limo-ros1@0.1.5 failed with a RealSense-specific perception-only check and reported camera.capture_rgbd as the loader contract.

## Validation
- live installed LIMO contract verification now passes at H1
- pytest tests/robot_pack: 65 passed
- focused Robot Pack tests: 34 passed
- Ruff check/format and Mypy passed