### PR TITLE
feat(collective): replay MotionDecode terminal repairs

### DIFF
--- a/docs/integrations/motiondecode.md
+++ b/docs/integrations/motiondecode.md
@@ -2,7 +2,8 @@
 
 ROSClaw treats MotionDecode CSVs as external motion references, not as trusted
 robot actions or offline-RL transitions. The adapter does not download data,
-authorize hardware, repair clips, or activate a policy.
+authorize hardware, persist derived motion, or activate a policy. Its repair
+stage can only dry-run a bounded terminal-reset trim in memory.
 
 ## Evidence loop
 
@@ -29,6 +30,13 @@ Write all generated evidence outside the source checkout.
   --dataset-root /data/MotionDecode \
   --target-model e-urdf-zoo/g1/robot.mjcf.xml \
   --output /evidence/motiondecode-ingest.json
+
+.venv/bin/python -m rosclaw.entrypoint collective repair motiondecode \
+  --registration /evidence/motiondecode-registration.json \
+  --ingest-report /evidence/motiondecode-ingest.json \
+  --dataset-root /data/MotionDecode \
+  --target-model e-urdf-zoo/g1/robot.mjcf.xml \
+  --output /evidence/motiondecode-repair.json
 ```
 
 `source add` hashes the catalog and a bounded set of selected CSVs. `inspect`
@@ -37,6 +45,17 @@ replays the content-addressed registration without opening the dataset.
 Unitree HG 29-joint mapping, constructs read-only canonical episodes, and
 performs finite-value, quaternion, discontinuity, joint-limit, velocity, and
 acceleration checks.
+
+`repair` replays the exact registration, source hashes, target body, target
+model, ingest report, and audit thresholds. It detects a unique high-speed
+reset to the initial pose within the bounded tail window, creates a
+content-addressed `SegmentationRepairManifest`, trims the reset frame and
+everything after it in memory, recomputes time derivatives, and runs the full
+kinematic audit again. The output contains hashes, frame ranges, measurements,
+and before/after audits, but no raw or repaired motion arrays.
+Downstream simulation must call `replay_segmentation_repair`; it reconstructs
+the retained prefix from the immutable source, replays every lineage and
+detector commitment, and refuses a prefix that no longer passes Q1.
 
 ## Fail-closed rules
 
@@ -49,11 +68,17 @@ acceleration checks.
   football-contact, or offline-RL data.
 - Kinematic audit stops at Q1. Only later Q3/Q4 MuJoCo qualification may allow
   motion-tracker training.
+- Automatic repair supports only `trim_tail_before_terminal_reset`. Multiple
+  reset candidates, a reset outside the bounded tail, an explicit timeline,
+  too few retained frames, root jumps outside the reset boundary, parser
+  errors, and unrelated kinematic errors are rejected.
+- A repaired clip is Q1 only after its retained frames pass the same audit.
+  Repair never implies Q2/Q3 physics trackability or training permission.
 - External evidence may discover candidates but cannot be Promotion truth.
 - Every receipt declares `hardware_authorized=false`; no ROS, DDS, motor, or
   real-robot path exists in this adapter.
 
 Loop-reset or clip-concatenation boundaries are errors, even if the reset is
-near the end of a file. A future repair stage must emit a separate,
-content-addressed repair manifest, preserve the source hash and semantics, and
-pass the full audit again before MuJoCo qualification.
+near the end of a file. The separate repair manifest preserves the original
+source hash, revision, attribution, motion family, retained prefix, and
+left/right joint semantics. It cannot weaken these invariants.

--- a/src/rosclaw/collective/cli.py
+++ b/src/rosclaw/collective/cli.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from rosclaw.collective.contracts import LicenseDecision, LicenseUse
 from rosclaw.continual.services.persistence import atomic_write_json
+from rosclaw.feedback.contracts import canonical_hash
 
 if TYPE_CHECKING:
     from rosclaw.collective.sources.motiondecode.manifest import MotionDecodeRegistration
@@ -96,6 +97,20 @@ def _parser() -> argparse.ArgumentParser:
     ingest.add_argument("--source-checkout", type=Path, default=Path.cwd())
     ingest.add_argument("--force", action="store_true")
     ingest.set_defaults(handler=_ingest)
+
+    repair = commands.add_parser(
+        "repair",
+        help="dry-run bounded repairs and re-audit retained motion",
+    )
+    repair.add_argument("adapter", choices=["motiondecode"])
+    repair.add_argument("--registration", type=Path, required=True)
+    repair.add_argument("--ingest-report", type=Path, required=True)
+    repair.add_argument("--dataset-root", type=Path, required=True)
+    repair.add_argument("--target-model", type=Path, required=True)
+    repair.add_argument("--output", type=Path, required=True)
+    repair.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    repair.add_argument("--force", action="store_true")
+    repair.set_defaults(handler=_repair)
     return parser
 
 
@@ -209,6 +224,74 @@ def _ingest(args: argparse.Namespace) -> int:
         }
     )
     return 0 if report.kinematic_valid_count > 0 else 1
+
+
+def _repair(args: argparse.Namespace) -> int:
+    from rosclaw.collective.sources.motiondecode.audit import (
+        MotionDecodeAuditThresholds,
+    )
+    from rosclaw.collective.sources.motiondecode.repair import (
+        repair_motiondecode_snapshot,
+    )
+
+    output = _output_path(args.output, args.source_checkout, force=args.force)
+    registration = _read_registration(args.registration)
+    ingest = _read_object(args.ingest_report)
+    report_value = ingest.get("report")
+    if not isinstance(report_value, dict):
+        raise ValueError("ingest artifact lacks a report object")
+    expected_ingest_hash = ingest.get("report_hash")
+    if not isinstance(expected_ingest_hash, str) or expected_ingest_hash != canonical_hash(
+        report_value
+    ):
+        raise ValueError("ingest report_hash does not replay")
+    thresholds_value = report_value.get("thresholds")
+    if not isinstance(thresholds_value, dict):
+        raise ValueError("ingest report lacks audit thresholds")
+    expected_fields = set(MotionDecodeAuditThresholds().to_dict())
+    if set(thresholds_value) != expected_fields or any(
+        isinstance(value, bool) or not isinstance(value, (int, float))
+        for value in thresholds_value.values()
+    ):
+        raise ValueError("ingest report audit thresholds are invalid")
+    thresholds = MotionDecodeAuditThresholds(**thresholds_value)
+    report = repair_motiondecode_snapshot(
+        registration,
+        args.dataset_root,
+        target_model_path=args.target_model,
+        expected_ingest_report_hash=expected_ingest_hash,
+        thresholds=thresholds,
+    )
+    artifact = {
+        "schema_version": "rosclaw.collective.motiondecode_repair_artifact.v1",
+        "report": report.to_dict(),
+        "report_hash": report.report_hash,
+    }
+    atomic_write_json(output, artifact)
+    _print(
+        {
+            "schema_version": "rosclaw.collective.repair_receipt.v1",
+            "ok": report.q1_after_count > 0,
+            "output": str(output),
+            "report_hash": report.report_hash,
+            "original_ingest_report_hash": report.original_ingest_report_hash,
+            "detector_hash": report.detector_hash,
+            "clip_count": len(report.results),
+            "disposition_counts": report.disposition_counts,
+            "repaired_q1_count": report.repaired_q1_count,
+            "q1_after_count": report.q1_after_count,
+            "rejected_count": report.rejected_count,
+            "reason_clip_counts": report.reason_clip_counts,
+            "quality_commitment": report.quality_commitment,
+            "dry_run_only": True,
+            "raw_motion_persisted": False,
+            "training_eligible": report.training_eligible,
+            "training_blockers": report.training_blockers,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+    )
+    return 0 if report.q1_after_count > 0 else 1
 
 
 def _families(value: str) -> tuple[MotionFamily, ...]:

--- a/src/rosclaw/collective/sources/motiondecode/__init__.py
+++ b/src/rosclaw/collective/sources/motiondecode/__init__.py
@@ -22,6 +22,13 @@ from rosclaw.collective.sources.motiondecode.manifest import (
     register_motiondecode_source,
 )
 from rosclaw.collective.sources.motiondecode.parser import CanonicalMotionEpisode
+from rosclaw.collective.sources.motiondecode.repair import (
+    MotionDecodeRepairReport,
+    MotionRepairDisposition,
+    SegmentationRepairManifest,
+    repair_motiondecode_snapshot,
+    replay_segmentation_repair,
+)
 from rosclaw.collective.sources.motiondecode.taxonomy import MotionFamily
 
 __all__ = [
@@ -31,10 +38,15 @@ __all__ = [
     "MotionDecodeIngestReport",
     "MotionDecodeLicenseSnapshot",
     "MotionDecodeRegistration",
+    "MotionDecodeRepairReport",
     "MotionDecodeSourceManifest",
     "MotionFamily",
     "MotionQualificationLevel",
+    "MotionRepairDisposition",
+    "SegmentationRepairManifest",
     "audit_motiondecode_snapshot",
     "register_motiondecode_source",
+    "repair_motiondecode_snapshot",
+    "replay_segmentation_repair",
     "snapshot_license",
 ]

--- a/src/rosclaw/collective/sources/motiondecode/audit.py
+++ b/src/rosclaw/collective/sources/motiondecode/audit.py
@@ -110,6 +110,59 @@ class MotionDecodeAuditIssue:
 
 
 @dataclass(frozen=True)
+class TerminalResetDetection:
+    """One high-speed reset to the initial pose near a clip tail."""
+
+    transition_frame: int
+    reset_frame: int
+    root_match_error_m: float
+    quaternion_match_error: float
+    joint_match_error_rad: float
+    root_speed_m_s: float
+    joint_speed_rad_s: float
+    schema_version: str = "rosclaw.collective.motiondecode_terminal_reset.v1"
+
+    def __post_init__(self) -> None:
+        if self.transition_frame < 0 or self.reset_frame != self.transition_frame + 1:
+            raise ValueError("terminal reset frame indices are inconsistent")
+        values = (
+            self.root_match_error_m,
+            self.quaternion_match_error,
+            self.joint_match_error_rad,
+            self.root_speed_m_s,
+            self.joint_speed_rad_s,
+        )
+        if any(not math.isfinite(value) or value < 0.0 for value in values):
+            raise ValueError("terminal reset measurements must be finite and non-negative")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "transition_frame": self.transition_frame,
+            "reset_frame": self.reset_frame,
+            "root_match_error_m": self.root_match_error_m,
+            "quaternion_match_error": self.quaternion_match_error,
+            "joint_match_error_rad": self.joint_match_error_rad,
+            "root_speed_m_s": self.root_speed_m_s,
+            "joint_speed_rad_s": self.joint_speed_rad_s,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> TerminalResetDetection:
+        if value.get("schema_version") != cls.schema_version:
+            raise ValueError("terminal reset schema version is unsupported")
+        return cls(
+            transition_frame=int(value["transition_frame"]),
+            reset_frame=int(value["reset_frame"]),
+            root_match_error_m=float(value["root_match_error_m"]),
+            quaternion_match_error=float(value["quaternion_match_error"]),
+            joint_match_error_rad=float(value["joint_match_error_rad"]),
+            root_speed_m_s=float(value["root_speed_m_s"]),
+            joint_speed_rad_s=float(value["joint_speed_rad_s"]),
+        )
+
+
+@dataclass(frozen=True)
 class MotionDecodeClipAudit:
     relative_path: str
     source_file_hash: str
@@ -270,7 +323,7 @@ def audit_motiondecode_snapshot(
 ) -> MotionDecodeIngestReport:
     """Replay source hashes, parse registered clips and stop at Q1."""
 
-    limits, target_body_hash, model_hash = _load_joint_limits(target_model_path)
+    limits, target_body_hash, model_hash = load_g1_joint_contract(target_model_path)
     verified = verify_registered_files(registration, dataset_root)
     selected_thresholds = thresholds or MotionDecodeAuditThresholds()
     clips: list[MotionDecodeClipAudit] = []
@@ -332,7 +385,7 @@ def _audit_record(
             target_body_hash=target_body_hash,
             sample_rate_hz=sample_rate_hz,
         )
-        issues = _kinematic_issues(episode, joint_limits, thresholds)
+        issues = audit_canonical_episode(episode, joint_limits, thresholds)
     except (OSError, ValueError, csv.Error) as exc:
         return MotionDecodeClipAudit(
             relative_path=record.relative_path,
@@ -356,11 +409,13 @@ def _audit_record(
     )
 
 
-def _kinematic_issues(
+def audit_canonical_episode(
     episode: CanonicalMotionEpisode,
     joint_limits: dict[str, tuple[float, float]],
     thresholds: MotionDecodeAuditThresholds,
 ) -> list[MotionDecodeAuditIssue]:
+    """Apply the reusable Q1 kinematic checks to a canonical episode."""
+
     issues: list[MotionDecodeAuditIssue] = []
     norms = np.linalg.norm(episode.root_quaternion, axis=1)
     quaternion_error = np.abs(norms - 1.0)
@@ -465,34 +520,17 @@ def _loop_closure_issues(
 ) -> list[MotionDecodeAuditIssue]:
     """Find an appended reset-to-start frame near a non-cyclic clip tail."""
 
-    transition_count = episode.time.shape[0] - 1
-    start = max(0, transition_count - thresholds.loop_closure_search_frames)
-    root_speeds: list[float] = []
-    joint_speeds: list[float] = []
-    for index in range(start, transition_count):
-        post = index + 1
-        if (
-            float(np.linalg.norm(episode.root_position[post] - episode.root_position[0]))
-            > thresholds.terminal_root_match_m
-            or float(np.linalg.norm(episode.root_quaternion[post] - episode.root_quaternion[0]))
-            > thresholds.terminal_quaternion_match
-            or float(np.max(np.abs(episode.joint_position[post] - episode.joint_position[0])))
-            > thresholds.terminal_joint_match_rad
-        ):
-            continue
-        step_seconds = float(episode.time[post] - episode.time[index])
-        root_speed = float(
-            np.linalg.norm(episode.root_position[post] - episode.root_position[index])
-            / step_seconds
-        )
-        joint_speed = float(
-            np.max(np.abs(episode.joint_position[post] - episode.joint_position[index]))
-            / step_seconds
-        )
-        if root_speed > thresholds.loop_closure_root_speed_error_m_s:
-            root_speeds.append(root_speed)
-        if joint_speed > thresholds.loop_closure_joint_speed_error_rad_s:
-            joint_speeds.append(joint_speed)
+    detections = detect_terminal_resets(episode, thresholds)
+    root_speeds = [
+        item.root_speed_m_s
+        for item in detections
+        if item.root_speed_m_s > thresholds.loop_closure_root_speed_error_m_s
+    ]
+    joint_speeds = [
+        item.joint_speed_rad_s
+        for item in detections
+        if item.joint_speed_rad_s > thresholds.loop_closure_joint_speed_error_rad_s
+    ]
     issues: list[MotionDecodeAuditIssue] = []
     if root_speeds:
         issues.append(
@@ -515,6 +553,58 @@ def _loop_closure_issues(
             )
         )
     return issues
+
+
+def detect_terminal_resets(
+    episode: CanonicalMotionEpisode,
+    thresholds: MotionDecodeAuditThresholds,
+) -> tuple[TerminalResetDetection, ...]:
+    """Return bounded reset-to-initial discontinuities near the clip tail."""
+
+    transition_count = episode.time.shape[0] - 1
+    start = max(0, transition_count - thresholds.loop_closure_search_frames)
+    detections: list[TerminalResetDetection] = []
+    for index in range(start, transition_count):
+        post = index + 1
+        root_match = float(np.linalg.norm(episode.root_position[post] - episode.root_position[0]))
+        quaternion_match = float(
+            np.linalg.norm(episode.root_quaternion[post] - episode.root_quaternion[0])
+        )
+        joint_match = float(
+            np.max(np.abs(episode.joint_position[post] - episode.joint_position[0]))
+        )
+        if (
+            root_match > thresholds.terminal_root_match_m
+            or quaternion_match > thresholds.terminal_quaternion_match
+            or joint_match > thresholds.terminal_joint_match_rad
+        ):
+            continue
+        step_seconds = float(episode.time[post] - episode.time[index])
+        root_speed = float(
+            np.linalg.norm(episode.root_position[post] - episode.root_position[index])
+            / step_seconds
+        )
+        joint_speed = float(
+            np.max(np.abs(episode.joint_position[post] - episode.joint_position[index]))
+            / step_seconds
+        )
+        if (
+            root_speed <= thresholds.loop_closure_root_speed_error_m_s
+            and joint_speed <= thresholds.loop_closure_joint_speed_error_rad_s
+        ):
+            continue
+        detections.append(
+            TerminalResetDetection(
+                transition_frame=index,
+                reset_frame=post,
+                root_match_error_m=root_match,
+                quaternion_match_error=quaternion_match,
+                joint_match_error_rad=joint_match,
+                root_speed_m_s=root_speed,
+                joint_speed_rad_s=joint_speed,
+            )
+        )
+    return tuple(detections)
 
 
 def _build_capsule(
@@ -585,7 +675,7 @@ def _build_capsule(
     )
 
 
-def _load_joint_limits(
+def load_g1_joint_contract(
     model_path: Path,
 ) -> tuple[dict[str, tuple[float, float]], str, str]:
     resolved = model_path.expanduser().resolve(strict=True)
@@ -629,5 +719,9 @@ __all__ = [
     "MotionDecodeClipAudit",
     "MotionDecodeIngestReport",
     "MotionQualificationLevel",
+    "TerminalResetDetection",
+    "audit_canonical_episode",
     "audit_motiondecode_snapshot",
+    "detect_terminal_resets",
+    "load_g1_joint_contract",
 ]

--- a/src/rosclaw/collective/sources/motiondecode/parser.py
+++ b/src/rosclaw/collective/sources/motiondecode/parser.py
@@ -45,6 +45,7 @@ class CanonicalMotionEpisode:
     joint_velocity: np.ndarray
     joint_acceleration: np.ndarray
     implicit_timeline: bool
+    derivation_manifest_hash: str | None = None
     ball_pose_available: bool = False
     action_semantics_available: bool = False
     reward_semantics_available: bool = False
@@ -61,6 +62,11 @@ class CanonicalMotionEpisode:
                 raise ValueError(f"{label} must be a sha256: content hash")
         if not isinstance(self.mapping, MotionDecodeJointMapping):
             raise ValueError("mapping must be MotionDecodeJointMapping")
+        if self.derivation_manifest_hash is not None and (
+            not self.derivation_manifest_hash.startswith("sha256:")
+            or len(self.derivation_manifest_hash) != 71
+        ):
+            raise ValueError("derivation_manifest_hash must be a sha256: content hash")
         if not math.isfinite(self.sample_rate_hz) or self.sample_rate_hz <= 0.0:
             raise ValueError("sample_rate_hz must be finite and positive")
         frames = int(self.time.shape[0])
@@ -96,7 +102,7 @@ class CanonicalMotionEpisode:
         return False
 
     def summary(self) -> dict[str, Any]:
-        return {
+        summary = {
             "schema_version": self.schema_version,
             "source_manifest_hash": self.source_manifest_hash,
             "source_file_hash": self.source_file_hash,
@@ -116,6 +122,9 @@ class CanonicalMotionEpisode:
             "transition_semantics_available": self.transition_semantics_available,
             "hardware_authorized": self.hardware_authorized,
         }
+        if self.derivation_manifest_hash is not None:
+            summary["derivation_manifest_hash"] = self.derivation_manifest_hash
+        return summary
 
 
 def parse_motion_csv(

--- a/src/rosclaw/collective/sources/motiondecode/repair.py
+++ b/src/rosclaw/collective/sources/motiondecode/repair.py
@@ -1,0 +1,742 @@
+"""Content-addressed, dry-run repair of terminal MotionDecode resets."""
+
+from __future__ import annotations
+
+import csv
+import math
+from collections import Counter
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.collective.contracts import LicenseDecision
+from rosclaw.collective.sources.motiondecode.audit import (
+    AuditSeverity,
+    MotionDecodeAuditThresholds,
+    MotionDecodeClipAudit,
+    MotionQualificationLevel,
+    TerminalResetDetection,
+    audit_canonical_episode,
+    audit_motiondecode_snapshot,
+    detect_terminal_resets,
+    load_g1_joint_contract,
+)
+from rosclaw.collective.sources.motiondecode.manifest import (
+    MotionDecodeFileRecord,
+    MotionDecodeRegistration,
+    verify_registered_files,
+)
+from rosclaw.collective.sources.motiondecode.parser import (
+    CanonicalMotionEpisode,
+    parse_motion_csv,
+)
+from rosclaw.feedback.contracts import canonical_hash
+
+_DETECTOR_VERSION = "terminal_reset_tail_trim_v1"
+_REPAIRABLE_ERROR_CODES = frozenset(
+    {
+        "ROOT_LOOP_CLOSURE_DISCONTINUITY",
+        "JOINT_LOOP_CLOSURE_DISCONTINUITY",
+        "ROOT_STEP_ERROR",
+    }
+)
+_SEMANTIC_INVARIANTS = (
+    "motion_family",
+    "key_pose_prefix",
+    "left_right_joint_semantics",
+    "source_attribution",
+    "source_revision",
+)
+
+
+class MotionRepairDisposition(StrEnum):
+    NOT_REQUIRED_Q1 = "not_required_q1"
+    REPAIRED_Q1 = "repaired_q1"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class SegmentationRepairManifest:
+    """A bounded plan that trims only an appended reset and its tail."""
+
+    registration_hash: str
+    source_manifest_hash: str
+    source_file_hash: str
+    relative_path: str
+    motion_family: str
+    target_body_hash: str
+    target_model_file_hash: str
+    before_audit_hash: str
+    detector_hash: str
+    detection: TerminalResetDetection
+    original_frame_count: int
+    retained_frame_count: int
+    removed_frame_count: int
+    sample_rate_hz: float
+    operation: str = "trim_tail_before_terminal_reset"
+    semantic_invariants: tuple[str, ...] = _SEMANTIC_INVARIANTS
+    schema_version: str = "rosclaw.collective.motiondecode_segmentation_repair.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("registration_hash", self.registration_hash),
+            ("source_manifest_hash", self.source_manifest_hash),
+            ("source_file_hash", self.source_file_hash),
+            ("target_body_hash", self.target_body_hash),
+            ("target_model_file_hash", self.target_model_file_hash),
+            ("before_audit_hash", self.before_audit_hash),
+            ("detector_hash", self.detector_hash),
+        ):
+            if not value.startswith("sha256:") or len(value) != 71:
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not self.relative_path or not self.motion_family:
+            raise ValueError("repair source identity must not be empty")
+        if self.operation != "trim_tail_before_terminal_reset":
+            raise ValueError("only terminal tail trimming is supported")
+        if self.original_frame_count < 3 or self.retained_frame_count < 3:
+            raise ValueError("repair must retain at least three frames")
+        if self.removed_frame_count <= 0:
+            raise ValueError("repair must remove at least one frame")
+        if self.retained_frame_count + self.removed_frame_count != self.original_frame_count:
+            raise ValueError("repair frame accounting is inconsistent")
+        if self.detection.reset_frame != self.retained_frame_count:
+            raise ValueError("repair boundary does not match the detected reset")
+        if not math.isfinite(self.sample_rate_hz) or self.sample_rate_hz <= 0.0:
+            raise ValueError("repair sample rate must be finite and positive")
+        if tuple(self.semantic_invariants) != _SEMANTIC_INVARIANTS:
+            raise ValueError("repair semantic invariants cannot be weakened")
+
+    @property
+    def manifest_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "registration_hash": self.registration_hash,
+            "source_manifest_hash": self.source_manifest_hash,
+            "source_file_hash": self.source_file_hash,
+            "relative_path": self.relative_path,
+            "motion_family": self.motion_family,
+            "target_body_hash": self.target_body_hash,
+            "target_model_file_hash": self.target_model_file_hash,
+            "before_audit_hash": self.before_audit_hash,
+            "detector_hash": self.detector_hash,
+            "detection": self.detection.to_dict(),
+            "operation": self.operation,
+            "original_frame_count": self.original_frame_count,
+            "retained_frame_range": [0, self.retained_frame_count - 1],
+            "retained_frame_count": self.retained_frame_count,
+            "removed_frame_count": self.removed_frame_count,
+            "sample_rate_hz": self.sample_rate_hz,
+            "semantic_invariants": list(self.semantic_invariants),
+            "raw_motion_embedded": False,
+            "hardware_authorized": False,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> SegmentationRepairManifest:
+        if value.get("schema_version") != cls.schema_version:
+            raise ValueError("segmentation repair schema version is unsupported")
+        if value.get("raw_motion_embedded") is not False:
+            raise ValueError("segmentation repair cannot embed raw motion")
+        if value.get("hardware_authorized") is not False:
+            raise ValueError("segmentation repair cannot authorize hardware")
+        detection_value = value.get("detection")
+        invariants_value = value.get("semantic_invariants")
+        retained_range = value.get("retained_frame_range")
+        if not isinstance(detection_value, dict):
+            raise ValueError("segmentation repair lacks a reset detection")
+        if not isinstance(invariants_value, list):
+            raise ValueError("segmentation repair semantic invariants must be an array")
+        manifest = cls(
+            registration_hash=str(value["registration_hash"]),
+            source_manifest_hash=str(value["source_manifest_hash"]),
+            source_file_hash=str(value["source_file_hash"]),
+            relative_path=str(value["relative_path"]),
+            motion_family=str(value["motion_family"]),
+            target_body_hash=str(value["target_body_hash"]),
+            target_model_file_hash=str(value["target_model_file_hash"]),
+            before_audit_hash=str(value["before_audit_hash"]),
+            detector_hash=str(value["detector_hash"]),
+            detection=TerminalResetDetection.from_dict(detection_value),
+            original_frame_count=int(value["original_frame_count"]),
+            retained_frame_count=int(value["retained_frame_count"]),
+            removed_frame_count=int(value["removed_frame_count"]),
+            sample_rate_hz=float(value["sample_rate_hz"]),
+            operation=str(value["operation"]),
+            semantic_invariants=tuple(str(item) for item in invariants_value),
+        )
+        if retained_range != [0, manifest.retained_frame_count - 1]:
+            raise ValueError("segmentation repair retained frame range is inconsistent")
+        return manifest
+
+
+@dataclass(frozen=True)
+class MotionDecodeRepairResult:
+    relative_path: str
+    source_file_hash: str
+    disposition: MotionRepairDisposition
+    reason_codes: tuple[str, ...]
+    before_audit: MotionDecodeClipAudit
+    repair_manifest: SegmentationRepairManifest | None = None
+    after_audit: MotionDecodeClipAudit | None = None
+    schema_version: str = "rosclaw.collective.motiondecode_repair_result.v1"
+
+    def __post_init__(self) -> None:
+        if not self.source_file_hash.startswith("sha256:") or len(self.source_file_hash) != 71:
+            raise ValueError("repair result source hash must be a sha256: content hash")
+        if not isinstance(self.disposition, MotionRepairDisposition):
+            raise ValueError("repair result disposition is unknown")
+        if self.relative_path != self.before_audit.relative_path:
+            raise ValueError("repair result path does not match its before audit")
+        if self.source_file_hash != self.before_audit.source_file_hash:
+            raise ValueError("repair result source hash does not match its before audit")
+        if not self.reason_codes or any(not item for item in self.reason_codes):
+            raise ValueError("repair result requires non-empty reason codes")
+        if len(self.reason_codes) != len(set(self.reason_codes)):
+            raise ValueError("repair result reason codes must be unique")
+        if (self.repair_manifest is None) != (self.after_audit is None):
+            raise ValueError("repair manifest and after audit must be present together")
+        if self.repair_manifest is not None and (
+            self.repair_manifest.relative_path != self.relative_path
+            or self.repair_manifest.source_file_hash != self.source_file_hash
+        ):
+            raise ValueError("repair manifest does not match its result source")
+        if self.after_audit is not None and (
+            self.after_audit.relative_path != self.relative_path
+            or self.after_audit.source_file_hash != self.source_file_hash
+        ):
+            raise ValueError("after audit does not match its result source")
+        if self.disposition is MotionRepairDisposition.REPAIRED_Q1:
+            if self.repair_manifest is None or self.after_audit is None:
+                raise ValueError("a repaired result requires a manifest and after audit")
+            if not self.after_audit.kinematic_valid:
+                raise ValueError("a repaired Q1 result must pass the after audit")
+            summary = self.after_audit.episode_summary
+            if (
+                summary is None
+                or summary.get("derivation_manifest_hash") != self.repair_manifest.manifest_hash
+            ):
+                raise ValueError("repaired episode is not bound to its repair manifest")
+        if self.disposition is MotionRepairDisposition.NOT_REQUIRED_Q1:
+            if not self.before_audit.kinematic_valid:
+                raise ValueError("not-required disposition requires an existing Q1 clip")
+            if self.repair_manifest is not None or self.after_audit is not None:
+                raise ValueError("an existing Q1 clip must not have a repair")
+
+    @property
+    def result_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def q1_after(self) -> bool:
+        return self.disposition in {
+            MotionRepairDisposition.NOT_REQUIRED_Q1,
+            MotionRepairDisposition.REPAIRED_Q1,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "relative_path": self.relative_path,
+            "source_file_hash": self.source_file_hash,
+            "disposition": self.disposition.value,
+            "reason_codes": list(self.reason_codes),
+            "before_audit": self.before_audit.to_dict(),
+            "before_audit_hash": self.before_audit.audit_hash,
+            "repair_manifest": (
+                self.repair_manifest.to_dict() if self.repair_manifest is not None else None
+            ),
+            "repair_manifest_hash": (
+                self.repair_manifest.manifest_hash if self.repair_manifest is not None else None
+            ),
+            "after_audit": self.after_audit.to_dict() if self.after_audit is not None else None,
+            "after_audit_hash": (
+                self.after_audit.audit_hash if self.after_audit is not None else None
+            ),
+            "q1_after": self.q1_after,
+            "raw_motion_persisted": False,
+            "training_eligible": False,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+
+
+@dataclass(frozen=True)
+class MotionDecodeRepairReport:
+    registration_hash: str
+    source_manifest_hash: str
+    original_ingest_report_hash: str
+    target_body_hash: str
+    target_model_file_hash: str
+    license_decision: LicenseDecision
+    thresholds: MotionDecodeAuditThresholds
+    detector_hash: str
+    results: tuple[MotionDecodeRepairResult, ...]
+    schema_version: str = "rosclaw.collective.motiondecode_repair_report.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("registration_hash", self.registration_hash),
+            ("source_manifest_hash", self.source_manifest_hash),
+            ("original_ingest_report_hash", self.original_ingest_report_hash),
+            ("target_body_hash", self.target_body_hash),
+            ("target_model_file_hash", self.target_model_file_hash),
+            ("detector_hash", self.detector_hash),
+        ):
+            if not value.startswith("sha256:") or len(value) != 71:
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not isinstance(self.license_decision, LicenseDecision):
+            raise ValueError("repair report license decision is unknown")
+        if not isinstance(self.thresholds, MotionDecodeAuditThresholds):
+            raise ValueError("repair report thresholds are invalid")
+        if self.detector_hash != _detector_hash(self.thresholds):
+            raise ValueError("repair report detector hash does not replay")
+        results = tuple(self.results)
+        if any(not isinstance(item, MotionDecodeRepairResult) for item in results):
+            raise ValueError("repair report contains an invalid result")
+        paths = tuple(item.relative_path for item in results)
+        if len(paths) != len(set(paths)) or paths != tuple(sorted(paths)):
+            raise ValueError("repair report results must be unique and sorted")
+        for result in results:
+            manifest = result.repair_manifest
+            if manifest is None:
+                continue
+            if (
+                manifest.registration_hash != self.registration_hash
+                or manifest.source_manifest_hash != self.source_manifest_hash
+                or manifest.target_body_hash != self.target_body_hash
+                or manifest.target_model_file_hash != self.target_model_file_hash
+                or manifest.detector_hash != self.detector_hash
+            ):
+                raise ValueError("repair manifest lineage does not match its report")
+        object.__setattr__(self, "results", results)
+
+    @property
+    def report_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def disposition_counts(self) -> dict[str, int]:
+        return dict(sorted(Counter(result.disposition.value for result in self.results).items()))
+
+    @property
+    def repaired_q1_count(self) -> int:
+        return sum(
+            result.disposition is MotionRepairDisposition.REPAIRED_Q1 for result in self.results
+        )
+
+    @property
+    def q1_after_count(self) -> int:
+        return sum(result.q1_after for result in self.results)
+
+    @property
+    def rejected_count(self) -> int:
+        return sum(
+            result.disposition is MotionRepairDisposition.REJECTED for result in self.results
+        )
+
+    @property
+    def reason_clip_counts(self) -> dict[str, int]:
+        counts = Counter(reason for result in self.results for reason in result.reason_codes)
+        return dict(sorted(counts.items()))
+
+    @property
+    def quality_commitment(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": "rosclaw.collective.motiondecode_repair_quality.v1",
+                "original_ingest_report_hash": self.original_ingest_report_hash,
+                "detector_hash": self.detector_hash,
+                "result_hashes": [result.result_hash for result in self.results],
+            }
+        )
+
+    @property
+    def training_eligible(self) -> bool:
+        return False
+
+    @property
+    def training_blockers(self) -> list[str]:
+        blockers = [
+            "Q3_OR_Q4_PHYSICS_QUALIFICATION_REQUIRED",
+            "SOURCE_COORDINATE_FRAME_UNSPECIFIED",
+            "SYNCHRONIZED_BALL_POSE_ABSENT",
+            "ACTION_REWARD_TRANSITION_SEMANTICS_ABSENT",
+            "REPAIRED_MOTION_NOT_PERSISTED",
+        ]
+        if self.q1_after_count != len(self.results):
+            blockers.insert(0, "KINEMATIC_REPAIR_PARTIAL")
+        if self.license_decision is not LicenseDecision.PERMITTED:
+            blockers.insert(0, "LICENSE_NOT_PERMITTED")
+        return blockers
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "registration_hash": self.registration_hash,
+            "source_manifest_hash": self.source_manifest_hash,
+            "original_ingest_report_hash": self.original_ingest_report_hash,
+            "target_body_hash": self.target_body_hash,
+            "target_model_file_hash": self.target_model_file_hash,
+            "license_decision": self.license_decision.value,
+            "thresholds": self.thresholds.to_dict(),
+            "detector_version": _DETECTOR_VERSION,
+            "detector_hash": self.detector_hash,
+            "results": [result.to_dict() for result in self.results],
+            "clip_count": len(self.results),
+            "disposition_counts": self.disposition_counts,
+            "repaired_q1_count": self.repaired_q1_count,
+            "q1_after_count": self.q1_after_count,
+            "rejected_count": self.rejected_count,
+            "reason_clip_counts": self.reason_clip_counts,
+            "quality_commitment": self.quality_commitment,
+            "dry_run_only": True,
+            "raw_motion_persisted": False,
+            "eligibility": {
+                "q1_motion_reference": self.q1_after_count > 0,
+                "mujoco_qualification_candidate": self.q1_after_count > 0,
+                "mujoco_qualification_authorized": (
+                    self.q1_after_count > 0 and self.license_decision is LicenseDecision.PERMITTED
+                ),
+                "motion_tracker_training": False,
+                "behavior_cloning": False,
+                "offline_rl": False,
+                "promotion_truth": False,
+            },
+            "training_eligible": self.training_eligible,
+            "training_blockers": self.training_blockers,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+
+
+def repair_motiondecode_snapshot(
+    registration: MotionDecodeRegistration,
+    dataset_root: Path,
+    *,
+    target_model_path: Path,
+    expected_ingest_report_hash: str,
+    thresholds: MotionDecodeAuditThresholds | None = None,
+) -> MotionDecodeRepairReport:
+    """Plan terminal trims in memory and re-run Q1 audit on retained frames."""
+
+    selected_thresholds = thresholds or MotionDecodeAuditThresholds()
+    before_report = audit_motiondecode_snapshot(
+        registration,
+        dataset_root,
+        target_model_path=target_model_path,
+        thresholds=selected_thresholds,
+    )
+    if before_report.report_hash != expected_ingest_report_hash:
+        raise ValueError("ingest report hash does not match the replayed source audit")
+    joint_limits, target_body_hash, model_hash = load_g1_joint_contract(target_model_path)
+    if (
+        before_report.target_body_hash != target_body_hash
+        or before_report.target_model_file_hash != model_hash
+    ):
+        raise ValueError("target model contract changed during repair audit")
+    verified = verify_registered_files(registration, dataset_root)
+    before_by_path = {clip.relative_path: clip for clip in before_report.clips}
+    detector_hash = _detector_hash(selected_thresholds)
+    results: list[MotionDecodeRepairResult] = []
+    for record in registration.manifest.files:
+        if not record.relative_path.startswith("samples/"):
+            continue
+        results.append(
+            _repair_record(
+                registration,
+                record,
+                verified[record.relative_path],
+                before=before_by_path[record.relative_path],
+                target_body_hash=target_body_hash,
+                target_model_file_hash=model_hash,
+                joint_limits=joint_limits,
+                thresholds=selected_thresholds,
+                detector_hash=detector_hash,
+            )
+        )
+    return MotionDecodeRepairReport(
+        registration_hash=registration.registration_hash,
+        source_manifest_hash=registration.manifest.manifest_hash,
+        original_ingest_report_hash=before_report.report_hash,
+        target_body_hash=target_body_hash,
+        target_model_file_hash=model_hash,
+        license_decision=registration.manifest.license_snapshot.decision,
+        thresholds=selected_thresholds,
+        detector_hash=detector_hash,
+        results=tuple(results),
+    )
+
+
+def replay_segmentation_repair(
+    registration: MotionDecodeRegistration,
+    dataset_root: Path,
+    *,
+    target_model_path: Path,
+    manifest: SegmentationRepairManifest,
+    thresholds: MotionDecodeAuditThresholds | None = None,
+) -> CanonicalMotionEpisode:
+    """Reconstruct one repaired prefix from immutable source and manifest evidence."""
+
+    selected_thresholds = thresholds or MotionDecodeAuditThresholds()
+    if (
+        manifest.registration_hash != registration.registration_hash
+        or manifest.source_manifest_hash != registration.manifest.manifest_hash
+    ):
+        raise ValueError("repair manifest source lineage does not match registration")
+    if manifest.detector_hash != _detector_hash(selected_thresholds):
+        raise ValueError("repair manifest detector does not match audit thresholds")
+    joint_limits, target_body_hash, model_hash = load_g1_joint_contract(target_model_path)
+    if (
+        manifest.target_body_hash != target_body_hash
+        or manifest.target_model_file_hash != model_hash
+    ):
+        raise ValueError("repair manifest target model lineage does not replay")
+    records = {
+        item.relative_path: item
+        for item in registration.manifest.files
+        if item.relative_path.startswith("samples/")
+    }
+    record = records.get(manifest.relative_path)
+    if record is None or record.content_hash != manifest.source_file_hash:
+        raise ValueError("repair manifest source file does not replay")
+    verified = verify_registered_files(registration, dataset_root)
+    episode = parse_motion_csv(
+        verified[record.relative_path],
+        source_manifest_hash=registration.manifest.manifest_hash,
+        expected_file_hash=record.content_hash,
+        target_body_hash=target_body_hash,
+        sample_rate_hz=registration.manifest.sample_rate_hz,
+    )
+    before_issues = tuple(audit_canonical_episode(episode, joint_limits, selected_thresholds))
+    before = MotionDecodeClipAudit(
+        relative_path=record.relative_path,
+        source_file_hash=record.content_hash,
+        qualification=(
+            MotionQualificationLevel.Q0_INVALID
+            if any(issue.severity is AuditSeverity.ERROR for issue in before_issues)
+            else MotionQualificationLevel.Q1_KINEMATIC_ONLY
+        ),
+        issues=before_issues,
+        episode_summary=episode.summary(),
+    )
+    error_codes = {issue.code for issue in before.issues if issue.severity is AuditSeverity.ERROR}
+    unsupported = sorted(error_codes - _REPAIRABLE_ERROR_CODES)
+    if before.kinematic_valid or unsupported:
+        raise ValueError("repair manifest source is not an eligible segmentation failure")
+    if not episode.implicit_timeline:
+        raise ValueError("repair manifest cannot rewrite an explicit timeline")
+    detections = detect_terminal_resets(episode, selected_thresholds)
+    if len(detections) != 1 or detections[0] != manifest.detection:
+        raise ValueError("repair manifest reset detection does not replay")
+    if not _root_errors_are_at_reset(episode, selected_thresholds, detections[0]):
+        raise ValueError("repair manifest cannot hide a root error outside its boundary")
+    expected = SegmentationRepairManifest(
+        registration_hash=registration.registration_hash,
+        source_manifest_hash=registration.manifest.manifest_hash,
+        source_file_hash=record.content_hash,
+        relative_path=record.relative_path,
+        motion_family=record.family.value,
+        target_body_hash=target_body_hash,
+        target_model_file_hash=model_hash,
+        before_audit_hash=before.audit_hash,
+        detector_hash=manifest.detector_hash,
+        detection=detections[0],
+        original_frame_count=int(episode.time.shape[0]),
+        retained_frame_count=detections[0].reset_frame,
+        removed_frame_count=int(episode.time.shape[0]) - detections[0].reset_frame,
+        sample_rate_hz=episode.sample_rate_hz,
+    )
+    if expected.manifest_hash != manifest.manifest_hash:
+        raise ValueError("repair manifest content does not replay")
+    repaired = _apply_tail_trim(episode, manifest)
+    after_issues = audit_canonical_episode(repaired, joint_limits, selected_thresholds)
+    if any(issue.severity is AuditSeverity.ERROR for issue in after_issues):
+        raise ValueError("replayed repair does not pass the Q1 audit")
+    return repaired
+
+
+def _repair_record(
+    registration: MotionDecodeRegistration,
+    record: MotionDecodeFileRecord,
+    path: Path,
+    *,
+    before: MotionDecodeClipAudit,
+    target_body_hash: str,
+    target_model_file_hash: str,
+    joint_limits: dict[str, tuple[float, float]],
+    thresholds: MotionDecodeAuditThresholds,
+    detector_hash: str,
+) -> MotionDecodeRepairResult:
+    if before.kinematic_valid:
+        return MotionDecodeRepairResult(
+            relative_path=record.relative_path,
+            source_file_hash=record.content_hash,
+            disposition=MotionRepairDisposition.NOT_REQUIRED_Q1,
+            reason_codes=("ALREADY_Q1",),
+            before_audit=before,
+        )
+    if before.parser_error is not None:
+        return _rejected(record, before, "SOURCE_PARSE_FAILED")
+    error_codes = {issue.code for issue in before.issues if issue.severity is AuditSeverity.ERROR}
+    unsupported = sorted(error_codes - _REPAIRABLE_ERROR_CODES)
+    if unsupported:
+        return _rejected(
+            record,
+            before,
+            *(f"UNREPAIRABLE_{code}" for code in unsupported),
+        )
+    try:
+        episode = parse_motion_csv(
+            path,
+            source_manifest_hash=registration.manifest.manifest_hash,
+            expected_file_hash=record.content_hash,
+            target_body_hash=target_body_hash,
+            sample_rate_hz=registration.manifest.sample_rate_hz,
+        )
+    except (OSError, ValueError, csv.Error):
+        return _rejected(record, before, "SOURCE_CHANGED_OR_PARSE_FAILED")
+    if not episode.implicit_timeline:
+        return _rejected(record, before, "EXPLICIT_TIMELINE_REPAIR_UNSUPPORTED")
+    detections = detect_terminal_resets(episode, thresholds)
+    if not detections:
+        return _rejected(record, before, "NO_TERMINAL_RESET")
+    if len(detections) != 1:
+        return _rejected(record, before, "AMBIGUOUS_TERMINAL_RESETS")
+    detection = detections[0]
+    if detection.reset_frame < 3:
+        return _rejected(record, before, "INSUFFICIENT_RETAINED_FRAMES")
+    if not _root_errors_are_at_reset(episode, thresholds, detection):
+        return _rejected(record, before, "ROOT_STEP_OUTSIDE_RESET_BOUNDARY")
+    manifest = SegmentationRepairManifest(
+        registration_hash=registration.registration_hash,
+        source_manifest_hash=registration.manifest.manifest_hash,
+        source_file_hash=record.content_hash,
+        relative_path=record.relative_path,
+        motion_family=record.family.value,
+        target_body_hash=target_body_hash,
+        target_model_file_hash=target_model_file_hash,
+        before_audit_hash=before.audit_hash,
+        detector_hash=detector_hash,
+        detection=detection,
+        original_frame_count=int(episode.time.shape[0]),
+        retained_frame_count=detection.reset_frame,
+        removed_frame_count=int(episode.time.shape[0]) - detection.reset_frame,
+        sample_rate_hz=episode.sample_rate_hz,
+    )
+    repaired = _apply_tail_trim(episode, manifest)
+    issues = tuple(audit_canonical_episode(repaired, joint_limits, thresholds))
+    qualification = (
+        MotionQualificationLevel.Q0_INVALID
+        if any(issue.severity is AuditSeverity.ERROR for issue in issues)
+        else MotionQualificationLevel.Q1_KINEMATIC_ONLY
+    )
+    after = MotionDecodeClipAudit(
+        relative_path=record.relative_path,
+        source_file_hash=record.content_hash,
+        qualification=qualification,
+        issues=issues,
+        episode_summary=repaired.summary(),
+    )
+    if not after.kinematic_valid:
+        return MotionDecodeRepairResult(
+            relative_path=record.relative_path,
+            source_file_hash=record.content_hash,
+            disposition=MotionRepairDisposition.REJECTED,
+            reason_codes=("AFTER_REPAIR_Q0",),
+            before_audit=before,
+            repair_manifest=manifest,
+            after_audit=after,
+        )
+    return MotionDecodeRepairResult(
+        relative_path=record.relative_path,
+        source_file_hash=record.content_hash,
+        disposition=MotionRepairDisposition.REPAIRED_Q1,
+        reason_codes=("TERMINAL_RESET_TAIL_TRIMMED",),
+        before_audit=before,
+        repair_manifest=manifest,
+        after_audit=after,
+    )
+
+
+def _apply_tail_trim(
+    episode: CanonicalMotionEpisode,
+    manifest: SegmentationRepairManifest,
+) -> CanonicalMotionEpisode:
+    stop = manifest.retained_frame_count
+    time = np.arange(stop, dtype=np.float64) / episode.sample_rate_hz
+    joint_position = episode.joint_position[:stop].copy()
+    joint_velocity = np.gradient(joint_position, time, axis=0, edge_order=2)
+    joint_acceleration = np.gradient(joint_velocity, time, axis=0, edge_order=2)
+    return CanonicalMotionEpisode(
+        source_manifest_hash=episode.source_manifest_hash,
+        source_file_hash=episode.source_file_hash,
+        target_body_hash=episode.target_body_hash,
+        mapping=episode.mapping,
+        sample_rate_hz=episode.sample_rate_hz,
+        time=time,
+        root_position=episode.root_position[:stop].copy(),
+        root_quaternion=episode.root_quaternion[:stop].copy(),
+        joint_position=joint_position,
+        joint_velocity=joint_velocity,
+        joint_acceleration=joint_acceleration,
+        implicit_timeline=True,
+        derivation_manifest_hash=manifest.manifest_hash,
+        ball_pose_available=episode.ball_pose_available,
+        action_semantics_available=episode.action_semantics_available,
+        reward_semantics_available=episode.reward_semantics_available,
+        transition_semantics_available=episode.transition_semantics_available,
+    )
+
+
+def _root_errors_are_at_reset(
+    episode: CanonicalMotionEpisode,
+    thresholds: MotionDecodeAuditThresholds,
+    detection: TerminalResetDetection,
+) -> bool:
+    root_steps = np.linalg.norm(np.diff(episode.root_position, axis=0), axis=1)
+    error_indices = {
+        int(item) for item in np.flatnonzero(root_steps > thresholds.root_step_error_m)
+    }
+    return not error_indices or error_indices == {detection.transition_frame}
+
+
+def _rejected(
+    record: MotionDecodeFileRecord,
+    before: MotionDecodeClipAudit,
+    *reason_codes: str,
+) -> MotionDecodeRepairResult:
+    return MotionDecodeRepairResult(
+        relative_path=record.relative_path,
+        source_file_hash=record.content_hash,
+        disposition=MotionRepairDisposition.REJECTED,
+        reason_codes=tuple(reason_codes),
+        before_audit=before,
+    )
+
+
+def _detector_hash(thresholds: MotionDecodeAuditThresholds) -> str:
+    return canonical_hash(
+        {
+            "schema_version": "rosclaw.collective.motiondecode_repair_detector.v1",
+            "detector_version": _DETECTOR_VERSION,
+            "thresholds": thresholds.to_dict(),
+            "supported_operation": "trim_tail_before_terminal_reset",
+            "maximum_tail_frames": thresholds.loop_closure_search_frames,
+        }
+    )
+
+
+__all__ = [
+    "MotionDecodeRepairReport",
+    "MotionDecodeRepairResult",
+    "MotionRepairDisposition",
+    "SegmentationRepairManifest",
+    "repair_motiondecode_snapshot",
+    "replay_segmentation_repair",
+]

--- a/tests/collective/test_motiondecode_source.py
+++ b/tests/collective/test_motiondecode_source.py
@@ -25,6 +25,12 @@ from rosclaw.collective.sources.motiondecode.manifest import (
     verify_registered_files,
 )
 from rosclaw.collective.sources.motiondecode.parser import parse_motion_csv
+from rosclaw.collective.sources.motiondecode.repair import (
+    MotionRepairDisposition,
+    SegmentationRepairManifest,
+    repair_motiondecode_snapshot,
+    replay_segmentation_repair,
+)
 from rosclaw.collective.sources.motiondecode.taxonomy import (
     MOTIONDECODE_INDEX_COLUMNS,
     MotionFamily,
@@ -138,6 +144,17 @@ def _register(root: Path) -> MotionDecodeRegistration:
         families=(MotionFamily.FOOTBALL,),
         limit=40,
     )
+
+
+def _append_terminal_reset(sample: Path) -> None:
+    with sample.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.reader(handle))
+    rows[2][0] = "0.04"
+    rows[3][0] = "0.08"
+    rows[4][0] = "0.12"
+    rows[-1] = rows[1]
+    with sample.open("w", encoding="utf-8", newline="") as handle:
+        csv.writer(handle).writerows(rows)
 
 
 def test_empty_current_license_is_pending_and_cannot_be_permitted(tmp_path: Path) -> None:
@@ -343,14 +360,7 @@ def test_joint_limit_violation_is_q0_and_yields_no_capsule(tmp_path: Path) -> No
 
 def test_terminal_loop_closure_is_detected_as_a_discontinuity(tmp_path: Path) -> None:
     sample = _dataset(tmp_path)
-    with sample.open("r", encoding="utf-8", newline="") as handle:
-        rows = list(csv.reader(handle))
-    rows[2][0] = "0.04"
-    rows[3][0] = "0.08"
-    rows[4][0] = "0.12"
-    rows[-1] = rows[1]
-    with sample.open("w", encoding="utf-8", newline="") as handle:
-        csv.writer(handle).writerows(rows)
+    _append_terminal_reset(sample)
     registration = _register(tmp_path)
 
     report = audit_motiondecode_snapshot(
@@ -365,6 +375,262 @@ def test_terminal_loop_closure_is_detected_as_a_discontinuity(tmp_path: Path) ->
     assert "NO_KINEMATICALLY_VALID_CLIPS" in report.training_blockers
     assert report.segmentation_repair_candidate_count == 1
     assert report.issue_clip_counts["ROOT_LOOP_CLOSURE_DISCONTINUITY"] == 1
+
+
+def test_terminal_reset_repair_is_content_addressed_and_reaches_q1(
+    tmp_path: Path,
+) -> None:
+    sample = _dataset(tmp_path)
+    _append_terminal_reset(sample)
+    registration = _register(tmp_path)
+    before = audit_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+    )
+
+    report = repair_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=before.report_hash,
+    )
+
+    assert report.repaired_q1_count == 1
+    assert report.q1_after_count == 1
+    assert report.training_eligible is False
+    assert "LICENSE_NOT_PERMITTED" in report.training_blockers
+    result = report.results[0]
+    assert result.disposition is MotionRepairDisposition.REPAIRED_Q1
+    assert result.repair_manifest is not None
+    assert result.repair_manifest.original_frame_count == 5
+    assert result.repair_manifest.retained_frame_count == 4
+    assert result.repair_manifest.removed_frame_count == 1
+    assert result.after_audit is not None
+    assert result.after_audit.kinematic_valid is True
+    assert result.after_audit.episode_summary is not None
+    assert (
+        result.after_audit.episode_summary["derivation_manifest_hash"]
+        == result.repair_manifest.manifest_hash
+    )
+    persisted = report.to_dict()
+    assert persisted["raw_motion_persisted"] is False
+    assert persisted["eligibility"]["mujoco_qualification_candidate"] is True
+    assert persisted["eligibility"]["mujoco_qualification_authorized"] is False
+    assert persisted["eligibility"]["motion_tracker_training"] is False
+
+    replayed_manifest = SegmentationRepairManifest.from_dict(result.repair_manifest.to_dict())
+    replayed_episode = replay_segmentation_repair(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        manifest=replayed_manifest,
+    )
+    assert replayed_manifest.manifest_hash == result.repair_manifest.manifest_hash
+    assert replayed_episode.time.shape == (4,)
+    assert replayed_episode.joint_position.flags.writeable is False
+    assert replayed_episode.derivation_manifest_hash == replayed_manifest.manifest_hash
+    embedded = result.repair_manifest.to_dict()
+    embedded["raw_motion_embedded"] = True
+    with pytest.raises(ValueError, match="cannot embed raw motion"):
+        SegmentationRepairManifest.from_dict(embedded)
+
+
+def test_ambiguous_terminal_resets_are_not_automatically_trimmed(
+    tmp_path: Path,
+) -> None:
+    sample = _dataset(tmp_path)
+    with sample.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.reader(handle))
+    header = rows[0]
+    initial = rows[1]
+    sequence: list[list[str]] = []
+    for root_x in (0.0, 0.06, 0.12, 0.0, 0.06, 0.12, 0.0):
+        row = initial.copy()
+        row[0] = str(root_x)
+        sequence.append(row)
+    with sample.open("w", encoding="utf-8", newline="") as handle:
+        csv.writer(handle).writerows([header, *sequence])
+    registration = _register(tmp_path)
+    before = audit_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+    )
+
+    report = repair_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=before.report_hash,
+    )
+
+    assert report.repaired_q1_count == 0
+    assert report.rejected_count == 1
+    assert report.results[0].disposition is MotionRepairDisposition.REJECTED
+    assert report.results[0].reason_codes == ("AMBIGUOUS_TERMINAL_RESETS",)
+    assert report.results[0].repair_manifest is None
+
+
+def test_repair_replays_the_exact_ingest_commitment(tmp_path: Path) -> None:
+    sample = _dataset(tmp_path)
+    _append_terminal_reset(sample)
+    registration = _register(tmp_path)
+
+    with pytest.raises(ValueError, match="ingest report hash"):
+        repair_motiondecode_snapshot(
+            registration,
+            tmp_path,
+            target_model_path=G1_MODEL,
+            expected_ingest_report_hash="sha256:" + "0" * 64,
+        )
+
+
+def test_non_segmentation_error_blocks_terminal_trim(tmp_path: Path) -> None:
+    sample = _dataset(tmp_path, joint_value=99.0)
+    _append_terminal_reset(sample)
+    registration = _register(tmp_path)
+    before = audit_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+    )
+
+    report = repair_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=before.report_hash,
+    )
+
+    assert report.repaired_q1_count == 0
+    assert report.results[0].reason_codes == ("UNREPAIRABLE_JOINT_LIMIT_ERROR",)
+
+
+def test_cli_terminal_repair_persists_only_audit_evidence(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sample = _dataset(tmp_path / "dataset")
+    _append_terminal_reset(sample)
+    registration = _register(tmp_path / "dataset")
+    before = audit_motiondecode_snapshot(
+        registration,
+        tmp_path / "dataset",
+        target_model_path=G1_MODEL,
+    )
+    registration_path = tmp_path / "registration.json"
+    ingest_path = tmp_path / "ingest.json"
+    repair_path = tmp_path / "repair.json"
+    registration_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "rosclaw.collective.motiondecode_registration_artifact.v1",
+                "registration": registration.to_dict(),
+                "registration_hash": registration.registration_hash,
+            }
+        ),
+        encoding="utf-8",
+    )
+    ingest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "rosclaw.collective.motiondecode_ingest_artifact.v1",
+                "report": before.to_dict(),
+                "report_hash": before.report_hash,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        dispatch_collective_argv(
+            [
+                "collective",
+                "repair",
+                "motiondecode",
+                "--registration",
+                str(registration_path),
+                "--ingest-report",
+                str(ingest_path),
+                "--dataset-root",
+                str(tmp_path / "dataset"),
+                "--target-model",
+                str(G1_MODEL),
+                "--output",
+                str(repair_path),
+                "--source-checkout",
+                str(ROOT),
+            ]
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["repaired_q1_count"] == 1
+    assert receipt["dry_run_only"] is True
+    assert receipt["raw_motion_persisted"] is False
+    assert receipt["training_eligible"] is False
+    artifact = json.loads(repair_path.read_text(encoding="utf-8"))
+    assert artifact["report_hash"] == receipt["report_hash"]
+    assert artifact["report"]["results"][0]["repair_manifest"]["raw_motion_embedded"] is False
+
+
+def test_cli_rejects_tampered_ingest_commitment(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sample = _dataset(tmp_path / "dataset")
+    _append_terminal_reset(sample)
+    registration = _register(tmp_path / "dataset")
+    before = audit_motiondecode_snapshot(
+        registration,
+        tmp_path / "dataset",
+        target_model_path=G1_MODEL,
+    )
+    registration_path = tmp_path / "registration.json"
+    ingest_path = tmp_path / "ingest.json"
+    registration_path.write_text(
+        json.dumps(
+            {
+                "registration": registration.to_dict(),
+                "registration_hash": registration.registration_hash,
+            }
+        ),
+        encoding="utf-8",
+    )
+    ingest_path.write_text(
+        json.dumps(
+            {
+                "report": before.to_dict(),
+                "report_hash": "sha256:" + "0" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        dispatch_collective_argv(
+            [
+                "collective",
+                "repair",
+                "motiondecode",
+                "--registration",
+                str(registration_path),
+                "--ingest-report",
+                str(ingest_path),
+                "--dataset-root",
+                str(tmp_path / "dataset"),
+                "--target-model",
+                str(G1_MODEL),
+                "--output",
+                str(tmp_path / "repair.json"),
+                "--source-checkout",
+                str(ROOT),
+            ]
+        )
+        == 2
+    )
+    error = json.loads(capsys.readouterr().err)
+    assert error["training_eligible"] is False
+    assert "does not replay" in error["error"]
 
 
 def test_cli_registration_inspection_and_ingest_are_replayable(


### PR DESCRIPTION
## What changed

- add a content-addressed `SegmentationRepairManifest` for a single bounded
  `trim_tail_before_terminal_reset` operation
- detect unique reset-to-initial discontinuities near clip tails, retain only
  the immutable prefix in memory, recompute derivatives, and rerun the full Q1
  audit
- add downstream repair replay that revalidates registration, source file,
  detector thresholds, target body/model, before-audit hash, boundary,
  semantic invariants, and after-audit result
- add `rosclaw collective repair motiondecode` with external-only evidence
  output and explicit training/activation/hardware blockers
- cover valid repair, ambiguous boundaries, joint-limit rejection,
  source/ingest commitment replay, raw-motion embedding rejection, and CLI
  persistence

## Why

The first 40 official MotionDecode Shooting samples all failed Q1. Thirty-six
contained a systematic appended reset-to-first-frame tail, which creates
artificial root speeds up to 137.745 m/s and severe derivative spikes.
Directly training on those discontinuities would teach twitching instead of
motion quality.

This PR removes only the provable reset suffix, preserves every retained pose
and source lineage, and fails closed for unrelated or ambiguous errors.

## Real-data result

Against the content-addressed Phase 8 official snapshot:

- before: 0/40 Q1
- after: 36/40 Q1 (90%)
- retained: 32,744 / 33,043 frames
- removed: 299 frames (0.905%; median 1.5, range 1–28)
- remaining rejects: 1 joint-limit violation, 3 clips without a provable
  terminal reset
- report:
  `sha256:d4022779f281173c049d79e18c6b2e4e25f62f4dd0a2f2854cd88ae37dab7b3e`

The result remains dry-run Q1 only. License is `PENDING`; repaired motion is
not persisted; training, policy activation, Promotion truth, and hardware stay
disabled. A stock-PD exploratory MuJoCo replay fell, so no Q2/Q3 claim is
made.

## Validation

- `5505 passed, 60 skipped, 27 deselected, 26 warnings` (full suite with
  configured LeRobot 0.6.1 runtime)
- MotionDecode focused: `22 passed`
- Collective + Growth + Dream: `85 passed`
- scoped Ruff: pass
- mypy (`collective` plus AGENTS.md source set, 131 files): pass
- compileall: pass
- `git diff --check`: pass

Repository-wide Ruff has pre-existing findings outside this diff (244 checks /
148 format files); no unrelated files were rewritten.

## Stack

Draft stacked on #152 (`agent/phase8-motiondecode-source`).
