### PR TITLE
feat(collective): qualify MotionDecode contact physics

### DIFF
--- a/docs/integrations/motiondecode.md
+++ b/docs/integrations/motiondecode.md
@@ -37,6 +37,24 @@ Write all generated evidence outside the source checkout.
   --dataset-root /data/MotionDecode \
   --target-model e-urdf-zoo/g1/robot.mjcf.xml \
   --output /evidence/motiondecode-repair.json
+
+.venv/bin/python -m rosclaw.entrypoint collective contact motiondecode \
+  --registration /evidence/motiondecode-registration.json \
+  --ingest-report /evidence/motiondecode-ingest.json \
+  --repair-report /evidence/motiondecode-repair.json \
+  --dataset-root /data/MotionDecode \
+  --target-model e-urdf-zoo/g1/robot.mjcf.xml \
+  --output /evidence/motiondecode-contact.json
+
+.venv/bin/python -m rosclaw.entrypoint collective qualify motiondecode \
+  --registration /evidence/motiondecode-registration.json \
+  --ingest-report /evidence/motiondecode-ingest.json \
+  --repair-report /evidence/motiondecode-repair.json \
+  --contact-report /evidence/motiondecode-contact.json \
+  --dataset-root /data/MotionDecode \
+  --target-model e-urdf-zoo/g1/robot.mjcf.xml \
+  --scene e-urdf-zoo/g1/scene.xml \
+  --output /evidence/motiondecode-qualification.json
 ```
 
 `source add` hashes the catalog and a bounded set of selected CSVs. `inspect`
@@ -57,6 +75,28 @@ Downstream simulation must call `replay_segmentation_repair`; it reconstructs
 the retained prefix from the immutable source, replays every lineage and
 detector commitment, and refuses a prefix that no longer passes Q1.
 
+`contact` uses MuJoCo forward kinematics without advancing physics. It derives
+left/right sole position, whole-body COM, foot speed, hysteretic contact, and
+flight/left/right/double support phases. The receipt stores only trace hashes
+and aggregate metrics. Frame-level labels and motion arrays stay in memory.
+The current source does not declare its world frame, so the ground plane is an
+explicitly unverified per-clip lower-foot quantile.
+
+Contact candidates must meet all frozen gates:
+
+- supported-frame ratio at least 75%;
+- maximum continuous inferred flight no longer than 0.5 s;
+- near-ground skating ratio no greater than 10%;
+- near-ground foot-speed P95 no greater than 0.5 m/s.
+
+`qualify` advances real CPU MuJoCo physics only when the registered license
+decision is `PERMITTED`. It binds both the scene XML hash and a compiled
+dynamics/geometry hash, requires the canonical 29-joint body and actuator
+order, and checks finite replay, pelvis height, non-foot floor contact, joint
+and root tracking, torque saturation, and support slip. Hard fall, non-foot
+contact, non-finite state, torque violation, or MuJoCo warning stays Q1;
+bounded non-safety tracking failures are Q2; only a gate-clean replay is Q3.
+
 ## Fail-closed rules
 
 - A dataset card or public download does not prove training permission.
@@ -74,6 +114,13 @@ detector commitment, and refuses a prefix that no longer passes Q1.
   errors, and unrelated kinematic errors are rejected.
 - A repaired clip is Q1 only after its retained frames pass the same audit.
   Repair never implies Q2/Q3 physics trackability or training permission.
+- Contact inference is derived kinematic evidence, not measured force contact.
+  A phase candidate is not Q2/Q3.
+- `PENDING` or `DENIED` license evidence produces exactly zero physics steps.
+- Q3 requires at least one second of complete, strict CPU MuJoCo replay.
+- Even Q3 cannot authorize MotionDecode training while the source coordinate
+  frame, synchronized ball pose, and frame-level trace contract remain
+  unresolved.
 - External evidence may discover candidates but cannot be Promotion truth.
 - Every receipt declares `hardware_authorized=false`; no ROS, DDS, motor, or
   real-robot path exists in this adapter.

--- a/src/rosclaw/collective/cli.py
+++ b/src/rosclaw/collective/cli.py
@@ -111,6 +111,38 @@ def _parser() -> argparse.ArgumentParser:
     repair.add_argument("--source-checkout", type=Path, default=Path.cwd())
     repair.add_argument("--force", action="store_true")
     repair.set_defaults(handler=_repair)
+
+    contact = commands.add_parser(
+        "contact",
+        help="infer kinematic foot contact and support phases from repaired motion",
+    )
+    contact.add_argument("adapter", choices=["motiondecode"])
+    contact.add_argument("--registration", type=Path, required=True)
+    contact.add_argument("--ingest-report", type=Path, required=True)
+    contact.add_argument("--repair-report", type=Path, required=True)
+    contact.add_argument("--dataset-root", type=Path, required=True)
+    contact.add_argument("--target-model", type=Path, required=True)
+    contact.add_argument("--output", type=Path, required=True)
+    contact.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    contact.add_argument("--force", action="store_true")
+    contact.set_defaults(handler=_contact)
+
+    qualify = commands.add_parser(
+        "qualify",
+        help="run strict CPU MuJoCo qualification for eligible motion references",
+    )
+    qualify.add_argument("adapter", choices=["motiondecode"])
+    qualify.add_argument("--registration", type=Path, required=True)
+    qualify.add_argument("--ingest-report", type=Path, required=True)
+    qualify.add_argument("--repair-report", type=Path, required=True)
+    qualify.add_argument("--contact-report", type=Path, required=True)
+    qualify.add_argument("--dataset-root", type=Path, required=True)
+    qualify.add_argument("--target-model", type=Path, required=True)
+    qualify.add_argument("--scene", type=Path, required=True)
+    qualify.add_argument("--output", type=Path, required=True)
+    qualify.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    qualify.add_argument("--force", action="store_true")
+    qualify.set_defaults(handler=_qualify)
     return parser
 
 
@@ -236,25 +268,10 @@ def _repair(args: argparse.Namespace) -> int:
 
     output = _output_path(args.output, args.source_checkout, force=args.force)
     registration = _read_registration(args.registration)
-    ingest = _read_object(args.ingest_report)
-    report_value = ingest.get("report")
-    if not isinstance(report_value, dict):
-        raise ValueError("ingest artifact lacks a report object")
-    expected_ingest_hash = ingest.get("report_hash")
-    if not isinstance(expected_ingest_hash, str) or expected_ingest_hash != canonical_hash(
-        report_value
-    ):
-        raise ValueError("ingest report_hash does not replay")
-    thresholds_value = report_value.get("thresholds")
-    if not isinstance(thresholds_value, dict):
-        raise ValueError("ingest report lacks audit thresholds")
-    expected_fields = set(MotionDecodeAuditThresholds().to_dict())
-    if set(thresholds_value) != expected_fields or any(
-        isinstance(value, bool) or not isinstance(value, (int, float))
-        for value in thresholds_value.values()
-    ):
-        raise ValueError("ingest report audit thresholds are invalid")
-    thresholds = MotionDecodeAuditThresholds(**thresholds_value)
+    expected_ingest_hash, thresholds = _read_ingest_commitment(
+        args.ingest_report,
+        MotionDecodeAuditThresholds,
+    )
     report = repair_motiondecode_snapshot(
         registration,
         args.dataset_root,
@@ -294,6 +311,126 @@ def _repair(args: argparse.Namespace) -> int:
     return 0 if report.q1_after_count > 0 else 1
 
 
+def _contact(args: argparse.Namespace) -> int:
+    from rosclaw.collective.sources.motiondecode.audit import (
+        MotionDecodeAuditThresholds,
+    )
+    from rosclaw.collective.sources.motiondecode.contact import (
+        infer_motiondecode_contacts,
+    )
+
+    output = _output_path(args.output, args.source_checkout, force=args.force)
+    registration = _read_registration(args.registration)
+    expected_ingest_hash, audit_thresholds = _read_ingest_commitment(
+        args.ingest_report,
+        MotionDecodeAuditThresholds,
+    )
+    expected_repair_hash = _read_report_commitment(
+        args.repair_report,
+        label="repair",
+    )
+    report = infer_motiondecode_contacts(
+        registration,
+        args.dataset_root,
+        target_model_path=args.target_model,
+        expected_ingest_report_hash=expected_ingest_hash,
+        expected_repair_report_hash=expected_repair_hash,
+        audit_thresholds=audit_thresholds,
+    )
+    artifact = {
+        "schema_version": "rosclaw.collective.motiondecode_contact_artifact.v1",
+        "report": report.to_dict(),
+        "report_hash": report.report_hash,
+    }
+    atomic_write_json(output, artifact)
+    _print(
+        {
+            "schema_version": "rosclaw.collective.contact_receipt.v1",
+            "ok": report.phase_candidate_count > 0,
+            "output": str(output),
+            "report_hash": report.report_hash,
+            "repair_report_hash": report.repair_report_hash,
+            "threshold_hash": report.thresholds.threshold_hash,
+            "clip_count": len(report.clips),
+            "inferred_count": report.inferred_count,
+            "phase_candidate_count": report.phase_candidate_count,
+            "issue_clip_counts": report.issue_clip_counts,
+            "quality_commitment": report.quality_commitment,
+            "frame_level_trace_persisted": False,
+            "training_eligible": False,
+            "training_blockers": report.training_blockers,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+    )
+    return 0 if report.phase_candidate_count > 0 else 1
+
+
+def _qualify(args: argparse.Namespace) -> int:
+    from rosclaw.collective.sources.motiondecode.audit import (
+        MotionDecodeAuditThresholds,
+    )
+    from rosclaw.collective.sources.motiondecode.qualification import (
+        qualify_motiondecode_snapshot,
+    )
+
+    output = _output_path(args.output, args.source_checkout, force=args.force)
+    registration = _read_registration(args.registration)
+    expected_ingest_hash, audit_thresholds = _read_ingest_commitment(
+        args.ingest_report,
+        MotionDecodeAuditThresholds,
+    )
+    expected_repair_hash = _read_report_commitment(
+        args.repair_report,
+        label="repair",
+    )
+    expected_contact_hash = _read_report_commitment(
+        args.contact_report,
+        label="contact",
+    )
+    report = qualify_motiondecode_snapshot(
+        registration,
+        args.dataset_root,
+        target_model_path=args.target_model,
+        scene_path=args.scene,
+        expected_ingest_report_hash=expected_ingest_hash,
+        expected_repair_report_hash=expected_repair_hash,
+        expected_contact_report_hash=expected_contact_hash,
+        audit_thresholds=audit_thresholds,
+    )
+    artifact = {
+        "schema_version": "rosclaw.collective.motiondecode_qualification_artifact.v1",
+        "report": report.to_dict(),
+        "report_hash": report.report_hash,
+    }
+    atomic_write_json(output, artifact)
+    _print(
+        {
+            "schema_version": "rosclaw.collective.qualification_receipt.v1",
+            "ok": report.q3_count > 0,
+            "output": str(output),
+            "report_hash": report.report_hash,
+            "contact_report_hash": report.contact_report_hash,
+            "scene_file_hash": report.scene_file_hash,
+            "compiled_scene_hash": report.compiled_scene_hash,
+            "threshold_hash": report.thresholds.threshold_hash,
+            "clip_count": len(report.clips),
+            "status_counts": report.status_counts,
+            "qualification_counts": report.qualification_counts,
+            "physics_executed_count": report.physics_executed_count,
+            "physics_step_count": report.physics_step_count,
+            "q3_count": report.q3_count,
+            "quality_commitment": report.quality_commitment,
+            "training_eligible": False,
+            "training_blockers": report.training_blockers,
+            "promotion_truth_eligible": False,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+    )
+    return 0 if report.q3_count > 0 else 1
+
+
 def _families(value: str) -> tuple[MotionFamily, ...]:
     from rosclaw.collective.sources.motiondecode.taxonomy import MotionFamily
 
@@ -329,6 +466,40 @@ def _read_registration(path: Path) -> MotionDecodeRegistration:
     if value.get("registration_hash") != registration.registration_hash:
         raise ValueError("registration_hash does not replay")
     return registration
+
+
+def _read_ingest_commitment(
+    path: Path,
+    thresholds_type: Any,
+) -> tuple[str, Any]:
+    value = _read_object(path)
+    report_value = value.get("report")
+    if not isinstance(report_value, dict):
+        raise ValueError("ingest artifact lacks a report object")
+    expected_hash = value.get("report_hash")
+    if not isinstance(expected_hash, str) or expected_hash != canonical_hash(report_value):
+        raise ValueError("ingest report_hash does not replay")
+    thresholds_value = report_value.get("thresholds")
+    if not isinstance(thresholds_value, dict):
+        raise ValueError("ingest report lacks audit thresholds")
+    expected_fields = set(thresholds_type().to_dict())
+    if set(thresholds_value) != expected_fields or any(
+        isinstance(item, bool) or not isinstance(item, (int, float))
+        for item in thresholds_value.values()
+    ):
+        raise ValueError("ingest report audit thresholds are invalid")
+    return expected_hash, thresholds_type(**thresholds_value)
+
+
+def _read_report_commitment(path: Path, *, label: str) -> str:
+    value = _read_object(path)
+    report_value = value.get("report")
+    if not isinstance(report_value, dict):
+        raise ValueError(f"{label} artifact lacks a report object")
+    expected_hash = value.get("report_hash")
+    if not isinstance(expected_hash, str) or expected_hash != canonical_hash(report_value):
+        raise ValueError(f"{label} report_hash does not replay")
+    return expected_hash
 
 
 def _read_object(path: Path) -> Mapping[str, Any]:

--- a/src/rosclaw/collective/sources/motiondecode/__init__.py
+++ b/src/rosclaw/collective/sources/motiondecode/__init__.py
@@ -11,6 +11,13 @@ from rosclaw.collective.sources.motiondecode.audit import (
     MotionQualificationLevel,
     audit_motiondecode_snapshot,
 )
+from rosclaw.collective.sources.motiondecode.contact import (
+    CanonicalContactTrace,
+    ContactInferenceThresholds,
+    MotionDecodeContactReport,
+    SupportPhase,
+    infer_motiondecode_contacts,
+)
 from rosclaw.collective.sources.motiondecode.license import (
     MotionDecodeLicenseSnapshot,
     snapshot_license,
@@ -22,6 +29,13 @@ from rosclaw.collective.sources.motiondecode.manifest import (
     register_motiondecode_source,
 )
 from rosclaw.collective.sources.motiondecode.parser import CanonicalMotionEpisode
+from rosclaw.collective.sources.motiondecode.qualification import (
+    MotionDecodeQualificationReport,
+    MotionPhysicsQualification,
+    PhysicsQualificationThresholds,
+    qualify_canonical_motion,
+    qualify_motiondecode_snapshot,
+)
 from rosclaw.collective.sources.motiondecode.repair import (
     MotionDecodeRepairReport,
     MotionRepairDisposition,
@@ -33,20 +47,30 @@ from rosclaw.collective.sources.motiondecode.taxonomy import MotionFamily
 
 __all__ = [
     "CanonicalMotionEpisode",
+    "CanonicalContactTrace",
+    "ContactInferenceThresholds",
     "MotionDecodeClipAudit",
+    "MotionDecodeContactReport",
     "MotionDecodeFileRecord",
     "MotionDecodeIngestReport",
     "MotionDecodeLicenseSnapshot",
     "MotionDecodeRegistration",
     "MotionDecodeRepairReport",
+    "MotionDecodeQualificationReport",
     "MotionDecodeSourceManifest",
     "MotionFamily",
     "MotionQualificationLevel",
     "MotionRepairDisposition",
+    "MotionPhysicsQualification",
+    "PhysicsQualificationThresholds",
     "SegmentationRepairManifest",
+    "SupportPhase",
     "audit_motiondecode_snapshot",
+    "infer_motiondecode_contacts",
     "register_motiondecode_source",
     "repair_motiondecode_snapshot",
     "replay_segmentation_repair",
+    "qualify_canonical_motion",
+    "qualify_motiondecode_snapshot",
     "snapshot_license",
 ]

--- a/src/rosclaw/collective/sources/motiondecode/contact.py
+++ b/src/rosclaw/collective/sources/motiondecode/contact.py
@@ -1,0 +1,867 @@
+"""Deterministic kinematic contact and support-phase inference."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections import Counter
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.collective.contracts import LicenseDecision
+from rosclaw.collective.sources.motiondecode.audit import (
+    AuditSeverity,
+    MotionDecodeAuditThresholds,
+    load_g1_joint_contract,
+)
+from rosclaw.collective.sources.motiondecode.manifest import (
+    MotionDecodeRegistration,
+    verify_registered_files,
+)
+from rosclaw.collective.sources.motiondecode.parser import (
+    CanonicalMotionEpisode,
+    parse_motion_csv,
+)
+from rosclaw.collective.sources.motiondecode.repair import (
+    MotionDecodeRepairResult,
+    MotionRepairDisposition,
+    repair_motiondecode_snapshot,
+    replay_segmentation_repair,
+)
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_DDS_JOINT_NAMES
+
+_MAX_MODEL_BYTES = 10 * 1024 * 1024
+
+
+class SupportPhase(StrEnum):
+    FLIGHT = "flight"
+    LEFT = "left"
+    RIGHT = "right"
+    DOUBLE = "double"
+
+
+_PHASE_CODE = {
+    SupportPhase.FLIGHT: 0,
+    SupportPhase.LEFT: 1,
+    SupportPhase.RIGHT: 2,
+    SupportPhase.DOUBLE: 3,
+}
+
+
+@dataclass(frozen=True)
+class ContactInferenceThresholds:
+    ground_quantile: float = 0.05
+    sole_offset_m: float = 0.03
+    contact_enter_height_m: float = 0.025
+    contact_exit_height_m: float = 0.04
+    contact_enter_speed_m_s: float = 0.30
+    contact_exit_speed_m_s: float = 0.45
+    minimum_contact_frames: int = 3
+    maximum_gap_frames: int = 2
+    minimum_supported_ratio: float = 0.75
+    maximum_flight_run_s: float = 0.50
+    maximum_skating_ratio: float = 0.10
+    maximum_near_ground_speed_p95_m_s: float = 0.50
+
+    def __post_init__(self) -> None:
+        numeric = tuple(vars(self).values())
+        if any(
+            isinstance(value, bool) or not math.isfinite(value) or value <= 0.0 for value in numeric
+        ):
+            raise ValueError("contact inference thresholds must be finite and positive")
+        if not 0.0 < self.ground_quantile < 0.5:
+            raise ValueError("ground_quantile must be in (0, 0.5)")
+        if not 0.0 < self.minimum_supported_ratio <= 1.0:
+            raise ValueError("minimum_supported_ratio must be in (0, 1]")
+        if not 0.0 < self.maximum_skating_ratio <= 1.0:
+            raise ValueError("maximum_skating_ratio must be in (0, 1]")
+        if not isinstance(self.minimum_contact_frames, int) or not isinstance(
+            self.maximum_gap_frames, int
+        ):
+            raise ValueError("contact frame thresholds must be integers")
+        if self.contact_enter_height_m >= self.contact_exit_height_m:
+            raise ValueError("contact enter height must be below exit height")
+        if self.contact_enter_speed_m_s >= self.contact_exit_speed_m_s:
+            raise ValueError("contact enter speed must be below exit speed")
+
+    @property
+    def threshold_hash(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": "rosclaw.collective.motiondecode_contact_thresholds.v1",
+                **self.to_dict(),
+            }
+        )
+
+    def to_dict(self) -> dict[str, float | int]:
+        return dict(vars(self))
+
+
+@dataclass(frozen=True)
+class ContactInferenceIssue:
+    code: str
+    severity: AuditSeverity
+    observed: float
+    threshold: float
+
+    def __post_init__(self) -> None:
+        if not self.code or not isinstance(self.severity, AuditSeverity):
+            raise ValueError("contact inference issue is invalid")
+        if not math.isfinite(self.observed) or not math.isfinite(self.threshold):
+            raise ValueError("contact inference issue values must be finite")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "severity": self.severity.value,
+            "observed": self.observed,
+            "threshold": self.threshold,
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalContactTrace:
+    """Read-only derived arrays; only their hash and summary enter receipts."""
+
+    episode_hash: str
+    target_model_file_hash: str
+    threshold_hash: str
+    ground_height_m: float
+    left_sole_position: np.ndarray
+    right_sole_position: np.ndarray
+    center_of_mass: np.ndarray
+    left_foot_speed: np.ndarray
+    right_foot_speed: np.ndarray
+    left_contact: np.ndarray
+    right_contact: np.ndarray
+    phase_code: np.ndarray
+    schema_version: str = "rosclaw.collective.motiondecode_contact_trace.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("episode_hash", self.episode_hash),
+            ("target_model_file_hash", self.target_model_file_hash),
+            ("threshold_hash", self.threshold_hash),
+        ):
+            if not value.startswith("sha256:") or len(value) != 71:
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not math.isfinite(self.ground_height_m):
+            raise ValueError("ground height must be finite")
+        frames = int(self.phase_code.shape[0])
+        expected = {
+            "left_sole_position": ((frames, 3), np.float64),
+            "right_sole_position": ((frames, 3), np.float64),
+            "center_of_mass": ((frames, 3), np.float64),
+            "left_foot_speed": ((frames,), np.float64),
+            "right_foot_speed": ((frames,), np.float64),
+            "left_contact": ((frames,), np.bool_),
+            "right_contact": ((frames,), np.bool_),
+            "phase_code": ((frames,), np.uint8),
+        }
+        if frames < 3:
+            raise ValueError("contact trace requires at least three frames")
+        for label, (shape, dtype) in expected.items():
+            array = np.asarray(getattr(self, label), dtype=dtype)
+            if array.shape != shape:
+                raise ValueError(f"{label} must have shape {shape}")
+            if np.issubdtype(dtype, np.floating) and not np.all(np.isfinite(array)):
+                raise ValueError(f"{label} must be finite")
+            array.setflags(write=False)
+            object.__setattr__(self, label, array)
+        if np.any(self.phase_code > max(_PHASE_CODE.values())):
+            raise ValueError("contact trace contains an unknown support phase")
+
+    @property
+    def trace_hash(self) -> str:
+        digest = hashlib.sha256()
+        digest.update(self.schema_version.encode("ascii"))
+        digest.update(self.episode_hash.encode("ascii"))
+        digest.update(self.target_model_file_hash.encode("ascii"))
+        digest.update(self.threshold_hash.encode("ascii"))
+        digest.update(np.asarray([self.ground_height_m], dtype="<f8").tobytes())
+        for array in (
+            self.left_sole_position,
+            self.right_sole_position,
+            self.center_of_mass,
+            self.left_foot_speed,
+            self.right_foot_speed,
+        ):
+            digest.update(np.ascontiguousarray(array, dtype="<f8").tobytes())
+        digest.update(np.ascontiguousarray(self.left_contact, dtype=np.uint8).tobytes())
+        digest.update(np.ascontiguousarray(self.right_contact, dtype=np.uint8).tobytes())
+        digest.update(np.ascontiguousarray(self.phase_code, dtype=np.uint8).tobytes())
+        return "sha256:" + digest.hexdigest()
+
+    @property
+    def phases(self) -> tuple[SupportPhase, ...]:
+        by_code = {code: phase for phase, code in _PHASE_CODE.items()}
+        return tuple(by_code[int(value)] for value in self.phase_code)
+
+
+@dataclass(frozen=True)
+class MotionDecodeContactAudit:
+    relative_path: str
+    source_file_hash: str
+    repair_manifest_hash: str | None
+    episode_hash: str | None
+    trace_hash: str | None
+    metrics: dict[str, float | int] | None
+    issues: tuple[ContactInferenceIssue, ...]
+    upstream_q1: bool
+    schema_version: str = "rosclaw.collective.motiondecode_contact_audit.v1"
+
+    def __post_init__(self) -> None:
+        if not self.relative_path:
+            raise ValueError("contact audit relative path must not be empty")
+        for label, value in (
+            ("source_file_hash", self.source_file_hash),
+            ("repair_manifest_hash", self.repair_manifest_hash),
+            ("episode_hash", self.episode_hash),
+            ("trace_hash", self.trace_hash),
+        ):
+            if value is not None and (not value.startswith("sha256:") or len(value) != 71):
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not self.issues or any(
+            not isinstance(issue, ContactInferenceIssue) for issue in self.issues
+        ):
+            raise ValueError("contact audit requires inference issues")
+        if self.upstream_q1:
+            if self.episode_hash is None or self.trace_hash is None or self.metrics is None:
+                raise ValueError("upstream Q1 contact audit requires derived summary evidence")
+        elif any(
+            value is not None
+            for value in (
+                self.repair_manifest_hash,
+                self.episode_hash,
+                self.trace_hash,
+                self.metrics,
+            )
+        ):
+            raise ValueError("upstream rejected contact audit cannot claim derived evidence")
+
+    @property
+    def phase_segmentation_candidate(self) -> bool:
+        return (
+            self.upstream_q1
+            and self.trace_hash is not None
+            and not any(issue.severity is AuditSeverity.ERROR for issue in self.issues)
+        )
+
+    @property
+    def audit_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "relative_path": self.relative_path,
+            "source_file_hash": self.source_file_hash,
+            "repair_manifest_hash": self.repair_manifest_hash,
+            "episode_hash": self.episode_hash,
+            "trace_hash": self.trace_hash,
+            "metrics": self.metrics,
+            "issues": [issue.to_dict() for issue in self.issues],
+            "upstream_q1": self.upstream_q1,
+            "phase_segmentation_candidate": self.phase_segmentation_candidate,
+            "frame_level_trace_persisted": False,
+            "training_eligible": False,
+            "hardware_authorized": False,
+        }
+
+
+@dataclass(frozen=True)
+class MotionDecodeContactReport:
+    registration_hash: str
+    source_manifest_hash: str
+    ingest_report_hash: str
+    repair_report_hash: str
+    target_body_hash: str
+    target_model_file_hash: str
+    license_decision: LicenseDecision
+    thresholds: ContactInferenceThresholds
+    clips: tuple[MotionDecodeContactAudit, ...]
+    schema_version: str = "rosclaw.collective.motiondecode_contact_report.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("registration_hash", self.registration_hash),
+            ("source_manifest_hash", self.source_manifest_hash),
+            ("ingest_report_hash", self.ingest_report_hash),
+            ("repair_report_hash", self.repair_report_hash),
+            ("target_body_hash", self.target_body_hash),
+            ("target_model_file_hash", self.target_model_file_hash),
+        ):
+            if not value.startswith("sha256:") or len(value) != 71:
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not isinstance(self.license_decision, LicenseDecision):
+            raise ValueError("contact report license decision is unknown")
+        if not isinstance(self.thresholds, ContactInferenceThresholds):
+            raise ValueError("contact report thresholds are invalid")
+        clips = tuple(self.clips)
+        if any(not isinstance(clip, MotionDecodeContactAudit) for clip in clips):
+            raise ValueError("contact report contains an invalid clip")
+        paths = tuple(clip.relative_path for clip in clips)
+        if len(paths) != len(set(paths)) or paths != tuple(sorted(paths)):
+            raise ValueError("contact report clips must be unique and sorted")
+        object.__setattr__(self, "clips", clips)
+
+    @property
+    def report_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def inferred_count(self) -> int:
+        return sum(clip.trace_hash is not None for clip in self.clips)
+
+    @property
+    def phase_candidate_count(self) -> int:
+        return sum(clip.phase_segmentation_candidate for clip in self.clips)
+
+    @property
+    def issue_clip_counts(self) -> dict[str, int]:
+        counts = Counter(issue.code for clip in self.clips for issue in clip.issues)
+        return dict(sorted(counts.items()))
+
+    @property
+    def quality_commitment(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": "rosclaw.collective.motiondecode_contact_quality.v1",
+                "repair_report_hash": self.repair_report_hash,
+                "threshold_hash": self.thresholds.threshold_hash,
+                "clip_audit_hashes": [clip.audit_hash for clip in self.clips],
+            }
+        )
+
+    @property
+    def training_blockers(self) -> list[str]:
+        blockers = [
+            "Q3_OR_Q4_PHYSICS_QUALIFICATION_REQUIRED",
+            "SOURCE_COORDINATE_FRAME_UNSPECIFIED",
+            "SYNCHRONIZED_BALL_POSE_ABSENT",
+            "ACTION_REWARD_TRANSITION_SEMANTICS_ABSENT",
+            "FRAME_LEVEL_CONTACT_TRACE_NOT_PERSISTED",
+        ]
+        if self.phase_candidate_count != self.inferred_count:
+            blockers.insert(0, "CONTACT_INFERENCE_PARTIAL")
+        if self.inferred_count != len(self.clips):
+            blockers.insert(0, "UPSTREAM_Q1_PARTIAL")
+        if self.license_decision is not LicenseDecision.PERMITTED:
+            blockers.insert(0, "LICENSE_NOT_PERMITTED")
+        return blockers
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "registration_hash": self.registration_hash,
+            "source_manifest_hash": self.source_manifest_hash,
+            "ingest_report_hash": self.ingest_report_hash,
+            "repair_report_hash": self.repair_report_hash,
+            "target_body_hash": self.target_body_hash,
+            "target_model_file_hash": self.target_model_file_hash,
+            "license_decision": self.license_decision.value,
+            "thresholds": self.thresholds.to_dict(),
+            "threshold_hash": self.thresholds.threshold_hash,
+            "clips": [clip.to_dict() for clip in self.clips],
+            "clip_count": len(self.clips),
+            "inferred_count": self.inferred_count,
+            "phase_candidate_count": self.phase_candidate_count,
+            "issue_clip_counts": self.issue_clip_counts,
+            "quality_commitment": self.quality_commitment,
+            "coordinate_frame": {
+                "source_declared": False,
+                "ground_estimation": "per_clip_lower_foot_quantile",
+                "verified": False,
+            },
+            "eligibility": {
+                "support_phase_discovery": self.phase_candidate_count > 0,
+                "mujoco_qualification_candidate": self.phase_candidate_count > 0,
+                "mujoco_qualification_authorized": (
+                    self.phase_candidate_count > 0
+                    and self.license_decision is LicenseDecision.PERMITTED
+                ),
+                "motion_tracker_training": False,
+                "promotion_truth": False,
+            },
+            "frame_level_trace_persisted": False,
+            "training_eligible": False,
+            "training_blockers": self.training_blockers,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+
+
+@dataclass(frozen=True)
+class MotionDecodeContactBundle:
+    relative_path: str
+    episode: CanonicalMotionEpisode
+    trace: CanonicalContactTrace
+
+    def __post_init__(self) -> None:
+        if not self.relative_path:
+            raise ValueError("contact bundle relative path must not be empty")
+        if self.trace.episode_hash != self.episode.episode_hash:
+            raise ValueError("contact bundle trace does not match its episode")
+
+
+@dataclass(frozen=True)
+class MotionDecodeContactBatch:
+    report: MotionDecodeContactReport
+    bundles: tuple[MotionDecodeContactBundle, ...]
+
+    def __post_init__(self) -> None:
+        paths = tuple(bundle.relative_path for bundle in self.bundles)
+        if len(paths) != len(set(paths)) or paths != tuple(sorted(paths)):
+            raise ValueError("contact bundles must be unique and sorted")
+        expected = {clip.relative_path for clip in self.report.clips if clip.trace_hash is not None}
+        if set(paths) != expected:
+            raise ValueError("contact bundles do not match inferred report clips")
+
+
+def infer_motiondecode_contacts(
+    registration: MotionDecodeRegistration,
+    dataset_root: Path,
+    *,
+    target_model_path: Path,
+    expected_ingest_report_hash: str,
+    expected_repair_report_hash: str,
+    audit_thresholds: MotionDecodeAuditThresholds | None = None,
+    contact_thresholds: ContactInferenceThresholds | None = None,
+) -> MotionDecodeContactReport:
+    """Return the serializable report while keeping frame traces in memory."""
+
+    return infer_motiondecode_contact_batch(
+        registration,
+        dataset_root,
+        target_model_path=target_model_path,
+        expected_ingest_report_hash=expected_ingest_report_hash,
+        expected_repair_report_hash=expected_repair_report_hash,
+        audit_thresholds=audit_thresholds,
+        contact_thresholds=contact_thresholds,
+    ).report
+
+
+def infer_motiondecode_contact_batch(
+    registration: MotionDecodeRegistration,
+    dataset_root: Path,
+    *,
+    target_model_path: Path,
+    expected_ingest_report_hash: str,
+    expected_repair_report_hash: str,
+    audit_thresholds: MotionDecodeAuditThresholds | None = None,
+    contact_thresholds: ContactInferenceThresholds | None = None,
+) -> MotionDecodeContactBatch:
+    """Replay repaired Q1 clips and infer contact without persisting frame labels."""
+
+    selected_audit = audit_thresholds or MotionDecodeAuditThresholds()
+    selected_contact = contact_thresholds or ContactInferenceThresholds()
+    repair_report = repair_motiondecode_snapshot(
+        registration,
+        dataset_root,
+        target_model_path=target_model_path,
+        expected_ingest_report_hash=expected_ingest_report_hash,
+        thresholds=selected_audit,
+    )
+    if repair_report.report_hash != expected_repair_report_hash:
+        raise ValueError("repair report hash does not match replayed repair evidence")
+    _, target_body_hash, model_hash = load_g1_joint_contract(target_model_path)
+    model, data, qpos_addresses, left_site, right_site = _load_contact_model(
+        target_model_path,
+        expected_model_hash=model_hash,
+    )
+    verified = verify_registered_files(registration, dataset_root)
+    record_by_path = {
+        record.relative_path: record
+        for record in registration.manifest.files
+        if record.relative_path.startswith("samples/")
+    }
+    clips: list[MotionDecodeContactAudit] = []
+    bundles: list[MotionDecodeContactBundle] = []
+    for result in repair_report.results:
+        if not result.q1_after:
+            clips.append(_upstream_rejected_contact(result))
+            continue
+        record = record_by_path[result.relative_path]
+        episode = _episode_for_contact(
+            registration,
+            result,
+            verified[result.relative_path],
+            dataset_root=dataset_root,
+            target_model_path=target_model_path,
+            target_body_hash=target_body_hash,
+            audit_thresholds=selected_audit,
+        )
+        trace = infer_contact_trace(
+            episode,
+            model=model,
+            data=data,
+            qpos_addresses=qpos_addresses,
+            left_site_id=left_site,
+            right_site_id=right_site,
+            target_model_file_hash=model_hash,
+            thresholds=selected_contact,
+        )
+        bundles.append(
+            MotionDecodeContactBundle(
+                relative_path=result.relative_path,
+                episode=episode,
+                trace=trace,
+            )
+        )
+        clips.append(
+            _audit_contact_trace(
+                result,
+                trace,
+                sample_rate_hz=episode.sample_rate_hz,
+                thresholds=selected_contact,
+                expected_source_hash=record.content_hash,
+            )
+        )
+    report = MotionDecodeContactReport(
+        registration_hash=registration.registration_hash,
+        source_manifest_hash=registration.manifest.manifest_hash,
+        ingest_report_hash=expected_ingest_report_hash,
+        repair_report_hash=repair_report.report_hash,
+        target_body_hash=target_body_hash,
+        target_model_file_hash=model_hash,
+        license_decision=registration.manifest.license_snapshot.decision,
+        thresholds=selected_contact,
+        clips=tuple(clips),
+    )
+    return MotionDecodeContactBatch(report=report, bundles=tuple(bundles))
+
+
+def infer_contact_trace(
+    episode: CanonicalMotionEpisode,
+    *,
+    model: Any,
+    data: Any,
+    qpos_addresses: np.ndarray,
+    left_site_id: int,
+    right_site_id: int,
+    target_model_file_hash: str,
+    thresholds: ContactInferenceThresholds | None = None,
+) -> CanonicalContactTrace:
+    """Run MuJoCo forward kinematics only; no physics step or actuator command."""
+
+    selected = thresholds or ContactInferenceThresholds()
+    frames = int(episode.time.shape[0])
+    left: np.ndarray = np.empty((frames, 3), dtype=np.float64)
+    right: np.ndarray = np.empty((frames, 3), dtype=np.float64)
+    com: np.ndarray = np.empty((frames, 3), dtype=np.float64)
+    import mujoco
+
+    for frame in range(frames):
+        data.qpos[:3] = episode.root_position[frame]
+        quaternion = episode.root_quaternion[frame]
+        data.qpos[3:7] = quaternion / np.linalg.norm(quaternion)
+        data.qpos[qpos_addresses] = episode.joint_position[frame]
+        data.qvel[:] = 0.0
+        mujoco.mj_forward(model, data)
+        left[frame] = data.site_xpos[left_site_id]
+        right[frame] = data.site_xpos[right_site_id]
+        com[frame] = data.subtree_com[0]
+    left[:, 2] -= selected.sole_offset_m
+    right[:, 2] -= selected.sole_offset_m
+    left_velocity = np.gradient(left, episode.time, axis=0, edge_order=2)
+    right_velocity = np.gradient(right, episode.time, axis=0, edge_order=2)
+    left_speed = np.linalg.norm(left_velocity, axis=1)
+    right_speed = np.linalg.norm(right_velocity, axis=1)
+    ground = float(
+        np.quantile(
+            np.minimum(left[:, 2], right[:, 2]),
+            selected.ground_quantile,
+        )
+    )
+    left_height = left[:, 2] - ground
+    right_height = right[:, 2] - ground
+    left_contact = _contact_hysteresis(left_height, left_speed, selected)
+    right_contact = _contact_hysteresis(right_height, right_speed, selected)
+    phase: np.ndarray = np.zeros(frames, dtype=np.uint8)
+    phase[left_contact & ~right_contact] = _PHASE_CODE[SupportPhase.LEFT]
+    phase[~left_contact & right_contact] = _PHASE_CODE[SupportPhase.RIGHT]
+    phase[left_contact & right_contact] = _PHASE_CODE[SupportPhase.DOUBLE]
+    return CanonicalContactTrace(
+        episode_hash=episode.episode_hash,
+        target_model_file_hash=target_model_file_hash,
+        threshold_hash=selected.threshold_hash,
+        ground_height_m=ground,
+        left_sole_position=left,
+        right_sole_position=right,
+        center_of_mass=com,
+        left_foot_speed=left_speed,
+        right_foot_speed=right_speed,
+        left_contact=left_contact,
+        right_contact=right_contact,
+        phase_code=phase,
+    )
+
+
+def _contact_hysteresis(
+    height: np.ndarray,
+    speed: np.ndarray,
+    thresholds: ContactInferenceThresholds,
+) -> np.ndarray:
+    contact = np.zeros(height.shape[0], dtype=np.bool_)
+    active = False
+    for index in range(height.shape[0]):
+        if active:
+            active = bool(
+                height[index] <= thresholds.contact_exit_height_m
+                and speed[index] <= thresholds.contact_exit_speed_m_s
+            )
+        else:
+            active = bool(
+                height[index] <= thresholds.contact_enter_height_m
+                and speed[index] <= thresholds.contact_enter_speed_m_s
+            )
+        contact[index] = active
+    _remove_short_true_runs(contact, thresholds.minimum_contact_frames)
+    _fill_short_false_gaps(contact, thresholds.maximum_gap_frames)
+    return contact
+
+
+def _remove_short_true_runs(values: np.ndarray, minimum: int) -> None:
+    start: int | None = None
+    for index in range(values.shape[0] + 1):
+        active = index < values.shape[0] and bool(values[index])
+        if active and start is None:
+            start = index
+        elif not active and start is not None:
+            if index - start < minimum:
+                values[start:index] = False
+            start = None
+
+
+def _fill_short_false_gaps(values: np.ndarray, maximum: int) -> None:
+    start: int | None = None
+    for index in range(values.shape[0] + 1):
+        inactive = index < values.shape[0] and not bool(values[index])
+        if inactive and start is None:
+            start = index
+        elif not inactive and start is not None:
+            if start > 0 and index < values.shape[0] and index - start <= maximum:
+                values[start:index] = True
+            start = None
+
+
+def _load_contact_model(
+    model_path: Path,
+    *,
+    expected_model_hash: str,
+) -> tuple[Any, Any, np.ndarray, int, int]:
+    resolved = model_path.expanduser().resolve(strict=True)
+    if not resolved.is_file() or resolved.is_symlink():
+        raise ValueError("contact model must be a non-symlink regular file")
+    if resolved.stat().st_size > _MAX_MODEL_BYTES:
+        raise ValueError("contact model exceeds the 10 MB safety limit")
+    actual_hash = "sha256:" + hashlib.sha256(resolved.read_bytes()).hexdigest()
+    if actual_hash != expected_model_hash:
+        raise ValueError("contact model hash changed before kinematic inference")
+    try:
+        import mujoco
+    except ImportError as exc:
+        raise ValueError("MuJoCo is required for contact forward kinematics") from exc
+    model = mujoco.MjModel.from_xml_path(str(resolved))
+    data = mujoco.MjData(model)
+    addresses: list[int] = []
+    for name in G1_DDS_JOINT_NAMES:
+        joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+        if joint_id < 0:
+            raise ValueError(f"contact model is missing target joint: {name}")
+        addresses.append(int(model.jnt_qposadr[joint_id]))
+    left_site = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "left_foot")
+    right_site = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "right_foot")
+    if left_site < 0 or right_site < 0:
+        raise ValueError("contact model must define left_foot and right_foot sites")
+    return (
+        model,
+        data,
+        np.asarray(addresses, dtype=np.int64),
+        int(left_site),
+        int(right_site),
+    )
+
+
+def _episode_for_contact(
+    registration: MotionDecodeRegistration,
+    result: MotionDecodeRepairResult,
+    source_path: Path,
+    *,
+    dataset_root: Path,
+    target_model_path: Path,
+    target_body_hash: str,
+    audit_thresholds: MotionDecodeAuditThresholds,
+) -> CanonicalMotionEpisode:
+    if result.disposition is MotionRepairDisposition.REPAIRED_Q1:
+        if result.repair_manifest is None:
+            raise ValueError("repaired Q1 result lacks a repair manifest")
+        return replay_segmentation_repair(
+            registration,
+            dataset_root,
+            target_model_path=target_model_path,
+            manifest=result.repair_manifest,
+            thresholds=audit_thresholds,
+        )
+    if result.disposition is not MotionRepairDisposition.NOT_REQUIRED_Q1:
+        raise ValueError("contact inference received a non-Q1 repair result")
+    return parse_motion_csv(
+        source_path,
+        source_manifest_hash=registration.manifest.manifest_hash,
+        expected_file_hash=result.source_file_hash,
+        target_body_hash=target_body_hash,
+        sample_rate_hz=registration.manifest.sample_rate_hz,
+    )
+
+
+def _audit_contact_trace(
+    result: MotionDecodeRepairResult,
+    trace: CanonicalContactTrace,
+    *,
+    sample_rate_hz: float,
+    thresholds: ContactInferenceThresholds,
+    expected_source_hash: str,
+) -> MotionDecodeContactAudit:
+    if result.source_file_hash != expected_source_hash:
+        raise ValueError("contact source hash does not match repair evidence")
+    supported = trace.left_contact | trace.right_contact
+    near_left = (
+        trace.left_sole_position[:, 2] - trace.ground_height_m <= thresholds.contact_enter_height_m
+    )
+    near_right = (
+        trace.right_sole_position[:, 2] - trace.ground_height_m <= thresholds.contact_enter_height_m
+    )
+    skating = (near_left & ~trace.left_contact) | (near_right & ~trace.right_contact)
+    near_speeds = np.concatenate(
+        (
+            trace.left_foot_speed[near_left],
+            trace.right_foot_speed[near_right],
+        )
+    )
+    near_speed_p95 = float(np.quantile(near_speeds, 0.95)) if near_speeds.size else 0.0
+    supported_ratio = float(np.mean(supported))
+    skating_ratio = float(np.mean(skating))
+    maximum_flight_run_s = _maximum_false_run(supported) / sample_rate_hz
+    phase_switches = int(np.count_nonzero(np.diff(trace.phase_code) != 0))
+    issues = [
+        ContactInferenceIssue(
+            code="SOURCE_COORDINATE_FRAME_UNSPECIFIED",
+            severity=AuditSeverity.WARNING,
+            observed=0.0,
+            threshold=1.0,
+        )
+    ]
+    if supported_ratio < thresholds.minimum_supported_ratio:
+        issues.append(
+            ContactInferenceIssue(
+                code="SUPPORT_COVERAGE_LOW",
+                severity=AuditSeverity.ERROR,
+                observed=supported_ratio,
+                threshold=thresholds.minimum_supported_ratio,
+            )
+        )
+    if maximum_flight_run_s > thresholds.maximum_flight_run_s:
+        issues.append(
+            ContactInferenceIssue(
+                code="FLIGHT_RUN_TOO_LONG",
+                severity=AuditSeverity.ERROR,
+                observed=maximum_flight_run_s,
+                threshold=thresholds.maximum_flight_run_s,
+            )
+        )
+    if skating_ratio > thresholds.maximum_skating_ratio:
+        issues.append(
+            ContactInferenceIssue(
+                code="FOOT_SKATING_RATIO_HIGH",
+                severity=AuditSeverity.ERROR,
+                observed=skating_ratio,
+                threshold=thresholds.maximum_skating_ratio,
+            )
+        )
+    if near_speed_p95 > thresholds.maximum_near_ground_speed_p95_m_s:
+        issues.append(
+            ContactInferenceIssue(
+                code="NEAR_GROUND_FOOT_SPEED_HIGH",
+                severity=AuditSeverity.ERROR,
+                observed=near_speed_p95,
+                threshold=thresholds.maximum_near_ground_speed_p95_m_s,
+            )
+        )
+    metrics: dict[str, float | int] = {
+        "frame_count": int(trace.phase_code.shape[0]),
+        "ground_height_m": trace.ground_height_m,
+        "supported_ratio": supported_ratio,
+        "left_contact_ratio": float(np.mean(trace.left_contact)),
+        "right_contact_ratio": float(np.mean(trace.right_contact)),
+        "double_support_ratio": float(np.mean(trace.left_contact & trace.right_contact)),
+        "flight_ratio": float(np.mean(~supported)),
+        "maximum_flight_run_s": maximum_flight_run_s,
+        "skating_ratio": skating_ratio,
+        "near_ground_foot_speed_p95_m_s": near_speed_p95,
+        "phase_switch_count": phase_switches,
+        "center_of_mass_height_min_m": float(np.min(trace.center_of_mass[:, 2])),
+        "center_of_mass_height_max_m": float(np.max(trace.center_of_mass[:, 2])),
+    }
+    return MotionDecodeContactAudit(
+        relative_path=result.relative_path,
+        source_file_hash=result.source_file_hash,
+        repair_manifest_hash=(
+            result.repair_manifest.manifest_hash if result.repair_manifest is not None else None
+        ),
+        episode_hash=trace.episode_hash,
+        trace_hash=trace.trace_hash,
+        metrics=metrics,
+        issues=tuple(issues),
+        upstream_q1=True,
+    )
+
+
+def _upstream_rejected_contact(
+    result: MotionDecodeRepairResult,
+) -> MotionDecodeContactAudit:
+    return MotionDecodeContactAudit(
+        relative_path=result.relative_path,
+        source_file_hash=result.source_file_hash,
+        repair_manifest_hash=None,
+        episode_hash=None,
+        trace_hash=None,
+        metrics=None,
+        issues=(
+            ContactInferenceIssue(
+                code="UPSTREAM_Q1_REQUIRED",
+                severity=AuditSeverity.ERROR,
+                observed=0.0,
+                threshold=1.0,
+            ),
+        ),
+        upstream_q1=False,
+    )
+
+
+def _maximum_false_run(values: np.ndarray) -> int:
+    longest = 0
+    current = 0
+    for value in values:
+        current = 0 if bool(value) else current + 1
+        longest = max(longest, current)
+    return longest
+
+
+__all__ = [
+    "CanonicalContactTrace",
+    "ContactInferenceIssue",
+    "ContactInferenceThresholds",
+    "MotionDecodeContactAudit",
+    "MotionDecodeContactBatch",
+    "MotionDecodeContactBundle",
+    "MotionDecodeContactReport",
+    "SupportPhase",
+    "infer_contact_trace",
+    "infer_motiondecode_contact_batch",
+    "infer_motiondecode_contacts",
+]

--- a/src/rosclaw/collective/sources/motiondecode/qualification.py
+++ b/src/rosclaw/collective/sources/motiondecode/qualification.py
@@ -1,0 +1,1017 @@
+"""Strict CPU MuJoCo qualification for canonical motion references."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+from collections import Counter
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.collective.contracts import LicenseDecision
+from rosclaw.collective.sources.motiondecode.audit import (
+    AuditSeverity,
+    MotionDecodeAuditThresholds,
+    MotionQualificationLevel,
+    load_g1_joint_contract,
+)
+from rosclaw.collective.sources.motiondecode.contact import (
+    CanonicalContactTrace,
+    ContactInferenceThresholds,
+    MotionDecodeContactAudit,
+    infer_motiondecode_contact_batch,
+)
+from rosclaw.collective.sources.motiondecode.manifest import MotionDecodeRegistration
+from rosclaw.collective.sources.motiondecode.parser import CanonicalMotionEpisode
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.simforge.tasks.g1_goalforge.concepts import (
+    G1_DDS_JOINT_NAMES,
+    G1_HARD_TORQUE_LIMITS,
+)
+
+_MAX_SCENE_BYTES = 20 * 1024 * 1024
+_HARD_FAILURES = frozenset(
+    {
+        "NONFINITE_PHYSICS",
+        "INCOMPLETE_PHYSICS_REPLAY",
+        "PELVIS_HEIGHT_FALL",
+        "NON_FOOT_FLOOR_CONTACT",
+        "TORQUE_LIMIT_EXCEEDED",
+        "MUJOCO_WARNING",
+    }
+)
+
+
+class PhysicsClipStatus(StrEnum):
+    BLOCKED_LICENSE = "blocked_license"
+    CONTACT_NOT_ELIGIBLE = "contact_not_eligible"
+    PHYSICS_EXECUTED = "physics_executed"
+
+
+@dataclass(frozen=True)
+class PhysicsQualificationThresholds:
+    minimum_duration_s: float = 1.0
+    minimum_pelvis_height_m: float = 0.45
+    maximum_joint_tracking_rmse_rad: float = 0.15
+    maximum_root_position_rmse_m: float = 0.25
+    maximum_root_orientation_rmse_rad: float = 0.35
+    maximum_torque_ratio: float = 1.001
+    maximum_torque_saturation_ratio: float = 0.10
+    maximum_support_slip_p95_m_s: float = 0.25
+    maximum_nonfoot_contact_steps: int = 0
+    maximum_frames: int = 10_000
+    maximum_simulation_seconds: float = 30.0
+
+    def __post_init__(self) -> None:
+        for value in vars(self).values():
+            if isinstance(value, bool) or not math.isfinite(value) or value < 0.0:
+                raise ValueError("physics qualification thresholds must be finite")
+        if self.minimum_duration_s <= 0.0 or self.minimum_pelvis_height_m <= 0.0:
+            raise ValueError("physics duration and pelvis height must be positive")
+        if not isinstance(self.maximum_nonfoot_contact_steps, int) or not isinstance(
+            self.maximum_frames, int
+        ):
+            raise ValueError("physics count thresholds must be integers")
+        if self.maximum_frames < 3:
+            raise ValueError("maximum_frames must retain at least three frames")
+
+    @property
+    def threshold_hash(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": "rosclaw.collective.motiondecode_physics_thresholds.v1",
+                **self.to_dict(),
+            }
+        )
+
+    def to_dict(self) -> dict[str, float | int]:
+        return dict(vars(self))
+
+
+@dataclass(frozen=True)
+class PhysicsQualificationIssue:
+    code: str
+    observed: float
+    threshold: float
+
+    def __post_init__(self) -> None:
+        if not self.code:
+            raise ValueError("physics qualification issue code must not be empty")
+        if not math.isfinite(self.observed) or not math.isfinite(self.threshold):
+            raise ValueError("physics qualification issue values must be finite")
+
+    @property
+    def hard_failure(self) -> bool:
+        return self.code in _HARD_FAILURES
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "severity": AuditSeverity.ERROR.value,
+            "observed": self.observed,
+            "threshold": self.threshold,
+            "hard_failure": self.hard_failure,
+        }
+
+
+@dataclass(frozen=True)
+class MotionPhysicsQualification:
+    episode_hash: str
+    contact_trace_hash: str
+    target_body_hash: str
+    target_model_file_hash: str
+    scene_file_hash: str
+    compiled_scene_hash: str
+    threshold_hash: str
+    qualification: MotionQualificationLevel
+    metrics: dict[str, float | int | bool]
+    issues: tuple[PhysicsQualificationIssue, ...]
+    root_alignment_m: tuple[float, float, float]
+    controller: str = "mujoco_model_position_reference_v1"
+    backend: str = "mujoco_cpu"
+    schema_version: str = "rosclaw.collective.motiondecode_physics_qualification.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("episode_hash", self.episode_hash),
+            ("contact_trace_hash", self.contact_trace_hash),
+            ("target_body_hash", self.target_body_hash),
+            ("target_model_file_hash", self.target_model_file_hash),
+            ("scene_file_hash", self.scene_file_hash),
+            ("compiled_scene_hash", self.compiled_scene_hash),
+            ("threshold_hash", self.threshold_hash),
+        ):
+            if not value.startswith("sha256:") or len(value) != 71:
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if self.backend != "mujoco_cpu" or self.controller != (
+            "mujoco_model_position_reference_v1"
+        ):
+            raise ValueError("physics qualification backend/controller is unsupported")
+        if self.qualification not in {
+            MotionQualificationLevel.Q1_KINEMATIC_ONLY,
+            MotionQualificationLevel.Q2_TRACKABLE_WITH_REPAIR,
+            MotionQualificationLevel.Q3_PHYSICS_TRACKABLE,
+        }:
+            raise ValueError("physics qualification level is unsupported")
+        if len(self.root_alignment_m) != 3 or not all(
+            math.isfinite(value) for value in self.root_alignment_m
+        ):
+            raise ValueError("physics root alignment must be finite")
+        if self.qualification is MotionQualificationLevel.Q3_PHYSICS_TRACKABLE and self.issues:
+            raise ValueError("Q3 physics qualification cannot contain gate failures")
+        if any(issue.hard_failure for issue in self.issues) and (
+            self.qualification is not MotionQualificationLevel.Q1_KINEMATIC_ONLY
+        ):
+            raise ValueError("hard physics failures must remain Q1")
+
+    @property
+    def qualification_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def physics_trackable(self) -> bool:
+        return self.qualification in {
+            MotionQualificationLevel.Q3_PHYSICS_TRACKABLE,
+            MotionQualificationLevel.Q4_ROBUST_TRACKABLE,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "episode_hash": self.episode_hash,
+            "contact_trace_hash": self.contact_trace_hash,
+            "target_body_hash": self.target_body_hash,
+            "target_model_file_hash": self.target_model_file_hash,
+            "scene_file_hash": self.scene_file_hash,
+            "compiled_scene_hash": self.compiled_scene_hash,
+            "threshold_hash": self.threshold_hash,
+            "backend": self.backend,
+            "controller": self.controller,
+            "qualification": self.qualification.value,
+            "metrics": self.metrics,
+            "issues": [issue.to_dict() for issue in self.issues],
+            "root_alignment_m": list(self.root_alignment_m),
+            "truth_level": "T1_CPU_MUJOCO",
+            "physics_trackable": self.physics_trackable,
+            "promotion_truth_eligible": False,
+            "hardware_authorized": False,
+        }
+
+
+@dataclass(frozen=True)
+class MotionDecodePhysicsClip:
+    relative_path: str
+    source_file_hash: str
+    contact_audit_hash: str
+    status: PhysicsClipStatus
+    qualification: MotionQualificationLevel
+    blocker_codes: tuple[str, ...]
+    result: MotionPhysicsQualification | None = None
+    schema_version: str = "rosclaw.collective.motiondecode_physics_clip.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("source_file_hash", self.source_file_hash),
+            ("contact_audit_hash", self.contact_audit_hash),
+        ):
+            if not value.startswith("sha256:") or len(value) != 71:
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not self.relative_path or not isinstance(self.status, PhysicsClipStatus):
+            raise ValueError("physics clip identity/status is invalid")
+        if not isinstance(self.qualification, MotionQualificationLevel):
+            raise ValueError("physics clip qualification is unknown")
+        if self.status is PhysicsClipStatus.PHYSICS_EXECUTED:
+            if self.result is None or self.result.qualification is not self.qualification:
+                raise ValueError("executed physics clip requires a matching result")
+        elif self.result is not None:
+            raise ValueError("non-executed physics clip cannot claim a result")
+
+    @property
+    def clip_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "relative_path": self.relative_path,
+            "source_file_hash": self.source_file_hash,
+            "contact_audit_hash": self.contact_audit_hash,
+            "status": self.status.value,
+            "qualification": self.qualification.value,
+            "blocker_codes": list(self.blocker_codes),
+            "result": self.result.to_dict() if self.result is not None else None,
+            "result_hash": (self.result.qualification_hash if self.result is not None else None),
+            "physics_step_count": (
+                int(self.result.metrics["physics_step_count"]) if self.result is not None else 0
+            ),
+            "training_eligible": False,
+            "hardware_authorized": False,
+        }
+
+
+@dataclass(frozen=True)
+class MotionDecodeQualificationReport:
+    registration_hash: str
+    source_manifest_hash: str
+    contact_report_hash: str
+    target_body_hash: str
+    target_model_file_hash: str
+    scene_file_hash: str
+    compiled_scene_hash: str
+    license_decision: LicenseDecision
+    thresholds: PhysicsQualificationThresholds
+    clips: tuple[MotionDecodePhysicsClip, ...]
+    schema_version: str = "rosclaw.collective.motiondecode_qualification_report.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("registration_hash", self.registration_hash),
+            ("source_manifest_hash", self.source_manifest_hash),
+            ("contact_report_hash", self.contact_report_hash),
+            ("target_body_hash", self.target_body_hash),
+            ("target_model_file_hash", self.target_model_file_hash),
+            ("scene_file_hash", self.scene_file_hash),
+            ("compiled_scene_hash", self.compiled_scene_hash),
+        ):
+            if not value.startswith("sha256:") or len(value) != 71:
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if not isinstance(self.license_decision, LicenseDecision):
+            raise ValueError("qualification report license decision is unknown")
+        if not isinstance(self.thresholds, PhysicsQualificationThresholds):
+            raise ValueError("qualification report thresholds are invalid")
+        clips = tuple(self.clips)
+        if any(not isinstance(clip, MotionDecodePhysicsClip) for clip in clips):
+            raise ValueError("qualification report contains an invalid clip")
+        paths = tuple(clip.relative_path for clip in clips)
+        if len(paths) != len(set(paths)) or paths != tuple(sorted(paths)):
+            raise ValueError("qualification report clips must be unique and sorted")
+        for clip in clips:
+            if clip.result is not None and (
+                clip.result.target_body_hash != self.target_body_hash
+                or clip.result.target_model_file_hash != self.target_model_file_hash
+                or clip.result.scene_file_hash != self.scene_file_hash
+                or clip.result.compiled_scene_hash != self.compiled_scene_hash
+                or clip.result.threshold_hash != self.thresholds.threshold_hash
+            ):
+                raise ValueError("physics result lineage does not match its report")
+        object.__setattr__(self, "clips", clips)
+
+    @property
+    def report_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def qualification_counts(self) -> dict[str, int]:
+        counts = Counter(clip.qualification.value for clip in self.clips)
+        return dict(sorted(counts.items()))
+
+    @property
+    def status_counts(self) -> dict[str, int]:
+        counts = Counter(clip.status.value for clip in self.clips)
+        return dict(sorted(counts.items()))
+
+    @property
+    def physics_executed_count(self) -> int:
+        return sum(clip.status is PhysicsClipStatus.PHYSICS_EXECUTED for clip in self.clips)
+
+    @property
+    def q3_count(self) -> int:
+        return sum(
+            clip.qualification is MotionQualificationLevel.Q3_PHYSICS_TRACKABLE
+            for clip in self.clips
+        )
+
+    @property
+    def physics_step_count(self) -> int:
+        return sum(
+            int(clip.result.metrics["physics_step_count"])
+            for clip in self.clips
+            if clip.result is not None
+        )
+
+    @property
+    def quality_commitment(self) -> str:
+        return canonical_hash(
+            {
+                "schema_version": "rosclaw.collective.motiondecode_physics_quality.v1",
+                "contact_report_hash": self.contact_report_hash,
+                "scene_file_hash": self.scene_file_hash,
+                "compiled_scene_hash": self.compiled_scene_hash,
+                "threshold_hash": self.thresholds.threshold_hash,
+                "clip_hashes": [clip.clip_hash for clip in self.clips],
+            }
+        )
+
+    @property
+    def training_blockers(self) -> list[str]:
+        blockers = [
+            "SOURCE_COORDINATE_FRAME_UNSPECIFIED",
+            "SYNCHRONIZED_BALL_POSE_ABSENT",
+            "ACTION_REWARD_TRANSITION_SEMANTICS_ABSENT",
+            "FRAME_LEVEL_CONTACT_TRACE_NOT_PERSISTED",
+        ]
+        if self.q3_count == 0:
+            blockers.insert(0, "NO_Q3_PHYSICS_TRACKABLE_CLIPS")
+        if self.physics_executed_count != len(self.clips):
+            blockers.insert(0, "PHYSICS_QUALIFICATION_PARTIAL")
+        if self.license_decision is not LicenseDecision.PERMITTED:
+            blockers.insert(0, "LICENSE_NOT_PERMITTED")
+        return blockers
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "registration_hash": self.registration_hash,
+            "source_manifest_hash": self.source_manifest_hash,
+            "contact_report_hash": self.contact_report_hash,
+            "target_body_hash": self.target_body_hash,
+            "target_model_file_hash": self.target_model_file_hash,
+            "scene_file_hash": self.scene_file_hash,
+            "compiled_scene_hash": self.compiled_scene_hash,
+            "license_decision": self.license_decision.value,
+            "thresholds": self.thresholds.to_dict(),
+            "threshold_hash": self.thresholds.threshold_hash,
+            "clips": [clip.to_dict() for clip in self.clips],
+            "clip_count": len(self.clips),
+            "status_counts": self.status_counts,
+            "qualification_counts": self.qualification_counts,
+            "physics_executed_count": self.physics_executed_count,
+            "physics_step_count": self.physics_step_count,
+            "q3_count": self.q3_count,
+            "quality_commitment": self.quality_commitment,
+            "backend": "mujoco_cpu",
+            "controller": "mujoco_model_position_reference_v1",
+            "physics_execution_authorized": (self.license_decision is LicenseDecision.PERMITTED),
+            "coordinate_frame_verified": False,
+            "training_eligible": False,
+            "training_blockers": self.training_blockers,
+            "promotion_truth_eligible": False,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+
+
+def qualify_motiondecode_snapshot(
+    registration: MotionDecodeRegistration,
+    dataset_root: Path,
+    *,
+    target_model_path: Path,
+    scene_path: Path,
+    expected_ingest_report_hash: str,
+    expected_repair_report_hash: str,
+    expected_contact_report_hash: str,
+    audit_thresholds: MotionDecodeAuditThresholds | None = None,
+    contact_thresholds: ContactInferenceThresholds | None = None,
+    physics_thresholds: PhysicsQualificationThresholds | None = None,
+) -> MotionDecodeQualificationReport:
+    """Replay contact evidence and run physics only when the source is permitted."""
+
+    selected_physics = physics_thresholds or PhysicsQualificationThresholds()
+    batch = infer_motiondecode_contact_batch(
+        registration,
+        dataset_root,
+        target_model_path=target_model_path,
+        expected_ingest_report_hash=expected_ingest_report_hash,
+        expected_repair_report_hash=expected_repair_report_hash,
+        audit_thresholds=audit_thresholds,
+        contact_thresholds=contact_thresholds,
+    )
+    if batch.report.report_hash != expected_contact_report_hash:
+        raise ValueError("contact report hash does not match replayed contact evidence")
+    joint_limits, _, target_model_hash = load_g1_joint_contract(target_model_path)
+    *_, scene_hash, compiled_scene_hash = _load_physics_scene(
+        scene_path,
+        expected_joint_limits=joint_limits,
+        expected_target_model_hash=target_model_hash,
+    )
+    contact_by_path = {clip.relative_path: clip for clip in batch.report.clips}
+    bundle_by_path = {bundle.relative_path: bundle for bundle in batch.bundles}
+    clips: list[MotionDecodePhysicsClip] = []
+    for contact in batch.report.clips:
+        if not contact.phase_segmentation_candidate:
+            clips.append(_contact_rejected_physics(contact))
+            continue
+        if registration.manifest.license_snapshot.decision is not LicenseDecision.PERMITTED:
+            clips.append(_license_blocked_physics(contact))
+            continue
+        bundle = bundle_by_path[contact.relative_path]
+        result = qualify_canonical_motion(
+            bundle.episode,
+            bundle.trace,
+            target_model_path=target_model_path,
+            scene_path=scene_path,
+            thresholds=selected_physics,
+        )
+        clips.append(
+            MotionDecodePhysicsClip(
+                relative_path=contact.relative_path,
+                source_file_hash=contact.source_file_hash,
+                contact_audit_hash=contact.audit_hash,
+                status=PhysicsClipStatus.PHYSICS_EXECUTED,
+                qualification=result.qualification,
+                blocker_codes=tuple(issue.code for issue in result.issues),
+                result=result,
+            )
+        )
+    if set(contact_by_path) != {clip.relative_path for clip in clips}:
+        raise ValueError("physics qualification did not cover every contact audit")
+    return MotionDecodeQualificationReport(
+        registration_hash=registration.registration_hash,
+        source_manifest_hash=registration.manifest.manifest_hash,
+        contact_report_hash=batch.report.report_hash,
+        target_body_hash=batch.report.target_body_hash,
+        target_model_file_hash=batch.report.target_model_file_hash,
+        scene_file_hash=scene_hash,
+        compiled_scene_hash=compiled_scene_hash,
+        license_decision=registration.manifest.license_snapshot.decision,
+        thresholds=selected_physics,
+        clips=tuple(clips),
+    )
+
+
+def qualify_canonical_motion(
+    episode: CanonicalMotionEpisode,
+    contact: CanonicalContactTrace,
+    *,
+    target_model_path: Path,
+    scene_path: Path,
+    thresholds: PhysicsQualificationThresholds | None = None,
+) -> MotionPhysicsQualification:
+    """Advance real CPU MuJoCo physics with the scene's position actuators."""
+
+    selected = thresholds or PhysicsQualificationThresholds()
+    if contact.episode_hash != episode.episode_hash:
+        raise ValueError("contact trace does not match the motion episode")
+    frames = int(episode.time.shape[0])
+    if frames > selected.maximum_frames:
+        raise ValueError("motion exceeds the bounded physics frame budget")
+    if episode.duration_seconds > selected.maximum_simulation_seconds:
+        raise ValueError("motion exceeds the bounded physics duration")
+    joint_limits, target_body_hash, target_model_hash = load_g1_joint_contract(target_model_path)
+    if episode.target_body_hash != target_body_hash:
+        raise ValueError("motion episode target body does not match physics model")
+    if contact.target_model_file_hash != target_model_hash:
+        raise ValueError("contact trace target model does not match physics model")
+    (
+        model,
+        data,
+        qpos_addresses,
+        dof_addresses,
+        left_site,
+        right_site,
+        floor_geom,
+        allowed_floor_bodies,
+        scene_hash,
+        compiled_scene_hash,
+    ) = _load_physics_scene(
+        scene_path,
+        expected_joint_limits=joint_limits,
+        expected_target_model_hash=target_model_hash,
+    )
+    aligned_root = episode.root_position.copy()
+    alignment = (
+        -float(aligned_root[0, 0]),
+        -float(aligned_root[0, 1]),
+        -float(contact.ground_height_m),
+    )
+    aligned_root[:, 0] += alignment[0]
+    aligned_root[:, 1] += alignment[1]
+    aligned_root[:, 2] += alignment[2]
+    data.qpos[:3] = aligned_root[0]
+    data.qpos[3:7] = _unit_quaternion(episode.root_quaternion[0])
+    data.qpos[qpos_addresses] = episode.joint_position[0]
+    data.qvel[:] = 0.0
+    import mujoco
+
+    mujoco.mj_forward(model, data)
+    joint_errors: list[np.ndarray] = []
+    root_errors: list[np.ndarray] = []
+    orientation_errors: list[float] = []
+    left_positions: list[np.ndarray] = []
+    right_positions: list[np.ndarray] = []
+    minimum_pelvis_height = float(data.qpos[2])
+    maximum_torque_ratio = 0.0
+    saturated_steps = 0
+    nonfoot_contact_steps = 0
+    physics_steps = 0
+    finite = True
+    completed_frames = 0
+    torque_limits = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float64)
+    for frame in range(frames):
+        data.ctrl[:] = episode.joint_position[frame]
+        target_time = float(frame + 1) / episode.sample_rate_hz
+        while data.time + 1e-12 < target_time:
+            mujoco.mj_step(model, data)
+            physics_steps += 1
+            if not np.all(np.isfinite(data.qpos)) or not np.all(np.isfinite(data.qvel)):
+                finite = False
+                break
+            torque = np.abs(data.qfrc_actuator[dof_addresses])
+            ratio = float(np.max(torque / torque_limits))
+            maximum_torque_ratio = max(maximum_torque_ratio, ratio)
+            saturated_steps += int(ratio >= 0.999)
+            minimum_pelvis_height = min(minimum_pelvis_height, float(data.qpos[2]))
+            nonfoot_contact_steps += int(
+                _has_nonfoot_floor_contact(
+                    model,
+                    data,
+                    floor_geom=floor_geom,
+                    allowed_body_ids=allowed_floor_bodies,
+                )
+            )
+        if not finite:
+            break
+        actual_joint = np.asarray(data.qpos[qpos_addresses], dtype=np.float64)
+        joint_errors.append(actual_joint - episode.joint_position[frame])
+        root_errors.append(np.asarray(data.qpos[:3]) - aligned_root[frame])
+        orientation_errors.append(
+            _quaternion_distance(
+                np.asarray(data.qpos[3:7]),
+                episode.root_quaternion[frame],
+            )
+        )
+        left_positions.append(np.asarray(data.site_xpos[left_site]).copy())
+        right_positions.append(np.asarray(data.site_xpos[right_site]).copy())
+        completed_frames += 1
+    joint_rmse = _array_rmse(joint_errors)
+    root_rmse = _array_rmse(root_errors)
+    orientation_rmse = (
+        float(np.sqrt(np.mean(np.square(orientation_errors)))) if orientation_errors else math.inf
+    )
+    saturation_ratio = saturated_steps / max(1, physics_steps)
+    support_slip_p95 = _support_slip_p95(
+        left_positions,
+        right_positions,
+        contact,
+        completed_frames=completed_frames,
+        sample_rate_hz=episode.sample_rate_hz,
+    )
+    warning_count = int(np.sum(data.warning.number))
+    issues = _physics_issues(
+        finite=finite,
+        completed_frames=completed_frames,
+        expected_frames=frames,
+        duration_s=episode.duration_seconds,
+        minimum_pelvis_height=minimum_pelvis_height,
+        joint_rmse=joint_rmse,
+        root_rmse=root_rmse,
+        orientation_rmse=orientation_rmse,
+        maximum_torque_ratio=maximum_torque_ratio,
+        saturation_ratio=saturation_ratio,
+        support_slip_p95=support_slip_p95,
+        nonfoot_contact_steps=nonfoot_contact_steps,
+        warning_count=warning_count,
+        thresholds=selected,
+    )
+    if any(issue.hard_failure for issue in issues):
+        qualification = MotionQualificationLevel.Q1_KINEMATIC_ONLY
+    elif issues:
+        qualification = MotionQualificationLevel.Q2_TRACKABLE_WITH_REPAIR
+    else:
+        qualification = MotionQualificationLevel.Q3_PHYSICS_TRACKABLE
+    metrics: dict[str, float | int | bool] = {
+        "frame_count": frames,
+        "completed_frame_count": completed_frames,
+        "physics_step_count": physics_steps,
+        "simulation_duration_s": float(data.time),
+        "reference_duration_s": episode.duration_seconds,
+        "finite": finite,
+        "minimum_pelvis_height_m": minimum_pelvis_height,
+        "joint_tracking_rmse_rad": joint_rmse,
+        "root_position_rmse_m": root_rmse,
+        "root_orientation_rmse_rad": orientation_rmse,
+        "maximum_torque_ratio": maximum_torque_ratio,
+        "torque_saturation_ratio": saturation_ratio,
+        "support_slip_p95_m_s": support_slip_p95,
+        "nonfoot_floor_contact_steps": nonfoot_contact_steps,
+        "mujoco_warning_count": warning_count,
+    }
+    return MotionPhysicsQualification(
+        episode_hash=episode.episode_hash,
+        contact_trace_hash=contact.trace_hash,
+        target_body_hash=target_body_hash,
+        target_model_file_hash=target_model_hash,
+        scene_file_hash=scene_hash,
+        compiled_scene_hash=compiled_scene_hash,
+        threshold_hash=selected.threshold_hash,
+        qualification=qualification,
+        metrics=metrics,
+        issues=tuple(issues),
+        root_alignment_m=alignment,
+    )
+
+
+def hash_scene_file(scene_path: Path) -> str:
+    resolved = scene_path.expanduser().resolve(strict=True)
+    if not resolved.is_file() or resolved.is_symlink():
+        raise ValueError("MuJoCo scene must be a non-symlink regular file")
+    payload = _read_stable_scene(resolved)
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _load_physics_scene(
+    scene_path: Path,
+    *,
+    expected_joint_limits: dict[str, tuple[float, float]],
+    expected_target_model_hash: str,
+) -> tuple[
+    Any,
+    Any,
+    np.ndarray,
+    np.ndarray,
+    int,
+    int,
+    int,
+    frozenset[int],
+    str,
+    str,
+]:
+    scene_hash = hash_scene_file(scene_path)
+    try:
+        import mujoco
+    except ImportError as exc:
+        raise ValueError("MuJoCo is required for physics qualification") from exc
+    resolved = scene_path.expanduser().resolve(strict=True)
+    included_model = resolved.parent / "g1.xml"
+    if (
+        not included_model.is_file()
+        or included_model.is_symlink()
+        or "sha256:" + hashlib.sha256(_read_stable_scene(included_model)).hexdigest()
+        != expected_target_model_hash
+    ):
+        raise ValueError("physics scene does not include the committed target G1 model")
+    model = mujoco.MjModel.from_xml_path(str(resolved))
+    data = mujoco.MjData(model)
+    if model.nu != len(G1_DDS_JOINT_NAMES):
+        raise ValueError("physics scene must define exactly 29 G1 actuators")
+    qpos_addresses: list[int] = []
+    dof_addresses: list[int] = []
+    actuator_names: list[str] = []
+    for index, name in enumerate(G1_DDS_JOINT_NAMES):
+        joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+        actuator_name = mujoco.mj_id2name(
+            model,
+            mujoco.mjtObj.mjOBJ_ACTUATOR,
+            index,
+        )
+        if joint_id < 0 or actuator_name != name:
+            raise ValueError("physics scene G1 joint/actuator order is incompatible")
+        qpos_addresses.append(int(model.jnt_qposadr[joint_id]))
+        dof_addresses.append(int(model.jnt_dofadr[joint_id]))
+        actuator_names.append(str(actuator_name))
+        observed = tuple(float(item) for item in model.jnt_range[joint_id])
+        expected = expected_joint_limits[name]
+        if not np.allclose(observed, expected, atol=1e-9, rtol=0.0):
+            raise ValueError(f"physics scene joint range mismatch: {name}")
+    if tuple(actuator_names) != G1_DDS_JOINT_NAMES:
+        raise ValueError("physics scene actuator names do not match Unitree HG order")
+    left_site = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "left_foot")
+    right_site = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "right_foot")
+    floor_geom = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "floor")
+    allowed_bodies = frozenset(
+        mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+        for name in ("left_ankle_roll_link", "right_ankle_roll_link")
+    )
+    if (
+        left_site < 0
+        or right_site < 0
+        or floor_geom < 0
+        or any(item < 0 for item in allowed_bodies)
+    ):
+        raise ValueError("physics scene lacks floor or canonical G1 foot contracts")
+    return (
+        model,
+        data,
+        np.asarray(qpos_addresses, dtype=np.int64),
+        np.asarray(dof_addresses, dtype=np.int64),
+        int(left_site),
+        int(right_site),
+        int(floor_geom),
+        allowed_bodies,
+        scene_hash,
+        _compiled_model_hash(model),
+    )
+
+
+def _compiled_model_hash(model: Any) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"rosclaw.collective.mujoco_compiled_scene.v1")
+    for label, value in (
+        ("body_mass", model.body_mass),
+        ("body_inertia", model.body_inertia),
+        ("body_pos", model.body_pos),
+        ("body_quat", model.body_quat),
+        ("jnt_type", model.jnt_type),
+        ("jnt_axis", model.jnt_axis),
+        ("jnt_pos", model.jnt_pos),
+        ("jnt_range", model.jnt_range),
+        ("dof_armature", model.dof_armature),
+        ("dof_damping", model.dof_damping),
+        ("dof_frictionloss", model.dof_frictionloss),
+        ("geom_type", model.geom_type),
+        ("geom_bodyid", model.geom_bodyid),
+        ("geom_size", model.geom_size),
+        ("geom_pos", model.geom_pos),
+        ("geom_quat", model.geom_quat),
+        ("geom_friction", model.geom_friction),
+        ("geom_condim", model.geom_condim),
+        ("mesh_vert", model.mesh_vert),
+        ("mesh_face", model.mesh_face),
+        ("actuator_trnid", model.actuator_trnid),
+        ("actuator_gear", model.actuator_gear),
+        ("actuator_gainprm", model.actuator_gainprm),
+        ("actuator_biasprm", model.actuator_biasprm),
+        ("actuator_ctrlrange", model.actuator_ctrlrange),
+        ("actuator_forcerange", model.actuator_forcerange),
+    ):
+        array = np.ascontiguousarray(value)
+        digest.update(label.encode("ascii"))
+        digest.update(str(array.dtype).encode("ascii"))
+        digest.update(np.asarray(array.shape, dtype="<i8").tobytes())
+        digest.update(array.tobytes())
+    digest.update(
+        np.asarray(
+            [
+                model.opt.timestep,
+                *model.opt.gravity,
+                float(model.opt.integrator),
+            ],
+            dtype="<f8",
+        ).tobytes()
+    )
+    return "sha256:" + digest.hexdigest()
+
+
+def _has_nonfoot_floor_contact(
+    model: Any,
+    data: Any,
+    *,
+    floor_geom: int,
+    allowed_body_ids: frozenset[int],
+) -> bool:
+    for index in range(data.ncon):
+        contact = data.contact[index]
+        if contact.geom1 == floor_geom:
+            other = int(contact.geom2)
+        elif contact.geom2 == floor_geom:
+            other = int(contact.geom1)
+        else:
+            continue
+        if int(model.geom_bodyid[other]) not in allowed_body_ids:
+            return True
+    return False
+
+
+def _support_slip_p95(
+    left_positions: list[np.ndarray],
+    right_positions: list[np.ndarray],
+    contact: CanonicalContactTrace,
+    *,
+    completed_frames: int,
+    sample_rate_hz: float,
+) -> float:
+    if completed_frames < 3:
+        return math.inf
+    left = np.asarray(left_positions, dtype=np.float64)
+    right = np.asarray(right_positions, dtype=np.float64)
+    left_speed = np.linalg.norm(
+        np.gradient(left, 1.0 / sample_rate_hz, axis=0, edge_order=2),
+        axis=1,
+    )
+    right_speed = np.linalg.norm(
+        np.gradient(right, 1.0 / sample_rate_hz, axis=0, edge_order=2),
+        axis=1,
+    )
+    samples = np.concatenate(
+        (
+            left_speed[contact.left_contact[:completed_frames]],
+            right_speed[contact.right_contact[:completed_frames]],
+        )
+    )
+    return float(np.quantile(samples, 0.95)) if samples.size else math.inf
+
+
+def _physics_issues(
+    *,
+    finite: bool,
+    completed_frames: int,
+    expected_frames: int,
+    duration_s: float,
+    minimum_pelvis_height: float,
+    joint_rmse: float,
+    root_rmse: float,
+    orientation_rmse: float,
+    maximum_torque_ratio: float,
+    saturation_ratio: float,
+    support_slip_p95: float,
+    nonfoot_contact_steps: int,
+    warning_count: int,
+    thresholds: PhysicsQualificationThresholds,
+) -> list[PhysicsQualificationIssue]:
+    values = (
+        (
+            not finite,
+            "NONFINITE_PHYSICS",
+            float(not finite),
+            0.0,
+        ),
+        (
+            completed_frames != expected_frames,
+            "INCOMPLETE_PHYSICS_REPLAY",
+            float(completed_frames),
+            float(expected_frames),
+        ),
+        (
+            duration_s < thresholds.minimum_duration_s,
+            "REFERENCE_DURATION_TOO_SHORT",
+            duration_s,
+            thresholds.minimum_duration_s,
+        ),
+        (
+            minimum_pelvis_height < thresholds.minimum_pelvis_height_m,
+            "PELVIS_HEIGHT_FALL",
+            minimum_pelvis_height,
+            thresholds.minimum_pelvis_height_m,
+        ),
+        (
+            joint_rmse > thresholds.maximum_joint_tracking_rmse_rad,
+            "JOINT_TRACKING_ERROR_HIGH",
+            joint_rmse,
+            thresholds.maximum_joint_tracking_rmse_rad,
+        ),
+        (
+            root_rmse > thresholds.maximum_root_position_rmse_m,
+            "ROOT_POSITION_ERROR_HIGH",
+            root_rmse,
+            thresholds.maximum_root_position_rmse_m,
+        ),
+        (
+            orientation_rmse > thresholds.maximum_root_orientation_rmse_rad,
+            "ROOT_ORIENTATION_ERROR_HIGH",
+            orientation_rmse,
+            thresholds.maximum_root_orientation_rmse_rad,
+        ),
+        (
+            maximum_torque_ratio > thresholds.maximum_torque_ratio,
+            "TORQUE_LIMIT_EXCEEDED",
+            maximum_torque_ratio,
+            thresholds.maximum_torque_ratio,
+        ),
+        (
+            saturation_ratio > thresholds.maximum_torque_saturation_ratio,
+            "TORQUE_SATURATION_HIGH",
+            saturation_ratio,
+            thresholds.maximum_torque_saturation_ratio,
+        ),
+        (
+            support_slip_p95 > thresholds.maximum_support_slip_p95_m_s,
+            "SUPPORT_SLIP_HIGH",
+            support_slip_p95,
+            thresholds.maximum_support_slip_p95_m_s,
+        ),
+        (
+            nonfoot_contact_steps > thresholds.maximum_nonfoot_contact_steps,
+            "NON_FOOT_FLOOR_CONTACT",
+            float(nonfoot_contact_steps),
+            float(thresholds.maximum_nonfoot_contact_steps),
+        ),
+        (
+            warning_count > 0,
+            "MUJOCO_WARNING",
+            float(warning_count),
+            0.0,
+        ),
+    )
+    return [
+        PhysicsQualificationIssue(code=code, observed=observed, threshold=threshold)
+        for failed, code, observed, threshold in values
+        if failed
+    ]
+
+
+def _contact_rejected_physics(
+    contact: MotionDecodeContactAudit,
+) -> MotionDecodePhysicsClip:
+    qualification = (
+        MotionQualificationLevel.Q1_KINEMATIC_ONLY
+        if contact.upstream_q1
+        else MotionQualificationLevel.Q0_INVALID
+    )
+    return MotionDecodePhysicsClip(
+        relative_path=contact.relative_path,
+        source_file_hash=contact.source_file_hash,
+        contact_audit_hash=contact.audit_hash,
+        status=PhysicsClipStatus.CONTACT_NOT_ELIGIBLE,
+        qualification=qualification,
+        blocker_codes=tuple(
+            issue.code for issue in contact.issues if issue.severity is AuditSeverity.ERROR
+        ),
+    )
+
+
+def _license_blocked_physics(
+    contact: MotionDecodeContactAudit,
+) -> MotionDecodePhysicsClip:
+    return MotionDecodePhysicsClip(
+        relative_path=contact.relative_path,
+        source_file_hash=contact.source_file_hash,
+        contact_audit_hash=contact.audit_hash,
+        status=PhysicsClipStatus.BLOCKED_LICENSE,
+        qualification=MotionQualificationLevel.Q1_KINEMATIC_ONLY,
+        blocker_codes=("LICENSE_NOT_PERMITTED",),
+    )
+
+
+def _unit_quaternion(value: np.ndarray) -> np.ndarray:
+    norm = float(np.linalg.norm(value))
+    if not math.isfinite(norm) or norm <= 0.0:
+        raise ValueError("reference quaternion is invalid")
+    return np.asarray(value, dtype=np.float64) / norm
+
+
+def _quaternion_distance(first: np.ndarray, second: np.ndarray) -> float:
+    left = _unit_quaternion(first)
+    right = _unit_quaternion(second)
+    cosine = float(np.clip(abs(np.dot(left, right)), 0.0, 1.0))
+    return 2.0 * math.acos(cosine)
+
+
+def _array_rmse(values: list[np.ndarray]) -> float:
+    if not values:
+        return math.inf
+    array = np.asarray(values, dtype=np.float64)
+    return float(np.sqrt(np.mean(np.square(array))))
+
+
+def _read_stable_scene(path: Path) -> bytes:
+    with path.open("rb") as handle:
+        before = os.fstat(handle.fileno())
+        payload = handle.read(_MAX_SCENE_BYTES + 1)
+        after = os.fstat(handle.fileno())
+    if (
+        before.st_ino != after.st_ino
+        or before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+    ):
+        raise ValueError("MuJoCo scene changed while it was read")
+    if len(payload) > _MAX_SCENE_BYTES:
+        raise ValueError("MuJoCo scene exceeds the 20 MB safety limit")
+    return payload
+
+
+__all__ = [
+    "MotionDecodePhysicsClip",
+    "MotionDecodeQualificationReport",
+    "MotionPhysicsQualification",
+    "PhysicsClipStatus",
+    "PhysicsQualificationIssue",
+    "PhysicsQualificationThresholds",
+    "hash_scene_file",
+    "qualify_canonical_motion",
+    "qualify_motiondecode_snapshot",
+]

--- a/tests/collective/test_motiondecode_contact.py
+++ b/tests/collective/test_motiondecode_contact.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from rosclaw.collective.cli import dispatch_collective_argv
+from rosclaw.collective.contracts import LicenseDecision, LicenseUse
+from rosclaw.collective.sources.motiondecode.audit import (
+    MotionQualificationLevel,
+    audit_motiondecode_snapshot,
+)
+from rosclaw.collective.sources.motiondecode.contact import (
+    ContactInferenceThresholds,
+    infer_motiondecode_contact_batch,
+    infer_motiondecode_contacts,
+)
+from rosclaw.collective.sources.motiondecode.joint_mapping import (
+    MOTIONDECODE_ROOT_COLUMNS,
+)
+from rosclaw.collective.sources.motiondecode.manifest import (
+    MotionDecodeRegistration,
+    register_motiondecode_source,
+)
+from rosclaw.collective.sources.motiondecode.qualification import (
+    PhysicsClipStatus,
+    qualify_canonical_motion,
+    qualify_motiondecode_snapshot,
+)
+from rosclaw.collective.sources.motiondecode.repair import (
+    repair_motiondecode_snapshot,
+)
+from rosclaw.collective.sources.motiondecode.taxonomy import (
+    MOTIONDECODE_INDEX_COLUMNS,
+    MotionFamily,
+)
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_DDS_JOINT_NAMES
+
+ROOT = Path(__file__).parents[2]
+G1_MODEL = ROOT / "e-urdf-zoo/g1/robot.mjcf.xml"
+G1_SCENE = ROOT / "e-urdf-zoo/g1/scene.xml"
+REVISION = "c460808e801b35c683eb4cf4c8338ce61481a9bb"
+
+
+def _dataset(
+    root: Path,
+    *,
+    root_step_m: float = 0.0,
+    frames: int = 12,
+    quaternion: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
+    license_payload: bytes = b"",
+) -> None:
+    metadata = root / "metadata"
+    sample_dir = root / "samples/3.3.Ball_Game_Interaction/3.3.1.Football"
+    metadata.mkdir(parents=True)
+    sample_dir.mkdir(parents=True)
+    with (metadata / "index.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(MOTIONDECODE_INDEX_COLUMNS)
+        writer.writerow(
+            (
+                "3.3.1",
+                "Ball_Game_Interaction",
+                "Football",
+                "Instep_Kick",
+                "csv",
+                "Unitree_G1",
+            )
+        )
+    (root / "LICENSE").write_bytes(license_payload)
+    header = MOTIONDECODE_ROOT_COLUMNS + tuple(f"dof_{name}(rad)" for name in G1_DDS_JOINT_NAMES)
+    with (sample_dir / "contact.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        for frame in range(frames):
+            writer.writerow(
+                [
+                    root_step_m * frame,
+                    0.0,
+                    0.793,
+                    *quaternion,
+                    *([0.0] * len(G1_DDS_JOINT_NAMES)),
+                ]
+            )
+
+
+def _registration(
+    root: Path,
+    *,
+    license_decision: LicenseDecision = LicenseDecision.PENDING,
+) -> MotionDecodeRegistration:
+    return register_motiondecode_source(
+        root,
+        revision=REVISION,
+        requested_use=LicenseUse.RESEARCH_NONCOMMERCIAL,
+        license_decision=license_decision,
+        terms_path=root / "LICENSE",
+        terms_uri=(f"https://huggingface.co/datasets/CMRobot/MotionDecode/blob/{REVISION}/LICENSE"),
+        families=(MotionFamily.FOOTBALL,),
+        limit=40,
+    )
+
+
+def _reports(
+    root: Path,
+    *,
+    license_decision: LicenseDecision = LicenseDecision.PENDING,
+) -> tuple[MotionDecodeRegistration, object, object]:
+    registration = _registration(root, license_decision=license_decision)
+    ingest = audit_motiondecode_snapshot(
+        registration,
+        root,
+        target_model_path=G1_MODEL,
+    )
+    repair = repair_motiondecode_snapshot(
+        registration,
+        root,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=ingest.report_hash,
+    )
+    return registration, ingest, repair
+
+
+def test_static_g1_reference_yields_deterministic_double_support(
+    tmp_path: Path,
+) -> None:
+    _dataset(tmp_path)
+    registration, ingest, repair = _reports(tmp_path)
+
+    first = infer_motiondecode_contacts(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=ingest.report_hash,
+        expected_repair_report_hash=repair.report_hash,
+    )
+    second = infer_motiondecode_contacts(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=ingest.report_hash,
+        expected_repair_report_hash=repair.report_hash,
+    )
+
+    assert first.report_hash == second.report_hash
+    assert first.inferred_count == 1
+    assert first.phase_candidate_count == 1
+    clip = first.clips[0]
+    assert clip.trace_hash is not None
+    assert clip.metrics is not None
+    assert clip.metrics["supported_ratio"] == pytest.approx(1.0)
+    assert clip.metrics["double_support_ratio"] == pytest.approx(1.0)
+    assert clip.metrics["maximum_flight_run_s"] == 0.0
+    assert clip.phase_segmentation_candidate is True
+    result = first.to_dict()
+    assert result["frame_level_trace_persisted"] is False
+    assert result["eligibility"]["mujoco_qualification_authorized"] is False
+    assert result["training_eligible"] is False
+    assert "LICENSE_NOT_PERMITTED" in result["training_blockers"]
+
+
+def test_fast_near_ground_slide_is_preserved_as_a_contact_counterexample(
+    tmp_path: Path,
+) -> None:
+    _dataset(tmp_path, root_step_m=0.01)
+    registration, ingest, repair = _reports(tmp_path)
+
+    report = infer_motiondecode_contacts(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=ingest.report_hash,
+        expected_repair_report_hash=repair.report_hash,
+    )
+
+    assert report.inferred_count == 1
+    assert report.phase_candidate_count == 0
+    codes = {issue.code for issue in report.clips[0].issues}
+    assert "SUPPORT_COVERAGE_LOW" in codes
+    assert "FOOT_SKATING_RATIO_HIGH" in codes
+    assert "NEAR_GROUND_FOOT_SPEED_HIGH" in codes
+
+
+def test_contact_threshold_contract_rejects_weakened_hysteresis() -> None:
+    with pytest.raises(ValueError, match="enter height"):
+        ContactInferenceThresholds(
+            contact_enter_height_m=0.05,
+            contact_exit_height_m=0.04,
+        )
+    with pytest.raises(ValueError, match="frame thresholds"):
+        ContactInferenceThresholds(minimum_contact_frames=1.5)  # type: ignore[arg-type]
+
+
+def test_contact_replays_the_exact_repair_commitment(tmp_path: Path) -> None:
+    _dataset(tmp_path)
+    registration, ingest, _ = _reports(tmp_path)
+
+    with pytest.raises(ValueError, match="repair report hash"):
+        infer_motiondecode_contacts(
+            registration,
+            tmp_path,
+            target_model_path=G1_MODEL,
+            expected_ingest_report_hash=ingest.report_hash,
+            expected_repair_report_hash="sha256:" + "0" * 64,
+        )
+
+
+def test_pending_license_blocks_physics_before_any_mujoco_step(
+    tmp_path: Path,
+) -> None:
+    _dataset(tmp_path, frames=240)
+    registration, ingest, repair = _reports(tmp_path)
+    contact = infer_motiondecode_contacts(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=ingest.report_hash,
+        expected_repair_report_hash=repair.report_hash,
+    )
+
+    report = qualify_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        scene_path=G1_SCENE,
+        expected_ingest_report_hash=ingest.report_hash,
+        expected_repair_report_hash=repair.report_hash,
+        expected_contact_report_hash=contact.report_hash,
+    )
+
+    assert report.physics_executed_count == 0
+    assert report.physics_step_count == 0
+    assert report.q3_count == 0
+    assert report.clips[0].status is PhysicsClipStatus.BLOCKED_LICENSE
+    assert report.clips[0].blocker_codes == ("LICENSE_NOT_PERMITTED",)
+
+
+def test_permitted_static_reference_advances_physics_and_reaches_q3(
+    tmp_path: Path,
+) -> None:
+    _dataset(
+        tmp_path,
+        frames=240,
+        license_payload=b"explicit synthetic research permission",
+    )
+    registration, ingest, repair = _reports(
+        tmp_path,
+        license_decision=LicenseDecision.PERMITTED,
+    )
+    contact = infer_motiondecode_contacts(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=ingest.report_hash,
+        expected_repair_report_hash=repair.report_hash,
+    )
+
+    report = qualify_motiondecode_snapshot(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        scene_path=G1_SCENE,
+        expected_ingest_report_hash=ingest.report_hash,
+        expected_repair_report_hash=repair.report_hash,
+        expected_contact_report_hash=contact.report_hash,
+    )
+
+    assert report.physics_executed_count == 1
+    assert report.physics_step_count >= 900
+    assert report.q3_count == 1
+    result = report.clips[0].result
+    assert result is not None
+    assert result.qualification is MotionQualificationLevel.Q3_PHYSICS_TRACKABLE
+    assert result.metrics["finite"] is True
+    assert result.metrics["minimum_pelvis_height_m"] > 0.75
+    assert result.metrics["nonfoot_floor_contact_steps"] == 0
+
+
+def test_sideways_reference_is_a_hard_q1_physics_failure(tmp_path: Path) -> None:
+    _dataset(
+        tmp_path,
+        frames=240,
+        quaternion=(2**-0.5, 0.0, 2**-0.5, 0.0),
+        license_payload=b"explicit synthetic research permission",
+    )
+    registration, ingest, repair = _reports(
+        tmp_path,
+        license_decision=LicenseDecision.PERMITTED,
+    )
+    batch = infer_motiondecode_contact_batch(
+        registration,
+        tmp_path,
+        target_model_path=G1_MODEL,
+        expected_ingest_report_hash=ingest.report_hash,
+        expected_repair_report_hash=repair.report_hash,
+    )
+    bundle = batch.bundles[0]
+
+    result = qualify_canonical_motion(
+        bundle.episode,
+        bundle.trace,
+        target_model_path=G1_MODEL,
+        scene_path=G1_SCENE,
+    )
+
+    assert result.qualification is MotionQualificationLevel.Q1_KINEMATIC_ONLY
+    codes = {issue.code for issue in result.issues}
+    assert "PELVIS_HEIGHT_FALL" in codes or "NON_FOOT_FLOOR_CONTACT" in codes
+    assert result.metrics["physics_step_count"] > 0
+
+
+def test_cli_contact_receipt_contains_no_frame_level_labels(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dataset = tmp_path / "dataset"
+    _dataset(dataset)
+    registration, ingest, repair = _reports(dataset)
+    registration_path = tmp_path / "registration.json"
+    ingest_path = tmp_path / "ingest.json"
+    repair_path = tmp_path / "repair.json"
+    output_path = tmp_path / "contact.json"
+    qualification_path = tmp_path / "qualification.json"
+    registration_path.write_text(
+        json.dumps(
+            {
+                "registration": registration.to_dict(),
+                "registration_hash": registration.registration_hash,
+            }
+        ),
+        encoding="utf-8",
+    )
+    ingest_path.write_text(
+        json.dumps({"report": ingest.to_dict(), "report_hash": ingest.report_hash}),
+        encoding="utf-8",
+    )
+    repair_path.write_text(
+        json.dumps({"report": repair.to_dict(), "report_hash": repair.report_hash}),
+        encoding="utf-8",
+    )
+
+    assert (
+        dispatch_collective_argv(
+            [
+                "collective",
+                "contact",
+                "motiondecode",
+                "--registration",
+                str(registration_path),
+                "--ingest-report",
+                str(ingest_path),
+                "--repair-report",
+                str(repair_path),
+                "--dataset-root",
+                str(dataset),
+                "--target-model",
+                str(G1_MODEL),
+                "--output",
+                str(output_path),
+                "--source-checkout",
+                str(ROOT),
+            ]
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["inferred_count"] == 1
+    assert receipt["phase_candidate_count"] == 1
+    assert receipt["frame_level_trace_persisted"] is False
+    artifact = json.loads(output_path.read_text(encoding="utf-8"))
+    assert artifact["report_hash"] == canonical_hash(artifact["report"])
+    serialized = output_path.read_text(encoding="utf-8")
+    assert '"left_contact"' not in serialized
+    assert '"right_contact"' not in serialized
+    assert '"phase_code"' not in serialized
+
+    assert (
+        dispatch_collective_argv(
+            [
+                "collective",
+                "qualify",
+                "motiondecode",
+                "--registration",
+                str(registration_path),
+                "--ingest-report",
+                str(ingest_path),
+                "--repair-report",
+                str(repair_path),
+                "--contact-report",
+                str(output_path),
+                "--dataset-root",
+                str(dataset),
+                "--target-model",
+                str(G1_MODEL),
+                "--scene",
+                str(G1_SCENE),
+                "--output",
+                str(qualification_path),
+                "--source-checkout",
+                str(ROOT),
+            ]
+        )
+        == 1
+    )
+    qualification_receipt = json.loads(capsys.readouterr().out)
+    assert qualification_receipt["physics_executed_count"] == 0
+    assert qualification_receipt["physics_step_count"] == 0
+    assert qualification_receipt["q3_count"] == 0
+    assert qualification_receipt["hardware_authorized"] is False


### PR DESCRIPTION
## Summary

- replay exact repaired MotionDecode Q1 episodes into deterministic, read-only G1 foot-contact, COM, and support-phase traces
- add strict CPU MuJoCo qualification with license gating, scene/compiled-model commitments, fall/contact/torque/tracking/slip gates, and Q1/Q2/Q3 outcomes
- expose content-addressed `collective contact motiondecode` and `collective qualify motiondecode` CLI stages without persisting frame-level traces or authorizing training/hardware
- document the fail-closed workflow and add synthetic positive/negative controls

## Why

MotionDecode source qualification previously stopped at kinematic Q1. ROSClaw
needed a reproducible bridge from repaired motion references to contact-phase
discovery and real physics evidence, while keeping unverified licensing,
source frames, and absent ball/action semantics from becoming training or
activation authority.

## Evidence

Official 40-clip snapshot:

- 36 repaired Q1 clips reconstructed in memory
- 20 pass frozen contact gates; 16 remain explicit contact counterexamples; 4 remain upstream Q0
- license decision is `PENDING`, so 20 candidates are `blocked_license`
- `physics_executed_count=0`, `physics_step_count=0`, `q3_count=0`
- contact report: `sha256:b581d6425fd4053f55608b73c6a5d864d6e638ff56ddfb02f782e36d438bb618`
- qualification report: `sha256:883ab143b185085b3aea9c080976ddabc6e42caa3d7e52681a11dffb47b09f67`

Synthetic controls with an explicit non-empty permission snapshot verify that
a stable 240-frame reference advances real CPU MuJoCo physics and reaches Q3,
while a sideways reference remains hard Q1 and a pending-license reference
performs zero steps.

## Validation

- `ruff format --check src/rosclaw/collective tests/collective/test_motiondecode_contact.py`
- `ruff check src/rosclaw/collective tests/collective/test_motiondecode_contact.py`
- `mypy src/rosclaw/collective` (15 files)
- project CI mypy scope (118 files)
- `pytest tests/collective/test_motiondecode_contact.py tests/collective/test_motiondecode_source.py -q` — 30 passed
- `pytest tests/collective tests/growth tests/dream -q` — 94 passed
- `pytest tests/practice -q` — 189 passed, 4 skipped
- full suite — 5513 passed, 60 skipped, 27 deselected

Repo-wide Ruff/format retain the existing baseline of 244 lint findings and
148 unformatted files; all touched scope is clean.

## Safety

Simulation/CPU only. No ROS, DDS, serial, CAN, vendor SDK, motor command, GPU
training, policy activation, or real robot path is authorized. Frame-level
MotionDecode-derived traces are not persisted.

## Stack

This draft PR is intentionally based on #155
(`agent/phase8-motiondecode-repair`).
