### PR TITLE
fix: scope default MCP sessions per capability

### DIFF
--- a/src/rosclaw/mcp/adapters/runtime_client.py
+++ b/src/rosclaw/mcp/adapters/runtime_client.py
@@ -813,10 +813,12 @@ class RuntimeClient:
                 f"Unsupported evidence level {required_evidence!r}.",
             ) from exc
 
+        default_session_id = f"mcp-session:{capability_id}"
         action_kwargs: dict[str, Any] = {
             "actor_id": os.environ.get("ROSCLAW_AGENT_ACTOR", "rosclaw-mcp"),
             "agent_framework": os.environ.get("ROSCLAW_AGENT_CLIENT", "mcp"),
-            "session_id": session_id or os.environ.get("ROSCLAW_AGENT_SESSION", "mcp-session"),
+            "session_id": session_id
+            or os.environ.get("ROSCLAW_AGENT_SESSION", default_session_id),
             "body_id": body_id or self.robot_id,
             "body_snapshot_hash": body_snapshot_hash,
             "capability_id": capability_id,

--- a/tests/mcp/adapters/test_daemon_boundary.py
+++ b/tests/mcp/adapters/test_daemon_boundary.py
@@ -159,6 +159,26 @@ async def test_request_action_preserves_operator_proposal_deadline(
     assert daemon.actions[0].to_dict()["deadline_at"] == "2030-01-02T03:04:05Z"
 
 
+async def test_default_shadow_sessions_are_scoped_per_capability(
+    client: tuple[RuntimeClient, _FakeDaemonClient],
+) -> None:
+    runtime_client, daemon = client
+
+    for capability_id in ("limo.play_tone", "limo.set_initial_pose"):
+        await runtime_client.request_action(
+            capability_id=capability_id,
+            arguments={"schema_version": "test.v1"},
+            execution_mode="SHADOW",
+            body_snapshot_hash="sha256:body",
+            wait_timeout_sec=0.0,
+        )
+
+    assert [action.session_id for action in daemon.actions] == [
+        "mcp-session:limo.play_tone",
+        "mcp-session:limo.set_initial_pose",
+    ]
+
+
 async def test_interactive_confirmation_injects_permit_without_exposing_it(
     client: tuple[RuntimeClient, _FakeDaemonClient],
 ) -> None:


### PR DESCRIPTION
## Summary
- derive default MCP Agent Session IDs from the requested capability
- preserve explicit session overrides and REAL action-scoped sessions
- allow one MCP connection to submit tone, localization, and navigation SHADOW actions without capability-scope collisions

## Validation
- 15 focused daemon/MCP tests passed
- ruff and mypy passed
- reproduced on the live LIMO chain as SESSION_CAPABILITY_SCOPE_MISMATCH before this change