### PR TITLE
Add fail-closed contextual and recovery-state G1 learning

### DIFF
--- a/docs/validation/ROSCLAW_PHASE8_CONTEXTUAL_RECOVERY.md
+++ b/docs/validation/ROSCLAW_PHASE8_CONTEXTUAL_RECOVERY.md
@@ -159,6 +159,12 @@ baseline.  The current artifact, failed validation reports, and exact fallback
 suite provide the anchors needed to prevent forgetting while that model is
 trained.
 
+That follow-up has now been implemented and evaluated through six evidence
+generations.  Its architecture, rejected local-physics validation, fail-closed
+hardening, and action-conditioned critic follow-up are documented in
+`ROSCLAW_PHASE8_RECOVERY_STATE_MEMORY.md`.  The rejected state-memory artifact
+does not supersede the results in this document.
+
 ## Terminal-damping follow-up and multi-challenge video
 
 The `g1-contextual-recovery-v5-terminal-damping` follow-up adds a third,

--- a/docs/validation/ROSCLAW_PHASE8_CONTEXTUAL_RECOVERY.md
+++ b/docs/validation/ROSCLAW_PHASE8_CONTEXTUAL_RECOVERY.md
@@ -1,0 +1,174 @@
+# Phase 8 contextual G1 recovery: implementation and falsification report
+
+## Status
+
+This increment is **SIM-only** and **not promoted**.
+
+It demonstrates a material learned contribution on the DEVELOPMENT regimes,
+but the frozen policy did not generalize to the sealed VALIDATION regimes.
+The runtime therefore routes those states to the retained parent.  That safe
+fallback is correct behavior, but it is not evidence of an independently
+generalizing learned skill.
+
+## What changed
+
+The earlier temporal muscle-memory actor added a small joint residual after a
+single structured recovery primitive.  Its isolated learned contribution was
+only about `0.008%` to `0.014%`, far below the Phase 8 `5%` gate.
+
+This increment adds a content-addressed contextual motor memory:
+
+1. CPU MuJoCo evaluates a bounded library of target-space recovery primitives.
+2. The learner records the causal proprioceptive state at the first recovery
+   frame, after contact and kick-foot landing.
+3. A nearest-prototype actor selects the primitive associated with that state.
+4. The selection is latched for the episode.
+5. Missing, non-finite, incompatible, or out-of-distribution observations
+   fail closed to the retained parent primitive.
+
+The actor cannot emit torque, raw joint targets, ROS/DDS commands, leases, or
+hardware authorization.  Its activation ceiling is `SIM_ONLY`.
+
+The model artifact binds:
+
+- qualified Body and motion hashes;
+- fixed structured and retained fallback configuration hashes;
+- normalization and proprioceptive feature contracts;
+- DEVELOPMENT trajectory and primitive-trial commitments;
+- validation-suite commitment;
+- bounded primitives and their prototypes.
+
+## Controller defect fixed
+
+The slow structured controller previously stored the target *after* adding
+the learned muscle residual as its next smoothing state.  This unintentionally
+integrated a supposedly bounded per-frame residual and could create drift or
+twitching.
+
+The smoothing state now stores only the structured target.  A regression test
+applies the same learned residual on consecutive frames and proves that it is
+not integrated into the next frame.
+
+## Closed-loop qualification
+
+The qualification distinguishes three comparisons:
+
+- **Safety and retention:** candidate versus the retained parent.
+- **Learned causal contribution:** contextual candidate versus the same fixed
+  structured controller with zero learning.
+- **Generalization:** frozen candidate on a precommitted VALIDATION suite.
+
+Promotion gates include:
+
+- mean learned composite contribution at least `5%`;
+- deterministic bootstrap 95% lower bound greater than zero;
+- no learned component regressing more than `2%` on DEVELOPMENT;
+- goal, fall, joint, torque, saturation, slip, bilateral-support, recovery-time,
+  and naturalness guards;
+- exact deterministic replay;
+- private HOLDOUT routing to and exactly replaying the retained parent.
+
+## Results
+
+The strongest frozen DEVELOPMENT run is
+`g1-contextual-recovery-v4`.
+
+| Metric | Learned contribution versus fixed structured baseline |
+| --- | ---: |
+| Backward reversal | `22.65%` reduction |
+| Tail wobble | `18.86%` reduction |
+| Leg jerk | `6.08%` reduction |
+| Weighted composite | `17.82%` improvement |
+| Bootstrap 95% lower bound | `3.51%` |
+| Worst DEVELOPMENT case | `1.98%` improvement |
+
+All five DEVELOPMENT cases were safe, goal-preserving, naturalness-preserving,
+and strict-replay deterministic.
+
+The private retention suite passed:
+
+| Retention check | Result |
+| --- | ---: |
+| Cases | `3 / 3` |
+| OOD fallback routes | `3 / 3` |
+| Strict replays | `3 / 3` |
+| Exact retained-parent trajectories | `3 / 3` |
+
+The sealed VALIDATION suite did **not** pass.  The richer delayed
+proprioceptive router correctly classified all three cases as outside its
+covered state set and selected the retained parent.  Because the learned
+primitive was not applied, this is a safety success but a learning
+generalization failure.  The candidate remains rejected.
+
+Earlier frozen variants that used the contact/landing snapshot did select an
+expert primitive on novel states, but produced large wobble regression.  This
+falsified the assumption that a single impact snapshot is sufficient for
+reliable recovery selection.
+
+## Stage video
+
+The external evidence directory contains a split-screen DEVELOPMENT replay:
+
+`/code/rosclaw/phase8_evidence/g1-contextual-recovery-v4/g1-contextual-recovery-development.mp4`
+
+It compares:
+
+- left: fixed structured recovery with zero learning;
+- right: learned contextual router.
+
+The selected DEVELOPMENT case measures:
+
+| Metric | Improvement |
+| --- | ---: |
+| Backward reversal | `84.56%` |
+| Tail wobble | `74.17%` |
+| Leg jerk | `19.13%` |
+| Composite | `67.32%` |
+
+The frame overlay and hash-bound manifest explicitly say:
+
+`DEVELOPMENT ONLY · SEALED VALIDATION FAILED · NOT PROMOTED`
+
+The video is visualization downstream of strict MuJoCo evidence and cannot
+create or upgrade task evidence.
+
+## Interpretation
+
+The result is useful precisely because it separates memorization from growth.
+ROSClaw can now:
+
+- discover materially different recovery strategies from data;
+- bind them into a portable, auditable motor-memory artifact;
+- use proprioception to select them online;
+- reproduce large local improvements;
+- recognize when a novel body state is not covered;
+- preserve historical behavior by exact parent fallback.
+
+It has not yet shown that the selected motor memory generalizes through the
+highly discontinuous RoboNaldo contact dynamics.  More optimizer budget does
+not solve that representation problem.
+
+## Next implementation target
+
+The next candidate should replace hard nearest-prototype selection with a
+short-horizon recovery-state model trained from a denser applicability-gated
+curriculum.  Promotion still requires CPU MuJoCo truth and a new sealed suite.
+The model should estimate both expected return and epistemic uncertainty, and
+it should abstain unless the lower confidence bound beats the fixed structured
+baseline.  The current artifact, failed validation reports, and exact fallback
+suite provide the anchors needed to prevent forgetting while that model is
+trained.
+
+## Verification
+
+- Ruff on `src` and `tests`: passed.
+- Mypy: `895` source files passed.
+- Full pytest: `5389 passed`, `67 skipped`, `27 deselected`; four LeRobot
+  tests initially failed because collection saw a persisted runtime while the
+  isolated test home had no runtime registration.
+- LeRobot failure set rerun with the existing real runtime at
+  `/code/rosclaw/phase6_runtime/lerobot-0.6.1/bin/python`: `4 passed`.
+- Contextual recovery focused suite after final fail-closed hardening:
+  `37 passed`.
+- Video: H.264, `1280x720`, `30 fps`, `285` frames, `9.5 s`; manifest and
+  trajectory hashes verified.

--- a/docs/validation/ROSCLAW_PHASE8_CONTEXTUAL_RECOVERY.md
+++ b/docs/validation/ROSCLAW_PHASE8_CONTEXTUAL_RECOVERY.md
@@ -159,16 +159,71 @@ baseline.  The current artifact, failed validation reports, and exact fallback
 suite provide the anchors needed to prevent forgetting while that model is
 trained.
 
+## Terminal-damping follow-up and multi-challenge video
+
+The `g1-contextual-recovery-v5-terminal-damping` follow-up adds a third,
+smoothstep-gated recovery stage after unloading and upright settling.  It
+reduces leg proportional gain to `0.93x` and raises leg derivative damping to
+`1.50x`, starting at policy frame `500` over `80` frames.  It does not change
+the kick, emit torque, or cross the `SIM_ONLY` boundary.
+
+The parameters were selected from DEVELOPMENT-only sweeps and then evaluated
+against an exact ablation with the same contextual primitive and terminal
+damping disabled:
+
+| Terminal-damping metric | Five-case DEVELOPMENT result |
+| --- | ---: |
+| Passed cases | `5 / 5` |
+| Mean backward reversal | `5.82%` reduction |
+| Mean tail joint jerk | `21.05%` reduction |
+| Minimum tail joint jerk | `14.33%` reduction |
+| Mean tail wobble | `0.89%` regression |
+| Worst tail wobble | `2.24%` regression |
+
+This is a deliberate stability/plasticity trade: visible late joint twitch is
+materially lower and backward reversal improves, while the aggregate and
+per-case wobble regressions remain inside the predeclared `2%`/`5%` limits.
+Gentle upper-body and whole-body damping were also tested; neither matched the
+leg-only controller's combined backstep and tail-jerk gains.
+
+The contextual DEVELOPMENT result also improved relative to the matched fixed
+structured baseline:
+
+| Metric | v5 learned contribution |
+| --- | ---: |
+| Backward reversal | `28.56%` reduction |
+| Tail wobble | `20.22%` reduction |
+| Leg jerk | `6.46%` reduction |
+| Weighted composite | `20.81%` improvement |
+| Bootstrap 95% lower bound | `5.81%` |
+| Worst DEVELOPMENT case | `4.41%` improvement |
+
+The candidate remains **rejected** because sealed VALIDATION again routed all
+three states to the retained parent (`0 / 3` contextual routes).  Private
+retention remained exact (`3 / 3`).
+
+The new external video is:
+
+`/code/rosclaw/phase8_evidence/g1-contextual-recovery-v5-terminal-damping/g1-contextual-recovery-multichallenge.mp4`
+
+It is `49.83 s`, H.264, `1280x720`, `30 fps`, and contains five strict-replay
+experiments: a `0.55 m` high target with `0.10 m` lateral ball offset, nominal
+moving ball, lateral moving ball, speed shift, and lighter ball.  The high
+target demonstrates exact OOD fallback; the other four compare the same
+contextual primitive with damping off versus on.  The manifest binds all ten
+MuJoCo trajectories and keeps the `SEALED VALIDATION FAILED · NOT PROMOTED`
+label visible throughout.
+
 ## Verification
 
-- Ruff on `src` and `tests`: passed.
-- Mypy: `895` source files passed.
-- Full pytest: `5389 passed`, `67 skipped`, `27 deselected`; four LeRobot
-  tests initially failed because collection saw a persisted runtime while the
-  isolated test home had no runtime registration.
-- LeRobot failure set rerun with the existing real runtime at
-  `/code/rosclaw/phase6_runtime/lerobot-0.6.1/bin/python`: `4 passed`.
-- Contextual recovery focused suite after final fail-closed hardening:
-  `37 passed`.
-- Video: H.264, `1280x720`, `30 fps`, `285` frames, `9.5 s`; manifest and
-  trajectory hashes verified.
+- Ruff check on all `src` and `tests`: passed.
+- Ruff format on the seven changed files: passed.  The older chained base has
+  108 unrelated pre-existing files outside this change that do not match the
+  current formatter; they were not rewritten.
+- Mypy on the five changed source files: passed.
+- Repository CI mypy gate: `203` source files passed.
+- Full pytest with the existing isolated LeRobot runtime:
+  `5406 passed`, `59 skipped`, `27 deselected`, `26 warnings` in `1067.60 s`.
+- Contextual/cerebellar focused suite: `27 passed`.
+- Multi-challenge video: H.264, `1280x720`, `30 fps`, `1495` frames,
+  `49.83 s`; manifest and ten trajectory hashes verified.

--- a/docs/validation/ROSCLAW_PHASE8_RECOVERY_STATE_MEMORY.md
+++ b/docs/validation/ROSCLAW_PHASE8_RECOVERY_STATE_MEMORY.md
@@ -1,0 +1,139 @@
+# Phase 8 recovery-state memory: closed-loop review
+
+## Outcome
+
+This increment implements a SIM-only, short-horizon recovery-state memory for
+G1 post-kick control.  It is useful infrastructure, but the learned candidate
+is **not promoted**.  DEVELOPMENT and private fallback checks passed; sealed
+local-physics VALIDATION exposed unsafe generalization of the discrete
+open-loop recovery primitives.  The promotion gate returned rejection and the
+retained recovery controller remains authoritative.
+
+The final post-rejection hardening requires two of two nearby DEVELOPMENT
+examples to carry positive evidence.  On the same eight v6 stress cases this
+changed two unsafe learned routes into fallback, producing eight of eight
+strict, exact parent replays.  That replay is a safety check, not a new
+performance qualification.
+
+## What was added
+
+- `g1_recovery_state_memory.py` defines a content-addressed artifact and a
+  deterministic evidence-neighborhood policy.
+- A five-policy-frame sequence records both the mean state and its trend.
+- The observation contract combines proprioception with ball-relative
+  position and velocity: 22 raw observations, 16 descriptor features, and a
+  32-value mean-plus-trend descriptor.
+- Positive examples carry a bounded recovery primitive and measured composite
+  and component lower bounds.  Failed searches are explicit negative
+  prototypes, not discarded data.
+- Missing, non-numeric, non-finite, feature-envelope, distance, negative-nearest,
+  consensus, advantage, and component gates all fail closed.
+- Selection is allowed immediately after observed ball contact and right-foot
+  landing, but target adaptation remains gated by the primitive's original
+  start frame.  This lets the controller observe before acting without
+  introducing a target discontinuity.
+- `G1CerebellarRecoveryController` accepts exactly one learned recovery mode at
+  a time, binds artifacts to Body/motion/baseline/fallback hashes, and records
+  the recovery-state receipt.
+- The MuJoCo backend records observation-update and policy-frame evidence plus
+  the expanded environment-and-body state.  It remains CPU physics and does
+  not open ROS, DDS, simulator bridges, or hardware transport.
+- The CLI adds `goalforge muscle-memory state-train` and `state-inspect`.
+
+## Why the earlier router failed
+
+The first implementation revealed two train/deploy mismatches:
+
+1. The offline window required right-foot support on every sample even though
+   runtime landing was latched.  Some moving-ball descriptors therefore came
+   from different policy frames.  Recording the exact observation-update
+   event and mirroring the landing latch reduced same-case descriptor distance
+   to exactly zero.
+2. Collecting five frames starting at recovery frame 300 delayed execution to
+   roughly frame 304.  In this contact-sensitive motion, four frames were
+   enough to turn a positive primitive into a large regression.  Moving
+   observation before the action gate restored byte-identical equivalence
+   between a forced primitive route and direct baseline execution.
+
+The later v5 test found a representation gap: states with almost identical
+body descriptors (distance 0.0017--0.0024) could diverge from success to fall
+after small ball-restitution changes.  Ball-relative position and velocity
+were therefore added in v6, and the failed restitution points became the next
+generation's positive/negative curriculum.
+
+## v6 evidence
+
+All figures below are aggregate, frozen-policy CPU MuJoCo evidence from
+`/code/rosclaw/phase8_evidence/g1-recovery-state-v6`.
+
+| Suite | Result | Learned / fallback | Key measurements |
+|---|---:|---:|---|
+| DEVELOPMENT | pass, 27/27 | 6 / 21 | backstep +28.97%, tail wobble +25.18%, leg jerk +6.58%, composite +22.98%, bootstrap lower +7.36% |
+| sealed VALIDATION | **reject**, 6/8 passed | 2 / 6 | routed mean tail wobble -5911.76%, leg jerk -100.56%, composite -2363.17%; 6/8 parent-valid |
+| private HOLDOUT | pass, 3/3 | 0 / 3 | 3/3 strict and exact parent fallback |
+
+The large validation regressions are not clipped or omitted.  They demonstrate
+that a nearest-state selector over discrete open-loop primitives does not yet
+model the action-conditioned future of the contact dynamics.  More features
+alone are insufficient.
+
+After rejection, the consensus gate was raised from 0.5 to 1.0.  A safety
+replay using artifact hash
+`sha256:64bfa6b216caf5115d34be936c3af7040fab161c84b068575d258c1df23d3754`
+produced 0 learned routes, 8 fallback routes, 8 strict replays, and 8 exact
+parent replays on the v6 validation suite.  This hardened policy is not claimed
+as a performance candidate.
+
+## Stability-plasticity interpretation
+
+The useful result is not that the G1 has learned a generally better kick; it
+has not.  The useful result is an operational stability-plasticity loop:
+
+1. search bounded actions on DEVELOPMENT;
+2. store success and failure as signed episodic memory;
+3. select only inside a content-bound evidence neighborhood;
+4. test the frozen policy on unseen local physics;
+5. reject unsafe generalization;
+6. convert the failure boundary into the next generation's curriculum;
+7. tighten the safety gate immediately while preserving the old parent.
+
+This loop prevented all failed candidates from silently replacing the known
+controller.  It also showed where the next model must be qualitatively
+different.
+
+## Next implementation
+
+The next candidate should replace nearest-primitive routing with an
+action-conditioned recurrent critic.  For each bounded primitive (including
+the retained parent), it should predict the vector of future backstep, wobble,
+jerk, safety, and goal outcomes plus epistemic uncertainty from the joint
+body-ball history.  A primitive may run only when its conservative lower bound
+dominates the parent on every guardrail.  The actor should then modulate the
+selected primitive through bounded closed-loop target residuals rather than
+execute a purely open-loop switch.
+
+Dream/replay training should prioritize validation-failure boundaries, retain
+parent-anchor and negative exemplars, and use a fresh sealed interpolation
+suite for every generation.  No promotional video should be generated from a
+rejected candidate; the existing qualified contextual-recovery video remains
+the current visual result.
+
+## Safety status
+
+- Activation ceiling: `SIM_ONLY`
+- Physics authority: `CPU_MUJOCO`
+- Hardware command sent: `false`
+- Candidate promotion: `REJECTED`
+- Retained parent: unchanged
+
+## Verification
+
+- Focused recovery/controller/GoalForge suite: `53 passed, 2 deselected`.
+- Ruff over all `src` and `tests`: passed.
+- CI mypy gate: `203` source files passed.
+- Changed recovery/backend source files under mypy: passed.
+- Full pytest with the explicit isolated LeRobot runtime:
+  `5416 passed, 59 skipped, 27 deselected, 26 warnings` in `1043.67 s`.
+- v6 training/evaluation: `312` training-side, `32` validation, and `12`
+  holdout CPU MuJoCo rollouts; no CUDA physics authority and no hardware
+  command.

--- a/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
+++ b/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
@@ -38,6 +38,10 @@ from rosclaw.simforge.g1_muscle_memory import (
     G1_MUSCLE_MEMORY_OBSERVATIONS,
     G1MuscleMemoryArtifact,
 )
+from rosclaw.simforge.g1_recovery_state_memory import (
+    G1_RECOVERY_STATE_OBSERVATIONS,
+    G1RecoveryStateArtifact,
+)
 from rosclaw.simforge.tasks.g1_goalforge.concepts import (
     G1_DDS_JOINT_NAMES,
     G1_HARD_TORQUE_LIMITS,
@@ -224,6 +228,7 @@ class G1MuJoCoBackend:
         config: G1CerebellarRecoveryConfig | None = None,
         muscle_memory_artifact: G1MuscleMemoryArtifact | None = None,
         contextual_recovery_artifact: G1ContextualRecoveryArtifact | None = None,
+        recovery_state_artifact: G1RecoveryStateArtifact | None = None,
         fallback_config: G1CerebellarRecoveryConfig | None = None,
     ) -> G1CerebellarRecoveryController:
         """Bind the recovery segment to the exact qualified Body and motion."""
@@ -251,6 +256,7 @@ class G1MuJoCoBackend:
             config=resolved,
             muscle_memory_artifact=muscle_memory_artifact,
             contextual_recovery_artifact=contextual_recovery_artifact,
+            recovery_state_artifact=recovery_state_artifact,
             fallback_config=fallback_config,
         )
 
@@ -515,6 +521,9 @@ class G1MuJoCoBackend:
                     "recovery_smoothing_active": [],
                     "recovery_smoothing_residual_rms_rad": [],
                     "recovery_proprioception": [],
+                    "recovery_policy_frame": [],
+                    "recovery_observation_updated": [],
+                    "recovery_state_observation": [],
                 }
             )
             if recovery_controller.muscle_memory is not None:
@@ -589,6 +598,12 @@ class G1MuJoCoBackend:
             len(G1_MUSCLE_MEMORY_OBSERVATIONS),
             dtype=np.float64,
         )
+        recovery_state_observation: np.ndarray = np.zeros(
+            len(G1_RECOVERY_STATE_OBSERVATIONS),
+            dtype=np.float64,
+        )
+        recovery_policy_frame = 0
+        recovery_observation_updated = False
         muscle_memory_active = False
         muscle_memory_out_of_distribution = False
         muscle_memory_residual_rms_rad = 0.0
@@ -598,6 +613,7 @@ class G1MuJoCoBackend:
         )
 
         for frame in range(total_control_frames):
+            recovery_observation_updated = False
             if feedforward is not None:
                 feedforward_residual = feedforward.value_at(frame)
             _fill_state(state, model, data, ids)
@@ -669,6 +685,33 @@ class G1MuJoCoBackend:
                             ],
                             dtype=np.float64,
                         )
+                        state_observation = {
+                            **proprioceptive_observation,
+                            "ball_relative_position_x_m": float(
+                                data.xpos[ids.ball][0] - data.qpos[0]
+                            ),
+                            "ball_relative_position_y_m": float(
+                                data.xpos[ids.ball][1] - data.qpos[1]
+                            ),
+                            "ball_relative_position_z_m": float(
+                                data.xpos[ids.ball][2] - data.qpos[2]
+                            ),
+                            "ball_relative_velocity_x_m_s": float(
+                                data.qvel[ids.ball_qvel] - data.qvel[0]
+                            ),
+                            "ball_relative_velocity_y_m_s": float(
+                                data.qvel[ids.ball_qvel + 1] - data.qvel[1]
+                            ),
+                            "ball_relative_velocity_z_m_s": float(
+                                data.qvel[ids.ball_qvel + 2] - data.qvel[2]
+                            ),
+                        }
+                        recovery_state_observation = np.asarray(
+                            [state_observation[name] for name in G1_RECOVERY_STATE_OBSERVATIONS],
+                            dtype=np.float64,
+                        )
+                        recovery_policy_frame = policy_frame
+                        recovery_observation_updated = True
                         recovery_effect = recovery_controller.adapt_target(
                             target=target,
                             policy_frame=policy_frame,
@@ -677,12 +720,16 @@ class G1MuJoCoBackend:
                             left_support=latest_left_support,
                             right_support=latest_right_support,
                             muscle_memory_observation=(
-                                proprioceptive_observation
-                                if (
-                                    recovery_controller.muscle_memory is not None
-                                    or recovery_controller.contextual_recovery is not None
+                                state_observation
+                                if recovery_controller.recovery_state is not None
+                                else (
+                                    proprioceptive_observation
+                                    if (
+                                        recovery_controller.muscle_memory is not None
+                                        or recovery_controller.contextual_recovery is not None
+                                    )
+                                    else None
                                 )
-                                else None
                             ),
                         )
                         target = recovery_effect.target
@@ -890,6 +937,9 @@ class G1MuJoCoBackend:
                     recovery_smoothing_active=recovery_smoothing_active,
                     recovery_smoothing_residual_rms_rad=(recovery_smoothing_residual_rms_rad),
                     recovery_proprioception=recovery_proprioception,
+                    recovery_policy_frame=recovery_policy_frame,
+                    recovery_observation_updated=recovery_observation_updated,
+                    recovery_state_observation=recovery_state_observation,
                     muscle_memory_active=muscle_memory_active,
                     muscle_memory_out_of_distribution=muscle_memory_out_of_distribution,
                     muscle_memory_residual_rms_rad=muscle_memory_residual_rms_rad,
@@ -931,6 +981,9 @@ class G1MuJoCoBackend:
                 recovery_smoothing_active=recovery_smoothing_active,
                 recovery_smoothing_residual_rms_rad=recovery_smoothing_residual_rms_rad,
                 recovery_proprioception=recovery_proprioception,
+                recovery_policy_frame=recovery_policy_frame,
+                recovery_observation_updated=recovery_observation_updated,
+                recovery_state_observation=recovery_state_observation,
                 muscle_memory_active=muscle_memory_active,
                 muscle_memory_out_of_distribution=muscle_memory_out_of_distribution,
                 muscle_memory_residual_rms_rad=muscle_memory_residual_rms_rad,
@@ -1299,6 +1352,9 @@ def _append_trace(
     recovery_smoothing_active: bool = False,
     recovery_smoothing_residual_rms_rad: float = 0.0,
     recovery_proprioception: np.ndarray | None = None,
+    recovery_policy_frame: int = 0,
+    recovery_observation_updated: bool = False,
+    recovery_state_observation: np.ndarray | None = None,
     muscle_memory_active: bool = False,
     muscle_memory_out_of_distribution: bool = False,
     muscle_memory_residual_rms_rad: float = 0.0,
@@ -1348,6 +1404,10 @@ def _append_trace(
         trace["recovery_smoothing_active"].append(recovery_smoothing_active)
         trace["recovery_smoothing_residual_rms_rad"].append(recovery_smoothing_residual_rms_rad)
         trace["recovery_proprioception"].append(recovery_proprioception.copy())
+        trace["recovery_policy_frame"].append(recovery_policy_frame)
+        trace["recovery_observation_updated"].append(recovery_observation_updated)
+        assert recovery_state_observation is not None
+        trace["recovery_state_observation"].append(recovery_state_observation.copy())
     if "muscle_memory_active" in trace:
         assert muscle_memory_synergy_actions is not None
         trace["muscle_memory_active"].append(muscle_memory_active)

--- a/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
+++ b/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
@@ -585,11 +585,17 @@ class G1MuJoCoBackend:
         recovery_settling_fraction = 0.0
         recovery_smoothing_active = False
         recovery_smoothing_residual_rms_rad = 0.0
-        recovery_proprioception = np.zeros(len(G1_MUSCLE_MEMORY_OBSERVATIONS), dtype=np.float64)
+        recovery_proprioception: np.ndarray = np.zeros(
+            len(G1_MUSCLE_MEMORY_OBSERVATIONS),
+            dtype=np.float64,
+        )
         muscle_memory_active = False
         muscle_memory_out_of_distribution = False
         muscle_memory_residual_rms_rad = 0.0
-        muscle_memory_synergy_actions = np.zeros(len(G1_MUSCLE_MEMORY_ACTIONS), dtype=np.float64)
+        muscle_memory_synergy_actions: np.ndarray = np.zeros(
+            len(G1_MUSCLE_MEMORY_ACTIONS),
+            dtype=np.float64,
+        )
 
         for frame in range(total_control_frames):
             if feedforward is not None:
@@ -680,6 +686,16 @@ class G1MuJoCoBackend:
                             ),
                         )
                         target = recovery_effect.target
+                        terminal_group = recovery_effect.terminal_damping_joint_group
+                        terminal_slice = {
+                            "whole_body": slice(None),
+                            "legs": slice(0, 12),
+                            "upper_body": slice(12, None),
+                        }[terminal_group]
+                        kp = kp.copy()
+                        kd = kd.copy()
+                        kp[terminal_slice] *= recovery_effect.terminal_kp_scale
+                        kd[terminal_slice] *= recovery_effect.terminal_kd_scale
                         recovery_active = recovery_effect.active
                         recovery_blend_fraction = recovery_effect.blend_fraction
                         recovery_settling_fraction = recovery_effect.settling_fraction

--- a/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
+++ b/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
@@ -32,6 +32,7 @@ from rosclaw.simforge.g1_cerebellar_recovery import (
     G1CerebellarRecoveryReceipt,
     evaluate_g1_cerebellar_recovery_regime,
 )
+from rosclaw.simforge.g1_contextual_recovery import G1ContextualRecoveryArtifact
 from rosclaw.simforge.g1_muscle_memory import (
     G1_MUSCLE_MEMORY_ACTIONS,
     G1_MUSCLE_MEMORY_OBSERVATIONS,
@@ -222,6 +223,7 @@ class G1MuJoCoBackend:
         scenario: GoalForgeScenario,
         config: G1CerebellarRecoveryConfig | None = None,
         muscle_memory_artifact: G1MuscleMemoryArtifact | None = None,
+        contextual_recovery_artifact: G1ContextualRecoveryArtifact | None = None,
         fallback_config: G1CerebellarRecoveryConfig | None = None,
     ) -> G1CerebellarRecoveryController:
         """Bind the recovery segment to the exact qualified Body and motion."""
@@ -248,6 +250,7 @@ class G1MuJoCoBackend:
             standing_pose=standing_pose,
             config=resolved,
             muscle_memory_artifact=muscle_memory_artifact,
+            contextual_recovery_artifact=contextual_recovery_artifact,
             fallback_config=fallback_config,
         )
 
@@ -669,7 +672,10 @@ class G1MuJoCoBackend:
                             right_support=latest_right_support,
                             muscle_memory_observation=(
                                 proprioceptive_observation
-                                if recovery_controller.muscle_memory is not None
+                                if (
+                                    recovery_controller.muscle_memory is not None
+                                    or recovery_controller.contextual_recovery is not None
+                                )
                                 else None
                             ),
                         )

--- a/src/rosclaw/simforge/g1_cerebellar_recovery.py
+++ b/src/rosclaw/simforge/g1_cerebellar_recovery.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 import math
 import re
 from collections.abc import Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from typing import Any
 
 import numpy as np
 
+from rosclaw.simforge.g1_contextual_recovery import (
+    G1ContextualRecoveryArtifact,
+    G1ContextualRecoveryPolicy,
+    G1ContextualRecoveryPrimitive,
+)
 from rosclaw.simforge.g1_muscle_memory import (
     G1MuscleMemoryArtifact,
     G1MuscleMemoryPolicy,
@@ -138,6 +143,9 @@ class G1CerebellarRecoveryEffect:
     muscle_memory_out_of_distribution: bool
     muscle_memory_residual_rms_rad: float
     muscle_memory_synergy_actions: np.ndarray
+    contextual_recovery_active: bool
+    contextual_recovery_out_of_distribution: bool
+    contextual_recovery_primitive_index: int | None
 
 
 @dataclass(frozen=True)
@@ -169,7 +177,8 @@ class G1CerebellarRecoveryReceipt:
     fallback_routed_count: int
     expert_route_latched: bool | None
     muscle_memory_receipt: dict[str, Any] | None = None
-    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v6"
+    contextual_recovery_receipt: dict[str, Any] | None = None
+    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v7"
 
     def to_dict(self) -> dict[str, Any]:
         value = asdict(self)
@@ -197,6 +206,7 @@ class G1CerebellarRecoveryController:
         standing_pose: np.ndarray,
         config: G1CerebellarRecoveryConfig | None = None,
         muscle_memory_artifact: G1MuscleMemoryArtifact | None = None,
+        contextual_recovery_artifact: G1ContextualRecoveryArtifact | None = None,
         fallback_config: G1CerebellarRecoveryConfig | None = None,
     ) -> None:
         for label, value in (
@@ -228,6 +238,15 @@ class G1CerebellarRecoveryController:
             if muscle_memory_artifact is not None
             else None
         )
+        self.contextual_recovery = (
+            G1ContextualRecoveryPolicy(contextual_recovery_artifact)
+            if contextual_recovery_artifact is not None
+            else None
+        )
+        if self.muscle_memory is not None and self.contextual_recovery is not None:
+            raise ValueError(
+                "muscle-memory residual and contextual recovery cannot be active together"
+            )
         if self.muscle_memory is not None:
             if (
                 not self.muscle_memory.artifact.schema_version.endswith(".v1")
@@ -248,6 +267,15 @@ class G1CerebellarRecoveryController:
                 )
                 if structured != self.muscle_memory.artifact.structured_recovery_parameters:
                     raise ValueError("muscle-memory structured recovery parameters mismatch")
+        if self.contextual_recovery is not None:
+            if self.fallback_config is None:
+                raise ValueError("contextual recovery requires a fallback recovery config")
+            self.contextual_recovery.require_compatible(
+                body_hash=self.body_hash,
+                motion_hash=self.motion_hash,
+                baseline_recovery_config_hash=self.config_hash,
+                fallback_recovery_config_hash=self.fallback_config_hash or "",
+            )
         self.reset()
 
     @property
@@ -281,8 +309,19 @@ class G1CerebellarRecoveryController:
 
     @property
     def controller_hash(self) -> str:
-        if self.muscle_memory is None:
+        if self.muscle_memory is None and self.contextual_recovery is None:
             return self.base_controller_hash
+        if self.contextual_recovery is not None:
+            return hash_json(
+                {
+                    "controller_type": ("g1_cerebellar_post_kick_recovery_with_contextual_memory"),
+                    "version": 1,
+                    "base_controller_hash": self.base_controller_hash,
+                    "contextual_recovery_artifact_hash": (
+                        self.contextual_recovery.artifact.artifact_hash
+                    ),
+                }
+            )
         return hash_json(
             {
                 "controller_type": "g1_cerebellar_post_kick_recovery_with_muscle_memory",
@@ -323,6 +362,8 @@ class G1CerebellarRecoveryController:
         self._expert_route_latched: bool | None = None
         if self.muscle_memory is not None:
             self.muscle_memory.reset()
+        if self.contextual_recovery is not None:
+            self.contextual_recovery.reset()
 
     def adapt_target(
         self,
@@ -345,6 +386,30 @@ class G1CerebellarRecoveryController:
         if self._contact_latched and right_support:
             self._landing_latched = True
         config = self.config
+        contextual_primitive_index: int | None = None
+        contextual_ood = False
+        if self.contextual_recovery is not None:
+            if muscle_memory_observation is None:
+                raise ValueError("contextual recovery routing requires proprioceptive observations")
+            if (
+                self._contact_latched
+                and self._landing_latched
+                and policy_frame >= self.config.start_policy_frame
+            ):
+                selection = self.contextual_recovery.select(muscle_memory_observation)
+                contextual_primitive_index = selection.primitive_index
+                contextual_ood = selection.out_of_distribution
+                if selection.primitive_index is None:
+                    if self.fallback_config is None:
+                        raise RuntimeError(
+                            "validated contextual fallback config became unavailable"
+                        )
+                    config = self.fallback_config
+                else:
+                    config = _apply_contextual_primitive(
+                        self.config,
+                        self.contextual_recovery.artifact.primitives[selection.primitive_index],
+                    )
         if self.fallback_config is not None and self.muscle_memory is not None:
             if muscle_memory_observation is None:
                 raise ValueError("temporal recovery routing requires proprioceptive observations")
@@ -443,6 +508,11 @@ class G1CerebellarRecoveryController:
             )
         else:
             smoothing_residual = 0.0
+        # Keep the slow structured controller's state independent from the
+        # learned residual.  Feeding the combined target back through
+        # ``_smoothed_target`` turns a bounded per-frame residual into an
+        # unintended integrator and makes even tiny learned actions drift.
+        structured_target = adapted.copy()
         muscle_memory_active = False
         muscle_memory_ood = False
         muscle_memory_residual_rms = 0.0
@@ -456,7 +526,7 @@ class G1CerebellarRecoveryController:
             muscle_memory_ood = muscle_effect.out_of_distribution
             muscle_memory_residual_rms = muscle_effect.residual_rms_rad
             muscle_memory_actions = muscle_effect.synergy_actions.copy()
-        self._smoothed_target = adapted.copy()
+        self._smoothed_target = structured_target
         active = fraction > 0.0 or smoothing_active or muscle_memory_active
         if active and self._activation_policy_frame is None:
             self._activation_policy_frame = policy_frame
@@ -479,6 +549,13 @@ class G1CerebellarRecoveryController:
             muscle_memory_out_of_distribution=muscle_memory_ood,
             muscle_memory_residual_rms_rad=muscle_memory_residual_rms,
             muscle_memory_synergy_actions=muscle_memory_actions,
+            contextual_recovery_active=(
+                self.contextual_recovery is not None
+                and contextual_primitive_index is not None
+                and causal_gate
+            ),
+            contextual_recovery_out_of_distribution=contextual_ood,
+            contextual_recovery_primitive_index=contextual_primitive_index,
         )
 
     def build_receipt(
@@ -521,7 +598,31 @@ class G1CerebellarRecoveryController:
                 if self.muscle_memory is not None
                 else None
             ),
+            contextual_recovery_receipt=(
+                self.contextual_recovery.build_receipt().to_dict()
+                if self.contextual_recovery is not None
+                else None
+            ),
         )
+
+
+def _apply_contextual_primitive(
+    config: G1CerebellarRecoveryConfig,
+    primitive: G1ContextualRecoveryPrimitive,
+) -> G1CerebellarRecoveryConfig:
+    """Apply only the bounded fields carried by a learned SIM primitive."""
+
+    return replace(
+        config,
+        start_policy_frame=primitive.start_policy_frame,
+        blend_frames=primitive.blend_frames,
+        settling_start_policy_frame=primitive.settling_start_policy_frame,
+        settling_blend_frames=primitive.settling_blend_frames,
+        settling_standing_pose_blend=primitive.settling_standing_pose_blend,
+        settling_waist_pitch_bias_rad=primitive.settling_waist_pitch_bias_rad,
+        target_smoothing_alpha=primitive.target_smoothing_alpha,
+        target_smoothing_start_policy_frame=primitive.start_policy_frame,
+    )
 
 
 def evaluate_g1_cerebellar_recovery_regime(

--- a/src/rosclaw/simforge/g1_cerebellar_recovery.py
+++ b/src/rosclaw/simforge/g1_cerebellar_recovery.py
@@ -24,6 +24,10 @@ from rosclaw.simforge.g1_muscle_memory import (
     G1MuscleMemoryArtifact,
     G1MuscleMemoryPolicy,
 )
+from rosclaw.simforge.g1_recovery_state_memory import (
+    G1RecoveryStateArtifact,
+    G1RecoveryStatePolicy,
+)
 from rosclaw.simforge.tasks.g1_goalforge.concepts import (
     G1_DDS_JOINT_NAMES,
     hash_bytes,
@@ -176,6 +180,10 @@ class G1CerebellarRecoveryEffect:
     contextual_recovery_active: bool
     contextual_recovery_out_of_distribution: bool
     contextual_recovery_primitive_index: int | None
+    recovery_state_active: bool
+    recovery_state_pending: bool
+    recovery_state_out_of_distribution: bool
+    recovery_state_primitive_index: int | None
 
 
 @dataclass(frozen=True)
@@ -211,7 +219,8 @@ class G1CerebellarRecoveryReceipt:
     expert_route_latched: bool | None
     muscle_memory_receipt: dict[str, Any] | None = None
     contextual_recovery_receipt: dict[str, Any] | None = None
-    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v8"
+    recovery_state_receipt: dict[str, Any] | None = None
+    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v9"
 
     def to_dict(self) -> dict[str, Any]:
         value = asdict(self)
@@ -240,6 +249,7 @@ class G1CerebellarRecoveryController:
         config: G1CerebellarRecoveryConfig | None = None,
         muscle_memory_artifact: G1MuscleMemoryArtifact | None = None,
         contextual_recovery_artifact: G1ContextualRecoveryArtifact | None = None,
+        recovery_state_artifact: G1RecoveryStateArtifact | None = None,
         fallback_config: G1CerebellarRecoveryConfig | None = None,
     ) -> None:
         for label, value in (
@@ -276,9 +286,22 @@ class G1CerebellarRecoveryController:
             if contextual_recovery_artifact is not None
             else None
         )
-        if self.muscle_memory is not None and self.contextual_recovery is not None:
+        self.recovery_state = (
+            G1RecoveryStatePolicy(recovery_state_artifact)
+            if recovery_state_artifact is not None
+            else None
+        )
+        learned_controllers = sum(
+            controller is not None
+            for controller in (
+                self.muscle_memory,
+                self.contextual_recovery,
+                self.recovery_state,
+            )
+        )
+        if learned_controllers > 1:
             raise ValueError(
-                "muscle-memory residual and contextual recovery cannot be active together"
+                "only one muscle-memory, contextual, or recovery-state policy may be active"
             )
         if self.muscle_memory is not None:
             if (
@@ -304,6 +327,15 @@ class G1CerebellarRecoveryController:
             if self.fallback_config is None:
                 raise ValueError("contextual recovery requires a fallback recovery config")
             self.contextual_recovery.require_compatible(
+                body_hash=self.body_hash,
+                motion_hash=self.motion_hash,
+                baseline_recovery_config_hash=self.config_hash,
+                fallback_recovery_config_hash=self.fallback_config_hash or "",
+            )
+        if self.recovery_state is not None:
+            if self.fallback_config is None:
+                raise ValueError("recovery-state memory requires a fallback recovery config")
+            self.recovery_state.require_compatible(
                 body_hash=self.body_hash,
                 motion_hash=self.motion_hash,
                 baseline_recovery_config_hash=self.config_hash,
@@ -342,8 +374,23 @@ class G1CerebellarRecoveryController:
 
     @property
     def controller_hash(self) -> str:
-        if self.muscle_memory is None and self.contextual_recovery is None:
+        if (
+            self.muscle_memory is None
+            and self.contextual_recovery is None
+            and self.recovery_state is None
+        ):
             return self.base_controller_hash
+        if self.recovery_state is not None:
+            return hash_json(
+                {
+                    "controller_type": (
+                        "g1_cerebellar_post_kick_recovery_with_recovery_state_memory"
+                    ),
+                    "version": 1,
+                    "base_controller_hash": self.base_controller_hash,
+                    "recovery_state_artifact_hash": self.recovery_state.artifact.artifact_hash,
+                }
+            )
         if self.contextual_recovery is not None:
             return hash_json(
                 {
@@ -400,6 +447,8 @@ class G1CerebellarRecoveryController:
             self.muscle_memory.reset()
         if self.contextual_recovery is not None:
             self.contextual_recovery.reset()
+        if self.recovery_state is not None:
+            self.recovery_state.reset()
 
     def adapt_target(
         self,
@@ -424,6 +473,9 @@ class G1CerebellarRecoveryController:
         config = self.config
         contextual_primitive_index: int | None = None
         contextual_ood = False
+        recovery_state_primitive_index: int | None = None
+        recovery_state_pending = False
+        recovery_state_ood = False
         if self.contextual_recovery is not None:
             if muscle_memory_observation is None:
                 raise ValueError("contextual recovery routing requires proprioceptive observations")
@@ -445,6 +497,29 @@ class G1CerebellarRecoveryController:
                     config = _apply_contextual_primitive(
                         self.config,
                         self.contextual_recovery.artifact.primitives[selection.primitive_index],
+                    )
+        if self.recovery_state is not None:
+            if muscle_memory_observation is None:
+                raise ValueError("recovery-state routing requires proprioceptive observations")
+            # Observe immediately after the causal contact-and-landing gate so
+            # the short window is complete before the recovery action opens.
+            # Selection alone cannot move the robot: target adaptation remains
+            # gated below by the selected config's start_policy_frame.
+            if self._contact_latched and self._landing_latched:
+                selection = self.recovery_state.select(muscle_memory_observation)
+                recovery_state_pending = not selection.ready
+                recovery_state_primitive_index = selection.primitive_index
+                recovery_state_ood = selection.out_of_distribution
+                if selection.primitive_index is None:
+                    if self.fallback_config is None:
+                        raise RuntimeError(
+                            "validated recovery-state fallback config became unavailable"
+                        )
+                    config = self.fallback_config
+                else:
+                    config = _apply_contextual_primitive(
+                        self.config,
+                        self.recovery_state.artifact.primitives[selection.primitive_index],
                     )
         if self.fallback_config is not None and self.muscle_memory is not None:
             if muscle_memory_observation is None:
@@ -622,6 +697,14 @@ class G1CerebellarRecoveryController:
             ),
             contextual_recovery_out_of_distribution=contextual_ood,
             contextual_recovery_primitive_index=contextual_primitive_index,
+            recovery_state_active=(
+                self.recovery_state is not None
+                and recovery_state_primitive_index is not None
+                and eligible
+            ),
+            recovery_state_pending=recovery_state_pending,
+            recovery_state_out_of_distribution=recovery_state_ood,
+            recovery_state_primitive_index=recovery_state_primitive_index,
         )
 
     def build_receipt(
@@ -672,6 +755,11 @@ class G1CerebellarRecoveryController:
             contextual_recovery_receipt=(
                 self.contextual_recovery.build_receipt().to_dict()
                 if self.contextual_recovery is not None
+                else None
+            ),
+            recovery_state_receipt=(
+                self.recovery_state.build_receipt().to_dict()
+                if self.recovery_state is not None
                 else None
             ),
         )

--- a/src/rosclaw/simforge/g1_cerebellar_recovery.py
+++ b/src/rosclaw/simforge/g1_cerebellar_recovery.py
@@ -37,9 +37,10 @@ _SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
 class G1CerebellarRecoveryConfig:
     """Bounded target-space recovery segment discovered by matched SIM A/B.
 
-    The first smoothstep unloads the kick while the second, optional smoothstep
-    settles into a more upright terminal posture.  Both are contact- and
-    landing-gated, so the kick itself is never modified.
+    The first smoothstep unloads the kick, the second settles into a more
+    upright posture, and an optional third envelope adds bounded terminal PD
+    damping.  Every stage is contact- and landing-gated, so the kick itself is
+    never modified.
     """
 
     start_policy_frame: int = 420
@@ -54,6 +55,11 @@ class G1CerebellarRecoveryConfig:
     target_smoothing_alpha: float = 1.0
     target_smoothing_start_policy_frame: int = 400
     target_smoothing_joint_group: str = "upper_body"
+    terminal_damping_start_policy_frame: int | None = None
+    terminal_damping_blend_frames: int = 80
+    terminal_kp_scale: float = 1.0
+    terminal_kd_scale: float = 1.0
+    terminal_damping_joint_group: str = "whole_body"
     contact_required: bool = True
     kick_foot_landing_required: bool = True
     minimum_calibrated_support_friction: float = 0.95
@@ -110,6 +116,26 @@ class G1CerebellarRecoveryConfig:
             raise ValueError("target_smoothing_start_policy_frame must be non-negative")
         if self.target_smoothing_joint_group not in {"upper_body", "arms"}:
             raise ValueError("target_smoothing_joint_group must be upper_body or arms")
+        if self.terminal_damping_blend_frames <= 0:
+            raise ValueError("terminal_damping_blend_frames must be positive")
+        if self.terminal_damping_start_policy_frame is None:
+            if self.terminal_kp_scale != 1.0 or self.terminal_kd_scale != 1.0:
+                raise ValueError("terminal gain scaling requires terminal damping")
+        else:
+            earliest = self.start_policy_frame + self.blend_frames
+            if self.settling_start_policy_frame is not None:
+                earliest = max(
+                    earliest,
+                    self.settling_start_policy_frame + self.settling_blend_frames,
+                )
+            if self.terminal_damping_start_policy_frame < earliest:
+                raise ValueError("terminal damping cannot overlap recovery blending")
+        if not 0.75 <= self.terminal_kp_scale <= 1.0:
+            raise ValueError("terminal_kp_scale must be in [0.75, 1.0]")
+        if not 1.0 <= self.terminal_kd_scale <= 2.0:
+            raise ValueError("terminal_kd_scale must be in [1.0, 2.0]")
+        if self.terminal_damping_joint_group not in {"whole_body", "legs", "upper_body"}:
+            raise ValueError("terminal_damping_joint_group must be whole_body, legs, or upper_body")
         if not 0.0 < self.minimum_calibrated_support_friction <= 2.0:
             raise ValueError("minimum calibrated support friction must be in (0, 2]")
         if not 0.0 <= self.maximum_calibrated_control_latency_ms <= 100.0:
@@ -123,7 +149,7 @@ class G1CerebellarRecoveryConfig:
 def _recovery_config_hash(config: G1CerebellarRecoveryConfig) -> str:
     return hash_json(
         {
-            "schema_version": "rosclaw.g1_goalforge.cerebellar_recovery_config.v1",
+            "schema_version": "rosclaw.g1_goalforge.cerebellar_recovery_config.v2",
             "config": asdict(config),
         }
     )
@@ -139,6 +165,10 @@ class G1CerebellarRecoveryEffect:
     kick_foot_landing_latched: bool
     smoothing_active: bool
     smoothing_residual_rms_rad: float
+    terminal_damping_fraction: float
+    terminal_kp_scale: float
+    terminal_kd_scale: float
+    terminal_damping_joint_group: str
     muscle_memory_active: bool
     muscle_memory_out_of_distribution: bool
     muscle_memory_residual_rms_rad: float
@@ -166,8 +196,11 @@ class G1CerebellarRecoveryReceipt:
     smoothing_activation_time_sec: float | None
     settling_activation_policy_frame: int | None
     settling_activation_time_sec: float | None
+    terminal_damping_activation_policy_frame: int | None
+    terminal_damping_activation_time_sec: float | None
     peak_blend_fraction: float
     peak_settling_fraction: float
+    peak_terminal_damping_fraction: float
     peak_smoothing_residual_rms_rad: float
     strict_replay: bool
     evidence_domain: str
@@ -178,7 +211,7 @@ class G1CerebellarRecoveryReceipt:
     expert_route_latched: bool | None
     muscle_memory_receipt: dict[str, Any] | None = None
     contextual_recovery_receipt: dict[str, Any] | None = None
-    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v7"
+    schema_version: str = "rosclaw.g1_goalforge.cerebellar_recovery_receipt.v8"
 
     def to_dict(self) -> dict[str, Any]:
         value = asdict(self)
@@ -293,7 +326,7 @@ class G1CerebellarRecoveryController:
         return hash_json(
             {
                 "controller_type": "g1_cerebellar_post_kick_recovery",
-                "version": 4,
+                "version": 5,
                 "body_hash": self.body_hash,
                 "motion_hash": self.motion_hash,
                 "standing_pose_hash": self.standing_pose_hash,
@@ -354,9 +387,12 @@ class G1CerebellarRecoveryController:
         self._smoothing_activation_time_sec: float | None = None
         self._settling_activation_policy_frame: int | None = None
         self._settling_activation_time_sec: float | None = None
+        self._terminal_damping_activation_policy_frame: int | None = None
+        self._terminal_damping_activation_time_sec: float | None = None
         self._smoothed_target: np.ndarray | None = None
         self._peak_blend_fraction = 0.0
         self._peak_settling_fraction = 0.0
+        self._peak_terminal_damping_fraction = 0.0
         self._peak_smoothing_residual_rms_rad = 0.0
         self._fallback_routed_count = 0
         self._expert_route_latched: bool | None = None
@@ -508,6 +544,23 @@ class G1CerebellarRecoveryController:
             )
         else:
             smoothing_residual = 0.0
+        terminal_fraction = 0.0
+        if (
+            causal_gate
+            and config.terminal_damping_start_policy_frame is not None
+            and policy_frame >= config.terminal_damping_start_policy_frame
+        ):
+            terminal_linear = min(
+                1.0,
+                max(
+                    0.0,
+                    (policy_frame - config.terminal_damping_start_policy_frame)
+                    / config.terminal_damping_blend_frames,
+                ),
+            )
+            terminal_fraction = terminal_linear * terminal_linear * (3.0 - 2.0 * terminal_linear)
+        terminal_kp_scale = 1.0 + terminal_fraction * (config.terminal_kp_scale - 1.0)
+        terminal_kd_scale = 1.0 + terminal_fraction * (config.terminal_kd_scale - 1.0)
         # Keep the slow structured controller's state independent from the
         # learned residual.  Feeding the combined target back through
         # ``_smoothed_target`` turns a bounded per-frame residual into an
@@ -527,15 +580,24 @@ class G1CerebellarRecoveryController:
             muscle_memory_residual_rms = muscle_effect.residual_rms_rad
             muscle_memory_actions = muscle_effect.synergy_actions.copy()
         self._smoothed_target = structured_target
-        active = fraction > 0.0 or smoothing_active or muscle_memory_active
+        active = (
+            fraction > 0.0 or smoothing_active or terminal_fraction > 0.0 or muscle_memory_active
+        )
         if active and self._activation_policy_frame is None:
             self._activation_policy_frame = policy_frame
             self._activation_time_sec = timestamp_sec
         if settling_fraction > 0.0 and self._settling_activation_policy_frame is None:
             self._settling_activation_policy_frame = policy_frame
             self._settling_activation_time_sec = timestamp_sec
+        if terminal_fraction > 0.0 and self._terminal_damping_activation_policy_frame is None:
+            self._terminal_damping_activation_policy_frame = policy_frame
+            self._terminal_damping_activation_time_sec = timestamp_sec
         self._peak_blend_fraction = max(self._peak_blend_fraction, fraction)
         self._peak_settling_fraction = max(self._peak_settling_fraction, settling_fraction)
+        self._peak_terminal_damping_fraction = max(
+            self._peak_terminal_damping_fraction,
+            terminal_fraction,
+        )
         return G1CerebellarRecoveryEffect(
             target=adapted,
             active=active,
@@ -545,6 +607,10 @@ class G1CerebellarRecoveryController:
             kick_foot_landing_latched=self._landing_latched,
             smoothing_active=smoothing_active,
             smoothing_residual_rms_rad=smoothing_residual,
+            terminal_damping_fraction=terminal_fraction,
+            terminal_kp_scale=terminal_kp_scale,
+            terminal_kd_scale=terminal_kd_scale,
+            terminal_damping_joint_group=config.terminal_damping_joint_group,
             muscle_memory_active=muscle_memory_active,
             muscle_memory_out_of_distribution=muscle_memory_ood,
             muscle_memory_residual_rms_rad=muscle_memory_residual_rms,
@@ -581,8 +647,13 @@ class G1CerebellarRecoveryController:
             smoothing_activation_time_sec=self._smoothing_activation_time_sec,
             settling_activation_policy_frame=self._settling_activation_policy_frame,
             settling_activation_time_sec=self._settling_activation_time_sec,
+            terminal_damping_activation_policy_frame=(
+                self._terminal_damping_activation_policy_frame
+            ),
+            terminal_damping_activation_time_sec=self._terminal_damping_activation_time_sec,
             peak_blend_fraction=self._peak_blend_fraction,
             peak_settling_fraction=self._peak_settling_fraction,
+            peak_terminal_damping_fraction=self._peak_terminal_damping_fraction,
             peak_smoothing_residual_rms_rad=self._peak_smoothing_residual_rms_rad,
             strict_replay=strict_replay,
             evidence_domain=evidence_domain,

--- a/src/rosclaw/simforge/g1_contextual_recovery.py
+++ b/src/rosclaw/simforge/g1_contextual_recovery.py
@@ -1,0 +1,422 @@
+"""SIM-only contextual motor-primitive memory for G1 post-kick recovery.
+
+The learned object maps the proprioceptive landing state to one of a bounded
+set of already validated recovery primitives.  It cannot emit torque, raw
+joint targets, ROS/DDS commands, or a hardware authorization.  Out-of-
+distribution states deterministically route to the retained parent primitive.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.simforge.g1_muscle_memory import G1_MUSCLE_MEMORY_OBSERVATIONS
+from rosclaw.simforge.tasks.g1_goalforge.concepts import hash_json
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MAX_ARTIFACT_BYTES = 1024 * 1024
+G1_CONTEXTUAL_RECOVERY_FEATURES = G1_MUSCLE_MEMORY_OBSERVATIONS
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoveryPrimitive:
+    """Bounded parameters for one contact-and-landing recovery primitive."""
+
+    start_policy_frame: int
+    blend_frames: int
+    settling_start_policy_frame: int
+    settling_blend_frames: int
+    settling_standing_pose_blend: float
+    settling_waist_pitch_bias_rad: float
+    target_smoothing_alpha: float
+    schema_version: str = "rosclaw.g1_goalforge.contextual_recovery_primitive.v1"
+
+    def __post_init__(self) -> None:
+        if self.schema_version != "rosclaw.g1_goalforge.contextual_recovery_primitive.v1":
+            raise ValueError("unsupported contextual recovery primitive schema")
+        counts = (
+            self.start_policy_frame,
+            self.blend_frames,
+            self.settling_start_policy_frame,
+            self.settling_blend_frames,
+        )
+        if any(isinstance(value, bool) or not isinstance(value, int) for value in counts):
+            raise ValueError("contextual recovery frame parameters must be integers")
+        if self.start_policy_frame < 0 or self.blend_frames <= 0:
+            raise ValueError("contextual recovery start/blend frames are invalid")
+        if self.settling_start_policy_frame < self.start_policy_frame + self.blend_frames:
+            raise ValueError("contextual settling cannot overlap the unloading blend")
+        if self.settling_blend_frames <= 0:
+            raise ValueError("contextual settling blend frames must be positive")
+        values = (
+            self.settling_standing_pose_blend,
+            self.settling_waist_pitch_bias_rad,
+            self.target_smoothing_alpha,
+        )
+        if any(isinstance(value, bool) for value in values) or not all(
+            isinstance(value, (int, float)) and math.isfinite(value) for value in values
+        ):
+            raise ValueError("contextual recovery parameters must be finite")
+        if not 0.0 <= self.settling_standing_pose_blend <= 0.50:
+            raise ValueError("contextual standing blend must be in [0, 0.50]")
+        if not -0.12 <= self.settling_waist_pitch_bias_rad <= 0.12:
+            raise ValueError("contextual waist pitch must be in [-0.12, 0.12]")
+        if not 0.25 <= self.target_smoothing_alpha <= 1.0:
+            raise ValueError("contextual smoothing alpha must be in [0.25, 1]")
+
+    @property
+    def primitive_hash(self) -> str:
+        return hash_json(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> G1ContextualRecoveryPrimitive:
+        expected = {
+            "schema_version",
+            "start_policy_frame",
+            "blend_frames",
+            "settling_start_policy_frame",
+            "settling_blend_frames",
+            "settling_standing_pose_blend",
+            "settling_waist_pitch_bias_rad",
+            "target_smoothing_alpha",
+        }
+        if set(value) != expected:
+            raise ValueError("contextual recovery primitive fields are invalid")
+        return cls(
+            schema_version=str(value["schema_version"]),
+            start_policy_frame=_strict_int(value["start_policy_frame"]),
+            blend_frames=_strict_int(value["blend_frames"]),
+            settling_start_policy_frame=_strict_int(value["settling_start_policy_frame"]),
+            settling_blend_frames=_strict_int(value["settling_blend_frames"]),
+            settling_standing_pose_blend=_strict_float(value["settling_standing_pose_blend"]),
+            settling_waist_pitch_bias_rad=_strict_float(value["settling_waist_pitch_bias_rad"]),
+            target_smoothing_alpha=_strict_float(value["target_smoothing_alpha"]),
+        )
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoveryArtifact:
+    """Content-addressed nearest-prototype contextual recovery policy."""
+
+    body_hash: str
+    motion_hash: str
+    baseline_recovery_config_hash: str
+    fallback_recovery_config_hash: str
+    training_dataset_hash: str
+    observation_mean: tuple[float, ...]
+    observation_scale: tuple[float, ...]
+    regime_feature_names: tuple[str, ...]
+    regime_prototypes: tuple[tuple[float, ...], ...]
+    primitives: tuple[G1ContextualRecoveryPrimitive, ...]
+    maximum_regime_distance: float
+    maximum_feature_z: float
+    training_episode_count: int
+    training_seed: int
+    activation_ceiling: str = "SIM_ONLY"
+    schema_version: str = "rosclaw.g1_goalforge.contextual_recovery_artifact.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("body_hash", self.body_hash),
+            ("motion_hash", self.motion_hash),
+            ("baseline_recovery_config_hash", self.baseline_recovery_config_hash),
+            ("fallback_recovery_config_hash", self.fallback_recovery_config_hash),
+            ("training_dataset_hash", self.training_dataset_hash),
+        ):
+            if not _SHA256.fullmatch(value):
+                raise ValueError(f"{label} must be a sha256 content hash")
+        if self.schema_version != "rosclaw.g1_goalforge.contextual_recovery_artifact.v1":
+            raise ValueError("unsupported contextual recovery artifact schema")
+        if self.regime_feature_names != G1_CONTEXTUAL_RECOVERY_FEATURES:
+            raise ValueError("contextual recovery feature contract mismatch")
+        observation_count = len(G1_MUSCLE_MEMORY_OBSERVATIONS)
+        feature_count = len(self.regime_feature_names)
+        if (
+            len(self.observation_mean) != observation_count
+            or len(self.observation_scale) != observation_count
+        ):
+            raise ValueError("contextual recovery normalization shape is invalid")
+        if not 1 <= len(self.regime_prototypes) <= 16:
+            raise ValueError("contextual recovery requires 1 to 16 prototypes")
+        if len(self.primitives) != len(self.regime_prototypes) or any(
+            len(row) != feature_count for row in self.regime_prototypes
+        ):
+            raise ValueError("contextual recovery prototype/primitive shape is invalid")
+        arrays = (
+            np.asarray(self.observation_mean, dtype=np.float64),
+            np.asarray(self.observation_scale, dtype=np.float64),
+            np.asarray(self.regime_prototypes, dtype=np.float64),
+        )
+        if not all(np.all(np.isfinite(value)) for value in arrays):
+            raise ValueError("contextual recovery artifact contains non-finite values")
+        if np.any(arrays[1] <= 0.0):
+            raise ValueError("contextual recovery observation scales must be positive")
+        thresholds = (self.maximum_regime_distance, self.maximum_feature_z)
+        if any(isinstance(value, bool) for value in thresholds) or not all(
+            isinstance(value, (int, float)) and math.isfinite(value) for value in thresholds
+        ):
+            raise ValueError("contextual recovery thresholds must be finite numbers")
+        if not 0.01 <= self.maximum_regime_distance <= 2.0:
+            raise ValueError("contextual recovery distance must be in [0.01, 2]")
+        if not 2.0 <= self.maximum_feature_z <= 12.0:
+            raise ValueError("contextual recovery feature envelope must be in [2, 12]")
+        if isinstance(self.training_episode_count, bool) or not isinstance(
+            self.training_episode_count, int
+        ):
+            raise ValueError("contextual recovery episode count must be an integer")
+        if isinstance(self.training_seed, bool) or not isinstance(self.training_seed, int):
+            raise ValueError("contextual recovery training seed must be an integer")
+        if self.training_episode_count <= 0 or self.training_seed < 0:
+            raise ValueError("contextual recovery training evidence is invalid")
+        if self.activation_ceiling != "SIM_ONLY":
+            raise ValueError("contextual recovery must remain SIM_ONLY")
+
+    @property
+    def artifact_hash(self) -> str:
+        return hash_json(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["observation_names"] = list(G1_MUSCLE_MEMORY_OBSERVATIONS)
+        value["observation_mean"] = list(self.observation_mean)
+        value["observation_scale"] = list(self.observation_scale)
+        value["regime_feature_names"] = list(self.regime_feature_names)
+        value["regime_prototypes"] = [list(row) for row in self.regime_prototypes]
+        value["primitives"] = [item.to_dict() for item in self.primitives]
+        return value
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> G1ContextualRecoveryArtifact:
+        expected = {
+            "schema_version",
+            "body_hash",
+            "motion_hash",
+            "baseline_recovery_config_hash",
+            "fallback_recovery_config_hash",
+            "training_dataset_hash",
+            "observation_names",
+            "observation_mean",
+            "observation_scale",
+            "regime_feature_names",
+            "regime_prototypes",
+            "primitives",
+            "maximum_regime_distance",
+            "maximum_feature_z",
+            "training_episode_count",
+            "training_seed",
+            "activation_ceiling",
+        }
+        if set(value) != expected:
+            raise ValueError("contextual recovery artifact fields are invalid")
+        observation_names = value["observation_names"]
+        feature_names = value["regime_feature_names"]
+        if (
+            not isinstance(observation_names, list)
+            or not all(isinstance(item, str) for item in observation_names)
+            or tuple(observation_names) != G1_MUSCLE_MEMORY_OBSERVATIONS
+        ):
+            raise ValueError("contextual recovery observation contract mismatch")
+        if not isinstance(feature_names, list) or not all(
+            isinstance(item, str) for item in feature_names
+        ):
+            raise ValueError("contextual recovery feature names must be an array of strings")
+        prototypes_value = value["regime_prototypes"]
+        primitives_value = value["primitives"]
+        if not isinstance(prototypes_value, list) or not isinstance(primitives_value, list):
+            raise ValueError("contextual recovery prototypes/primitives must be arrays")
+        if not all(isinstance(row, list) for row in prototypes_value):
+            raise ValueError("contextual recovery prototypes must contain numeric arrays")
+        if not all(isinstance(item, Mapping) for item in primitives_value):
+            raise ValueError("contextual recovery primitives must contain objects")
+        return cls(
+            schema_version=str(value["schema_version"]),
+            body_hash=str(value["body_hash"]),
+            motion_hash=str(value["motion_hash"]),
+            baseline_recovery_config_hash=str(value["baseline_recovery_config_hash"]),
+            fallback_recovery_config_hash=str(value["fallback_recovery_config_hash"]),
+            training_dataset_hash=str(value["training_dataset_hash"]),
+            observation_mean=_float_tuple(value["observation_mean"]),
+            observation_scale=_float_tuple(value["observation_scale"]),
+            regime_feature_names=tuple(feature_names),
+            regime_prototypes=tuple(_float_tuple(row) for row in prototypes_value),
+            primitives=tuple(
+                G1ContextualRecoveryPrimitive.from_dict(item) for item in primitives_value
+            ),
+            maximum_regime_distance=_strict_float(value["maximum_regime_distance"]),
+            maximum_feature_z=_strict_float(value["maximum_feature_z"]),
+            training_episode_count=_strict_int(value["training_episode_count"]),
+            training_seed=_strict_int(value["training_seed"]),
+            activation_ceiling=str(value["activation_ceiling"]),
+        )
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoverySelection:
+    primitive_index: int | None
+    nearest_distance: float
+    out_of_distribution: bool
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoveryReceipt:
+    artifact_hash: str
+    selected_primitive_index: int | None
+    nearest_distance: float | None
+    selection_count: int
+    fallback_count: int
+    activation_ceiling: str = "SIM_ONLY"
+    hardware_command_sent: bool = False
+    schema_version: str = "rosclaw.g1_goalforge.contextual_recovery_receipt.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class G1ContextualRecoveryPolicy:
+    """Select a bounded primitive from normalized proprioceptive context."""
+
+    def __init__(self, artifact: G1ContextualRecoveryArtifact) -> None:
+        self.artifact = artifact
+        self._mean = np.asarray(artifact.observation_mean, dtype=np.float64)
+        self._scale = np.asarray(artifact.observation_scale, dtype=np.float64)
+        self._feature_indices = np.asarray(
+            [G1_MUSCLE_MEMORY_OBSERVATIONS.index(name) for name in artifact.regime_feature_names],
+            dtype=np.int64,
+        )
+        self._prototypes = np.asarray(artifact.regime_prototypes, dtype=np.float64)
+        self.reset()
+
+    def require_compatible(
+        self,
+        *,
+        body_hash: str,
+        motion_hash: str,
+        baseline_recovery_config_hash: str,
+        fallback_recovery_config_hash: str,
+    ) -> None:
+        expected = self.artifact
+        if body_hash != expected.body_hash:
+            raise ValueError("contextual recovery Body hash mismatch")
+        if motion_hash != expected.motion_hash:
+            raise ValueError("contextual recovery motion hash mismatch")
+        if baseline_recovery_config_hash != expected.baseline_recovery_config_hash:
+            raise ValueError("contextual recovery baseline config hash mismatch")
+        if fallback_recovery_config_hash != expected.fallback_recovery_config_hash:
+            raise ValueError("contextual recovery fallback config hash mismatch")
+
+    def reset(self) -> None:
+        self._selection: G1ContextualRecoverySelection | None = None
+        self._selection_count = 0
+        self._fallback_count = 0
+
+    def select(self, observation: Mapping[str, float]) -> G1ContextualRecoverySelection:
+        if self._selection is not None:
+            return self._selection
+        missing = set(G1_MUSCLE_MEMORY_OBSERVATIONS).difference(observation)
+        if missing:
+            return self._latch_fallback()
+        try:
+            ordered = np.asarray(
+                [float(observation[name]) for name in G1_MUSCLE_MEMORY_OBSERVATIONS],
+                dtype=np.float64,
+            )
+        except (TypeError, ValueError):
+            return self._latch_fallback()
+        if not np.all(np.isfinite(ordered)):
+            return self._latch_fallback()
+        normalized = (ordered - self._mean) / self._scale
+        feature = normalized[self._feature_indices]
+        distances = np.linalg.norm(self._prototypes - feature, axis=1)
+        nearest = int(np.argmin(distances))
+        distance = float(distances[nearest])
+        ood = bool(
+            np.max(np.abs(normalized)) > self.artifact.maximum_feature_z
+            or distance > self.artifact.maximum_regime_distance
+        )
+        self._selection = G1ContextualRecoverySelection(
+            primitive_index=None if ood else nearest,
+            nearest_distance=distance,
+            out_of_distribution=ood,
+        )
+        self._selection_count += 1
+        self._fallback_count += int(ood)
+        return self._selection
+
+    def _latch_fallback(self) -> G1ContextualRecoverySelection:
+        self._selection = G1ContextualRecoverySelection(
+            primitive_index=None,
+            nearest_distance=self.artifact.maximum_regime_distance + 1.0,
+            out_of_distribution=True,
+        )
+        self._selection_count += 1
+        self._fallback_count += 1
+        return self._selection
+
+    def build_receipt(self) -> G1ContextualRecoveryReceipt:
+        return G1ContextualRecoveryReceipt(
+            artifact_hash=self.artifact.artifact_hash,
+            selected_primitive_index=(
+                self._selection.primitive_index if self._selection is not None else None
+            ),
+            nearest_distance=(
+                self._selection.nearest_distance if self._selection is not None else None
+            ),
+            selection_count=self._selection_count,
+            fallback_count=self._fallback_count,
+        )
+
+
+def load_g1_contextual_recovery_artifact(path: Path) -> G1ContextualRecoveryArtifact:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file() or resolved.stat().st_size > _MAX_ARTIFACT_BYTES:
+        raise ValueError("contextual recovery artifact is missing or exceeds 1 MiB")
+    try:
+        value = json.loads(resolved.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError("contextual recovery artifact is not readable JSON") from exc
+    if not isinstance(value, Mapping):
+        raise ValueError("contextual recovery artifact root must be an object")
+    return G1ContextualRecoveryArtifact.from_dict(value)
+
+
+def _strict_float(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("contextual recovery numeric field has invalid type")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError("contextual recovery numeric field must be finite")
+    return result
+
+
+def _strict_int(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("contextual recovery integer field has invalid type")
+    return value
+
+
+def _float_tuple(value: Any) -> tuple[float, ...]:
+    if not isinstance(value, list):
+        raise ValueError("contextual recovery numeric vector must be an array")
+    return tuple(_strict_float(item) for item in value)
+
+
+__all__ = [
+    "G1ContextualRecoveryArtifact",
+    "G1_CONTEXTUAL_RECOVERY_FEATURES",
+    "G1ContextualRecoveryPolicy",
+    "G1ContextualRecoveryPrimitive",
+    "G1ContextualRecoveryReceipt",
+    "G1ContextualRecoverySelection",
+    "load_g1_contextual_recovery_artifact",
+]

--- a/src/rosclaw/simforge/g1_contextual_recovery_training.py
+++ b/src/rosclaw/simforge/g1_contextual_recovery_training.py
@@ -112,6 +112,22 @@ class G1ContextualRecoveryHoldoutSummary:
 
 
 @dataclass(frozen=True)
+class G1TerminalDampingDevelopmentSummary:
+    case_count: int
+    passed_count: int
+    mean_backward_reduction: float
+    mean_tail_wobble_reduction: float
+    minimum_tail_wobble_reduction: float
+    mean_tail_joint_jerk_reduction: float
+    minimum_tail_joint_jerk_reduction: float
+    qualified: bool
+    development_only: bool = True
+    evidence_domain: str = "SIM"
+    physics_authority: str = "CPU_MUJOCO"
+    schema_version: str = "rosclaw.g1_goalforge.terminal_damping_development.v1"
+
+
+@dataclass(frozen=True)
 class G1ContextualRecoveryTrainingReport:
     artifact: G1ContextualRecoveryArtifact
     development_cases: tuple[G1MuscleMemoryCaseResult, ...]
@@ -129,6 +145,7 @@ class G1ContextualRecoveryTrainingReport:
     learned_component_composite_reduction: float
     learned_component_worst_case_composite: float
     learned_component_bootstrap_lower_95: float
+    terminal_damping: G1TerminalDampingDevelopmentSummary
     validation: G1ContextualRecoveryValidationSummary
     holdout: G1ContextualRecoveryHoldoutSummary
     qualified: bool
@@ -163,6 +180,7 @@ class G1ContextualRecoveryTrainingReport:
             "learned_component_composite_reduction": (self.learned_component_composite_reduction),
             "learned_component_worst_case_composite": (self.learned_component_worst_case_composite),
             "learned_component_bootstrap_lower_95": (self.learned_component_bootstrap_lower_95),
+            "terminal_damping": asdict(self.terminal_damping),
             "validation": asdict(self.validation),
             "holdout": asdict(self.holdout),
             "qualified": self.qualified,
@@ -246,6 +264,11 @@ class G1ContextualRecoveryTrainer:
             settling_standing_pose_blend=0.42,
             settling_waist_pitch_bias_rad=0.11,
             target_smoothing_alpha=0.54,
+            terminal_damping_start_policy_frame=500,
+            terminal_damping_blend_frames=80,
+            terminal_kp_scale=0.93,
+            terminal_kd_scale=1.50,
+            terminal_damping_joint_group="legs",
         )
         self.base = G1MuscleMemoryTrainer(
             asset_root=asset_root,
@@ -418,6 +441,13 @@ class G1ContextualRecoveryTrainer:
             training_seed=self.seed,
         )
 
+        terminal_damping = self._evaluate_terminal_damping(
+            artifact=artifact,
+            moving_indices=moving_indices,
+        )
+        if not terminal_damping.qualified:
+            reasons.append("terminal_damping_development_failed")
+
         development_rows: list[G1MuscleMemoryCaseResult] = []
         learned_rows: list[tuple[float, float, float]] = []
         learned_composites: list[float] = []
@@ -428,6 +458,7 @@ class G1ContextualRecoveryTrainer:
             replay = self._run_contextual(case, artifact)
             strict = _strict_replay(candidate, replay)
             candidate_metric = measure_g1_recovery_quality(candidate.trajectory)
+            expected_route: int | None
             if index in moving_indices:
                 local_index = moving_indices.index(index)
                 causal_baseline_metric = fixed_quality[local_index]
@@ -515,7 +546,11 @@ class G1ContextualRecoveryTrainer:
             fixed_structured_config_hash=fixed_hash,
             fixed_structured_config=asdict(self.fixed_config),
             training_rollout_count=(
-                len(parents) + len(fixed) + len(library) * len(moving_indices) + 2 * len(self.cases)
+                len(parents)
+                + len(fixed)
+                + len(library) * len(moving_indices)
+                + 2 * len(moving_indices)
+                + 2 * len(self.cases)
             ),
             validation_rollout_count=validation_rollouts,
             holdout_rollout_count=holdout_rollouts,
@@ -525,6 +560,7 @@ class G1ContextualRecoveryTrainer:
             learned_component_composite_reduction=mean_composite,
             learned_component_worst_case_composite=worst_composite,
             learned_component_bootstrap_lower_95=bootstrap_lower,
+            terminal_damping=terminal_damping,
             validation=validation,
             holdout=holdout,
             qualified=not reasons,
@@ -586,6 +622,7 @@ class G1ContextualRecoveryTrainer:
             "rosclaw.g1_goalforge.contextual_validation.v4",
             cases,
         )
+
         qualified = bool(
             suite_hash == expected_suite_hash
             and passed_count == len(cases)
@@ -612,6 +649,67 @@ class G1ContextualRecoveryTrainer:
                 qualified=qualified,
             ),
             4 * len(cases),
+        )
+
+    def _evaluate_terminal_damping(
+        self,
+        *,
+        artifact: G1ContextualRecoveryArtifact,
+        moving_indices: tuple[int, ...],
+    ) -> G1TerminalDampingDevelopmentSummary:
+        """Measure the third-stage damping against an exact parameter ablation."""
+
+        rows: list[tuple[float, float, float]] = []
+        passed = 0
+        for local_index, case_index in enumerate(moving_indices):
+            case = self.cases[case_index]
+            damped_config = _config_from_primitive(
+                self.fixed_config,
+                artifact.primitives[local_index],
+            )
+            ablated_config = replace(
+                damped_config,
+                terminal_damping_start_policy_frame=None,
+                terminal_kp_scale=1.0,
+                terminal_kd_scale=1.0,
+            )
+            ablated = self._run_config(case, ablated_config)
+            damped = self._run_config(case, damped_config)
+            ablated_quality = measure_g1_recovery_quality(ablated.trajectory)
+            damped_quality = measure_g1_recovery_quality(damped.trajectory)
+            _, safe, goal, natural = _case_score(
+                parent=ablated,
+                parent_quality=ablated_quality,
+                candidate=damped,
+                candidate_quality=damped_quality,
+            )
+            reductions = _terminal_damping_reductions(ablated_quality, damped_quality)
+            rows.append(reductions)
+            passed += int(
+                safe
+                and goal
+                and natural
+                and reductions[0] >= 0.0
+                and reductions[1] >= -0.05
+                and reductions[2] >= 0.12
+            )
+        values = np.asarray(rows, dtype=np.float64)
+        means = np.mean(values, axis=0)
+        qualified = bool(
+            passed == len(moving_indices)
+            and means[0] >= 0.0
+            and means[1] >= -0.02
+            and means[2] >= 0.20
+        )
+        return G1TerminalDampingDevelopmentSummary(
+            case_count=len(moving_indices),
+            passed_count=passed,
+            mean_backward_reduction=float(means[0]),
+            mean_tail_wobble_reduction=float(means[1]),
+            minimum_tail_wobble_reduction=float(np.min(values[:, 1])),
+            mean_tail_joint_jerk_reduction=float(means[2]),
+            minimum_tail_joint_jerk_reduction=float(np.min(values[:, 2])),
+            qualified=qualified,
         )
 
     def _evaluate_holdout(
@@ -823,6 +921,30 @@ def _composite(reductions: tuple[float, float, float]) -> float:
     return float(0.40 * reductions[0] + 0.40 * reductions[1] + 0.20 * reductions[2])
 
 
+def _terminal_damping_reductions(
+    ablated: G1RecoveryQuality,
+    damped: G1RecoveryQuality,
+) -> tuple[float, float, float]:
+    """Return physical gains for backstep, whole-body wobble, and tail twitch."""
+
+    def reduction(parent: float, candidate: float, floor: float) -> float:
+        return (parent - candidate) / max(abs(parent), floor)
+
+    return (
+        reduction(
+            ablated.post_contact_backward_reversal_m,
+            damped.post_contact_backward_reversal_m,
+            0.05,
+        ),
+        reduction(ablated.tail_wobble_index, damped.tail_wobble_index, 0.05),
+        reduction(
+            ablated.tail_joint_jerk_rms_rad_s3,
+            damped.tail_joint_jerk_rms_rad_s3,
+            0.10,
+        ),
+    )
+
+
 def _bootstrap_lower_95(values: tuple[float, ...], *, seed: int) -> float:
     sample = np.asarray(values, dtype=np.float64)
     if sample.ndim != 1 or len(sample) < 2 or not np.all(np.isfinite(sample)):
@@ -872,5 +994,6 @@ __all__ = [
     "G1ContextualRecoveryTrainer",
     "G1ContextualRecoveryTrainingReport",
     "G1ContextualRecoveryValidationSummary",
+    "G1TerminalDampingDevelopmentSummary",
     "write_g1_contextual_recovery_report",
 ]

--- a/src/rosclaw/simforge/g1_contextual_recovery_training.py
+++ b/src/rosclaw/simforge/g1_contextual_recovery_training.py
@@ -1,0 +1,876 @@
+"""Rollout learning for contextual G1 post-kick recovery primitives.
+
+CPU MuJoCo remains the sole physics authority.  The learner evaluates a
+bounded library of recovery primitives on DEVELOPMENT regimes, then freezes a
+nearest-prototype selector before opening VALIDATION and private HOLDOUT
+suites.  The exported actor can only select a validated target-space primitive
+or route to the retained parent; it cannot emit torque or authorize hardware.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.simforge.backends.unitree_mujoco_backend import (
+    GoalForgeEpisode,
+    trajectory_digest,
+)
+from rosclaw.simforge.g1_cerebellar_recovery import G1CerebellarRecoveryConfig
+from rosclaw.simforge.g1_contextual_recovery import (
+    G1_CONTEXTUAL_RECOVERY_FEATURES,
+    G1ContextualRecoveryArtifact,
+    G1ContextualRecoveryPrimitive,
+)
+from rosclaw.simforge.g1_moving_ball import MovingBallInterceptAdapter
+from rosclaw.simforge.g1_muscle_memory import G1_MUSCLE_MEMORY_OBSERVATIONS
+from rosclaw.simforge.g1_muscle_memory_training import (
+    G1MuscleMemoryCase,
+    G1MuscleMemoryCaseResult,
+    G1MuscleMemoryTrainer,
+    _case_score,
+    _normalization,
+    g1_muscle_memory_parent_config,
+)
+from rosclaw.simforge.g1_recovery_quality import (
+    G1RecoveryQuality,
+    measure_g1_recovery_quality,
+)
+from rosclaw.simforge.g1_temporal_muscle_memory_training import (
+    _build_temporal_holdout_cases,
+    _case_commitment_hash,
+    _moving_reductions,
+    build_g1_temporal_muscle_memory_cases,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import hash_json
+
+_POINT_ESTIMATE_GATE = 0.05
+_COMPONENT_REGRESSION_LIMIT = 0.02
+_BOOTSTRAP_DRAWS = 10_000
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoveryPrimitiveTrial:
+    case_name: str
+    primitive_hash: str
+    primitive: dict[str, Any]
+    score: float
+    backward_reduction: float
+    tail_wobble_reduction: float
+    leg_jerk_reduction: float
+    composite_reduction: float
+    safe: bool
+    goal_preserved: bool
+    naturalness_preserved: bool
+    selected: bool
+    schema_version: str = "rosclaw.g1_goalforge.contextual_primitive_trial.v1"
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoveryValidationSummary:
+    suite_hash: str
+    case_count: int
+    parent_valid_count: int
+    contextual_route_count: int
+    strict_replay_count: int
+    passed_count: int
+    mean_composite_reduction: float
+    minimum_composite_reduction: float
+    bootstrap_lower_95: float
+    mean_backward_reduction: float
+    mean_tail_wobble_reduction: float
+    mean_leg_jerk_reduction: float
+    qualified: bool
+    development_search_excluded: bool = True
+    case_rows_disclosed: bool = False
+    evidence_domain: str = "SIM"
+    physics_authority: str = "CPU_MUJOCO"
+    schema_version: str = "rosclaw.g1_goalforge.contextual_validation.v2"
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoveryHoldoutSummary:
+    suite_hash: str
+    case_count: int
+    parent_valid_count: int
+    fallback_route_count: int
+    strict_replay_count: int
+    exact_parent_replay_count: int
+    passed_count: int
+    qualified: bool
+    development_search_excluded: bool = True
+    case_rows_disclosed: bool = False
+    evidence_domain: str = "SIM"
+    physics_authority: str = "CPU_MUJOCO"
+    schema_version: str = "rosclaw.g1_goalforge.contextual_holdout.v1"
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoveryTrainingReport:
+    artifact: G1ContextualRecoveryArtifact
+    development_cases: tuple[G1MuscleMemoryCaseResult, ...]
+    primitive_trials: tuple[G1ContextualRecoveryPrimitiveTrial, ...]
+    retained_recovery_config_hash: str
+    retained_recovery_config: dict[str, Any]
+    fixed_structured_config_hash: str
+    fixed_structured_config: dict[str, Any]
+    training_rollout_count: int
+    validation_rollout_count: int
+    holdout_rollout_count: int
+    learned_component_backward_reduction: float
+    learned_component_tail_wobble_reduction: float
+    learned_component_leg_jerk_reduction: float
+    learned_component_composite_reduction: float
+    learned_component_worst_case_composite: float
+    learned_component_bootstrap_lower_95: float
+    validation: G1ContextualRecoveryValidationSummary
+    holdout: G1ContextualRecoveryHoldoutSummary
+    qualified: bool
+    rejection_reasons: tuple[str, ...]
+    activation_ceiling: str = "SIM_ONLY"
+    evidence_domain: str = "SIM"
+    physics_authority: str = "CPU_MUJOCO"
+    hardware_command_sent: bool = False
+    schema_version: str = "rosclaw.g1_goalforge.contextual_recovery_training.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "artifact": {
+                **self.artifact.to_dict(),
+                "artifact_hash": self.artifact.artifact_hash,
+            },
+            "development_cases": [asdict(item) for item in self.development_cases],
+            "primitive_trials": [asdict(item) for item in self.primitive_trials],
+            "retained_recovery_config_hash": self.retained_recovery_config_hash,
+            "retained_recovery_config": self.retained_recovery_config,
+            "fixed_structured_config_hash": self.fixed_structured_config_hash,
+            "fixed_structured_config": self.fixed_structured_config,
+            "training_rollout_count": self.training_rollout_count,
+            "validation_rollout_count": self.validation_rollout_count,
+            "holdout_rollout_count": self.holdout_rollout_count,
+            "learned_component_backward_reduction": (self.learned_component_backward_reduction),
+            "learned_component_tail_wobble_reduction": (
+                self.learned_component_tail_wobble_reduction
+            ),
+            "learned_component_leg_jerk_reduction": (self.learned_component_leg_jerk_reduction),
+            "learned_component_composite_reduction": (self.learned_component_composite_reduction),
+            "learned_component_worst_case_composite": (self.learned_component_worst_case_composite),
+            "learned_component_bootstrap_lower_95": (self.learned_component_bootstrap_lower_95),
+            "validation": asdict(self.validation),
+            "holdout": asdict(self.holdout),
+            "qualified": self.qualified,
+            "rejection_reasons": list(self.rejection_reasons),
+            "qualification_thresholds": {
+                "learned_component_point_estimate": _POINT_ESTIMATE_GATE,
+                "component_regression_limit": _COMPONENT_REGRESSION_LIMIT,
+                "bootstrap_lower_95": 0.0,
+            },
+            "activation_ceiling": self.activation_ceiling,
+            "evidence_domain": self.evidence_domain,
+            "physics_authority": self.physics_authority,
+            "hardware_command_sent": self.hardware_command_sent,
+        }
+
+
+def build_g1_contextual_recovery_cases() -> tuple[G1MuscleMemoryCase, ...]:
+    """Expand DEVELOPMENT around three regimes without opening validation."""
+
+    static, nominal, lateral, light, disturbed = build_g1_temporal_muscle_memory_cases()
+    specifications = (
+        ("moving_ball_nominal_velocity_070", nominal, {"ball_velocity_x_mps": -0.070}),
+        ("moving_ball_light_402g", light, {"ball_mass_kg": 0.402}),
+    )
+    adapter = MovingBallInterceptAdapter()
+    variants: list[G1MuscleMemoryCase] = []
+    for name, source, changes in specifications:
+        scenario = replace(source.scenario, scenario_id=name, **changes)
+        plan = adapter.plan(scenario)
+        if not plan.eligible:
+            raise RuntimeError(f"contextual development case is ineligible: {name}")
+        variants.append(
+            G1MuscleMemoryCase(name=name, scenario=scenario, parameters=plan.parameters)
+        )
+    return (
+        static,
+        nominal,
+        lateral,
+        light,
+        variants[0],
+        variants[1],
+        disturbed,
+    )
+
+
+def _build_contextual_validation_cases() -> tuple[G1MuscleMemoryCase, ...]:
+    """Predeclare v2 VALIDATION interpolation cases before policy search."""
+
+    _, nominal, _lateral, light, _ = build_g1_temporal_muscle_memory_cases()
+    specifications = (
+        (
+            "contextual_validation_nominal_velocity_0725",
+            nominal,
+            {"ball_velocity_x_mps": -0.0725},
+        ),
+        ("contextual_validation_light_4015g", light, {"ball_mass_kg": 0.4015}),
+        ("contextual_validation_light_4038g", light, {"ball_mass_kg": 0.4038}),
+    )
+    adapter = MovingBallInterceptAdapter()
+    cases: list[G1MuscleMemoryCase] = []
+    for name, source, changes in specifications:
+        scenario = replace(source.scenario, scenario_id=name, **changes)
+        plan = adapter.plan(scenario)
+        if not plan.eligible:
+            raise RuntimeError(f"contextual validation case is ineligible: {name}")
+        cases.append(G1MuscleMemoryCase(name=name, scenario=scenario, parameters=plan.parameters))
+    return tuple(cases)
+
+
+class G1ContextualRecoveryTrainer:
+    """Learn a proprioceptive router over bounded recovery primitives."""
+
+    def __init__(self, *, asset_root: Path, seed: int = 20260802) -> None:
+        if seed < 0:
+            raise ValueError("contextual recovery seed must be non-negative")
+        self.seed = seed
+        self.cases = build_g1_contextual_recovery_cases()
+        self.retained_config = g1_muscle_memory_parent_config()
+        self.fixed_config = replace(
+            self.retained_config,
+            settling_standing_pose_blend=0.42,
+            settling_waist_pitch_bias_rad=0.11,
+            target_smoothing_alpha=0.54,
+        )
+        self.base = G1MuscleMemoryTrainer(
+            asset_root=asset_root,
+            cases=self.cases,
+            recovery_config=self.retained_config,
+        )
+
+    def train(self) -> G1ContextualRecoveryTrainingReport:
+        reasons: list[str] = []
+        moving_indices = tuple(
+            index for index, case in enumerate(self.cases) if case.name.startswith("moving_ball")
+        )
+        if len(moving_indices) < 5:
+            raise RuntimeError("contextual recovery requires a multi-regime development suite")
+
+        parents = tuple(self._run_config(case, self.retained_config) for case in self.cases)
+        parent_quality = tuple(
+            measure_g1_recovery_quality(episode.trajectory) for episode in parents
+        )
+        fixed = tuple(
+            self._run_config(self.cases[index], self.fixed_config) for index in moving_indices
+        )
+        fixed_quality = tuple(measure_g1_recovery_quality(episode.trajectory) for episode in fixed)
+        mean, scale = _normalization(parents)
+        retained_hash = self._config_hash(self.retained_config)
+        fixed_hash = self._config_hash(self.fixed_config)
+        validation_cases = _build_contextual_validation_cases()
+        validation_suite_hash = _case_commitment_hash(
+            "rosclaw.g1_goalforge.contextual_validation.v4",
+            validation_cases,
+        )
+
+        selected_primitives: list[G1ContextualRecoveryPrimitive] = []
+        trial_rows: list[G1ContextualRecoveryPrimitiveTrial] = []
+        trial_commitments: list[dict[str, Any]] = []
+        library = _primitive_library()
+        for local_index, case_index in enumerate(moving_indices):
+            case = self.cases[case_index]
+            baseline_quality = fixed_quality[local_index]
+            retained_parent = parents[case_index]
+            retained_parent_quality = parent_quality[case_index]
+            scored: list[
+                tuple[
+                    float,
+                    str,
+                    G1ContextualRecoveryPrimitive,
+                    GoalForgeEpisode,
+                    G1RecoveryQuality,
+                    float,
+                    bool,
+                    bool,
+                    bool,
+                    tuple[float, float, float],
+                ]
+            ] = []
+            for primitive in library:
+                config = _config_from_primitive(self.fixed_config, primitive)
+                episode = self._run_config(case, config)
+                quality = measure_g1_recovery_quality(episode.trajectory)
+                score, safe, goal, natural = _case_score(
+                    parent=retained_parent,
+                    parent_quality=retained_parent_quality,
+                    candidate=episode,
+                    candidate_quality=quality,
+                )
+                reductions = _moving_reductions(baseline_quality, quality)
+                composite = _composite(reductions)
+                eligible = bool(
+                    safe
+                    and goal
+                    and natural
+                    and min(reductions) >= -_COMPONENT_REGRESSION_LIMIT
+                    and composite >= 0.0
+                )
+                selection_score = composite + 0.02 * score if eligible else -1_000_000.0
+                scored.append(
+                    (
+                        selection_score,
+                        primitive.primitive_hash,
+                        primitive,
+                        episode,
+                        quality,
+                        score,
+                        safe,
+                        goal,
+                        natural,
+                        reductions,
+                    )
+                )
+                trial_commitments.append(
+                    {
+                        "case_name": case.name,
+                        "primitive_hash": primitive.primitive_hash,
+                        "trajectory_hash": trajectory_digest(episode.trajectory),
+                        "result": episode.result.summary_dict(),
+                        "score": score,
+                        "reductions": list(reductions),
+                        "composite": composite,
+                        "eligible": eligible,
+                    }
+                )
+            scored.sort(key=lambda item: (item[0], item[1]), reverse=True)
+            if scored[0][0] <= -1_000_000.0:
+                raise RuntimeError(f"no contextual primitive passed for {case.name}")
+            selected = scored[0]
+            selected_primitives.append(selected[2])
+            for row in scored:
+                reductions = row[9]
+                trial_rows.append(
+                    G1ContextualRecoveryPrimitiveTrial(
+                        case_name=case.name,
+                        primitive_hash=row[2].primitive_hash,
+                        primitive=row[2].to_dict(),
+                        score=row[5],
+                        backward_reduction=reductions[0],
+                        tail_wobble_reduction=reductions[1],
+                        leg_jerk_reduction=reductions[2],
+                        composite_reduction=_composite(reductions),
+                        safe=row[6],
+                        goal_preserved=row[7],
+                        naturalness_preserved=row[8],
+                        selected=row[2].primitive_hash == selected[2].primitive_hash,
+                    )
+                )
+
+        dataset_hash = hash_json(
+            {
+                "schema_version": "rosclaw.g1_goalforge.contextual_recovery_dataset.v1",
+                "development_cases": [
+                    {
+                        "name": case.name,
+                        "scenario_commitment": case.scenario.scenario_commitment,
+                        "policy_hash": case.parameters.policy_hash,
+                        "retained_trajectory_hash": trajectory_digest(parent.trajectory),
+                    }
+                    for case, parent in zip(self.cases, parents, strict=True)
+                ],
+                "fixed_structured_config_hash": fixed_hash,
+                "retained_recovery_config_hash": retained_hash,
+                "primitive_library": [primitive.to_dict() for primitive in library],
+                "trial_commitments": trial_commitments,
+                "observation_mean": list(mean),
+                "observation_scale": list(scale),
+                "validation_suite_hash": validation_suite_hash,
+                "validation_excluded": True,
+                "private_holdout_excluded": True,
+            }
+        )
+        artifact = G1ContextualRecoveryArtifact(
+            body_hash=self.base.backend.qualification.body_hash,
+            motion_hash=self.base.backend.qualification.motion_hash,
+            baseline_recovery_config_hash=fixed_hash,
+            fallback_recovery_config_hash=retained_hash,
+            training_dataset_hash=dataset_hash,
+            observation_mean=mean,
+            observation_scale=scale,
+            regime_feature_names=(self._feature_names()),
+            regime_prototypes=tuple(
+                _contextual_route_prototype(
+                    parents[index],
+                    observation_mean=mean,
+                    observation_scale=scale,
+                )
+                for index in moving_indices
+            ),
+            primitives=tuple(selected_primitives),
+            maximum_regime_distance=0.50,
+            maximum_feature_z=8.0,
+            training_episode_count=(len(parents) + len(fixed) + len(library) * len(moving_indices)),
+            training_seed=self.seed,
+        )
+
+        development_rows: list[G1MuscleMemoryCaseResult] = []
+        learned_rows: list[tuple[float, float, float]] = []
+        learned_composites: list[float] = []
+        for index, (case, parent, parent_metric) in enumerate(
+            zip(self.cases, parents, parent_quality, strict=True)
+        ):
+            candidate = self._run_contextual(case, artifact)
+            replay = self._run_contextual(case, artifact)
+            strict = _strict_replay(candidate, replay)
+            candidate_metric = measure_g1_recovery_quality(candidate.trajectory)
+            if index in moving_indices:
+                local_index = moving_indices.index(index)
+                causal_baseline_metric = fixed_quality[local_index]
+                expected_route = local_index
+                reductions = _moving_reductions(causal_baseline_metric, candidate_metric)
+                learned_rows.append(reductions)
+                learned_composites.append(_composite(reductions))
+            comparison = parent
+            comparison_metric = parent_metric
+            if index not in moving_indices:
+                expected_route = None
+            score, safe, goal, natural = _case_score(
+                parent=comparison,
+                parent_quality=comparison_metric,
+                candidate=candidate,
+                candidate_quality=candidate_metric,
+            )
+            route = _contextual_route(candidate)
+            if route != expected_route:
+                reasons.append(case.name + ":contextual_route_mismatch")
+            if expected_route is None and (
+                trajectory_digest(parent.trajectory) != trajectory_digest(candidate.trajectory)
+                or parent.result.summary_dict() != candidate.result.summary_dict()
+            ):
+                reasons.append(case.name + ":retained_parent_replay_mismatch")
+            if not safe:
+                reasons.append(case.name + ":safety_regressed")
+            if not goal:
+                reasons.append(case.name + ":goal_regressed")
+            if not natural:
+                reasons.append(case.name + ":naturalness_regressed")
+            if not strict:
+                reasons.append(case.name + ":strict_replay_failed")
+            development_rows.append(
+                G1MuscleMemoryCaseResult(
+                    name=case.name,
+                    parent_result=comparison.result.summary_dict(),
+                    candidate_result=candidate.result.summary_dict(),
+                    parent_metrics=comparison_metric.to_dict(),
+                    candidate_metrics=candidate_metric.to_dict(),
+                    score=score,
+                    safe=safe,
+                    goal_preserved=goal,
+                    naturalness_preserved=natural,
+                    strict_replay=strict,
+                )
+            )
+
+        learned = np.asarray(learned_rows, dtype=np.float64)
+        means = np.mean(learned, axis=0)
+        mean_composite = float(np.mean(learned_composites))
+        worst_composite = float(np.min(learned_composites))
+        bootstrap_lower = _bootstrap_lower_95(
+            tuple(learned_composites),
+            seed=self.seed,
+        )
+        if mean_composite < _POINT_ESTIMATE_GATE:
+            reasons.append("learned_component_point_estimate_below_5pct")
+        if float(np.min(learned)) < -_COMPONENT_REGRESSION_LIMIT:
+            reasons.append("learned_component_regression_limit_exceeded")
+        if np.any(means < 0.0):
+            reasons.append("learned_component_mean_regressed")
+        if worst_composite < 0.0:
+            reasons.append("learned_component_case_regressed")
+        if bootstrap_lower <= 0.0:
+            reasons.append("learned_component_bootstrap_lower_not_positive")
+
+        validation, validation_rollouts = self._evaluate_validation(
+            artifact,
+            validation_cases,
+            expected_suite_hash=validation_suite_hash,
+        )
+        if not validation.qualified:
+            reasons.append("sealed_validation_failed")
+        holdout, holdout_rollouts = self._evaluate_holdout(artifact)
+        if not holdout.qualified:
+            reasons.append("private_holdout_failed")
+
+        return G1ContextualRecoveryTrainingReport(
+            artifact=artifact,
+            development_cases=tuple(development_rows),
+            primitive_trials=tuple(trial_rows),
+            retained_recovery_config_hash=retained_hash,
+            retained_recovery_config=asdict(self.retained_config),
+            fixed_structured_config_hash=fixed_hash,
+            fixed_structured_config=asdict(self.fixed_config),
+            training_rollout_count=(
+                len(parents) + len(fixed) + len(library) * len(moving_indices) + 2 * len(self.cases)
+            ),
+            validation_rollout_count=validation_rollouts,
+            holdout_rollout_count=holdout_rollouts,
+            learned_component_backward_reduction=float(means[0]),
+            learned_component_tail_wobble_reduction=float(means[1]),
+            learned_component_leg_jerk_reduction=float(means[2]),
+            learned_component_composite_reduction=mean_composite,
+            learned_component_worst_case_composite=worst_composite,
+            learned_component_bootstrap_lower_95=bootstrap_lower,
+            validation=validation,
+            holdout=holdout,
+            qualified=not reasons,
+            rejection_reasons=tuple(reasons),
+        )
+
+    def _evaluate_validation(
+        self,
+        artifact: G1ContextualRecoveryArtifact,
+        cases: tuple[G1MuscleMemoryCase, ...],
+        *,
+        expected_suite_hash: str,
+    ) -> tuple[G1ContextualRecoveryValidationSummary, int]:
+        rows: list[tuple[float, float, float]] = []
+        composites: list[float] = []
+        parent_valid_count = 0
+        route_count = 0
+        strict_count = 0
+        passed_count = 0
+        for case in cases:
+            parent = self._run_config(case, self.retained_config)
+            fixed = self._run_config(case, self.fixed_config)
+            candidate = self._run_contextual(case, artifact)
+            replay = self._run_contextual(case, artifact)
+            parent_metric = measure_g1_recovery_quality(parent.trajectory)
+            fixed_metric = measure_g1_recovery_quality(fixed.trajectory)
+            candidate_metric = measure_g1_recovery_quality(candidate.trajectory)
+            parent_valid = _parent_valid(parent, parent_metric)
+            parent_valid_count += int(parent_valid)
+            route = _contextual_route(candidate)
+            route_count += int(route is not None)
+            strict = _strict_replay(candidate, replay)
+            strict_count += int(strict)
+            score, safe, goal, natural = _case_score(
+                parent=parent,
+                parent_quality=parent_metric,
+                candidate=candidate,
+                candidate_quality=candidate_metric,
+            )
+            reductions = _moving_reductions(fixed_metric, candidate_metric)
+            composite = _composite(reductions)
+            rows.append(reductions)
+            composites.append(composite)
+            passed_count += int(
+                parent_valid
+                and route is not None
+                and strict
+                and safe
+                and goal
+                and natural
+                and score >= -0.03
+                and min(reductions) >= -_COMPONENT_REGRESSION_LIMIT
+                and composite > 0.0
+            )
+        values = np.asarray(rows, dtype=np.float64)
+        means = np.mean(values, axis=0)
+        bootstrap_lower = _bootstrap_lower_95(tuple(composites), seed=self.seed + 1)
+        suite_hash = _case_commitment_hash(
+            "rosclaw.g1_goalforge.contextual_validation.v4",
+            cases,
+        )
+        qualified = bool(
+            suite_hash == expected_suite_hash
+            and passed_count == len(cases)
+            and parent_valid_count == len(cases)
+            and route_count == len(cases)
+            and strict_count == len(cases)
+            and float(np.mean(composites)) >= _POINT_ESTIMATE_GATE
+            and bootstrap_lower > 0.0
+        )
+        return (
+            G1ContextualRecoveryValidationSummary(
+                suite_hash=suite_hash,
+                case_count=len(cases),
+                parent_valid_count=parent_valid_count,
+                contextual_route_count=route_count,
+                strict_replay_count=strict_count,
+                passed_count=passed_count,
+                mean_composite_reduction=float(np.mean(composites)),
+                minimum_composite_reduction=float(np.min(composites)),
+                bootstrap_lower_95=bootstrap_lower,
+                mean_backward_reduction=float(means[0]),
+                mean_tail_wobble_reduction=float(means[1]),
+                mean_leg_jerk_reduction=float(means[2]),
+                qualified=qualified,
+            ),
+            4 * len(cases),
+        )
+
+    def _evaluate_holdout(
+        self,
+        artifact: G1ContextualRecoveryArtifact,
+    ) -> tuple[G1ContextualRecoveryHoldoutSummary, int]:
+        cases = _build_temporal_holdout_cases()
+        parent_valid_count = 0
+        fallback_count = 0
+        strict_count = 0
+        exact_count = 0
+        passed_count = 0
+        for case in cases:
+            parent = self._run_config(case, self.retained_config)
+            candidate = self._run_contextual(case, artifact)
+            replay = self._run_contextual(case, artifact)
+            parent_metric = measure_g1_recovery_quality(parent.trajectory)
+            candidate_metric = measure_g1_recovery_quality(candidate.trajectory)
+            parent_valid = _parent_valid(parent, parent_metric)
+            parent_valid_count += int(parent_valid)
+            fallback = _contextual_route(candidate) is None
+            fallback_count += int(fallback)
+            strict = _strict_replay(candidate, replay)
+            strict_count += int(strict)
+            exact = bool(
+                parent.result.summary_dict() == candidate.result.summary_dict()
+                and trajectory_digest(parent.trajectory) == trajectory_digest(candidate.trajectory)
+            )
+            exact_count += int(exact)
+            _, safe, goal, natural = _case_score(
+                parent=parent,
+                parent_quality=parent_metric,
+                candidate=candidate,
+                candidate_quality=candidate_metric,
+            )
+            passed_count += int(
+                parent_valid and fallback and strict and exact and safe and goal and natural
+            )
+        suite_hash = _case_commitment_hash(
+            "rosclaw.g1_goalforge.contextual_private_holdout.v1",
+            cases,
+        )
+        qualified = bool(
+            passed_count == len(cases)
+            and parent_valid_count == len(cases)
+            and fallback_count == len(cases)
+            and strict_count == len(cases)
+            and exact_count == len(cases)
+        )
+        return (
+            G1ContextualRecoveryHoldoutSummary(
+                suite_hash=suite_hash,
+                case_count=len(cases),
+                parent_valid_count=parent_valid_count,
+                fallback_route_count=fallback_count,
+                strict_replay_count=strict_count,
+                exact_parent_replay_count=exact_count,
+                passed_count=passed_count,
+                qualified=qualified,
+            ),
+            3 * len(cases),
+        )
+
+    def _run_config(
+        self,
+        case: G1MuscleMemoryCase,
+        config: G1CerebellarRecoveryConfig,
+    ) -> GoalForgeEpisode:
+        controller = self.base.backend.build_cerebellar_recovery_controller(
+            case.scenario,
+            config,
+        )
+        return self.base.backend.run(
+            case.scenario,
+            case.parameters,
+            feedback_runtime=self.base._feedback_runtime(case),
+            recovery_controller=controller,
+        )
+
+    def _run_contextual(
+        self,
+        case: G1MuscleMemoryCase,
+        artifact: G1ContextualRecoveryArtifact,
+    ) -> GoalForgeEpisode:
+        controller = self.base.backend.build_cerebellar_recovery_controller(
+            case.scenario,
+            self.fixed_config,
+            contextual_recovery_artifact=artifact,
+            fallback_config=self.retained_config,
+        )
+        return self.base.backend.run(
+            case.scenario,
+            case.parameters,
+            feedback_runtime=self.base._feedback_runtime(case),
+            recovery_controller=controller,
+        )
+
+    def _config_hash(self, config: G1CerebellarRecoveryConfig) -> str:
+        return self.base.backend.build_cerebellar_recovery_controller(
+            self.cases[0].scenario,
+            config,
+        ).config_hash
+
+    @staticmethod
+    def _feature_names() -> tuple[str, ...]:
+        return G1_CONTEXTUAL_RECOVERY_FEATURES
+
+
+def _primitive_library() -> tuple[G1ContextualRecoveryPrimitive, ...]:
+    """Predeclared bounded library; only DEVELOPMENT rollouts may select it."""
+
+    raw = (
+        (300, 100, 400, 100, 0.42, 0.11, 0.54),
+        (300, 100, 400, 100, 0.38, 0.08, 0.56),
+        (300, 80, 380, 60, 0.42182, 0.12, 0.54294),
+        (300, 100, 400, 100, 0.42, 0.12, 0.52),
+        (300, 100, 400, 100, 0.40, 0.10, 0.52),
+        (300, 100, 400, 100, 0.44, 0.12, 0.56),
+    )
+    return tuple(
+        G1ContextualRecoveryPrimitive(
+            start_policy_frame=start,
+            blend_frames=blend,
+            settling_start_policy_frame=settle,
+            settling_blend_frames=settle_blend,
+            settling_standing_pose_blend=standing,
+            settling_waist_pitch_bias_rad=waist,
+            target_smoothing_alpha=smoothing,
+        )
+        for start, blend, settle, settle_blend, standing, waist, smoothing in raw
+    )
+
+
+def _config_from_primitive(
+    baseline: G1CerebellarRecoveryConfig,
+    primitive: G1ContextualRecoveryPrimitive,
+) -> G1CerebellarRecoveryConfig:
+    return replace(
+        baseline,
+        start_policy_frame=primitive.start_policy_frame,
+        blend_frames=primitive.blend_frames,
+        settling_start_policy_frame=primitive.settling_start_policy_frame,
+        settling_blend_frames=primitive.settling_blend_frames,
+        settling_standing_pose_blend=primitive.settling_standing_pose_blend,
+        settling_waist_pitch_bias_rad=primitive.settling_waist_pitch_bias_rad,
+        target_smoothing_alpha=primitive.target_smoothing_alpha,
+        target_smoothing_start_policy_frame=primitive.start_policy_frame,
+    )
+
+
+def _contextual_route_prototype(
+    episode: GoalForgeEpisode,
+    *,
+    observation_mean: tuple[float, ...],
+    observation_scale: tuple[float, ...],
+) -> tuple[float, ...]:
+    """Capture the post-impact state at the first causal recovery frame."""
+
+    rows = np.asarray(episode.trajectory["recovery_proprioception"], dtype=np.float64)
+    active = np.asarray(episode.trajectory["recovery_active"], dtype=np.bool_)
+    impulse_index = G1_MUSCLE_MEMORY_OBSERVATIONS.index("contact_impulse_ns")
+    right_support_index = G1_MUSCLE_MEMORY_OBSERVATIONS.index("right_support")
+    route_rows = np.flatnonzero(
+        active & (rows[:, impulse_index] > 0.0) & (rows[:, right_support_index] > 0.5)
+    )
+    if not len(route_rows):
+        raise ValueError("development episode has no causal recovery route state")
+    normalized = (
+        rows[int(route_rows[0])] - np.asarray(observation_mean, dtype=np.float64)
+    ) / np.asarray(observation_scale, dtype=np.float64)
+    indices = [
+        G1_MUSCLE_MEMORY_OBSERVATIONS.index(name) for name in G1_CONTEXTUAL_RECOVERY_FEATURES
+    ]
+    return tuple(map(float, normalized[indices]))
+
+
+def _contextual_route(episode: GoalForgeEpisode) -> int | None:
+    receipt = episode.recovery_receipt
+    if receipt is None or receipt.contextual_recovery_receipt is None:
+        return None
+    value = receipt.contextual_recovery_receipt["selected_primitive_index"]
+    return int(value) if value is not None else None
+
+
+def _strict_replay(first: GoalForgeEpisode, second: GoalForgeEpisode) -> bool:
+    return bool(
+        first.result.summary_dict() == second.result.summary_dict()
+        and trajectory_digest(first.trajectory) == trajectory_digest(second.trajectory)
+    )
+
+
+def _parent_valid(episode: GoalForgeEpisode, quality: G1RecoveryQuality) -> bool:
+    result = episode.result
+    return bool(
+        result.success
+        and result.contact_observed
+        and result.goal_crossed
+        and result.target_zone_hit
+        and not result.post_kick_fall
+        and not result.joint_limit_violation
+        and not result.torque_limit_violation
+        and not result.actuator_saturation
+        and result.support_foot_slip_m <= 0.04
+        and quality.terminal_bilateral_support
+    )
+
+
+def _composite(reductions: tuple[float, float, float]) -> float:
+    return float(0.40 * reductions[0] + 0.40 * reductions[1] + 0.20 * reductions[2])
+
+
+def _bootstrap_lower_95(values: tuple[float, ...], *, seed: int) -> float:
+    sample = np.asarray(values, dtype=np.float64)
+    if sample.ndim != 1 or len(sample) < 2 or not np.all(np.isfinite(sample)):
+        raise ValueError("bootstrap requires at least two finite case values")
+    rng = np.random.default_rng(seed)
+    indices = rng.integers(0, len(sample), size=(_BOOTSTRAP_DRAWS, len(sample)))
+    means = np.mean(sample[indices], axis=1)
+    return float(np.quantile(means, 0.025))
+
+
+def write_g1_contextual_recovery_report(
+    report: G1ContextualRecoveryTrainingReport,
+    *,
+    output_dir: Path,
+    source_checkout: Path,
+) -> tuple[Path, Path]:
+    root = output_dir.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if root == checkout or checkout in root.parents:
+        raise ValueError("contextual recovery evidence must remain outside the checkout")
+    root.mkdir(parents=True, exist_ok=False)
+    artifact_path = root / "g1-contextual-recovery.json"
+    report_path = root / "g1-contextual-recovery-training.json"
+    _atomic_json(artifact_path, report.artifact.to_dict())
+    _atomic_json(report_path, report.to_dict())
+    return artifact_path, report_path
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    payload = json.dumps(value, sort_keys=True, indent=2, allow_nan=False) + "\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    temp_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+__all__ = [
+    "build_g1_contextual_recovery_cases",
+    "G1ContextualRecoveryHoldoutSummary",
+    "G1ContextualRecoveryPrimitiveTrial",
+    "G1ContextualRecoveryTrainer",
+    "G1ContextualRecoveryTrainingReport",
+    "G1ContextualRecoveryValidationSummary",
+    "write_g1_contextual_recovery_report",
+]

--- a/src/rosclaw/simforge/g1_contextual_recovery_video.py
+++ b/src/rosclaw/simforge/g1_contextual_recovery_video.py
@@ -1,0 +1,379 @@
+"""Evidence-bound DEVELOPMENT video for contextual G1 recovery learning.
+
+The renderer is deliberately downstream of MuJoCo rollouts.  It never creates
+promotion evidence and it refuses to label a validation-rejected candidate as
+qualified.  The split-screen clip is useful for inspecting visible motion
+while preserving the rejection state in both the frame labels and manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, BinaryIO, cast
+
+import numpy as np
+
+from rosclaw.simforge.backends.unitree_mujoco_backend import trajectory_digest
+from rosclaw.simforge.g1_contextual_recovery import (
+    load_g1_contextual_recovery_artifact,
+)
+from rosclaw.simforge.g1_contextual_recovery_training import (
+    G1ContextualRecoveryTrainer,
+    _composite,
+)
+from rosclaw.simforge.g1_hat_trick_video import (
+    _escape_filtergraph_option,
+    _render_pose,
+)
+from rosclaw.simforge.g1_muscle_memory_training import _case_score
+from rosclaw.simforge.g1_recovery_quality import measure_g1_recovery_quality
+from rosclaw.simforge.g1_temporal_muscle_memory_training import _moving_reductions
+
+_SCENE_REL = Path("g1_description/scene_with_ball.xml")
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoveryVideoResult:
+    output_path: str
+    manifest_path: str
+    video_hash: str
+    artifact_hash: str
+    training_report_hash: str
+    case_name: str
+    fixed_trajectory_hash: str
+    learned_trajectory_hash: str
+    strict_replay: bool
+    backward_reduction: float
+    tail_wobble_reduction: float
+    leg_jerk_reduction: float
+    composite_reduction: float
+    width: int
+    height: int
+    fps: int
+    frame_count: int
+    duration_sec: float
+    promotion_status: str = "REJECTED"
+    validation_qualified: bool = False
+    development_only: bool = True
+    visualization_only: bool = True
+    generates_task_evidence: bool = False
+    hardware_command_sent: bool = False
+    schema_version: str = "rosclaw.g1_goalforge.contextual_recovery_video.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def render_g1_contextual_recovery_video(
+    *,
+    artifact_path: Path,
+    training_report_path: Path,
+    asset_root: Path,
+    output_path: Path,
+    source_checkout: Path,
+    case_name: str = "moving_ball_nominal_velocity_070",
+    fps: int = 30,
+) -> G1ContextualRecoveryVideoResult:
+    """Render fixed-vs-learned DEVELOPMENT motion with rejection labels."""
+
+    artifact_file = artifact_path.expanduser().resolve()
+    report_file = training_report_path.expanduser().resolve()
+    output = output_path.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if output == checkout or checkout in output.parents:
+        raise ValueError("contextual recovery video must remain outside the checkout")
+    if any(path == checkout or checkout in path.parents for path in (artifact_file, report_file)):
+        raise ValueError("contextual recovery video evidence must remain outside the checkout")
+    if output.suffix.lower() != ".mp4":
+        raise ValueError("contextual recovery video output must use .mp4")
+    if output.exists() or output.with_suffix(".json").exists():
+        raise FileExistsError("contextual recovery video or manifest already exists")
+    if not 10 <= fps <= 60:
+        raise ValueError("contextual recovery video fps must be in [10, 60]")
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("ffmpeg is required for contextual recovery video")
+    report = json.loads(report_file.read_text(encoding="utf-8"))
+    if not isinstance(report, dict):
+        raise ValueError("contextual recovery training report must be an object")
+    if report.get("qualified") is not False:
+        raise ValueError("development video requires an explicitly rejected candidate")
+    rejection_reasons = report.get("rejection_reasons")
+    if rejection_reasons != ["sealed_validation_failed"]:
+        raise ValueError("development video only permits the sealed-validation rejection state")
+    artifact = load_g1_contextual_recovery_artifact(artifact_file)
+    report_artifact = report.get("artifact")
+    if (
+        not isinstance(report_artifact, dict)
+        or report_artifact.get("artifact_hash") != artifact.artifact_hash
+    ):
+        raise ValueError("contextual recovery artifact/report hash mismatch")
+    if float(report.get("learned_component_composite_reduction", 0.0)) < 0.05:
+        raise ValueError("development video requires at least 5% measured learning contribution")
+
+    trainer = G1ContextualRecoveryTrainer(asset_root=asset_root)
+    matches = [case for case in trainer.cases if case.name == case_name]
+    if len(matches) != 1:
+        raise ValueError("contextual recovery video case is not a unique DEVELOPMENT case")
+    case = matches[0]
+    parent = trainer._run_config(case, trainer.retained_config)
+    fixed = trainer._run_config(case, trainer.fixed_config)
+    learned = trainer._run_contextual(case, artifact)
+    replay = trainer._run_contextual(case, artifact)
+    strict = bool(
+        learned.result.summary_dict() == replay.result.summary_dict()
+        and trajectory_digest(learned.trajectory) == trajectory_digest(replay.trajectory)
+    )
+    parent_quality = measure_g1_recovery_quality(parent.trajectory)
+    fixed_quality = measure_g1_recovery_quality(fixed.trajectory)
+    learned_quality = measure_g1_recovery_quality(learned.trajectory)
+    _, safe, goal, natural = _case_score(
+        parent=parent,
+        parent_quality=parent_quality,
+        candidate=learned,
+        candidate_quality=learned_quality,
+    )
+    if not (strict and safe and goal and natural):
+        raise ValueError("contextual recovery video requires safe strict DEVELOPMENT replay")
+    reductions = _moving_reductions(fixed_quality, learned_quality)
+    composite = _composite(reductions)
+    if composite <= 0.05:
+        raise ValueError("selected video case does not show a material learned contribution")
+
+    evidence_root = output.parent / (output.stem + "-evidence")
+    evidence_root.mkdir(parents=True, exist_ok=False)
+    fixed_path = evidence_root / "fixed-structured.npz"
+    learned_path = evidence_root / "learned-contextual.npz"
+    np.savez_compressed(fixed_path, **fixed.trajectory)  # type: ignore[arg-type]
+    np.savez_compressed(learned_path, **learned.trajectory)  # type: ignore[arg-type]
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    contact = float(learned.result.ball_contact_time_sec or 5.25)
+    start = max(float(learned.trajectory["time"][0]), contact - 2.5)
+    end = min(float(learned.trajectory["time"][-1]), contact + 7.0)
+    frame_count = max(1, int(np.ceil((end - start) * fps)))
+    timeline = np.linspace(start, end, frame_count, endpoint=False)
+    previous_gl = os.environ.get("MUJOCO_GL")
+    os.environ.setdefault("MUJOCO_GL", "egl")
+    try:
+        import mujoco
+
+        scene = asset_root.expanduser().resolve() / _SCENE_REL
+        model = mujoco.MjModel.from_xml_path(str(scene))
+        left_data = mujoco.MjData(model)
+        right_data = mujoco.MjData(model)
+        renderer = mujoco.Renderer(model, height=360, width=640)
+        camera = mujoco.MjvCamera()
+        camera.type = mujoco.mjtCamera.mjCAMERA_FREE
+        process = subprocess.Popen(
+            _ffmpeg_command(
+                ffmpeg=ffmpeg,
+                output=output,
+                fps=fps,
+                reductions=reductions,
+                composite=composite,
+            ),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        if process.stdin is None:
+            raise RuntimeError("contextual recovery ffmpeg pipe is unavailable")
+        try:
+            _write_frames(
+                mujoco=mujoco,
+                model=model,
+                left_data=left_data,
+                right_data=right_data,
+                renderer=renderer,
+                camera=camera,
+                fixed=fixed.trajectory,
+                learned=learned.trajectory,
+                scenario=case.scenario.to_private_dict(),
+                contact_time=contact,
+                timeline=timeline,
+                stream=cast(BinaryIO, process.stdin),
+            )
+        except BaseException:
+            process.stdin.close()
+            process.kill()
+            process.wait()
+            raise
+        finally:
+            renderer.close()
+        process.stdin.close()
+        stderr = process.stderr.read().decode(errors="replace") if process.stderr else ""
+        code = process.wait()
+        if code:
+            raise RuntimeError(f"contextual recovery ffmpeg failed ({code}): {stderr[-2000:]}")
+    finally:
+        if previous_gl is None:
+            os.environ.pop("MUJOCO_GL", None)
+        else:
+            os.environ["MUJOCO_GL"] = previous_gl
+
+    manifest = output.with_suffix(".json")
+    result = G1ContextualRecoveryVideoResult(
+        output_path=str(output),
+        manifest_path=str(manifest),
+        video_hash=_hash_file(output),
+        artifact_hash=artifact.artifact_hash,
+        training_report_hash=_hash_file(report_file),
+        case_name=case_name,
+        fixed_trajectory_hash=_hash_file(fixed_path),
+        learned_trajectory_hash=_hash_file(learned_path),
+        strict_replay=strict,
+        backward_reduction=reductions[0],
+        tail_wobble_reduction=reductions[1],
+        leg_jerk_reduction=reductions[2],
+        composite_reduction=composite,
+        width=1280,
+        height=720,
+        fps=fps,
+        frame_count=frame_count,
+        duration_sec=frame_count / fps,
+    )
+    manifest.write_text(
+        json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def _write_frames(
+    *,
+    mujoco: Any,
+    model: Any,
+    left_data: Any,
+    right_data: Any,
+    renderer: Any,
+    camera: Any,
+    fixed: dict[str, np.ndarray],
+    learned: dict[str, np.ndarray],
+    scenario: dict[str, Any],
+    contact_time: float,
+    timeline: np.ndarray,
+    stream: BinaryIO,
+) -> None:
+    ball_joint = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "ball_free")
+    ball_qpos = int(model.jnt_qposadr[ball_joint])
+    for simulation_time in timeline:
+        left = _render_pose(
+            mujoco=mujoco,
+            model=model,
+            data=left_data,
+            renderer=renderer,
+            camera=camera,
+            trajectory=fixed,
+            simulation_time=float(simulation_time),
+            ball_qpos=ball_qpos,
+            scenario=scenario,
+            contact_time=contact_time,
+            show_grid=False,
+            show_push=False,
+        )
+        right = _render_pose(
+            mujoco=mujoco,
+            model=model,
+            data=right_data,
+            renderer=renderer,
+            camera=camera,
+            trajectory=learned,
+            simulation_time=float(simulation_time),
+            ball_qpos=ball_qpos,
+            scenario=scenario,
+            contact_time=contact_time,
+            show_grid=False,
+            show_push=False,
+        )
+        canvas = np.zeros((720, 1280, 3), dtype=np.uint8)
+        canvas[180:540, :640] = left
+        canvas[180:540, 640:] = right
+        stream.write(np.ascontiguousarray(canvas).tobytes())
+
+
+def _ffmpeg_command(
+    *,
+    ffmpeg: str,
+    output: Path,
+    fps: int,
+    reductions: tuple[float, float, float],
+    composite: float,
+) -> list[str]:
+    font = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf")
+    font_option = f"fontfile={_escape_filtergraph_option(str(font))}:" if font.is_file() else ""
+    labels = (
+        ("ROSClaw G1 Contextual Recovery · DEVELOPMENT REPLAY", 34, 20, 34, "white"),
+        ("FIXED STRUCTURED · ZERO LEARNING", 95, 145, 20, "0xFFB45F"),
+        ("LEARNED ROUTER · DEVELOPMENT ONLY", 720, 145, 20, "0x65F59A"),
+        (
+            f"backstep -{100 * reductions[0]:.1f}%  ·  wobble -{100 * reductions[1]:.1f}%  "
+            f"·  leg jerk -{100 * reductions[2]:.1f}%  ·  composite +{100 * composite:.1f}%",
+            34,
+            80,
+            22,
+            "0x65F59A",
+        ),
+        (
+            "SIM VISUALIZATION ONLY · SEALED VALIDATION FAILED · NOT PROMOTED",
+            34,
+            674,
+            21,
+            "0xFF7070",
+        ),
+    )
+    filters = [
+        "drawbox=x=0:y=0:w=iw:h=120:color=0x050A12@0.82:t=fill",
+        "drawbox=x=0:y=h-72:w=iw:h=72:color=0x050A12@0.82:t=fill",
+    ]
+    filters.extend(
+        f"drawtext={font_option}text={_escape_filtergraph_option(text)}:"
+        f"expansion=none:x={x}:y={y}:fontsize={size}:fontcolor={color}"
+        for text, x, y, size, color in labels
+    )
+    return [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "rawvideo",
+        "-pixel_format",
+        "rgb24",
+        "-video_size",
+        "1280x720",
+        "-framerate",
+        str(fps),
+        "-i",
+        "pipe:0",
+        "-vf",
+        ",".join(filters),
+        "-an",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "medium",
+        "-crf",
+        "18",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        str(output),
+    ]
+
+
+def _hash_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+__all__ = [
+    "G1ContextualRecoveryVideoResult",
+    "render_g1_contextual_recovery_video",
+]

--- a/src/rosclaw/simforge/g1_contextual_recovery_video.py
+++ b/src/rosclaw/simforge/g1_contextual_recovery_video.py
@@ -13,7 +13,8 @@ import json
 import os
 import shutil
 import subprocess
-from dataclasses import asdict, dataclass
+import tempfile
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any, BinaryIO, cast
 
@@ -26,6 +27,9 @@ from rosclaw.simforge.g1_contextual_recovery import (
 from rosclaw.simforge.g1_contextual_recovery_training import (
     G1ContextualRecoveryTrainer,
     _composite,
+    _config_from_primitive,
+    _contextual_route,
+    _terminal_damping_reductions,
 )
 from rosclaw.simforge.g1_hat_trick_video import (
     _escape_filtergraph_option,
@@ -65,6 +69,59 @@ class G1ContextualRecoveryVideoResult:
     generates_task_evidence: bool = False
     hardware_command_sent: bool = False
     schema_version: str = "rosclaw.g1_goalforge.contextual_recovery_video.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoverySuiteClip:
+    case_name: str
+    challenge_label: str
+    selected_primitive_index: int | None
+    exact_fallback_replay: bool
+    strict_replay: bool
+    baseline_trajectory_hash: str
+    candidate_trajectory_hash: str
+    backward_reduction: float
+    tail_wobble_reduction: float
+    tail_joint_jerk_reduction: float
+    baseline_backward_reversal_m: float
+    candidate_backward_reversal_m: float
+    baseline_tail_wobble_index: float
+    candidate_tail_wobble_index: float
+    baseline_tail_joint_jerk_rms_rad_s3: float
+    candidate_tail_joint_jerk_rms_rad_s3: float
+    duration_sec: float
+    frame_count: int
+    safe: bool
+    goal_preserved: bool
+    naturalness_preserved: bool
+    schema_version: str = "rosclaw.g1_goalforge.contextual_recovery_suite_clip.v1"
+
+
+@dataclass(frozen=True)
+class G1ContextualRecoverySuiteVideoResult:
+    output_path: str
+    manifest_path: str
+    video_hash: str
+    artifact_hash: str
+    training_report_hash: str
+    clips: tuple[G1ContextualRecoverySuiteClip, ...]
+    width: int
+    height: int
+    fps: int
+    frame_count: int
+    duration_sec: float
+    strict_replay_count: int
+    exact_fallback_replay_count: int
+    promotion_status: str = "REJECTED"
+    validation_qualified: bool = False
+    development_only: bool = True
+    visualization_only: bool = True
+    generates_task_evidence: bool = False
+    hardware_command_sent: bool = False
+    schema_version: str = "rosclaw.g1_goalforge.contextual_recovery_suite_video.v1"
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -246,6 +303,299 @@ def render_g1_contextual_recovery_video(
     return result
 
 
+def render_g1_contextual_recovery_suite_video(
+    *,
+    artifact_path: Path,
+    training_report_path: Path,
+    asset_root: Path,
+    output_path: Path,
+    source_checkout: Path,
+    case_names: tuple[str, ...] = (
+        "static_high",
+        "moving_ball_nominal",
+        "moving_ball_lateral_005",
+        "moving_ball_nominal_velocity_070",
+        "moving_ball_light_400g",
+    ),
+    fps: int = 30,
+) -> G1ContextualRecoverySuiteVideoResult:
+    """Render a long multi-challenge DEVELOPMENT suite with a damping ablation."""
+
+    artifact_file = artifact_path.expanduser().resolve()
+    report_file = training_report_path.expanduser().resolve()
+    output = output_path.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if output == checkout or checkout in output.parents:
+        raise ValueError("contextual recovery suite video must remain outside the checkout")
+    if any(path == checkout or checkout in path.parents for path in (artifact_file, report_file)):
+        raise ValueError("contextual recovery suite evidence must remain outside the checkout")
+    if output.suffix.lower() != ".mp4":
+        raise ValueError("contextual recovery suite video output must use .mp4")
+    if output.exists() or output.with_suffix(".json").exists():
+        raise FileExistsError("contextual recovery suite video or manifest already exists")
+    if not 10 <= fps <= 60:
+        raise ValueError("contextual recovery suite video fps must be in [10, 60]")
+    if not 2 <= len(case_names) <= 8 or len(set(case_names)) != len(case_names):
+        raise ValueError("contextual recovery suite requires 2 to 8 unique cases")
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError("ffmpeg is required for contextual recovery suite video")
+
+    report = json.loads(report_file.read_text(encoding="utf-8"))
+    if not isinstance(report, dict) or report.get("qualified") is not False:
+        raise ValueError("suite video requires an explicitly rejected training report")
+    if report.get("rejection_reasons") != ["sealed_validation_failed"]:
+        raise ValueError("suite video only permits the sealed-validation rejection state")
+    terminal_report = report.get("terminal_damping")
+    if not isinstance(terminal_report, dict) or terminal_report.get("qualified") is not True:
+        raise ValueError("suite video requires a qualified DEVELOPMENT damping ablation")
+    artifact = load_g1_contextual_recovery_artifact(artifact_file)
+    report_artifact = report.get("artifact")
+    if (
+        not isinstance(report_artifact, dict)
+        or report_artifact.get("artifact_hash") != artifact.artifact_hash
+    ):
+        raise ValueError("contextual recovery suite artifact/report hash mismatch")
+
+    trainer = G1ContextualRecoveryTrainer(asset_root=asset_root)
+    available = {case.name: case for case in trainer.cases}
+    missing = set(case_names).difference(available)
+    if missing:
+        raise ValueError(f"unknown contextual recovery suite cases: {sorted(missing)}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    evidence_root = output.parent / (output.stem + "-evidence")
+    evidence_root.mkdir(parents=True, exist_ok=False)
+    challenge_labels = {
+        "static_high": "HIGH TARGET 0.55m + LATERAL BALL OFFSET 0.10m",
+        "moving_ball_nominal": "MOVING BALL · -0.08 m/s",
+        "moving_ball_lateral_005": "MOVING BALL + LATERAL OFFSET 0.005m",
+        "moving_ball_nominal_velocity_070": "MOVING BALL SPEED SHIFT · -0.07 m/s",
+        "moving_ball_light_400g": "MOVING BALL + LIGHTER 0.400kg BALL",
+    }
+
+    clips: list[G1ContextualRecoverySuiteClip] = []
+    temporary_root = Path(tempfile.mkdtemp(prefix="rosclaw-g1-suite-"))
+    previous_gl = os.environ.get("MUJOCO_GL")
+    os.environ.setdefault("MUJOCO_GL", "egl")
+    try:
+        import mujoco
+
+        scene = asset_root.expanduser().resolve() / _SCENE_REL
+        model = mujoco.MjModel.from_xml_path(str(scene))
+        left_data = mujoco.MjData(model)
+        right_data = mujoco.MjData(model)
+        renderer = mujoco.Renderer(model, height=440, width=640)
+        camera = mujoco.MjvCamera()
+        camera.type = mujoco.mjtCamera.mjCAMERA_FREE
+        temporary_clips: list[Path] = []
+        try:
+            for clip_index, case_name in enumerate(case_names, start=1):
+                case = available[case_name]
+                candidate = trainer._run_contextual(case, artifact)
+                replay = trainer._run_contextual(case, artifact)
+                strict = bool(
+                    candidate.result.summary_dict() == replay.result.summary_dict()
+                    and trajectory_digest(candidate.trajectory)
+                    == trajectory_digest(replay.trajectory)
+                )
+                route = _contextual_route(candidate)
+                if route is None:
+                    baseline = trainer._run_config(case, trainer.retained_config)
+                    exact_fallback = bool(
+                        baseline.result.summary_dict() == candidate.result.summary_dict()
+                        and trajectory_digest(baseline.trajectory)
+                        == trajectory_digest(candidate.trajectory)
+                    )
+                else:
+                    damped_config = _config_from_primitive(
+                        trainer.fixed_config,
+                        artifact.primitives[route],
+                    )
+                    baseline = trainer._run_config(
+                        case,
+                        replace(
+                            damped_config,
+                            terminal_damping_start_policy_frame=None,
+                            terminal_kp_scale=1.0,
+                            terminal_kd_scale=1.0,
+                        ),
+                    )
+                    exact_fallback = False
+                baseline_quality = measure_g1_recovery_quality(baseline.trajectory)
+                candidate_quality = measure_g1_recovery_quality(candidate.trajectory)
+                _, safe, goal, natural = _case_score(
+                    parent=baseline,
+                    parent_quality=baseline_quality,
+                    candidate=candidate,
+                    candidate_quality=candidate_quality,
+                )
+                reductions = (
+                    (0.0, 0.0, 0.0)
+                    if route is None
+                    else _terminal_damping_reductions(baseline_quality, candidate_quality)
+                )
+                if not (strict and safe and goal and natural):
+                    raise ValueError(f"suite case failed replay/safety gates: {case_name}")
+                if route is None and not exact_fallback:
+                    raise ValueError(f"suite fallback is not exact: {case_name}")
+                if route is not None and (
+                    reductions[0] < 0.0 or reductions[1] < -0.05 or reductions[2] < 0.10
+                ):
+                    raise ValueError(f"suite damping ablation failed: {case_name}")
+
+                baseline_path = evidence_root / f"{clip_index:02d}-{case_name}-ablation.npz"
+                candidate_path = evidence_root / f"{clip_index:02d}-{case_name}-candidate.npz"
+                np.savez_compressed(baseline_path, **baseline.trajectory)  # type: ignore[arg-type]
+                np.savez_compressed(candidate_path, **candidate.trajectory)  # type: ignore[arg-type]
+                contact = float(candidate.result.ball_contact_time_sec or 5.25)
+                start = max(float(candidate.trajectory["time"][0]), contact - 2.2)
+                end = float(candidate.trajectory["time"][-1])
+                frame_count = max(1, int(np.ceil((end - start) * fps)))
+                timeline = np.linspace(start, end, frame_count, endpoint=False)
+                temporary_clip = temporary_root / f"clip-{clip_index:02d}.mp4"
+                process = subprocess.Popen(
+                    _suite_ffmpeg_command(
+                        ffmpeg=ffmpeg,
+                        output=temporary_clip,
+                        fps=fps,
+                        clip_index=clip_index,
+                        clip_count=len(case_names),
+                        challenge_label=challenge_labels.get(case_name, case_name.upper()),
+                        reductions=reductions,
+                        exact_fallback=exact_fallback,
+                    ),
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                )
+                if process.stdin is None:
+                    raise RuntimeError("contextual recovery suite ffmpeg pipe is unavailable")
+                try:
+                    _write_frames(
+                        mujoco=mujoco,
+                        model=model,
+                        left_data=left_data,
+                        right_data=right_data,
+                        renderer=renderer,
+                        camera=camera,
+                        fixed=baseline.trajectory,
+                        learned=candidate.trajectory,
+                        scenario=case.scenario.to_private_dict(),
+                        contact_time=contact,
+                        timeline=timeline,
+                        stream=cast(BinaryIO, process.stdin),
+                        panel_top=140,
+                    )
+                except BaseException:
+                    process.stdin.close()
+                    process.kill()
+                    process.wait()
+                    raise
+                process.stdin.close()
+                stderr = process.stderr.read().decode(errors="replace") if process.stderr else ""
+                code = process.wait()
+                if code:
+                    raise RuntimeError(
+                        f"contextual recovery suite ffmpeg failed ({code}): {stderr[-2000:]}"
+                    )
+                temporary_clips.append(temporary_clip)
+                clips.append(
+                    G1ContextualRecoverySuiteClip(
+                        case_name=case_name,
+                        challenge_label=challenge_labels.get(case_name, case_name.upper()),
+                        selected_primitive_index=route,
+                        exact_fallback_replay=exact_fallback,
+                        strict_replay=strict,
+                        baseline_trajectory_hash=_hash_file(baseline_path),
+                        candidate_trajectory_hash=_hash_file(candidate_path),
+                        backward_reduction=reductions[0],
+                        tail_wobble_reduction=reductions[1],
+                        tail_joint_jerk_reduction=reductions[2],
+                        baseline_backward_reversal_m=(
+                            baseline_quality.post_contact_backward_reversal_m
+                        ),
+                        candidate_backward_reversal_m=(
+                            candidate_quality.post_contact_backward_reversal_m
+                        ),
+                        baseline_tail_wobble_index=baseline_quality.tail_wobble_index,
+                        candidate_tail_wobble_index=candidate_quality.tail_wobble_index,
+                        baseline_tail_joint_jerk_rms_rad_s3=(
+                            baseline_quality.tail_joint_jerk_rms_rad_s3
+                        ),
+                        candidate_tail_joint_jerk_rms_rad_s3=(
+                            candidate_quality.tail_joint_jerk_rms_rad_s3
+                        ),
+                        duration_sec=frame_count / fps,
+                        frame_count=frame_count,
+                        safe=safe,
+                        goal_preserved=goal,
+                        naturalness_preserved=natural,
+                    )
+                )
+        finally:
+            renderer.close()
+        concat_file = temporary_root / "clips.txt"
+        concat_file.write_text(
+            "".join(f"file '{path}'\n" for path in temporary_clips),
+            encoding="utf-8",
+        )
+        completed = subprocess.run(
+            [
+                ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(concat_file),
+                "-c",
+                "copy",
+                "-movflags",
+                "+faststart",
+                str(output),
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode:
+            raise RuntimeError(
+                "contextual recovery suite concatenation failed: "
+                + completed.stderr.decode(errors="replace")[-2000:]
+            )
+    finally:
+        shutil.rmtree(temporary_root, ignore_errors=True)
+        if previous_gl is None:
+            os.environ.pop("MUJOCO_GL", None)
+        else:
+            os.environ["MUJOCO_GL"] = previous_gl
+
+    total_frames = sum(clip.frame_count for clip in clips)
+    manifest = output.with_suffix(".json")
+    result = G1ContextualRecoverySuiteVideoResult(
+        output_path=str(output),
+        manifest_path=str(manifest),
+        video_hash=_hash_file(output),
+        artifact_hash=artifact.artifact_hash,
+        training_report_hash=_hash_file(report_file),
+        clips=tuple(clips),
+        width=1280,
+        height=720,
+        fps=fps,
+        frame_count=total_frames,
+        duration_sec=total_frames / fps,
+        strict_replay_count=sum(clip.strict_replay for clip in clips),
+        exact_fallback_replay_count=sum(clip.exact_fallback_replay for clip in clips),
+    )
+    manifest.write_text(
+        json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
 def _write_frames(
     *,
     mujoco: Any,
@@ -260,6 +610,7 @@ def _write_frames(
     contact_time: float,
     timeline: np.ndarray,
     stream: BinaryIO,
+    panel_top: int = 180,
 ) -> None:
     ball_joint = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "ball_free")
     ball_qpos = int(model.jnt_qposadr[ball_joint])
@@ -292,9 +643,10 @@ def _write_frames(
             show_grid=False,
             show_push=False,
         )
-        canvas = np.zeros((720, 1280, 3), dtype=np.uint8)
-        canvas[180:540, :640] = left
-        canvas[180:540, 640:] = right
+        canvas: np.ndarray = np.zeros((720, 1280, 3), dtype=np.uint8)
+        panel_bottom = panel_top + int(left.shape[0])
+        canvas[panel_top:panel_bottom, :640] = left
+        canvas[panel_top:panel_bottom, 640:] = right
         stream.write(np.ascontiguousarray(canvas).tobytes())
 
 
@@ -369,11 +721,101 @@ def _ffmpeg_command(
     ]
 
 
+def _suite_ffmpeg_command(
+    *,
+    ffmpeg: str,
+    output: Path,
+    fps: int,
+    clip_index: int,
+    clip_count: int,
+    challenge_label: str,
+    reductions: tuple[float, float, float],
+    exact_fallback: bool,
+) -> list[str]:
+    font = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf")
+    font_option = f"fontfile={_escape_filtergraph_option(str(font))}:" if font.is_file() else ""
+    if exact_fallback:
+        left_label = "RETAINED PARENT"
+        right_label = "SAFE OOD FALLBACK · EXACT REPLAY"
+        metric_label = "HIGH-TARGET CHALLENGE · UNSEEN STATE ROUTED FAIL-CLOSED"
+        metric_color = "0x74C7FF"
+    else:
+        left_label = "CONTEXTUAL PRIMITIVE · DAMPING OFF"
+        right_label = "CONTEXTUAL + TERMINAL LEG DAMPING"
+        metric_label = (
+            f"backstep improvement {100 * reductions[0]:+.1f}%  ·  "
+            f"wobble improvement {100 * reductions[1]:+.1f}%  ·  "
+            f"tail jerk improvement {100 * reductions[2]:+.1f}%"
+        )
+        metric_color = "0x65F59A"
+    labels = (
+        (
+            f"ROSClaw G1 Recovery Suite · EXP {clip_index}/{clip_count}",
+            28,
+            14,
+            29,
+            "white",
+        ),
+        (challenge_label, 28, 57, 22, "0x74C7FF"),
+        (metric_label, 28, 92, 19, metric_color),
+        (left_label, 72, 118, 17, "0xFFB45F"),
+        (right_label, 690, 118, 17, "0x65F59A"),
+        (
+            "SIM DEVELOPMENT VISUALIZATION · SEALED VALIDATION FAILED · NOT PROMOTED",
+            28,
+            674,
+            18,
+            "0xFF7070",
+        ),
+    )
+    filters = [
+        "drawbox=x=0:y=0:w=iw:h=140:color=0x050A12@0.86:t=fill",
+        "drawbox=x=0:y=h-72:w=iw:h=72:color=0x050A12@0.86:t=fill",
+        "drawbox=x=638:y=140:w=4:h=440:color=0xD9E3F0@0.45:t=fill",
+    ]
+    filters.extend(
+        f"drawtext={font_option}text={_escape_filtergraph_option(text)}:"
+        f"expansion=none:x={x}:y={y}:fontsize={size}:fontcolor={color}"
+        for text, x, y, size, color in labels
+    )
+    return [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "rawvideo",
+        "-pixel_format",
+        "rgb24",
+        "-video_size",
+        "1280x720",
+        "-framerate",
+        str(fps),
+        "-i",
+        "pipe:0",
+        "-vf",
+        ",".join(filters),
+        "-an",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "medium",
+        "-crf",
+        "18",
+        "-pix_fmt",
+        "yuv420p",
+        str(output),
+    ]
+
+
 def _hash_file(path: Path) -> str:
     return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 __all__ = [
+    "G1ContextualRecoverySuiteClip",
+    "G1ContextualRecoverySuiteVideoResult",
     "G1ContextualRecoveryVideoResult",
+    "render_g1_contextual_recovery_suite_video",
     "render_g1_contextual_recovery_video",
 ]

--- a/src/rosclaw/simforge/g1_muscle_memory_cli.py
+++ b/src/rosclaw/simforge/g1_muscle_memory_cli.py
@@ -52,6 +52,19 @@ def dispatch_muscle_memory_argv(argv: list[str]) -> int | None:
         help="validate a contextual recovery artifact and print its commitments",
     )
     contextual_inspect.add_argument("artifact", type=Path)
+    state_train = commands.add_parser(
+        "state-train",
+        help="learn and qualify a short-horizon recovery-state evidence router",
+    )
+    state_train.add_argument("--asset-root", type=Path, required=True)
+    state_train.add_argument("--output-dir", type=Path, required=True)
+    state_train.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    state_train.add_argument("--seed", type=int, default=20260803)
+    state_inspect = commands.add_parser(
+        "state-inspect",
+        help="validate a recovery-state artifact and print its commitments",
+    )
+    state_inspect.add_argument("artifact", type=Path)
     contextual_video = commands.add_parser(
         "contextual-video",
         help="render a rejection-labelled DEVELOPMENT fixed-vs-learned comparison",
@@ -165,6 +178,43 @@ def dispatch_muscle_memory_argv(argv: list[str]) -> int | None:
         )
         return 0
 
+    if args.command == "state-inspect":
+        from rosclaw.simforge.g1_recovery_state_memory import (
+            G1_RECOVERY_STATE_OBSERVATIONS,
+            load_g1_recovery_state_artifact,
+        )
+
+        state_artifact = load_g1_recovery_state_artifact(args.artifact)
+        positive_routes = sum(index >= 0 for index in state_artifact.prototype_primitive_indices)
+        print(
+            json.dumps(
+                {
+                    "artifact_hash": state_artifact.artifact_hash,
+                    "body_hash": state_artifact.body_hash,
+                    "motion_hash": state_artifact.motion_hash,
+                    "baseline_recovery_config_hash": (state_artifact.baseline_recovery_config_hash),
+                    "fallback_recovery_config_hash": (state_artifact.fallback_recovery_config_hash),
+                    "training_dataset_hash": state_artifact.training_dataset_hash,
+                    "training_episode_count": state_artifact.training_episode_count,
+                    "observation_names": list(G1_RECOVERY_STATE_OBSERVATIONS),
+                    "descriptor_feature_names": list(state_artifact.descriptor_feature_names),
+                    "selection_window_frames": state_artifact.selection_window_frames,
+                    "prototype_count": len(state_artifact.descriptor_prototypes),
+                    "positive_route_count": positive_routes,
+                    "abstention_prototype_count": (
+                        len(state_artifact.descriptor_prototypes) - positive_routes
+                    ),
+                    "neighbor_count": state_artifact.neighbor_count,
+                    "maximum_neighbor_distance": (state_artifact.maximum_neighbor_distance),
+                    "minimum_primitive_consensus": (state_artifact.minimum_primitive_consensus),
+                    "activation_ceiling": state_artifact.activation_ceiling,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
     if args.command == "contextual-video":
         from rosclaw.simforge.g1_contextual_recovery_video import (
             render_g1_contextual_recovery_video,
@@ -220,6 +270,28 @@ def dispatch_muscle_memory_argv(argv: list[str]) -> int | None:
         value["report_path"] = str(report_path)
         print(json.dumps(value, indent=2, sort_keys=True))
         return 0 if contextual_report.qualified else 2
+
+    if args.command == "state-train":
+        from rosclaw.simforge.g1_recovery_state_training import (
+            G1RecoveryStateTrainer,
+            write_g1_recovery_state_report,
+        )
+
+        state_trainer = G1RecoveryStateTrainer(
+            asset_root=args.asset_root,
+            seed=args.seed,
+        )
+        state_report = state_trainer.train()
+        artifact_path, report_path = write_g1_recovery_state_report(
+            state_report,
+            output_dir=args.output_dir,
+            source_checkout=args.source_checkout,
+        )
+        value = state_report.to_dict()
+        value["artifact_path"] = str(artifact_path)
+        value["report_path"] = str(report_path)
+        print(json.dumps(value, indent=2, sort_keys=True))
+        return 0 if state_report.qualified else 2
 
     if args.command == "temporal-train":
         from rosclaw.simforge.g1_temporal_muscle_memory_training import (

--- a/src/rosclaw/simforge/g1_muscle_memory_cli.py
+++ b/src/rosclaw/simforge/g1_muscle_memory_cli.py
@@ -66,6 +66,31 @@ def dispatch_muscle_memory_argv(argv: list[str]) -> int | None:
         default="moving_ball_nominal_velocity_070",
     )
     contextual_video.add_argument("--fps", type=int, default=30)
+    contextual_suite_video = commands.add_parser(
+        "contextual-suite-video",
+        help="render a long rejection-labelled multi-challenge damping suite",
+    )
+    contextual_suite_video.add_argument("--artifact", type=Path, required=True)
+    contextual_suite_video.add_argument("--report", type=Path, required=True)
+    contextual_suite_video.add_argument("--asset-root", type=Path, required=True)
+    contextual_suite_video.add_argument("--output", type=Path, required=True)
+    contextual_suite_video.add_argument(
+        "--source-checkout",
+        type=Path,
+        default=Path.cwd(),
+    )
+    contextual_suite_video.add_argument(
+        "--cases",
+        nargs="+",
+        default=(
+            "static_high",
+            "moving_ball_nominal",
+            "moving_ball_lateral_005",
+            "moving_ball_nominal_velocity_070",
+            "moving_ball_light_400g",
+        ),
+    )
+    contextual_suite_video.add_argument("--fps", type=int, default=30)
     inspect = commands.add_parser(
         "inspect",
         help="validate a safe JSON artifact and print its commitments",
@@ -155,6 +180,23 @@ def dispatch_muscle_memory_argv(argv: list[str]) -> int | None:
             fps=args.fps,
         )
         print(json.dumps(video_result.to_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "contextual-suite-video":
+        from rosclaw.simforge.g1_contextual_recovery_video import (
+            render_g1_contextual_recovery_suite_video,
+        )
+
+        suite_result = render_g1_contextual_recovery_suite_video(
+            artifact_path=args.artifact,
+            training_report_path=args.report,
+            asset_root=args.asset_root,
+            output_path=args.output,
+            source_checkout=args.source_checkout,
+            case_names=tuple(args.cases),
+            fps=args.fps,
+        )
+        print(json.dumps(suite_result.to_dict(), indent=2, sort_keys=True))
         return 0
 
     if args.command == "contextual-train":

--- a/src/rosclaw/simforge/g1_muscle_memory_cli.py
+++ b/src/rosclaw/simforge/g1_muscle_memory_cli.py
@@ -39,6 +39,33 @@ def dispatch_muscle_memory_argv(argv: list[str]) -> int | None:
         default=(0, 1, 2, 3),
         help="CUDA devices used only for exported-policy parity, never physics authority",
     )
+    contextual_train = commands.add_parser(
+        "contextual-train",
+        help="learn and qualify a proprioceptive router over bounded recovery primitives",
+    )
+    contextual_train.add_argument("--asset-root", type=Path, required=True)
+    contextual_train.add_argument("--output-dir", type=Path, required=True)
+    contextual_train.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    contextual_train.add_argument("--seed", type=int, default=20260802)
+    contextual_inspect = commands.add_parser(
+        "contextual-inspect",
+        help="validate a contextual recovery artifact and print its commitments",
+    )
+    contextual_inspect.add_argument("artifact", type=Path)
+    contextual_video = commands.add_parser(
+        "contextual-video",
+        help="render a rejection-labelled DEVELOPMENT fixed-vs-learned comparison",
+    )
+    contextual_video.add_argument("--artifact", type=Path, required=True)
+    contextual_video.add_argument("--report", type=Path, required=True)
+    contextual_video.add_argument("--asset-root", type=Path, required=True)
+    contextual_video.add_argument("--output", type=Path, required=True)
+    contextual_video.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    contextual_video.add_argument(
+        "--case",
+        default="moving_ball_nominal_velocity_070",
+    )
+    contextual_video.add_argument("--fps", type=int, default=30)
     inspect = commands.add_parser(
         "inspect",
         help="validate a safe JSON artifact and print its commitments",
@@ -77,6 +104,80 @@ def dispatch_muscle_memory_argv(argv: list[str]) -> int | None:
             )
         )
         return 0
+
+    if args.command == "contextual-inspect":
+        from rosclaw.simforge.g1_contextual_recovery import (
+            load_g1_contextual_recovery_artifact,
+        )
+
+        contextual_artifact = load_g1_contextual_recovery_artifact(args.artifact)
+        print(
+            json.dumps(
+                {
+                    "artifact_hash": contextual_artifact.artifact_hash,
+                    "body_hash": contextual_artifact.body_hash,
+                    "motion_hash": contextual_artifact.motion_hash,
+                    "baseline_recovery_config_hash": (
+                        contextual_artifact.baseline_recovery_config_hash
+                    ),
+                    "fallback_recovery_config_hash": (
+                        contextual_artifact.fallback_recovery_config_hash
+                    ),
+                    "training_dataset_hash": contextual_artifact.training_dataset_hash,
+                    "training_episode_count": contextual_artifact.training_episode_count,
+                    "regime_feature_names": list(contextual_artifact.regime_feature_names),
+                    "prototype_count": len(contextual_artifact.regime_prototypes),
+                    "primitive_hashes": [
+                        primitive.primitive_hash for primitive in contextual_artifact.primitives
+                    ],
+                    "maximum_regime_distance": (contextual_artifact.maximum_regime_distance),
+                    "maximum_feature_z": contextual_artifact.maximum_feature_z,
+                    "activation_ceiling": contextual_artifact.activation_ceiling,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    if args.command == "contextual-video":
+        from rosclaw.simforge.g1_contextual_recovery_video import (
+            render_g1_contextual_recovery_video,
+        )
+
+        video_result = render_g1_contextual_recovery_video(
+            artifact_path=args.artifact,
+            training_report_path=args.report,
+            asset_root=args.asset_root,
+            output_path=args.output,
+            source_checkout=args.source_checkout,
+            case_name=args.case,
+            fps=args.fps,
+        )
+        print(json.dumps(video_result.to_dict(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "contextual-train":
+        from rosclaw.simforge.g1_contextual_recovery_training import (
+            G1ContextualRecoveryTrainer,
+            write_g1_contextual_recovery_report,
+        )
+
+        contextual_trainer = G1ContextualRecoveryTrainer(
+            asset_root=args.asset_root,
+            seed=args.seed,
+        )
+        contextual_report = contextual_trainer.train()
+        artifact_path, report_path = write_g1_contextual_recovery_report(
+            contextual_report,
+            output_dir=args.output_dir,
+            source_checkout=args.source_checkout,
+        )
+        value = contextual_report.to_dict()
+        value["artifact_path"] = str(artifact_path)
+        value["report_path"] = str(report_path)
+        print(json.dumps(value, indent=2, sort_keys=True))
+        return 0 if contextual_report.qualified else 2
 
     if args.command == "temporal-train":
         from rosclaw.simforge.g1_temporal_muscle_memory_training import (

--- a/src/rosclaw/simforge/g1_recovery_state_memory.py
+++ b/src/rosclaw/simforge/g1_recovery_state_memory.py
@@ -1,0 +1,555 @@
+"""SIM-only short-horizon recovery-state memory for G1 post-kick control.
+
+The policy observes a brief proprioceptive window after contact and landing,
+then consults a conservative evidence neighborhood.  A primitive is selected
+only when enough nearby DEVELOPMENT exemplars agree on the primitive and all
+matching exemplars retain a positive measured advantage.  Negative exemplars
+are first-class abstention votes.  The actor cannot emit torque, joint targets,
+ROS/DDS commands, or hardware authorization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.simforge.g1_contextual_recovery import G1ContextualRecoveryPrimitive
+from rosclaw.simforge.g1_muscle_memory import G1_MUSCLE_MEMORY_OBSERVATIONS
+from rosclaw.simforge.tasks.g1_goalforge.concepts import hash_json
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MAX_ARTIFACT_BYTES = 2 * 1024 * 1024
+
+G1_RECOVERY_STATE_FEATURES = (
+    "pelvis_velocity_x_m_s",
+    "pelvis_velocity_y_m_s",
+    "pelvis_velocity_z_m_s",
+    "torso_roll_rad",
+    "torso_pitch_rad",
+    "torso_angular_velocity_x_rad_s",
+    "torso_angular_velocity_y_rad_s",
+    "torso_angular_velocity_z_rad_s",
+    "com_y_relative_m",
+    "contact_impulse_ns",
+    "ball_relative_position_x_m",
+    "ball_relative_position_y_m",
+    "ball_relative_position_z_m",
+    "ball_relative_velocity_x_m_s",
+    "ball_relative_velocity_y_m_s",
+    "ball_relative_velocity_z_m_s",
+)
+
+G1_RECOVERY_STATE_OBSERVATIONS = G1_MUSCLE_MEMORY_OBSERVATIONS + (
+    "ball_relative_position_x_m",
+    "ball_relative_position_y_m",
+    "ball_relative_position_z_m",
+    "ball_relative_velocity_x_m_s",
+    "ball_relative_velocity_y_m_s",
+    "ball_relative_velocity_z_m_s",
+)
+
+
+@dataclass(frozen=True)
+class G1RecoveryStateArtifact:
+    """Content-addressed temporal evidence-neighborhood policy."""
+
+    body_hash: str
+    motion_hash: str
+    baseline_recovery_config_hash: str
+    fallback_recovery_config_hash: str
+    training_dataset_hash: str
+    observation_mean: tuple[float, ...]
+    observation_scale: tuple[float, ...]
+    descriptor_feature_names: tuple[str, ...]
+    descriptor_prototypes: tuple[tuple[float, ...], ...]
+    prototype_primitive_indices: tuple[int, ...]
+    prototype_composite_advantages: tuple[float, ...]
+    prototype_component_minimums: tuple[float, ...]
+    primitives: tuple[G1ContextualRecoveryPrimitive, ...]
+    selection_window_frames: int
+    neighbor_count: int
+    maximum_neighbor_distance: float
+    minimum_primitive_consensus: float
+    minimum_advantage_lower_bound: float
+    minimum_component_lower_bound: float
+    maximum_feature_z: float
+    training_episode_count: int
+    training_seed: int
+    activation_ceiling: str = "SIM_ONLY"
+    schema_version: str = "rosclaw.g1_goalforge.recovery_state_artifact.v2"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("body_hash", self.body_hash),
+            ("motion_hash", self.motion_hash),
+            ("baseline_recovery_config_hash", self.baseline_recovery_config_hash),
+            ("fallback_recovery_config_hash", self.fallback_recovery_config_hash),
+            ("training_dataset_hash", self.training_dataset_hash),
+        ):
+            if not _SHA256.fullmatch(value):
+                raise ValueError(f"{label} must be a sha256 content hash")
+        if self.schema_version != "rosclaw.g1_goalforge.recovery_state_artifact.v2":
+            raise ValueError("unsupported recovery-state artifact schema")
+        if self.descriptor_feature_names != G1_RECOVERY_STATE_FEATURES:
+            raise ValueError("recovery-state descriptor feature contract mismatch")
+        observation_count = len(G1_RECOVERY_STATE_OBSERVATIONS)
+        if (
+            len(self.observation_mean) != observation_count
+            or len(self.observation_scale) != observation_count
+        ):
+            raise ValueError("recovery-state normalization shape is invalid")
+        descriptor_width = 2 * len(self.descriptor_feature_names)
+        prototype_count = len(self.descriptor_prototypes)
+        if not 3 <= prototype_count <= 64:
+            raise ValueError("recovery-state artifact requires 3 to 64 prototypes")
+        if any(len(row) != descriptor_width for row in self.descriptor_prototypes):
+            raise ValueError("recovery-state descriptor prototype shape is invalid")
+        aligned = (
+            len(self.prototype_primitive_indices),
+            len(self.prototype_composite_advantages),
+            len(self.prototype_component_minimums),
+        )
+        if any(count != prototype_count for count in aligned):
+            raise ValueError("recovery-state prototype evidence is misaligned")
+        if not 1 <= len(self.primitives) <= 16:
+            raise ValueError("recovery-state primitive library is invalid")
+        if any(
+            isinstance(index, bool)
+            or not isinstance(index, int)
+            or index < -1
+            or index >= len(self.primitives)
+            for index in self.prototype_primitive_indices
+        ):
+            raise ValueError("recovery-state prototype route is invalid")
+        arrays = (
+            np.asarray(self.observation_mean, dtype=np.float64),
+            np.asarray(self.observation_scale, dtype=np.float64),
+            np.asarray(self.descriptor_prototypes, dtype=np.float64),
+            np.asarray(self.prototype_composite_advantages, dtype=np.float64),
+            np.asarray(self.prototype_component_minimums, dtype=np.float64),
+        )
+        if not all(np.all(np.isfinite(value)) for value in arrays):
+            raise ValueError("recovery-state artifact contains non-finite values")
+        if np.any(arrays[1] <= 0.0):
+            raise ValueError("recovery-state observation scales must be positive")
+        integer_fields = (
+            self.selection_window_frames,
+            self.neighbor_count,
+            self.training_episode_count,
+            self.training_seed,
+        )
+        if any(isinstance(value, bool) or not isinstance(value, int) for value in integer_fields):
+            raise ValueError("recovery-state count fields must be integers")
+        if not 3 <= self.selection_window_frames <= 12:
+            raise ValueError("recovery-state window must contain 3 to 12 frames")
+        if not 2 <= self.neighbor_count <= 5 or self.neighbor_count > prototype_count:
+            raise ValueError("recovery-state neighbor count is invalid")
+        if self.training_episode_count <= 0 or self.training_seed < 0:
+            raise ValueError("recovery-state training evidence is invalid")
+        thresholds = (
+            self.maximum_neighbor_distance,
+            self.minimum_primitive_consensus,
+            self.minimum_advantage_lower_bound,
+            self.minimum_component_lower_bound,
+            self.maximum_feature_z,
+        )
+        if any(isinstance(value, bool) for value in thresholds) or not all(
+            isinstance(value, (int, float)) and math.isfinite(value) for value in thresholds
+        ):
+            raise ValueError("recovery-state thresholds must be finite numbers")
+        if not 0.05 <= self.maximum_neighbor_distance <= 2.0:
+            raise ValueError("recovery-state distance must be in [0.05, 2]")
+        if not 0.50 <= self.minimum_primitive_consensus <= 1.0:
+            raise ValueError("recovery-state consensus must be in [0.50, 1]")
+        if not 0.0 <= self.minimum_advantage_lower_bound <= 0.50:
+            raise ValueError("recovery-state advantage lower bound is invalid")
+        if not -0.10 <= self.minimum_component_lower_bound <= 0.0:
+            raise ValueError("recovery-state component lower bound is invalid")
+        if not 2.0 <= self.maximum_feature_z <= 12.0:
+            raise ValueError("recovery-state feature envelope must be in [2, 12]")
+        if self.activation_ceiling != "SIM_ONLY":
+            raise ValueError("recovery-state memory must remain SIM_ONLY")
+
+    @property
+    def artifact_hash(self) -> str:
+        return hash_json(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["observation_names"] = list(G1_RECOVERY_STATE_OBSERVATIONS)
+        value["observation_mean"] = list(self.observation_mean)
+        value["observation_scale"] = list(self.observation_scale)
+        value["descriptor_feature_names"] = list(self.descriptor_feature_names)
+        value["descriptor_prototypes"] = [list(row) for row in self.descriptor_prototypes]
+        value["prototype_primitive_indices"] = list(self.prototype_primitive_indices)
+        value["prototype_composite_advantages"] = list(self.prototype_composite_advantages)
+        value["prototype_component_minimums"] = list(self.prototype_component_minimums)
+        value["primitives"] = [primitive.to_dict() for primitive in self.primitives]
+        return value
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> G1RecoveryStateArtifact:
+        expected = {
+            "schema_version",
+            "body_hash",
+            "motion_hash",
+            "baseline_recovery_config_hash",
+            "fallback_recovery_config_hash",
+            "training_dataset_hash",
+            "observation_names",
+            "observation_mean",
+            "observation_scale",
+            "descriptor_feature_names",
+            "descriptor_prototypes",
+            "prototype_primitive_indices",
+            "prototype_composite_advantages",
+            "prototype_component_minimums",
+            "primitives",
+            "selection_window_frames",
+            "neighbor_count",
+            "maximum_neighbor_distance",
+            "minimum_primitive_consensus",
+            "minimum_advantage_lower_bound",
+            "minimum_component_lower_bound",
+            "maximum_feature_z",
+            "training_episode_count",
+            "training_seed",
+            "activation_ceiling",
+        }
+        if set(value) != expected:
+            raise ValueError("recovery-state artifact fields are invalid")
+        if tuple(value["observation_names"]) != G1_RECOVERY_STATE_OBSERVATIONS:
+            raise ValueError("recovery-state observation contract mismatch")
+        features = value["descriptor_feature_names"]
+        prototypes = value["descriptor_prototypes"]
+        primitives = value["primitives"]
+        if not isinstance(features, list) or not all(isinstance(item, str) for item in features):
+            raise ValueError("recovery-state feature names must be strings")
+        if not isinstance(prototypes, list) or not all(isinstance(row, list) for row in prototypes):
+            raise ValueError("recovery-state prototypes must be numeric arrays")
+        if not isinstance(primitives, list) or not all(
+            isinstance(item, Mapping) for item in primitives
+        ):
+            raise ValueError("recovery-state primitives must be objects")
+        return cls(
+            schema_version=str(value["schema_version"]),
+            body_hash=str(value["body_hash"]),
+            motion_hash=str(value["motion_hash"]),
+            baseline_recovery_config_hash=str(value["baseline_recovery_config_hash"]),
+            fallback_recovery_config_hash=str(value["fallback_recovery_config_hash"]),
+            training_dataset_hash=str(value["training_dataset_hash"]),
+            observation_mean=_float_tuple(value["observation_mean"]),
+            observation_scale=_float_tuple(value["observation_scale"]),
+            descriptor_feature_names=tuple(features),
+            descriptor_prototypes=tuple(_float_tuple(row) for row in prototypes),
+            prototype_primitive_indices=_int_tuple(value["prototype_primitive_indices"]),
+            prototype_composite_advantages=_float_tuple(value["prototype_composite_advantages"]),
+            prototype_component_minimums=_float_tuple(value["prototype_component_minimums"]),
+            primitives=tuple(G1ContextualRecoveryPrimitive.from_dict(item) for item in primitives),
+            selection_window_frames=_strict_int(value["selection_window_frames"]),
+            neighbor_count=_strict_int(value["neighbor_count"]),
+            maximum_neighbor_distance=_strict_float(value["maximum_neighbor_distance"]),
+            minimum_primitive_consensus=_strict_float(value["minimum_primitive_consensus"]),
+            minimum_advantage_lower_bound=_strict_float(value["minimum_advantage_lower_bound"]),
+            minimum_component_lower_bound=_strict_float(value["minimum_component_lower_bound"]),
+            maximum_feature_z=_strict_float(value["maximum_feature_z"]),
+            training_episode_count=_strict_int(value["training_episode_count"]),
+            training_seed=_strict_int(value["training_seed"]),
+            activation_ceiling=str(value["activation_ceiling"]),
+        )
+
+
+@dataclass(frozen=True)
+class G1RecoveryStateSelection:
+    ready: bool
+    primitive_index: int | None
+    nearest_distance: float | None
+    neighbor_count: int
+    primitive_consensus: float
+    advantage_lower_bound: float | None
+    component_lower_bound: float | None
+    out_of_distribution: bool
+    fallback_reason: str | None
+
+
+@dataclass(frozen=True)
+class G1RecoveryStateReceipt:
+    artifact_hash: str
+    selected_primitive_index: int | None
+    nearest_distance: float | None
+    neighbor_count: int
+    primitive_consensus: float
+    advantage_lower_bound: float | None
+    component_lower_bound: float | None
+    fallback_reason: str | None
+    pending_count: int
+    selection_count: int
+    fallback_count: int
+    descriptor_hash: str | None
+    activation_ceiling: str = "SIM_ONLY"
+    hardware_command_sent: bool = False
+    schema_version: str = "rosclaw.g1_goalforge.recovery_state_receipt.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class G1RecoveryStatePolicy:
+    """Conservative temporal k-nearest-evidence primitive router."""
+
+    def __init__(self, artifact: G1RecoveryStateArtifact) -> None:
+        self.artifact = artifact
+        self._mean = np.asarray(artifact.observation_mean, dtype=np.float64)
+        self._scale = np.asarray(artifact.observation_scale, dtype=np.float64)
+        self._prototypes = np.asarray(artifact.descriptor_prototypes, dtype=np.float64)
+        self._prototype_routes = np.asarray(
+            artifact.prototype_primitive_indices,
+            dtype=np.int64,
+        )
+        self._advantages = np.asarray(
+            artifact.prototype_composite_advantages,
+            dtype=np.float64,
+        )
+        self._component_minimums = np.asarray(
+            artifact.prototype_component_minimums,
+            dtype=np.float64,
+        )
+        self._feature_indices = np.asarray(
+            [G1_RECOVERY_STATE_OBSERVATIONS.index(name) for name in G1_RECOVERY_STATE_FEATURES],
+            dtype=np.int64,
+        )
+        self.reset()
+
+    def reset(self) -> None:
+        self._window: deque[np.ndarray] = deque(maxlen=self.artifact.selection_window_frames)
+        self._selection: G1RecoveryStateSelection | None = None
+        self._descriptor: np.ndarray | None = None
+        self._pending_count = 0
+        self._selection_count = 0
+        self._fallback_count = 0
+
+    def require_compatible(
+        self,
+        *,
+        body_hash: str,
+        motion_hash: str,
+        baseline_recovery_config_hash: str,
+        fallback_recovery_config_hash: str,
+    ) -> None:
+        expected = self.artifact
+        if body_hash != expected.body_hash:
+            raise ValueError("recovery-state Body hash mismatch")
+        if motion_hash != expected.motion_hash:
+            raise ValueError("recovery-state motion hash mismatch")
+        if baseline_recovery_config_hash != expected.baseline_recovery_config_hash:
+            raise ValueError("recovery-state baseline config hash mismatch")
+        if fallback_recovery_config_hash != expected.fallback_recovery_config_hash:
+            raise ValueError("recovery-state fallback config hash mismatch")
+
+    def select(self, observation: Mapping[str, float]) -> G1RecoveryStateSelection:
+        if self._selection is not None:
+            return self._selection
+        missing = set(G1_RECOVERY_STATE_OBSERVATIONS).difference(observation)
+        if missing:
+            return self._fallback("missing_observation")
+        try:
+            ordered = np.asarray(
+                [float(observation[name]) for name in G1_RECOVERY_STATE_OBSERVATIONS],
+                dtype=np.float64,
+            )
+        except (TypeError, ValueError, OverflowError):
+            return self._fallback("invalid_observation")
+        if not np.all(np.isfinite(ordered)):
+            return self._fallback("nonfinite_observation")
+        normalized = (ordered - self._mean) / self._scale
+        if float(np.max(np.abs(normalized))) > self.artifact.maximum_feature_z:
+            return self._fallback("feature_envelope_exceeded")
+        self._window.append(normalized[self._feature_indices].copy())
+        if len(self._window) < self.artifact.selection_window_frames:
+            self._pending_count += 1
+            return G1RecoveryStateSelection(
+                ready=False,
+                primitive_index=None,
+                nearest_distance=None,
+                neighbor_count=0,
+                primitive_consensus=0.0,
+                advantage_lower_bound=None,
+                component_lower_bound=None,
+                out_of_distribution=False,
+                fallback_reason=None,
+            )
+        window = np.asarray(self._window, dtype=np.float64)
+        descriptor = np.concatenate((np.mean(window, axis=0), window[-1] - window[0]))
+        self._descriptor = descriptor
+        distances = np.linalg.norm(self._prototypes - descriptor, axis=1) / math.sqrt(
+            descriptor.size
+        )
+        order = np.argsort(distances, kind="stable")
+        neighbors = order[: self.artifact.neighbor_count]
+        nearest = float(distances[neighbors[0]])
+        covered = distances[neighbors] <= self.artifact.maximum_neighbor_distance
+        if not bool(np.all(covered)):
+            return self._fallback(
+                "insufficient_covered_neighbors",
+                nearest_distance=nearest,
+                neighbor_count=int(np.count_nonzero(covered)),
+            )
+        routes = self._prototype_routes[neighbors]
+        positive = routes >= 0
+        consensus = float(np.count_nonzero(positive) / len(neighbors))
+        if int(routes[0]) < 0:
+            return self._fallback(
+                "nearest_exemplar_abstains",
+                nearest_distance=nearest,
+                neighbor_count=len(neighbors),
+                consensus=consensus,
+            )
+        if consensus + 1e-12 < self.artifact.minimum_primitive_consensus:
+            return self._fallback(
+                "primitive_consensus_below_gate",
+                nearest_distance=nearest,
+                neighbor_count=len(neighbors),
+                consensus=consensus,
+            )
+        route = int(routes[0])
+        positive_neighbors = neighbors[positive]
+        advantage_lower = float(np.min(self._advantages[positive_neighbors]))
+        component_lower = float(np.min(self._component_minimums[positive_neighbors]))
+        if advantage_lower + 1e-12 < self.artifact.minimum_advantage_lower_bound:
+            return self._fallback(
+                "advantage_lower_bound_below_gate",
+                nearest_distance=nearest,
+                neighbor_count=len(neighbors),
+                consensus=consensus,
+                advantage_lower=advantage_lower,
+                component_lower=component_lower,
+            )
+        if component_lower + 1e-12 < self.artifact.minimum_component_lower_bound:
+            return self._fallback(
+                "component_lower_bound_below_gate",
+                nearest_distance=nearest,
+                neighbor_count=len(neighbors),
+                consensus=consensus,
+                advantage_lower=advantage_lower,
+                component_lower=component_lower,
+            )
+        self._selection = G1RecoveryStateSelection(
+            ready=True,
+            primitive_index=route,
+            nearest_distance=nearest,
+            neighbor_count=len(neighbors),
+            primitive_consensus=consensus,
+            advantage_lower_bound=advantage_lower,
+            component_lower_bound=component_lower,
+            out_of_distribution=False,
+            fallback_reason=None,
+        )
+        self._selection_count += 1
+        return self._selection
+
+    def _fallback(
+        self,
+        reason: str,
+        *,
+        nearest_distance: float | None = None,
+        neighbor_count: int = 0,
+        consensus: float = 0.0,
+        advantage_lower: float | None = None,
+        component_lower: float | None = None,
+    ) -> G1RecoveryStateSelection:
+        self._selection = G1RecoveryStateSelection(
+            ready=True,
+            primitive_index=None,
+            nearest_distance=nearest_distance,
+            neighbor_count=neighbor_count,
+            primitive_consensus=consensus,
+            advantage_lower_bound=advantage_lower,
+            component_lower_bound=component_lower,
+            out_of_distribution=True,
+            fallback_reason=reason,
+        )
+        self._fallback_count += 1
+        return self._selection
+
+    def build_receipt(self) -> G1RecoveryStateReceipt:
+        selection = self._selection
+        descriptor_hash = None
+        if self._descriptor is not None:
+            descriptor_hash = (
+                "sha256:"
+                + hashlib.sha256(np.ascontiguousarray(self._descriptor).tobytes()).hexdigest()
+            )
+        return G1RecoveryStateReceipt(
+            artifact_hash=self.artifact.artifact_hash,
+            selected_primitive_index=(selection.primitive_index if selection else None),
+            nearest_distance=(selection.nearest_distance if selection else None),
+            neighbor_count=(selection.neighbor_count if selection else 0),
+            primitive_consensus=(selection.primitive_consensus if selection else 0.0),
+            advantage_lower_bound=(selection.advantage_lower_bound if selection else None),
+            component_lower_bound=(selection.component_lower_bound if selection else None),
+            fallback_reason=(selection.fallback_reason if selection else None),
+            pending_count=self._pending_count,
+            selection_count=self._selection_count,
+            fallback_count=self._fallback_count,
+            descriptor_hash=descriptor_hash,
+        )
+
+
+def load_g1_recovery_state_artifact(path: Path) -> G1RecoveryStateArtifact:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file() or resolved.stat().st_size > _MAX_ARTIFACT_BYTES:
+        raise ValueError("recovery-state artifact is missing or exceeds 2 MiB")
+    try:
+        value = json.loads(resolved.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError("recovery-state artifact is not readable JSON") from exc
+    if not isinstance(value, Mapping):
+        raise ValueError("recovery-state artifact root must be an object")
+    return G1RecoveryStateArtifact.from_dict(value)
+
+
+def _strict_int(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("recovery-state integer field is invalid")
+    return value
+
+
+def _strict_float(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("recovery-state numeric field is invalid")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError("recovery-state numeric field must be finite")
+    return result
+
+
+def _float_tuple(value: Any) -> tuple[float, ...]:
+    if not isinstance(value, list):
+        raise ValueError("recovery-state numeric vector must be an array")
+    return tuple(_strict_float(item) for item in value)
+
+
+def _int_tuple(value: Any) -> tuple[int, ...]:
+    if not isinstance(value, list):
+        raise ValueError("recovery-state integer vector must be an array")
+    return tuple(_strict_int(item) for item in value)
+
+
+__all__ = [
+    "G1_RECOVERY_STATE_FEATURES",
+    "G1_RECOVERY_STATE_OBSERVATIONS",
+    "G1RecoveryStateArtifact",
+    "G1RecoveryStatePolicy",
+    "G1RecoveryStateReceipt",
+    "G1RecoveryStateSelection",
+    "load_g1_recovery_state_artifact",
+]

--- a/src/rosclaw/simforge/g1_recovery_state_training.py
+++ b/src/rosclaw/simforge/g1_recovery_state_training.py
@@ -1,0 +1,868 @@
+"""Evidence-gated training for short-horizon G1 recovery-state memory.
+
+The trainer expands the DEVELOPMENT curriculum around ball velocity, lateral
+offset, and mass.  It searches only a fixed library of bounded target-space
+recovery primitives.  Both successful and failed searches become temporal
+prototypes: failed examples cast explicit abstention votes.  CPU MuJoCo is the
+only physics authority; exported artifacts remain SIM_ONLY.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.simforge.backends.unitree_mujoco_backend import (
+    GoalForgeEpisode,
+    trajectory_digest,
+)
+from rosclaw.simforge.g1_cerebellar_recovery import G1CerebellarRecoveryConfig
+from rosclaw.simforge.g1_contextual_recovery import G1ContextualRecoveryPrimitive
+from rosclaw.simforge.g1_contextual_recovery_training import (
+    _bootstrap_lower_95,
+    _composite,
+    _parent_valid,
+    _primitive_library,
+    _strict_replay,
+)
+from rosclaw.simforge.g1_moving_ball import MovingBallInterceptAdapter
+from rosclaw.simforge.g1_muscle_memory_training import (
+    G1MuscleMemoryCase,
+    G1MuscleMemoryTrainer,
+    _case_score,
+    g1_muscle_memory_parent_config,
+)
+from rosclaw.simforge.g1_recovery_quality import measure_g1_recovery_quality
+from rosclaw.simforge.g1_recovery_state_memory import (
+    G1_RECOVERY_STATE_FEATURES,
+    G1_RECOVERY_STATE_OBSERVATIONS,
+    G1RecoveryStateArtifact,
+)
+from rosclaw.simforge.g1_temporal_muscle_memory_training import (
+    _build_temporal_holdout_cases,
+    _case_commitment_hash,
+    _moving_reductions,
+    build_g1_temporal_muscle_memory_cases,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import hash_json
+
+_WINDOW_FRAMES = 5
+_NEIGHBOR_COUNT = 2
+_MAXIMUM_NEIGHBOR_DISTANCE = 0.25
+# A single contradictory neighbor proved insufficient under contact-dynamics
+# interpolation (v6).  Require both local exemplars to carry positive evidence;
+# plasticity resumes only after the curriculum supplies a coherent region.
+_MINIMUM_CONSENSUS = 1.0
+_ADVANTAGE_GATE = 0.02
+_COMPONENT_REGRESSION_LIMIT = 0.02
+
+
+@dataclass(frozen=True)
+class G1RecoveryStatePrototypeResult:
+    case_name: str
+    route_primitive_index: int
+    selected_primitive_hash: str | None
+    composite_advantage: float
+    component_minimum: float
+    safe: bool
+    goal_preserved: bool
+    naturalness_preserved: bool
+    abstention_reason: str | None
+    schema_version: str = "rosclaw.g1_goalforge.recovery_state_prototype_result.v1"
+
+
+@dataclass(frozen=True)
+class G1RecoveryStateSuiteSummary:
+    suite_hash: str
+    case_count: int
+    parent_valid_count: int
+    learned_route_count: int
+    fallback_route_count: int
+    strict_replay_count: int
+    exact_parent_fallback_count: int
+    passed_count: int
+    mean_composite_reduction: float
+    minimum_composite_reduction: float
+    bootstrap_lower_95: float
+    mean_backward_reduction: float
+    mean_tail_wobble_reduction: float
+    mean_leg_jerk_reduction: float
+    qualified: bool
+    case_rows_disclosed: bool = False
+    evidence_domain: str = "SIM"
+    physics_authority: str = "CPU_MUJOCO"
+    schema_version: str = "rosclaw.g1_goalforge.recovery_state_suite.v1"
+
+
+@dataclass(frozen=True)
+class G1RecoveryStateTrainingReport:
+    artifact: G1RecoveryStateArtifact
+    prototype_results: tuple[G1RecoveryStatePrototypeResult, ...]
+    development: G1RecoveryStateSuiteSummary
+    validation: G1RecoveryStateSuiteSummary
+    holdout: G1RecoveryStateSuiteSummary
+    retained_recovery_config_hash: str
+    retained_recovery_config: dict[str, Any]
+    baseline_recovery_config_hash: str
+    baseline_recovery_config: dict[str, Any]
+    primitive_trial_count: int
+    training_rollout_count: int
+    validation_rollout_count: int
+    holdout_rollout_count: int
+    qualified: bool
+    rejection_reasons: tuple[str, ...]
+    activation_ceiling: str = "SIM_ONLY"
+    evidence_domain: str = "SIM"
+    physics_authority: str = "CPU_MUJOCO"
+    hardware_command_sent: bool = False
+    schema_version: str = "rosclaw.g1_goalforge.recovery_state_training.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "artifact": {**self.artifact.to_dict(), "artifact_hash": self.artifact.artifact_hash},
+            "prototype_results": [asdict(item) for item in self.prototype_results],
+            "development": asdict(self.development),
+            "validation": asdict(self.validation),
+            "holdout": asdict(self.holdout),
+            "retained_recovery_config_hash": self.retained_recovery_config_hash,
+            "retained_recovery_config": self.retained_recovery_config,
+            "baseline_recovery_config_hash": self.baseline_recovery_config_hash,
+            "baseline_recovery_config": self.baseline_recovery_config,
+            "primitive_trial_count": self.primitive_trial_count,
+            "training_rollout_count": self.training_rollout_count,
+            "validation_rollout_count": self.validation_rollout_count,
+            "holdout_rollout_count": self.holdout_rollout_count,
+            "qualified": self.qualified,
+            "rejection_reasons": list(self.rejection_reasons),
+            "qualification_thresholds": {
+                "maximum_neighbor_distance": _MAXIMUM_NEIGHBOR_DISTANCE,
+                "minimum_primitive_consensus": _MINIMUM_CONSENSUS,
+                "minimum_composite_advantage": _ADVANTAGE_GATE,
+                "component_regression_limit": _COMPONENT_REGRESSION_LIMIT,
+            },
+            "activation_ceiling": self.activation_ceiling,
+            "evidence_domain": self.evidence_domain,
+            "physics_authority": self.physics_authority,
+            "hardware_command_sent": self.hardware_command_sent,
+        }
+
+
+def build_g1_recovery_state_cases() -> tuple[G1MuscleMemoryCase, ...]:
+    """Predeclare a dense DEVELOPMENT neighborhood before primitive search."""
+
+    static, nominal, lateral, light, disturbed = build_g1_temporal_muscle_memory_cases()
+    specifications = (
+        ("moving_ball_velocity_068", nominal, {"ball_velocity_x_mps": -0.068}),
+        ("moving_ball_velocity_070", nominal, {"ball_velocity_x_mps": -0.070}),
+        ("moving_ball_velocity_072", nominal, {"ball_velocity_x_mps": -0.072}),
+        ("moving_ball_velocity_075", nominal, {"ball_velocity_x_mps": -0.075}),
+        ("moving_ball_velocity_085", nominal, {"ball_velocity_x_mps": -0.085}),
+        ("moving_ball_lateral_0025", lateral, {"ball_y_m": 0.0025}),
+        ("moving_ball_lateral_004", lateral, {"ball_y_m": 0.004}),
+        ("moving_ball_lateral_006", lateral, {"ball_y_m": 0.006}),
+        ("moving_ball_lateral_0075", lateral, {"ball_y_m": 0.0075}),
+        ("moving_ball_mass_395g", light, {"ball_mass_kg": 0.395}),
+        ("moving_ball_mass_398g", light, {"ball_mass_kg": 0.398}),
+        ("moving_ball_mass_4015g", light, {"ball_mass_kg": 0.4015}),
+        ("moving_ball_mass_4038g", light, {"ball_mass_kg": 0.4038}),
+        ("moving_ball_mass_405g", light, {"ball_mass_kg": 0.405}),
+        (
+            "moving_ball_velocity_070_r545",
+            nominal,
+            {"ball_velocity_x_mps": -0.070, "restitution": 0.545},
+        ),
+        (
+            "moving_ball_velocity_070_r547",
+            nominal,
+            {"ball_velocity_x_mps": -0.070, "restitution": 0.547},
+        ),
+        (
+            "moving_ball_velocity_070_r549",
+            nominal,
+            {"ball_velocity_x_mps": -0.070, "restitution": 0.549},
+        ),
+        (
+            "moving_ball_velocity_070_r551",
+            nominal,
+            {"ball_velocity_x_mps": -0.070, "restitution": 0.551},
+        ),
+        (
+            "moving_ball_velocity_070_r553",
+            nominal,
+            {"ball_velocity_x_mps": -0.070, "restitution": 0.553},
+        ),
+        (
+            "moving_ball_velocity_070_r555",
+            nominal,
+            {"ball_velocity_x_mps": -0.070, "restitution": 0.555},
+        ),
+        (
+            "moving_ball_velocity_070_r557",
+            nominal,
+            {"ball_velocity_x_mps": -0.070, "restitution": 0.557},
+        ),
+        (
+            "moving_ball_velocity_070_r559",
+            nominal,
+            {"ball_velocity_x_mps": -0.070, "restitution": 0.559},
+        ),
+    )
+    return (static, nominal, lateral, light, *_variants(specifications), disturbed)
+
+
+def build_g1_recovery_state_validation_cases() -> tuple[G1MuscleMemoryCase, ...]:
+    """Precommit v6 restitution-interpolation cases not consumed by search."""
+
+    development = {case.name: case for case in build_g1_recovery_state_cases()}
+    velocity_070 = development["moving_ball_velocity_070"]
+    specifications = (
+        ("state_v6_validation_velocity_070_r5455", velocity_070, {"restitution": 0.5455}),
+        ("state_v6_validation_velocity_070_r5465", velocity_070, {"restitution": 0.5465}),
+        ("state_v6_validation_velocity_070_r5485", velocity_070, {"restitution": 0.5485}),
+        ("state_v6_validation_velocity_070_r5505", velocity_070, {"restitution": 0.5505}),
+        ("state_v6_validation_velocity_070_r5525", velocity_070, {"restitution": 0.5525}),
+        ("state_v6_validation_velocity_070_r5545", velocity_070, {"restitution": 0.5545}),
+        ("state_v6_validation_velocity_070_r5565", velocity_070, {"restitution": 0.5565}),
+        ("state_v6_validation_velocity_070_r5585", velocity_070, {"restitution": 0.5585}),
+    )
+    return _variants(specifications)
+
+
+def _variants(
+    specifications: tuple[tuple[str, G1MuscleMemoryCase, dict[str, float]], ...],
+) -> tuple[G1MuscleMemoryCase, ...]:
+    adapter = MovingBallInterceptAdapter()
+    cases: list[G1MuscleMemoryCase] = []
+    for name, source, changes in specifications:
+        scenario = replace(source.scenario, scenario_id=name, **changes)
+        plan = adapter.plan(scenario)
+        if not plan.eligible:
+            raise RuntimeError(f"recovery-state curriculum case is ineligible: {name}")
+        cases.append(G1MuscleMemoryCase(name=name, scenario=scenario, parameters=plan.parameters))
+    return tuple(cases)
+
+
+class G1RecoveryStateTrainer:
+    """Learn a conservative temporal evidence router over recovery primitives."""
+
+    def __init__(self, *, asset_root: Path, seed: int = 20260803) -> None:
+        if seed < 0:
+            raise ValueError("recovery-state seed must be non-negative")
+        self.seed = seed
+        self.cases = build_g1_recovery_state_cases()
+        self.validation_cases = build_g1_recovery_state_validation_cases()
+        self.retained_config = g1_muscle_memory_parent_config()
+        self.baseline_config = replace(
+            self.retained_config,
+            settling_standing_pose_blend=0.42,
+            settling_waist_pitch_bias_rad=0.11,
+            target_smoothing_alpha=0.54,
+            terminal_damping_start_policy_frame=500,
+            terminal_damping_blend_frames=80,
+            terminal_kp_scale=0.93,
+            terminal_kd_scale=1.50,
+            terminal_damping_joint_group="legs",
+        )
+        self.base = G1MuscleMemoryTrainer(
+            asset_root=asset_root,
+            cases=self.cases,
+            recovery_config=self.retained_config,
+        )
+
+    def train(self) -> G1RecoveryStateTrainingReport:
+        reasons: list[str] = []
+        moving_indices = tuple(
+            index for index, case in enumerate(self.cases) if case.name.startswith("moving_ball")
+        )
+        parents = tuple(self._run_config(case, self.retained_config) for case in self.cases)
+        parent_metrics = tuple(measure_g1_recovery_quality(row.trajectory) for row in parents)
+        baselines = tuple(self._run_config(case, self.baseline_config) for case in self.cases)
+        baseline_metrics = tuple(measure_g1_recovery_quality(row.trajectory) for row in baselines)
+        mean, scale = _recovery_state_normalization(parents)
+        retained_hash = self._config_hash(self.retained_config)
+        baseline_hash = self._config_hash(self.baseline_config)
+        validation_suite_hash = _case_commitment_hash(
+            "rosclaw.g1_goalforge.recovery_state_validation.v6",
+            self.validation_cases,
+        )
+        # Deployment runs the retained parent while the temporal window is
+        # pending.  Build prototypes from that exact causal rollout.
+        descriptors = tuple(
+            _recovery_state_descriptor(
+                episode,
+                observation_mean=mean,
+                observation_scale=scale,
+            )
+            for episode in parents
+        )
+
+        library = _primitive_library()
+        labels: list[int] = []
+        advantages: list[float] = []
+        component_minimums: list[float] = []
+        prototype_results: list[G1RecoveryStatePrototypeResult] = []
+        trial_commitments: list[dict[str, Any]] = []
+        primitive_trials = 0
+        for index, case in enumerate(self.cases):
+            if index not in moving_indices:
+                labels.append(-1)
+                advantages.append(0.0)
+                component_minimums.append(0.0)
+                prototype_results.append(
+                    G1RecoveryStatePrototypeResult(
+                        case_name=case.name,
+                        route_primitive_index=-1,
+                        selected_primitive_hash=None,
+                        composite_advantage=0.0,
+                        component_minimum=0.0,
+                        safe=True,
+                        goal_preserved=True,
+                        naturalness_preserved=True,
+                        abstention_reason="non_moving_retained_parent",
+                    )
+                )
+                continue
+            scored: list[
+                tuple[
+                    float,
+                    int,
+                    G1ContextualRecoveryPrimitive,
+                    tuple[float, float, float],
+                    bool,
+                    bool,
+                    bool,
+                ]
+            ] = []
+            for primitive_index, primitive in enumerate(library):
+                # Evaluate the primitive through the same five-frame pending
+                # window and causal state router used after export.  A forced
+                # local evidence artifact removes only the final neighborhood
+                # decision; it does not alter controller timing or physics.
+                trial_artifact = self._trial_artifact(
+                    descriptor=descriptors[index],
+                    primitive_index=primitive_index,
+                    primitives=library,
+                    observation_mean=mean,
+                    observation_scale=scale,
+                    baseline_hash=baseline_hash,
+                    retained_hash=retained_hash,
+                )
+                candidate = self._run_state(
+                    case,
+                    trial_artifact,
+                )
+                quality = measure_g1_recovery_quality(candidate.trajectory)
+                score, safe, goal, natural = _case_score(
+                    parent=parents[index],
+                    parent_quality=parent_metrics[index],
+                    candidate=candidate,
+                    candidate_quality=quality,
+                )
+                reductions = _moving_reductions(baseline_metrics[index], quality)
+                composite = _composite(reductions)
+                eligible = bool(
+                    safe
+                    and goal
+                    and natural
+                    and min(reductions) >= -_COMPONENT_REGRESSION_LIMIT
+                    and composite >= _ADVANTAGE_GATE
+                )
+                selection_score = composite + 0.02 * score if eligible else -1_000_000.0
+                scored.append(
+                    (
+                        selection_score,
+                        primitive_index,
+                        primitive,
+                        reductions,
+                        safe,
+                        goal,
+                        natural,
+                    )
+                )
+                primitive_trials += 1
+                trial_commitments.append(
+                    {
+                        "case_name": case.name,
+                        "primitive_hash": primitive.primitive_hash,
+                        "trajectory_hash": trajectory_digest(candidate.trajectory),
+                        "result": candidate.result.summary_dict(),
+                        "score": score,
+                        "reductions": list(reductions),
+                        "eligible": eligible,
+                    }
+                )
+            scored.sort(key=lambda item: (item[0], item[2].primitive_hash), reverse=True)
+            selected = scored[0]
+            if selected[0] <= -1_000_000.0:
+                best_observed = max(
+                    scored, key=lambda item: (_composite(item[3]), item[2].primitive_hash)
+                )
+                labels.append(-1)
+                advantages.append(_composite(best_observed[3]))
+                component_minimums.append(min(best_observed[3]))
+                prototype_results.append(
+                    G1RecoveryStatePrototypeResult(
+                        case_name=case.name,
+                        route_primitive_index=-1,
+                        selected_primitive_hash=None,
+                        composite_advantage=_composite(best_observed[3]),
+                        component_minimum=min(best_observed[3]),
+                        safe=best_observed[4],
+                        goal_preserved=best_observed[5],
+                        naturalness_preserved=best_observed[6],
+                        abstention_reason="no_primitive_passed_all_gates",
+                    )
+                )
+            else:
+                labels.append(selected[1])
+                advantages.append(_composite(selected[3]))
+                component_minimums.append(min(selected[3]))
+                prototype_results.append(
+                    G1RecoveryStatePrototypeResult(
+                        case_name=case.name,
+                        route_primitive_index=selected[1],
+                        selected_primitive_hash=selected[2].primitive_hash,
+                        composite_advantage=_composite(selected[3]),
+                        component_minimum=min(selected[3]),
+                        safe=selected[4],
+                        goal_preserved=selected[5],
+                        naturalness_preserved=selected[6],
+                        abstention_reason=None,
+                    )
+                )
+
+        dataset_hash = hash_json(
+            {
+                "schema_version": "rosclaw.g1_goalforge.recovery_state_dataset.v1",
+                "development_cases": [
+                    {
+                        "name": case.name,
+                        "scenario_commitment": case.scenario.scenario_commitment,
+                        "policy_hash": case.parameters.policy_hash,
+                        "retained_trajectory_hash": trajectory_digest(parent.trajectory),
+                        "baseline_trajectory_hash": trajectory_digest(baseline.trajectory),
+                    }
+                    for case, parent, baseline in zip(
+                        self.cases,
+                        parents,
+                        baselines,
+                        strict=True,
+                    )
+                ],
+                "primitive_library": [primitive.to_dict() for primitive in library],
+                "trial_commitments": trial_commitments,
+                "observation_mean": list(mean),
+                "observation_scale": list(scale),
+                "validation_suite_hash": validation_suite_hash,
+                "validation_excluded": True,
+                "private_holdout_excluded": True,
+            }
+        )
+        artifact = G1RecoveryStateArtifact(
+            body_hash=self.base.backend.qualification.body_hash,
+            motion_hash=self.base.backend.qualification.motion_hash,
+            baseline_recovery_config_hash=baseline_hash,
+            fallback_recovery_config_hash=retained_hash,
+            training_dataset_hash=dataset_hash,
+            observation_mean=mean,
+            observation_scale=scale,
+            descriptor_feature_names=G1_RECOVERY_STATE_FEATURES,
+            descriptor_prototypes=descriptors,
+            prototype_primitive_indices=tuple(labels),
+            prototype_composite_advantages=tuple(advantages),
+            prototype_component_minimums=tuple(component_minimums),
+            primitives=library,
+            selection_window_frames=_WINDOW_FRAMES,
+            neighbor_count=_NEIGHBOR_COUNT,
+            maximum_neighbor_distance=_MAXIMUM_NEIGHBOR_DISTANCE,
+            minimum_primitive_consensus=_MINIMUM_CONSENSUS,
+            minimum_advantage_lower_bound=_ADVANTAGE_GATE,
+            minimum_component_lower_bound=-_COMPONENT_REGRESSION_LIMIT,
+            maximum_feature_z=8.0,
+            training_episode_count=len(parents) + len(baselines) + primitive_trials,
+            training_seed=self.seed,
+        )
+
+        development, development_rollouts = self._evaluate_suite(
+            artifact=artifact,
+            cases=self.cases,
+            suite_hash=_case_commitment_hash(
+                "rosclaw.g1_goalforge.recovery_state_development.v1",
+                self.cases,
+            ),
+            require_all_learned=False,
+            require_all_fallback=False,
+        )
+        if not development.qualified:
+            reasons.append("development_replay_failed")
+        validation, validation_rollouts = self._evaluate_suite(
+            artifact=artifact,
+            cases=self.validation_cases,
+            suite_hash=validation_suite_hash,
+            require_all_learned=True,
+            require_all_fallback=False,
+        )
+        if not validation.qualified:
+            reasons.append("sealed_local_physics_validation_failed")
+        holdout_cases = _build_temporal_holdout_cases()
+        holdout, holdout_rollouts = self._evaluate_suite(
+            artifact=artifact,
+            cases=holdout_cases,
+            suite_hash=_case_commitment_hash(
+                "rosclaw.g1_goalforge.recovery_state_private_holdout.v1",
+                holdout_cases,
+            ),
+            require_all_learned=False,
+            require_all_fallback=True,
+        )
+        if not holdout.qualified:
+            reasons.append("private_holdout_failed")
+        return G1RecoveryStateTrainingReport(
+            artifact=artifact,
+            prototype_results=tuple(prototype_results),
+            development=development,
+            validation=validation,
+            holdout=holdout,
+            retained_recovery_config_hash=retained_hash,
+            retained_recovery_config=asdict(self.retained_config),
+            baseline_recovery_config_hash=baseline_hash,
+            baseline_recovery_config=asdict(self.baseline_config),
+            primitive_trial_count=primitive_trials,
+            training_rollout_count=(
+                len(parents) + len(baselines) + primitive_trials + development_rollouts
+            ),
+            validation_rollout_count=validation_rollouts,
+            holdout_rollout_count=holdout_rollouts,
+            qualified=not reasons,
+            rejection_reasons=tuple(reasons),
+        )
+
+    def _evaluate_suite(
+        self,
+        *,
+        artifact: G1RecoveryStateArtifact,
+        cases: tuple[G1MuscleMemoryCase, ...],
+        suite_hash: str,
+        require_all_learned: bool,
+        require_all_fallback: bool,
+    ) -> tuple[G1RecoveryStateSuiteSummary, int]:
+        parent_valid_count = 0
+        route_count = 0
+        fallback_count = 0
+        strict_count = 0
+        exact_fallback_count = 0
+        passed_count = 0
+        routed_composites: list[float] = []
+        routed_reductions: list[tuple[float, float, float]] = []
+        for case in cases:
+            parent = self._run_config(case, self.retained_config)
+            baseline = self._run_config(case, self.baseline_config)
+            candidate = self._run_state(case, artifact)
+            replay = self._run_state(case, artifact)
+            parent_metric = measure_g1_recovery_quality(parent.trajectory)
+            baseline_metric = measure_g1_recovery_quality(baseline.trajectory)
+            candidate_metric = measure_g1_recovery_quality(candidate.trajectory)
+            parent_valid = _parent_valid(parent, parent_metric)
+            parent_valid_count += int(parent_valid)
+            route = _recovery_state_route(candidate)
+            routed = route is not None
+            route_count += int(routed)
+            fallback_count += int(not routed)
+            strict = _strict_replay(candidate, replay)
+            strict_count += int(strict)
+            exact_fallback = bool(
+                not routed
+                and parent.result.summary_dict() == candidate.result.summary_dict()
+                and trajectory_digest(parent.trajectory) == trajectory_digest(candidate.trajectory)
+            )
+            exact_fallback_count += int(exact_fallback)
+            _, safe, goal, natural = _case_score(
+                parent=parent,
+                parent_quality=parent_metric,
+                candidate=candidate,
+                candidate_quality=candidate_metric,
+            )
+            if routed:
+                reductions = _moving_reductions(baseline_metric, candidate_metric)
+                composite = _composite(reductions)
+                routed_reductions.append(reductions)
+                routed_composites.append(composite)
+                passed = bool(
+                    parent_valid
+                    and strict
+                    and safe
+                    and goal
+                    and natural
+                    and min(reductions) >= -_COMPONENT_REGRESSION_LIMIT
+                    and composite >= _ADVANTAGE_GATE
+                )
+            else:
+                # Boundary negatives can have an invalid retained parent.  The
+                # router passes only by reproducing it exactly; it cannot claim
+                # to repair a regime for which no bounded primitive qualified.
+                passed = bool(strict and exact_fallback)
+            passed_count += int(passed)
+        mean_composite = float(np.mean(routed_composites)) if routed_composites else 0.0
+        minimum_composite = float(np.min(routed_composites)) if routed_composites else 0.0
+        bootstrap = (
+            _bootstrap_lower_95(tuple(routed_composites), seed=self.seed + 1)
+            if len(routed_composites) >= 2
+            else 0.0
+        )
+        mean_components = (
+            np.mean(np.asarray(routed_reductions, dtype=np.float64), axis=0)
+            if routed_reductions
+            else np.zeros(3, dtype=np.float64)
+        )
+        route_requirement = not require_all_learned or route_count == len(cases)
+        fallback_requirement = not require_all_fallback or fallback_count == len(cases)
+        require_valid_parents = require_all_learned or require_all_fallback
+        qualified = bool(
+            passed_count == len(cases)
+            and strict_count == len(cases)
+            and route_requirement
+            and fallback_requirement
+            and (not require_valid_parents or parent_valid_count == len(cases))
+            and (not require_all_learned or bootstrap > 0.0)
+        )
+        return (
+            G1RecoveryStateSuiteSummary(
+                suite_hash=suite_hash,
+                case_count=len(cases),
+                parent_valid_count=parent_valid_count,
+                learned_route_count=route_count,
+                fallback_route_count=fallback_count,
+                strict_replay_count=strict_count,
+                exact_parent_fallback_count=exact_fallback_count,
+                passed_count=passed_count,
+                mean_composite_reduction=mean_composite,
+                minimum_composite_reduction=minimum_composite,
+                bootstrap_lower_95=bootstrap,
+                mean_backward_reduction=float(mean_components[0]),
+                mean_tail_wobble_reduction=float(mean_components[1]),
+                mean_leg_jerk_reduction=float(mean_components[2]),
+                qualified=qualified,
+            ),
+            4 * len(cases),
+        )
+
+    def _run_config(
+        self,
+        case: G1MuscleMemoryCase,
+        config: G1CerebellarRecoveryConfig,
+    ) -> GoalForgeEpisode:
+        controller = self.base.backend.build_cerebellar_recovery_controller(
+            case.scenario,
+            config,
+        )
+        return self.base.backend.run(
+            case.scenario,
+            case.parameters,
+            feedback_runtime=self.base._feedback_runtime(case),
+            recovery_controller=controller,
+        )
+
+    def _trial_artifact(
+        self,
+        *,
+        descriptor: tuple[float, ...],
+        primitive_index: int,
+        primitives: tuple[G1ContextualRecoveryPrimitive, ...],
+        observation_mean: tuple[float, ...],
+        observation_scale: tuple[float, ...],
+        baseline_hash: str,
+        retained_hash: str,
+    ) -> G1RecoveryStateArtifact:
+        return G1RecoveryStateArtifact(
+            body_hash=self.base.backend.qualification.body_hash,
+            motion_hash=self.base.backend.qualification.motion_hash,
+            baseline_recovery_config_hash=baseline_hash,
+            fallback_recovery_config_hash=retained_hash,
+            training_dataset_hash="sha256:" + "0" * 64,
+            observation_mean=observation_mean,
+            observation_scale=observation_scale,
+            descriptor_feature_names=G1_RECOVERY_STATE_FEATURES,
+            descriptor_prototypes=(descriptor, descriptor, descriptor),
+            prototype_primitive_indices=(primitive_index, primitive_index, -1),
+            prototype_composite_advantages=(1.0, 1.0, -1.0),
+            prototype_component_minimums=(0.0, 0.0, -1.0),
+            primitives=primitives,
+            selection_window_frames=_WINDOW_FRAMES,
+            neighbor_count=_NEIGHBOR_COUNT,
+            maximum_neighbor_distance=_MAXIMUM_NEIGHBOR_DISTANCE,
+            minimum_primitive_consensus=_MINIMUM_CONSENSUS,
+            minimum_advantage_lower_bound=_ADVANTAGE_GATE,
+            minimum_component_lower_bound=-_COMPONENT_REGRESSION_LIMIT,
+            maximum_feature_z=8.0,
+            training_episode_count=1,
+            training_seed=self.seed,
+        )
+
+    def _run_state(
+        self,
+        case: G1MuscleMemoryCase,
+        artifact: G1RecoveryStateArtifact,
+    ) -> GoalForgeEpisode:
+        controller = self.base.backend.build_cerebellar_recovery_controller(
+            case.scenario,
+            self.baseline_config,
+            recovery_state_artifact=artifact,
+            fallback_config=self.retained_config,
+        )
+        return self.base.backend.run(
+            case.scenario,
+            case.parameters,
+            feedback_runtime=self.base._feedback_runtime(case),
+            recovery_controller=controller,
+        )
+
+    def _config_hash(self, config: G1CerebellarRecoveryConfig) -> str:
+        return self.base.backend.build_cerebellar_recovery_controller(
+            self.cases[0].scenario,
+            config,
+        ).config_hash
+
+
+def _recovery_state_descriptor(
+    episode: GoalForgeEpisode,
+    *,
+    observation_mean: tuple[float, ...],
+    observation_scale: tuple[float, ...],
+) -> tuple[float, ...]:
+    """Reconstruct the first five distinct causal policy observations."""
+
+    rows = np.asarray(episode.trajectory["recovery_state_observation"], dtype=np.float64)
+    updated = np.asarray(
+        episode.trajectory["recovery_observation_updated"],
+        dtype=np.bool_,
+    )
+    impulse_index = G1_RECOVERY_STATE_OBSERVATIONS.index("contact_impulse_ns")
+    support_index = G1_RECOVERY_STATE_OBSERVATIONS.index("right_support")
+    indices = np.asarray(
+        [G1_RECOVERY_STATE_OBSERVATIONS.index(name) for name in G1_RECOVERY_STATE_FEATURES],
+        dtype=np.int64,
+    )
+    landing_rows = np.flatnonzero(
+        updated & (rows[:, impulse_index] > 0.0) & (rows[:, support_index] > 0.5)
+    )
+    if not len(landing_rows):
+        raise ValueError("development episode has no causal recovery-state window")
+    # The runtime latches landing.  Support may lift again during the next
+    # observations, so only the first row requires right support; subsequent
+    # rows must mirror the latched online policy exactly.
+    eligible = np.flatnonzero(
+        updated & (np.arange(len(rows), dtype=np.int64) >= int(landing_rows[0]))
+    )
+    unique = [rows[int(row_index)].copy() for row_index in eligible[:_WINDOW_FRAMES]]
+    if len(unique) != _WINDOW_FRAMES:
+        raise ValueError("development episode has an incomplete recovery-state window")
+    normalized = (np.asarray(unique) - np.asarray(observation_mean)) / np.asarray(observation_scale)
+    window = normalized[:, indices]
+    descriptor = np.concatenate((np.mean(window, axis=0), window[-1] - window[0]))
+    return tuple(map(float, descriptor))
+
+
+def _recovery_state_normalization(
+    episodes: tuple[GoalForgeEpisode, ...],
+) -> tuple[tuple[float, ...], tuple[float, ...]]:
+    rows = np.concatenate(
+        [
+            np.asarray(item.trajectory["recovery_state_observation"], dtype=np.float64)
+            for item in episodes
+        ],
+        axis=0,
+    )
+    if rows.ndim != 2 or rows.shape[1] != len(G1_RECOVERY_STATE_OBSERVATIONS):
+        raise ValueError("recorded recovery-state observations have an invalid shape")
+    if not np.all(np.isfinite(rows)):
+        raise ValueError("recorded recovery-state observations must be finite")
+    mean = np.mean(rows, axis=0)
+    scale = np.maximum(
+        np.std(rows, axis=0),
+        np.asarray(
+            (
+                0.50,
+                0.05,
+                0.10,
+                0.10,
+                0.10,
+                0.05,
+                0.05,
+                0.10,
+                0.10,
+                0.10,
+                0.03,
+                0.25,
+                0.25,
+                0.10,
+                0.10,
+                0.25,
+                0.10,
+                0.10,
+                0.10,
+                0.25,
+                0.25,
+                0.25,
+            ),
+            dtype=np.float64,
+        ),
+    )
+    return tuple(map(float, mean)), tuple(map(float, scale))
+
+
+def _recovery_state_route(episode: GoalForgeEpisode) -> int | None:
+    receipt = episode.recovery_receipt
+    if receipt is None or receipt.recovery_state_receipt is None:
+        return None
+    value = receipt.recovery_state_receipt["selected_primitive_index"]
+    return int(value) if value is not None else None
+
+
+def write_g1_recovery_state_report(
+    report: G1RecoveryStateTrainingReport,
+    *,
+    output_dir: Path,
+    source_checkout: Path,
+) -> tuple[Path, Path]:
+    root = output_dir.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if root == checkout or checkout in root.parents:
+        raise ValueError("recovery-state evidence must remain outside the checkout")
+    root.mkdir(parents=True, exist_ok=False)
+    artifact_path = root / "g1-recovery-state.json"
+    report_path = root / "g1-recovery-state-training.json"
+    _atomic_json(artifact_path, report.artifact.to_dict())
+    _atomic_json(report_path, report.to_dict())
+    return artifact_path, report_path
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    payload = json.dumps(value, sort_keys=True, indent=2, allow_nan=False) + "\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    temp_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+__all__ = [
+    "build_g1_recovery_state_cases",
+    "build_g1_recovery_state_validation_cases",
+    "G1RecoveryStatePrototypeResult",
+    "G1RecoveryStateSuiteSummary",
+    "G1RecoveryStateTrainer",
+    "G1RecoveryStateTrainingReport",
+    "write_g1_recovery_state_report",
+]

--- a/tests/simforge/test_g1_cerebellar_recovery.py
+++ b/tests/simforge/test_g1_cerebellar_recovery.py
@@ -185,6 +185,56 @@ def test_recovery_causally_smooths_only_upper_body_after_landing() -> None:
     assert receipt.peak_smoothing_residual_rms_rad > 0.0
 
 
+def test_recovery_adds_bounded_terminal_damping_after_settling() -> None:
+    controller = _controller(
+        G1CerebellarRecoveryConfig(
+            start_policy_frame=100,
+            blend_frames=100,
+            settling_start_policy_frame=200,
+            settling_blend_frames=100,
+            settling_standing_pose_blend=0.40,
+            settling_roll_posture_bias_rad=0.0,
+            terminal_damping_start_policy_frame=300,
+            terminal_damping_blend_frames=100,
+            terminal_kp_scale=0.90,
+            terminal_kd_scale=1.50,
+            terminal_damping_joint_group="legs",
+        )
+    )
+
+    effect = controller.adapt_target(
+        target=np.ones(29, dtype=np.float64),
+        policy_frame=350,
+        timestamp_sec=7.0,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+    )
+    receipt = controller.build_receipt(strict_replay=True)
+
+    assert effect.terminal_damping_fraction == pytest.approx(0.5)
+    assert effect.terminal_kp_scale == pytest.approx(0.95)
+    assert effect.terminal_kd_scale == pytest.approx(1.25)
+    assert effect.terminal_damping_joint_group == "legs"
+    assert receipt.terminal_damping_activation_policy_frame == 350
+    assert receipt.peak_terminal_damping_fraction == pytest.approx(0.5)
+
+
+def test_recovery_rejects_terminal_damping_that_overlaps_settling() -> None:
+    with pytest.raises(ValueError, match="cannot overlap"):
+        G1CerebellarRecoveryConfig(
+            start_policy_frame=100,
+            blend_frames=100,
+            settling_start_policy_frame=200,
+            settling_blend_frames=100,
+            settling_standing_pose_blend=0.40,
+            settling_roll_posture_bias_rad=0.0,
+            terminal_damping_start_policy_frame=299,
+            terminal_kp_scale=0.95,
+            terminal_kd_scale=1.20,
+        )
+
+
 def test_recovery_quality_detects_lower_wobble_and_preserved_goal() -> None:
     baseline_trace = _trajectory(wobble_scale=1.0)
     candidate_trace = _trajectory(wobble_scale=0.35)

--- a/tests/simforge/test_g1_contextual_recovery.py
+++ b/tests/simforge/test_g1_contextual_recovery.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from rosclaw.simforge.g1_cerebellar_recovery import (
+    G1CerebellarRecoveryConfig,
+    G1CerebellarRecoveryController,
+)
+from rosclaw.simforge.g1_contextual_recovery import (
+    G1_CONTEXTUAL_RECOVERY_FEATURES,
+    G1ContextualRecoveryArtifact,
+    G1ContextualRecoveryPolicy,
+    G1ContextualRecoveryPrimitive,
+    load_g1_contextual_recovery_artifact,
+)
+from rosclaw.simforge.g1_contextual_recovery_training import (
+    _bootstrap_lower_95,
+    _primitive_library,
+)
+from rosclaw.simforge.g1_muscle_memory import G1_MUSCLE_MEMORY_OBSERVATIONS
+
+_BODY_HASH = "sha256:" + "1" * 64
+_MOTION_HASH = "sha256:" + "2" * 64
+_REGIME_HASH = "sha256:" + "3" * 64
+_DATASET_HASH = "sha256:" + "4" * 64
+
+
+def _observation(**changes: float) -> dict[str, float]:
+    value = dict.fromkeys(G1_MUSCLE_MEMORY_OBSERVATIONS, 0.0)
+    value.update(changes)
+    return value
+
+
+def _configs() -> tuple[G1CerebellarRecoveryConfig, G1CerebellarRecoveryConfig]:
+    baseline = G1CerebellarRecoveryConfig(
+        start_policy_frame=300,
+        blend_frames=100,
+        standing_pose_blend=0.20,
+        roll_posture_bias_rad=0.0,
+        settling_start_policy_frame=400,
+        settling_blend_frames=100,
+        settling_standing_pose_blend=0.42,
+        settling_roll_posture_bias_rad=0.0,
+        settling_waist_pitch_bias_rad=0.11,
+        target_smoothing_alpha=0.54,
+        target_smoothing_start_policy_frame=300,
+    )
+    return baseline, G1CerebellarRecoveryConfig()
+
+
+def _controller_without_artifact(
+    config: G1CerebellarRecoveryConfig,
+) -> G1CerebellarRecoveryController:
+    return G1CerebellarRecoveryController(
+        body_hash=_BODY_HASH,
+        motion_hash=_MOTION_HASH,
+        regime_commitment=_REGIME_HASH,
+        regime_eligible=True,
+        regime_reasons=(),
+        standing_pose=np.zeros(29),
+        config=config,
+    )
+
+
+def _artifact() -> G1ContextualRecoveryArtifact:
+    baseline, fallback = _configs()
+    baseline_hash = _controller_without_artifact(baseline).config_hash
+    fallback_hash = _controller_without_artifact(fallback).config_hash
+    feature_count = len(G1_CONTEXTUAL_RECOVERY_FEATURES)
+    return G1ContextualRecoveryArtifact(
+        body_hash=_BODY_HASH,
+        motion_hash=_MOTION_HASH,
+        baseline_recovery_config_hash=baseline_hash,
+        fallback_recovery_config_hash=fallback_hash,
+        training_dataset_hash=_DATASET_HASH,
+        observation_mean=(0.0,) * len(G1_MUSCLE_MEMORY_OBSERVATIONS),
+        observation_scale=(1.0,) * len(G1_MUSCLE_MEMORY_OBSERVATIONS),
+        regime_feature_names=G1_CONTEXTUAL_RECOVERY_FEATURES,
+        regime_prototypes=(
+            (0.0,) * feature_count,
+            (0.5,) * feature_count,
+        ),
+        primitives=(
+            G1ContextualRecoveryPrimitive(
+                start_policy_frame=300,
+                blend_frames=100,
+                settling_start_policy_frame=400,
+                settling_blend_frames=80,
+                settling_standing_pose_blend=0.38,
+                settling_waist_pitch_bias_rad=0.08,
+                target_smoothing_alpha=0.56,
+            ),
+            G1ContextualRecoveryPrimitive(
+                start_policy_frame=300,
+                blend_frames=80,
+                settling_start_policy_frame=380,
+                settling_blend_frames=60,
+                settling_standing_pose_blend=0.42,
+                settling_waist_pitch_bias_rad=0.12,
+                target_smoothing_alpha=0.54,
+            ),
+        ),
+        maximum_regime_distance=0.30,
+        maximum_feature_z=8.0,
+        training_episode_count=12,
+        training_seed=20260802,
+    )
+
+
+def _controller(artifact: G1ContextualRecoveryArtifact) -> G1CerebellarRecoveryController:
+    baseline, fallback = _configs()
+    return G1CerebellarRecoveryController(
+        body_hash=_BODY_HASH,
+        motion_hash=_MOTION_HASH,
+        regime_commitment=_REGIME_HASH,
+        regime_eligible=True,
+        regime_reasons=(),
+        standing_pose=np.zeros(29),
+        config=baseline,
+        contextual_recovery_artifact=artifact,
+        fallback_config=fallback,
+    )
+
+
+def test_contextual_artifact_roundtrips_as_content_addressed_safe_json(tmp_path) -> None:
+    artifact = _artifact()
+    path = tmp_path / "contextual-recovery.json"
+    path.write_text(json.dumps(artifact.to_dict()), encoding="utf-8")
+
+    loaded = load_g1_contextual_recovery_artifact(path)
+
+    assert loaded == artifact
+    assert loaded.artifact_hash == artifact.artifact_hash
+    assert loaded.activation_ceiling == "SIM_ONLY"
+
+
+def test_contextual_artifact_rejects_non_object_primitive() -> None:
+    payload = _artifact().to_dict()
+    payload["primitives"][0] = "not-an-object"
+
+    with pytest.raises(ValueError, match="primitives must contain objects"):
+        G1ContextualRecoveryArtifact.from_dict(payload)
+
+
+def test_contextual_contract_rejects_schema_and_boolean_threshold_spoofing() -> None:
+    with pytest.raises(ValueError, match="unsupported contextual recovery primitive schema"):
+        replace(
+            _artifact().primitives[0],
+            schema_version="rosclaw.g1_goalforge.contextual_recovery_primitive.v999",
+        )
+    with pytest.raises(ValueError, match="thresholds must be finite numbers"):
+        replace(_artifact(), maximum_regime_distance=True)
+
+
+def test_contextual_policy_latches_nearest_prototype_once() -> None:
+    policy = G1ContextualRecoveryPolicy(_artifact())
+
+    first = policy.select(_observation())
+    second = policy.select(
+        _observation(
+            pelvis_velocity_x_m_s=0.5,
+            pelvis_velocity_y_m_s=0.5,
+            pelvis_velocity_z_m_s=0.5,
+            torso_pitch_rad=0.5,
+            torso_angular_velocity_y_rad_s=0.5,
+            left_ground_force_scale=0.5,
+            right_ground_force_scale=0.5,
+            contact_impulse_ns=0.5,
+        )
+    )
+
+    assert first.primitive_index == 0
+    assert second == first
+    assert policy.build_receipt().selection_count == 1
+
+
+def test_contextual_policy_routes_ood_state_to_retained_parent() -> None:
+    policy = G1ContextualRecoveryPolicy(_artifact())
+
+    selection = policy.select(_observation(torso_roll_rad=20.0))
+    receipt = policy.build_receipt()
+
+    assert selection.out_of_distribution
+    assert selection.primitive_index is None
+    assert receipt.fallback_count == 1
+    assert not receipt.hardware_command_sent
+
+
+@pytest.mark.parametrize(
+    "observation",
+    [
+        {},
+        _observation(torso_roll_rad=float("nan")),
+        _observation(torso_roll_rad=float("inf")),
+    ],
+)
+def test_contextual_policy_fails_closed_on_missing_or_nonfinite_observation(
+    observation: dict[str, float],
+) -> None:
+    policy = G1ContextualRecoveryPolicy(_artifact())
+
+    selection = policy.select(observation)
+    receipt = policy.build_receipt()
+
+    assert selection.primitive_index is None
+    assert selection.out_of_distribution
+    assert np.isfinite(selection.nearest_distance)
+    assert receipt.selection_count == 1
+    assert receipt.fallback_count == 1
+
+
+def test_controller_applies_selected_primitive_after_contact_and_landing() -> None:
+    artifact = _artifact()
+    controller = _controller(artifact)
+
+    effect = controller.adapt_target(
+        target=np.ones(29),
+        policy_frame=350,
+        timestamp_sec=7.0,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+        muscle_memory_observation=_observation(),
+    )
+    receipt = controller.build_receipt(strict_replay=True)
+
+    assert effect.active
+    assert effect.contextual_recovery_active
+    assert not effect.contextual_recovery_out_of_distribution
+    assert effect.contextual_recovery_primitive_index == 0
+    assert effect.blend_fraction == pytest.approx(0.5)
+    assert receipt.contextual_recovery_receipt is not None
+    assert receipt.contextual_recovery_receipt["selected_primitive_index"] == 0
+    assert receipt.contextual_recovery_receipt["activation_ceiling"] == "SIM_ONLY"
+
+
+def test_controller_waits_for_causal_recovery_frame_before_context_selection() -> None:
+    controller = _controller(_artifact())
+
+    before = controller.adapt_target(
+        target=np.ones(29),
+        policy_frame=250,
+        timestamp_sec=5.0,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+        muscle_memory_observation=_observation(),
+    )
+    before_receipt = controller.build_receipt(strict_replay=True)
+    after = controller.adapt_target(
+        target=np.ones(29),
+        policy_frame=350,
+        timestamp_sec=7.0,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+        muscle_memory_observation=_observation(),
+    )
+    after_receipt = controller.build_receipt(strict_replay=True)
+
+    assert not before.active
+    assert before.contextual_recovery_primitive_index is None
+    assert before_receipt.contextual_recovery_receipt is not None
+    assert before_receipt.contextual_recovery_receipt["selection_count"] == 0
+    assert after.contextual_recovery_primitive_index == 0
+    assert after_receipt.contextual_recovery_receipt is not None
+    assert after_receipt.contextual_recovery_receipt["selection_count"] == 1
+
+
+def test_controller_ood_fallback_is_bound_and_deterministic() -> None:
+    controller = _controller(_artifact())
+
+    first = controller.adapt_target(
+        target=np.ones(29),
+        policy_frame=520,
+        timestamp_sec=10.4,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+        muscle_memory_observation=_observation(torso_roll_rad=20.0),
+    )
+    second = controller.adapt_target(
+        target=np.ones(29),
+        policy_frame=521,
+        timestamp_sec=10.42,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+        muscle_memory_observation=_observation(),
+    )
+    receipt = controller.build_receipt(strict_replay=True)
+
+    assert first.contextual_recovery_out_of_distribution
+    assert second.contextual_recovery_out_of_distribution
+    assert first.contextual_recovery_primitive_index is None
+    assert second.contextual_recovery_primitive_index is None
+    assert receipt.contextual_recovery_receipt is not None
+    assert receipt.contextual_recovery_receipt["fallback_count"] == 1
+
+
+def test_contextual_artifact_compatibility_is_fail_closed() -> None:
+    baseline, fallback = _configs()
+    artifact = replace(
+        _artifact(),
+        fallback_recovery_config_hash="sha256:" + "f" * 64,
+    )
+
+    with pytest.raises(ValueError, match="fallback config hash mismatch"):
+        G1CerebellarRecoveryController(
+            body_hash=_BODY_HASH,
+            motion_hash=_MOTION_HASH,
+            regime_commitment=_REGIME_HASH,
+            regime_eligible=True,
+            regime_reasons=(),
+            standing_pose=np.zeros(29),
+            config=baseline,
+            contextual_recovery_artifact=artifact,
+            fallback_config=fallback,
+        )
+
+
+def test_contextual_training_library_and_bootstrap_are_bounded_and_deterministic() -> None:
+    library = _primitive_library()
+    first = _bootstrap_lower_95((0.02, 0.07, 0.08), seed=17)
+    second = _bootstrap_lower_95((0.02, 0.07, 0.08), seed=17)
+
+    assert len(library) == len({primitive.primitive_hash for primitive in library})
+    assert first == second
+    assert first > 0.0

--- a/tests/simforge/test_g1_muscle_memory.py
+++ b/tests/simforge/test_g1_muscle_memory.py
@@ -377,6 +377,66 @@ def test_cerebellar_controller_keeps_learned_policy_behind_contact_and_landing()
     assert receipt.muscle_memory_receipt["inference_count"] == 1
 
 
+def test_cerebellar_smoothing_does_not_integrate_learned_residual() -> None:
+    config = G1CerebellarRecoveryConfig(
+        start_policy_frame=0,
+        blend_frames=1,
+        standing_pose_blend=0.0,
+        roll_posture_bias_rad=0.0,
+        target_smoothing_alpha=0.50,
+        target_smoothing_start_policy_frame=0,
+    )
+    parent = G1CerebellarRecoveryController(
+        body_hash=_digest("1"),
+        motion_hash=_digest("2"),
+        regime_commitment=_digest("3"),
+        regime_eligible=True,
+        regime_reasons=(),
+        standing_pose=np.zeros(29),
+        config=config,
+    )
+    artifact = _artifact(parent_config_hash=parent.config_hash)
+    controller = G1CerebellarRecoveryController(
+        body_hash=_digest("1"),
+        motion_hash=_digest("2"),
+        regime_commitment=_digest("3"),
+        regime_eligible=True,
+        regime_reasons=(),
+        standing_pose=np.zeros(29),
+        config=config,
+        muscle_memory_artifact=artifact,
+    )
+    reference_policy = G1MuscleMemoryPolicy(artifact)
+    observation = _observation(
+        pelvis_velocity_x_m_s=-0.20,
+        contact_impulse_ns=3.0,
+    )
+
+    first = controller.adapt_target(
+        target=np.zeros(29),
+        policy_frame=1,
+        timestamp_sec=0.02,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+        muscle_memory_observation=observation,
+    )
+    expected_first = reference_policy.infer(observation)
+    second = controller.adapt_target(
+        target=np.zeros(29),
+        policy_frame=2,
+        timestamp_sec=0.04,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+        muscle_memory_observation=observation,
+    )
+    expected_second = reference_policy.infer(observation)
+
+    np.testing.assert_allclose(first.target, expected_first.residual)
+    np.testing.assert_allclose(second.target, expected_second.residual)
+
+
 def test_artifact_rejects_identity_and_shape_tampering() -> None:
     parent = _controller()
     artifact = _artifact(parent_config_hash=parent.config_hash)

--- a/tests/simforge/test_g1_muscle_memory_cli.py
+++ b/tests/simforge/test_g1_muscle_memory_cli.py
@@ -13,6 +13,11 @@ from rosclaw.simforge.g1_muscle_memory import (
     G1MuscleMemoryArtifact,
 )
 from rosclaw.simforge.g1_muscle_memory_cli import dispatch_muscle_memory_argv
+from rosclaw.simforge.g1_recovery_state_memory import (
+    G1_RECOVERY_STATE_FEATURES,
+    G1_RECOVERY_STATE_OBSERVATIONS,
+    G1RecoveryStateArtifact,
+)
 
 
 def _digest(character: str) -> str:
@@ -91,4 +96,53 @@ def test_contextual_inspect_summarizes_bounded_primitive_commitments(tmp_path, c
     assert payload["artifact_hash"] == artifact.artifact_hash
     assert payload["prototype_count"] == 1
     assert payload["primitive_hashes"] == [artifact.primitives[0].primitive_hash]
+    assert payload["activation_ceiling"] == "SIM_ONLY"
+
+
+def test_state_inspect_summarizes_temporal_evidence_commitments(tmp_path, capsys) -> None:
+    primitive = G1ContextualRecoveryPrimitive(
+        start_policy_frame=300,
+        blend_frames=100,
+        settling_start_policy_frame=400,
+        settling_blend_frames=100,
+        settling_standing_pose_blend=0.42,
+        settling_waist_pitch_bias_rad=0.11,
+        target_smoothing_alpha=0.54,
+    )
+    width = 2 * len(G1_RECOVERY_STATE_FEATURES)
+    artifact = G1RecoveryStateArtifact(
+        body_hash=_digest("1"),
+        motion_hash=_digest("2"),
+        baseline_recovery_config_hash=_digest("3"),
+        fallback_recovery_config_hash=_digest("4"),
+        training_dataset_hash=_digest("5"),
+        observation_mean=(0.0,) * len(G1_RECOVERY_STATE_OBSERVATIONS),
+        observation_scale=(1.0,) * len(G1_RECOVERY_STATE_OBSERVATIONS),
+        descriptor_feature_names=G1_RECOVERY_STATE_FEATURES,
+        descriptor_prototypes=((0.0,) * width, (0.1,) * width, (0.2,) * width),
+        prototype_primitive_indices=(0, 0, -1),
+        prototype_composite_advantages=(0.10, 0.08, -0.05),
+        prototype_component_minimums=(0.01, 0.02, -0.10),
+        primitives=(primitive,),
+        selection_window_frames=5,
+        neighbor_count=3,
+        maximum_neighbor_distance=0.25,
+        minimum_primitive_consensus=2.0 / 3.0,
+        minimum_advantage_lower_bound=0.02,
+        minimum_component_lower_bound=-0.02,
+        maximum_feature_z=8.0,
+        training_episode_count=24,
+        training_seed=17,
+    )
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps(artifact.to_dict()), encoding="utf-8")
+
+    result = dispatch_muscle_memory_argv(["goalforge", "muscle-memory", "state-inspect", str(path)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert payload["artifact_hash"] == artifact.artifact_hash
+    assert payload["selection_window_frames"] == 5
+    assert payload["positive_route_count"] == 2
+    assert payload["abstention_prototype_count"] == 1
     assert payload["activation_ceiling"] == "SIM_ONLY"

--- a/tests/simforge/test_g1_muscle_memory_cli.py
+++ b/tests/simforge/test_g1_muscle_memory_cli.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import json
 
+from rosclaw.simforge.g1_contextual_recovery import (
+    G1_CONTEXTUAL_RECOVERY_FEATURES,
+    G1ContextualRecoveryArtifact,
+    G1ContextualRecoveryPrimitive,
+)
 from rosclaw.simforge.g1_muscle_memory import (
     G1_MUSCLE_MEMORY_ACTIONS,
     G1_MUSCLE_MEMORY_OBSERVATIONS,
@@ -45,3 +50,45 @@ def test_inspect_validates_and_summarizes_safe_json(tmp_path, capsys) -> None:
     assert payload["activation_ceiling"] == "SIM_ONLY"
     assert payload["expert_regime_feature_names"] == []
     assert payload["expert_regime_prototype_count"] == 0
+
+
+def test_contextual_inspect_summarizes_bounded_primitive_commitments(tmp_path, capsys) -> None:
+    artifact = G1ContextualRecoveryArtifact(
+        body_hash=_digest("1"),
+        motion_hash=_digest("2"),
+        baseline_recovery_config_hash=_digest("3"),
+        fallback_recovery_config_hash=_digest("4"),
+        training_dataset_hash=_digest("5"),
+        observation_mean=(0.0,) * len(G1_MUSCLE_MEMORY_OBSERVATIONS),
+        observation_scale=(1.0,) * len(G1_MUSCLE_MEMORY_OBSERVATIONS),
+        regime_feature_names=G1_CONTEXTUAL_RECOVERY_FEATURES,
+        regime_prototypes=((0.0,) * len(G1_CONTEXTUAL_RECOVERY_FEATURES),),
+        primitives=(
+            G1ContextualRecoveryPrimitive(
+                start_policy_frame=300,
+                blend_frames=100,
+                settling_start_policy_frame=400,
+                settling_blend_frames=100,
+                settling_standing_pose_blend=0.42,
+                settling_waist_pitch_bias_rad=0.11,
+                target_smoothing_alpha=0.54,
+            ),
+        ),
+        maximum_regime_distance=0.25,
+        maximum_feature_z=8.0,
+        training_episode_count=20,
+        training_seed=7,
+    )
+    path = tmp_path / "contextual.json"
+    path.write_text(json.dumps(artifact.to_dict()), encoding="utf-8")
+
+    result = dispatch_muscle_memory_argv(
+        ["goalforge", "muscle-memory", "contextual-inspect", str(path)]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert payload["artifact_hash"] == artifact.artifact_hash
+    assert payload["prototype_count"] == 1
+    assert payload["primitive_hashes"] == [artifact.primitives[0].primitive_hash]
+    assert payload["activation_ceiling"] == "SIM_ONLY"

--- a/tests/simforge/test_g1_recovery_state_memory.py
+++ b/tests/simforge/test_g1_recovery_state_memory.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from rosclaw.simforge.g1_cerebellar_recovery import (
+    G1CerebellarRecoveryConfig,
+    G1CerebellarRecoveryController,
+)
+from rosclaw.simforge.g1_contextual_recovery import G1ContextualRecoveryPrimitive
+from rosclaw.simforge.g1_recovery_state_memory import (
+    G1_RECOVERY_STATE_FEATURES,
+    G1_RECOVERY_STATE_OBSERVATIONS,
+    G1RecoveryStateArtifact,
+    G1RecoveryStatePolicy,
+    load_g1_recovery_state_artifact,
+)
+
+_HASH = "sha256:" + "1" * 64
+_MOTION_HASH = "sha256:" + "2" * 64
+_REGIME_HASH = "sha256:" + "6" * 64
+
+
+def _primitive() -> G1ContextualRecoveryPrimitive:
+    return G1ContextualRecoveryPrimitive(
+        start_policy_frame=300,
+        blend_frames=80,
+        settling_start_policy_frame=380,
+        settling_blend_frames=60,
+        settling_standing_pose_blend=0.42,
+        settling_waist_pitch_bias_rad=0.10,
+        target_smoothing_alpha=0.54,
+    )
+
+
+def _artifact() -> G1RecoveryStateArtifact:
+    width = 2 * len(G1_RECOVERY_STATE_FEATURES)
+    return G1RecoveryStateArtifact(
+        body_hash=_HASH,
+        motion_hash=_MOTION_HASH,
+        baseline_recovery_config_hash="sha256:" + "3" * 64,
+        fallback_recovery_config_hash="sha256:" + "4" * 64,
+        training_dataset_hash="sha256:" + "5" * 64,
+        observation_mean=(0.0,) * len(G1_RECOVERY_STATE_OBSERVATIONS),
+        observation_scale=(1.0,) * len(G1_RECOVERY_STATE_OBSERVATIONS),
+        descriptor_feature_names=G1_RECOVERY_STATE_FEATURES,
+        descriptor_prototypes=(
+            (0.0,) * width,
+            (0.01,) * width,
+            (1.0,) * width,
+        ),
+        prototype_primitive_indices=(0, 0, -1),
+        prototype_composite_advantages=(0.12, 0.09, -0.20),
+        prototype_component_minimums=(0.02, 0.01, -0.50),
+        primitives=(_primitive(),),
+        selection_window_frames=5,
+        neighbor_count=2,
+        maximum_neighbor_distance=0.20,
+        minimum_primitive_consensus=1.0,
+        minimum_advantage_lower_bound=0.05,
+        minimum_component_lower_bound=-0.02,
+        maximum_feature_z=8.0,
+        training_episode_count=12,
+        training_seed=17,
+    )
+
+
+def _observation(value: float = 0.0) -> dict[str, float]:
+    return dict.fromkeys(G1_RECOVERY_STATE_OBSERVATIONS, value)
+
+
+def _controller() -> G1CerebellarRecoveryController:
+    baseline = G1CerebellarRecoveryConfig(
+        start_policy_frame=300,
+        blend_frames=100,
+        standing_pose_blend=0.20,
+        roll_posture_bias_rad=0.0,
+        settling_start_policy_frame=400,
+        settling_blend_frames=100,
+        settling_standing_pose_blend=0.42,
+        settling_roll_posture_bias_rad=0.0,
+        settling_waist_pitch_bias_rad=0.11,
+        target_smoothing_alpha=0.54,
+        target_smoothing_start_policy_frame=300,
+    )
+    fallback = G1CerebellarRecoveryConfig()
+    common = {
+        "body_hash": _HASH,
+        "motion_hash": _MOTION_HASH,
+        "regime_commitment": _REGIME_HASH,
+        "regime_eligible": True,
+        "regime_reasons": (),
+        "standing_pose": np.zeros(29),
+    }
+    baseline_hash = G1CerebellarRecoveryController(config=baseline, **common).config_hash
+    fallback_hash = G1CerebellarRecoveryController(config=fallback, **common).config_hash
+    artifact = replace(
+        _artifact(),
+        baseline_recovery_config_hash=baseline_hash,
+        fallback_recovery_config_hash=fallback_hash,
+    )
+    return G1CerebellarRecoveryController(
+        config=baseline,
+        fallback_config=fallback,
+        recovery_state_artifact=artifact,
+        **common,
+    )
+
+
+def test_recovery_state_policy_waits_for_window_then_routes_conservative_neighbor() -> None:
+    policy = G1RecoveryStatePolicy(_artifact())
+
+    pending = [policy.select(_observation()) for _ in range(4)]
+    selected = policy.select(_observation())
+    replay = policy.select(_observation(7.0))
+    receipt = policy.build_receipt()
+
+    assert all(not item.ready for item in pending)
+    assert selected.ready and not selected.out_of_distribution
+    assert selected.primitive_index == 0
+    assert selected.neighbor_count == 2
+    assert selected.primitive_consensus == 1.0
+    assert selected.advantage_lower_bound == pytest.approx(0.09)
+    assert replay == selected
+    assert receipt.pending_count == 4
+    assert receipt.selection_count == 1
+    assert receipt.fallback_count == 0
+    assert receipt.descriptor_hash is not None
+
+
+def test_recovery_state_policy_treats_negative_neighbors_as_abstention_evidence() -> None:
+    artifact = replace(
+        _artifact(),
+        prototype_primitive_indices=(-1, -1, 0),
+        prototype_composite_advantages=(-0.10, -0.05, 0.20),
+        prototype_component_minimums=(-0.20, -0.10, 0.10),
+    )
+    policy = G1RecoveryStatePolicy(artifact)
+
+    selections = [policy.select(_observation()) for _ in range(5)]
+    receipt = policy.build_receipt()
+
+    assert selections[-1].ready
+    assert selections[-1].out_of_distribution
+    assert selections[-1].primitive_index is None
+    assert selections[-1].fallback_reason == "nearest_exemplar_abstains"
+    assert receipt.fallback_count == 1
+
+
+def test_recovery_state_policy_fails_closed_on_nonfinite_observation() -> None:
+    policy = G1RecoveryStatePolicy(_artifact())
+    observation = _observation()
+    observation["pelvis_velocity_x_m_s"] = np.nan
+
+    selection = policy.select(observation)
+
+    assert selection.ready and selection.out_of_distribution
+    assert selection.fallback_reason == "nonfinite_observation"
+
+
+def test_recovery_state_policy_fails_closed_on_non_numeric_observation() -> None:
+    policy = G1RecoveryStatePolicy(_artifact())
+    observation = _observation()
+    observation["pelvis_velocity_x_m_s"] = "not-a-number"  # type: ignore[assignment]
+
+    selection = policy.select(observation)
+
+    assert selection.ready and selection.out_of_distribution
+    assert selection.fallback_reason == "invalid_observation"
+
+
+def test_recovery_state_artifact_roundtrips_as_content_addressed_json(tmp_path) -> None:
+    artifact = _artifact()
+    path = tmp_path / "recovery-state.json"
+    path.write_text(json.dumps(artifact.to_dict()), encoding="utf-8")
+
+    loaded = load_g1_recovery_state_artifact(path)
+
+    assert loaded == artifact
+    assert loaded.artifact_hash == artifact.artifact_hash
+
+
+def test_recovery_state_artifact_rejects_invalid_routes_and_hardware_ceiling() -> None:
+    with pytest.raises(ValueError, match="route"):
+        replace(_artifact(), prototype_primitive_indices=(2, 0, -1))
+    with pytest.raises(ValueError, match="SIM_ONLY"):
+        replace(_artifact(), activation_ceiling="REAL")
+
+
+def test_controller_collects_temporal_state_before_latching_primitive() -> None:
+    controller = _controller()
+
+    effects = [
+        controller.adapt_target(
+            target=np.ones(29),
+            policy_frame=300 + frame,
+            timestamp_sec=6.0 + frame * 0.02,
+            ball_contact_detected=True,
+            left_support=True,
+            right_support=True,
+            muscle_memory_observation=_observation(),
+        )
+        for frame in range(5)
+    ]
+    receipt = controller.build_receipt(strict_replay=True)
+
+    assert all(effect.recovery_state_pending for effect in effects[:4])
+    assert not effects[-1].recovery_state_pending
+    assert effects[-1].recovery_state_active
+    assert effects[-1].recovery_state_primitive_index == 0
+    assert receipt.recovery_state_receipt is not None
+    assert receipt.recovery_state_receipt["pending_count"] == 4
+    assert receipt.recovery_state_receipt["selection_count"] == 1
+    assert receipt.recovery_state_receipt["activation_ceiling"] == "SIM_ONLY"
+
+
+def test_controller_can_select_before_motion_gate_without_early_actuation() -> None:
+    controller = _controller()
+
+    effects = [
+        controller.adapt_target(
+            target=np.ones(29),
+            policy_frame=250 + frame,
+            timestamp_sec=5.0 + frame * 0.02,
+            ball_contact_detected=True,
+            left_support=True,
+            right_support=True,
+            muscle_memory_observation=_observation(),
+        )
+        for frame in range(5)
+    ]
+    after_gate = controller.adapt_target(
+        target=np.ones(29),
+        policy_frame=350,
+        timestamp_sec=7.0,
+        ball_contact_detected=True,
+        left_support=True,
+        right_support=True,
+        muscle_memory_observation=_observation(),
+    )
+
+    assert all(not effect.active for effect in effects)
+    assert effects[-1].recovery_state_primitive_index == 0
+    assert not effects[-1].recovery_state_active
+    assert after_gate.active
+    assert after_gate.recovery_state_primitive_index == 0
+
+
+def test_controller_temporal_state_failure_latches_retained_parent() -> None:
+    controller = _controller()
+    fallback_effects = []
+    for frame in range(5):
+        observation = _observation()
+        if frame == 0:
+            observation["pelvis_velocity_x_m_s"] = float("nan")
+        fallback_effects.append(
+            controller.adapt_target(
+                target=np.ones(29),
+                policy_frame=520 + frame,
+                timestamp_sec=10.4 + frame * 0.02,
+                ball_contact_detected=True,
+                left_support=True,
+                right_support=True,
+                muscle_memory_observation=observation,
+            )
+        )
+    receipt = controller.build_receipt(strict_replay=True)
+
+    assert all(effect.recovery_state_out_of_distribution for effect in fallback_effects)
+    assert all(effect.recovery_state_primitive_index is None for effect in fallback_effects)
+    assert receipt.recovery_state_receipt is not None
+    assert receipt.recovery_state_receipt["fallback_reason"] == "nonfinite_observation"
+    assert receipt.recovery_state_receipt["fallback_count"] == 1


### PR DESCRIPTION
## Summary

- add content-addressed, SIM-only contextual and short-horizon recovery-state memory for G1 post-kick control
- bind learned routing into the cerebellar controller and MuJoCo backend with contact/landing gates, Body/motion/config hashes, explicit negative examples, exact fallback, and auditable receipts
- add terminal leg damping after unloading and upright settling, plus the existing 49.83-second multi-challenge DEVELOPMENT video
- expand recovery state from instantaneous proprioception to a five-frame body-and-ball mean/trend descriptor
- add `state-train` and `state-inspect`, dense restitution curriculum, sealed local-physics validation, and private retention tests
- preserve every failed candidate as `REJECTED / NOT PROMOTED`; the retained controller remains authoritative

Stacked on #132 (`agent/g1-muscle-memory`).

## Why

The earlier contextual memory produced material DEVELOPMENT gains but did not generalize beyond its prototypes. This follow-up tests whether a short body-state history can provide stable local reuse while retaining fail-closed behavior. Six evidence generations exposed and fixed two train/deploy timing mismatches, then showed that body-only similarity omitted ball dynamics. The final v6 adds ball-relative motion and converts prior validation failures into signed curriculum examples.

The result is useful infrastructure and a working stability-plasticity loop, but not a promoted learned policy: sealed v6 validation still proves that discrete open-loop recovery primitives are too sensitive to contact dynamics. The next model must predict action-conditioned futures and uncertainty instead of relying on state proximity alone.

## Existing contextual and damping evidence

- contextual DEVELOPMENT: backward reversal 28.56% reduction, tail wobble 20.22% reduction, leg jerk 6.46% reduction, composite 20.81%, bootstrap lower 5.81%
- terminal-damping exact ablation: 5/5 passed, backward reversal 5.82% reduction, tail joint jerk 21.05% reduction
- sealed contextual VALIDATION: 0/3 learned routes; private retention 3/3 exact fallback; candidate rejected
- multi-challenge video: 49.83 seconds, H.264, 1280x720, 30 fps, 1495 frames, with explicit rejection labels

## Recovery-state v6 evidence

DEVELOPMENT (27 cases):

- 27/27 passed and strictly replayed
- 6 learned routes, 21 exact parent fallbacks
- backward reversal 28.97% reduction
- tail wobble 25.18% reduction
- leg jerk 6.58% reduction
- composite 22.98%, worst case 4.41%, bootstrap 95% lower bound 7.36%

Sealed local-physics VALIDATION (8 unseen restitution interpolation cases):

- 6/8 parent-valid, 2 learned routes, 6 fallbacks, 8/8 strict replay
- only 6/8 passed
- routed mean tail wobble regressed 5911.76%, leg jerk regressed 100.56%, composite regressed 2363.17%
- bootstrap lower bound -2952.55%
- final decision: **REJECTED / NOT PROMOTED**

Private HOLDOUT:

- 3/3 parent-valid
- 3/3 strict, byte-exact parent fallback

After rejection, the neighborhood gate was hardened from one-of-two to two-of-two positive evidence. A safety replay changed both unsafe routes to fallback and produced 8/8 exact parent replays. This is safety evidence only, not a performance qualification.

## Safety boundary

- `SIM_ONLY` activation ceiling and CPU MuJoCo physics authority
- no ROS/DDS, robot transport, torque, raw motor, lease, permit, or hardware authorization output
- exactly one learned recovery mode may be bound at a time
- missing, malformed, non-numeric, non-finite, incompatible, feature-envelope, distance, negative-neighbor, consensus, advantage, or component failures route to the retained parent
- pre-action observation cannot actuate early; target adaptation retains the primitive's causal start frame
- rejected artifacts cannot replace the retained controller

## Validation

- Ruff over all `src` and `tests`: passed
- CI mypy gate: 203 source files passed
- changed recovery/backend source files under mypy: passed
- focused recovery/controller/GoalForge tests: 53 passed, 2 deselected
- full pytest with explicit isolated LeRobot runtime: 5416 passed, 59 skipped, 27 deselected, 26 warnings in 1043.67 seconds
- v6: 312 training-side, 32 validation, and 12 holdout CPU MuJoCo rollouts
- staged secret-pattern scan: clean

## Follow-up

Replace nearest-primitive routing with an action-conditioned recurrent critic that predicts future backstep, wobble, jerk, safety, goal preservation, and epistemic uncertainty for the retained parent and every bounded primitive. Allow action only when its conservative component-wise lower bounds dominate the parent, then use bounded closed-loop target residuals rather than a purely open-loop switch. Each generation must use a fresh sealed suite.
