### PR TITLE
simplify MCP operator confirmation

### DIFF
--- a/docs/ROSCLAWD.md
+++ b/docs/ROSCLAWD.md
@@ -107,6 +107,13 @@ sudo -u rosclaw-hw rosclaw daemon arm \
   --reason "operator preflight and controller deadman verified" --json
 ```
 
+For MCP clients that support form elicitation, accepting the exact REAL action
+also performs this arm step just in time when the current daemon generation is
+still `DISARMED`. The accepted form, action-intent hash, arm event, and
+single-use Permit remain separately audited, but the operator does not need to
+run a second CLI command or handle a `permit_id`. Declining the form or changing
+the action intent never arms the daemon.
+
 Arming is not a Permit and does not bypass per-action authorization. Disarm,
 Session loss, Action Lease expiry, Adapter generation change, and daemon close
 all request a coordinated safety stop. A controller-side deadman and physical

--- a/src/rosclaw/mcp/adapters/runtime_client.py
+++ b/src/rosclaw/mcp/adapters/runtime_client.py
@@ -712,7 +712,9 @@ class RuntimeClient:
                 "A trusted operator principal is required for REAL confirmation.",
             )
         reason = str(confirmation.get("reason") or "Accepted through MCP elicitation")
+        armed_by_confirmation = False
         try:
+            runtime_status = await asyncio.to_thread(self._daemon_client.get_runtime_status)
             await asyncio.to_thread(
                 self._daemon_client.create_session,
                 session_id=action.session_id,
@@ -722,6 +724,12 @@ class RuntimeClient:
                 capability_scope=[action.capability_id],
                 ttl_ms=60_000,
             )
+            if str(runtime_status.get("supervision_state")) != "ARMED":
+                await asyncio.to_thread(
+                    self._daemon_client.arm_runtime,
+                    f"Operator confirmed exact REAL action {action.action_id} through MCP elicitation",
+                )
+                armed_by_confirmation = True
             issued = await asyncio.to_thread(
                 self._daemon_client.issue_execution_permit,
                 action,
@@ -744,9 +752,17 @@ class RuntimeClient:
                     action.action_id,
                     timeout_sec=wait_timeout_sec,
                 )
-        except MCPError:
-            raise
         except Exception as exc:  # noqa: BLE001
+            if armed_by_confirmation:
+                try:
+                    await asyncio.to_thread(
+                        self._daemon_client.disarm_runtime,
+                        f"Automatic rollback after confirmed action {action.action_id} failed",
+                    )
+                except Exception as rollback_exc:  # noqa: BLE001
+                    self._raise_daemon_error("confirm_operator_action_rollback", rollback_exc)
+            if isinstance(exc, MCPError):
+                raise
             self._raise_daemon_error("confirm_operator_action", exc)
         return {
             **self._action_result_metadata(result, "REAL"),
@@ -754,6 +770,8 @@ class RuntimeClient:
                 "schema_version": "rosclaw.operator_confirmation_result.v1",
                 "accepted": True,
                 "action_intent_hash": expected_hash,
+                "supervision_armed": armed_by_confirmation,
+                "separate_arm_required": False,
                 "permit_injected": True,
                 "permit_exposed": False,
             },
@@ -817,8 +835,7 @@ class RuntimeClient:
         action_kwargs: dict[str, Any] = {
             "actor_id": os.environ.get("ROSCLAW_AGENT_ACTOR", "rosclaw-mcp"),
             "agent_framework": os.environ.get("ROSCLAW_AGENT_CLIENT", "mcp"),
-            "session_id": session_id
-            or os.environ.get("ROSCLAW_AGENT_SESSION", default_session_id),
+            "session_id": session_id or os.environ.get("ROSCLAW_AGENT_SESSION", default_session_id),
             "body_id": body_id or self.robot_id,
             "body_snapshot_hash": body_snapshot_hash,
             "capability_id": capability_id,

--- a/tests/mcp/adapters/test_daemon_boundary.py
+++ b/tests/mcp/adapters/test_daemon_boundary.py
@@ -17,6 +17,10 @@ class _FakeDaemonClient:
         self.actions: list[ActionEnvelope] = []
         self.stop_requests: list[tuple[str, str]] = []
         self.sessions: list[dict[str, Any]] = []
+        self.supervision_state = "DISARMED"
+        self.arm_reasons: list[str] = []
+        self.disarm_reasons: list[str] = []
+        self.permit_error: Exception | None = None
 
     def get_runtime_status(self) -> dict[str, Any]:
         return {
@@ -24,7 +28,18 @@ class _FakeDaemonClient:
             "daemon_pid": 4242,
             "southbound_owner": "rosclawd",
             "hardware_actions_executed": 0,
+            "supervision_state": self.supervision_state,
         }
+
+    def arm_runtime(self, reason: str) -> dict[str, Any]:
+        self.arm_reasons.append(reason)
+        self.supervision_state = "ARMED"
+        return {"supervision_state": self.supervision_state, "reason": reason}
+
+    def disarm_runtime(self, reason: str) -> dict[str, Any]:
+        self.disarm_reasons.append(reason)
+        self.supervision_state = "DISARMED"
+        return {"supervision_state": self.supervision_state, "reason": reason}
 
     def request_action(self, action: ActionEnvelope) -> dict[str, Any]:
         if isinstance(action, dict):
@@ -41,6 +56,8 @@ class _FakeDaemonClient:
         expires_in_sec: float,
         reason: str,
     ) -> dict[str, Any]:
+        if self.permit_error is not None:
+            raise self.permit_error
         payload = action.to_dict()
         payload["authorization"] = {
             "principal_id": principal_id,
@@ -204,10 +221,75 @@ async def test_interactive_confirmation_injects_permit_without_exposing_it(
 
     assert result["operator_confirmation"]["permit_injected"] is True
     assert result["operator_confirmation"]["permit_exposed"] is False
+    assert result["operator_confirmation"]["supervision_armed"] is True
+    assert result["operator_confirmation"]["separate_arm_required"] is False
     assert "permit" not in result
     assert "permit-secret" not in str(result)
     assert daemon.actions[-1].authorization.approved is True
     assert daemon.sessions[-1]["session_id"] == "action-interactive"
+    assert daemon.arm_reasons == [
+        "Operator confirmed exact REAL action action-interactive through MCP elicitation"
+    ]
+
+
+async def test_interactive_confirmation_does_not_rearm_armed_generation(
+    client: tuple[RuntimeClient, _FakeDaemonClient],
+) -> None:
+    runtime_client, daemon = client
+    daemon.supervision_state = "ARMED"
+    prepared = runtime_client.prepare_operator_action(
+        capability_id="limo.play_tone",
+        arguments={"frequency_hz": 660, "duration_sec": 0.6},
+        body_snapshot_hash="sha256:body",
+        action_id="action-already-armed",
+        deadline_at="2030-01-02T03:04:05Z",
+    )
+
+    result = await runtime_client.confirm_operator_action(
+        prepared,
+        principal_id="operator-1",
+        confirmation={
+            "accepted": True,
+            "action_intent_hash": prepared.approval_request["action_intent_hash"],
+        },
+        wait_timeout_sec=0.0,
+    )
+
+    assert result["operator_confirmation"]["supervision_armed"] is False
+    assert result["operator_confirmation"]["separate_arm_required"] is False
+    assert daemon.arm_reasons == []
+
+
+async def test_interactive_confirmation_rolls_back_just_in_time_arm_on_failure(
+    client: tuple[RuntimeClient, _FakeDaemonClient],
+) -> None:
+    runtime_client, daemon = client
+    daemon.permit_error = RuntimeError("permit broker unavailable")
+    prepared = runtime_client.prepare_operator_action(
+        capability_id="limo.play_tone",
+        arguments={"frequency_hz": 660, "duration_sec": 0.6},
+        body_snapshot_hash="sha256:body",
+        action_id="action-arm-rollback",
+        deadline_at="2030-01-02T03:04:05Z",
+    )
+
+    with pytest.raises(MCPError, match="permit broker unavailable"):
+        await runtime_client.confirm_operator_action(
+            prepared,
+            principal_id="operator-1",
+            confirmation={
+                "accepted": True,
+                "action_intent_hash": prepared.approval_request["action_intent_hash"],
+            },
+            wait_timeout_sec=0.0,
+        )
+
+    assert daemon.supervision_state == "DISARMED"
+    assert len(daemon.arm_reasons) == 1
+    assert daemon.disarm_reasons == [
+        "Automatic rollback after confirmed action action-arm-rollback failed"
+    ]
+    assert daemon.actions == []
 
 
 async def test_interactive_confirmation_rejects_mismatched_intent(
@@ -230,6 +312,7 @@ async def test_interactive_confirmation_rejects_mismatched_intent(
         )
 
     assert daemon.actions == []
+    assert daemon.arm_reasons == []
 
 
 async def test_runtime_status_and_cancel_are_daemon_calls(


### PR DESCRIPTION
## What changed

- let an accepted exact-action MCP form confirmation arm a disarmed daemon generation just in time
- keep the single-use permit opaque and automatically injected
- avoid re-arming an already armed generation
- roll back to `DISARMED` when authorization or dispatch setup fails after just-in-time arming
- document that operators no longer need a separate `daemon arm` command for this path

## Why

LIMO lab users were forced through both an in-context action confirmation and a separate CLI arm command after every daemon restart. The second step was redundant once the MCP host had already captured an exact action-intent-bound operator confirmation.

The daemon permit, ledger, session, intent hash, executor, E-stop, and receipt boundaries remain intact. No `permit_id` is exposed to the agent or operator.

## Validation

- `pytest tests/mcp/adapters -q` — 30 passed
- `pytest tests/daemon/test_server.py tests/daemon/test_process_boundary.py -q` — 40 passed
- targeted confirmation tests — 9 passed
- ruff check and format check passed
- mypy passed for `runtime_client.py`
- compileall passed for the modified runtime and tests
