### PR TITLE
feat(simforge): add continual neural torque and MotionDecode loop

### DIFF
--- a/docs/validation/ROSCLAW_PHASE8_MOTIONDECODE_CONTINUAL_RECOVERY.md
+++ b/docs/validation/ROSCLAW_PHASE8_MOTIONDECODE_CONTINUAL_RECOVERY.md
@@ -1,0 +1,212 @@
+# ROSClaw Phase 8：MotionDecode 小脑先验与恢复在线学习闭环
+
+## 结论先行
+
+本轮不是只把 MotionDecode “接进来”，而是完成了一个可审计、可拒绝、可回滚的闭环：
+
+```text
+外部动作数据
+  → 来源/许可/语义审计
+  → G1 运动学清洗与 Body 绑定
+  → 4×A6000 自监督本体先验
+  → 恢复段行为克隆
+  → MuJoCo 密集恢复 replay
+  → 受约束在线 actor-critic
+  → 物理信赖域搜索
+  → 独立 Validation 门
+  → REJECTED（不晋升）
+```
+
+确实训练出了模型，也确实更新了直接输出 29 维关节力矩的 actor。MotionDecode 稳定性先验在 source-episode-disjoint 留出集上将 next-proprioception Smooth-L1 从 `0.01797995` 降到 `0.01666687`，改善 `7.30298%`；4 张 A6000 的独立 seed 全部超过 `2%` 表征门。恢复段行为克隆的验证损失进一步降到 `0.00326415`。
+
+但是，最终在线候选在 4 个独立 Validation 场景中与父策略的成功率、临界失败率、恢复分和支撑脚滑移完全相同，没有形成可测的物理可塑性。因此最终决定是 `REJECTED`，没有晋升、没有硬件授权，也没有把“loss 下降”包装成“G1 已经更稳”。
+
+这次突破主要在 ROSClaw 的自进化基础设施：系统已经会摄取外部经验、训练表征、迁移到小脑、在线更新、验证并在收益不足时自我否决。尚未突破的是“数据表征收益稳定转化为可见踢后恢复收益”。
+
+## 1. 下载数据的真实状态
+
+本地 MotionDecode 快照包含：
+
+| 项目 | 本地事实 |
+|---|---:|
+| CSV | 30,387 个 |
+| CSV 字节数 | 76,903,739,232 |
+| 本地主类 | 6 个（`1.1`、`1.10`、`1.11`、`1.12`、`1.13`、`1.14`） |
+| 元数据声明主类 | 23 个 |
+| 本地足球/球类 CSV | 0 |
+| 同步球体位姿 | 0 |
+| 视频/逐 episode 语义标签 | 0 |
+
+本地内容量很大，但不是上游元数据声明的完整 23 类镜像。尤其缺少 `3.3 Ball_Game_Interaction`，所以它不能被称为“足球数据集”。本轮只把它用作人体/G1 运动学先验，不用它学习踢球接触、奖励或力矩。
+
+每个 CSV 的 36 列是根位置 3、根四元数 4 和 G1 关节角 29；时间仅由 `120 Hz` 隐含。没有关节力矩、控制 action、接触、球位姿或 reward。代码把这些缺失语义写入 `ExperienceCapsule`，并将能力上限硬限制为 `MOTION_PRIOR_ONLY`。
+
+许可检查采用非空的 `LICENSE.md`，而不是空的 `LICENSE`。当前用途允许研究/个人学习/非商业原型，但商业使用需要书面许可，且不允许再分发原始数据。本 PR 不提交原始 CSV、训练 pack 或派生权重。
+
+## 2. 数据质量闭环
+
+### 2.1 来源与版本
+
+`rosclaw collective source inspect` 会生成：
+
+- 上游项目、40 位 revision、许可哈希和本地 inventory 哈希；
+- 本地/索引分类差异；
+- 足球、对象位姿、视频和语义标签是否存在；
+- `VERIFIED` 或 `UNVERIFIED_LOCAL_SNAPSHOT` revision binding；
+- 不可用于晋升证据、不可授权硬件的 Experience Capsule。
+
+本地快照没有能把每个 payload 密码学绑定到上游 revision 的元数据，所以状态保持为 `UNVERIFIED_LOCAL_SNAPSHOT`。代码不会仅因为调用者传入一个 commit 字符串就声称已经验证。
+
+### 2.2 400 条确定性 pilot
+
+pilot 原计划在足球、平衡、步态、过渡/恢复四个 strata 各抽 100 条。因为本地足球为 0，系统显式记录 `football_shortage=100`，再加入 100 条 coordination supplement；替代数据仍标作 supplement，不冒充足球。
+
+首轮整段严格审计发现少量根瞬移和速度尖峰。第二轮引入连续 clean-span 提取：根瞬移、非有限值、关节限位、异常关节速度附近被切断，只从连续合格区间产生训练窗口。最终 pilot：
+
+- 400/400 条达到 `Q1_KINEMATIC_ONLY`；
+- 2,086,231 帧，17,381.925 秒（约 4.83 小时）；
+- 加权 clean-frame 比例 `99.6577%`；
+- 128,911 个可训练连续窗口；
+- 0 条达到 Q2 或更高，因为数据没有 action/contact/reward 语义。
+
+每条 episode 保存内容哈希、有限性、四元数误差、关节边界、速度/加速度、重复帧、clean spans 和抽样 MuJoCo 几何检查；证据目录不复制原始 CSV。
+
+## 3. 训练出的“小脑先验”是什么
+
+### 3.1 输入与目标
+
+稳定性 prior 使用 61 维本体特征：
+
+```text
+29 关节角 + 29 关节速度 + 3 维躯干投影重力
+```
+
+模型是 96 隐状态的 GRU residual predictor。它查看连续 32 帧，预测下一帧本体状态相对“保持上一帧”的残差。目标不是动作或力矩，而是学习人体/G1 姿态变化、协调和恢复的时序表征。
+
+数据按 source episode 做 80/20 分割，杜绝同一条动作的相邻窗口同时进入训练和验证。最终稳定性 pack 只使用 `balance_proxy` 与 `transition_recovery`：200 个源 episode、6,400 个训练窗口、1,600 个验证窗口。
+
+### 3.2 四卡结果
+
+4 张物理 A6000 分别运行 seed `8600..8603`。四个 worker 的验证改善为 `7.1875%`、`7.3030%`、`7.2909%`、`7.2504%`，均通过至少 `2%` 的表征门。选中的 GPU 1 artifact 哈希为：
+
+```text
+sha256:9037a55a2d519c90e1623a1f4a3a147d6055599b59fc633964af09cf4a401abb
+```
+
+MotionDecode prediction head 永远不能变成 torque head。迁移时只初始化 direct-torque actor 中语义对应的 GRU 输入列，并把源/目标 normalization 做代数变换；artifact 必须匹配完整 GoalForge G1 Body 哈希。之后仍必须经过教师 BC 和独立物理验证。
+
+## 4. Stability–Plasticity 的工程实现
+
+本轮增加了稳定 actor 与可塑 actor 的上下文组合：
+
+- stable actor 保留已验证父能力；
+- plastic actor 接受 MotionDecode prior、恢复段 BC 和在线 actor-critic 更新；
+- 只有进入踢后恢复相位、骨盆高度合格、躯干接近直立、至少一脚接触且连续满足 warmup 时，plastic actor 才能接管；
+- 任一条件失效立即回退 stable actor；
+- 两个 actor 都经过同一独立力矩安全投影器；
+- receipt 记录 plastic 激活比例、相位/姿态/接触拒绝和全部 fallback 原因。
+
+这不是在动作脚本上再叠一个参数补丁。最终控制路径仍是 102 维 observation 经 GRU 输出 29 维关节力矩，并在 500 Hz MuJoCo 物理子步中生效；上下文门只决定此刻使用稳定神经 actor 还是在线可塑神经 actor。
+
+## 5. 密集在线恢复学习
+
+在线 replay 与 MuJoCo trace 做精确时间对齐：500 Hz 策略记录与 50 Hz trace 是严格 `10:1`，只截取踢球后的恢复段。每个 transition 计算：
+
+- 躯干 roll/pitch、角速度和骨盆线速度惩罚；
+- 支撑脚滑移、COM 支撑裕量、单/双脚接触奖励；
+- 是否摔倒、关节/力矩约束与投影 fallback cost；
+- 相对父动作的 imitation/anchor 项；
+- episode 级恢复分。
+
+持续 learner 包含 twin reward critics、twin fall critics、twin constraint critics、target networks、熵温度、拉格朗日乘子、RECENT/ANCHOR/BOUNDARY replay、parent churn、历史 anchor 和 EWC。失败/临界轨迹可以训练 critic，但不能让 actor 模仿危险动作。
+
+最终 generation 的 replay 有 3,820 条 critic transitions、612 条新鲜 actor transitions、2,596 条 anchors；actor 和三组 critics 都发生了有限更新。随后沿父权重到 proposal 的线段做 MuJoCo 信赖域搜索，Development 选择了 `1%` 更新幅度。
+
+## 6. 为什么最终仍被拒绝
+
+独立 Validation 有 4 个从未参与在线更新和步长选择的场景：
+
+| 指标 | 父策略 | 在线候选 |
+|---|---:|---:|
+| 成功率 | 25% | 25% |
+| 临界失败率 | 75% | 75% |
+| 平均恢复分 | -11.7240 | -11.7240 |
+| 支撑脚滑移 | 0.04905 m | 0.04905 m |
+| 躯干 roll 峰值 | 2.41809 rad | 2.41809 rad |
+
+虽然候选 tensor 与父策略不同、在线 actor 确实更新、Development 信赖域也找到安全步长，但独立物理指标没有任何可测提升。候选因此同时未通过：
+
+```text
+validation_gate_passed = false
+validation_plasticity_measurable = false
+decision = REJECTED
+```
+
+这暴露出目前最关键的断点：prior 学会了“身体下一步通常怎么动”，BC 学会了“模仿父控制器后半段”，critic 也收到密集恢复信号，但 1% 的安全更新被父策略回退和投影壳大量吸收；更大的更新又容易导致混合动力学分支改变。现有 4 条在线轨迹也不足以估计高难度恢复的价值面。
+
+## 7. 新增的 ROSClaw 产品能力
+
+### 7.1 Collective Experience Plane
+
+新增 `rosclaw.collective`：
+
+- 外部数据 source descriptor、license result 和 Experience Capsule；
+- MotionDecode 精确 36 列 parser 与 120 Hz 导数；
+- 确定性分层 pilot、短缺/替代显式化；
+- G1 Body/关节顺序绑定；
+- clean-span 数据质量审计；
+- 无 pickle 的有界 `.npz` pack/artifact；
+- source-episode-disjoint split；
+- 4 个独立物理 GPU worker 和至少 2% 的留出门。
+
+用户接口：
+
+```bash
+rosclaw collective source inspect motiondecode ...
+rosclaw collective ingest motiondecode ...
+rosclaw collective prior build ...
+rosclaw collective prior train ...
+```
+
+### 7.2 持续恢复控制面
+
+- MotionDecode GRU 到 direct-torque GRU 的语义受限迁移；
+- 只选择 episode 末段的 recovery-focused BC；
+- stable/plastic 双 actor 上下文门；
+- 500/50 Hz 严格对齐的 dense online recovery replay；
+- simulator-side actor interpolation 与完整物理信赖域；
+- 独立 Validation 的 measurable-plasticity 硬门；
+- 全路径 `SIM_ONLY`、Body/父策略/数据哈希绑定和 fail-closed receipt。
+
+## 8. 数据质量、局限和禁止外推
+
+1. 本地 MotionDecode 仍缺上游 17 个主类，不能说“完整数据集已验证”。
+2. 本地没有 football、球位姿、接触、reward 或 torque，不能用此 prior 证明足球技巧提升。
+3. 坐标约定未得到上游机器可验证契约，现有模型只作表征初始化。
+4. 4 个 Validation 场景对安全回归很敏感，但统计功效仍不足；不能据此估计真实成功率。
+5. 候选仍有 75% 临界失败率，绝不能制作成“已成功的小脑”或进入真实机器人。
+6. 所有结果来自 MuJoCo；没有 ROS/DDS/Unitree SDK/真实机器人动作。
+
+## 9. 下一轮最有价值的开发
+
+下一轮不应简单增加 BC epoch，而应解决“可塑性穿不过安全壳”的问题：
+
+1. 建立并行 recovery curriculum：按冲量、支撑脚、目标高度、摩擦、质量和传感延迟覆盖更多踢后状态；
+2. 把 actor 分成 locomotion/balance foundation trunk 与 football residual head，先保证卸力迈步，再学击球风格；
+3. 在安全动作空间训练 residual torque 或 latent skill，逐步放宽接管，而不是一次改变 29 维全身力矩；
+4. 用 distributional/ensemble safety critics 给信赖域提供不确定性，而不只看点估计；
+5. 对 stable/plastic 的实际施加力矩差异设置最小 effect-size 门，避免“权重变了、运动没变”；
+6. 增加 20+ 独立恢复 Validation、历史 retention suite 和跨代 lineage，再允许任何宣传视频使用新候选；
+7. 等本地 `3.3` football 数据真正出现后，重新审计其列语义；只有同步球位姿/接触存在时，才进入球技表征训练。
+
+“见天地”对应外部经验和环境分布；“见自己”对应 Body、proprioception、自我模型和可测 effect；“见众生”对应跨机器人/跨任务的经验胶囊与共同验证。Dream/Collective 可以提出候选，但只有清醒世界的独立物理门能够决定它是否成长。
+
+## 10. 证据索引
+
+- `motiondecode-pilot-v3/motiondecode-pilot-report.json`：400 条 pilot 与数据质量；
+- `motiondecode-stability-prior-v1/stability-prior-pack.json`：61 维稳定性 pack；
+- `motiondecode-stability-prior-v1/four-gpu-residual/four-gpu-report.json`：4×A6000 训练；
+- `g1-recovery-online-rl-v2/g1-recovery-online-rl-report.json`：最终在线闭环和拒绝决定；
+- 上述目录都位于外部 `phase8_evidence` 根目录，不进入源码提交。
+
+证据中的程序退出成功只代表流水线完成；是否可用必须读取 `decision`、`checks`、`blockers`、`promotion_evidence_eligible` 和 `hardware_authorized`。

--- a/docs/validation/ROSCLAW_PHASE8_NEURAL_TORQUE_CEREBELLUM.md
+++ b/docs/validation/ROSCLAW_PHASE8_NEURAL_TORQUE_CEREBELLUM.md
@@ -1,0 +1,170 @@
+# ROSClaw Phase 8：端到端神经力矩小脑与持续 Actor-Critic
+
+## 结论先行
+
+本阶段已经把 G1 踢球从“参数补丁/动作片段选择”推进到一个真实的数据驱动控制闭环：
+
+- GRU actor 从 102 维本体感知与任务上下文直接输出 29 维关节力矩；
+- 力矩在 MuJoCo 的 500 Hz 物理子步中生效，不再只是修改目标落点或动作参数；
+- 四张物理 A6000 分别训练独立随机种子的行为克隆候选；
+- DAgger 用闭环偏移状态重新采集教师纠正；
+- 双 reward critic、双 fall critic、双 constraint critic 持续更新；
+- actor 只学习新鲜安全轨迹，失败轨迹只训练 critic；
+- anchor replay、父策略蒸馏和 EWC 抑制灾难性遗忘；
+- 每次 actor 更新必须经过多步长、匹配场景的 MuJoCo 物理回放，失败即恢复完整 checkpoint；
+- artifact 绑定 Body、父策略和数据集哈希，并被硬限制为 `SIM_ONLY`。
+
+这证明了“端到端小脑 + 在线强化学习 + 持续 actor-critic + 直接力矩输出”的工程链路能够运行、学习、筛选与回滚。但最新密封验证的最终决定仍为 `REJECTED`：安全与留存门已经通过，泛化增益和直接力矩放行比例还没有达到晋升标准。因此它是可继续训练的研究基础，不是已可部署到真实 G1 的控制器。
+
+## 1. 什么叫端到端小脑
+
+这里的“端到端”是运动控制意义上的端到端，不是从摄像头像素开始：
+
+```text
+29 关节位置 + 29 关节速度
+          + 躯干投影重力
+          + 球相对位置/速度
+          + 目标高度/横向位置
+          + 动作相位、双脚接触、上一拍力矩
+                         │
+                         ▼
+                   96 维 GRU
+                         │
+                         ▼
+                 29 维关节力矩
+                         │
+                         ▼
+       独立安全投影器 + 父控制器故障回退
+                         │
+                         ▼
+                 MuJoCo 500 Hz 物理环
+```
+
+冻结后的 observation 维度是 102，action 维度是 29。GRU 提供短期运动记忆，使策略能够根据“刚才身体怎么动、上一拍用了多少力”决定下一拍力矩，而不是逐帧孤立决策。
+
+独立安全投影器限制力矩幅值、变化率、机械功率、关节边界和相对父控制器的偏差。姿态异常、分布外输入、过度投影、非有限数或 artifact 不匹配都会 fail closed 到已验证父控制器。当前代码没有 ROS、DDS、Unitree SDK 或真实硬件授权路径。
+
+## 2. 数据与学习闭环
+
+### 2.1 教师数据
+
+合格的 RoboNaldo + PD 控制器在每个 2 ms 物理子步提供父力矩。采集器原样透传父力矩，同时记录 observation、实际施加力矩和父力矩。因果透明测试要求加入采集器前后：
+
+- episode summary 完全相同；
+- 全轨迹哈希完全相同；
+- 共记录 6520 个物理步/episode。
+
+### 2.2 四卡行为克隆
+
+四个隔离 worker 分别绑定 `CUDA_VISIBLE_DEVICES=0..3`，核验 GPU UUID 与 PCI bus id，并训练独立 seed。worker 只输出安全 tensor artifact，不使用 pickle。主流程选择验证损失最低的 seed，再在同一配置上进行 DAgger。
+
+### 2.3 DAgger
+
+只看教师轨迹会产生 covariate shift：开放环 BC loss 很低，机器人一旦产生微小姿态偏差，网络就进入没见过的状态并持续犯错。DAgger 让当前神经 actor 在闭环 MuJoCo 中运行，再对它真正访问到的状态记录父控制器纠正。最新完整实验中，验证 MSE 随代际持续下降；但密封物理指标而不是 MSE 决定是否晋升。
+
+### 2.4 持续 actor-critic
+
+训练器包含：
+
+- twin reward critic：学习任务收益；
+- twin fall critic：学习摔倒风险；
+- twin constraint critic：学习约束/投影风险；
+- target critics、SAC 熵温度和两个拉格朗日乘子；
+- RECENT、ANCHOR、BOUNDARY 三种 replay 分区；
+- policy lag：actor 只看 lag 不超过 1 的 RECENT 数据，critic 可以看全部数据；
+- 父策略蒸馏、历史 anchor rehearsal 和 EWC Fisher 正则。
+
+失败或临界轨迹进入 BOUNDARY：它们用于教 critic 识别危险，但不会让 actor 模仿失败动作。这是 stability-plasticity dilemma 的第一层工程解法。
+
+### 2.5 物理信赖域
+
+一次很小的神经参数变化也可能在混合控制器中触发不同的投影/回退分支。实验观察到约 `1e-12` 的 CUDA 末位权重差异在数秒后可形成不同轨迹。因此增加了两层处理：
+
+1. 导出前对推理 tensor 做 `1e-6` 确定性量化，消除无意义的末位噪声；
+2. actor 更新依次尝试 `1.0, 0.5, 0.2, 0.1, 0.05, 0.035, 0.02, 0.01, 0.005` 信赖域比例，每个比例都跑完整匹配物理回放。
+
+任一新临界失败、非有限值、成功率下降、均分下降超过 1% 或小脑放行比例下降超过 5 个百分点都会拒绝该步长。全部步长失败时，actor、critics、optimizers、熵温度、拉格朗日乘子、EWC 状态和 CPU/CUDA RNG 一起恢复。
+
+## 3. 最新完整实验结果
+
+证据目录：`/code/rosclaw/phase8_evidence/g1-neural-torque-pilot-v6`
+
+实验使用 4 个训练场景、2 个 DAgger 场景、4 个密封 Validation 场景和 3 个密封 Holdout 场景。在线安全门扩展到全部 6 个 Development 场景；Validation/Holdout 不参与更新或步长选择。
+
+### 3.1 在线更新局部门
+
+| actor 步长 | 6 场开发结果 | 决定 |
+|---|---|---|
+| 100% | 产生 1 个新临界回归，均分退化 | 拒绝 |
+| 50% | 均分 `0.146 → 0.783`，临界失败率 `33.3% → 16.7%`，小脑放行 `37.4% → 36.4%` | 接受 |
+
+这证明在线 actor 不是只更新了文件或 loss：经过缩步后的新权重真实改变了 MuJoCo 物理结果，并且完整步长被安全门拦截。
+
+### 3.2 密封聚合结果
+
+| 指标 | 合格父控制器 | BC 小脑 | 在线 RL 小脑 |
+|---|---:|---:|---:|
+| 成功率 | 28.57% | 28.57% | 28.57% |
+| 临界失败率 | 57.14% | 42.86% | 42.86% |
+| 平均任务分 | -6.459 | -3.105 | -4.897 |
+| 平均躯干 roll 峰值 | 1.460 rad | 1.286 rad | 1.521 rad |
+| 平均支撑脚滑移 | 0.0591 m | 0.0506 m | 0.0292 m |
+| 神经力矩实际放行 | 0% | 28.11% | 29.53% |
+
+在线小脑相对父控制器没有新增临界失败，平均分也守住了 3% 留存门；但相对 BC 小脑平均分下降，未获得要求的至少 5% 在线可塑性增益。直接力矩实际放行比例也低于 75% 门。因此最终为：
+
+```text
+decision = REJECTED
+blockers = online_plasticity_gain_at_least_5pct,
+           learned_output_fraction_at_least_75pct
+```
+
+所有密封 episode 均通过严格重放，所有候选均为 `SIM_ONLY`，没有真实机器人证据，也没有硬件授权。
+
+## 4. 已验证的 ROSClaw 能力
+
+- MuJoCo G1 Body/父策略哈希绑定；
+- 500 Hz direct torque callback 确实进入物理环；
+- 教师采集不扰动原轨迹；
+- 四张不同 UUID 的 A6000 均被实际使用；
+- 安全 tensor artifact 的确定性序列化、大小限制、shape 校验和篡改拒绝；
+- checkpoint 使用 `torch.load(..., weights_only=True)`；
+- 训练服务完整恢复 optimizer、critic、target、EWC 与 RNG；
+- 分区 replay 与 policy lag 防止 stale/boundary 数据污染 actor；
+- DAgger、在线 SAC、约束 critic、信赖域物理回放和逐步回滚；
+- 密封 Validation/Holdout 严格重放和 fail-closed 晋升。
+
+## 5. 尚未解决的问题
+
+1. 当前神经 actor 主要是在蒸馏父控制器，其能力上限仍受父数据覆盖限制。
+2. 安全壳频繁回退，说明网络的闭环状态覆盖不足；29.53% 放行率不应被描述为“已接管全身控制”。
+3. 在线 replay 规模仍小，critic 对高难度 g4/g7/g9 的价值估计不够可靠。
+4. 在线局部门提升没有泛化成密封收益；需要更丰富的 development curriculum 和 domain randomization，而不是使用密封集调参。
+5. 当前是 MuJoCo 中的力矩控制研究候选，不是 Isaac Lab 大规模训练完成的 locomotion foundation policy，也没有 sim-to-real 结论。
+6. 本阶段没有制作宣传视频。被拒绝的候选不应作为最终成果视频；后续应在候选通过密封门后再录制长时、多难度对比。
+
+## 6. 下一阶段建议
+
+优先顺序如下：
+
+1. 在 Isaac Lab/MJWarp 扩展到数千并行环境，训练站立、迈步、击球、随动卸力和恢复的分层课程；
+2. 给 critic 增加更密集的 COM、角动量、足底接触、关节裕量和动作平滑奖励，同时保留任务落点收益；
+3. 使用受安全壳限制的 stochastic rollout 收集真正有动作多样性的在线数据，而不只在已有 BC 轨迹上做 critic 拟合；
+4. 引入独立 locomotion/balance foundation policy，踢球 actor 只学习残差或技能条件，再逐步提高直接力矩接管比例；
+5. 建立固定历史技能库和跨任务 retention suite，防止“足球进步、站立退化”；
+6. 只有连续多个密封代际通过安全、留存、可塑性和直接控制比例门后，才讨论更接近真实机器人的 HIL 或受控硬件验证。
+
+## 7. 复现实验
+
+```bash
+PYTHONPATH=src .venv/bin/python -m rosclaw.entrypoint \
+  simforge validate g1-goalforge \
+  --profile neural-torque-pilot \
+  --asset-root /code/rosclaw/phase4_references/RoboNaldo/RoboNaldo_Deploy \
+  --gpu-epochs 12 \
+  --dagger-generations 3 \
+  --online-updates 1 \
+  --output /code/rosclaw/phase8_evidence/g1-neural-torque-pilot-v6
+```
+
+退出码表示流水线是否完成，不表示候选是否晋升。候选是否可用必须读取报告中的 `decision`、`blockers` 和 `promotion_checks`。

--- a/scripts/simforge/g1_neural_torque_gpu_worker.py
+++ b/scripts/simforge/g1_neural_torque_gpu_worker.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""One isolated GPU seed for G1 recurrent direct-torque distillation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from rosclaw.simforge.g1_neural_torque import (
+    G1TeacherTorqueEpisode,
+    G1TorqueSafetyConfig,
+)
+from rosclaw.simforge.g1_neural_torque_learning import (
+    G1ContinualTorqueActorCritic,
+    G1NeuralTorqueLearnerConfig,
+    teacher_dataset_hash,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--physical-gpu", type=int, required=True)
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--body-hash", required=True)
+    parser.add_argument("--parent-policy-hash", required=True)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--epochs", type=int, default=12)
+    args = parser.parse_args()
+    if args.physical_gpu not in range(4) or args.seed < 0 or not 1 <= args.epochs <= 100:
+        raise SystemExit("invalid neural torque GPU worker request")
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible != str(args.physical_gpu):
+        raise SystemExit(
+            f"neural torque CUDA identity mismatch: expected {args.physical_gpu}, visible={visible}"
+        )
+    if not torch.cuda.is_available() or torch.cuda.device_count() != 1:
+        raise SystemExit("neural torque worker requires exactly one visible CUDA device")
+    training, validation = _load_dataset(args.dataset)
+    safety = G1TorqueSafetyConfig(
+        torque_guard_scale=0.80,
+        maximum_mechanical_power_w=4000.0,
+        maximum_parent_deviation_ratio=0.05,
+        maximum_projection_ratio=0.35,
+        maximum_observation_z=5.0,
+        minimum_upright_gravity_z=-0.97,
+        minimum_pelvis_height_m=0.70,
+        recovery_cooldown_steps=250,
+        warmup_steps=100,
+    )
+    learner = G1ContinualTorqueActorCritic(
+        G1NeuralTorqueLearnerConfig(
+            hidden_dim=96,
+            sequence_length=32,
+            batch_size=256,
+            actor_lr=5e-5,
+            device="cuda:0",
+            seed=args.seed,
+        ),
+        safety=safety,
+    )
+    started = time.perf_counter()
+    metrics = learner.pretrain_behavior(
+        training,
+        validation=validation,
+        epochs=args.epochs,
+        stride=4,
+    )
+    dataset_hash = teacher_dataset_hash(training)
+    artifact = learner.artifact_bytes(
+        body_hash=args.body_hash,
+        parent_policy_hash=args.parent_policy_hash,
+        dataset_hash=dataset_hash,
+    )
+    args.artifact.write_bytes(artifact)
+    torch.cuda.synchronize()
+    gpu_uuid, pci_bus_id = _gpu_identity(args.physical_gpu)
+    value = {
+        "schema_version": "rosclaw.simforge.g1_neural_torque_gpu_worker.v1",
+        "physical_gpu": args.physical_gpu,
+        "cuda_visible_devices": visible,
+        "gpu_uuid": gpu_uuid,
+        "pci_bus_id": pci_bus_id,
+        "gpu_name": torch.cuda.get_device_name(0),
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+        "learner_seed": args.seed,
+        "dataset_hash": dataset_hash,
+        "training_episodes": len(training),
+        "validation_episodes": len(validation),
+        "epochs": len(metrics),
+        "initial_training_loss": metrics[0].training_loss,
+        "final_training_loss": metrics[-1].training_loss,
+        "initial_validation_loss": metrics[0].validation_loss,
+        "final_validation_loss": metrics[-1].validation_loss,
+        "finite": all(item.finite for item in metrics),
+        "action_limit_fraction": metrics[-1].action_limit_fraction,
+        "artifact_hash": "sha256:" + __import__("hashlib").sha256(artifact).hexdigest(),
+        "artifact_bytes": len(artifact),
+        "elapsed_sec": time.perf_counter() - started,
+        "max_memory_allocated_bytes": torch.cuda.max_memory_allocated(),
+        "claims": {
+            "action_semantics": "DIRECT_JOINT_TORQUE",
+            "activation_ceiling": "SIM_ONLY",
+            "physics_effect_proven": False,
+            "hardware_authorized": False,
+        },
+    }
+    args.output.write_text(
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+def _load_dataset(
+    path: Path,
+) -> tuple[tuple[G1TeacherTorqueEpisode, ...], tuple[G1TeacherTorqueEpisode, ...]]:
+    with np.load(path, allow_pickle=False) as value:
+        training_count = int(value["training_count"])
+        validation_count = int(value["validation_count"])
+        training = tuple(
+            G1TeacherTorqueEpisode(
+                value[f"training_{index}_observations"],
+                value[f"training_{index}_actions"],
+                value[f"training_{index}_parent_actions"],
+            )
+            for index in range(training_count)
+        )
+        validation = tuple(
+            G1TeacherTorqueEpisode(
+                value[f"validation_{index}_observations"],
+                value[f"validation_{index}_actions"],
+                value[f"validation_{index}_parent_actions"],
+            )
+            for index in range(validation_count)
+        )
+    if not training or not validation:
+        raise ValueError("neural torque worker dataset requires training and validation episodes")
+    return training, validation
+
+
+def _gpu_identity(physical_gpu: int) -> tuple[str, str]:
+    result = subprocess.run(
+        [
+            "nvidia-smi",
+            f"--id={physical_gpu}",
+            "--query-gpu=uuid,pci.bus_id",
+            "--format=csv,noheader,nounits",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    values = [item.strip() for item in result.stdout.strip().split(",")]
+    if len(values) != 2:
+        raise RuntimeError("unexpected nvidia-smi identity response")
+    return values[0], values[1]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -6710,6 +6710,14 @@ def cmd_restart(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "collective":
+        from rosclaw.collective.cli import dispatch_collective_argv
+
+        result = dispatch_collective_argv(sys.argv[1:])
+        if result is None:
+            raise RuntimeError("collective command was not dispatched")
+        return result
+
     if len(sys.argv) > 1 and sys.argv[1] == "simforge":
         from rosclaw.simforge.cli import dispatch_simforge_argv
 
@@ -6731,6 +6739,7 @@ def main() -> int:
 
     # The full SimForge parser is loaded lazily by the early dispatch above.
     subparsers.add_parser("simforge", help="Run simulation qualification and evolution")
+    subparsers.add_parser("collective", help="Inspect and ingest collective experience")
 
     # init
     init_parser = subparsers.add_parser("init", help="Initialize a ROSClaw workspace")

--- a/src/rosclaw/collective/__init__.py
+++ b/src/rosclaw/collective/__init__.py
@@ -1,0 +1,5 @@
+"""Bounded, provenance-preserving adapters for collective robot experience."""
+
+from rosclaw.collective.capsule import ExperienceCapsule, SourceDescriptor
+
+__all__ = ["ExperienceCapsule", "SourceDescriptor"]

--- a/src/rosclaw/collective/capsule.py
+++ b/src/rosclaw/collective/capsule.py
@@ -1,0 +1,70 @@
+"""Truthful contracts for experience acquired outside ROSClaw Practice."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class SourceDescriptor:
+    provider: str
+    dataset: str
+    revision: str
+    inventory_hash: str
+    license_hash: str
+    attribution: str
+    revision_binding: str
+
+    def __post_init__(self) -> None:
+        if not all(value.strip() for value in (self.provider, self.dataset, self.attribution)):
+            raise ValueError("collective source identity and attribution must not be empty")
+        if not re.fullmatch(r"[0-9a-f]{40}", self.revision):
+            raise ValueError("collective source revision must be a full git commit")
+        if not _SHA256.fullmatch(self.inventory_hash) or not _SHA256.fullmatch(
+            self.license_hash
+        ):
+            raise ValueError("collective source commitments must be sha256 digests")
+        if self.revision_binding not in {"VERIFIED", "UNVERIFIED_LOCAL_SNAPSHOT"}:
+            raise ValueError("unknown collective source revision binding")
+
+
+@dataclass(frozen=True)
+class ExperienceCapsule:
+    """A non-executable external experience record.
+
+    Capsules carry semantics and provenance.  They cannot authorize a policy,
+    hardware execution, or promotion evidence.
+    """
+
+    source: SourceDescriptor
+    source_body: str
+    target_body: str
+    target_body_mapping: str
+    task_semantics: tuple[str, ...]
+    observation_semantics: tuple[str, ...]
+    action_semantics: tuple[str, ...]
+    modalities: tuple[str, ...]
+    quality: str
+    truth_level: str
+    applicability: str
+    training_eligible: bool
+    promotion_evidence_eligible: bool = False
+    hardware_authorized: bool = False
+    schema_version: str = "rosclaw.experience_capsule.v1"
+
+    def __post_init__(self) -> None:
+        if self.truth_level not in {"T0", "T1", "T2", "T3", "T4", "T5"}:
+            raise ValueError("unknown Dream truth level")
+        if self.promotion_evidence_eligible:
+            raise ValueError("collective capsules cannot be promotion evidence")
+        if self.hardware_authorized:
+            raise ValueError("collective capsules cannot authorize hardware")
+        if not self.observation_semantics or not self.modalities:
+            raise ValueError("collective capsule must describe its observations and modalities")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/src/rosclaw/collective/cli.py
+++ b/src/rosclaw/collective/cli.py
@@ -1,0 +1,196 @@
+"""CLI for provenance-safe collective experience ingestion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from rosclaw.collective.sources.motiondecode.audit import run_motiondecode_pilot
+from rosclaw.collective.sources.motiondecode.manifest import inspect_motiondecode_source
+from rosclaw.collective.sources.motiondecode.motion_prior import (
+    build_motion_prior_pack,
+    run_four_gpu_motion_prior,
+)
+from rosclaw.collective.sources.motiondecode.taxonomy import MotionDecodeStratum
+
+
+def dispatch_collective_argv(argv: list[str]) -> int | None:
+    if not argv or argv[0] != "collective":
+        return None
+    parser = _parser()
+    args = parser.parse_args(argv[1:])
+    try:
+        if args.command == "source" and args.source_command == "inspect":
+            return _inspect(args)
+        if args.command == "ingest":
+            return _ingest(args)
+        if args.command == "prior" and args.prior_command == "build":
+            return _build_prior(args)
+        if args.command == "prior" and args.prior_command == "train":
+            return _train_prior(args)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": "rosclaw.collective.cli_error.v1",
+                    "ok": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                },
+                sort_keys=True,
+            )
+        )
+        return 2
+    parser.print_help()
+    return 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="rosclaw collective")
+    commands = parser.add_subparsers(dest="command")
+    source = commands.add_parser("source", help="Inspect an external experience source")
+    source_commands = source.add_subparsers(dest="source_command")
+    inspect = source_commands.add_parser("inspect")
+    _source_arguments(inspect)
+    inspect.add_argument("--json", action="store_true")
+
+    ingest = commands.add_parser("ingest", help="Build a bounded experience pilot")
+    _source_arguments(ingest)
+    ingest.add_argument("--model-path", type=Path, required=True)
+    ingest.add_argument("--asset-root", type=Path)
+    ingest.add_argument("--output-dir", type=Path, required=True)
+    ingest.add_argument("--limit", type=int, default=400)
+    ingest.add_argument("--seed", type=int, default=20260801)
+    ingest.add_argument("--json", action="store_true")
+
+    prior = commands.add_parser("prior", help="Build and train a kinematic motion prior")
+    prior_commands = prior.add_subparsers(dest="prior_command")
+    build = prior_commands.add_parser("build", help="Build a bounded audited tensor pack")
+    build.add_argument("--pilot-report", type=Path, required=True)
+    build.add_argument("--dataset-root", type=Path, required=True)
+    build.add_argument("--model-path", type=Path, required=True)
+    build.add_argument("--output", type=Path, required=True)
+    build.add_argument("--sequence-length", type=int, default=32)
+    build.add_argument("--maximum-windows", type=int, default=12_000)
+    build.add_argument("--seed", type=int, default=20260801)
+    build.add_argument(
+        "--stratum",
+        action="append",
+        choices=tuple(value.value for value in MotionDecodeStratum),
+    )
+    build.add_argument("--json", action="store_true")
+
+    train = prior_commands.add_parser(
+        "train", help="Train four independent physical-GPU representation candidates"
+    )
+    train.add_argument("--pack", type=Path, required=True)
+    train.add_argument("--output-dir", type=Path, required=True)
+    train.add_argument("--epochs", type=int, default=10)
+    train.add_argument("--hidden-dim", type=int, default=96)
+    train.add_argument("--batch-size", type=int, default=256)
+    train.add_argument("--base-seed", type=int, default=8200)
+    train.add_argument("--json", action="store_true")
+    return parser
+
+
+def _source_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("provider", choices=("motiondecode",))
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument(
+        "--usage",
+        choices=("research", "personal-study", "noncommercial-prototype"),
+        default="research",
+    )
+
+
+def _inspect(args: argparse.Namespace) -> int:
+    manifest, _ = inspect_motiondecode_source(
+        args.dataset_root,
+        revision=args.revision,
+        requested_usage=args.usage,
+    )
+    value = manifest.to_dict()
+    print(json.dumps(value, indent=2 if args.json else None, sort_keys=True))
+    return 0
+
+
+def _ingest(args: argparse.Namespace) -> int:
+    report = run_motiondecode_pilot(
+        dataset_root=args.dataset_root,
+        revision=args.revision,
+        model_path=args.model_path,
+        asset_root=args.asset_root,
+        output_dir=args.output_dir,
+        source_checkout=Path(__file__).resolve().parents[3],
+        requested_usage=args.usage,
+        limit=args.limit,
+        seed=args.seed,
+    )
+    value = {
+        "schema_version": report.schema_version,
+        "pipeline_passed": report.pipeline_passed,
+        "decision": report.decision,
+        "source_manifest_hash": report.source_manifest_hash,
+        "body_hash": report.body_hash,
+        "selection_counts": report.selection_counts,
+        "selection_shortages": report.selection_shortages,
+        "aggregates": report.aggregates,
+        "blockers": list(report.blockers),
+        "output_dir": str(args.output_dir.expanduser().resolve()),
+    }
+    print(json.dumps(value, indent=2 if args.json else None, sort_keys=True))
+    return 0 if report.pipeline_passed else 2
+
+
+def _build_prior(args: argparse.Namespace) -> int:
+    metadata = build_motion_prior_pack(
+        pilot_report_path=args.pilot_report,
+        dataset_root=args.dataset_root,
+        model_path=args.model_path,
+        output_path=args.output,
+        sequence_length=args.sequence_length,
+        maximum_windows=args.maximum_windows,
+        seed=args.seed,
+        allowed_strata=tuple(args.stratum) if args.stratum else None,
+    )
+    value = {
+        "schema_version": metadata["schema_version"],
+        "pack_hash": metadata["pack_hash"],
+        "body_hash": metadata["body_hash"],
+        "feature_count": len(metadata["feature_names"]),
+        "training_windows": metadata["training_windows"],
+        "validation_windows": metadata["validation_windows"],
+        "allowed_strata": metadata["allowed_strata"],
+        "action_semantics": metadata["action_semantics"],
+        "raw_data_exported": metadata["raw_data_exported"],
+        "output": str(args.output.expanduser().resolve()),
+    }
+    print(json.dumps(value, indent=2 if args.json else None, sort_keys=True))
+    return 0
+
+
+def _train_prior(args: argparse.Namespace) -> int:
+    report = run_four_gpu_motion_prior(
+        pack_path=args.pack,
+        output_dir=args.output_dir,
+        epochs=args.epochs,
+        hidden_dim=args.hidden_dim,
+        batch_size=args.batch_size,
+        base_seed=args.base_seed,
+    )
+    selected = report.get("selected")
+    value = {
+        "schema_version": report["schema_version"],
+        "decision": report["decision"],
+        "four_physical_gpus_exercised": report["four_physical_gpus_exercised"],
+        "quality_gate": report["quality_gate"],
+        "selected": selected,
+        "hardware_authorized": report["hardware_authorized"],
+        "output_dir": str(args.output_dir.expanduser().resolve()),
+    }
+    print(json.dumps(value, indent=2 if args.json else None, sort_keys=True))
+    return 0 if report["decision"] == "REPRESENTATION_CANDIDATE" else 2
+
+
+__all__ = ["dispatch_collective_argv"]

--- a/src/rosclaw/collective/cli.py
+++ b/src/rosclaw/collective/cli.py
@@ -5,13 +5,8 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import NoReturn
 
-from rosclaw.collective.sources.motiondecode.audit import run_motiondecode_pilot
-from rosclaw.collective.sources.motiondecode.manifest import inspect_motiondecode_source
-from rosclaw.collective.sources.motiondecode.motion_prior import (
-    build_motion_prior_pack,
-    run_four_gpu_motion_prior,
-)
 from rosclaw.collective.sources.motiondecode.taxonomy import MotionDecodeStratum
 
 
@@ -105,6 +100,10 @@ def _source_arguments(parser: argparse.ArgumentParser) -> None:
 
 
 def _inspect(args: argparse.Namespace) -> int:
+    from rosclaw.collective.sources.motiondecode.manifest import (
+        inspect_motiondecode_source,
+    )
+
     manifest, _ = inspect_motiondecode_source(
         args.dataset_root,
         revision=args.revision,
@@ -116,6 +115,8 @@ def _inspect(args: argparse.Namespace) -> int:
 
 
 def _ingest(args: argparse.Namespace) -> int:
+    from rosclaw.collective.sources.motiondecode.audit import run_motiondecode_pilot
+
     report = run_motiondecode_pilot(
         dataset_root=args.dataset_root,
         revision=args.revision,
@@ -144,6 +145,13 @@ def _ingest(args: argparse.Namespace) -> int:
 
 
 def _build_prior(args: argparse.Namespace) -> int:
+    try:
+        from rosclaw.collective.sources.motiondecode.motion_prior import (
+            build_motion_prior_pack,
+        )
+    except ModuleNotFoundError as exc:
+        _raise_missing_rl_extra(exc)
+
     metadata = build_motion_prior_pack(
         pilot_report_path=args.pilot_report,
         dataset_root=args.dataset_root,
@@ -171,6 +179,13 @@ def _build_prior(args: argparse.Namespace) -> int:
 
 
 def _train_prior(args: argparse.Namespace) -> int:
+    try:
+        from rosclaw.collective.sources.motiondecode.motion_prior import (
+            run_four_gpu_motion_prior,
+        )
+    except ModuleNotFoundError as exc:
+        _raise_missing_rl_extra(exc)
+
     report = run_four_gpu_motion_prior(
         pack_path=args.pack,
         output_dir=args.output_dir,
@@ -191,6 +206,15 @@ def _train_prior(args: argparse.Namespace) -> int:
     }
     print(json.dumps(value, indent=2 if args.json else None, sort_keys=True))
     return 0 if report["decision"] == "REPRESENTATION_CANDIDATE" else 2
+
+
+def _raise_missing_rl_extra(exc: ModuleNotFoundError) -> NoReturn:
+    if exc.name == "torch":
+        raise RuntimeError(
+            "Motion-prior build/train requires the optional RL dependencies; "
+            "install 'rosclaw[rl]'"
+        ) from exc
+    raise exc
 
 
 __all__ = ["dispatch_collective_argv"]

--- a/src/rosclaw/collective/sources/__init__.py
+++ b/src/rosclaw/collective/sources/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters for externally provided robot-experience sources."""

--- a/src/rosclaw/collective/sources/motiondecode/__init__.py
+++ b/src/rosclaw/collective/sources/motiondecode/__init__.py
@@ -1,0 +1,11 @@
+"""ChingMu MotionDecode source adapter and kinematic pilot."""
+
+from rosclaw.collective.sources.motiondecode.audit import run_motiondecode_pilot
+from rosclaw.collective.sources.motiondecode.manifest import inspect_motiondecode_source
+from rosclaw.collective.sources.motiondecode.parser import parse_motiondecode_csv
+
+__all__ = [
+    "inspect_motiondecode_source",
+    "parse_motiondecode_csv",
+    "run_motiondecode_pilot",
+]

--- a/src/rosclaw/collective/sources/motiondecode/audit.py
+++ b/src/rosclaw/collective/sources/motiondecode/audit.py
@@ -1,0 +1,589 @@
+"""Kinematic and MuJoCo-geometry qualification for MotionDecode pilots."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.collective.sources.motiondecode.manifest import (
+    MotionDecodeSourceManifest,
+    inspect_motiondecode_source,
+    manifest_hash,
+)
+from rosclaw.collective.sources.motiondecode.parser import (
+    CanonicalMotionEpisode,
+    parse_motiondecode_csv,
+)
+from rosclaw.collective.sources.motiondecode.taxonomy import (
+    MotionDecodeStratum,
+    select_motiondecode_pilot,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import (
+    G1_DDS_JOINT_NAMES,
+    hash_bytes,
+    hash_json,
+)
+
+
+@dataclass(frozen=True)
+class MotionDecodeEpisodeAudit:
+    relative_path: str
+    stratum: str
+    source_hash: str | None
+    frame_count: int
+    duration_sec: float
+    finite: bool
+    quaternion_norm_error_max: float | None
+    quaternion_sign_flip_count: int
+    joint_limit_violation_fraction: float | None
+    joint_limit_excess_max_rad: float | None
+    joint_speed_p99_rad_s: float | None
+    joint_speed_max_rad_s: float | None
+    joint_acceleration_p99_rad_s2: float | None
+    root_speed_max_m_s: float | None
+    duplicate_frame_fraction: float | None
+    clean_window_count: int
+    clean_frame_fraction: float | None
+    maximum_clean_window_frames: int
+    mujoco_frames_checked: int
+    mujoco_finite: bool
+    contact_frame_fraction: float | None
+    penetration_depth_max_m: float | None
+    qualification: str
+    training_eligible: bool
+    repair_eligible: bool
+    errors: tuple[str, ...]
+    warnings: tuple[str, ...]
+    schema_version: str = "rosclaw.collective.motiondecode_episode_audit.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MotionDecodePilotReport:
+    source_manifest: MotionDecodeSourceManifest
+    source_manifest_hash: str
+    body_hash: str
+    kinematic_body_hash: str
+    model_hash: str
+    selection_seed: int
+    requested_limit: int
+    selection_requested: dict[str, int]
+    selection_counts: dict[str, int]
+    selection_shortages: dict[str, int]
+    selection_substitutions: dict[str, int]
+    episodes: tuple[MotionDecodeEpisodeAudit, ...]
+    aggregates: dict[str, Any]
+    decision: str
+    blockers: tuple[str, ...]
+    pipeline_failures: tuple[str, ...]
+    evidence_domain: str = "SIM_ONLY"
+    hardware_authorized: bool = False
+    raw_data_exported: bool = False
+    promotion_evidence_eligible: bool = False
+    schema_version: str = "rosclaw.collective.motiondecode_pilot.v1"
+
+    @property
+    def pipeline_passed(self) -> bool:
+        return not self.pipeline_failures and len(self.episodes) == self.requested_limit
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["pipeline_passed"] = self.pipeline_passed
+        value["claims"] = {
+            "football_contact_training": False,
+            "direct_torque_labels": False,
+            "reward_labels": False,
+            "time_axis": "implicit_120hz",
+            "coordinate_convention": "UNVERIFIED",
+            "maximum_truth_level": "T4_SOURCE/T1_GEOMETRY_CHECK_ONLY",
+            "candidate_promoted": False,
+            "real_robot_evidence": False,
+        }
+        return value
+
+
+@dataclass(frozen=True)
+class _MuJoCoContract:
+    model: Any
+    data: Any
+    qpos_addresses: np.ndarray
+    joint_lower: np.ndarray
+    joint_upper: np.ndarray
+    robot_body_ids: frozenset[int]
+    ground_geom_ids: frozenset[int]
+    body_hash: str
+    model_hash: str
+
+
+def run_motiondecode_pilot(
+    *,
+    dataset_root: Path,
+    revision: str,
+    model_path: Path,
+    asset_root: Path | None = None,
+    output_dir: Path,
+    source_checkout: Path,
+    requested_usage: str = "research",
+    limit: int = 400,
+    seed: int = 20260801,
+) -> MotionDecodePilotReport:
+    """Run a deterministic pilot and persist only hashes and audit summaries."""
+
+    root = _external_output(output_dir, source_checkout)
+    root.mkdir(parents=True, exist_ok=False)
+    manifest, relative_paths = inspect_motiondecode_source(
+        dataset_root,
+        revision=revision,
+        requested_usage=requested_usage,
+    )
+    selection = select_motiondecode_pilot(relative_paths, limit=limit, seed=seed)
+    contract = _load_mujoco_contract(model_path)
+    execution_body_hash = contract.body_hash
+    if asset_root is not None:
+        from rosclaw.simforge.backends.unitree_mujoco_backend import qualify_g1_assets
+
+        qualification = qualify_g1_assets(asset_root)
+        qualification.require_eligible()
+        expected_scene = qualification.asset_root / "g1_description" / "scene_with_ball.xml"
+        if model_path.expanduser().resolve() != expected_scene.resolve():
+            raise ValueError("MotionDecode audit model is not the qualified execution scene")
+        execution_body_hash = qualification.body_hash
+    dataset = dataset_root.expanduser().resolve()
+    episodes: list[MotionDecodeEpisodeAudit] = []
+    pipeline_failures: list[str] = []
+    for stratum, relative_path in selection.selected:
+        episodes.append(
+            _audit_path(
+                dataset / relative_path,
+                dataset_root=dataset,
+                stratum=stratum,
+                contract=contract,
+            )
+        )
+    if len(selection.selected) != limit:
+        pipeline_failures.append(
+            f"pilot_selected={len(selection.selected)},requested={limit}"
+        )
+    aggregates = _aggregate(episodes)
+    blockers: list[str] = []
+    if manifest.source.revision_binding != "VERIFIED":
+        blockers.append("local payload is not cryptographically bound to the stated remote revision")
+    if manifest.football_files == 0:
+        blockers.append("local snapshot has no football or ball-game CSV")
+    if manifest.object_pose_files == 0:
+        blockers.append("no synchronized ball/object pose exists for contact learning")
+    if int(aggregates["q0_invalid_count"]) > 0:
+        blockers.append("one or more pilot episodes failed the kinematic contract")
+    if int(aggregates["training_eligible_count"]) < max(1, int(0.8 * len(episodes))):
+        blockers.append("fewer than 80% of selected episodes are motion-prior eligible")
+    decision = (
+        "MOTION_PRIOR_ONLY"
+        if not pipeline_failures and int(aggregates["training_eligible_count"]) > 0
+        else "REJECTED"
+    )
+    report = MotionDecodePilotReport(
+        source_manifest=manifest,
+        source_manifest_hash=manifest_hash(manifest),
+        body_hash=execution_body_hash,
+        kinematic_body_hash=contract.body_hash,
+        model_hash=contract.model_hash,
+        selection_seed=seed,
+        requested_limit=limit,
+        selection_requested=dict(selection.requested),
+        selection_counts=dict(selection.selected_counts),
+        selection_shortages=dict(selection.shortages),
+        selection_substitutions=dict(selection.substitutions),
+        episodes=tuple(episodes),
+        aggregates=aggregates,
+        decision=decision,
+        blockers=tuple(blockers),
+        pipeline_failures=tuple(pipeline_failures),
+    )
+    _atomic_json(root / "source-manifest.json", manifest.to_dict())
+    _atomic_json(root / "motiondecode-pilot-report.json", report.to_dict())
+    _atomic_json(
+        root / "experience-capsule.json",
+        replace(
+            manifest.capsule,
+            target_body_mapping=(
+                f"exact_29dof_names:{contract.body_hash};execution_body:{execution_body_hash}"
+            ),
+            quality=(
+                "KINEMATIC_AUDITED_MOTION_PRIOR"
+                if decision == "MOTION_PRIOR_ONLY"
+                else "REJECTED"
+            ),
+            applicability="MOTION_PRIOR_ONLY_NO_FOOTBALL_CONTACT",
+            training_eligible=decision == "MOTION_PRIOR_ONLY",
+        ).to_dict(),
+    )
+    return report
+
+
+def _audit_path(
+    path: Path,
+    *,
+    dataset_root: Path,
+    stratum: MotionDecodeStratum,
+    contract: _MuJoCoContract,
+) -> MotionDecodeEpisodeAudit:
+    try:
+        episode = parse_motiondecode_csv(path, dataset_root=dataset_root)
+        return _audit_episode(episode, stratum=stratum, contract=contract)
+    except (OSError, ValueError) as exc:
+        return MotionDecodeEpisodeAudit(
+            relative_path=path.relative_to(dataset_root).as_posix(),
+            stratum=stratum.value,
+            source_hash=None,
+            frame_count=0,
+            duration_sec=0.0,
+            finite=False,
+            quaternion_norm_error_max=None,
+            quaternion_sign_flip_count=0,
+            joint_limit_violation_fraction=None,
+            joint_limit_excess_max_rad=None,
+            joint_speed_p99_rad_s=None,
+            joint_speed_max_rad_s=None,
+            joint_acceleration_p99_rad_s2=None,
+            root_speed_max_m_s=None,
+            duplicate_frame_fraction=None,
+            clean_window_count=0,
+            clean_frame_fraction=None,
+            maximum_clean_window_frames=0,
+            mujoco_frames_checked=0,
+            mujoco_finite=False,
+            contact_frame_fraction=None,
+            penetration_depth_max_m=None,
+            qualification="Q0_INVALID",
+            training_eligible=False,
+            repair_eligible=False,
+            errors=(f"{type(exc).__name__}:{exc}",),
+            warnings=(),
+        )
+
+
+def _audit_episode(
+    episode: CanonicalMotionEpisode,
+    *,
+    stratum: MotionDecodeStratum,
+    contract: _MuJoCoContract,
+) -> MotionDecodeEpisodeAudit:
+    quaternion_norm = np.linalg.norm(episode.root_quaternion, axis=1)
+    quaternion_error = float(np.max(np.abs(quaternion_norm - 1.0)))
+    quaternion_dots = np.sum(
+        episode.root_quaternion[1:] * episode.root_quaternion[:-1], axis=1
+    )
+    sign_flips = int(np.count_nonzero(quaternion_dots < 0.0))
+    low_excess = np.maximum(contract.joint_lower - episode.joint_position, 0.0)
+    high_excess = np.maximum(episode.joint_position - contract.joint_upper, 0.0)
+    excess = np.maximum(low_excess, high_excess)
+    violation_fraction = float(np.count_nonzero(excess > 1e-6) / excess.size)
+    excess_max = float(np.max(excess))
+    speed = np.abs(episode.joint_velocity)
+    acceleration = np.abs(episode.joint_acceleration)
+    root_velocity = np.gradient(episode.root_position, 1.0 / episode.sample_rate_hz, axis=0)
+    root_speed = np.linalg.norm(root_velocity, axis=1)
+    differences = np.max(np.abs(np.diff(episode.joint_position, axis=0)), axis=1)
+    root_differences = np.max(np.abs(np.diff(episode.root_position, axis=0)), axis=1)
+    duplicate_fraction = float(np.mean((differences < 1e-9) & (root_differences < 1e-9)))
+    clean_spans = clean_motiondecode_spans(
+        episode,
+        joint_lower=contract.joint_lower,
+        joint_upper=contract.joint_upper,
+    )
+    clean_frames = sum(stop - start for start, stop in clean_spans)
+    clean_window_count = sum(max(0, 1 + (stop - start - 32) // 16) for start, stop in clean_spans)
+    clean_fraction = clean_frames / episode.frame_count
+    maximum_clean = max((stop - start for start, stop in clean_spans), default=0)
+    geometry = _mujoco_geometry(episode, contract)
+    errors: list[str] = []
+    warnings: list[str] = []
+    if quaternion_error > 0.10:
+        errors.append("quaternion_norm_error_gt_0p10")
+    elif quaternion_error > 0.02:
+        warnings.append("quaternion_norm_error_gt_0p02")
+    if violation_fraction > 0.01 or excess_max > 0.25:
+        warnings.append("joint_limit_frames_excluded_from_clean_windows")
+    elif violation_fraction > 0.0:
+        warnings.append("minor_joint_limit_violation")
+    joint_speed_max = float(np.max(speed))
+    root_speed_max = float(np.max(root_speed))
+    if joint_speed_max > 50.0:
+        warnings.append("joint_speed_spikes_segmented")
+    elif joint_speed_max > 25.0:
+        warnings.append("joint_speed_gt_25_rad_s")
+    if root_speed_max > 12.0:
+        warnings.append("root_position_jumps_segmented")
+    elif root_speed_max > 6.0:
+        warnings.append("root_speed_gt_6_m_s")
+    if duplicate_fraction > 0.95:
+        warnings.append("mostly_duplicate_frames")
+    if not geometry["finite"]:
+        errors.append("mujoco_geometry_non_finite")
+    penetration = float(geometry["penetration_depth_max_m"])
+    if penetration > 0.08:
+        warnings.append("root_height_alignment_required_gt_0p08_m")
+    elif penetration > 0.03:
+        warnings.append("mujoco_penetration_gt_0p03_m")
+    if clean_window_count == 0:
+        errors.append("no_continuous_32_frame_training_window")
+    elif clean_fraction < 0.50:
+        errors.append("clean_frame_fraction_lt_0p50")
+    repair_eligible = bool(clean_window_count) and bool(geometry["finite"])
+    training_eligible = not errors
+    return MotionDecodeEpisodeAudit(
+        relative_path=episode.relative_path.as_posix(),
+        stratum=stratum.value,
+        source_hash=episode.source_hash,
+        frame_count=episode.frame_count,
+        duration_sec=float(episode.time_sec[-1]),
+        finite=True,
+        quaternion_norm_error_max=quaternion_error,
+        quaternion_sign_flip_count=sign_flips,
+        joint_limit_violation_fraction=violation_fraction,
+        joint_limit_excess_max_rad=excess_max,
+        joint_speed_p99_rad_s=float(np.quantile(speed, 0.99)),
+        joint_speed_max_rad_s=joint_speed_max,
+        joint_acceleration_p99_rad_s2=float(np.quantile(acceleration, 0.99)),
+        root_speed_max_m_s=root_speed_max,
+        duplicate_frame_fraction=duplicate_fraction,
+        clean_window_count=clean_window_count,
+        clean_frame_fraction=clean_fraction,
+        maximum_clean_window_frames=maximum_clean,
+        mujoco_frames_checked=int(geometry["frames_checked"]),
+        mujoco_finite=bool(geometry["finite"]),
+        contact_frame_fraction=float(geometry["contact_frame_fraction"]),
+        penetration_depth_max_m=penetration,
+        qualification="Q1_KINEMATIC_ONLY" if training_eligible else "Q0_INVALID",
+        training_eligible=training_eligible,
+        repair_eligible=repair_eligible,
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )
+
+
+def _load_mujoco_contract(model_path: Path) -> _MuJoCoContract:
+    import mujoco
+
+    path = model_path.expanduser().resolve()
+    if not path.is_file() or path.is_symlink():
+        raise ValueError("G1 MuJoCo model must be a regular non-symlink file")
+    model = mujoco.MjModel.from_xml_path(str(path))
+    data = mujoco.MjData(model)
+    ids = np.asarray(
+        [mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name) for name in G1_DDS_JOINT_NAMES],
+        dtype=np.int32,
+    )
+    if np.any(ids < 0):
+        raise ValueError("G1 MuJoCo model does not contain all MotionDecode joints")
+    names = tuple(
+        str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, int(index))) for index in ids
+    )
+    if names != G1_DDS_JOINT_NAMES:
+        raise ValueError("G1 MuJoCo joint order does not match MotionDecode")
+    limited = model.jnt_limited[ids].astype(bool)
+    if not np.all(limited):
+        raise ValueError("G1 MuJoCo joint limits are incomplete")
+    qpos = model.jnt_qposadr[ids].astype(np.int32)
+    robot_body_ids = frozenset(_descendants(model, 1))
+    ground_geom_ids = frozenset(
+        index for index in range(model.ngeom) if int(model.geom_bodyid[index]) == 0
+    )
+    model_hash = hash_bytes(path.read_bytes())
+    body_hash = hash_json(
+        {
+            "model_hash": model_hash,
+            "joint_names": names,
+            "joint_lower": model.jnt_range[ids, 0].tolist(),
+            "joint_upper": model.jnt_range[ids, 1].tolist(),
+        }
+    )
+    return _MuJoCoContract(
+        model=model,
+        data=data,
+        qpos_addresses=qpos,
+        joint_lower=np.asarray(model.jnt_range[ids, 0], dtype=np.float64),
+        joint_upper=np.asarray(model.jnt_range[ids, 1], dtype=np.float64),
+        robot_body_ids=robot_body_ids,
+        ground_geom_ids=ground_geom_ids,
+        body_hash=body_hash,
+        model_hash=model_hash,
+    )
+
+
+def _mujoco_geometry(
+    episode: CanonicalMotionEpisode,
+    contract: _MuJoCoContract,
+) -> dict[str, float | int | bool]:
+    import mujoco
+
+    frames = np.unique(np.linspace(0, episode.frame_count - 1, num=min(16, episode.frame_count), dtype=int))
+    contact_frames = 0
+    maximum_penetration = 0.0
+    finite = True
+    root_xy = episode.root_position[0, :2]
+    for frame in frames:
+        mujoco.mj_resetData(contract.model, contract.data)
+        root = episode.root_position[frame].copy()
+        root[:2] -= root_xy
+        quaternion = episode.root_quaternion[frame]
+        norm = float(np.linalg.norm(quaternion))
+        if norm <= 1e-12 or not math.isfinite(norm):
+            finite = False
+            continue
+        contract.data.qpos[:3] = root
+        contract.data.qpos[3:7] = quaternion / norm
+        contract.data.qpos[contract.qpos_addresses] = episode.joint_position[frame]
+        mujoco.mj_forward(contract.model, contract.data)
+        finite = finite and bool(
+            np.all(np.isfinite(contract.data.qpos))
+            and np.all(np.isfinite(contract.data.xpos))
+        )
+        grounded = False
+        for contact_index in range(contract.data.ncon):
+            contact = contract.data.contact[contact_index]
+            geom1 = int(contact.geom1)
+            geom2 = int(contact.geom2)
+            body1 = int(contract.model.geom_bodyid[geom1])
+            body2 = int(contract.model.geom_bodyid[geom2])
+            ground_robot = (
+                geom1 in contract.ground_geom_ids and body2 in contract.robot_body_ids
+            ) or (geom2 in contract.ground_geom_ids and body1 in contract.robot_body_ids)
+            if ground_robot:
+                grounded = True
+                maximum_penetration = max(maximum_penetration, max(0.0, -float(contact.dist)))
+        contact_frames += int(grounded)
+    return {
+        "frames_checked": len(frames),
+        "finite": finite,
+        "contact_frame_fraction": contact_frames / len(frames),
+        "penetration_depth_max_m": maximum_penetration,
+    }
+
+
+def _descendants(model: Any, root_body: int) -> tuple[int, ...]:
+    values = []
+    for body in range(model.nbody):
+        current = body
+        while current > 0 and current != root_body:
+            current = int(model.body_parentid[current])
+        if current == root_body:
+            values.append(body)
+    return tuple(values)
+
+
+def _aggregate(episodes: list[MotionDecodeEpisodeAudit]) -> dict[str, Any]:
+    eligible = [item for item in episodes if item.training_eligible]
+    frame_counts = [item.frame_count for item in episodes if item.frame_count]
+    durations = [item.duration_sec for item in episodes if item.frame_count]
+    return {
+        "episode_count": len(episodes),
+        "training_eligible_count": len(eligible),
+        "training_eligible_fraction": len(eligible) / max(1, len(episodes)),
+        "q0_invalid_count": sum(item.qualification == "Q0_INVALID" for item in episodes),
+        "q1_kinematic_only_count": sum(
+            item.qualification == "Q1_KINEMATIC_ONLY" for item in episodes
+        ),
+        "q2_or_higher_count": 0,
+        "total_frames": sum(frame_counts),
+        "clean_training_window_count": sum(item.clean_window_count for item in episodes),
+        "clean_frame_fraction_weighted": (
+            sum(
+                item.frame_count * float(item.clean_frame_fraction or 0.0)
+                for item in episodes
+            )
+            / max(1, sum(frame_counts))
+        ),
+        "total_duration_sec": sum(durations),
+        "frame_count_median": float(np.median(frame_counts)) if frame_counts else 0.0,
+        "duration_sec_median": float(np.median(durations)) if durations else 0.0,
+        "episodes_with_joint_limit_warning_or_error": sum(
+            bool(item.joint_limit_violation_fraction) for item in episodes
+        ),
+        "episodes_with_mujoco_contact": sum(
+            bool(item.contact_frame_fraction) for item in episodes
+        ),
+        "source_hash_commitment": hash_json(
+            [item.source_hash for item in episodes if item.source_hash is not None]
+        ),
+        "qualification_ceiling": "Q1_KINEMATIC_ONLY",
+    }
+
+
+def clean_motiondecode_spans(
+    episode: CanonicalMotionEpisode,
+    *,
+    joint_lower: np.ndarray,
+    joint_upper: np.ndarray,
+    minimum_frames: int = 32,
+) -> tuple[tuple[int, int], ...]:
+    """Return half-open, physically continuous spans for representation learning.
+
+    This does not repair or relabel frames.  It excludes reset boundaries,
+    non-unit quaternions, joint-limit excursions, and implausible 120 Hz
+    derivatives, so a long clip can contribute clean windows without teaching
+    the network its capture discontinuities.
+    """
+
+    if minimum_frames < 2:
+        raise ValueError("clean MotionDecode span must contain at least two frames")
+    quaternion_error = np.abs(np.linalg.norm(episode.root_quaternion, axis=1) - 1.0)
+    in_limits = np.all(
+        (episode.joint_position >= joint_lower - 1e-4)
+        & (episode.joint_position <= joint_upper + 1e-4),
+        axis=1,
+    )
+    frame_valid = (quaternion_error <= 0.02) & in_limits
+    root_step_speed = (
+        np.linalg.norm(np.diff(episode.root_position, axis=0), axis=1) * episode.sample_rate_hz
+    )
+    joint_step_speed = (
+        np.max(np.abs(np.diff(episode.joint_position, axis=0)), axis=1)
+        * episode.sample_rate_hz
+    )
+    edge_valid = (root_step_speed <= 8.0) & (joint_step_speed <= 25.0)
+    spans: list[tuple[int, int]] = []
+    start: int | None = None
+    for frame in range(episode.frame_count):
+        valid = bool(frame_valid[frame]) and (frame == 0 or bool(edge_valid[frame - 1]))
+        if valid and start is None:
+            start = frame
+        if not valid and start is not None:
+            if frame - start >= minimum_frames:
+                spans.append((start, frame))
+            start = None
+    if start is not None and episode.frame_count - start >= minimum_frames:
+        spans.append((start, episode.frame_count))
+    return tuple(spans)
+
+
+def _external_output(path: Path, source_checkout: Path) -> Path:
+    target = path.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if target == checkout or checkout in target.parents:
+        raise ValueError("MotionDecode evidence output must be outside the source checkout")
+    return target
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)

--- a/src/rosclaw/collective/sources/motiondecode/license.py
+++ b/src/rosclaw/collective/sources/motiondecode/license.py
@@ -1,0 +1,66 @@
+"""Fail-closed interpretation of the custom ChingMu access terms."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+_MAX_LICENSE_BYTES = 1024 * 1024
+_ALLOWED_USAGE = {"research", "personal-study", "noncommercial-prototype"}
+
+
+@dataclass(frozen=True)
+class MotionDecodeLicenseDecision:
+    license_file: str
+    license_hash: str
+    requested_usage: str
+    permitted: bool
+    commercial_use_status: str
+    attribution_required: bool
+    redistribution_permitted: bool
+    warnings: tuple[str, ...]
+    schema_version: str = "rosclaw.collective.motiondecode_license.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def inspect_motiondecode_license(
+    dataset_root: Path,
+    *,
+    requested_usage: str,
+) -> MotionDecodeLicenseDecision:
+    root = dataset_root.expanduser().resolve()
+    usage = requested_usage.strip().lower()
+    warnings: list[str] = []
+    advertised = root / "LICENSE"
+    terms = root / "LICENSE.md"
+    if advertised.is_file() and advertised.stat().st_size == 0:
+        warnings.append("README license_link points to empty LICENSE; using non-empty LICENSE.md")
+    if not terms.is_file() or terms.is_symlink():
+        raise ValueError("MotionDecode LICENSE.md is missing or unsafe")
+    size = terms.stat().st_size
+    if not 1 <= size <= _MAX_LICENSE_BYTES:
+        raise ValueError("MotionDecode LICENSE.md is empty or too large")
+    payload = terms.read_bytes()
+    text = payload.decode("utf-8")
+    required_phrases = (
+        "non-commercial",
+        "Prohibited without written permission",
+        "retain attribution",
+    )
+    if any(phrase not in text for phrase in required_phrases):
+        raise ValueError("MotionDecode access terms do not match the reviewed contract")
+    permitted = usage in _ALLOWED_USAGE
+    return MotionDecodeLicenseDecision(
+        license_file="LICENSE.md",
+        license_hash="sha256:" + hashlib.sha256(payload).hexdigest(),
+        requested_usage=usage,
+        permitted=permitted,
+        commercial_use_status="WRITTEN_PERMISSION_REQUIRED",
+        attribution_required=True,
+        redistribution_permitted=False,
+        warnings=tuple(warnings),
+    )

--- a/src/rosclaw/collective/sources/motiondecode/manifest.py
+++ b/src/rosclaw/collective/sources/motiondecode/manifest.py
@@ -1,0 +1,241 @@
+"""Inventory and provenance manifest for a local MotionDecode snapshot."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from rosclaw.collective.capsule import ExperienceCapsule, SourceDescriptor
+from rosclaw.collective.sources.motiondecode.license import (
+    MotionDecodeLicenseDecision,
+    inspect_motiondecode_license,
+)
+
+_MAX_SOURCE_FILES = 2_000_000
+_MAX_INDEX_BYTES = 16 * 1024 * 1024
+_EXPECTED_REMOTE_PRIMARY = frozenset(
+    {
+        "1.1",
+        "1.2",
+        "1.3",
+        "1.4",
+        "1.5",
+        "1.6",
+        "1.7",
+        "1.8",
+        "1.9",
+        "1.10",
+        "1.11",
+        "1.12",
+        "1.13",
+        "1.14",
+        "2.1",
+        "2.2",
+        "2.3",
+        "2.4",
+        "3.1",
+        "3.2",
+        "3.3",
+        "4",
+        "5",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MotionDecodeSourceManifest:
+    source: SourceDescriptor
+    license: MotionDecodeLicenseDecision
+    csv_file_count: int
+    csv_total_bytes: int
+    local_primary_categories: tuple[str, ...]
+    indexed_primary_categories: tuple[str, ...]
+    absent_indexed_categories: tuple[str, ...]
+    expected_remote_categories_absent: tuple[str, ...]
+    football_files: int
+    object_pose_files: int
+    video_files: int
+    semantic_label_files: int
+    local_snapshot_complete: bool
+    safe_to_read: bool
+    capsule: ExperienceCapsule
+    warnings: tuple[str, ...]
+    schema_version: str = "rosclaw.collective.motiondecode_source_manifest.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def inspect_motiondecode_source(
+    dataset_root: Path,
+    *,
+    revision: str,
+    requested_usage: str = "research",
+) -> tuple[MotionDecodeSourceManifest, tuple[Path, ...]]:
+    """Inspect without loading motion payloads or trusting README claims."""
+
+    if not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise ValueError("MotionDecode revision must be a full git commit")
+    root = dataset_root.expanduser().resolve()
+    samples = root / "samples"
+    if not root.is_dir() or not samples.is_dir() or samples.is_symlink():
+        raise ValueError("MotionDecode root must contain a non-symlink samples directory")
+    license_decision = inspect_motiondecode_license(root, requested_usage=requested_usage)
+    if not license_decision.permitted:
+        raise ValueError("requested MotionDecode usage is not permitted by the local terms")
+
+    paths: list[Path] = []
+    total_bytes = 0
+    other_counts = {"object": 0, "video": 0, "labels": 0}
+    inventory = hashlib.sha256()
+    for directory, names, files in os.walk(samples, followlinks=False):
+        directory_path = Path(directory)
+        names[:] = sorted(
+            name for name in names if not (directory_path / name).is_symlink()
+        )
+        for name in sorted(files):
+            path = directory_path / name
+            if path.is_symlink() or not path.is_file():
+                raise ValueError(f"unsafe MotionDecode payload: {path.relative_to(root)}")
+            relative = path.relative_to(root)
+            suffix = path.suffix.lower()
+            if suffix == ".csv":
+                paths.append(relative)
+                size = path.stat().st_size
+                total_bytes += size
+                inventory.update(relative.as_posix().encode())
+                inventory.update(b"\0")
+                inventory.update(str(size).encode())
+                inventory.update(b"\n")
+            elif suffix in {".mp4", ".mov", ".mkv"}:
+                other_counts["video"] += 1
+            elif suffix in {".json", ".jsonl"}:
+                other_counts["labels"] += 1
+            if suffix == ".csv" and _looks_like_object_pose(relative):
+                other_counts["object"] += 1
+            if len(paths) > _MAX_SOURCE_FILES:
+                raise ValueError("MotionDecode source exceeds the bounded file-count ceiling")
+    if not paths:
+        raise ValueError("MotionDecode source contains no CSV payloads")
+    paths.sort(key=Path.as_posix)
+    inventory_hash = "sha256:" + inventory.hexdigest()
+
+    # Preserve numeric labels exactly (1.10 must not collapse to 1.1).
+    local_primary = tuple(sorted({_category_label(path.parts[1]) for path in paths}))
+    indexed = _indexed_primary_categories(root / "metadata" / "index.csv")
+    absent_indexed = tuple(sorted(set(indexed) - set(local_primary)))
+    expected_absent = tuple(sorted(_EXPECTED_REMOTE_PRIMARY - set(local_primary)))
+    football_files = sum(
+        "football" in path.as_posix().lower() or "ball_game" in path.as_posix().lower()
+        for path in paths
+    )
+    warnings = list(license_decision.warnings)
+    if absent_indexed:
+        warnings.append("local samples omit categories declared by metadata/index.csv")
+    if football_files == 0:
+        warnings.append("no local Football or Ball_Game CSV is available")
+    if not other_counts["object"]:
+        warnings.append("no synchronized object-pose CSV was identified")
+    if not other_counts["video"]:
+        warnings.append("no local multi-view video payload was identified")
+    if not other_counts["labels"]:
+        warnings.append("no local per-episode semantic label payload was identified")
+    source = SourceDescriptor(
+        provider="ChingMu",
+        dataset="CMRobot/MotionDecode",
+        revision=revision,
+        inventory_hash=inventory_hash,
+        license_hash=license_decision.license_hash,
+        attribution="Motion data from ChingMu (CMRobot/MotionDecode)",
+        # A ModelScope/HF materialized folder has no local commit binding.  A
+        # remote HEAD observation must never be represented as content proof.
+        revision_binding="UNVERIFIED_LOCAL_SNAPSHOT",
+    )
+    capsule = ExperienceCapsule(
+        source=source,
+        source_body="human_optical_mocap_retargeted_to_unitree_g1",
+        target_body="unitree_g1_29dof",
+        target_body_mapping="header_exact_joint_name_mapping_pending_body_hash",
+        task_semantics=tuple(sorted({path.parts[-2] for path in paths})),
+        observation_semantics=(
+            "root_position_m",
+            "root_quaternion_wxyz",
+            "joint_position_rad",
+            "implicit_time_120hz",
+        ),
+        action_semantics=(),
+        modalities=("kinematic_trajectory",),
+        quality="UNVERIFIED_LOCAL_SNAPSHOT",
+        truth_level="T4",
+        applicability="MOTION_REFERENCE_ONLY_PENDING_KINEMATIC_AUDIT",
+        training_eligible=False,
+    )
+    complete = not expected_absent and not absent_indexed
+    return (
+        MotionDecodeSourceManifest(
+            source=source,
+            license=license_decision,
+            csv_file_count=len(paths),
+            csv_total_bytes=total_bytes,
+            local_primary_categories=local_primary,
+            indexed_primary_categories=indexed,
+            absent_indexed_categories=absent_indexed,
+            expected_remote_categories_absent=expected_absent,
+            football_files=football_files,
+            object_pose_files=other_counts["object"],
+            video_files=other_counts["video"],
+            semantic_label_files=other_counts["labels"],
+            local_snapshot_complete=complete,
+            safe_to_read=True,
+            capsule=capsule,
+            warnings=tuple(warnings),
+        ),
+        tuple(paths),
+    )
+
+
+def manifest_hash(manifest: MotionDecodeSourceManifest) -> str:
+    payload = json.dumps(
+        manifest.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _category_label(directory_name: str) -> str:
+    match = re.match(r"^(\d+(?:\.\d+)?)\.", directory_name)
+    return match.group(1) if match else directory_name
+
+
+def _looks_like_object_pose(relative_path: Path) -> bool:
+    """Avoid confusing an action *about* an object with an object-pose stream."""
+
+    value = relative_path.as_posix().lower()
+    return any(token in value for token in ("object_pose", "object_6d", "6dop", "6d_pose"))
+
+
+def _indexed_primary_categories(index_path: Path) -> tuple[str, ...]:
+    if not index_path.is_file() or index_path.is_symlink():
+        raise ValueError("MotionDecode metadata/index.csv is missing or unsafe")
+    if not 1 <= index_path.stat().st_size <= _MAX_INDEX_BYTES:
+        raise ValueError("MotionDecode metadata/index.csv is empty or too large")
+    labels: set[str] = set()
+    with index_path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        if not reader.fieldnames or "Label" not in reader.fieldnames:
+            raise ValueError("MotionDecode index does not contain the Label column")
+        for row in reader:
+            label = (row.get("Label") or "").strip()
+            match = re.match(r"^(\d+(?:\.\d+)?)", label)
+            if match:
+                value = match.group(1)
+                parts = value.split(".")
+                labels.add(".".join(parts[:2]) if len(parts) > 1 else parts[0])
+    if not labels:
+        raise ValueError("MotionDecode index contains no parseable labels")
+    return tuple(sorted(labels))

--- a/src/rosclaw/collective/sources/motiondecode/motion_prior.py
+++ b/src/rosclaw/collective/sources/motiondecode/motion_prior.py
@@ -1,0 +1,658 @@
+"""Self-supervised G1 motion representation learned from audited kinematics.
+
+MotionDecode has no motor torque or reward labels.  This module therefore
+learns only a recurrent next-proprioception representation.  The representation
+may initialize the joint state and projected-gravity columns of the SIM_ONLY torque actor;
+it is never interpreted as an action policy or promotion evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch  # type: ignore[import-not-found]
+from torch import nn  # type: ignore[import-not-found]
+
+from rosclaw.collective.sources.motiondecode.audit import (
+    _load_mujoco_contract,
+    clean_motiondecode_spans,
+)
+from rosclaw.collective.sources.motiondecode.parser import parse_motiondecode_csv
+from rosclaw.simforge.g1_neural_torque import G1_NEURAL_TORQUE_OBSERVATIONS
+from rosclaw.simforge.tasks.g1_goalforge.concepts import hash_bytes, hash_json
+
+G1_MOTION_PRIOR_FEATURES = G1_NEURAL_TORQUE_OBSERVATIONS[:61]
+G1_MOTION_PRIOR_FEATURE_DIM = len(G1_MOTION_PRIOR_FEATURES)
+_PACK_SCHEMA = "rosclaw.collective.motiondecode_motion_prior_pack.v1"
+_ARTIFACT_SCHEMA = "rosclaw.collective.g1_motion_prior.v1"
+_MAX_REPORT_BYTES = 128 * 1024 * 1024
+_MAX_PACK_BYTES = 2 * 1024 * 1024 * 1024
+_MAX_ARTIFACT_BYTES = 128 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class G1MotionPriorMetrics:
+    epoch: int
+    training_loss: float
+    validation_loss: float
+    persistence_baseline_loss: float
+    validation_improvement_fraction: float
+    finite: bool
+    schema_version: str = "rosclaw.collective.g1_motion_prior_metrics.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class G1MotionPriorArtifact:
+    artifact_hash: str
+    weights_hash: str
+    pack_hash: str
+    pilot_report_hash: str
+    body_hash: str
+    feature_names: tuple[str, ...]
+    hidden_dim: int
+    sequence_length: int
+    observation_mean: np.ndarray
+    observation_std: np.ndarray
+    tensors: dict[str, np.ndarray]
+    source_truth_level: str
+    action_semantics: str
+    activation_ceiling: str
+    schema_version: str = _ARTIFACT_SCHEMA
+
+
+class _MotionPredictor(nn.Module):
+    def __init__(self, *, hidden_dim: int) -> None:
+        super().__init__()
+        self.gru = nn.GRU(len(G1_MOTION_PRIOR_FEATURES), hidden_dim, batch_first=True)
+        self.head = nn.Linear(hidden_dim, len(G1_MOTION_PRIOR_FEATURES))
+        nn.init.zeros_(self.head.weight)
+        nn.init.zeros_(self.head.bias)
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        encoded, _ = self.gru(value)
+        # At initialization this is exactly the strong 120 Hz persistence
+        # baseline.  Learning is limited to a recurrent state delta.
+        return value + self.head(encoded)
+
+
+def build_motion_prior_pack(
+    *,
+    pilot_report_path: Path,
+    dataset_root: Path,
+    model_path: Path,
+    output_path: Path,
+    sequence_length: int = 32,
+    maximum_windows: int = 12_000,
+    seed: int = 20260801,
+    allowed_strata: tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    if not 8 <= sequence_length <= 256:
+        raise ValueError("motion-prior sequence length must be in [8, 256]")
+    if not 8 <= maximum_windows <= 100_000:
+        raise ValueError("motion-prior window limit must be in [8, 100000]")
+    report_path = pilot_report_path.expanduser().resolve()
+    report = _bounded_json(report_path, _MAX_REPORT_BYTES)
+    if report.get("schema_version") != "rosclaw.collective.motiondecode_pilot.v1":
+        raise ValueError("motion-prior pack requires a MotionDecode pilot v1 report")
+    if not report.get("pipeline_passed") or report.get("decision") != "MOTION_PRIOR_ONLY":
+        raise ValueError("motion-prior pack requires a passed MOTION_PRIOR_ONLY pilot")
+    if report.get("raw_data_exported") is not False:
+        raise ValueError("MotionDecode pilot raw-data claim is missing or unsafe")
+    contract = _load_mujoco_contract(model_path)
+    if report.get("kinematic_body_hash") != contract.body_hash:
+        raise ValueError("MotionDecode pilot kinematic body hash does not match the requested model")
+    root = dataset_root.expanduser().resolve()
+    episode_records = report.get("episodes")
+    if not isinstance(episode_records, list):
+        raise ValueError("MotionDecode pilot episodes are missing")
+    allowed = set(allowed_strata or ())
+    known_strata = {
+        "football",
+        "balance_proxy",
+        "gait",
+        "transition_recovery",
+        "coordination_supplement",
+        "other",
+    }
+    if allowed and (not allowed.issubset(known_strata) or not all(allowed_strata or ())):
+        raise ValueError("motion-prior pack contains an unknown or empty stratum")
+
+    candidates: list[tuple[str, str, int, str]] = []
+    episode_hashes: dict[str, str] = {}
+    audited: list[tuple[str, str, tuple[tuple[int, int], ...], str]] = []
+    for record in episode_records:
+        if not isinstance(record, dict) or not record.get("training_eligible"):
+            continue
+        if allowed and str(record.get("stratum", "")) not in allowed:
+            continue
+        relative = str(record.get("relative_path", ""))
+        expected_hash = str(record.get("source_hash", ""))
+        episode = parse_motiondecode_csv(root / relative, dataset_root=root)
+        if episode.source_hash != expected_hash:
+            raise ValueError(f"MotionDecode pilot payload changed after audit: {relative}")
+        episode_hashes[relative] = expected_hash
+        spans = clean_motiondecode_spans(
+            episode,
+            joint_lower=contract.joint_lower,
+            joint_upper=contract.joint_upper,
+            minimum_frames=sequence_length + 1,
+        )
+        episode_split_hash = hashlib.sha256(f"{expected_hash}:{relative}".encode()).hexdigest()
+        audited.append((relative, expected_hash, spans, episode_split_hash))
+    if len(audited) < 2:
+        raise ValueError("motion-prior pack requires at least two source episodes")
+    validation_episode_count = max(1, round(len(audited) * 0.2))
+    validation_paths = {
+        item[0] for item in sorted(audited, key=lambda item: item[3])[:validation_episode_count]
+    }
+    for relative, expected_hash, spans, _ in audited:
+        split = "validation" if relative in validation_paths else "training"
+        for span_start, span_stop in spans:
+            for start in range(span_start, span_stop - sequence_length, 16):
+                score = hashlib.sha256(
+                    f"{seed}:{expected_hash}:{relative}:{start}".encode()
+                ).hexdigest()
+                candidates.append((score, relative, start, split))
+    if not candidates:
+        raise ValueError("MotionDecode pilot produced no clean motion-prior windows")
+    training_target = int(maximum_windows * 0.8)
+    validation_target = maximum_windows - training_target
+    selected = [
+        *sorted(item for item in candidates if item[3] == "training")[:training_target],
+        *sorted(item for item in candidates if item[3] == "validation")[:validation_target],
+    ]
+    if sum(item[3] == "training" for item in selected) < 4:
+        raise ValueError("motion-prior pack has too few training windows")
+    if sum(item[3] == "validation" for item in selected) < 1:
+        raise ValueError("motion-prior pack has too few validation windows")
+
+    by_path: dict[str, list[tuple[int, str, str]]] = {}
+    for score, relative, start, split in selected:
+        by_path.setdefault(relative, []).append((start, split, score))
+    values: dict[str, list[np.ndarray]] = {"training": [], "validation": []}
+    selection_commitment: list[dict[str, Any]] = []
+    for relative, starts in sorted(by_path.items()):
+        episode = parse_motiondecode_csv(root / relative, dataset_root=root)
+        for start, split, score in starts:
+            positions = episode.joint_position[start : start + sequence_length + 1]
+            velocities = np.gradient(positions, 1.0 / episode.sample_rate_hz, axis=0)
+            gravity = _projected_gravity(
+                episode.root_quaternion[start : start + sequence_length + 1]
+            )
+            feature = np.concatenate((positions, velocities, gravity), axis=1).astype(np.float32)
+            if feature.shape != (sequence_length + 1, len(G1_MOTION_PRIOR_FEATURES)):
+                raise ValueError("motion-prior feature window has the wrong shape")
+            if not np.all(np.isfinite(feature)):
+                raise ValueError("motion-prior feature window is non-finite")
+            values[split].append(feature)
+            selection_commitment.append(
+                {"episode_hash": episode_hashes[relative], "start": start, "split": split, "score": score}
+            )
+    training = np.asarray(values["training"], dtype=np.float32)
+    validation = np.asarray(values["validation"], dtype=np.float32)
+    mean = training.reshape(-1, training.shape[-1]).mean(axis=0).astype(np.float32)
+    std = np.maximum(
+        training.reshape(-1, training.shape[-1]).std(axis=0), 1e-3
+    ).astype(np.float32)
+    training = np.clip((training - mean) / std, -10.0, 10.0).astype(np.float32)
+    validation = np.clip((validation - mean) / std, -10.0, 10.0).astype(np.float32)
+    output = output_path.expanduser().resolve()
+    if output.exists() or output.with_suffix(".json").exists():
+        raise FileExistsError("motion-prior pack output already exists")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_npz(
+        output,
+        training=training,
+        validation=validation,
+        observation_mean=mean,
+        observation_std=std,
+    )
+    pack_hash = hash_bytes(output.read_bytes())
+    metadata = {
+        "schema_version": _PACK_SCHEMA,
+        "pack_hash": pack_hash,
+        "pilot_report_hash": hash_bytes(report_path.read_bytes()),
+        "source_manifest_hash": report["source_manifest_hash"],
+        "body_hash": report["body_hash"],
+        "kinematic_body_hash": contract.body_hash,
+        "feature_names": list(G1_MOTION_PRIOR_FEATURES),
+        "sequence_length": sequence_length,
+        "training_windows": len(training),
+        "validation_windows": len(validation),
+        "source_episode_count": len(by_path),
+        "allowed_strata": sorted(allowed) if allowed else ["all"],
+        "selection_commitment": hash_json(selection_commitment),
+        "source_truth_level": "T4",
+        "action_semantics": "ABSENT",
+        "reward_semantics": "ABSENT",
+        "raw_data_exported": False,
+        "redistribution_permitted": False,
+    }
+    _atomic_json(output.with_suffix(".json"), metadata)
+    return metadata
+
+
+def train_motion_prior_worker(
+    *,
+    pack_path: Path,
+    output_dir: Path,
+    device: str,
+    seed: int,
+    epochs: int = 10,
+    hidden_dim: int = 96,
+    batch_size: int = 256,
+) -> dict[str, Any]:
+    if not 2 <= epochs <= 100 or not 8 <= hidden_dim <= 1024 or batch_size <= 0:
+        raise ValueError("invalid motion-prior learner configuration")
+    pack, metadata = _load_pack(pack_path)
+    torch.manual_seed(seed)
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        raise RuntimeError("CUDA motion-prior worker requested without CUDA")
+    target = torch.device(device)
+    model = _MotionPredictor(hidden_dim=hidden_dim).to(target)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=3e-4, weight_decay=1e-5)
+    training = pack["training"]
+    validation = pack["validation"]
+    rng = np.random.default_rng(seed)
+    baseline = _smooth_l1_numpy(validation[:, :-1] - validation[:, 1:])
+    metrics: list[G1MotionPriorMetrics] = []
+    for epoch in range(epochs):
+        order = rng.permutation(len(training))
+        losses: list[float] = []
+        model.train()
+        for offset in range(0, len(order), batch_size):
+            batch = torch.as_tensor(
+                training[order[offset : offset + batch_size]],
+                dtype=torch.float32,
+                device=target,
+            )
+            prediction = model(batch[:, :-1])
+            loss = torch.nn.functional.smooth_l1_loss(prediction, batch[:, 1:])
+            optimizer.zero_grad(set_to_none=True)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 5.0)
+            optimizer.step()
+            losses.append(float(loss.detach().item()))
+        validation_loss = _validation_loss(model, validation, target, batch_size)
+        training_loss = float(sum(losses) / len(losses))
+        metrics.append(
+            G1MotionPriorMetrics(
+                epoch=epoch,
+                training_loss=training_loss,
+                validation_loss=validation_loss,
+                persistence_baseline_loss=baseline,
+                validation_improvement_fraction=(baseline - validation_loss) / max(baseline, 1e-12),
+                finite=all(math.isfinite(value) for value in (training_loss, validation_loss)),
+            )
+        )
+    output = output_dir.expanduser().resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    state = model.state_dict()
+    tensor_values = {
+        "gru.weight_ih_l0": state["gru.weight_ih_l0"].detach().cpu().numpy(),
+        "gru.weight_hh_l0": state["gru.weight_hh_l0"].detach().cpu().numpy(),
+        "gru.bias_ih_l0": state["gru.bias_ih_l0"].detach().cpu().numpy(),
+        "gru.bias_hh_l0": state["gru.bias_hh_l0"].detach().cpu().numpy(),
+        "head.weight": state["head.weight"].detach().cpu().numpy(),
+        "head.bias": state["head.bias"].detach().cpu().numpy(),
+        "observation_mean": pack["observation_mean"],
+        "observation_std": pack["observation_std"],
+    }
+    weights_path = output / "motion-prior-weights.npz"
+    _atomic_npz(weights_path, **tensor_values)
+    weights_hash = hash_bytes(weights_path.read_bytes())
+    artifact = {
+        "schema_version": _ARTIFACT_SCHEMA,
+        "weights_file": weights_path.name,
+        "weights_hash": weights_hash,
+        "pack_hash": metadata["pack_hash"],
+        "pilot_report_hash": metadata["pilot_report_hash"],
+        "body_hash": metadata["body_hash"],
+        "feature_names": list(G1_MOTION_PRIOR_FEATURES),
+        "hidden_dim": hidden_dim,
+        "sequence_length": metadata["sequence_length"],
+        "source_truth_level": "T4",
+        "objective": "SELF_SUPERVISED_NEXT_PROPRIOCEPTION",
+        "action_semantics": "ABSENT",
+        "activation_ceiling": "SIM_ONLY_REPRESENTATION_INITIALIZATION",
+        "hardware_authorized": False,
+        "promotion_evidence_eligible": False,
+        "seed": seed,
+        "device": str(target),
+        "device_name": torch.cuda.get_device_name(target) if target.type == "cuda" else "cpu",
+        "metrics": [value.to_dict() for value in metrics],
+    }
+    artifact["artifact_hash"] = hash_json(artifact)
+    _atomic_json(output / "motion-prior-artifact.json", artifact)
+    return artifact
+
+
+def run_four_gpu_motion_prior(
+    *,
+    pack_path: Path,
+    output_dir: Path,
+    epochs: int = 10,
+    hidden_dim: int = 96,
+    batch_size: int = 256,
+    base_seed: int = 8200,
+) -> dict[str, Any]:
+    if torch.cuda.device_count() < 4:
+        raise RuntimeError("four-GPU motion-prior run requires four visible CUDA devices")
+    root = output_dir.expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=False)
+    processes: list[tuple[int, int, Path, subprocess.Popen[str]]] = []
+    for physical_gpu in range(4):
+        seed = base_seed + physical_gpu
+        worker_root = root / f"gpu-{physical_gpu}"
+        command = [
+            sys.executable,
+            "-m",
+            "rosclaw.collective.sources.motiondecode.motion_prior",
+            "worker",
+            "--pack",
+            str(pack_path.expanduser().resolve()),
+            "--output-dir",
+            str(worker_root),
+            "--device",
+            "cuda:0",
+            "--seed",
+            str(seed),
+            "--epochs",
+            str(epochs),
+            "--hidden-dim",
+            str(hidden_dim),
+            "--batch-size",
+            str(batch_size),
+        ]
+        environment = dict(os.environ)
+        environment["CUDA_VISIBLE_DEVICES"] = str(physical_gpu)
+        process = subprocess.Popen(
+            command,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        processes.append((physical_gpu, seed, worker_root, process))
+    workers: list[dict[str, Any]] = []
+    failures: list[str] = []
+    for physical_gpu, seed, worker_root, process in processes:
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            failures.append(f"gpu={physical_gpu},returncode={process.returncode},stderr={stderr[-1000:]}")
+            continue
+        try:
+            artifact = _bounded_json(
+                worker_root / "motion-prior-artifact.json", _MAX_REPORT_BYTES
+            )
+            metrics = artifact.get("metrics")
+            if (
+                artifact.get("schema_version") != _ARTIFACT_SCHEMA
+                or not isinstance(metrics, list)
+                or not metrics
+                or not isinstance(metrics[-1], dict)
+            ):
+                raise ValueError("worker artifact metadata is incomplete")
+            final = metrics[-1]
+            validation_loss = float(final["validation_loss"])
+            persistence_loss = float(final["persistence_baseline_loss"])
+            improvement = float(final["validation_improvement_fraction"])
+            if not all(
+                math.isfinite(value)
+                for value in (validation_loss, persistence_loss, improvement)
+            ):
+                raise ValueError("worker metrics are non-finite")
+        except (KeyError, OSError, TypeError, ValueError) as exc:
+            failures.append(f"gpu={physical_gpu},invalid_artifact={type(exc).__name__}:{exc}")
+            continue
+        workers.append(
+            {
+                "physical_gpu": physical_gpu,
+                "visible_device": "cuda:0",
+                "seed": seed,
+                "artifact_hash": artifact["artifact_hash"],
+                "artifact_path": str(worker_root / "motion-prior-artifact.json"),
+                "validation_loss": validation_loss,
+                "persistence_baseline_loss": persistence_loss,
+                "improvement_fraction": improvement,
+                "stdout": stdout.strip(),
+            }
+        )
+    selected = (
+        min(workers, key=lambda value: (value["validation_loss"], value["seed"]))
+        if workers
+        else None
+    )
+    quality_gate_passed = bool(
+        selected is not None
+        and math.isfinite(float(selected["validation_loss"]))
+        and float(selected["improvement_fraction"]) >= 0.02
+    )
+    report = {
+        "schema_version": "rosclaw.collective.g1_motion_prior_four_gpu.v1",
+        "pack_hash": _load_pack(pack_path)[1]["pack_hash"],
+        "requested_physical_gpus": [0, 1, 2, 3],
+        "workers": workers,
+        "failures": failures,
+        "selected": selected,
+        "four_physical_gpus_exercised": len(workers) == 4 and not failures,
+        "quality_gate": {
+            "metric": "held_out_episode_smooth_l1_vs_persistence",
+            "minimum_improvement_fraction": 0.02,
+            "passed": quality_gate_passed,
+        },
+        "decision": (
+            "REPRESENTATION_CANDIDATE"
+            if len(workers) == 4 and not failures and quality_gate_passed
+            else "REJECTED"
+        ),
+        "hardware_authorized": False,
+        "promotion_evidence_eligible": False,
+    }
+    _atomic_json(root / "four-gpu-report.json", report)
+    return report
+
+
+def load_g1_motion_prior_artifact(path: Path) -> G1MotionPriorArtifact:
+    metadata_path = path.expanduser().resolve()
+    metadata = _bounded_json(metadata_path, _MAX_ARTIFACT_BYTES)
+    if metadata.get("schema_version") != _ARTIFACT_SCHEMA:
+        raise ValueError("unsupported G1 motion-prior artifact")
+    committed = str(metadata.get("artifact_hash", ""))
+    unsigned = {key: value for key, value in metadata.items() if key != "artifact_hash"}
+    if committed != hash_json(unsigned):
+        raise ValueError("G1 motion-prior artifact metadata hash mismatch")
+    weights_path = metadata_path.parent / str(metadata.get("weights_file", ""))
+    if not weights_path.is_file() or weights_path.stat().st_size > _MAX_ARTIFACT_BYTES:
+        raise ValueError("G1 motion-prior weights are missing or too large")
+    if hash_bytes(weights_path.read_bytes()) != metadata.get("weights_hash"):
+        raise ValueError("G1 motion-prior weights hash mismatch")
+    with np.load(weights_path, allow_pickle=False) as archive:
+        tensors = {name: np.asarray(archive[name], dtype=np.float32) for name in archive.files}
+    hidden_dim = int(metadata.get("hidden_dim", 0))
+    expected = {
+        "gru.weight_ih_l0": (3 * hidden_dim, G1_MOTION_PRIOR_FEATURE_DIM),
+        "gru.weight_hh_l0": (3 * hidden_dim, hidden_dim),
+        "gru.bias_ih_l0": (3 * hidden_dim,),
+        "gru.bias_hh_l0": (3 * hidden_dim,),
+        "head.weight": (G1_MOTION_PRIOR_FEATURE_DIM, hidden_dim),
+        "head.bias": (G1_MOTION_PRIOR_FEATURE_DIM,),
+        "observation_mean": (G1_MOTION_PRIOR_FEATURE_DIM,),
+        "observation_std": (G1_MOTION_PRIOR_FEATURE_DIM,),
+    }
+    if set(tensors) != set(expected):
+        raise ValueError("G1 motion-prior tensor set is invalid")
+    for name, shape in expected.items():
+        if tensors[name].shape != shape or not np.all(np.isfinite(tensors[name])):
+            raise ValueError(f"G1 motion-prior tensor {name} is invalid")
+    if np.any(tensors["observation_std"] <= 1e-6):
+        raise ValueError("G1 motion-prior observation scale is invalid")
+    feature_names = tuple(metadata.get("feature_names", ()))
+    if feature_names != G1_MOTION_PRIOR_FEATURES:
+        raise ValueError("G1 motion-prior feature contract mismatch")
+    return G1MotionPriorArtifact(
+        artifact_hash=str(metadata["artifact_hash"]),
+        weights_hash=str(metadata["weights_hash"]),
+        pack_hash=str(metadata["pack_hash"]),
+        pilot_report_hash=str(metadata["pilot_report_hash"]),
+        body_hash=str(metadata["body_hash"]),
+        feature_names=feature_names,
+        hidden_dim=hidden_dim,
+        sequence_length=int(metadata["sequence_length"]),
+        observation_mean=tensors["observation_mean"],
+        observation_std=tensors["observation_std"],
+        tensors=tensors,
+        source_truth_level=str(metadata["source_truth_level"]),
+        action_semantics=str(metadata["action_semantics"]),
+        activation_ceiling=str(metadata["activation_ceiling"]),
+    )
+
+
+def _load_pack(path: Path) -> tuple[dict[str, np.ndarray], dict[str, Any]]:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file() or not 1 <= resolved.stat().st_size <= _MAX_PACK_BYTES:
+        raise ValueError("motion-prior pack is missing or too large")
+    metadata = _bounded_json(resolved.with_suffix(".json"), _MAX_REPORT_BYTES)
+    if metadata.get("schema_version") != _PACK_SCHEMA:
+        raise ValueError("unsupported motion-prior pack schema")
+    if hash_bytes(resolved.read_bytes()) != metadata.get("pack_hash"):
+        raise ValueError("motion-prior pack hash mismatch")
+    with np.load(resolved, allow_pickle=False) as archive:
+        if set(archive.files) != {"training", "validation", "observation_mean", "observation_std"}:
+            raise ValueError("motion-prior pack tensor set is invalid")
+        values = {name: np.asarray(archive[name], dtype=np.float32) for name in archive.files}
+    sequence_length = int(metadata["sequence_length"])
+    for split in ("training", "validation"):
+        if values[split].ndim != 3 or values[split].shape[1:] != (
+            sequence_length + 1,
+            G1_MOTION_PRIOR_FEATURE_DIM,
+        ):
+            raise ValueError(f"motion-prior {split} tensor shape is invalid")
+    if values["observation_mean"].shape != (
+        G1_MOTION_PRIOR_FEATURE_DIM,
+    ) or values["observation_std"].shape != (G1_MOTION_PRIOR_FEATURE_DIM,):
+        raise ValueError("motion-prior normalization shape is invalid")
+    if any(not np.all(np.isfinite(value)) for value in values.values()):
+        raise ValueError("motion-prior pack contains non-finite values")
+    return values, metadata
+
+
+def _validation_loss(
+    model: _MotionPredictor,
+    validation: np.ndarray,
+    device: torch.device,
+    batch_size: int,
+) -> float:
+    total = 0.0
+    model.eval()
+    with torch.no_grad():
+        for offset in range(0, len(validation), batch_size):
+            batch = torch.as_tensor(validation[offset : offset + batch_size], device=device)
+            loss = torch.nn.functional.smooth_l1_loss(
+                model(batch[:, :-1]), batch[:, 1:], reduction="sum"
+            )
+            total += float(loss.item())
+    return total / (len(validation) * (validation.shape[1] - 1) * validation.shape[2])
+
+
+def _projected_gravity(quaternion_wxyz: np.ndarray) -> np.ndarray:
+    quaternion = np.asarray(quaternion_wxyz, dtype=np.float64)
+    norms = np.linalg.norm(quaternion, axis=1, keepdims=True)
+    if quaternion.ndim != 2 or quaternion.shape[1] != 4 or np.any(norms <= 1e-12):
+        raise ValueError("motion-prior root quaternion is invalid")
+    quaternion = quaternion / norms
+    # Rotate world gravity by the inverse body quaternion, matching the
+    # direct-torque observation contract.
+    vector = np.broadcast_to(np.asarray((0.0, 0.0, -1.0)), (len(quaternion), 3))
+    inverse_vector = -quaternion[:, 1:]
+    uv = np.cross(inverse_vector, vector)
+    uuv = np.cross(inverse_vector, uv)
+    return vector + 2.0 * (quaternion[:, :1] * uv + uuv)
+
+
+def _smooth_l1_numpy(delta: np.ndarray) -> float:
+    absolute = np.abs(delta)
+    return float(np.mean(np.where(absolute < 1.0, 0.5 * np.square(absolute), absolute - 0.5)))
+
+
+def _bounded_json(path: Path, maximum: int) -> dict[str, Any]:
+    if not path.is_file() or not 1 <= path.stat().st_size <= maximum:
+        raise ValueError(f"bounded JSON is missing or too large: {path}")
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError("expected a JSON object")
+    return value
+
+
+def _atomic_npz(path: Path, **values: np.ndarray) -> None:
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    os.close(descriptor)
+    try:
+        with open(temporary, "wb") as handle:
+            np.savez_compressed(handle, **values)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    payload = json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    worker = subparsers.add_parser("worker")
+    worker.add_argument("--pack", type=Path, required=True)
+    worker.add_argument("--output-dir", type=Path, required=True)
+    worker.add_argument("--device", required=True)
+    worker.add_argument("--seed", type=int, required=True)
+    worker.add_argument("--epochs", type=int, required=True)
+    worker.add_argument("--hidden-dim", type=int, required=True)
+    worker.add_argument("--batch-size", type=int, required=True)
+    args = parser.parse_args()
+    if args.command != "worker":
+        parser.print_help()
+        return 1
+    result = train_motion_prior_worker(
+        pack_path=args.pack,
+        output_dir=args.output_dir,
+        device=args.device,
+        seed=args.seed,
+        epochs=args.epochs,
+        hidden_dim=args.hidden_dim,
+        batch_size=args.batch_size,
+    )
+    print(json.dumps({"artifact_hash": result["artifact_hash"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/src/rosclaw/collective/sources/motiondecode/parser.py
+++ b/src/rosclaw/collective/sources/motiondecode/parser.py
@@ -1,0 +1,113 @@
+"""Bounded parser for the Unitree G1 MotionDecode CSV representation."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_DDS_JOINT_NAMES
+
+MOTIONDECODE_HZ = 120.0
+MOTIONDECODE_HEADER = (
+    "root_pos_x(m)",
+    "root_pos_y(m)",
+    "root_pos_z(m)",
+    "root_rot_w",
+    "root_rot_x",
+    "root_rot_y",
+    "root_rot_z",
+    *(f"dof_{name}(rad)" for name in G1_DDS_JOINT_NAMES),
+)
+_MAX_CSV_BYTES = 128 * 1024 * 1024
+_MAX_FRAMES = 120 * 60 * 20
+
+
+@dataclass(frozen=True)
+class CanonicalMotionEpisode:
+    relative_path: Path
+    source_hash: str
+    time_sec: np.ndarray
+    root_position: np.ndarray
+    root_quaternion: np.ndarray
+    joint_position: np.ndarray
+    joint_velocity: np.ndarray
+    joint_acceleration: np.ndarray
+    sample_rate_hz: float = MOTIONDECODE_HZ
+    time_semantics: str = "IMPLICIT_FIXED_RATE_FROM_DATA_CARD"
+    action_semantics: str = "ABSENT"
+    reward_semantics: str = "ABSENT"
+    schema_version: str = "rosclaw.canonical_motion_episode.v1"
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.time_sec)
+
+
+def parse_motiondecode_csv(
+    path: Path,
+    *,
+    dataset_root: Path,
+    max_bytes: int = _MAX_CSV_BYTES,
+    max_frames: int = _MAX_FRAMES,
+) -> CanonicalMotionEpisode:
+    root = dataset_root.expanduser().resolve()
+    resolved = path.expanduser().resolve()
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("MotionDecode CSV escapes the dataset root") from exc
+    if path.is_symlink() or not resolved.is_file() or resolved.suffix.lower() != ".csv":
+        raise ValueError("MotionDecode payload must be a regular non-symlink CSV")
+    size = resolved.stat().st_size
+    if not 1 <= size <= max_bytes:
+        raise ValueError("MotionDecode CSV is empty or exceeds the byte ceiling")
+    if not 2 <= max_frames <= _MAX_FRAMES:
+        raise ValueError("MotionDecode frame ceiling is invalid")
+
+    rows: list[list[float]] = []
+    digest = hashlib.sha256()
+    with resolved.open("rb") as raw:
+        for chunk in iter(lambda: raw.read(1024 * 1024), b""):
+            digest.update(chunk)
+    with resolved.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.reader(handle)
+        try:
+            header = tuple(next(reader))
+        except StopIteration as exc:
+            raise ValueError("MotionDecode CSV is empty") from exc
+        if header != MOTIONDECODE_HEADER:
+            raise ValueError("MotionDecode CSV header does not match the 29-DoF G1 contract")
+        for frame_index, row in enumerate(reader):
+            if frame_index >= max_frames:
+                raise ValueError("MotionDecode CSV exceeds the frame ceiling")
+            if len(row) != len(MOTIONDECODE_HEADER):
+                raise ValueError(f"MotionDecode frame {frame_index} has the wrong column count")
+            try:
+                values = [float(item) for item in row]
+            except ValueError as exc:
+                raise ValueError(f"MotionDecode frame {frame_index} is not numeric") from exc
+            if not all(math.isfinite(value) for value in values):
+                raise ValueError(f"MotionDecode frame {frame_index} contains non-finite values")
+            rows.append(values)
+    if len(rows) < 2:
+        raise ValueError("MotionDecode episode must contain at least two frames")
+    value = np.asarray(rows, dtype=np.float64)
+    time = np.arange(len(value), dtype=np.float64) / MOTIONDECODE_HZ
+    joint_position = value[:, 7:]
+    joint_velocity = np.gradient(joint_position, 1.0 / MOTIONDECODE_HZ, axis=0)
+    joint_acceleration = np.gradient(joint_velocity, 1.0 / MOTIONDECODE_HZ, axis=0)
+    return CanonicalMotionEpisode(
+        relative_path=relative,
+        source_hash="sha256:" + digest.hexdigest(),
+        time_sec=time,
+        root_position=value[:, :3],
+        root_quaternion=value[:, 3:7],
+        joint_position=joint_position,
+        joint_velocity=joint_velocity,
+        joint_acceleration=joint_acceleration,
+    )

--- a/src/rosclaw/collective/sources/motiondecode/taxonomy.py
+++ b/src/rosclaw/collective/sources/motiondecode/taxonomy.py
@@ -1,0 +1,159 @@
+"""Deterministic, semantics-preserving MotionDecode pilot selection."""
+
+from __future__ import annotations
+
+import hashlib
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+
+class MotionDecodeStratum(StrEnum):
+    FOOTBALL = "football"
+    BALANCE_PROXY = "balance_proxy"
+    GAIT = "gait"
+    TRANSITION_RECOVERY = "transition_recovery"
+    COORDINATION_SUPPLEMENT = "coordination_supplement"
+    OTHER = "other"
+
+
+@dataclass(frozen=True)
+class MotionDecodePilotSelection:
+    selected: tuple[tuple[MotionDecodeStratum, Path], ...]
+    requested: Mapping[str, int]
+    selected_counts: Mapping[str, int]
+    shortages: Mapping[str, int]
+    substitutions: Mapping[str, int]
+
+
+_RECOVERY = (
+    "ground_recovery",
+    "stand_up",
+    "get_up",
+    "sit_to_stand",
+    "stand_to_sit",
+    "stand_to_prone",
+    "prone_to_stand",
+    "pre_fall_prevention",
+    "turning_over_to_sitting_up",
+    "sitting_up_to_standing",
+)
+_GAIT = (
+    "gait",
+    "walking",
+    "small_backward_steps",
+    "slow_lateral_movement",
+    "retreating",
+    "approaching",
+    "stage_entry",
+)
+_BALANCE = (
+    "balance",
+    "single_leg",
+    "slight_weight_shift",
+    "standing_waiting",
+    "spotlight_standing",
+    "lower_body_rhythm",
+    "standing_high_jump",
+)
+_COORDINATION = (
+    "throw",
+    "dance",
+    "groove",
+    "jump",
+    "rhythm",
+    "lifting",
+    "carrying",
+    "pushing",
+    "pulling",
+)
+
+
+def classify_motiondecode_path(relative_path: Path) -> MotionDecodeStratum:
+    value = relative_path.as_posix().lower()
+    if "football" in value or "ball_game" in value:
+        return MotionDecodeStratum.FOOTBALL
+    if any(token in value for token in _RECOVERY):
+        return MotionDecodeStratum.TRANSITION_RECOVERY
+    if any(token in value for token in _GAIT):
+        return MotionDecodeStratum.GAIT
+    if any(token in value for token in _BALANCE):
+        return MotionDecodeStratum.BALANCE_PROXY
+    if any(token in value for token in _COORDINATION):
+        return MotionDecodeStratum.COORDINATION_SUPPLEMENT
+    return MotionDecodeStratum.OTHER
+
+
+def select_motiondecode_pilot(
+    relative_paths: Iterable[Path],
+    *,
+    limit: int = 400,
+    seed: int = 20260801,
+) -> MotionDecodePilotSelection:
+    if not 4 <= limit <= 4000:
+        raise ValueError("MotionDecode pilot limit must be in [4, 4000]")
+    base = limit // 4
+    remainder = limit - base * 4
+    requested = {
+        MotionDecodeStratum.FOOTBALL.value: base + remainder,
+        MotionDecodeStratum.BALANCE_PROXY.value: base,
+        MotionDecodeStratum.GAIT.value: base,
+        MotionDecodeStratum.TRANSITION_RECOVERY.value: base,
+    }
+    pools: dict[MotionDecodeStratum, list[Path]] = defaultdict(list)
+    for path in relative_paths:
+        pools[classify_motiondecode_path(path)].append(path)
+    for stratum, paths in pools.items():
+        paths.sort(key=lambda item: _selection_key(item, seed=seed, stratum=stratum))
+
+    selected: list[tuple[MotionDecodeStratum, Path]] = []
+    shortages: dict[str, int] = {}
+    for name, count in requested.items():
+        stratum = MotionDecodeStratum(name)
+        values = pools[stratum][:count]
+        selected.extend((stratum, path) for path in values)
+        if len(values) < count:
+            shortages[name] = count - len(values)
+
+    # Keep the audit statistically useful without pretending a substitute is
+    # football.  Backfilled records retain an explicit supplement stratum.
+    missing = limit - len(selected)
+    selected_paths = {path for _, path in selected}
+    supplements = [
+        path
+        for stratum in (MotionDecodeStratum.COORDINATION_SUPPLEMENT, MotionDecodeStratum.OTHER)
+        for path in pools[stratum]
+        if path not in selected_paths
+    ]
+    supplements.sort(
+        key=lambda item: _selection_key(
+            item,
+            seed=seed,
+            stratum=MotionDecodeStratum.COORDINATION_SUPPLEMENT,
+        )
+    )
+    fill = supplements[:missing]
+    selected.extend((MotionDecodeStratum.COORDINATION_SUPPLEMENT, path) for path in fill)
+    substitutions = (
+        {MotionDecodeStratum.COORDINATION_SUPPLEMENT.value: len(fill)} if fill else {}
+    )
+    selected.sort(key=lambda item: (item[0].value, item[1].as_posix()))
+    selected_counts: dict[str, int] = {
+        stratum.value: 0 for stratum in MotionDecodeStratum
+    }
+    for stratum, _ in selected:
+        selected_counts[stratum.value] += 1
+    return MotionDecodePilotSelection(
+        selected=tuple(selected),
+        requested=requested,
+        selected_counts=dict(selected_counts),
+        shortages=shortages,
+        substitutions=substitutions,
+    )
+
+
+def _selection_key(path: Path, *, seed: int, stratum: MotionDecodeStratum) -> str:
+    value = f"{seed}:{stratum.value}:{path.as_posix()}".encode()
+    return hashlib.sha256(value).hexdigest()

--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -32,6 +32,12 @@ def main() -> int:
     if result is not None:
         return result
 
+    from rosclaw.collective.cli import dispatch_collective_argv
+
+    result = dispatch_collective_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
     from rosclaw.simforge.g1_hat_trick_cli import dispatch_hat_trick_argv
 
     result = dispatch_hat_trick_argv(sys.argv[1:])

--- a/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
+++ b/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
@@ -32,6 +32,12 @@ from rosclaw.simforge.g1_cerebellar_recovery import (
     G1CerebellarRecoveryReceipt,
     evaluate_g1_cerebellar_recovery_regime,
 )
+from rosclaw.simforge.g1_neural_torque import (
+    G1NeuralTorquePolicy,
+    G1TorqueControlFrame,
+    G1TorquePolicy,
+    G1TorquePolicyReceipt,
+)
 from rosclaw.simforge.tasks.g1_goalforge.concepts import (
     G1_DDS_JOINT_NAMES,
     G1_HARD_TORQUE_LIMITS,
@@ -91,6 +97,7 @@ class GoalForgeEpisode:
     feedback_receipt: FeedbackReceipt | None = None
     feedforward_hash: str | None = None
     recovery_receipt: G1CerebellarRecoveryReceipt | None = None
+    torque_policy_receipt: G1TorquePolicyReceipt | None = None
 
     @property
     def result_hash(self) -> str:
@@ -250,7 +257,14 @@ class G1MuJoCoBackend:
         feedback_runtime: FeedbackRuntime | None = None,
         feedforward: ILCFeedforward | None = None,
         recovery_controller: G1CerebellarRecoveryController | None = None,
+        torque_policy: G1TorquePolicy | None = None,
     ) -> GoalForgeEpisode:
+        if torque_policy is not None and any(
+            value is not None for value in (feedback_runtime, feedforward, recovery_controller)
+        ):
+            raise ValueError(
+                "direct neural torque policy cannot be combined with target-space adapters"
+            )
         if (
             feedback_runtime is not None
             and feedback_runtime.spec.body_hash != self.qualification.body_hash
@@ -292,6 +306,7 @@ class G1MuJoCoBackend:
             feedback_runtime=feedback_runtime,
             feedforward=feedforward,
             recovery_controller=recovery_controller,
+            torque_policy=torque_policy,
         )
 
     def run_and_record(
@@ -387,6 +402,7 @@ class G1MuJoCoBackend:
         feedback_runtime: FeedbackRuntime | None = None,
         feedforward: ILCFeedforward | None = None,
         recovery_controller: G1CerebellarRecoveryController | None = None,
+        torque_policy: G1TorquePolicy | None = None,
     ) -> GoalForgeEpisode:
         import mujoco
 
@@ -399,6 +415,8 @@ class G1MuJoCoBackend:
             feedback_runtime.reset()
         if recovery_controller is not None:
             recovery_controller.reset()
+        if torque_policy is not None:
+            torque_policy.reset()
         _configure_scene(model, scenario)
         state = state_type(29)
         output = output_type(29)
@@ -561,6 +579,10 @@ class G1MuJoCoBackend:
         recovery_settling_fraction = 0.0
         recovery_smoothing_active = False
         recovery_smoothing_residual_rms_rad = 0.0
+        joint_limited = model.jnt_limited[1:30].astype(bool)
+        joint_ranges = np.asarray(model.jnt_range[1:30], dtype=np.float64)
+        joint_lower_limits = np.where(joint_limited, joint_ranges[:, 0], -1.0e6)
+        joint_upper_limits = np.where(joint_limited, joint_ranges[:, 1], 1.0e6)
 
         for frame in range(total_control_frames):
             if feedforward is not None:
@@ -691,6 +713,38 @@ class G1MuJoCoBackend:
                 raw_scale = float(np.max(np.abs(raw_torque) / hard_limits))
                 peak_torque_scale = max(peak_torque_scale, min(raw_scale, self.torque_guard_scale))
                 frame_torque = np.clip(raw_torque, -guarded_limits, guarded_limits)
+                if torque_policy is not None:
+                    parent_torque = frame_torque.copy()
+                    frame_torque = _apply_direct_torque_policy(
+                        policy=torque_policy,
+                        frame=G1TorqueControlFrame(
+                            joint_position=np.asarray(data.qpos[7:36], dtype=np.float64),
+                            joint_velocity=np.asarray(data.qvel[6:35], dtype=np.float64),
+                            joint_lower_limits=joint_lower_limits,
+                            joint_upper_limits=joint_upper_limits,
+                            torso_quaternion_wxyz=np.asarray(
+                                data.xquat[ids.torso], dtype=np.float64
+                            ),
+                            pelvis_position=np.asarray(data.qpos[:3], dtype=np.float64),
+                            ball_position=np.asarray(
+                                data.qpos[ids.ball_qpos : ids.ball_qpos + 3],
+                                dtype=np.float64,
+                            ),
+                            ball_velocity=np.asarray(
+                                data.qvel[ids.ball_qvel : ids.ball_qvel + 3],
+                                dtype=np.float64,
+                            ),
+                            target_y_m=scenario.target_y_m,
+                            target_z_m=scenario.target_z_m,
+                            policy_phase=policy_phase,
+                            left_contact=latest_left_support,
+                            right_contact=latest_right_support,
+                        ),
+                        parent_torque=parent_torque,
+                        guarded_limits=guarded_limits,
+                    )
+                    raw_scale = float(np.max(np.abs(frame_torque) / hard_limits))
+                    peak_torque_scale = max(peak_torque_scale, raw_scale)
                 torque_violation = torque_violation or bool(
                     np.any(np.abs(frame_torque) > hard_limits)
                 )
@@ -915,6 +969,11 @@ class G1MuJoCoBackend:
             if recovery_controller is not None
             else None
         )
+        torque_policy_receipt = (
+            torque_policy.build_receipt()
+            if isinstance(torque_policy, G1NeuralTorquePolicy)
+            else None
+        )
         return GoalForgeEpisode(
             scenario=scenario,
             parameters=parameters,
@@ -925,6 +984,7 @@ class G1MuJoCoBackend:
             feedback_receipt=feedback_receipt,
             feedforward_hash=feedforward.trajectory_hash if feedforward is not None else None,
             recovery_receipt=recovery_receipt,
+            torque_policy_receipt=torque_policy_receipt,
         )
 
 
@@ -977,6 +1037,26 @@ class _Contacts:
 class _FeedbackEffect:
     joint_residual: np.ndarray
     kick_phase_rate: float
+
+
+def _apply_direct_torque_policy(
+    *,
+    policy: G1TorquePolicy,
+    frame: G1TorqueControlFrame,
+    parent_torque: np.ndarray,
+    guarded_limits: np.ndarray,
+) -> np.ndarray:
+    """Apply a SIM-only torque callback behind the backend's final hard guard."""
+
+    try:
+        proposed = np.asarray(policy.command(frame, parent_torque), dtype=np.float64)
+        if proposed.shape != (29,) or not np.all(np.isfinite(proposed)):
+            raise ValueError("direct torque callback returned an invalid 29-vector")
+    except (ValueError, FloatingPointError):
+        proposed = parent_torque
+    applied = np.clip(proposed, -guarded_limits, guarded_limits)
+    policy.note_applied(applied)
+    return applied
 
 
 def _load_robonaldo(root: Path) -> tuple[Any, Any, Any, np.ndarray]:

--- a/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
+++ b/src/rosclaw/simforge/backends/unitree_mujoco_backend.py
@@ -33,7 +33,6 @@ from rosclaw.simforge.g1_cerebellar_recovery import (
     evaluate_g1_cerebellar_recovery_regime,
 )
 from rosclaw.simforge.g1_neural_torque import (
-    G1NeuralTorquePolicy,
     G1TorqueControlFrame,
     G1TorquePolicy,
     G1TorquePolicyReceipt,
@@ -969,11 +968,12 @@ class G1MuJoCoBackend:
             if recovery_controller is not None
             else None
         )
-        torque_policy_receipt = (
-            torque_policy.build_receipt()
-            if isinstance(torque_policy, G1NeuralTorquePolicy)
-            else None
-        )
+        receipt_builder = getattr(torque_policy, "build_receipt", None)
+        torque_policy_receipt = receipt_builder() if callable(receipt_builder) else None
+        if torque_policy_receipt is not None and not isinstance(
+            torque_policy_receipt, G1TorquePolicyReceipt
+        ):
+            raise ValueError("direct torque policy returned an invalid receipt")
         return GoalForgeEpisode(
             scenario=scenario,
             parameters=parameters,

--- a/src/rosclaw/simforge/g1_motion_prior_transfer_validation.py
+++ b/src/rosclaw/simforge/g1_motion_prior_transfer_validation.py
@@ -1,0 +1,479 @@
+"""A/B qualification of MotionDecode representation transfer into torque BC."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.collective.sources.motiondecode.motion_prior import load_g1_motion_prior_artifact
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.simforge.backends.unitree_mujoco_backend import G1MuJoCoBackend
+from rosclaw.simforge.g1_neural_torque import (
+    G1NeuralTorqueArtifact,
+    G1TeacherTorqueEpisode,
+    G1TorqueSafetyConfig,
+    load_g1_neural_torque_artifact,
+    serialize_g1_neural_torque_artifact,
+)
+from rosclaw.simforge.g1_neural_torque_learning import (
+    G1ContinualTorqueActorCritic,
+    G1NeuralTorqueLearnerConfig,
+    teacher_dataset_hash,
+)
+from rosclaw.simforge.g1_neural_torque_validation import (
+    G1NeuralTorqueRolloutEvidence,
+    _aggregate,
+    _collect_teacher,
+    _evaluate_candidate_with_replay,
+    _online_update_gate,
+    _pilot_scenarios,
+    _write_candidate,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import ShotParameters
+
+
+@dataclass(frozen=True)
+class G1MotionPriorTransferReport:
+    body_hash: str
+    parent_policy_hash: str
+    teacher_dataset_hash: str
+    motion_prior_artifact_hash: str
+    motion_prior_pack_hash: str
+    training_runs: tuple[dict[str, Any], ...]
+    trust_region_runs: tuple[dict[str, Any], ...]
+    proposal_initialization_fraction: float
+    selected_transfer_fraction: float
+    baseline_rollouts: tuple[G1NeuralTorqueRolloutEvidence, ...]
+    transfer_rollouts: tuple[G1NeuralTorqueRolloutEvidence, ...]
+    checks: dict[str, bool]
+    decision: str
+    blockers: tuple[str, ...]
+    evidence_domain: str = "SIM_ONLY"
+    hardware_authorized: bool = False
+    promotion_evidence_eligible: bool = False
+    schema_version: str = "rosclaw.simforge.g1_motion_prior_transfer.v2"
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["baseline_rollouts"] = [item.to_dict() for item in self.baseline_rollouts]
+        value["transfer_rollouts"] = [item.to_dict() for item in self.transfer_rollouts]
+        value["aggregates"] = {
+            "baseline": _aggregate(self.baseline_rollouts),
+            "transfer": _aggregate(self.transfer_rollouts),
+        }
+        value["claims"] = {
+            "motion_prior_outputs_torque": False,
+            "motion_prior_initializes_actor_gru": True,
+            "direct_torque_actor_physics_executed": bool(self.transfer_rollouts),
+            "online_rl_executed": False,
+            "candidate_promoted": False,
+            "real_robot_evidence": False,
+        }
+        return value
+
+
+def run_g1_motion_prior_transfer_validation(
+    *,
+    asset_root: Path,
+    motion_prior_path: Path,
+    output_dir: Path,
+    source_checkout: Path,
+    device: str = "cuda:2",
+    epochs: int = 6,
+    seed: int = 8500,
+) -> G1MotionPriorTransferReport:
+    if not 2 <= epochs <= 30:
+        raise ValueError("motion-prior transfer epochs must be in [2, 30]")
+    root = _external_root(output_dir, source_checkout)
+    root.mkdir(parents=True, exist_ok=False)
+    backend = G1MuJoCoBackend(asset_root=asset_root, trace_stride=1)
+    qualification = backend.qualification
+    prior = load_g1_motion_prior_artifact(motion_prior_path)
+    if prior.body_hash != qualification.body_hash:
+        raise ValueError("motion-prior artifact does not match the qualified G1 body")
+    training_scenarios, development_scenarios, validation_scenarios = _pilot_scenarios()
+    parameters = ShotParameters()
+    training = tuple(
+        _collect_teacher(backend, scenario, parameters)[1] for scenario in training_scenarios
+    )
+    validation = tuple(
+        _collect_teacher(backend, scenario, parameters)[1] for scenario in development_scenarios
+    )
+    teacher_hash = teacher_dataset_hash(training)
+    config = G1NeuralTorqueLearnerConfig(
+        hidden_dim=96,
+        sequence_length=32,
+        batch_size=256,
+        actor_lr=5e-5,
+        critic_lr=2e-4,
+        behavior_cloning_weight=5.0,
+        parent_churn_weight=2.0,
+        ewc_weight=20.0,
+        device=device,
+        seed=seed,
+    )
+    safety = G1TorqueSafetyConfig(
+        torque_guard_scale=0.80,
+        maximum_mechanical_power_w=4000.0,
+        maximum_parent_deviation_ratio=0.05,
+        maximum_projection_ratio=0.35,
+        maximum_observation_z=5.0,
+        minimum_upright_gravity_z=-0.97,
+        minimum_pelvis_height_m=0.70,
+        recovery_cooldown_steps=250,
+        warmup_steps=100,
+    )
+    runs: list[dict[str, Any]] = []
+    artifacts: dict[float, Path] = {}
+    for fraction in (0.0, 0.25, 0.50, 0.75, 1.0):
+        learner = G1ContinualTorqueActorCritic(config, safety=safety)
+        if fraction:
+            learner.install_motion_prior(
+                prior,
+                expected_body_hash=qualification.body_hash,
+                fraction=fraction,
+            )
+        metrics = learner.pretrain_behavior(
+            training,
+            validation=validation,
+            epochs=epochs,
+            stride=4,
+        )
+        dataset_hash = (
+            teacher_hash
+            if not fraction
+            else canonical_hash(
+                {
+                    "teacher_dataset_hash": teacher_hash,
+                    "motion_prior_artifact_hash": prior.artifact_hash,
+                    "transfer_fraction": fraction,
+                }
+            )
+        )
+        label = str(fraction).replace(".", "p")
+        artifact_path = root / f"torque-bc-transfer-{label}.bin"
+        _write_candidate(
+            artifact_path,
+            learner,
+            body_hash=qualification.body_hash,
+            parent_policy_hash=qualification.kick_prior_hash,
+            dataset_hash=dataset_hash,
+        )
+        artifacts[fraction] = artifact_path
+        runs.append(
+            {
+                "fraction": fraction,
+                "motion_prior_installed": bool(fraction),
+                "motion_prior_artifact_hash": learner.motion_prior_artifact_hash,
+                "initial_validation_loss": metrics[0].validation_loss,
+                "final_training_loss": metrics[-1].training_loss,
+                "final_validation_loss": metrics[-1].validation_loss,
+                "finite": all(item.finite for item in metrics),
+                "artifact_path": str(artifact_path),
+            }
+        )
+    baseline = runs[0]
+    baseline_development = tuple(
+        _evaluate_candidate_with_replay(
+            backend,
+            scenario,
+            parameters,
+            artifacts[0.0],
+            stage="motion_prior_baseline_development",
+        )
+        for scenario in development_scenarios
+    )
+    baseline["development_rollouts"] = [item.to_dict() for item in baseline_development]
+    baseline["development_aggregate"] = _aggregate(baseline_development)
+    eligible_runs: list[dict[str, Any]] = []
+    for run in runs[1:]:
+        fraction = float(run["fraction"])
+        development = tuple(
+            _evaluate_candidate_with_replay(
+                backend,
+                scenario,
+                parameters,
+                artifacts[fraction],
+                stage=f"motion_prior_transfer_{fraction}_development",
+            )
+            for scenario in development_scenarios
+        )
+        accepted, reasons = _online_update_gate(
+            parent=baseline_development,
+            candidate=development,
+        )
+        teacher_improved = (
+            float(run["final_validation_loss"])
+            <= float(baseline["final_validation_loss"]) * 0.98
+        )
+        run["development_rollouts"] = [item.to_dict() for item in development]
+        run["development_aggregate"] = _aggregate(development)
+        run["development_gate_passed"] = accepted
+        run["development_gate_reasons"] = list(reasons)
+        run["teacher_improved_2pct"] = teacher_improved
+        if accepted and teacher_improved:
+            eligible_runs.append(run)
+    proposal = min(
+        eligible_runs or runs[1:],
+        key=lambda item: (item["final_validation_loss"], item["fraction"]),
+    )
+    proposal_fraction = float(proposal["fraction"])
+    baseline_artifact = load_g1_neural_torque_artifact(
+        artifacts[0.0], expected_body_hash=qualification.body_hash
+    )
+    proposal_artifact = load_g1_neural_torque_artifact(
+        artifacts[proposal_fraction], expected_body_hash=qualification.body_hash
+    )
+    trust_runs: list[dict[str, Any]] = []
+    eligible_trust_runs: list[dict[str, Any]] = []
+    for trust_fraction in (0.05, 0.10, 0.20, 0.35, 0.50, 0.75, 1.0):
+        trust_path = root / f"torque-bc-trust-{str(trust_fraction).replace('.', 'p')}.bin"
+        _write_interpolated_artifact(
+            trust_path,
+            baseline=baseline_artifact,
+            proposal=proposal_artifact,
+            fraction=trust_fraction,
+            dataset_hash=canonical_hash(
+                {
+                    "teacher_dataset_hash": teacher_hash,
+                    "motion_prior_artifact_hash": prior.artifact_hash,
+                    "proposal_initialization_fraction": proposal_fraction,
+                    "post_bc_trust_fraction": trust_fraction,
+                }
+            ),
+        )
+        development = tuple(
+            _evaluate_candidate_with_replay(
+                backend,
+                scenario,
+                parameters,
+                trust_path,
+                stage=f"motion_prior_trust_{trust_fraction}_development",
+            )
+            for scenario in development_scenarios
+        )
+        accepted, reasons = _online_update_gate(
+            parent=baseline_development,
+            candidate=development,
+        )
+        artifact = load_g1_neural_torque_artifact(
+            trust_path, expected_body_hash=qualification.body_hash
+        )
+        behavior_loss = _artifact_behavior_loss(artifact, validation, sequence_length=32, stride=4)
+        teacher_improved = behavior_loss <= float(baseline["final_validation_loss"]) * 0.98
+        value = {
+            "trust_fraction": trust_fraction,
+            "artifact_path": str(trust_path),
+            "artifact_hash": artifact.artifact_hash,
+            "validation_loss": behavior_loss,
+            "teacher_improved_2pct": teacher_improved,
+            "development_gate_passed": accepted,
+            "development_gate_reasons": list(reasons),
+            "development_aggregate": _aggregate(development),
+            "development_rollouts": [item.to_dict() for item in development],
+        }
+        trust_runs.append(value)
+        if accepted and teacher_improved:
+            eligible_trust_runs.append(value)
+    selected_trust = min(
+        eligible_trust_runs or trust_runs,
+        key=lambda item: (item["trust_fraction"], item["validation_loss"]),
+    )
+    selected_fraction = float(selected_trust["trust_fraction"])
+    # Development chose the transfer fraction.  The following disjoint
+    # validation scenarios check physics retention but are not promotion data.
+    physics_scenarios = validation_scenarios[:4]
+    baseline_rollouts = tuple(
+        _evaluate_candidate_with_replay(
+            backend,
+            scenario,
+            parameters,
+            artifacts[0.0],
+            stage="motion_prior_baseline_validation",
+        )
+        for scenario in physics_scenarios
+    )
+    transfer_rollouts = tuple(
+        _evaluate_candidate_with_replay(
+            backend,
+            scenario,
+            parameters,
+        Path(str(selected_trust["artifact_path"])),
+            stage="motion_prior_transfer_validation",
+        )
+        for scenario in physics_scenarios
+    )
+    baseline_aggregate = _aggregate(baseline_rollouts)
+    transfer_aggregate = _aggregate(transfer_rollouts)
+    new_critical = any(
+        (
+            after.fall
+            or after.joint_violation
+            or after.torque_violation
+            or not after.finite
+        )
+        and not (
+            before.fall
+            or before.joint_violation
+            or before.torque_violation
+            or not before.finite
+        )
+        for before, after in zip(baseline_rollouts, transfer_rollouts, strict=True)
+    )
+    checks = {
+        "development_trust_region_passed": selected_trust in eligible_trust_runs,
+        "held_out_teacher_loss_improved_2pct": (
+            float(selected_trust["validation_loss"])
+            <= float(baseline["final_validation_loss"]) * 0.98
+        ),
+        "all_training_finite": all(bool(item["finite"]) for item in runs),
+        "strict_physics_replay": all(
+            item.strict_replay for item in (*baseline_rollouts, *transfer_rollouts)
+        ),
+        "no_new_critical_failure": not new_critical,
+        "physics_score_retained_within_1pct": (
+            transfer_aggregate["mean_score"]
+            >= baseline_aggregate["mean_score"]
+            - 0.01 * max(abs(baseline_aggregate["mean_score"]), 1.0)
+        ),
+        "learned_output_fraction_retained_within_5pp": (
+            transfer_aggregate["learned_output_fraction"]
+            >= baseline_aggregate["learned_output_fraction"] - 0.05
+        ),
+        "sim_only_boundary_preserved": all(
+            item.activation_ceiling == "SIM_ONLY" and not item.hardware_authorized
+            for item in transfer_rollouts
+        ),
+    }
+    blockers = tuple(name for name, passed in checks.items() if not passed)
+    decision = "TRANSFER_CANDIDATE" if not blockers else "REJECTED"
+    report = G1MotionPriorTransferReport(
+        body_hash=qualification.body_hash,
+        parent_policy_hash=qualification.kick_prior_hash,
+        teacher_dataset_hash=teacher_hash,
+        motion_prior_artifact_hash=prior.artifact_hash,
+        motion_prior_pack_hash=prior.pack_hash,
+        training_runs=tuple(runs),
+        trust_region_runs=tuple(trust_runs),
+        proposal_initialization_fraction=proposal_fraction,
+        selected_transfer_fraction=selected_fraction,
+        baseline_rollouts=baseline_rollouts,
+        transfer_rollouts=transfer_rollouts,
+        checks=checks,
+        decision=decision,
+        blockers=blockers,
+    )
+    _atomic_json(root / "g1-motion-prior-transfer-report.json", report.to_dict())
+    return report
+
+
+def _write_interpolated_artifact(
+    path: Path,
+    *,
+    baseline: G1NeuralTorqueArtifact,
+    proposal: G1NeuralTorqueArtifact,
+    fraction: float,
+    dataset_hash: str,
+) -> None:
+    if baseline.body_hash != proposal.body_hash or baseline.hidden_dim != proposal.hidden_dim:
+        raise ValueError("torque artifacts cannot be interpolated across body or architecture")
+    tensors: dict[str, np.ndarray] = {}
+    for name, baseline_value in baseline.tensors.items():
+        proposal_value = proposal.tensors[name]
+        if name.startswith("actor."):
+            value = baseline_value.astype(np.float64) + fraction * (
+                proposal_value.astype(np.float64) - baseline_value.astype(np.float64)
+            )
+        else:
+            if not np.allclose(baseline_value, proposal_value, rtol=0.0, atol=1e-6):
+                raise ValueError(f"torque artifact contract tensor differs: {name}")
+            value = baseline_value
+        tensors[name] = np.asarray(value, dtype=np.float32)
+    payload = serialize_g1_neural_torque_artifact(
+        body_hash=baseline.body_hash,
+        parent_policy_hash=baseline.parent_policy_hash,
+        dataset_hash=dataset_hash,
+        hidden_dim=baseline.hidden_dim,
+        observation_clip=baseline.observation_clip,
+        update_index=0,
+        safety=baseline.safety,
+        tensors=tensors,
+    )
+    path.write_bytes(payload)
+    load_g1_neural_torque_artifact(
+        path,
+        expected_hash="sha256:" + __import__("hashlib").sha256(payload).hexdigest(),
+        expected_body_hash=baseline.body_hash,
+    )
+
+
+def _artifact_behavior_loss(
+    artifact: G1NeuralTorqueArtifact,
+    episodes: tuple[G1TeacherTorqueEpisode, ...],
+    *,
+    sequence_length: int,
+    stride: int,
+) -> float:
+    tensors = artifact.tensors
+    limits = tensors["action_limits"]
+    losses: list[float] = []
+    for episode in episodes:
+        for end in range(sequence_length, len(episode.observations) + 1, stride):
+            sequence = episode.observations[end - sequence_length : end]
+            normalized = np.clip(
+                (sequence - tensors["observation_mean"]) / tensors["observation_std"],
+                -artifact.observation_clip,
+                artifact.observation_clip,
+            )
+            hidden = np.zeros(artifact.hidden_dim, dtype=np.float32)
+            for observation in normalized:
+                input_gates = tensors["actor.gru.weight_ih_l0"] @ observation + tensors[
+                    "actor.gru.bias_ih_l0"
+                ]
+                hidden_gates = tensors["actor.gru.weight_hh_l0"] @ hidden + tensors[
+                    "actor.gru.bias_hh_l0"
+                ]
+                reset_i, update_i, new_i = np.split(input_gates, 3)
+                reset_h, update_h, new_h = np.split(hidden_gates, 3)
+                reset = 1.0 / (1.0 + np.exp(-(reset_i + reset_h)))
+                update = 1.0 / (1.0 + np.exp(-(update_i + update_h)))
+                new = np.tanh(new_i + reset * new_h)
+                hidden = (1.0 - update) * new + update * hidden
+            output = tensors["actor.head.weight"] @ hidden + tensors["actor.head.bias"]
+            prediction = np.tanh(output[: len(limits)]) * limits
+            target = np.clip(episode.actions[end - 1], -limits, limits)
+            losses.append(float(np.mean(np.square((prediction - target) / limits))))
+    if not losses:
+        raise ValueError("torque artifact behavior evaluation has no sequences")
+    return float(sum(losses) / len(losses))
+
+
+def _external_root(path: Path, source_checkout: Path) -> Path:
+    root = path.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if root == checkout or checkout in root.parents:
+        raise ValueError("motion-prior transfer evidence must be outside the source checkout")
+    return root
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    payload = json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+__all__ = ["G1MotionPriorTransferReport", "run_g1_motion_prior_transfer_validation"]

--- a/src/rosclaw/simforge/g1_neural_torque.py
+++ b/src/rosclaw/simforge/g1_neural_torque.py
@@ -430,6 +430,14 @@ class G1NeuralTorquePolicy:
         self._peak_power = 0.0
         self._recovery_cooldown = 0
 
+    @property
+    def pending_projection(self) -> G1TorqueProjection:
+        """Expose the current guarded proposal to trusted policy composers."""
+
+        if self._pending is None:
+            raise RuntimeError("neural torque policy has no pending projection")
+        return self._pending
+
     def command(
         self,
         frame: G1TorqueControlFrame,

--- a/src/rosclaw/simforge/g1_neural_torque.py
+++ b/src/rosclaw/simforge/g1_neural_torque.py
@@ -1,0 +1,971 @@
+"""Fail-closed recurrent G1 joint-torque policy for MuJoCo only.
+
+This module deliberately has no ROS, DDS, vendor SDK, Registry, or hardware
+dependency.  A candidate consumes raw proprioception plus task context and
+emits all 29 joint torques, but the output remains behind an independent
+amplitude/rate/power/joint-limit safety envelope.  Any malformed, incompatible,
+or over-projecting proposal falls back to the qualified parent controller.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import struct
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Protocol
+
+import numpy as np
+
+from rosclaw.simforge.tasks.g1_goalforge.concepts import (
+    G1_DDS_JOINT_NAMES,
+    G1_HARD_TORQUE_LIMITS,
+)
+
+_SCHEMA = "rosclaw.simforge.g1_neural_torque_artifact.v1"
+_MAX_ARTIFACT_BYTES = 128 * 1024 * 1024
+_SHA256 = __import__("re").compile(r"^sha256:[0-9a-f]{64}$")
+
+G1_NEURAL_TORQUE_OBSERVATIONS = (
+    *(f"joint_position/{name}" for name in G1_DDS_JOINT_NAMES),
+    *(f"joint_velocity/{name}" for name in G1_DDS_JOINT_NAMES),
+    "projected_gravity/x",
+    "projected_gravity/y",
+    "projected_gravity/z",
+    "ball_relative/x",
+    "ball_relative/y",
+    "ball_relative/z",
+    "ball_velocity/x",
+    "ball_velocity/y",
+    "ball_velocity/z",
+    "target/y",
+    "target/z",
+    "phase/sin",
+    "phase/cos",
+    "contact/left",
+    "contact/right",
+    *(f"previous_torque_ratio/{name}" for name in G1_DDS_JOINT_NAMES),
+)
+G1_NEURAL_TORQUE_ACTIONS = tuple(f"joint_torque/{name}" for name in G1_DDS_JOINT_NAMES)
+
+
+@dataclass(frozen=True)
+class G1TorqueSafetyConfig:
+    """Immutable outer envelope around a neural torque proposal."""
+
+    torque_guard_scale: float = 0.70
+    max_delta_ratio_per_step: float = 0.08
+    joint_limit_margin_rad: float = 0.035
+    maximum_mechanical_power_w: float = 2500.0
+    maximum_projection_ratio: float = 0.35
+    maximum_parent_deviation_ratio: float = 0.08
+    maximum_observation_z: float = 6.0
+    minimum_upright_gravity_z: float = -0.75
+    minimum_pelvis_height_m: float = 0.62
+    recovery_cooldown_steps: int = 0
+    warmup_steps: int = 50
+    activation_ceiling: str = "SIM_ONLY"
+
+    def __post_init__(self) -> None:
+        if not 0.05 <= self.torque_guard_scale <= 0.85:
+            raise ValueError("neural torque guard scale must be in [0.05, 0.85]")
+        if not 0.001 <= self.max_delta_ratio_per_step <= 0.25:
+            raise ValueError("neural torque delta ratio must be in [0.001, 0.25]")
+        if not 0.005 <= self.joint_limit_margin_rad <= 0.20:
+            raise ValueError("joint limit margin must be in [0.005, 0.20] rad")
+        if not 100.0 <= self.maximum_mechanical_power_w <= 5000.0:
+            raise ValueError("mechanical power ceiling must be in [100, 5000] W")
+        if not 0.0 <= self.maximum_projection_ratio <= 1.0:
+            raise ValueError("maximum projection ratio must be in [0, 1]")
+        if not 0.0 <= self.maximum_parent_deviation_ratio <= 0.25:
+            raise ValueError("maximum parent torque deviation ratio must be in [0, 0.25]")
+        if not 2.0 <= self.maximum_observation_z <= 20.0:
+            raise ValueError("maximum neural torque observation z must be in [2, 20]")
+        if not -0.999 <= self.minimum_upright_gravity_z <= -0.50:
+            raise ValueError("minimum upright gravity z must be in [-0.999, -0.50]")
+        if not 0.40 <= self.minimum_pelvis_height_m <= 0.95:
+            raise ValueError("minimum pelvis height must be in [0.40, 0.95] m")
+        if not 0 <= self.recovery_cooldown_steps <= 5000:
+            raise ValueError("recovery cooldown must be in [0, 5000] steps")
+        if not 0 <= self.warmup_steps <= 5000:
+            raise ValueError("neural torque warmup steps must be in [0, 5000]")
+        if self.activation_ceiling != "SIM_ONLY":
+            raise ValueError("neural torque candidates are restricted to SIM_ONLY")
+
+
+@dataclass(frozen=True)
+class G1TorqueControlFrame:
+    """One simulator state used to construct the end-to-end policy input."""
+
+    joint_position: np.ndarray
+    joint_velocity: np.ndarray
+    joint_lower_limits: np.ndarray
+    joint_upper_limits: np.ndarray
+    torso_quaternion_wxyz: np.ndarray
+    pelvis_position: np.ndarray
+    ball_position: np.ndarray
+    ball_velocity: np.ndarray
+    target_y_m: float
+    target_z_m: float
+    policy_phase: float
+    left_contact: bool
+    right_contact: bool
+
+
+@dataclass(frozen=True)
+class G1TorqueProjection:
+    torque: np.ndarray
+    used_parent: bool
+    reason: str | None
+    projected_joint_count: int
+    maximum_limit_ratio: float
+    mechanical_power_w: float
+
+
+@dataclass(frozen=True)
+class G1TorquePolicyReceipt:
+    artifact_hash: str
+    body_hash: str
+    parent_policy_hash: str
+    inference_count: int
+    learned_output_count: int
+    fallback_count: int
+    nonfinite_fallback_count: int
+    projection_fallback_count: int
+    out_of_distribution_fallback_count: int
+    warmup_fallback_count: int
+    state_guard_fallback_count: int
+    projected_joint_count: int
+    maximum_limit_ratio: float
+    peak_mechanical_power_w: float
+    direct_torque_output: bool
+    activation_ceiling: str
+    hardware_authorized: bool = False
+    dds_opened: bool = False
+    schema_version: str = "rosclaw.simforge.g1_neural_torque_receipt.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class G1TorquePolicy(Protocol):
+    """Minimal callback surface accepted by the MuJoCo backend."""
+
+    def reset(self) -> None: ...
+
+    def command(
+        self,
+        frame: G1TorqueControlFrame,
+        parent_torque: np.ndarray,
+    ) -> np.ndarray: ...
+
+    def note_applied(self, torque: np.ndarray) -> None: ...
+
+
+@dataclass(frozen=True)
+class G1NeuralTorqueArtifact:
+    """Verified, inference-only recurrent actor."""
+
+    artifact_hash: str
+    body_hash: str
+    parent_policy_hash: str
+    dataset_hash: str
+    observation_names: tuple[str, ...]
+    action_names: tuple[str, ...]
+    action_limits: tuple[float, ...]
+    hidden_dim: int
+    observation_clip: float
+    update_index: int
+    safety: G1TorqueSafetyConfig
+    tensors: Mapping[str, np.ndarray]
+    schema_version: str = _SCHEMA
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tensors", MappingProxyType(dict(self.tensors)))
+
+
+@dataclass(frozen=True)
+class G1TeacherTorqueEpisode:
+    observations: np.ndarray
+    actions: np.ndarray
+    parent_actions: np.ndarray
+
+    def __post_init__(self) -> None:
+        observations = np.asarray(self.observations, dtype=np.float32)
+        actions = np.asarray(self.actions, dtype=np.float32)
+        parent = np.asarray(self.parent_actions, dtype=np.float32)
+        if observations.ndim != 2 or observations.shape[1] != len(G1_NEURAL_TORQUE_OBSERVATIONS):
+            raise ValueError("teacher observations have the wrong shape")
+        if actions.shape != (len(observations), len(G1_DDS_JOINT_NAMES)):
+            raise ValueError("teacher actions have the wrong shape")
+        if parent.shape != actions.shape:
+            raise ValueError("teacher parent actions must align with actions")
+        if not all(np.all(np.isfinite(value)) for value in (observations, actions, parent)):
+            raise ValueError("teacher torque episode must contain only finite values")
+        object.__setattr__(self, "observations", observations)
+        object.__setattr__(self, "actions", actions)
+        object.__setattr__(self, "parent_actions", parent)
+
+
+class G1TeacherTorqueCollector:
+    """Pass-through policy that records the 500 Hz parent-torque teacher."""
+
+    def __init__(self) -> None:
+        self._observations: list[np.ndarray] = []
+        self._actions: list[np.ndarray] = []
+        self._parents: list[np.ndarray] = []
+        self._previous: np.ndarray = np.zeros(len(G1_DDS_JOINT_NAMES), dtype=np.float64)
+        self._pending_observation: np.ndarray | None = None
+        self._pending_parent: np.ndarray | None = None
+
+    def reset(self) -> None:
+        self._observations.clear()
+        self._actions.clear()
+        self._parents.clear()
+        self._previous.fill(0.0)
+        self._pending_observation = None
+        self._pending_parent = None
+
+    def command(
+        self,
+        frame: G1TorqueControlFrame,
+        parent_torque: np.ndarray,
+    ) -> np.ndarray:
+        if self._pending_observation is not None:
+            raise RuntimeError("teacher collector did not receive note_applied")
+        self._pending_observation = build_g1_neural_torque_observation(frame, self._previous)
+        self._pending_parent = _vector(parent_torque, label="parent torque")
+        return self._pending_parent.copy()
+
+    def note_applied(self, torque: np.ndarray) -> None:
+        if self._pending_observation is None or self._pending_parent is None:
+            raise RuntimeError("teacher collector received applied torque without a command")
+        applied = _vector(torque, label="applied teacher torque")
+        self._observations.append(self._pending_observation)
+        self._actions.append(applied)
+        self._parents.append(self._pending_parent)
+        self._previous = applied.copy()
+        self._pending_observation = None
+        self._pending_parent = None
+
+    def episode(self) -> G1TeacherTorqueEpisode:
+        if self._pending_observation is not None or not self._observations:
+            raise ValueError("teacher torque episode is empty or incomplete")
+        return G1TeacherTorqueEpisode(
+            observations=np.asarray(self._observations, dtype=np.float32),
+            actions=np.asarray(self._actions, dtype=np.float32),
+            parent_actions=np.asarray(self._parents, dtype=np.float32),
+        )
+
+
+class G1TorqueSafetyProjector:
+    """Independent state-aware envelope for direct neural torques."""
+
+    def __init__(self, config: G1TorqueSafetyConfig) -> None:
+        self.config = config
+        self._hard = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float64)
+        self._guarded = self._hard * config.torque_guard_scale
+        self._parent_guarded = self._hard * 0.85
+        self._delta = self._hard * config.max_delta_ratio_per_step
+
+    def project(
+        self,
+        proposed: np.ndarray,
+        *,
+        parent: np.ndarray,
+        previous: np.ndarray,
+        frame: G1TorqueControlFrame,
+    ) -> G1TorqueProjection:
+        parent_value = self._safe_parent(parent)
+        previous_value = self._safe_previous(previous, parent_value)
+        try:
+            candidate = _vector(proposed, label="neural torque proposal")
+        except ValueError as exc:
+            return self._fallback(parent_value, frame, f"invalid_proposal:{exc}")
+
+        clipped = np.clip(candidate, -self._guarded, self._guarded)
+        parent_delta = self._hard * self.config.maximum_parent_deviation_ratio
+        clipped = np.clip(clipped, parent_value - parent_delta, parent_value + parent_delta)
+        clipped = np.clip(clipped, previous_value - self._delta, previous_value + self._delta)
+        lower = _vector(frame.joint_lower_limits, label="joint lower limits")
+        upper = _vector(frame.joint_upper_limits, label="joint upper limits")
+        position = _vector(frame.joint_position, label="joint position")
+        if np.any(lower >= upper):
+            return self._fallback(parent_value, frame, "invalid_joint_limits")
+        outward_low = (position <= lower + self.config.joint_limit_margin_rad) & (clipped < 0.0)
+        outward_high = (position >= upper - self.config.joint_limit_margin_rad) & (clipped > 0.0)
+        if np.any(outward_low | outward_high):
+            return self._fallback(parent_value, frame, "joint_limit_guard")
+        clipped = self._limit_power(clipped, frame.joint_velocity)
+        changed = np.abs(clipped - candidate) > 1e-8
+        projection_ratio = float(np.count_nonzero(changed)) / len(changed)
+        if projection_ratio > self.config.maximum_projection_ratio:
+            return self._fallback(parent_value, frame, "projection_ratio_exceeded")
+        return self._result(
+            clipped,
+            frame=frame,
+            used_parent=False,
+            reason=None,
+            projected_joint_count=int(np.count_nonzero(changed)),
+        )
+
+    def fallback(
+        self,
+        *,
+        parent: np.ndarray,
+        frame: G1TorqueControlFrame,
+        reason: str,
+    ) -> G1TorqueProjection:
+        """Return the independently bounded parent with an auditable reason."""
+
+        if not reason.strip():
+            raise ValueError("neural torque fallback reason must not be empty")
+        return self._fallback(self._safe_parent(parent), frame, reason)
+
+    def _safe_parent(self, parent: np.ndarray) -> np.ndarray:
+        try:
+            value = _vector(parent, label="parent torque")
+        except ValueError:
+            return np.zeros_like(self._hard)
+        return np.clip(value, -self._parent_guarded, self._parent_guarded)
+
+    def _safe_previous(self, previous: np.ndarray, parent: np.ndarray) -> np.ndarray:
+        try:
+            return np.clip(
+                _vector(previous, label="previous torque"), -self._guarded, self._guarded
+            )
+        except ValueError:
+            return parent.copy()
+
+    def _fallback(
+        self,
+        parent: np.ndarray,
+        frame: G1TorqueControlFrame,
+        reason: str,
+    ) -> G1TorqueProjection:
+        # The qualified parent has already passed the backend's immutable
+        # torque guard.  Preserve it exactly; candidate-only limits must not
+        # turn a fail-closed fallback into a different controller.
+        safe = np.clip(parent, -self._parent_guarded, self._parent_guarded)
+        return self._result(
+            safe,
+            frame=frame,
+            used_parent=True,
+            reason=reason,
+            projected_joint_count=0,
+        )
+
+    def _limit_power(self, torque: np.ndarray, velocity: np.ndarray) -> np.ndarray:
+        speed = _vector(velocity, label="joint velocity")
+        power = float(np.sum(np.abs(torque * speed)))
+        if power <= self.config.maximum_mechanical_power_w or power <= 1e-12:
+            return torque
+        return torque * (self.config.maximum_mechanical_power_w / power)
+
+    def _result(
+        self,
+        torque: np.ndarray,
+        *,
+        frame: G1TorqueControlFrame,
+        used_parent: bool,
+        reason: str | None,
+        projected_joint_count: int,
+    ) -> G1TorqueProjection:
+        ratio = float(np.max(np.abs(torque) / self._hard))
+        power = float(
+            np.sum(np.abs(torque * _vector(frame.joint_velocity, label="joint velocity")))
+        )
+        return G1TorqueProjection(
+            torque=np.asarray(torque, dtype=np.float64),
+            used_parent=used_parent,
+            reason=reason,
+            projected_joint_count=projected_joint_count,
+            maximum_limit_ratio=ratio,
+            mechanical_power_w=power,
+        )
+
+
+class G1NeuralTorquePolicy:
+    """Allocation-light NumPy GRU actor with parent fallback and receipts."""
+
+    def __init__(
+        self,
+        artifact: G1NeuralTorqueArtifact,
+        *,
+        expected_body_hash: str,
+        expected_parent_policy_hash: str,
+    ) -> None:
+        if artifact.body_hash != expected_body_hash:
+            raise ValueError("neural torque artifact body hash mismatch")
+        if artifact.parent_policy_hash != expected_parent_policy_hash:
+            raise ValueError("neural torque artifact parent policy hash mismatch")
+        self.artifact = artifact
+        self.projector = G1TorqueSafetyProjector(artifact.safety)
+        self._hidden: np.ndarray = np.zeros(artifact.hidden_dim, dtype=np.float32)
+        self._previous: np.ndarray = np.zeros(len(G1_DDS_JOINT_NAMES), dtype=np.float64)
+        self._pending: G1TorqueProjection | None = None
+        self._observations: list[np.ndarray] = []
+        self._actions: list[np.ndarray] = []
+        self._parents: list[np.ndarray] = []
+        self._fallback_reasons: list[str] = []
+        self._projected_joint_count = 0
+        self._maximum_limit_ratio = 0.0
+        self._peak_power = 0.0
+        self._recovery_cooldown = 0
+
+    def reset(self) -> None:
+        self._hidden.fill(0.0)
+        self._previous.fill(0.0)
+        self._pending = None
+        self._observations.clear()
+        self._actions.clear()
+        self._parents.clear()
+        self._fallback_reasons.clear()
+        self._projected_joint_count = 0
+        self._maximum_limit_ratio = 0.0
+        self._peak_power = 0.0
+        self._recovery_cooldown = 0
+
+    def command(
+        self,
+        frame: G1TorqueControlFrame,
+        parent_torque: np.ndarray,
+    ) -> np.ndarray:
+        if self._pending is not None:
+            raise RuntimeError("neural torque policy did not receive note_applied")
+        parent = np.asarray(parent_torque, dtype=np.float64)
+        try:
+            raw = build_g1_neural_torque_observation(frame, self._previous)
+            normalized = self._normalize(raw)
+            if len(self._observations) < self.artifact.safety.warmup_steps:
+                projection = self.projector.fallback(
+                    parent=parent,
+                    frame=frame,
+                    reason="warmup_parent",
+                )
+                self._advance_hidden(normalized)
+            elif (
+                float(frame.pelvis_position[2])
+                < self.artifact.safety.minimum_pelvis_height_m
+                or float(raw[60]) > self.artifact.safety.minimum_upright_gravity_z
+            ):
+                self._recovery_cooldown = self.artifact.safety.recovery_cooldown_steps
+                projection = self.projector.fallback(
+                    parent=parent,
+                    frame=frame,
+                    reason="state_recovery_parent",
+                )
+                self._advance_hidden(normalized)
+            elif self._recovery_cooldown > 0:
+                self._recovery_cooldown -= 1
+                projection = self.projector.fallback(
+                    parent=parent,
+                    frame=frame,
+                    reason="recovery_cooldown_parent",
+                )
+                self._advance_hidden(normalized)
+            elif float(np.max(np.abs(normalized))) > self.artifact.safety.maximum_observation_z:
+                projection = self.projector.fallback(
+                    parent=parent,
+                    frame=frame,
+                    reason="observation_out_of_distribution",
+                )
+                self._hidden.fill(0.0)
+            else:
+                proposed = self._infer_normalized(normalized)
+                projection = self.projector.project(
+                    proposed,
+                    parent=parent,
+                    previous=self._previous,
+                    frame=frame,
+                )
+        except (ValueError, FloatingPointError) as exc:
+            projection = self.projector.project(
+                np.full(len(G1_DDS_JOINT_NAMES), np.nan),
+                parent=parent,
+                previous=self._previous,
+                frame=frame,
+            )
+            projection = G1TorqueProjection(
+                torque=projection.torque,
+                used_parent=True,
+                reason=f"observation_or_inference:{type(exc).__name__}",
+                projected_joint_count=projection.projected_joint_count,
+                maximum_limit_ratio=projection.maximum_limit_ratio,
+                mechanical_power_w=projection.mechanical_power_w,
+            )
+            raw = np.zeros(len(self.artifact.observation_names), dtype=np.float32)
+        self._pending = projection
+        self._observations.append(raw)
+        self._parents.append(np.asarray(parent, dtype=np.float32))
+        if projection.reason is not None:
+            self._fallback_reasons.append(projection.reason)
+        self._projected_joint_count += projection.projected_joint_count
+        self._maximum_limit_ratio = max(
+            self._maximum_limit_ratio,
+            projection.maximum_limit_ratio,
+        )
+        self._peak_power = max(self._peak_power, projection.mechanical_power_w)
+        return projection.torque.copy()
+
+    def note_applied(self, torque: np.ndarray) -> None:
+        if self._pending is None:
+            raise RuntimeError("neural torque policy received applied torque without command")
+        applied = _vector(torque, label="applied neural torque")
+        self._actions.append(np.asarray(applied, dtype=np.float32))
+        self._previous = applied.copy()
+        self._pending = None
+
+    def build_receipt(self) -> G1TorquePolicyReceipt:
+        if self._pending is not None or not self._actions:
+            raise ValueError("cannot build an incomplete neural torque receipt")
+        fallback_count = len(self._fallback_reasons)
+        return G1TorquePolicyReceipt(
+            artifact_hash=self.artifact.artifact_hash,
+            body_hash=self.artifact.body_hash,
+            parent_policy_hash=self.artifact.parent_policy_hash,
+            inference_count=len(self._actions),
+            learned_output_count=len(self._actions) - fallback_count,
+            fallback_count=fallback_count,
+            nonfinite_fallback_count=sum(
+                "invalid_proposal" in reason or "observation_or_inference" in reason
+                for reason in self._fallback_reasons
+            ),
+            projection_fallback_count=sum(
+                reason == "projection_ratio_exceeded" for reason in self._fallback_reasons
+            ),
+            out_of_distribution_fallback_count=sum(
+                reason == "observation_out_of_distribution" for reason in self._fallback_reasons
+            ),
+            warmup_fallback_count=sum(
+                reason == "warmup_parent" for reason in self._fallback_reasons
+            ),
+            state_guard_fallback_count=sum(
+                reason
+                in {
+                    "state_recovery_parent",
+                    "recovery_cooldown_parent",
+                    "joint_limit_guard",
+                }
+                for reason in self._fallback_reasons
+            ),
+            projected_joint_count=self._projected_joint_count,
+            maximum_limit_ratio=self._maximum_limit_ratio,
+            peak_mechanical_power_w=self._peak_power,
+            direct_torque_output=True,
+            activation_ceiling=self.artifact.safety.activation_ceiling,
+        )
+
+    def episode(self) -> G1TeacherTorqueEpisode:
+        if self._pending is not None or not self._actions:
+            raise ValueError("neural torque episode is empty or incomplete")
+        return G1TeacherTorqueEpisode(
+            observations=np.asarray(self._observations, dtype=np.float32),
+            actions=np.asarray(self._actions, dtype=np.float32),
+            parent_actions=np.asarray(self._parents, dtype=np.float32),
+        )
+
+    def _normalize(self, raw_observation: np.ndarray) -> np.ndarray:
+        tensors = self.artifact.tensors
+        return np.clip(
+            (raw_observation - tensors["observation_mean"]) / tensors["observation_std"],
+            -self.artifact.observation_clip,
+            self.artifact.observation_clip,
+        ).astype(np.float32)
+
+    def _advance_hidden(self, normalized: np.ndarray) -> None:
+        tensors = self.artifact.tensors
+        weight_ih = tensors["actor.gru.weight_ih_l0"]
+        weight_hh = tensors["actor.gru.weight_hh_l0"]
+        bias_ih = tensors["actor.gru.bias_ih_l0"]
+        bias_hh = tensors["actor.gru.bias_hh_l0"]
+        input_gates = weight_ih @ normalized + bias_ih
+        hidden_gates = weight_hh @ self._hidden + bias_hh
+        reset_i, update_i, new_i = np.split(input_gates, 3)
+        reset_h, update_h, new_h = np.split(hidden_gates, 3)
+        reset = _sigmoid(reset_i + reset_h)
+        update = _sigmoid(update_i + update_h)
+        new = np.tanh(new_i + reset * new_h)
+        self._hidden = ((1.0 - update) * new + update * self._hidden).astype(np.float32)
+
+    def _infer_normalized(self, normalized: np.ndarray) -> np.ndarray:
+        self._advance_hidden(normalized)
+        tensors = self.artifact.tensors
+        output = tensors["actor.head.weight"] @ self._hidden + tensors["actor.head.bias"]
+        mean = output[: len(G1_DDS_JOINT_NAMES)]
+        proposed = np.tanh(mean) * tensors["action_limits"]
+        if not np.all(np.isfinite(proposed)):
+            raise FloatingPointError("neural torque actor produced non-finite output")
+        return proposed.astype(np.float64)
+
+
+def build_g1_neural_torque_observation(
+    frame: G1TorqueControlFrame,
+    previous_torque: np.ndarray,
+) -> np.ndarray:
+    """Build the frozen raw observation order shared by training and runtime."""
+
+    position = _vector(frame.joint_position, label="joint position")
+    velocity = _vector(frame.joint_velocity, label="joint velocity")
+    previous = _vector(previous_torque, label="previous torque")
+    quaternion = np.asarray(frame.torso_quaternion_wxyz, dtype=np.float64)
+    pelvis = np.asarray(frame.pelvis_position, dtype=np.float64)
+    ball = np.asarray(frame.ball_position, dtype=np.float64)
+    ball_velocity = np.asarray(frame.ball_velocity, dtype=np.float64)
+    if quaternion.shape != (4,) or pelvis.shape != (3,) or ball.shape != (3,):
+        raise ValueError("neural torque body pose fields have the wrong shape")
+    if ball_velocity.shape != (3,):
+        raise ValueError("neural torque ball velocity has the wrong shape")
+    scalars = (frame.target_y_m, frame.target_z_m, frame.policy_phase)
+    if not all(math.isfinite(float(value)) for value in scalars):
+        raise ValueError("neural torque task context must be finite")
+    norm = float(np.linalg.norm(quaternion))
+    if not math.isfinite(norm) or norm < 1e-8:
+        raise ValueError("neural torque torso quaternion is invalid")
+    quaternion = quaternion / norm
+    gravity = _inverse_rotate(quaternion, np.asarray((0.0, 0.0, -1.0)))
+    phase = float(np.clip(frame.policy_phase, 0.0, 1.0)) * (2.0 * math.pi)
+    limits = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float64)
+    value = np.concatenate(
+        (
+            position,
+            velocity,
+            gravity,
+            ball - pelvis,
+            ball_velocity,
+            np.asarray((frame.target_y_m, frame.target_z_m)),
+            np.asarray((math.sin(phase), math.cos(phase))),
+            np.asarray((float(frame.left_contact), float(frame.right_contact))),
+            previous / limits,
+        )
+    ).astype(np.float32)
+    if value.shape != (len(G1_NEURAL_TORQUE_OBSERVATIONS),) or not np.all(np.isfinite(value)):
+        raise ValueError("neural torque observation is malformed or non-finite")
+    return value
+
+
+def load_g1_neural_torque_artifact(
+    path: Path,
+    *,
+    expected_hash: str | None = None,
+    expected_body_hash: str | None = None,
+) -> G1NeuralTorqueArtifact:
+    """Load a bounded safe-tensor actor artifact without pickle execution."""
+
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise FileNotFoundError(f"neural torque artifact is missing: {resolved}")
+    size = resolved.stat().st_size
+    if size <= 0 or size > _MAX_ARTIFACT_BYTES:
+        raise ValueError("neural torque artifact size is outside the loader limit")
+    payload = resolved.read_bytes()
+    artifact_hash = "sha256:" + hashlib.sha256(payload).hexdigest()
+    if expected_hash is not None and artifact_hash != expected_hash:
+        raise ValueError("neural torque artifact hash mismatch")
+    metadata_end = _json_object_end(payload)
+    try:
+        metadata = json.loads(payload[:metadata_end].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("neural torque artifact metadata is invalid") from exc
+    if not isinstance(metadata, dict) or metadata.get("schema_version") != _SCHEMA:
+        raise ValueError("unsupported neural torque artifact schema")
+    body_hash = _hash(metadata, "body_hash")
+    parent_hash = _hash(metadata, "parent_policy_hash")
+    dataset_hash = _hash(metadata, "dataset_hash")
+    if expected_body_hash is not None and body_hash != expected_body_hash:
+        raise ValueError("neural torque artifact body hash mismatch")
+    observations = _names(metadata, "observation_names")
+    actions = _names(metadata, "action_names")
+    if observations != G1_NEURAL_TORQUE_OBSERVATIONS:
+        raise ValueError("neural torque observation contract mismatch")
+    if actions != G1_NEURAL_TORQUE_ACTIONS:
+        raise ValueError("neural torque action contract mismatch")
+    limits = _float_tuple(metadata, "action_limits", len(actions))
+    hard = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float64)
+    if np.any(np.asarray(limits) <= 0.0) or np.any(np.asarray(limits) > hard * 0.85 + 1e-8):
+        raise ValueError("neural torque action limits exceed the immutable ceiling")
+    hidden_dim = _positive_int(metadata, "hidden_dim", maximum=1024)
+    update_index = _nonnegative_int(metadata, "update_index")
+    observation_clip = float(metadata.get("observation_clip", math.nan))
+    if not math.isfinite(observation_clip) or not 1.0 <= observation_clip <= 20.0:
+        raise ValueError("neural torque observation clip is invalid")
+    safety_raw = metadata.get("safety")
+    if not isinstance(safety_raw, dict):
+        raise ValueError("neural torque artifact lacks its safety envelope")
+    try:
+        safety = G1TorqueSafetyConfig(**safety_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("neural torque artifact safety envelope is invalid") from exc
+    if not np.allclose(
+        limits,
+        hard * safety.torque_guard_scale,
+        rtol=0.0,
+        atol=1e-6,
+    ):
+        raise ValueError("neural torque action limits do not match the safety envelope")
+    tensors = _parse_tensors(payload, metadata_end)
+    _verify_tensors(tensors, hidden_dim=hidden_dim, action_limits=limits)
+    return G1NeuralTorqueArtifact(
+        artifact_hash=artifact_hash,
+        body_hash=body_hash,
+        parent_policy_hash=parent_hash,
+        dataset_hash=dataset_hash,
+        observation_names=observations,
+        action_names=actions,
+        action_limits=limits,
+        hidden_dim=hidden_dim,
+        observation_clip=observation_clip,
+        update_index=update_index,
+        safety=safety,
+        tensors=tensors,
+    )
+
+
+def serialize_g1_neural_torque_artifact(
+    *,
+    body_hash: str,
+    parent_policy_hash: str,
+    dataset_hash: str,
+    hidden_dim: int,
+    observation_clip: float,
+    update_index: int,
+    safety: G1TorqueSafetyConfig,
+    tensors: Mapping[str, np.ndarray],
+) -> bytes:
+    """Create deterministic metadata+float32 tensor bytes for content addressing."""
+
+    for label, value in (
+        ("body_hash", body_hash),
+        ("parent_policy_hash", parent_policy_hash),
+        ("dataset_hash", dataset_hash),
+    ):
+        if not _SHA256.fullmatch(value):
+            raise ValueError(f"{label} must be a sha256 content hash")
+    limits = tuple(float(value) * safety.torque_guard_scale for value in G1_HARD_TORQUE_LIMITS)
+    metadata = {
+        "schema_version": _SCHEMA,
+        "body_hash": body_hash,
+        "parent_policy_hash": parent_policy_hash,
+        "dataset_hash": dataset_hash,
+        "observation_names": list(G1_NEURAL_TORQUE_OBSERVATIONS),
+        "action_names": list(G1_NEURAL_TORQUE_ACTIONS),
+        "action_limits": list(limits),
+        "action_semantics": "DIRECT_JOINT_TORQUE",
+        "hidden_dim": hidden_dim,
+        "observation_clip": observation_clip,
+        "update_index": update_index,
+        "safety": asdict(safety),
+        "activation_ceiling": "SIM_ONLY",
+    }
+    chunks = [json.dumps(metadata, sort_keys=True, separators=(",", ":")).encode()]
+    for name, original in sorted(tensors.items()):
+        value = np.ascontiguousarray(original, dtype=np.float32)
+        if not name or not np.all(np.isfinite(value)):
+            raise ValueError("neural torque artifact tensors must be named and finite")
+        name_bytes = name.encode()
+        dtype_bytes = b"float32"
+        chunks.extend(
+            (
+                struct.pack("!I", len(name_bytes)),
+                name_bytes,
+                struct.pack("!I", len(dtype_bytes)),
+                dtype_bytes,
+                struct.pack("!I", value.ndim),
+                struct.pack("!" + "Q" * value.ndim, *value.shape),
+                value.tobytes(),
+            )
+        )
+    payload = b"".join(chunks)
+    if len(payload) > _MAX_ARTIFACT_BYTES:
+        raise ValueError("neural torque artifact exceeds the loader size limit")
+    return payload
+
+
+def _verify_tensors(
+    tensors: Mapping[str, np.ndarray],
+    *,
+    hidden_dim: int,
+    action_limits: tuple[float, ...],
+) -> None:
+    observation_dim = len(G1_NEURAL_TORQUE_OBSERVATIONS)
+    action_dim = len(G1_DDS_JOINT_NAMES)
+    expected = {
+        "action_limits": (action_dim,),
+        "observation_mean": (observation_dim,),
+        "observation_std": (observation_dim,),
+        "actor.gru.weight_ih_l0": (3 * hidden_dim, observation_dim),
+        "actor.gru.weight_hh_l0": (3 * hidden_dim, hidden_dim),
+        "actor.gru.bias_ih_l0": (3 * hidden_dim,),
+        "actor.gru.bias_hh_l0": (3 * hidden_dim,),
+        "actor.head.weight": (2 * action_dim, hidden_dim),
+        "actor.head.bias": (2 * action_dim,),
+    }
+    if set(tensors) != set(expected):
+        raise ValueError("neural torque artifact has an unexpected tensor set")
+    for name, shape in expected.items():
+        if tensors[name].shape != shape:
+            raise ValueError(f"neural torque tensor {name} has the wrong shape")
+    if np.any(tensors["observation_std"] <= 1e-6):
+        raise ValueError("neural torque observation standard deviations must be positive")
+    if not np.allclose(tensors["action_limits"], action_limits, rtol=0.0, atol=1e-5):
+        raise ValueError("neural torque tensor limits do not match metadata")
+
+
+def _parse_tensors(payload: bytes, offset: int) -> Mapping[str, np.ndarray]:
+    result: dict[str, np.ndarray] = {}
+    cursor = offset
+    while cursor < len(payload):
+        name_size, cursor = _read_u32(payload, cursor, "tensor name length")
+        name_raw, cursor = _read(payload, cursor, name_size, "tensor name")
+        dtype_size, cursor = _read_u32(payload, cursor, "tensor dtype length")
+        dtype_raw, cursor = _read(payload, cursor, dtype_size, "tensor dtype")
+        rank, cursor = _read_u32(payload, cursor, "tensor rank")
+        if rank > 4:
+            raise ValueError("neural torque tensor rank exceeds four")
+        shape_raw, cursor = _read(payload, cursor, 8 * rank, "tensor shape")
+        shape = tuple(struct.unpack("!" + "Q" * rank, shape_raw)) if rank else ()
+        try:
+            name = name_raw.decode("utf-8")
+            dtype = dtype_raw.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise ValueError("neural torque tensor descriptor is invalid") from exc
+        if not name or name in result or dtype != "float32":
+            raise ValueError("neural torque tensor name or dtype is invalid")
+        if any(dimension <= 0 or dimension > 2_000_000 for dimension in shape):
+            raise ValueError("neural torque tensor shape is invalid")
+        count = math.prod(shape)
+        raw, cursor = _read(payload, cursor, count * 4, f"tensor {name}")
+        value = np.frombuffer(raw, dtype=np.float32).reshape(shape).copy()
+        if not np.all(np.isfinite(value)):
+            raise ValueError(f"neural torque tensor {name} is non-finite")
+        value.flags.writeable = False
+        result[name] = value
+    if not result or cursor != len(payload):
+        raise ValueError("neural torque tensor payload is empty or truncated")
+    return MappingProxyType(result)
+
+
+def _json_object_end(payload: bytes) -> int:
+    if not payload or payload[0] != ord("{"):
+        raise ValueError("neural torque artifact must begin with JSON metadata")
+    depth = 0
+    in_string = False
+    escaped = False
+    for index, byte in enumerate(payload):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif byte == ord("\\"):
+                escaped = True
+            elif byte == ord('"'):
+                in_string = False
+            continue
+        if byte == ord('"'):
+            in_string = True
+        elif byte == ord("{"):
+            depth += 1
+        elif byte == ord("}"):
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    raise ValueError("neural torque artifact metadata is incomplete")
+
+
+def _read_u32(payload: bytes, cursor: int, label: str) -> tuple[int, int]:
+    raw, cursor = _read(payload, cursor, 4, label)
+    return struct.unpack("!I", raw)[0], cursor
+
+
+def _read(payload: bytes, cursor: int, count: int, label: str) -> tuple[bytes, int]:
+    if count < 0 or cursor < 0 or cursor + count > len(payload):
+        raise ValueError(f"neural torque artifact is truncated at {label}")
+    return payload[cursor : cursor + count], cursor + count
+
+
+def _names(metadata: Mapping[str, Any], key: str) -> tuple[str, ...]:
+    value = metadata.get(key)
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"neural torque {key} must be a non-empty list")
+    names = tuple(item for item in value if isinstance(item, str) and item.strip())
+    if len(names) != len(value) or len(set(names)) != len(names):
+        raise ValueError(f"neural torque {key} must contain unique strings")
+    return names
+
+
+def _float_tuple(metadata: Mapping[str, Any], key: str, count: int) -> tuple[float, ...]:
+    value = metadata.get(key)
+    if not isinstance(value, list) or len(value) != count:
+        raise ValueError(f"neural torque {key} has the wrong length")
+    result = tuple(float(item) for item in value)
+    if any(not math.isfinite(item) for item in result):
+        raise ValueError(f"neural torque {key} must contain finite numbers")
+    return result
+
+
+def _hash(metadata: Mapping[str, Any], key: str) -> str:
+    value = metadata.get(key)
+    if not isinstance(value, str) or not _SHA256.fullmatch(value):
+        raise ValueError(f"neural torque {key} must be a sha256 content hash")
+    return value
+
+
+def _positive_int(metadata: Mapping[str, Any], key: str, *, maximum: int) -> int:
+    value = metadata.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or not 1 <= value <= maximum:
+        raise ValueError(f"neural torque {key} must be in [1, {maximum}]")
+    return value
+
+
+def _nonnegative_int(metadata: Mapping[str, Any], key: str) -> int:
+    value = metadata.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"neural torque {key} must be a non-negative integer")
+    return value
+
+
+def _vector(value: np.ndarray, *, label: str) -> np.ndarray:
+    result = np.asarray(value, dtype=np.float64)
+    if result.shape != (len(G1_DDS_JOINT_NAMES),) or not np.all(np.isfinite(result)):
+        raise ValueError(f"{label} must be a finite 29-vector")
+    return result.copy()
+
+
+def _sigmoid(value: np.ndarray) -> np.ndarray:
+    clipped = np.clip(value, -60.0, 60.0)
+    return 1.0 / (1.0 + np.exp(-clipped))
+
+
+def _inverse_rotate(quaternion_wxyz: np.ndarray, vector: np.ndarray) -> np.ndarray:
+    w, x, y, z = map(float, quaternion_wxyz)
+    rotation = np.asarray(
+        (
+            (1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)),
+            (2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)),
+            (2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)),
+        ),
+        dtype=np.float64,
+    )
+    return rotation.T @ vector
+
+
+__all__ = [
+    "G1_NEURAL_TORQUE_ACTIONS",
+    "G1_NEURAL_TORQUE_OBSERVATIONS",
+    "G1NeuralTorqueArtifact",
+    "G1NeuralTorquePolicy",
+    "G1TeacherTorqueCollector",
+    "G1TeacherTorqueEpisode",
+    "G1TorqueControlFrame",
+    "G1TorquePolicy",
+    "G1TorquePolicyReceipt",
+    "G1TorqueProjection",
+    "G1TorqueSafetyConfig",
+    "G1TorqueSafetyProjector",
+    "build_g1_neural_torque_observation",
+    "load_g1_neural_torque_artifact",
+    "serialize_g1_neural_torque_artifact",
+]

--- a/src/rosclaw/simforge/g1_neural_torque_learning.py
+++ b/src/rosclaw/simforge/g1_neural_torque_learning.py
@@ -1,0 +1,1120 @@
+"""Recurrent direct-torque actor-critic for the G1 MuJoCo sandbox.
+
+The learner supports three stages:
+
+1. behavior-clone the qualified RoboNaldo+PD teacher into a GRU actor;
+2. update twin reward and safety-cost critics from versioned simulation replay;
+3. update the actor only from fresh transitions while rehearsing historical
+   anchors and applying an EWC penalty around the consolidated parent.
+
+Only the actor is exported, using the safe tensor format in
+``g1_neural_torque``.  Training checkpoints are service-owned and restored
+with ``weights_only=True``.  Neither form can authorize hardware execution.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import io
+import math
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+import torch  # type: ignore[import-not-found]
+from torch import nn  # type: ignore[import-not-found]
+
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.simforge.g1_neural_torque import (
+    G1_NEURAL_TORQUE_OBSERVATIONS,
+    G1TeacherTorqueEpisode,
+    G1TorqueSafetyConfig,
+    serialize_g1_neural_torque_artifact,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_HARD_TORQUE_LIMITS
+
+_RECENT = 0
+_ANCHOR = 1
+_BOUNDARY = 2
+
+
+@dataclass(frozen=True)
+class G1NeuralTorqueLearnerConfig:
+    hidden_dim: int = 96
+    sequence_length: int = 16
+    batch_size: int = 256
+    gamma: float = 0.995
+    tau: float = 0.01
+    actor_lr: float = 2e-4
+    critic_lr: float = 3e-4
+    alpha_lr: float = 2e-4
+    initial_alpha: float = 0.02
+    initial_log_std: float = -3.0
+    lagrange_lr: float = 1e-3
+    maximum_lagrange: float = 100.0
+    fall_cost_limit: float = 0.0
+    constraint_cost_limit: float = 0.01
+    behavior_cloning_weight: float = 1.0
+    online_behavior_weight: float = 5.0
+    parent_churn_weight: float = 0.5
+    ewc_weight: float = 5.0
+    observation_clip: float = 8.0
+    log_std_min: float = -5.0
+    log_std_max: float = 0.5
+    device: str = "cpu"
+    seed: int = 0
+
+    def __post_init__(self) -> None:
+        if not 8 <= self.hidden_dim <= 1024:
+            raise ValueError("neural torque hidden dimension must be in [8, 1024]")
+        if not 2 <= self.sequence_length <= 256:
+            raise ValueError("neural torque sequence length must be in [2, 256]")
+        if self.batch_size <= 0:
+            raise ValueError("neural torque batch size must be positive")
+        if not 0.0 < self.gamma <= 1.0 or not 0.0 < self.tau <= 1.0:
+            raise ValueError("neural torque gamma and tau must be in (0, 1]")
+        if min(self.actor_lr, self.critic_lr, self.alpha_lr, self.lagrange_lr) <= 0.0:
+            raise ValueError("neural torque learning rates must be positive")
+        if not 1e-4 <= self.initial_alpha <= 1.0:
+            raise ValueError("neural torque initial alpha must be in [1e-4, 1]")
+        if not self.log_std_min <= self.initial_log_std <= self.log_std_max:
+            raise ValueError("initial log standard deviation must be within the configured range")
+        if (
+            min(
+                self.maximum_lagrange,
+                self.fall_cost_limit,
+                self.constraint_cost_limit,
+                self.behavior_cloning_weight,
+                self.online_behavior_weight,
+                self.parent_churn_weight,
+                self.ewc_weight,
+            )
+            < 0.0
+        ):
+            raise ValueError("neural torque cost and retention weights must be non-negative")
+        if not 1.0 <= self.observation_clip <= 20.0:
+            raise ValueError("neural torque observation clip must be in [1, 20]")
+        if self.log_std_min >= self.log_std_max:
+            raise ValueError("neural torque log standard-deviation range is invalid")
+
+
+@dataclass(frozen=True)
+class G1NeuralTorqueBCMetrics:
+    epoch: int
+    training_loss: float
+    validation_loss: float
+    action_limit_fraction: float
+    finite: bool
+    schema_version: str = "rosclaw.simforge.g1_neural_torque_bc_metrics.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class G1NeuralTorqueUpdate:
+    update_index: int
+    actor_updated: bool
+    reward_critic_loss: float
+    fall_critic_loss: float
+    constraint_critic_loss: float
+    actor_loss: float
+    alpha: float
+    fall_lagrange: float
+    constraint_lagrange: float
+    anchor_loss: float
+    online_behavior_loss: float
+    parent_churn_loss: float
+    ewc_loss: float
+    actor_transition_count: int
+    critic_transition_count: int
+    stale_actor_transition_count: int
+    anchor_transition_count: int
+    finite: bool
+    schema_version: str = "rosclaw.simforge.g1_neural_torque_update.v2"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class G1NeuralTorqueReplay:
+    observations: np.ndarray
+    actions: np.ndarray
+    next_observations: np.ndarray
+    rewards: np.ndarray
+    fall_costs: np.ndarray
+    constraint_costs: np.ndarray
+    terminals: np.ndarray
+    parent_actions: np.ndarray
+    partitions: np.ndarray
+    policy_lags: np.ndarray
+
+    def __post_init__(self) -> None:
+        count = len(np.asarray(self.observations))
+        observation_dim = len(G1_NEURAL_TORQUE_OBSERVATIONS)
+        action_dim = len(G1_HARD_TORQUE_LIMITS)
+        expected = {
+            "observations": (count, None, observation_dim),
+            "actions": (count, action_dim),
+            "next_observations": (count, None, observation_dim),
+            "rewards": (count, 1),
+            "fall_costs": (count, 1),
+            "constraint_costs": (count, 1),
+            "terminals": (count, 1),
+            "parent_actions": (count, action_dim),
+            "partitions": (count,),
+            "policy_lags": (count,),
+        }
+        arrays = {name: np.asarray(getattr(self, name)) for name in expected}
+        if count == 0:
+            raise ValueError("neural torque replay must not be empty")
+        if (
+            arrays["observations"].ndim != 3
+            or arrays["next_observations"].shape != arrays["observations"].shape
+        ):
+            raise ValueError("neural torque replay sequences are misaligned")
+        if arrays["observations"].shape[2] != observation_dim:
+            raise ValueError("neural torque replay observation dimension is invalid")
+        for name, shape in expected.items():
+            if len(shape) == 3 and shape[1] is None:
+                continue
+            if arrays[name].shape != shape:
+                raise ValueError(f"neural torque replay {name} has the wrong shape")
+        numeric = tuple(value for name, value in arrays.items() if name != "partitions")
+        if any(not np.all(np.isfinite(value)) for value in numeric):
+            raise ValueError("neural torque replay contains non-finite values")
+        partitions = arrays["partitions"].astype(np.int8)
+        if not set(map(int, np.unique(partitions))).issubset({_RECENT, _ANCHOR, _BOUNDARY}):
+            raise ValueError("neural torque replay has an unknown partition")
+        lags = arrays["policy_lags"].astype(np.int64)
+        if np.any(lags < 0):
+            raise ValueError("neural torque replay policy lags must be non-negative")
+        for name, value in arrays.items():
+            if name == "partitions":
+                value = partitions
+            elif name == "policy_lags":
+                value = lags
+            elif name not in {"partitions", "policy_lags"}:
+                value = value.astype(np.float32)
+            object.__setattr__(self, name, value)
+
+    @property
+    def count(self) -> int:
+        return len(self.observations)
+
+    @classmethod
+    def combine(cls, *replays: G1NeuralTorqueReplay) -> G1NeuralTorqueReplay:
+        if not replays:
+            raise ValueError("at least one neural torque replay is required")
+        sequence_lengths = {value.observations.shape[1] for value in replays}
+        if len(sequence_lengths) != 1:
+            raise ValueError("neural torque replay sequence lengths must match")
+        return cls(
+            **{
+                name: np.concatenate([getattr(value, name) for value in replays], axis=0)
+                for name in (
+                    "observations",
+                    "actions",
+                    "next_observations",
+                    "rewards",
+                    "fall_costs",
+                    "constraint_costs",
+                    "terminals",
+                    "parent_actions",
+                    "partitions",
+                    "policy_lags",
+                )
+            }
+        )
+
+
+class _RecurrentActor(nn.Module):
+    def __init__(self, config: G1NeuralTorqueLearnerConfig, limits: np.ndarray) -> None:
+        super().__init__()
+        self.gru = nn.GRU(
+            len(G1_NEURAL_TORQUE_OBSERVATIONS),
+            config.hidden_dim,
+            batch_first=True,
+        )
+        self.head = nn.Linear(config.hidden_dim, 2 * len(G1_HARD_TORQUE_LIMITS))
+        nn.init.zeros_(self.head.weight)
+        nn.init.zeros_(self.head.bias)
+        with torch.no_grad():
+            self.head.bias[len(G1_HARD_TORQUE_LIMITS) :].fill_(config.initial_log_std)
+        self.register_buffer("action_limits", torch.as_tensor(limits, dtype=torch.float32))
+        self.log_std_min = config.log_std_min
+        self.log_std_max = config.log_std_max
+
+    def distribution_parameters(
+        self, observations: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        encoded, _ = self.gru(observations)
+        mean, log_std = self.head(encoded[:, -1]).chunk(2, dim=-1)
+        return mean, torch.clamp(log_std, self.log_std_min, self.log_std_max)
+
+    def deterministic(self, observations: torch.Tensor) -> torch.Tensor:
+        mean, _ = self.distribution_parameters(observations)
+        return torch.tanh(mean) * self.action_limits
+
+    def sample(self, observations: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mean, log_std = self.distribution_parameters(observations)
+        distribution = torch.distributions.Normal(mean, log_std.exp())
+        latent = distribution.rsample()
+        unit = torch.tanh(latent)
+        action = unit * self.action_limits
+        # Optimize entropy in normalized action space.  Including the fixed
+        # physical torque scale adds a large constant (29 joints) to every
+        # target and destabilizes early online critic updates.
+        jacobian = 1.0 - unit.square()
+        log_probability = (distribution.log_prob(latent) - torch.log(jacobian.clamp_min(1e-6))).sum(
+            dim=-1, keepdim=True
+        )
+        return action, log_probability
+
+
+class _SequenceQ(nn.Module):
+    def __init__(self, config: G1NeuralTorqueLearnerConfig) -> None:
+        super().__init__()
+        self.gru = nn.GRU(
+            len(G1_NEURAL_TORQUE_OBSERVATIONS),
+            config.hidden_dim,
+            batch_first=True,
+        )
+        self.head = nn.Sequential(
+            nn.Linear(config.hidden_dim + len(G1_HARD_TORQUE_LIMITS), config.hidden_dim),
+            nn.ReLU(),
+            nn.Linear(config.hidden_dim, 1),
+        )
+
+    def forward(self, observations: torch.Tensor, action_ratio: torch.Tensor) -> torch.Tensor:
+        encoded, _ = self.gru(observations)
+        return self.head(torch.cat((encoded[:, -1], action_ratio), dim=-1))
+
+
+class _TwinSequenceCritic(nn.Module):
+    def __init__(self, config: G1NeuralTorqueLearnerConfig) -> None:
+        super().__init__()
+        self.q1 = _SequenceQ(config)
+        self.q2 = _SequenceQ(config)
+
+    def forward(
+        self,
+        observations: torch.Tensor,
+        action_ratio: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.q1(observations, action_ratio), self.q2(observations, action_ratio)
+
+
+class G1ContinualTorqueActorCritic:
+    """End-to-end recurrent torque learner with retention and cost critics."""
+
+    def __init__(
+        self,
+        config: G1NeuralTorqueLearnerConfig,
+        *,
+        safety: G1TorqueSafetyConfig | None = None,
+    ) -> None:
+        self.config = config
+        self.safety = safety or G1TorqueSafetyConfig()
+        torch.manual_seed(config.seed)
+        if config.device.startswith("cuda") and not torch.cuda.is_available():
+            raise RuntimeError("CUDA neural torque learner requested without CUDA")
+        self.device = torch.device(config.device)
+        limits = np.asarray(G1_HARD_TORQUE_LIMITS) * self.safety.torque_guard_scale
+        self.action_limits = limits.astype(np.float32)
+        self.actor = _RecurrentActor(config, limits).to(self.device)
+        self.parent_actor = copy.deepcopy(self.actor).eval()
+        self._freeze_parent()
+        self.reward_critic = _TwinSequenceCritic(config).to(self.device)
+        self.fall_critic = _TwinSequenceCritic(config).to(self.device)
+        self.constraint_critic = _TwinSequenceCritic(config).to(self.device)
+        self.reward_target = copy.deepcopy(self.reward_critic).eval()
+        self.fall_target = copy.deepcopy(self.fall_critic).eval()
+        self.constraint_target = copy.deepcopy(self.constraint_critic).eval()
+        self.actor_optimizer = torch.optim.Adam(self.actor.parameters(), lr=config.actor_lr)
+        critic_parameters = (
+            list(self.reward_critic.parameters())
+            + list(self.fall_critic.parameters())
+            + list(self.constraint_critic.parameters())
+        )
+        self.critic_optimizer = torch.optim.Adam(critic_parameters, lr=config.critic_lr)
+        self.log_alpha = torch.tensor(
+            math.log(config.initial_alpha),
+            device=self.device,
+            requires_grad=True,
+        )
+        self.alpha_optimizer = torch.optim.Adam((self.log_alpha,), lr=config.alpha_lr)
+        self.target_entropy = -float(len(G1_HARD_TORQUE_LIMITS))
+        self.fall_lagrange = 0.0
+        self.constraint_lagrange = 0.0
+        self.update_index = 0
+        self.observation_mean: np.ndarray = np.zeros(
+            len(G1_NEURAL_TORQUE_OBSERVATIONS), dtype=np.float32
+        )
+        self.observation_std: np.ndarray = np.ones(
+            len(G1_NEURAL_TORQUE_OBSERVATIONS), dtype=np.float32
+        )
+        self._anchor_parameters: dict[str, torch.Tensor] = {}
+        self._fisher: dict[str, torch.Tensor] = {}
+
+    def pretrain_behavior(
+        self,
+        training: tuple[G1TeacherTorqueEpisode, ...],
+        *,
+        validation: tuple[G1TeacherTorqueEpisode, ...] = (),
+        epochs: int = 10,
+        stride: int = 4,
+    ) -> tuple[G1NeuralTorqueBCMetrics, ...]:
+        if not training or epochs <= 0 or stride <= 0:
+            raise ValueError("neural torque BC requires data, positive epochs, and stride")
+        all_observations = np.concatenate([item.observations for item in training], axis=0)
+        self.observation_mean = all_observations.mean(axis=0).astype(np.float32)
+        self.observation_std = np.maximum(all_observations.std(axis=0), 1e-3).astype(np.float32)
+        train_sequences, train_actions = _teacher_sequences(
+            training,
+            sequence_length=self.config.sequence_length,
+            stride=stride,
+        )
+        if validation:
+            validation_sequences, validation_actions = _teacher_sequences(
+                validation,
+                sequence_length=self.config.sequence_length,
+                stride=stride,
+            )
+        else:
+            validation_sequences, validation_actions = train_sequences, train_actions
+        rng = np.random.default_rng(self.config.seed)
+        metrics: list[G1NeuralTorqueBCMetrics] = []
+        for epoch in range(epochs):
+            order = rng.permutation(len(train_sequences))
+            losses: list[float] = []
+            for start in range(0, len(order), self.config.batch_size):
+                indices = order[start : start + self.config.batch_size]
+                observations = self._observation_tensor(train_sequences[indices])
+                targets = torch.as_tensor(
+                    train_actions[indices], dtype=torch.float32, device=self.device
+                )
+                targets = torch.clamp(
+                    targets,
+                    -self.actor.action_limits,
+                    self.actor.action_limits,
+                )
+                prediction = self.actor.deterministic(observations)
+                loss = torch.nn.functional.mse_loss(
+                    prediction / self.actor.action_limits,
+                    targets / self.actor.action_limits,
+                )
+                self.actor_optimizer.zero_grad(set_to_none=True)
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(self.actor.parameters(), max_norm=10.0)
+                self.actor_optimizer.step()
+                losses.append(float(loss.detach().item()))
+            validation_loss, saturation = self._behavior_loss(
+                validation_sequences,
+                validation_actions,
+            )
+            training_loss = float(sum(losses) / len(losses))
+            metrics.append(
+                G1NeuralTorqueBCMetrics(
+                    epoch=epoch,
+                    training_loss=training_loss,
+                    validation_loss=validation_loss,
+                    action_limit_fraction=saturation,
+                    finite=all(math.isfinite(value) for value in (training_loss, validation_loss)),
+                )
+            )
+        self._consolidate_parent(train_sequences, train_actions)
+        return tuple(metrics)
+
+    def update(
+        self,
+        replay: G1NeuralTorqueReplay,
+        *,
+        update_actor: bool = True,
+    ) -> G1NeuralTorqueUpdate:
+        if replay.observations.shape[1] != self.config.sequence_length:
+            raise ValueError("neural torque replay sequence length does not match learner")
+        fresh = np.flatnonzero((replay.partitions == _RECENT) & (replay.policy_lags <= 1))
+        anchors = np.flatnonzero(replay.partitions == _ANCHOR)
+        if update_actor and len(fresh) < self.config.batch_size:
+            raise ValueError("neural torque actor requires enough fresh online transitions")
+        if update_actor and len(anchors) == 0:
+            raise ValueError("neural torque actor update requires historical anchors")
+        rng = np.random.default_rng(self.config.seed + self.update_index)
+        critic_indices = rng.choice(
+            replay.count,
+            self.config.batch_size,
+            replace=replay.count < self.config.batch_size,
+        )
+        observations = self._observation_tensor(replay.observations[critic_indices])
+        next_observations = self._observation_tensor(replay.next_observations[critic_indices])
+        actions = self._tensor(replay.actions[critic_indices])
+        rewards = self._tensor(replay.rewards[critic_indices])
+        fall_costs = self._tensor(replay.fall_costs[critic_indices])
+        constraint_costs = self._tensor(replay.constraint_costs[critic_indices])
+        terminals = self._tensor(replay.terminals[critic_indices])
+        with torch.no_grad():
+            next_actions, next_log_probability = self.actor.sample(next_observations)
+            next_ratio = next_actions / self.actor.action_limits
+            reward_target = rewards + self.config.gamma * (1.0 - terminals) * (
+                torch.minimum(*self.reward_target(next_observations, next_ratio))
+                - self.log_alpha.exp().detach() * next_log_probability
+            )
+            fall_target = fall_costs + self.config.gamma * (1.0 - terminals) * torch.maximum(
+                *self.fall_target(next_observations, next_ratio)
+            )
+            constraint_target = constraint_costs + self.config.gamma * (
+                1.0 - terminals
+            ) * torch.maximum(*self.constraint_target(next_observations, next_ratio))
+        action_ratio = actions / self.actor.action_limits
+        reward_values = self.reward_critic(observations, action_ratio)
+        fall_values = self.fall_critic(observations, action_ratio)
+        constraint_values = self.constraint_critic(observations, action_ratio)
+        reward_loss = sum(
+            torch.nn.functional.mse_loss(value, reward_target) for value in reward_values
+        )
+        fall_loss = sum(torch.nn.functional.mse_loss(value, fall_target) for value in fall_values)
+        constraint_loss = sum(
+            torch.nn.functional.mse_loss(value, constraint_target) for value in constraint_values
+        )
+        self.critic_optimizer.zero_grad(set_to_none=True)
+        (reward_loss + fall_loss + constraint_loss).backward()
+        torch.nn.utils.clip_grad_norm_(
+            list(self.reward_critic.parameters())
+            + list(self.fall_critic.parameters())
+            + list(self.constraint_critic.parameters()),
+            max_norm=10.0,
+        )
+        self.critic_optimizer.step()
+
+        actor_loss = torch.zeros((), device=self.device)
+        anchor_loss = torch.zeros((), device=self.device)
+        online_behavior_loss = torch.zeros((), device=self.device)
+        parent_churn = torch.zeros((), device=self.device)
+        ewc_loss = torch.zeros((), device=self.device)
+        if update_actor:
+            actor_indices = rng.choice(fresh, self.config.batch_size, replace=False)
+            anchor_indices = rng.choice(
+                anchors,
+                min(self.config.batch_size, len(anchors)),
+                replace=False,
+            )
+            actor_observations = self._observation_tensor(replay.observations[actor_indices])
+            anchor_observations = self._observation_tensor(replay.observations[anchor_indices])
+            anchor_actions = self._tensor(replay.parent_actions[anchor_indices])
+            sampled_actions, log_probability = self.actor.sample(actor_observations)
+            behavior_actions = self._tensor(replay.actions[actor_indices])
+            sampled_ratio = sampled_actions / self.actor.action_limits
+            reward_q = torch.minimum(*self.reward_critic(actor_observations, sampled_ratio))
+            fall_q = torch.maximum(*self.fall_critic(actor_observations, sampled_ratio))
+            constraint_q = torch.maximum(*self.constraint_critic(actor_observations, sampled_ratio))
+            anchor_prediction = self.actor.deterministic(anchor_observations)
+            with torch.no_grad():
+                parent_prediction = self.parent_actor.deterministic(anchor_observations)
+            anchor_loss = torch.nn.functional.mse_loss(
+                anchor_prediction / self.actor.action_limits,
+                torch.clamp(
+                    anchor_actions,
+                    -self.actor.action_limits,
+                    self.actor.action_limits,
+                )
+                / self.actor.action_limits,
+            )
+            parent_churn = torch.nn.functional.mse_loss(
+                anchor_prediction / self.actor.action_limits,
+                parent_prediction / self.actor.action_limits,
+            )
+            online_behavior_loss = torch.nn.functional.mse_loss(
+                self.actor.deterministic(actor_observations) / self.actor.action_limits,
+                torch.clamp(
+                    behavior_actions,
+                    -self.actor.action_limits,
+                    self.actor.action_limits,
+                )
+                / self.actor.action_limits,
+            )
+            ewc_loss = self._ewc_loss()
+            actor_loss = (
+                (
+                    self.log_alpha.exp().detach() * log_probability
+                    - reward_q
+                    + self.fall_lagrange * fall_q
+                    + self.constraint_lagrange * constraint_q
+                ).mean()
+                + self.config.behavior_cloning_weight * anchor_loss
+                + self.config.online_behavior_weight * online_behavior_loss
+                + self.config.parent_churn_weight * parent_churn
+                + self.config.ewc_weight * ewc_loss
+            )
+            self.actor_optimizer.zero_grad(set_to_none=True)
+            actor_loss.backward()
+            torch.nn.utils.clip_grad_norm_(self.actor.parameters(), max_norm=10.0)
+            self.actor_optimizer.step()
+            alpha_loss = -(self.log_alpha * (log_probability.detach() + self.target_entropy)).mean()
+            self.alpha_optimizer.zero_grad(set_to_none=True)
+            alpha_loss.backward()
+            self.alpha_optimizer.step()
+        self.fall_lagrange = _lagrange_update(
+            self.fall_lagrange,
+            float(fall_costs.mean().item()) - self.config.fall_cost_limit,
+            self.config,
+        )
+        self.constraint_lagrange = _lagrange_update(
+            self.constraint_lagrange,
+            float(constraint_costs.mean().item()) - self.config.constraint_cost_limit,
+            self.config,
+        )
+        _soft_update(self.reward_target, self.reward_critic, self.config.tau)
+        _soft_update(self.fall_target, self.fall_critic, self.config.tau)
+        _soft_update(self.constraint_target, self.constraint_critic, self.config.tau)
+        values = (
+            reward_loss,
+            fall_loss,
+            constraint_loss,
+            actor_loss,
+            self.log_alpha.exp(),
+            anchor_loss,
+            online_behavior_loss,
+            parent_churn,
+            ewc_loss,
+        )
+        finite = all(bool(torch.isfinite(value).all().item()) for value in values)
+        result = G1NeuralTorqueUpdate(
+            update_index=self.update_index,
+            actor_updated=update_actor,
+            reward_critic_loss=float(reward_loss.detach().item()),
+            fall_critic_loss=float(fall_loss.detach().item()),
+            constraint_critic_loss=float(constraint_loss.detach().item()),
+            actor_loss=float(actor_loss.detach().item()),
+            alpha=float(self.log_alpha.exp().detach().item()),
+            fall_lagrange=self.fall_lagrange,
+            constraint_lagrange=self.constraint_lagrange,
+            anchor_loss=float(anchor_loss.detach().item()),
+            online_behavior_loss=float(online_behavior_loss.detach().item()),
+            parent_churn_loss=float(parent_churn.detach().item()),
+            ewc_loss=float(ewc_loss.detach().item()),
+            actor_transition_count=len(fresh) if update_actor else 0,
+            critic_transition_count=replay.count,
+            stale_actor_transition_count=int(
+                np.count_nonzero((replay.partitions == _RECENT) & (replay.policy_lags > 1))
+            ),
+            anchor_transition_count=len(anchors),
+            finite=finite,
+        )
+        self.update_index += 1
+        return result
+
+    def deterministic_action(self, observation_sequence: np.ndarray) -> np.ndarray:
+        value = np.asarray(observation_sequence, dtype=np.float32)
+        expected = (
+            self.config.sequence_length,
+            len(G1_NEURAL_TORQUE_OBSERVATIONS),
+        )
+        if value.shape != expected or not np.all(np.isfinite(value)):
+            raise ValueError("neural torque inference sequence has the wrong shape")
+        with torch.no_grad():
+            action = self.actor.deterministic(self._observation_tensor(value[None]))[0]
+        return action.cpu().numpy()
+
+    def artifact_bytes(
+        self,
+        *,
+        body_hash: str,
+        parent_policy_hash: str,
+        dataset_hash: str,
+    ) -> bytes:
+        state = self.actor.state_dict()
+        # Canonical 1e-6 quantization removes backend-dependent last-bit CUDA
+        # noise before a policy enters a discontinuous hybrid control loop.
+        # In experiments, 1e-12 weight differences could select a different
+        # fallback branch several seconds later despite identical losses.
+        tensors = {
+            "observation_mean": _quantized_export(self.observation_mean),
+            "observation_std": _quantized_export(self.observation_std),
+            "action_limits": _quantized_export(self.action_limits),
+            "actor.gru.weight_ih_l0": _quantized_export(
+                state["gru.weight_ih_l0"].detach().cpu().numpy()
+            ),
+            "actor.gru.weight_hh_l0": _quantized_export(
+                state["gru.weight_hh_l0"].detach().cpu().numpy()
+            ),
+            "actor.gru.bias_ih_l0": _quantized_export(
+                state["gru.bias_ih_l0"].detach().cpu().numpy()
+            ),
+            "actor.gru.bias_hh_l0": _quantized_export(
+                state["gru.bias_hh_l0"].detach().cpu().numpy()
+            ),
+            "actor.head.weight": _quantized_export(
+                state["head.weight"].detach().cpu().numpy()
+            ),
+            "actor.head.bias": _quantized_export(state["head.bias"].detach().cpu().numpy()),
+        }
+        return serialize_g1_neural_torque_artifact(
+            body_hash=body_hash,
+            parent_policy_hash=parent_policy_hash,
+            dataset_hash=dataset_hash,
+            hidden_dim=self.config.hidden_dim,
+            observation_clip=self.config.observation_clip,
+            update_index=self.update_index,
+            safety=self.safety,
+            tensors=tensors,
+        )
+
+    def actor_snapshot(self) -> dict[str, np.ndarray]:
+        """Return a finite CPU snapshot for a simulator-side trust-region search."""
+
+        return {
+            name: value.detach().cpu().numpy().copy()
+            for name, value in self.actor.state_dict().items()
+        }
+
+    def install_interpolated_actor(
+        self,
+        parent: dict[str, np.ndarray],
+        proposal: dict[str, np.ndarray],
+        *,
+        fraction: float,
+    ) -> None:
+        """Install one bounded point on the parent-to-proposal actor segment."""
+
+        if not math.isfinite(fraction) or not 0.0 <= fraction <= 1.0:
+            raise ValueError("neural torque actor interpolation fraction must be in [0, 1]")
+        expected = self.actor.state_dict()
+        if set(parent) != set(expected) or set(proposal) != set(expected):
+            raise ValueError("neural torque actor snapshot tensor set mismatch")
+        state: dict[str, torch.Tensor] = {}
+        for name, expected_value in expected.items():
+            before = np.asarray(parent[name], dtype=np.float32)
+            after = np.asarray(proposal[name], dtype=np.float32)
+            shape = tuple(expected_value.shape)
+            if before.shape != shape or after.shape != shape:
+                raise ValueError(f"neural torque actor snapshot shape mismatch: {name}")
+            if not np.all(np.isfinite(before)) or not np.all(np.isfinite(after)):
+                raise ValueError("neural torque actor snapshot contains non-finite values")
+            value = before.astype(np.float64) + fraction * (
+                after.astype(np.float64) - before.astype(np.float64)
+            )
+            state[name] = torch.as_tensor(value, dtype=expected_value.dtype, device=self.device)
+        self.actor.load_state_dict(state)
+        self.actor.gru.flatten_parameters()
+
+    def checkpoint_bytes(self) -> bytes:
+        payload = {
+            "schema_version": "rosclaw.simforge.g1_neural_torque_checkpoint.v1",
+            "config_hash": canonical_hash(asdict(self.config)),
+            "safety_hash": canonical_hash(asdict(self.safety)),
+            "actor": self.actor.state_dict(),
+            "parent_actor": self.parent_actor.state_dict(),
+            "reward_critic": self.reward_critic.state_dict(),
+            "fall_critic": self.fall_critic.state_dict(),
+            "constraint_critic": self.constraint_critic.state_dict(),
+            "reward_target": self.reward_target.state_dict(),
+            "fall_target": self.fall_target.state_dict(),
+            "constraint_target": self.constraint_target.state_dict(),
+            "actor_optimizer": self.actor_optimizer.state_dict(),
+            "critic_optimizer": self.critic_optimizer.state_dict(),
+            "alpha_optimizer": self.alpha_optimizer.state_dict(),
+            "log_alpha": self.log_alpha.detach(),
+            "fall_lagrange": self.fall_lagrange,
+            "constraint_lagrange": self.constraint_lagrange,
+            "update_index": self.update_index,
+            "observation_mean": torch.from_numpy(self.observation_mean),
+            "observation_std": torch.from_numpy(self.observation_std),
+            "anchor_parameters": self._anchor_parameters,
+            "fisher": self._fisher,
+            "torch_rng_state": torch.get_rng_state(),
+            "cuda_rng_state": (
+                torch.cuda.get_rng_state_all() if self.device.type == "cuda" else None
+            ),
+        }
+        buffer = io.BytesIO()
+        torch.save(payload, buffer)
+        return buffer.getvalue()
+
+    def restore_checkpoint(self, checkpoint: bytes) -> None:
+        if not checkpoint:
+            raise ValueError("neural torque checkpoint must not be empty")
+        payload = torch.load(io.BytesIO(checkpoint), map_location=self.device, weights_only=True)
+        if not isinstance(payload, dict):
+            raise ValueError("neural torque checkpoint payload must be a mapping")
+        if payload.get("schema_version") != "rosclaw.simforge.g1_neural_torque_checkpoint.v1":
+            raise ValueError("unsupported neural torque checkpoint schema")
+        if payload.get("config_hash") != canonical_hash(asdict(self.config)):
+            raise ValueError("neural torque checkpoint learner configuration mismatch")
+        if payload.get("safety_hash") != canonical_hash(asdict(self.safety)):
+            raise ValueError("neural torque checkpoint safety configuration mismatch")
+        required = (
+            "actor",
+            "parent_actor",
+            "reward_critic",
+            "fall_critic",
+            "constraint_critic",
+            "reward_target",
+            "fall_target",
+            "constraint_target",
+            "actor_optimizer",
+            "critic_optimizer",
+            "alpha_optimizer",
+            "log_alpha",
+            "fall_lagrange",
+            "constraint_lagrange",
+            "update_index",
+            "observation_mean",
+            "observation_std",
+            "anchor_parameters",
+            "fisher",
+            "torch_rng_state",
+        )
+        missing = [name for name in required if name not in payload]
+        if missing:
+            raise ValueError("neural torque checkpoint is missing: " + ", ".join(missing))
+        for name in (
+            "actor",
+            "parent_actor",
+            "reward_critic",
+            "fall_critic",
+            "constraint_critic",
+            "reward_target",
+            "fall_target",
+            "constraint_target",
+        ):
+            getattr(self, name).load_state_dict(payload[name])
+        self.actor_optimizer.load_state_dict(payload["actor_optimizer"])
+        self.critic_optimizer.load_state_dict(payload["critic_optimizer"])
+        self.alpha_optimizer.load_state_dict(payload["alpha_optimizer"])
+        with torch.no_grad():
+            self.log_alpha.copy_(payload["log_alpha"])
+        self.fall_lagrange = float(payload["fall_lagrange"])
+        self.constraint_lagrange = float(payload["constraint_lagrange"])
+        self.update_index = int(payload["update_index"])
+        self.observation_mean = payload["observation_mean"].cpu().numpy().astype(np.float32)
+        self.observation_std = payload["observation_std"].cpu().numpy().astype(np.float32)
+        self._anchor_parameters = {
+            str(name): value.to(self.device) for name, value in payload["anchor_parameters"].items()
+        }
+        self._fisher = {
+            str(name): value.to(self.device) for name, value in payload["fisher"].items()
+        }
+        torch.set_rng_state(payload["torch_rng_state"].cpu())
+        if self.device.type == "cuda":
+            states = payload.get("cuda_rng_state")
+            if states is None:
+                raise ValueError("CUDA neural torque checkpoint lacks CUDA RNG state")
+            torch.cuda.set_rng_state_all([value.cpu() for value in states])
+        self._freeze_parent()
+        self._flatten_recurrent_parameters()
+
+    def _behavior_loss(
+        self,
+        sequences: np.ndarray,
+        actions: np.ndarray,
+    ) -> tuple[float, float]:
+        losses: list[float] = []
+        saturated = 0
+        total = 0
+        with torch.no_grad():
+            for start in range(0, len(sequences), self.config.batch_size):
+                observations = self._observation_tensor(
+                    sequences[start : start + self.config.batch_size]
+                )
+                targets = self._tensor(actions[start : start + self.config.batch_size])
+                targets = torch.clamp(
+                    targets,
+                    -self.actor.action_limits,
+                    self.actor.action_limits,
+                )
+                prediction = self.actor.deterministic(observations)
+                loss = torch.nn.functional.mse_loss(
+                    prediction / self.actor.action_limits,
+                    targets / self.actor.action_limits,
+                )
+                losses.append(float(loss.item()) * len(observations))
+                saturated += int(
+                    torch.count_nonzero(
+                        torch.abs(prediction) >= self.actor.action_limits * 0.999
+                    ).item()
+                )
+                total += prediction.numel()
+        return float(sum(losses) / len(sequences)), saturated / max(1, total)
+
+    def _consolidate_parent(self, sequences: np.ndarray, actions: np.ndarray) -> None:
+        self.parent_actor.load_state_dict(copy.deepcopy(self.actor.state_dict()))
+        self._freeze_parent()
+        sample_count = min(len(sequences), max(self.config.batch_size, 1024))
+        rng = np.random.default_rng(self.config.seed ^ 0xE0C)
+        indices = rng.choice(len(sequences), sample_count, replace=False)
+        observations = self._observation_tensor(sequences[indices])
+        targets = self._tensor(actions[indices])
+        prediction = self.actor.deterministic(observations)
+        loss = torch.nn.functional.mse_loss(
+            prediction / self.actor.action_limits,
+            torch.clamp(targets, -self.actor.action_limits, self.actor.action_limits)
+            / self.actor.action_limits,
+        )
+        self.actor.zero_grad(set_to_none=True)
+        loss.backward()
+        self._anchor_parameters = {
+            name: parameter.detach().clone() for name, parameter in self.actor.named_parameters()
+        }
+        self._fisher = {
+            name: (
+                parameter.grad.detach().square().clone()
+                if parameter.grad is not None
+                else torch.zeros_like(parameter)
+            )
+            for name, parameter in self.actor.named_parameters()
+        }
+        self.actor.zero_grad(set_to_none=True)
+
+    def _ewc_loss(self) -> torch.Tensor:
+        if not self._anchor_parameters or not self._fisher:
+            return torch.zeros((), device=self.device)
+        numerator = torch.zeros((), device=self.device)
+        count = 0
+        for name, parameter in self.actor.named_parameters():
+            numerator = (
+                numerator
+                + (self._fisher[name] * (parameter - self._anchor_parameters[name]).square()).sum()
+            )
+            count += parameter.numel()
+        return numerator / max(1, count)
+
+    def _observation_tensor(self, value: np.ndarray) -> torch.Tensor:
+        normalized = np.clip(
+            (np.asarray(value, dtype=np.float32) - self.observation_mean) / self.observation_std,
+            -self.config.observation_clip,
+            self.config.observation_clip,
+        )
+        return torch.as_tensor(normalized, dtype=torch.float32, device=self.device)
+
+    def _tensor(self, value: np.ndarray) -> torch.Tensor:
+        return torch.as_tensor(value, dtype=torch.float32, device=self.device)
+
+    def _freeze_parent(self) -> None:
+        self.parent_actor.eval()
+        self.parent_actor.gru.flatten_parameters()
+        for parameter in self.parent_actor.parameters():
+            parameter.requires_grad_(False)
+
+    def _flatten_recurrent_parameters(self) -> None:
+        self.actor.gru.flatten_parameters()
+        self.parent_actor.gru.flatten_parameters()
+        for twin in (
+            self.reward_critic,
+            self.fall_critic,
+            self.constraint_critic,
+            self.reward_target,
+            self.fall_target,
+            self.constraint_target,
+        ):
+            twin.q1.gru.flatten_parameters()
+            twin.q2.gru.flatten_parameters()
+
+
+def teacher_dataset_hash(episodes: tuple[G1TeacherTorqueEpisode, ...]) -> str:
+    if not episodes:
+        raise ValueError("neural torque dataset hash requires at least one episode")
+    digest = hashlib.sha256()
+    for index, episode in enumerate(episodes):
+        digest.update(str(index).encode())
+        for value in (episode.observations, episode.actions, episode.parent_actions):
+            array = np.ascontiguousarray(value, dtype=np.float32)
+            digest.update(str(array.shape).encode())
+            digest.update(array.tobytes())
+    return "sha256:" + digest.hexdigest()
+
+
+def neural_torque_replay_hash(replay: G1NeuralTorqueReplay) -> str:
+    """Bind continual updates to the exact replay tensors and partitions."""
+
+    digest = hashlib.sha256()
+    for name in (
+        "observations",
+        "actions",
+        "next_observations",
+        "rewards",
+        "fall_costs",
+        "constraint_costs",
+        "terminals",
+        "parent_actions",
+        "partitions",
+        "policy_lags",
+    ):
+        value = np.ascontiguousarray(getattr(replay, name))
+        digest.update(name.encode())
+        digest.update(str(value.dtype).encode())
+        digest.update(str(value.shape).encode())
+        digest.update(value.tobytes())
+    return "sha256:" + digest.hexdigest()
+
+
+def teacher_replay(
+    episodes: tuple[G1TeacherTorqueEpisode, ...],
+    *,
+    sequence_length: int,
+    stride: int = 10,
+) -> G1NeuralTorqueReplay:
+    sequences, actions, next_sequences, parent_actions, terminals = _episode_transitions(
+        episodes,
+        sequence_length=sequence_length,
+        stride=stride,
+    )
+    count = len(sequences)
+    return G1NeuralTorqueReplay(
+        observations=sequences,
+        actions=actions,
+        next_observations=next_sequences,
+        rewards=np.zeros((count, 1), dtype=np.float32),
+        fall_costs=np.zeros((count, 1), dtype=np.float32),
+        constraint_costs=np.zeros((count, 1), dtype=np.float32),
+        terminals=terminals,
+        parent_actions=parent_actions,
+        partitions=np.full(count, _ANCHOR, dtype=np.int8),
+        policy_lags=np.full(count, 2, dtype=np.int64),
+    )
+
+
+def online_replay(
+    episode: G1TeacherTorqueEpisode,
+    *,
+    sequence_length: int,
+    task_score: float,
+    fell: bool,
+    critical_failure: bool,
+    projection_fallback_rate: float,
+    policy_lag: int = 0,
+    stride: int = 10,
+) -> G1NeuralTorqueReplay:
+    if not math.isfinite(task_score) or not -20.0 <= task_score <= 20.0:
+        raise ValueError("neural torque online task score must be finite and bounded")
+    if not 0.0 <= projection_fallback_rate <= 1.0:
+        raise ValueError("projection fallback rate must be in [0, 1]")
+    sequences, actions, next_sequences, parent_actions, terminals = _episode_transitions(
+        (episode,),
+        sequence_length=sequence_length,
+        stride=stride,
+    )
+    count = len(sequences)
+    limits = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float32) * 0.85
+    action_ratio = actions / limits
+    parent_ratio = np.clip(parent_actions, -limits, limits) / limits
+    imitation = -np.mean(np.square(action_ratio - parent_ratio), axis=1, keepdims=True)
+    smoothness: np.ndarray = np.zeros((count, 1), dtype=np.float32)
+    if count > 1:
+        smoothness[1:] = -np.mean(np.square(np.diff(action_ratio, axis=0)), axis=1)[:, None]
+    rewards = (0.05 * imitation + 0.02 * smoothness).astype(np.float32)
+    rewards[-1, 0] += task_score
+    fall_costs: np.ndarray = np.zeros((count, 1), dtype=np.float32)
+    fall_costs[-1, 0] = float(fell)
+    constraint_costs: np.ndarray = np.full(
+        (count, 1),
+        projection_fallback_rate,
+        dtype=np.float32,
+    )
+    if critical_failure:
+        constraint_costs[-1, 0] = max(1.0, constraint_costs[-1, 0])
+    return G1NeuralTorqueReplay(
+        observations=sequences,
+        actions=actions,
+        next_observations=next_sequences,
+        rewards=rewards,
+        fall_costs=fall_costs,
+        constraint_costs=constraint_costs,
+        terminals=terminals,
+        parent_actions=parent_actions,
+        partitions=np.full(
+            count,
+            _BOUNDARY if critical_failure else _RECENT,
+            dtype=np.int8,
+        ),
+        policy_lags=np.full(count, policy_lag, dtype=np.int64),
+    )
+
+
+def _teacher_sequences(
+    episodes: tuple[G1TeacherTorqueEpisode, ...],
+    *,
+    sequence_length: int,
+    stride: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    sequence_rows: list[np.ndarray] = []
+    actions: list[np.ndarray] = []
+    for episode in episodes:
+        if len(episode.observations) <= sequence_length:
+            continue
+        for end in range(sequence_length - 1, len(episode.observations), stride):
+            start = end - sequence_length + 1
+            sequence_rows.append(episode.observations[start : end + 1])
+            actions.append(episode.actions[end])
+    if not sequence_rows:
+        raise ValueError("teacher episodes are too short for the recurrent sequence length")
+    return np.asarray(sequence_rows, dtype=np.float32), np.asarray(actions, dtype=np.float32)
+
+
+def _episode_transitions(
+    episodes: tuple[G1TeacherTorqueEpisode, ...],
+    *,
+    sequence_length: int,
+    stride: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    observations: list[np.ndarray] = []
+    actions: list[np.ndarray] = []
+    next_observations: list[np.ndarray] = []
+    parent_actions: list[np.ndarray] = []
+    terminals: list[list[float]] = []
+    for episode in episodes:
+        final_end = len(episode.observations) - 2
+        for end in range(sequence_length - 1, final_end + 1, stride):
+            start = end - sequence_length + 1
+            observations.append(episode.observations[start : end + 1])
+            next_observations.append(episode.observations[start + 1 : end + 2])
+            actions.append(episode.actions[end])
+            parent_actions.append(episode.parent_actions[end])
+            terminals.append([float(end + stride > final_end)])
+    if not observations:
+        raise ValueError("neural torque episodes are too short for replay")
+    return (
+        np.asarray(observations, dtype=np.float32),
+        np.asarray(actions, dtype=np.float32),
+        np.asarray(next_observations, dtype=np.float32),
+        np.asarray(parent_actions, dtype=np.float32),
+        np.asarray(terminals, dtype=np.float32),
+    )
+
+
+def _lagrange_update(
+    value: float,
+    violation: float,
+    config: G1NeuralTorqueLearnerConfig,
+) -> float:
+    return min(
+        config.maximum_lagrange,
+        max(0.0, value + config.lagrange_lr * violation),
+    )
+
+
+def _soft_update(target: nn.Module, source: nn.Module, tau: float) -> None:
+    with torch.no_grad():
+        for target_value, source_value in zip(
+            target.parameters(), source.parameters(), strict=True
+        ):
+            target_value.mul_(1.0 - tau).add_(source_value, alpha=tau)
+
+
+def _quantized_export(value: np.ndarray) -> np.ndarray:
+    return np.round(np.asarray(value, dtype=np.float64), decimals=6).astype(np.float32)
+
+
+__all__ = [
+    "G1ContinualTorqueActorCritic",
+    "G1NeuralTorqueBCMetrics",
+    "G1NeuralTorqueLearnerConfig",
+    "G1NeuralTorqueReplay",
+    "G1NeuralTorqueUpdate",
+    "online_replay",
+    "neural_torque_replay_hash",
+    "teacher_dataset_hash",
+    "teacher_replay",
+]

--- a/src/rosclaw/simforge/g1_neural_torque_learning.py
+++ b/src/rosclaw/simforge/g1_neural_torque_learning.py
@@ -18,8 +18,9 @@ import copy
 import hashlib
 import io
 import math
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch  # type: ignore[import-not-found]
@@ -34,9 +35,13 @@ from rosclaw.simforge.g1_neural_torque import (
 )
 from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_HARD_TORQUE_LIMITS
 
+if TYPE_CHECKING:
+    from rosclaw.collective.sources.motiondecode.motion_prior import G1MotionPriorArtifact
+
 _RECENT = 0
 _ANCHOR = 1
 _BOUNDARY = 2
+_G1_MOTION_PRIOR_FEATURE_COUNT = 61
 
 
 @dataclass(frozen=True)
@@ -358,6 +363,49 @@ class G1ContinualTorqueActorCritic:
         )
         self._anchor_parameters: dict[str, torch.Tensor] = {}
         self._fisher: dict[str, torch.Tensor] = {}
+        self._pending_motion_prior: G1MotionPriorArtifact | None = None
+        self._pending_motion_prior_fraction: float = 0.0
+        self.motion_prior_artifact_hash: str | None = None
+        self.motion_prior_transfer_fraction: float = 0.0
+        # ``deepcopy`` does not preserve cuDNN's packed recurrent-weight
+        # layout. Pack every actor/critic once up front so the first online
+        # update does not silently take the slow fallback path.
+        self._flatten_recurrent_parameters()
+
+    def install_motion_prior(
+        self,
+        artifact: G1MotionPriorArtifact,
+        *,
+        expected_body_hash: str,
+        fraction: float = 1.0,
+    ) -> None:
+        """Stage an audited kinematic representation for the next BC pass.
+
+        The prior contributes GRU representation weights only.  Its prediction
+        head cannot become a torque head, and the torque actor still requires
+        teacher BC plus sealed physics validation.
+        """
+
+        if self.update_index or self._anchor_parameters:
+            raise ValueError("motion prior must be installed before torque consolidation")
+        if artifact.body_hash != expected_body_hash:
+            raise ValueError("motion-prior body hash does not match the torque learner")
+        if artifact.hidden_dim != self.config.hidden_dim:
+            raise ValueError("motion-prior hidden dimension does not match the torque learner")
+        feature_count = len(artifact.feature_names)
+        if (
+            feature_count != _G1_MOTION_PRIOR_FEATURE_COUNT
+            or artifact.feature_names != G1_NEURAL_TORQUE_OBSERVATIONS[:feature_count]
+        ):
+            raise ValueError("motion-prior feature order does not match torque proprioception")
+        if artifact.source_truth_level != "T4" or artifact.action_semantics != "ABSENT":
+            raise ValueError("motion-prior source semantics are not eligible")
+        if artifact.activation_ceiling != "SIM_ONLY_REPRESENTATION_INITIALIZATION":
+            raise ValueError("motion-prior activation ceiling is not SIM_ONLY")
+        if not math.isfinite(fraction) or not 0.0 < fraction <= 1.0:
+            raise ValueError("motion-prior transfer fraction must be in (0, 1]")
+        self._pending_motion_prior = artifact
+        self._pending_motion_prior_fraction = fraction
 
     def pretrain_behavior(
         self,
@@ -366,22 +414,37 @@ class G1ContinualTorqueActorCritic:
         validation: tuple[G1TeacherTorqueEpisode, ...] = (),
         epochs: int = 10,
         stride: int = 4,
+        minimum_end_fraction: float = 0.0,
     ) -> tuple[G1NeuralTorqueBCMetrics, ...]:
         if not training or epochs <= 0 or stride <= 0:
             raise ValueError("neural torque BC requires data, positive epochs, and stride")
+        if not 0.0 <= minimum_end_fraction <= 0.9:
+            raise ValueError("neural torque BC end fraction must be in [0, 0.9]")
+        self.actor.gru.flatten_parameters()
         all_observations = np.concatenate([item.observations for item in training], axis=0)
         self.observation_mean = all_observations.mean(axis=0).astype(np.float32)
         self.observation_std = np.maximum(all_observations.std(axis=0), 1e-3).astype(np.float32)
+        if self._pending_motion_prior is not None:
+            self._apply_motion_prior(
+                self._pending_motion_prior,
+                fraction=self._pending_motion_prior_fraction,
+            )
+            self.motion_prior_artifact_hash = self._pending_motion_prior.artifact_hash
+            self.motion_prior_transfer_fraction = self._pending_motion_prior_fraction
+            self._pending_motion_prior = None
+            self._pending_motion_prior_fraction = 0.0
         train_sequences, train_actions = _teacher_sequences(
             training,
             sequence_length=self.config.sequence_length,
             stride=stride,
+            minimum_end_fraction=minimum_end_fraction,
         )
         if validation:
             validation_sequences, validation_actions = _teacher_sequences(
                 validation,
                 sequence_length=self.config.sequence_length,
                 stride=stride,
+                minimum_end_fraction=minimum_end_fraction,
             )
         else:
             validation_sequences, validation_actions = train_sequences, train_actions
@@ -724,6 +787,8 @@ class G1ContinualTorqueActorCritic:
             "observation_std": torch.from_numpy(self.observation_std),
             "anchor_parameters": self._anchor_parameters,
             "fisher": self._fisher,
+            "motion_prior_artifact_hash": self.motion_prior_artifact_hash,
+            "motion_prior_transfer_fraction": self.motion_prior_transfer_fraction,
             "torch_rng_state": torch.get_rng_state(),
             "cuda_rng_state": (
                 torch.cuda.get_rng_state_all() if self.device.type == "cuda" else None
@@ -797,6 +862,11 @@ class G1ContinualTorqueActorCritic:
         self._fisher = {
             str(name): value.to(self.device) for name, value in payload["fisher"].items()
         }
+        prior_hash = payload.get("motion_prior_artifact_hash")
+        self.motion_prior_artifact_hash = str(prior_hash) if prior_hash is not None else None
+        self.motion_prior_transfer_fraction = float(
+            payload.get("motion_prior_transfer_fraction", 0.0)
+        )
         torch.set_rng_state(payload["torch_rng_state"].cpu())
         if self.device.type == "cuda":
             states = payload.get("cuda_rng_state")
@@ -838,6 +908,72 @@ class G1ContinualTorqueActorCritic:
                 )
                 total += prediction.numel()
         return float(sum(losses) / len(sequences)), saturated / max(1, total)
+
+    def _apply_motion_prior(
+        self,
+        artifact: G1MotionPriorArtifact,
+        *,
+        fraction: float,
+    ) -> None:
+        feature_count = len(artifact.feature_names)
+        prior_mean = np.asarray(artifact.observation_mean, dtype=np.float32)
+        prior_std = np.asarray(artifact.observation_std, dtype=np.float32)
+        actor_mean = self.observation_mean[:feature_count]
+        actor_std = self.observation_std[:feature_count]
+        required_tensors = {
+            "gru.weight_ih_l0",
+            "gru.weight_hh_l0",
+            "gru.bias_ih_l0",
+            "gru.bias_hh_l0",
+        }
+        if not required_tensors.issubset(artifact.tensors):
+            raise ValueError("motion-prior GRU tensor set is incomplete")
+        if (
+            prior_mean.shape != (feature_count,)
+            or prior_std.shape != (feature_count,)
+            or not np.all(np.isfinite(prior_mean))
+            or not np.all(np.isfinite(prior_std))
+            or np.any(prior_std <= 1e-6)
+        ):
+            raise ValueError("motion-prior normalization contract is invalid")
+        scale = actor_std / prior_std
+        offset = (actor_mean - prior_mean) / prior_std
+        weight_ih = np.asarray(artifact.tensors["gru.weight_ih_l0"], dtype=np.float32)
+        weight_hh = np.asarray(artifact.tensors["gru.weight_hh_l0"], dtype=np.float32)
+        bias_ih = np.asarray(artifact.tensors["gru.bias_ih_l0"], dtype=np.float32)
+        bias_hh = np.asarray(artifact.tensors["gru.bias_hh_l0"], dtype=np.float32)
+        expected = (3 * self.config.hidden_dim, feature_count)
+        if (
+            weight_ih.shape != expected
+            or weight_hh.shape
+            != (3 * self.config.hidden_dim, self.config.hidden_dim)
+            or bias_ih.shape != (3 * self.config.hidden_dim,)
+            or bias_hh.shape != (3 * self.config.hidden_dim,)
+        ):
+            raise ValueError("motion-prior GRU tensor shape is invalid")
+        if any(
+            not np.all(np.isfinite(value))
+            for value in (scale, offset, weight_ih, weight_hh, bias_ih, bias_hh)
+        ):
+            raise ValueError("motion-prior transfer contains non-finite values")
+        transformed_weight = weight_ih * scale[None, :]
+        transformed_bias = bias_ih + weight_ih @ offset
+        with torch.no_grad():
+            actor_weight = self.actor.gru.weight_ih_l0
+            transfers = (
+                (actor_weight[:, :feature_count], transformed_weight),
+                (self.actor.gru.weight_hh_l0, weight_hh),
+                (self.actor.gru.bias_ih_l0, transformed_bias),
+                (self.actor.gru.bias_hh_l0, bias_hh),
+            )
+            for target, source in transfers:
+                prior_value = torch.as_tensor(
+                    source,
+                    dtype=actor_weight.dtype,
+                    device=self.device,
+                )
+                target.copy_(target * (1.0 - fraction) + prior_value * fraction)
+        self.actor.gru.flatten_parameters()
 
     def _consolidate_parent(self, sequences: np.ndarray, actions: np.ndarray) -> None:
         self.parent_actor.load_state_dict(copy.deepcopy(self.actor.state_dict()))
@@ -1033,18 +1169,139 @@ def online_replay(
     )
 
 
+def recovery_online_replay(
+    episode: G1TeacherTorqueEpisode,
+    *,
+    trajectory: Mapping[str, np.ndarray],
+    sequence_length: int,
+    recovery_score: float,
+    fell: bool,
+    critical_failure: bool,
+    projection_fallback_rate: float,
+    recovery_start_phase: float = 0.55,
+    policy_lag: int = 0,
+    stride: int = 10,
+) -> G1NeuralTorqueReplay:
+    """Build dense, time-aligned post-kick replay from T1 MuJoCo evidence."""
+
+    if not -20.0 <= recovery_score <= 20.0 or not math.isfinite(recovery_score):
+        raise ValueError("recovery score must be finite and bounded")
+    if not 0.0 <= projection_fallback_rate <= 1.0:
+        raise ValueError("recovery projection fallback rate must be in [0, 1]")
+    if not 0.4 <= recovery_start_phase <= 0.95:
+        raise ValueError("recovery start phase must be in [0.4, 0.95]")
+    if stride <= 0:
+        raise ValueError("recovery replay stride must be positive")
+    required = (
+        "policy_phase",
+        "support_foot_slip",
+        "com_y_relative",
+        "left_foot_contact",
+        "right_foot_contact",
+    )
+    try:
+        values = {name: np.asarray(trajectory[name], dtype=np.float64) for name in required}
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("recovery trajectory signals are missing or non-numeric") from exc
+    trace_lengths = {len(value) for value in values.values() if value.ndim >= 1}
+    if any(value.ndim != 1 for value in values.values()) or len(trace_lengths) != 1:
+        raise ValueError("recovery trajectory signals are missing or misaligned")
+    trace_count = trace_lengths.pop()
+    if trace_count <= 0 or len(episode.observations) != trace_count * 10:
+        raise ValueError("recovery replay requires exact 500 Hz to 50 Hz alignment")
+    if any(not np.all(np.isfinite(value)) for value in values.values()):
+        raise ValueError("recovery trajectory contains non-finite values")
+
+    observations: list[np.ndarray] = []
+    actions: list[np.ndarray] = []
+    next_observations: list[np.ndarray] = []
+    parent_actions: list[np.ndarray] = []
+    rewards: list[list[float]] = []
+    fall_costs: list[list[float]] = []
+    constraint_costs: list[list[float]] = []
+    limits = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float32) * 0.85
+    final_end = len(episode.observations) - 2
+    for end in range(sequence_length - 1, final_end + 1, stride):
+        trace_index = min(end // 10, trace_count - 1)
+        if float(values["policy_phase"][trace_index]) < recovery_start_phase:
+            continue
+        start = end - sequence_length + 1
+        observation = episode.observations[start : end + 1]
+        action = episode.actions[end]
+        parent = episode.parent_actions[end]
+        gravity = observation[-1, 58:61]
+        tilt_cost = float(np.dot(gravity[:2], gravity[:2]))
+        velocity_cost = float(np.mean(np.square(observation[-1, 29:58] / 10.0)))
+        action_ratio = np.clip(action, -limits, limits) / limits
+        parent_ratio = np.clip(parent, -limits, limits) / limits
+        imitation_cost = float(np.mean(np.square(action_ratio - parent_ratio)))
+        slip = abs(float(values["support_foot_slip"][trace_index]))
+        com_offset = abs(float(values["com_y_relative"][trace_index]))
+        double_support = float(
+            bool(values["left_foot_contact"][trace_index])
+            and bool(values["right_foot_contact"][trace_index])
+        )
+        reward = (
+            0.02 * double_support
+            - 0.50 * tilt_cost
+            - 0.05 * velocity_cost
+            - 1.50 * min(slip, 0.20)
+            - 0.50 * min(com_offset, 0.30)
+            - 0.05 * imitation_cost
+        )
+        constraint = max(
+            projection_fallback_rate,
+            float(slip > 0.04),
+            float(tilt_cost > 0.20),
+            float(com_offset > 0.12),
+        )
+        observations.append(observation)
+        next_observations.append(episode.observations[start + 1 : end + 2])
+        actions.append(action)
+        parent_actions.append(parent)
+        rewards.append([float(np.clip(reward, -2.0, 0.1))])
+        fall_costs.append([0.0])
+        constraint_costs.append([constraint])
+    if not observations:
+        raise ValueError("recovery trajectory contains no eligible transitions")
+    rewards[-1][0] += 0.25 * recovery_score
+    fall_costs[-1][0] = float(fell)
+    if critical_failure:
+        constraint_costs[-1][0] = 1.0
+    count = len(observations)
+    terminals = np.zeros((count, 1), dtype=np.float32)
+    terminals[-1, 0] = 1.0
+    return G1NeuralTorqueReplay(
+        observations=np.asarray(observations, dtype=np.float32),
+        actions=np.asarray(actions, dtype=np.float32),
+        next_observations=np.asarray(next_observations, dtype=np.float32),
+        rewards=np.asarray(rewards, dtype=np.float32),
+        fall_costs=np.asarray(fall_costs, dtype=np.float32),
+        constraint_costs=np.asarray(constraint_costs, dtype=np.float32),
+        terminals=terminals,
+        parent_actions=np.asarray(parent_actions, dtype=np.float32),
+        partitions=np.full(count, _BOUNDARY if critical_failure else _RECENT, dtype=np.int8),
+        policy_lags=np.full(count, policy_lag, dtype=np.int64),
+    )
+
+
 def _teacher_sequences(
     episodes: tuple[G1TeacherTorqueEpisode, ...],
     *,
     sequence_length: int,
     stride: int,
+    minimum_end_fraction: float = 0.0,
 ) -> tuple[np.ndarray, np.ndarray]:
     sequence_rows: list[np.ndarray] = []
     actions: list[np.ndarray] = []
     for episode in episodes:
         if len(episode.observations) <= sequence_length:
             continue
-        for end in range(sequence_length - 1, len(episode.observations), stride):
+        first_end = max(
+            sequence_length - 1,
+            int(math.ceil((len(episode.observations) - 1) * minimum_end_fraction)),
+        )
+        for end in range(first_end, len(episode.observations), stride):
             start = end - sequence_length + 1
             sequence_rows.append(episode.observations[start : end + 1])
             actions.append(episode.actions[end])

--- a/src/rosclaw/simforge/g1_neural_torque_validation.py
+++ b/src/rosclaw/simforge/g1_neural_torque_validation.py
@@ -1,0 +1,987 @@
+"""Closed-loop G1 neural-torque distillation and online-RL pilot."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.simforge.backends.unitree_mujoco_backend import (
+    G1MuJoCoBackend,
+    GoalForgeEpisode,
+    trajectory_digest,
+)
+from rosclaw.simforge.g1_neural_torque import (
+    G1NeuralTorquePolicy,
+    G1TeacherTorqueCollector,
+    G1TeacherTorqueEpisode,
+    G1TorquePolicyReceipt,
+    G1TorqueSafetyConfig,
+    load_g1_neural_torque_artifact,
+)
+from rosclaw.simforge.g1_neural_torque_learning import (
+    G1ContinualTorqueActorCritic,
+    G1NeuralTorqueLearnerConfig,
+    G1NeuralTorqueReplay,
+    G1NeuralTorqueUpdate,
+    neural_torque_replay_hash,
+    online_replay,
+    teacher_dataset_hash,
+    teacher_replay,
+)
+from rosclaw.simforge.models import Partition
+from rosclaw.simforge.seed_ledger import SeedLedger
+from rosclaw.simforge.tasks.g1_goalforge.concepts import (
+    GoalForgeResult,
+    ShotParameters,
+    hash_bytes,
+)
+from rosclaw.simforge.tasks.g1_goalforge.scenario import (
+    GoalForgeScenario,
+    generate_goalforge_scenarios,
+)
+
+
+@dataclass(frozen=True)
+class G1NeuralTorqueRolloutEvidence:
+    stage: str
+    partition: str
+    scenario_id: str
+    scenario_commitment: str
+    status: str
+    success: bool
+    contact: bool
+    target_error_m: float | None
+    ball_speed_mps: float
+    support_slip_m: float
+    com_margin_min_m: float
+    torso_roll_peak_rad: float
+    torso_pitch_peak_rad: float
+    fall: bool
+    joint_violation: bool
+    torque_violation: bool
+    finite: bool
+    score: float
+    direct_torque_inferences: int
+    learned_output_fraction: float
+    fallback_fraction: float
+    artifact_hash: str | None
+    activation_ceiling: str | None
+    hardware_authorized: bool
+    strict_replay: bool
+    trace_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class G1NeuralTorquePilotReport:
+    source_commit: str
+    body_hash: str
+    parent_policy_hash: str
+    dataset_hash: str
+    gpu_workers: tuple[dict[str, Any], ...]
+    selected_seed: int
+    teacher_pass_through_exact: bool
+    dagger_metrics: tuple[dict[str, Any], ...]
+    online_updates: tuple[dict[str, Any], ...]
+    online_gate_decisions: tuple[dict[str, Any], ...]
+    parent_rollouts: tuple[G1NeuralTorqueRolloutEvidence, ...]
+    bc_rollouts: tuple[G1NeuralTorqueRolloutEvidence, ...]
+    online_rl_rollouts: tuple[G1NeuralTorqueRolloutEvidence, ...]
+    promotion_checks: dict[str, bool]
+    decision: str
+    blockers: tuple[str, ...]
+    artifact_paths: dict[str, str]
+    pipeline_failures: tuple[str, ...]
+    schema_version: str = "rosclaw.simforge.g1_neural_torque_pilot.v3"
+
+    @property
+    def pipeline_passed(self) -> bool:
+        return not self.pipeline_failures and all(
+            self.promotion_checks[name]
+            for name in (
+                "four_physical_gpus_exercised",
+                "teacher_collection_causally_transparent",
+                "behavior_cloning_converged",
+                "direct_torque_physics_executed",
+                "online_actor_critic_updated",
+                "sim_only_boundary_preserved",
+                "decision_fail_closed",
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source_commit": self.source_commit,
+            "body_hash": self.body_hash,
+            "parent_policy_hash": self.parent_policy_hash,
+            "dataset_hash": self.dataset_hash,
+            "gpu_workers": list(self.gpu_workers),
+            "selected_seed": self.selected_seed,
+            "teacher_pass_through_exact": self.teacher_pass_through_exact,
+            "dagger_metrics": list(self.dagger_metrics),
+            "online_updates": list(self.online_updates),
+            "online_gate_decisions": list(self.online_gate_decisions),
+            "parent_rollouts": [item.to_dict() for item in self.parent_rollouts],
+            "bc_rollouts": [item.to_dict() for item in self.bc_rollouts],
+            "online_rl_rollouts": [item.to_dict() for item in self.online_rl_rollouts],
+            "aggregates": {
+                "parent": _aggregate(self.parent_rollouts),
+                "bc": _aggregate(self.bc_rollouts),
+                "online_rl": _aggregate(self.online_rl_rollouts),
+            },
+            "promotion_checks": self.promotion_checks,
+            "decision": self.decision,
+            "blockers": list(self.blockers),
+            "artifact_paths": self.artifact_paths,
+            "pipeline_failures": list(self.pipeline_failures),
+            "pipeline_passed": self.pipeline_passed,
+            "claims": {
+                "evidence_domain": "SIM_ONLY",
+                "direct_joint_torque_actor": True,
+                "online_actor_critic": bool(self.online_updates),
+                "continual_retention": "anchor_replay+parent_distillation+EWC",
+                "candidate_promoted": self.decision == "SIM_CANDIDATE",
+                "hardware_authorized": False,
+                "real_robot_evidence": False,
+            },
+        }
+
+
+def run_g1_neural_torque_pilot(
+    *,
+    asset_root: Path,
+    output_dir: Path,
+    source_checkout: Path,
+    gpu_epochs: int = 12,
+    dagger_generations: int = 3,
+    online_updates: int = 8,
+) -> G1NeuralTorquePilotReport:
+    """Execute teacher collection, four-GPU BC, DAgger, SAC, and sealed replay."""
+
+    if not 4 <= gpu_epochs <= 50:
+        raise ValueError("neural torque GPU epochs must be in [4, 50]")
+    if not 1 <= dagger_generations <= 6:
+        raise ValueError("neural torque DAgger generations must be in [1, 6]")
+    if not 1 <= online_updates <= 30:
+        raise ValueError("neural torque online updates must be in [1, 30]")
+    root = _new_external_root(output_dir, source_checkout)
+    gpu_root = root / "gpu-workers"
+    gpu_root.mkdir()
+    backend = G1MuJoCoBackend(asset_root=asset_root, trace_stride=1)
+    qualification = backend.qualification
+    parameters = ShotParameters()
+    training_scenarios, dagger_scenarios, sealed_scenarios = _pilot_scenarios()
+    training_episodes: list[G1TeacherTorqueEpisode] = []
+    training_results: list[GoalForgeEpisode] = []
+    for scenario in training_scenarios:
+        episode, teacher = _collect_teacher(backend, scenario, parameters)
+        training_results.append(episode)
+        training_episodes.append(teacher)
+    validation_teachers = tuple(
+        _collect_teacher(backend, scenario, parameters)[1] for scenario in dagger_scenarios
+    )
+    control = backend.run(training_scenarios[0], parameters)
+    teacher_pass_through_exact = bool(
+        control.result.summary_dict() == training_results[0].result.summary_dict()
+        and trajectory_digest(control.trajectory)
+        == trajectory_digest(training_results[0].trajectory)
+    )
+    dataset_path = root / "teacher-dataset.npz"
+    _write_teacher_dataset(
+        dataset_path,
+        tuple(training_episodes),
+        validation_teachers,
+    )
+    dataset_hash = teacher_dataset_hash(tuple(training_episodes))
+    worker_values, worker_failures = _run_gpu_workers(
+        checkout=source_checkout,
+        dataset_path=dataset_path,
+        output_root=gpu_root,
+        body_hash=qualification.body_hash,
+        parent_policy_hash=qualification.kick_prior_hash,
+        epochs=gpu_epochs,
+    )
+    failures = list(worker_failures)
+    if worker_values:
+        selected = min(
+            worker_values,
+            key=lambda value: (float(value["final_validation_loss"]), int(value["learner_seed"])),
+        )
+        selected_seed = int(selected["learner_seed"])
+    else:
+        selected_seed = 8101
+        failures.append("no four-GPU behavior-cloning worker completed")
+
+    safety = G1TorqueSafetyConfig(
+        torque_guard_scale=0.80,
+        maximum_mechanical_power_w=4000.0,
+        maximum_parent_deviation_ratio=0.05,
+        maximum_projection_ratio=0.35,
+        maximum_observation_z=5.0,
+        minimum_upright_gravity_z=-0.97,
+        minimum_pelvis_height_m=0.70,
+        recovery_cooldown_steps=250,
+        warmup_steps=100,
+    )
+    learner = G1ContinualTorqueActorCritic(
+        G1NeuralTorqueLearnerConfig(
+            hidden_dim=96,
+            sequence_length=32,
+            batch_size=256,
+            actor_lr=5e-5,
+            critic_lr=2e-4,
+            behavior_cloning_weight=5.0,
+            parent_churn_weight=2.0,
+            ewc_weight=20.0,
+            device="cuda:2",
+            seed=selected_seed,
+        ),
+        safety=safety,
+    )
+    accumulated = list(training_episodes)
+    initial_metrics = learner.pretrain_behavior(
+        tuple(accumulated),
+        validation=validation_teachers,
+        epochs=gpu_epochs,
+        stride=4,
+    )
+    dagger_metrics: list[dict[str, Any]] = [{"generation": 0, **initial_metrics[-1].to_dict()}]
+    bc_development_rollouts: list[G1NeuralTorqueRolloutEvidence] = []
+    for generation in range(1, dagger_generations + 1):
+        artifact_path = root / f"dagger-generation-{generation - 1}.bin"
+        _write_candidate(
+            artifact_path,
+            learner,
+            body_hash=qualification.body_hash,
+            parent_policy_hash=qualification.kick_prior_hash,
+            dataset_hash=teacher_dataset_hash(tuple(accumulated)),
+        )
+        corrections: list[G1TeacherTorqueEpisode] = []
+        for scenario in dagger_scenarios:
+            episode, policy = _run_candidate(
+                backend,
+                scenario,
+                parameters,
+                artifact_path,
+            )
+            bc_development_rollouts.append(
+                _rollout_evidence(
+                    stage=f"dagger_generation_{generation - 1}",
+                    episode=episode,
+                    policy=policy,
+                    strict_replay=False,
+                )
+            )
+            trace = policy.episode()
+            corrections.append(
+                G1TeacherTorqueEpisode(
+                    observations=trace.observations,
+                    actions=trace.parent_actions,
+                    parent_actions=trace.parent_actions,
+                )
+            )
+        accumulated.extend(corrections)
+        metrics = learner.pretrain_behavior(
+            tuple(accumulated),
+            validation=validation_teachers,
+            epochs=6,
+            stride=4,
+        )
+        dagger_metrics.append({"generation": generation, **metrics[-1].to_dict()})
+
+    bc_artifact_path = root / "g1-neural-torque-bc.bin"
+    _write_candidate(
+        bc_artifact_path,
+        learner,
+        body_hash=qualification.body_hash,
+        parent_policy_hash=qualification.kick_prior_hash,
+        dataset_hash=teacher_dataset_hash(tuple(accumulated)),
+    )
+    recent_replays: list[G1NeuralTorqueReplay] = []
+    online_scenarios = (*training_scenarios, *dagger_scenarios)
+    bc_online_rollouts: list[G1NeuralTorqueRolloutEvidence] = []
+    for scenario in online_scenarios:
+        episode, policy = _run_candidate(
+            backend,
+            scenario,
+            parameters,
+            bc_artifact_path,
+        )
+        evidence = _rollout_evidence(
+            stage="bc_online_collection",
+            episode=episode,
+            policy=policy,
+            strict_replay=False,
+        )
+        bc_development_rollouts.append(evidence)
+        bc_online_rollouts.append(evidence)
+        receipt = _require_torque_receipt(episode)
+        critical = _critical(episode.result)
+        recent_replays.append(
+            online_replay(
+                policy.episode(),
+                sequence_length=learner.config.sequence_length,
+                task_score=_task_score(episode.result),
+                fell=episode.result.post_kick_fall,
+                critical_failure=critical,
+                projection_fallback_rate=(
+                    receipt.projection_fallback_count / max(1, receipt.inference_count)
+                ),
+                stride=10,
+            )
+        )
+    anchor = teacher_replay(
+        tuple(training_episodes),
+        sequence_length=learner.config.sequence_length,
+        stride=10,
+    )
+    replay = G1NeuralTorqueReplay.combine(anchor, *recent_replays)
+    online_dataset_hash = canonical_hash(
+        {
+            "teacher_dataset_hash": teacher_dataset_hash(tuple(accumulated)),
+            "online_replay_hash": neural_torque_replay_hash(replay),
+        }
+    )
+    update_values: list[G1NeuralTorqueUpdate] = []
+    online_gate_decisions: list[dict[str, Any]] = []
+    try:
+        critic_warmup_updates = max(16, min(64, online_updates * 4))
+        update_values.extend(
+            learner.update(replay, update_actor=False) for _ in range(critic_warmup_updates)
+        )
+        current_gate_rollouts = tuple(bc_online_rollouts)
+        trust_region_fractions = (1.0, 0.50, 0.20, 0.10, 0.05, 0.035, 0.02, 0.01, 0.005)
+        for attempt in range(online_updates):
+            rollback = learner.checkpoint_bytes()
+            actor_parent = learner.actor_snapshot()
+            update = learner.update(replay)
+            update_values.append(update)
+            actor_proposal = learner.actor_snapshot()
+            accepted_step = False
+            for fraction in trust_region_fractions:
+                learner.install_interpolated_actor(
+                    actor_parent,
+                    actor_proposal,
+                    fraction=fraction,
+                )
+                fraction_label = str(fraction).replace(".", "p")
+                attempt_path = root / (
+                    f"online-actor-attempt-{attempt}-fraction-{fraction_label}.bin"
+                )
+                _write_candidate(
+                    attempt_path,
+                    learner,
+                    body_hash=qualification.body_hash,
+                    parent_policy_hash=qualification.kick_prior_hash,
+                    dataset_hash=online_dataset_hash,
+                )
+                attempt_rollouts = tuple(
+                    _rollout_evidence(
+                        stage=f"online_actor_attempt_{attempt}",
+                        episode=episode,
+                        policy=policy,
+                        strict_replay=False,
+                    )
+                    for episode, policy in (
+                        _run_candidate(
+                            backend,
+                            scenario,
+                            parameters,
+                            attempt_path,
+                        )
+                            for scenario in online_scenarios
+                    )
+                )
+                accepted, reasons = _online_update_gate(
+                    parent=current_gate_rollouts,
+                    candidate=attempt_rollouts,
+                )
+                online_gate_decisions.append(
+                    {
+                        "attempt": attempt,
+                        "update_index": update.update_index,
+                        "trust_region_fraction": fraction,
+                        "accepted": accepted,
+                        "reasons": list(reasons),
+                        "parent": _aggregate(current_gate_rollouts),
+                        "candidate": _aggregate(attempt_rollouts),
+                        "artifact_path": str(attempt_path),
+                    }
+                )
+                if accepted:
+                    current_gate_rollouts = attempt_rollouts
+                    accepted_step = True
+                    break
+            if not accepted_step:
+                learner.restore_checkpoint(rollback)
+                break
+    except ValueError as exc:
+        failures.append(f"online_actor_critic:{exc}")
+    online_artifact_path = root / "g1-neural-torque-online-rl.bin"
+    _write_candidate(
+        online_artifact_path,
+        learner,
+        body_hash=qualification.body_hash,
+        parent_policy_hash=qualification.kick_prior_hash,
+        dataset_hash=online_dataset_hash,
+    )
+    checkpoint_path = root / "g1-neural-torque-learner.ckpt"
+    checkpoint_path.write_bytes(learner.checkpoint_bytes())
+
+    parent_rollouts = tuple(
+        _evaluate_parent_with_replay(
+            backend,
+            scenario,
+            parameters,
+            stage="sealed_parent",
+        )
+        for scenario in sealed_scenarios
+    )
+    bc_rollouts = tuple(
+        _evaluate_candidate_with_replay(
+            backend,
+            scenario,
+            parameters,
+            bc_artifact_path,
+            stage="sealed_bc",
+        )
+        for scenario in sealed_scenarios
+    )
+    online_rollouts = tuple(
+        _evaluate_candidate_with_replay(
+            backend,
+            scenario,
+            parameters,
+            online_artifact_path,
+            stage="sealed_online_rl",
+        )
+        for scenario in sealed_scenarios
+    )
+    parent_aggregate = _aggregate(parent_rollouts)
+    bc_aggregate = _aggregate(bc_rollouts)
+    online_aggregate = _aggregate(online_rollouts)
+    finite_workers = bool(
+        len(worker_values) == 4
+        and len({str(value["gpu_uuid"]) for value in worker_values}) == 4
+        and all(bool(value["finite"]) for value in worker_values)
+    )
+    direct_fraction = float(online_aggregate["learned_output_fraction"])
+    plasticity_gain = _relative_gain(
+        float(bc_aggregate["mean_score"]),
+        float(online_aggregate["mean_score"]),
+    )
+    parent_score = float(parent_aggregate["mean_score"])
+    retention_floor = parent_score - 0.03 * max(abs(parent_score), 1.0)
+    checks = {
+        "four_physical_gpus_exercised": finite_workers,
+        "teacher_collection_causally_transparent": teacher_pass_through_exact,
+        "behavior_cloning_converged": bool(
+            initial_metrics[-1].finite
+            and len(worker_values) == 4
+            and all(
+                float(value["final_validation_loss"]) < float(value["initial_validation_loss"])
+                for value in worker_values
+            )
+        ),
+        "direct_torque_physics_executed": bool(
+            direct_fraction > 0.0
+            and all(item.direct_torque_inferences > 0 for item in online_rollouts)
+        ),
+        "online_actor_critic_updated": bool(
+            any(item.actor_updated for item in update_values)
+            and all(item.finite for item in update_values)
+        ),
+        "online_update_locally_accepted": any(
+            bool(value["accepted"]) for value in online_gate_decisions
+        ),
+        "sim_only_boundary_preserved": bool(
+            all(
+                item.activation_ceiling == "SIM_ONLY" and not item.hardware_authorized
+                for item in online_rollouts
+            )
+        ),
+        "critical_safety_regression_zero": all(
+            not (
+                (
+                    candidate.fall
+                    or candidate.joint_violation
+                    or candidate.torque_violation
+                    or not candidate.finite
+                )
+                and not (
+                    parent.fall
+                    or parent.joint_violation
+                    or parent.torque_violation
+                    or not parent.finite
+                )
+            )
+            for parent, candidate in zip(
+                parent_rollouts,
+                online_rollouts,
+                strict=True,
+            )
+        ),
+        "historical_retention_within_3pct": bool(
+            float(online_aggregate["mean_score"]) >= retention_floor
+        ),
+        "online_plasticity_gain_at_least_5pct": plasticity_gain >= 0.05,
+        "learned_output_fraction_at_least_75pct": direct_fraction >= 0.75,
+        "strict_replay_all_sealed": all(item.strict_replay for item in online_rollouts),
+    }
+    promotion_names = (
+        "critical_safety_regression_zero",
+        "historical_retention_within_3pct",
+        "online_update_locally_accepted",
+        "online_plasticity_gain_at_least_5pct",
+        "learned_output_fraction_at_least_75pct",
+        "strict_replay_all_sealed",
+    )
+    decision = "SIM_CANDIDATE" if all(checks[name] for name in promotion_names) else "REJECTED"
+    checks["decision_fail_closed"] = decision == "SIM_CANDIDATE" or not all(
+        checks[name] for name in promotion_names
+    )
+    blockers = tuple(name for name in promotion_names if not checks[name])
+    report = G1NeuralTorquePilotReport(
+        source_commit=_git_commit(source_checkout),
+        body_hash=qualification.body_hash,
+        parent_policy_hash=qualification.kick_prior_hash,
+        dataset_hash=dataset_hash,
+        gpu_workers=tuple(worker_values),
+        selected_seed=selected_seed,
+        teacher_pass_through_exact=teacher_pass_through_exact,
+        dagger_metrics=tuple(dagger_metrics),
+        online_updates=tuple(value.to_dict() for value in update_values),
+        online_gate_decisions=tuple(online_gate_decisions),
+        parent_rollouts=parent_rollouts,
+        bc_rollouts=bc_rollouts,
+        online_rl_rollouts=online_rollouts,
+        promotion_checks=checks,
+        decision=decision,
+        blockers=blockers,
+        artifact_paths={
+            "teacher_dataset": str(dataset_path),
+            "bc_actor": str(bc_artifact_path),
+            "online_rl_actor": str(online_artifact_path),
+            "learner_checkpoint": str(checkpoint_path),
+        },
+        pipeline_failures=tuple(failures),
+    )
+    _atomic_json(root / "g1-neural-torque-pilot.json", report.to_dict())
+    return report
+
+
+def _collect_teacher(
+    backend: G1MuJoCoBackend,
+    scenario: GoalForgeScenario,
+    parameters: ShotParameters,
+) -> tuple[GoalForgeEpisode, G1TeacherTorqueEpisode]:
+    collector = G1TeacherTorqueCollector()
+    episode = backend.run(scenario, parameters, torque_policy=collector)
+    return episode, collector.episode()
+
+
+def _run_candidate(
+    backend: G1MuJoCoBackend,
+    scenario: GoalForgeScenario,
+    parameters: ShotParameters,
+    artifact_path: Path,
+) -> tuple[GoalForgeEpisode, G1NeuralTorquePolicy]:
+    artifact = load_g1_neural_torque_artifact(
+        artifact_path,
+        expected_body_hash=backend.qualification.body_hash,
+    )
+    policy = G1NeuralTorquePolicy(
+        artifact,
+        expected_body_hash=backend.qualification.body_hash,
+        expected_parent_policy_hash=backend.qualification.kick_prior_hash,
+    )
+    return backend.run(scenario, parameters, torque_policy=policy), policy
+
+
+def _evaluate_candidate_with_replay(
+    backend: G1MuJoCoBackend,
+    scenario: GoalForgeScenario,
+    parameters: ShotParameters,
+    artifact_path: Path,
+    *,
+    stage: str,
+) -> G1NeuralTorqueRolloutEvidence:
+    episode, policy = _run_candidate(backend, scenario, parameters, artifact_path)
+    replay, replay_policy = _run_candidate(backend, scenario, parameters, artifact_path)
+    strict = bool(
+        episode.result.summary_dict() == replay.result.summary_dict()
+        and trajectory_digest(episode.trajectory) == trajectory_digest(replay.trajectory)
+        and policy.build_receipt().to_dict() == replay_policy.build_receipt().to_dict()
+    )
+    return _rollout_evidence(
+        stage=stage,
+        episode=episode,
+        policy=policy,
+        strict_replay=strict,
+    )
+
+
+def _evaluate_parent_with_replay(
+    backend: G1MuJoCoBackend,
+    scenario: GoalForgeScenario,
+    parameters: ShotParameters,
+    *,
+    stage: str,
+) -> G1NeuralTorqueRolloutEvidence:
+    episode = backend.run(scenario, parameters)
+    replay = backend.run(scenario, parameters)
+    strict = bool(
+        episode.result.summary_dict() == replay.result.summary_dict()
+        and trajectory_digest(episode.trajectory) == trajectory_digest(replay.trajectory)
+    )
+    return _rollout_evidence(
+        stage=stage,
+        episode=episode,
+        policy=None,
+        strict_replay=strict,
+    )
+
+
+def _rollout_evidence(
+    *,
+    stage: str,
+    episode: GoalForgeEpisode,
+    policy: G1NeuralTorquePolicy | None,
+    strict_replay: bool,
+) -> G1NeuralTorqueRolloutEvidence:
+    receipt = policy.build_receipt() if policy is not None else None
+    count = receipt.inference_count if receipt is not None else 0
+    return G1NeuralTorqueRolloutEvidence(
+        stage=stage,
+        partition=episode.scenario.partition.value,
+        scenario_id=episode.scenario.scenario_id,
+        scenario_commitment=episode.scenario.scenario_commitment,
+        status=episode.result.status.value,
+        success=episode.result.success,
+        contact=episode.result.kick_foot_contacted,
+        target_error_m=(
+            episode.result.target_error_m if math.isfinite(episode.result.target_error_m) else None
+        ),
+        ball_speed_mps=episode.result.ball_speed_mps,
+        support_slip_m=episode.result.support_foot_slip_m,
+        com_margin_min_m=episode.result.com_margin_min_m,
+        torso_roll_peak_rad=episode.result.torso_roll_peak_rad,
+        torso_pitch_peak_rad=episode.result.torso_pitch_peak_rad,
+        fall=episode.result.post_kick_fall,
+        joint_violation=episode.result.joint_limit_violation,
+        torque_violation=episode.result.torque_limit_violation,
+        finite=episode.result.finite_state,
+        score=_task_score(episode.result),
+        direct_torque_inferences=count,
+        learned_output_fraction=(receipt.learned_output_count / count if count else 0.0),
+        fallback_fraction=(receipt.fallback_count / count if count else 0.0),
+        artifact_hash=receipt.artifact_hash if receipt is not None else None,
+        activation_ceiling=receipt.activation_ceiling if receipt is not None else None,
+        hardware_authorized=receipt.hardware_authorized if receipt is not None else False,
+        strict_replay=strict_replay,
+        trace_hash=trajectory_digest(episode.trajectory),
+    )
+
+
+def _require_torque_receipt(episode: GoalForgeEpisode) -> G1TorquePolicyReceipt:
+    if episode.torque_policy_receipt is None:
+        raise ValueError("neural torque rollout lacks its SIM receipt")
+    return episode.torque_policy_receipt
+
+
+def _write_candidate(
+    path: Path,
+    learner: G1ContinualTorqueActorCritic,
+    *,
+    body_hash: str,
+    parent_policy_hash: str,
+    dataset_hash: str,
+) -> None:
+    payload = learner.artifact_bytes(
+        body_hash=body_hash,
+        parent_policy_hash=parent_policy_hash,
+        dataset_hash=dataset_hash,
+    )
+    path.write_bytes(payload)
+    load_g1_neural_torque_artifact(
+        path,
+        expected_hash=hash_bytes(payload),
+        expected_body_hash=body_hash,
+    )
+
+
+def _write_teacher_dataset(
+    path: Path,
+    training: tuple[G1TeacherTorqueEpisode, ...],
+    validation: tuple[G1TeacherTorqueEpisode, ...],
+) -> None:
+    arrays: dict[str, np.ndarray] = {
+        "training_count": np.asarray(len(training), dtype=np.int64),
+        "validation_count": np.asarray(len(validation), dtype=np.int64),
+    }
+    for prefix, episodes in (("training", training), ("validation", validation)):
+        for index, episode in enumerate(episodes):
+            arrays[f"{prefix}_{index}_observations"] = episode.observations
+            arrays[f"{prefix}_{index}_actions"] = episode.actions
+            arrays[f"{prefix}_{index}_parent_actions"] = episode.parent_actions
+    np.savez_compressed(path, **arrays)  # type: ignore[arg-type]
+
+
+def _run_gpu_workers(
+    *,
+    checkout: Path,
+    dataset_path: Path,
+    output_root: Path,
+    body_hash: str,
+    parent_policy_hash: str,
+    epochs: int,
+) -> tuple[list[dict[str, Any]], tuple[str, ...]]:
+    worker = checkout / "scripts/simforge/g1_neural_torque_gpu_worker.py"
+    processes: list[tuple[int, Path, subprocess.Popen[str]]] = []
+    for gpu in range(4):
+        output = output_root / f"gpu-{gpu}.json"
+        artifact = output_root / f"gpu-{gpu}.bin"
+        environment = os.environ.copy()
+        environment["CUDA_VISIBLE_DEVICES"] = str(gpu)
+        existing = environment.get("PYTHONPATH")
+        environment["PYTHONPATH"] = str(checkout / "src") + (
+            os.pathsep + existing if existing else ""
+        )
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(worker),
+                "--physical-gpu",
+                str(gpu),
+                "--dataset",
+                str(dataset_path),
+                "--output",
+                str(output),
+                "--artifact",
+                str(artifact),
+                "--body-hash",
+                body_hash,
+                "--parent-policy-hash",
+                parent_policy_hash,
+                "--seed",
+                str(8101 + gpu),
+                "--epochs",
+                str(epochs),
+            ],
+            cwd=checkout,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        processes.append((gpu, output, process))
+    values: list[dict[str, Any]] = []
+    failures: list[str] = []
+    for gpu, output, process in processes:
+        try:
+            stdout, stderr = process.communicate(timeout=300.0)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+            failures.append(f"gpu{gpu}:timeout:{stdout[-200:]}:{stderr[-600:]}")
+            continue
+        if process.returncode != 0 or not output.is_file():
+            failures.append(f"gpu{gpu}:exit={process.returncode}:{stdout[-200:]}:{stderr[-800:]}")
+            continue
+        values.append(json.loads(output.read_text(encoding="utf-8")))
+    return sorted(values, key=lambda value: int(value["physical_gpu"])), tuple(failures)
+
+
+def _pilot_scenarios() -> tuple[
+    tuple[GoalForgeScenario, ...],
+    tuple[GoalForgeScenario, ...],
+    tuple[GoalForgeScenario, ...],
+]:
+    ledger = SeedLedger(task_id="g1_neural_torque_pilot", secret=b"rosclaw-phase8-torque-v1" * 2)
+
+    def build(
+        partition: Partition,
+        generations: tuple[int, ...],
+        prefix: str,
+        *,
+        start_index: int = 0,
+    ):
+        result = []
+        for local_index, generation in enumerate(generations):
+            index = start_index + local_index
+            generated = generate_goalforge_scenarios(
+                ledger=ledger,
+                partition=partition,
+                count=index + 1,
+                generation=generation,
+            )
+            scenario = generated[index]
+            result.append(
+                replace(
+                    scenario,
+                    scenario_id=f"{prefix}-{local_index:02d}-g{generation}",
+                )
+            )
+        return tuple(result)
+
+    training = build(Partition.DEVELOPMENT, (0, 2, 4, 7), "torque-train")
+    dagger = build(
+        Partition.DEVELOPMENT,
+        (2, 0),
+        "torque-dagger",
+        start_index=4,
+    )
+    sealed = (
+        *build(Partition.VALIDATION, (0, 2, 4, 7), "torque-validation"),
+        *build(Partition.HOLDOUT, (0, 2, 9), "torque-holdout"),
+    )
+    ledger.assert_disjoint()
+    return training, dagger, sealed
+
+
+def _critical(result: GoalForgeResult) -> bool:
+    return bool(
+        result.post_kick_fall
+        or result.joint_limit_violation
+        or result.torque_limit_violation
+        or not result.finite_state
+    )
+
+
+def _online_update_gate(
+    *,
+    parent: tuple[G1NeuralTorqueRolloutEvidence, ...],
+    candidate: tuple[G1NeuralTorqueRolloutEvidence, ...],
+) -> tuple[bool, tuple[str, ...]]:
+    """Accept one online actor step only when matched physics does not regress."""
+
+    if len(parent) != len(candidate) or not parent:
+        return False, ("matched_rollout_count_mismatch",)
+    reasons: list[str] = []
+    for index, (before, after) in enumerate(zip(parent, candidate, strict=True)):
+        before_critical = before.fall or before.joint_violation or before.torque_violation
+        after_critical = after.fall or after.joint_violation or after.torque_violation
+        if after_critical and not before_critical:
+            reasons.append(f"new_critical_regression:{index}")
+        if not after.finite:
+            reasons.append(f"nonfinite:{index}")
+        if not after.strict_replay and after.stage.startswith("sealed_"):
+            reasons.append(f"strict_replay_failed:{index}")
+    parent_value = _aggregate(parent)
+    candidate_value = _aggregate(candidate)
+    parent_score = float(parent_value["mean_score"])
+    minimum_score = parent_score - 0.01 * max(abs(parent_score), 1.0)
+    if float(candidate_value["mean_score"]) < minimum_score:
+        reasons.append("matched_score_regression_gt_1pct")
+    if float(candidate_value["success_rate"]) < float(parent_value["success_rate"]):
+        reasons.append("matched_success_regression")
+    if (
+        float(candidate_value["learned_output_fraction"])
+        < float(parent_value["learned_output_fraction"]) - 0.05
+    ):
+        reasons.append("learned_output_fraction_regression_gt_5pp")
+    return not reasons, tuple(reasons)
+
+
+def _task_score(result: GoalForgeResult) -> float:
+    score = 10.0 * float(result.success) + 2.0 * float(result.kick_foot_contacted)
+    if math.isfinite(result.target_error_m):
+        score -= min(3.0, result.target_error_m)
+    score -= 8.0 * float(result.post_kick_fall)
+    score -= 5.0 * float(result.joint_limit_violation or result.torque_limit_violation)
+    score -= 2.0 * max(0.0, result.support_foot_slip_m - 0.04) / 0.04
+    score -= 2.0 * max(0.0, -result.com_margin_min_m) / 0.04
+    return float(np.clip(score, -20.0, 20.0))
+
+
+def _aggregate(values: tuple[G1NeuralTorqueRolloutEvidence, ...]) -> dict[str, float]:
+    if not values:
+        return {
+            "count": 0.0,
+            "success_rate": 0.0,
+            "critical_failure_rate": 0.0,
+            "mean_score": 0.0,
+            "mean_ball_speed_mps": 0.0,
+            "learned_output_fraction": 0.0,
+        }
+    return {
+        "count": float(len(values)),
+        "success_rate": sum(item.success for item in values) / len(values),
+        "critical_failure_rate": sum(
+            item.fall or item.joint_violation or item.torque_violation or not item.finite
+            for item in values
+        )
+        / len(values),
+        "mean_score": sum(item.score for item in values) / len(values),
+        "mean_ball_speed_mps": sum(item.ball_speed_mps for item in values) / len(values),
+        "mean_support_slip_m": sum(item.support_slip_m for item in values) / len(values),
+        "mean_torso_roll_peak_rad": sum(item.torso_roll_peak_rad for item in values) / len(values),
+        "learned_output_fraction": sum(item.learned_output_fraction for item in values)
+        / len(values),
+        "fallback_fraction": sum(item.fallback_fraction for item in values) / len(values),
+    }
+
+
+def _relative_gain(parent: float, candidate: float) -> float:
+    return (candidate - parent) / max(abs(parent), 1e-6)
+
+
+def _git_commit(checkout: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    return result.stdout.strip()
+
+
+def _new_external_root(output: Path, checkout: Path) -> Path:
+    root = output.expanduser().resolve()
+    source = checkout.expanduser().resolve()
+    if root == source or source in root.parents:
+        raise ValueError("neural torque evidence must be outside the source checkout")
+    root.mkdir(parents=True, exist_ok=False)
+    return root
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True, allow_nan=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+__all__ = [
+    "G1NeuralTorquePilotReport",
+    "G1NeuralTorqueRolloutEvidence",
+    "run_g1_neural_torque_pilot",
+]

--- a/src/rosclaw/simforge/g1_recovery_online_rl_validation.py
+++ b/src/rosclaw/simforge/g1_recovery_online_rl_validation.py
@@ -1,0 +1,487 @@
+"""One fail-closed online actor-critic generation for post-kick recovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from rosclaw.collective.sources.motiondecode.motion_prior import (
+    load_g1_motion_prior_artifact,
+)
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.simforge.backends.unitree_mujoco_backend import (
+    G1MuJoCoBackend,
+    GoalForgeEpisode,
+    trajectory_digest,
+)
+from rosclaw.simforge.g1_neural_torque import (
+    G1NeuralTorqueArtifact,
+    G1NeuralTorquePolicy,
+    G1TorqueSafetyConfig,
+    load_g1_neural_torque_artifact,
+)
+from rosclaw.simforge.g1_neural_torque_learning import (
+    G1ContinualTorqueActorCritic,
+    G1NeuralTorqueLearnerConfig,
+    G1NeuralTorqueReplay,
+    neural_torque_replay_hash,
+    recovery_online_replay,
+    teacher_dataset_hash,
+    teacher_replay,
+)
+from rosclaw.simforge.g1_neural_torque_validation import (
+    G1NeuralTorqueRolloutEvidence,
+    _aggregate,
+    _collect_teacher,
+    _critical,
+    _online_update_gate,
+    _pilot_scenarios,
+    _rollout_evidence,
+    _write_candidate,
+)
+from rosclaw.simforge.g1_stability_plasticity_policy import (
+    G1StabilityPlasticityGateConfig,
+    G1StabilityPlasticityTorquePolicy,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import GoalForgeResult, ShotParameters
+
+
+def run_g1_recovery_online_rl_validation(
+    *,
+    asset_root: Path,
+    motion_prior_path: Path,
+    output_dir: Path,
+    source_checkout: Path,
+    device: str = "cuda:2",
+    seed: int = 8700,
+) -> dict[str, Any]:
+    root = _external_root(output_dir, source_checkout)
+    root.mkdir(parents=True, exist_ok=False)
+    backend = G1MuJoCoBackend(asset_root=asset_root, trace_stride=1)
+    qualification = backend.qualification
+    prior = load_g1_motion_prior_artifact(motion_prior_path)
+    if prior.body_hash != qualification.body_hash:
+        raise ValueError("recovery prior does not match the qualified G1 body")
+    training_scenarios, development_scenarios, validation_scenarios = _pilot_scenarios()
+    parameters = ShotParameters()
+    training = tuple(
+        _collect_teacher(backend, scenario, parameters)[1] for scenario in training_scenarios
+    )
+    teacher_validation = tuple(
+        _collect_teacher(backend, scenario, parameters)[1] for scenario in development_scenarios
+    )
+    config = G1NeuralTorqueLearnerConfig(
+        hidden_dim=96,
+        sequence_length=32,
+        batch_size=256,
+        actor_lr=2e-4,
+        critic_lr=2e-4,
+        behavior_cloning_weight=5.0,
+        online_behavior_weight=1.0,
+        parent_churn_weight=0.5,
+        ewc_weight=20.0,
+        device=device,
+        seed=seed,
+    )
+    safety = G1TorqueSafetyConfig(
+        torque_guard_scale=0.80,
+        maximum_mechanical_power_w=4000.0,
+        maximum_parent_deviation_ratio=0.05,
+        maximum_projection_ratio=0.35,
+        maximum_observation_z=5.0,
+        minimum_upright_gravity_z=-0.97,
+        minimum_pelvis_height_m=0.70,
+        recovery_cooldown_steps=250,
+        warmup_steps=100,
+    )
+    stable = G1ContinualTorqueActorCritic(config, safety=safety)
+    stable_metrics = stable.pretrain_behavior(
+        training, validation=teacher_validation, epochs=6, stride=4
+    )
+    teacher_hash = teacher_dataset_hash(training)
+    stable_path = root / "stable-torque-bc.bin"
+    _write_candidate(
+        stable_path,
+        stable,
+        body_hash=qualification.body_hash,
+        parent_policy_hash=qualification.kick_prior_hash,
+        dataset_hash=teacher_hash,
+    )
+    plastic = G1ContinualTorqueActorCritic(config, safety=safety)
+    plastic.install_motion_prior(
+        prior,
+        expected_body_hash=qualification.body_hash,
+        fraction=1.0,
+    )
+    plastic_warmup = plastic.pretrain_behavior(
+        training, validation=teacher_validation, epochs=2, stride=4
+    )
+    plastic_metrics = plastic.pretrain_behavior(
+        training,
+        validation=teacher_validation,
+        epochs=8,
+        stride=4,
+        minimum_end_fraction=0.60,
+    )
+    plastic_parent_path = root / "recovery-plastic-parent.bin"
+    plastic_dataset_hash = canonical_hash(
+        {
+            "teacher_dataset_hash": teacher_hash,
+            "motion_prior_artifact_hash": prior.artifact_hash,
+            "recovery_end_fraction": 0.60,
+        }
+    )
+    _write_candidate(
+        plastic_parent_path,
+        plastic,
+        body_hash=qualification.body_hash,
+        parent_policy_hash=qualification.kick_prior_hash,
+        dataset_hash=plastic_dataset_hash,
+    )
+    stable_artifact = load_g1_neural_torque_artifact(
+        stable_path, expected_body_hash=qualification.body_hash
+    )
+    plastic_parent_artifact = load_g1_neural_torque_artifact(
+        plastic_parent_path, expected_body_hash=qualification.body_hash
+    )
+    gate = G1StabilityPlasticityGateConfig(
+        minimum_recovery_phase=0.55,
+        minimum_pelvis_height_m=0.74,
+        maximum_projected_gravity_z=-0.92,
+        eligibility_warmup_steps=5,
+    )
+    recovery_replays: list[G1NeuralTorqueReplay] = []
+    collection: list[dict[str, Any]] = []
+    for scenario in training_scenarios:
+        episode, policy = _run_context(
+            backend,
+            scenario,
+            parameters,
+            stable=stable_artifact,
+            plastic=plastic_parent_artifact,
+            gate=gate,
+        )
+        receipt = policy.build_receipt()
+        score = _recovery_score(episode.result)
+        replay = recovery_online_replay(
+            policy.plastic.episode(),
+            trajectory=episode.trajectory,
+            sequence_length=config.sequence_length,
+            recovery_score=score,
+            fell=episode.result.post_kick_fall,
+            critical_failure=_critical(episode.result),
+            projection_fallback_rate=(
+                receipt.projection_fallback_count / max(1, receipt.inference_count)
+            ),
+            recovery_start_phase=0.55,
+            stride=10,
+        )
+        recovery_replays.append(replay)
+        collection.append(
+            {
+                "scenario_id": scenario.scenario_id,
+                "recovery_score": score,
+                "transition_count": replay.count,
+                "plastic_activation_fraction": receipt.plastic_activation_fraction,
+                "result": episode.result.summary_dict(),
+            }
+        )
+    anchor = teacher_replay(training, sequence_length=config.sequence_length, stride=10)
+    replay = G1NeuralTorqueReplay.combine(anchor, *recovery_replays)
+    updates = [plastic.update(replay, update_actor=False) for _ in range(16)]
+    parent_snapshot = plastic.actor_snapshot()
+    actor_update = plastic.update(replay, update_actor=True)
+    proposal_snapshot = plastic.actor_snapshot()
+
+    parent_development = tuple(
+        _context_evidence(
+            backend,
+            scenario,
+            parameters,
+            stable=stable_artifact,
+            plastic=plastic_parent_artifact,
+            gate=gate,
+            stage="recovery_online_parent_development",
+            strict=False,
+        )
+        for scenario in development_scenarios
+    )
+    trust_runs: list[dict[str, Any]] = []
+    eligible: list[dict[str, Any]] = []
+    online_hash = canonical_hash(
+        {
+            "plastic_parent_dataset_hash": plastic_dataset_hash,
+            "recovery_replay_hash": neural_torque_replay_hash(replay),
+        }
+    )
+    for fraction in (0.01, 0.02, 0.05, 0.10, 0.20, 0.50, 1.0):
+        plastic.install_interpolated_actor(parent_snapshot, proposal_snapshot, fraction=fraction)
+        path = root / f"recovery-online-trust-{str(fraction).replace('.', 'p')}.bin"
+        _write_candidate(
+            path,
+            plastic,
+            body_hash=qualification.body_hash,
+            parent_policy_hash=qualification.kick_prior_hash,
+            dataset_hash=canonical_hash(
+                {"online_dataset_hash": online_hash, "actor_trust_fraction": fraction}
+            ),
+        )
+        artifact = load_g1_neural_torque_artifact(
+            path, expected_body_hash=qualification.body_hash
+        )
+        values = tuple(
+            _context_evidence(
+                backend,
+                scenario,
+                parameters,
+                stable=stable_artifact,
+                plastic=artifact,
+                gate=gate,
+                stage=f"recovery_online_{fraction}_development",
+                strict=False,
+            )
+            for scenario in development_scenarios
+        )
+        accepted, reasons = _online_update_gate(parent=parent_development, candidate=values)
+        aggregate = _aggregate(values)
+        meaningful = _meaningful_recovery_improvement(
+            _aggregate(parent_development), aggregate
+        )
+        if accepted and not meaningful:
+            reasons = (*reasons, "no_measurable_recovery_improvement")
+            accepted = False
+        value = {
+            "fraction": fraction,
+            "artifact_path": str(path),
+            "artifact_hash": artifact.artifact_hash,
+            "accepted": accepted,
+            "reasons": list(reasons),
+            "aggregate": aggregate,
+            "rollouts": [item.to_dict() for item in values],
+        }
+        trust_runs.append(value)
+        if accepted:
+            eligible.append(value)
+    selected = (
+        max(
+            eligible,
+            key=lambda item: (
+                float(item["aggregate"]["mean_score"]),
+                -float(item["aggregate"]["mean_support_slip_m"]),
+                -float(item["fraction"]),
+            ),
+        )
+        if eligible
+        else None
+    )
+    selected_artifact = (
+        load_g1_neural_torque_artifact(
+            Path(str(selected["artifact_path"])), expected_body_hash=qualification.body_hash
+        )
+        if selected is not None
+        else plastic_parent_artifact
+    )
+    validation = validation_scenarios[:4]
+    parent_validation = tuple(
+        _context_evidence(
+            backend,
+            scenario,
+            parameters,
+            stable=stable_artifact,
+            plastic=plastic_parent_artifact,
+            gate=gate,
+            stage="recovery_online_parent_validation",
+            strict=True,
+        )
+        for scenario in validation
+    )
+    candidate_validation = tuple(
+        _context_evidence(
+            backend,
+            scenario,
+            parameters,
+            stable=stable_artifact,
+            plastic=selected_artifact,
+            gate=gate,
+            stage="recovery_online_candidate_validation",
+            strict=True,
+        )
+        for scenario in validation
+    )
+    validation_accepted, validation_reasons = _online_update_gate(
+        parent=parent_validation,
+        candidate=candidate_validation,
+    )
+    validation_meaningful = _meaningful_recovery_improvement(
+        _aggregate(parent_validation), _aggregate(candidate_validation)
+    )
+    if validation_accepted and not validation_meaningful:
+        validation_reasons = (*validation_reasons, "no_measurable_recovery_improvement")
+        validation_accepted = False
+    checks = {
+        "dense_replay_aligned": all(item.count > 0 for item in recovery_replays),
+        "critic_and_actor_updated": bool(updates) and actor_update.actor_updated,
+        "development_trust_region_found": selected is not None,
+        "strict_validation_replay": all(
+            item.strict_replay for item in (*parent_validation, *candidate_validation)
+        ),
+        "validation_gate_passed": validation_accepted,
+        "validation_plasticity_measurable": validation_meaningful,
+        "sim_only_boundary_preserved": all(
+            item.activation_ceiling == "SIM_ONLY" and not item.hardware_authorized
+            for item in candidate_validation
+        ),
+    }
+    blockers = [name for name, passed in checks.items() if not passed]
+    blockers.extend(validation_reasons)
+    report = {
+        "schema_version": "rosclaw.simforge.g1_recovery_online_rl.v1",
+        "body_hash": qualification.body_hash,
+        "parent_policy_hash": qualification.kick_prior_hash,
+        "motion_prior_artifact_hash": prior.artifact_hash,
+        "teacher_dataset_hash": teacher_hash,
+        "online_replay_hash": neural_torque_replay_hash(replay),
+        "gate": asdict(gate),
+        "bc_metrics": {
+            "stable_final_validation_loss": stable_metrics[-1].validation_loss,
+            "plastic_warmup_validation_loss": plastic_warmup[-1].validation_loss,
+            "plastic_recovery_validation_loss": plastic_metrics[-1].validation_loss,
+        },
+        "collection": collection,
+        "critic_updates": [item.to_dict() for item in updates],
+        "actor_update": actor_update.to_dict(),
+        "parent_development": [item.to_dict() for item in parent_development],
+        "trust_runs": trust_runs,
+        "selected": selected,
+        "parent_validation": [item.to_dict() for item in parent_validation],
+        "candidate_validation": [item.to_dict() for item in candidate_validation],
+        "aggregates": {
+            "parent_validation": _aggregate(parent_validation),
+            "candidate_validation": _aggregate(candidate_validation),
+        },
+        "checks": checks,
+        "decision": "ONLINE_RECOVERY_CANDIDATE" if not blockers else "REJECTED",
+        "blockers": blockers,
+        "evidence_domain": "SIM_ONLY",
+        "hardware_authorized": False,
+        "promotion_evidence_eligible": False,
+        "claims": {
+            "online_actor_critic": True,
+            "dense_recovery_reward": True,
+            "direct_joint_torque_actor": True,
+            "candidate_promoted": False,
+            "real_robot_evidence": False,
+        },
+    }
+    _atomic_json(root / "g1-recovery-online-rl-report.json", report)
+    return report
+
+
+def _run_context(
+    backend: G1MuJoCoBackend,
+    scenario: Any,
+    parameters: ShotParameters,
+    *,
+    stable: G1NeuralTorqueArtifact,
+    plastic: G1NeuralTorqueArtifact,
+    gate: G1StabilityPlasticityGateConfig,
+) -> tuple[GoalForgeEpisode, G1StabilityPlasticityTorquePolicy]:
+    policy = G1StabilityPlasticityTorquePolicy(
+        G1NeuralTorquePolicy(
+            stable,
+            expected_body_hash=backend.qualification.body_hash,
+            expected_parent_policy_hash=backend.qualification.kick_prior_hash,
+        ),
+        G1NeuralTorquePolicy(
+            plastic,
+            expected_body_hash=backend.qualification.body_hash,
+            expected_parent_policy_hash=backend.qualification.kick_prior_hash,
+        ),
+        config=gate,
+    )
+    return backend.run(scenario, parameters, torque_policy=policy), policy
+
+
+def _context_evidence(
+    backend: G1MuJoCoBackend,
+    scenario: Any,
+    parameters: ShotParameters,
+    *,
+    stable: G1NeuralTorqueArtifact,
+    plastic: G1NeuralTorqueArtifact,
+    gate: G1StabilityPlasticityGateConfig,
+    stage: str,
+    strict: bool,
+) -> G1NeuralTorqueRolloutEvidence:
+    episode, policy = _run_context(
+        backend, scenario, parameters, stable=stable, plastic=plastic, gate=gate
+    )
+    strict_replay = False
+    if strict:
+        replay, replay_policy = _run_context(
+            backend, scenario, parameters, stable=stable, plastic=plastic, gate=gate
+        )
+        strict_replay = bool(
+            episode.result.summary_dict() == replay.result.summary_dict()
+            and trajectory_digest(episode.trajectory) == trajectory_digest(replay.trajectory)
+            and policy.build_receipt().to_dict() == replay_policy.build_receipt().to_dict()
+        )
+    return _rollout_evidence(
+        stage=stage,
+        episode=episode,
+        policy=policy,  # type: ignore[arg-type]
+        strict_replay=strict_replay,
+    )
+
+
+def _recovery_score(result: GoalForgeResult) -> float:
+    value = 3.0 * float(not result.post_kick_fall)
+    value -= 8.0 * float(result.post_kick_fall)
+    value -= 5.0 * float(result.joint_limit_violation or result.torque_limit_violation)
+    value -= 20.0 * min(result.support_foot_slip_m, 0.20)
+    value -= 2.0 * result.torso_roll_peak_rad
+    value -= 2.0 * result.torso_pitch_peak_rad
+    value += min(result.post_kick_stability_time_sec, 2.0)
+    return float(max(-20.0, min(20.0, value)))
+
+
+def _meaningful_recovery_improvement(
+    parent: dict[str, float],
+    candidate: dict[str, float],
+) -> bool:
+    return bool(
+        candidate["critical_failure_rate"] < parent["critical_failure_rate"]
+        or candidate["mean_score"] >= parent["mean_score"] + 0.05
+        or candidate["mean_support_slip_m"] <= parent["mean_support_slip_m"] * 0.98
+        or candidate["mean_torso_roll_peak_rad"]
+        <= parent["mean_torso_roll_peak_rad"] * 0.98
+    )
+
+
+def _external_root(path: Path, source_checkout: Path) -> Path:
+    root = path.expanduser().resolve()
+    checkout = source_checkout.expanduser().resolve()
+    if root == checkout or checkout in root.parents:
+        raise ValueError("recovery online-RL evidence must be outside the source checkout")
+    return root
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    payload = json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+__all__ = ["run_g1_recovery_online_rl_validation"]

--- a/src/rosclaw/simforge/g1_stability_plasticity_policy.py
+++ b/src/rosclaw/simforge/g1_stability_plasticity_policy.py
@@ -1,0 +1,203 @@
+"""Context-gated composition of stable and plastic direct-torque actors."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+
+import numpy as np
+
+from rosclaw.simforge.g1_neural_torque import (
+    G1NeuralTorquePolicy,
+    G1TorqueControlFrame,
+    G1TorquePolicyReceipt,
+    build_g1_neural_torque_observation,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import hash_json
+
+
+@dataclass(frozen=True)
+class G1StabilityPlasticityGateConfig:
+    minimum_recovery_phase: float = 0.85
+    minimum_pelvis_height_m: float = 0.76
+    maximum_projected_gravity_z: float = -0.94
+    eligibility_warmup_steps: int = 20
+    activation_ceiling: str = "SIM_ONLY"
+
+    def __post_init__(self) -> None:
+        if not 0.5 <= self.minimum_recovery_phase <= 1.0:
+            raise ValueError("plastic recovery phase must be in [0.5, 1]")
+        if not 0.55 <= self.minimum_pelvis_height_m <= 0.95:
+            raise ValueError("plastic pelvis-height gate must be in [0.55, 0.95] m")
+        if not -0.999 <= self.maximum_projected_gravity_z <= -0.75:
+            raise ValueError("plastic gravity gate must be in [-0.999, -0.75]")
+        if not 1 <= self.eligibility_warmup_steps <= 500:
+            raise ValueError("plastic eligibility warmup must be in [1, 500]")
+        if self.activation_ceiling != "SIM_ONLY":
+            raise ValueError("stability-plasticity torque policy is SIM_ONLY")
+
+
+@dataclass(frozen=True)
+class G1StabilityPlasticityReceipt(G1TorquePolicyReceipt):
+    stable_artifact_hash: str = ""
+    plastic_artifact_hash: str = ""
+    gate_hash: str = ""
+    plastic_activation_count: int = 0
+    plastic_activation_fraction: float = 0.0
+    phase_rejection_count: int = 0
+    posture_rejection_count: int = 0
+    contact_rejection_count: int = 0
+    schema_version: str = "rosclaw.simforge.g1_stability_plasticity_receipt.v1"
+
+
+class G1StabilityPlasticityTorquePolicy:
+    """Use learned plasticity only in its post-kick stability regime."""
+
+    def __init__(
+        self,
+        stable: G1NeuralTorquePolicy,
+        plastic: G1NeuralTorquePolicy,
+        *,
+        config: G1StabilityPlasticityGateConfig | None = None,
+    ) -> None:
+        if stable.artifact.body_hash != plastic.artifact.body_hash:
+            raise ValueError("stable and plastic torque actors target different bodies")
+        if stable.artifact.parent_policy_hash != plastic.artifact.parent_policy_hash:
+            raise ValueError("stable and plastic torque actors have different parents")
+        self.stable = stable
+        self.plastic = plastic
+        self.config = config or G1StabilityPlasticityGateConfig()
+        self.artifact_hash = hash_json(
+            {
+                "stable_artifact_hash": stable.artifact.artifact_hash,
+                "plastic_artifact_hash": plastic.artifact.artifact_hash,
+                "gate": asdict(self.config),
+            }
+        )
+        self._pending = False
+        self._eligible_steps = 0
+        self._inference_count = 0
+        self._activation_count = 0
+        self._phase_rejections = 0
+        self._posture_rejections = 0
+        self._contact_rejections = 0
+        self._fallback_reasons: list[str] = []
+        self._projected_joint_count = 0
+        self._maximum_limit_ratio = 0.0
+        self._peak_power = 0.0
+
+    def reset(self) -> None:
+        self.stable.reset()
+        self.plastic.reset()
+        self._pending = False
+        self._eligible_steps = 0
+        self._inference_count = 0
+        self._activation_count = 0
+        self._phase_rejections = 0
+        self._posture_rejections = 0
+        self._contact_rejections = 0
+        self._fallback_reasons.clear()
+        self._projected_joint_count = 0
+        self._maximum_limit_ratio = 0.0
+        self._peak_power = 0.0
+
+    def command(self, frame: G1TorqueControlFrame, parent_torque: np.ndarray) -> np.ndarray:
+        if self._pending:
+            raise RuntimeError("stability-plasticity policy did not receive note_applied")
+        stable_torque = self.stable.command(frame, parent_torque)
+        plastic_torque = self.plastic.command(frame, parent_torque)
+        phase_ok = frame.policy_phase >= self.config.minimum_recovery_phase
+        posture_ok = self._posture_eligible(frame)
+        contact_ok = frame.left_contact or frame.right_contact
+        self._phase_rejections += int(not phase_ok)
+        self._posture_rejections += int(phase_ok and not posture_ok)
+        self._contact_rejections += int(phase_ok and posture_ok and not contact_ok)
+        eligible = phase_ok and posture_ok and contact_ok
+        self._eligible_steps = self._eligible_steps + 1 if eligible else 0
+        plastic_active = self._eligible_steps >= self.config.eligibility_warmup_steps
+        selected = self.plastic if plastic_active else self.stable
+        projection = selected.pending_projection
+        self._activation_count += int(plastic_active)
+        self._inference_count += 1
+        if projection.reason is not None:
+            self._fallback_reasons.append(projection.reason)
+        self._projected_joint_count += projection.projected_joint_count
+        self._maximum_limit_ratio = max(
+            self._maximum_limit_ratio, projection.maximum_limit_ratio
+        )
+        self._peak_power = max(self._peak_power, projection.mechanical_power_w)
+        self._pending = True
+        return (plastic_torque if plastic_active else stable_torque).copy()
+
+    def note_applied(self, torque: np.ndarray) -> None:
+        if not self._pending:
+            raise RuntimeError("stability-plasticity policy has no pending command")
+        self.stable.note_applied(torque)
+        self.plastic.note_applied(torque)
+        self._pending = False
+
+    def build_receipt(self) -> G1StabilityPlasticityReceipt:
+        if self._pending or not self._inference_count:
+            raise ValueError("cannot build an incomplete stability-plasticity receipt")
+        fallback_count = len(self._fallback_reasons)
+        return G1StabilityPlasticityReceipt(
+            artifact_hash=self.artifact_hash,
+            body_hash=self.stable.artifact.body_hash,
+            parent_policy_hash=self.stable.artifact.parent_policy_hash,
+            inference_count=self._inference_count,
+            learned_output_count=self._inference_count - fallback_count,
+            fallback_count=fallback_count,
+            nonfinite_fallback_count=sum(
+                "invalid_proposal" in reason or "observation_or_inference" in reason
+                for reason in self._fallback_reasons
+            ),
+            projection_fallback_count=sum(
+                reason == "projection_ratio_exceeded" for reason in self._fallback_reasons
+            ),
+            out_of_distribution_fallback_count=sum(
+                reason == "observation_out_of_distribution" for reason in self._fallback_reasons
+            ),
+            warmup_fallback_count=sum(
+                reason == "warmup_parent" for reason in self._fallback_reasons
+            ),
+            state_guard_fallback_count=sum(
+                reason
+                in {"state_recovery_parent", "recovery_cooldown_parent", "joint_limit_guard"}
+                for reason in self._fallback_reasons
+            ),
+            projected_joint_count=self._projected_joint_count,
+            maximum_limit_ratio=self._maximum_limit_ratio,
+            peak_mechanical_power_w=self._peak_power,
+            direct_torque_output=True,
+            activation_ceiling="SIM_ONLY",
+            stable_artifact_hash=self.stable.artifact.artifact_hash,
+            plastic_artifact_hash=self.plastic.artifact.artifact_hash,
+            gate_hash=hash_json(asdict(self.config)),
+            plastic_activation_count=self._activation_count,
+            plastic_activation_fraction=self._activation_count / self._inference_count,
+            phase_rejection_count=self._phase_rejections,
+            posture_rejection_count=self._posture_rejections,
+            contact_rejection_count=self._contact_rejections,
+        )
+
+    def _posture_eligible(self, frame: G1TorqueControlFrame) -> bool:
+        try:
+            observation = build_g1_neural_torque_observation(
+                frame,
+                np.zeros(29, dtype=np.float64),
+            )
+        except ValueError:
+            return False
+        gravity_z = float(observation[60])
+        return bool(
+            math.isfinite(gravity_z)
+            and gravity_z <= self.config.maximum_projected_gravity_z
+            and float(frame.pelvis_position[2]) >= self.config.minimum_pelvis_height_m
+        )
+
+
+__all__ = [
+    "G1StabilityPlasticityGateConfig",
+    "G1StabilityPlasticityReceipt",
+    "G1StabilityPlasticityTorquePolicy",
+]

--- a/src/rosclaw/simforge/phase4_cli.py
+++ b/src/rosclaw/simforge/phase4_cli.py
@@ -115,6 +115,7 @@ def _recovery_validation(argv: list[str]) -> int:
             "feedback-evolution",
             "continual-four-gpu-smoke",
             "continual-physical-foundation",
+            "neural-torque-pilot",
         ),
         default="recovery",
     )
@@ -127,7 +128,25 @@ def _recovery_validation(argv: list[str]) -> int:
     parser.add_argument("--ilc-evidence", type=Path)
     parser.add_argument("--chaos-evidence", type=Path)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--gpu-epochs", type=int, default=12)
+    parser.add_argument("--dagger-generations", type=int, default=3)
+    parser.add_argument("--online-updates", type=int, default=8)
     args = parser.parse_args(argv)
+    if args.profile == "neural-torque-pilot":
+        from rosclaw.simforge.g1_neural_torque_validation import (
+            run_g1_neural_torque_pilot,
+        )
+
+        result = run_g1_neural_torque_pilot(
+            asset_root=args.asset_root,
+            output_dir=args.output,
+            source_checkout=_source_checkout(),
+            gpu_epochs=args.gpu_epochs,
+            dagger_generations=args.dagger_generations,
+            online_updates=args.online_updates,
+        )
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return 0 if result.pipeline_passed else 2
     if args.profile == "continual-physical-foundation":
         result = run_g1_continual_physical_foundation(
             asset_root=args.asset_root,

--- a/tests/collective/test_collective_cli_optional_dependencies.py
+++ b/tests/collective/test_collective_cli_optional_dependencies.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_collective_cli_import_does_not_require_torch() -> None:
+    script = textwrap.dedent(
+        """
+        import builtins
+        import sys
+
+        sys.path.insert(0, "src")
+
+        original_import = builtins.__import__
+
+        def import_without_torch(name, *args, **kwargs):
+            if name == "torch" or name.startswith("torch."):
+                raise ModuleNotFoundError("No module named 'torch'", name="torch")
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = import_without_torch
+        from rosclaw.collective.cli import dispatch_collective_argv
+
+        assert dispatch_collective_argv(["not-collective"]) is None
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=_REPOSITORY_ROOT,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_motion_prior_without_torch_returns_structured_fail_closed_error() -> None:
+    script = textwrap.dedent(
+        """
+        import builtins
+        import sys
+
+        sys.path.insert(0, "src")
+
+        original_import = builtins.__import__
+
+        def import_without_torch(name, *args, **kwargs):
+            if name == "torch" or name.startswith("torch."):
+                raise ModuleNotFoundError("No module named 'torch'", name="torch")
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = import_without_torch
+        from rosclaw.collective.cli import dispatch_collective_argv
+
+        result = dispatch_collective_argv([
+            "collective", "prior", "build",
+            "--pilot-report", "pilot.json",
+            "--dataset-root", "dataset",
+            "--model-path", "g1.xml",
+            "--output", "prior.npz",
+        ])
+        assert result == 2
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=_REPOSITORY_ROOT,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is False
+    assert "rosclaw[rl]" in payload["error"]

--- a/tests/collective/test_motiondecode.py
+++ b/tests/collective/test_motiondecode.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rosclaw.collective.cli import dispatch_collective_argv
+from rosclaw.collective.sources.motiondecode.audit import run_motiondecode_pilot
+from rosclaw.collective.sources.motiondecode.license import inspect_motiondecode_license
+from rosclaw.collective.sources.motiondecode.manifest import inspect_motiondecode_source
+from rosclaw.collective.sources.motiondecode.motion_prior import (
+    load_g1_motion_prior_artifact,
+    train_motion_prior_worker,
+)
+from rosclaw.collective.sources.motiondecode.parser import (
+    MOTIONDECODE_HEADER,
+    parse_motiondecode_csv,
+)
+from rosclaw.collective.sources.motiondecode.taxonomy import (
+    MotionDecodeStratum,
+    select_motiondecode_pilot,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_DDS_JOINT_NAMES
+
+_REVISION = "a" * 40
+
+
+def _write_license(root: Path) -> None:
+    (root / "LICENSE").write_text("")
+    (root / "LICENSE.md").write_text(
+        "Permitted uses: academic research and prototyping (non-commercial).\n"
+        "Prohibited without written permission: commercial distribution.\n"
+        "Users must retain attribution.\n"
+    )
+
+
+def _write_csv(path: Path, *, invalid_header: bool = False, nonfinite: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = list(MOTIONDECODE_HEADER)
+    if invalid_header:
+        header[-1] = "wrong_joint"
+    frames = []
+    for index in range(80):
+        row = [0.01 * index, 0.0, 0.8, 1.0, 0.0, 0.0, 0.0, *([0.0] * 29)]
+        frames.append(row)
+    if nonfinite:
+        frames[2][-1] = float("nan")
+    lines = [",".join(header), *(",".join(str(value) for value in row) for row in frames)]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _dataset(root: Path) -> Path:
+    root.mkdir()
+    _write_license(root)
+    metadata = root / "metadata"
+    metadata.mkdir()
+    metadata.joinpath("index.csv").write_text(
+        "Label,Primary class name\n"
+        "1.1.2.2,Basic_Movement_Category\n"
+        "1.3.1.1,Basic_Gait_Category\n"
+        "1.5.1.1,Balance_Control_Actions\n"
+        "3.3.1.1,Ball_Game_Interaction\n"
+    )
+    relative = (
+        "samples/1.1.Basic_Movement_Category/1.1.2.Ground_Recovery_Movement/"
+        "1.1.2.2.Sit_to_Stand/recovery.csv"
+    )
+    _write_csv(root / relative)
+    _write_csv(
+        root
+        / "samples/1.3.Basic_Gait_Category/1.3.1.Walking/1.3.1.1.Normal_Walking/gait.csv"
+    )
+    _write_csv(
+        root
+        / "samples/1.5.Balance_Control_Actions/1.5.1.Dynamic_Balance/"
+        "1.5.1.1.Single_Leg_Standing/balance.csv"
+    )
+    _write_csv(
+        root
+        / "samples/3.3.Ball_Game_Interaction/3.3.1.Football/"
+        "3.3.1.1.Instep_Kick/football.csv"
+    )
+    return root
+
+
+def _model(path: Path) -> Path:
+    bodies = []
+    closing = []
+    indent = "      "
+    for index, name in enumerate(G1_DDS_JOINT_NAMES):
+        bodies.append(
+            f'{indent}<body name="link_{index}" pos="0 0 0.001">\n'
+            f'{indent}  <joint name="{name}" type="hinge" axis="1 0 0" range="-3 3"/>\n'
+            f'{indent}  <geom type="sphere" size="0.001" contype="0" conaffinity="0" mass="0.01"/>'
+        )
+        closing.append(f"{indent}</body>")
+        indent += "  "
+    xml = (
+        '<mujoco model="motiondecode_test">\n'
+        '  <option gravity="0 0 -9.81"/>\n'
+        "  <worldbody>\n"
+        '    <geom name="floor" type="plane" size="5 5 0.1"/>\n'
+        '    <body name="pelvis" pos="0 0 0.8">\n'
+        '      <freejoint name="floating_base_joint"/>\n'
+        '      <geom type="sphere" size="0.01" contype="0" conaffinity="0" mass="1"/>\n'
+        + "\n".join(bodies)
+        + "\n"
+        + "\n".join(reversed(closing))
+        + "\n    </body>\n  </worldbody>\n</mujoco>\n"
+    )
+    path.write_text(xml)
+    return path
+
+
+def test_source_manifest_is_honest_about_revision_license_and_modalities(tmp_path: Path) -> None:
+    root = _dataset(tmp_path / "motiondecode")
+    manifest, paths = inspect_motiondecode_source(root, revision=_REVISION)
+
+    assert len(paths) == 4
+    assert manifest.source.revision_binding == "UNVERIFIED_LOCAL_SNAPSHOT"
+    assert manifest.license.commercial_use_status == "WRITTEN_PERMISSION_REQUIRED"
+    assert manifest.license.redistribution_permitted is False
+    assert manifest.football_files == 1
+    assert manifest.object_pose_files == 0
+    assert manifest.capsule.action_semantics == ()
+    assert manifest.capsule.training_eligible is False
+
+
+def test_license_rejects_unpermitted_commercial_use(tmp_path: Path) -> None:
+    root = tmp_path / "motiondecode"
+    root.mkdir()
+    _write_license(root)
+    result = inspect_motiondecode_license(root, requested_usage="commercial")
+    assert result.permitted is False
+
+
+def test_parser_derives_120hz_state_but_not_actions(tmp_path: Path) -> None:
+    root = _dataset(tmp_path / "motiondecode")
+    path = next((root / "samples").rglob("recovery.csv"))
+    episode = parse_motiondecode_csv(path, dataset_root=root)
+
+    assert episode.joint_position.shape == (80, 29)
+    assert episode.joint_velocity.shape == (80, 29)
+    assert episode.sample_rate_hz == 120.0
+    assert episode.action_semantics == "ABSENT"
+    assert episode.reward_semantics == "ABSENT"
+    np.testing.assert_allclose(episode.time_sec[-1], 79 / 120)
+
+
+@pytest.mark.parametrize("mode", ["header", "nonfinite"])
+def test_parser_fails_closed_on_malformed_payload(tmp_path: Path, mode: str) -> None:
+    root = tmp_path / "motiondecode"
+    root.mkdir()
+    path = root / "samples" / "bad.csv"
+    _write_csv(path, invalid_header=mode == "header", nonfinite=mode == "nonfinite")
+    with pytest.raises(ValueError):
+        parse_motiondecode_csv(path, dataset_root=root)
+
+
+def test_selection_backfills_without_mislabeling_missing_football() -> None:
+    values = [
+        *(Path(f"samples/Ground_Recovery/recovery_{index}.csv") for index in range(2)),
+        *(Path(f"samples/Walking/gait_{index}.csv") for index in range(2)),
+        *(Path(f"samples/Balance/balance_{index}.csv") for index in range(2)),
+        *(Path(f"samples/Dance/dance_{index}.csv") for index in range(4)),
+    ]
+    selection = select_motiondecode_pilot(values, limit=8, seed=7)
+
+    assert selection.shortages == {MotionDecodeStratum.FOOTBALL.value: 2}
+    assert selection.substitutions == {MotionDecodeStratum.COORDINATION_SUPPLEMENT.value: 2}
+    assert selection.selected_counts[MotionDecodeStratum.FOOTBALL.value] == 0
+    assert len(selection.selected) == 8
+    assert selection == select_motiondecode_pilot(reversed(values), limit=8, seed=7)
+
+
+def test_pilot_emits_only_q1_kinematic_evidence_and_no_raw_data(tmp_path: Path) -> None:
+    dataset = _dataset(tmp_path / "motiondecode")
+    model = _model(tmp_path / "g1.xml")
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    output = tmp_path / "evidence"
+    report = run_motiondecode_pilot(
+        dataset_root=dataset,
+        revision=_REVISION,
+        model_path=model,
+        output_dir=output,
+        source_checkout=checkout,
+        limit=4,
+        seed=42,
+    )
+
+    assert report.pipeline_passed is True
+    assert report.decision == "MOTION_PRIOR_ONLY"
+    assert report.aggregates["q1_kinematic_only_count"] == 4
+    assert report.aggregates["q2_or_higher_count"] == 0
+    assert report.raw_data_exported is False
+    assert report.hardware_authorized is False
+    payload = json.loads((output / "motiondecode-pilot-report.json").read_text())
+    assert payload["claims"]["direct_torque_labels"] is False
+    assert not list(output.rglob("*.csv"))
+
+
+def test_collective_inspect_cli_reports_machine_readable_manifest(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dataset = _dataset(tmp_path / "motiondecode")
+    code = dispatch_collective_argv(
+        [
+            "collective",
+            "source",
+            "inspect",
+            "motiondecode",
+            "--dataset-root",
+            str(dataset),
+            "--revision",
+            _REVISION,
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["csv_file_count"] == 4
+    assert payload["safe_to_read"] is True
+
+
+def test_motion_prior_pack_cli_and_cpu_worker_are_safe_and_loadable(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dataset = _dataset(tmp_path / "motiondecode")
+    model = _model(tmp_path / "g1.xml")
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    evidence = tmp_path / "evidence"
+    report = run_motiondecode_pilot(
+        dataset_root=dataset,
+        revision=_REVISION,
+        model_path=model,
+        output_dir=evidence,
+        source_checkout=checkout,
+        limit=4,
+        seed=42,
+    )
+    assert report.pipeline_passed
+    pack_path = tmp_path / "pack" / "motion-prior.npz"
+    command = [
+        "collective",
+        "prior",
+        "build",
+        "--pilot-report",
+        str(evidence / "motiondecode-pilot-report.json"),
+        "--dataset-root",
+        str(dataset),
+        "--model-path",
+        str(model),
+        "--output",
+        str(pack_path),
+        "--sequence-length",
+        "32",
+        "--maximum-windows",
+        "8",
+        "--seed",
+        "9",
+        "--stratum",
+        "balance_proxy",
+        "--stratum",
+        "gait",
+        "--stratum",
+        "transition_recovery",
+        "--json",
+    ]
+    code = dispatch_collective_argv(command)
+    cli_payload = json.loads(capsys.readouterr().out)
+    metadata = json.loads(pack_path.with_suffix(".json").read_text())
+    assert code == 0
+    assert cli_payload["pack_hash"] == metadata["pack_hash"]
+    assert cli_payload["feature_count"] == 61
+    assert metadata["training_windows"] == 6
+    assert metadata["validation_windows"] == 2
+    assert metadata["allowed_strata"] == ["balance_proxy", "gait", "transition_recovery"]
+    assert metadata["raw_data_exported"] is False
+    assert dispatch_collective_argv(command) == 2
+    assert "already exists" in json.loads(capsys.readouterr().out)["error"]
+    artifact_value = train_motion_prior_worker(
+        pack_path=pack_path,
+        output_dir=tmp_path / "worker",
+        device="cpu",
+        seed=11,
+        epochs=2,
+        hidden_dim=8,
+        batch_size=4,
+    )
+    artifact = load_g1_motion_prior_artifact(
+        tmp_path / "worker" / "motion-prior-artifact.json"
+    )
+    assert artifact.artifact_hash == artifact_value["artifact_hash"]
+    assert artifact.action_semantics == "ABSENT"
+    assert artifact.activation_ceiling == "SIM_ONLY_REPRESENTATION_INITIALIZATION"
+    assert artifact.tensors["gru.weight_ih_l0"].shape == (24, 61)

--- a/tests/simforge/test_g1_neural_torque.py
+++ b/tests/simforge/test_g1_neural_torque.py
@@ -17,6 +17,10 @@ from rosclaw.simforge.g1_neural_torque import (
     load_g1_neural_torque_artifact,
     serialize_g1_neural_torque_artifact,
 )
+from rosclaw.simforge.g1_stability_plasticity_policy import (
+    G1StabilityPlasticityGateConfig,
+    G1StabilityPlasticityTorquePolicy,
+)
 from rosclaw.simforge.tasks.g1_goalforge.concepts import (
     G1_DDS_JOINT_NAMES,
     G1_HARD_TORQUE_LIMITS,
@@ -228,3 +232,71 @@ def test_teacher_collector_is_exact_pass_through_at_physics_rate() -> None:
     assert episode.observations.shape == (1, 102)
     assert episode.actions[0] == pytest.approx(parent)
     assert episode.parent_actions[0] == pytest.approx(parent)
+
+
+def test_stability_plasticity_gate_activates_only_after_safe_recovery_context(
+    tmp_path: Path,
+) -> None:
+    stable_path = tmp_path / "stable.bin"
+    plastic_path = tmp_path / "plastic.bin"
+    stable_path.write_bytes(_artifact_bytes(output_bias=0.01))
+    plastic_path.write_bytes(_artifact_bytes(output_bias=0.02))
+    stable = G1NeuralTorquePolicy(
+        load_g1_neural_torque_artifact(stable_path),
+        expected_body_hash=_digest("body"),
+        expected_parent_policy_hash=_digest("parent"),
+    )
+    plastic = G1NeuralTorquePolicy(
+        load_g1_neural_torque_artifact(plastic_path),
+        expected_body_hash=_digest("body"),
+        expected_parent_policy_hash=_digest("parent"),
+    )
+    policy = G1StabilityPlasticityTorquePolicy(
+        stable,
+        plastic,
+        config=G1StabilityPlasticityGateConfig(
+            minimum_recovery_phase=0.8,
+            eligibility_warmup_steps=2,
+        ),
+    )
+    parent = np.zeros(29)
+    policy.reset()
+    before = policy.command(_frame(policy_phase=0.5), parent)
+    policy.note_applied(before)
+    warmup = policy.command(_frame(policy_phase=0.9), parent)
+    policy.note_applied(warmup)
+    active = policy.command(_frame(policy_phase=0.9), parent)
+    policy.note_applied(active)
+    unstable = policy.command(
+        _frame(policy_phase=0.9, left_contact=False, right_contact=False), parent
+    )
+    policy.note_applied(unstable)
+    receipt = policy.build_receipt()
+
+    assert active[0] > before[0]
+    assert warmup == pytest.approx(before)
+    assert unstable == pytest.approx(before)
+    assert receipt.plastic_activation_count == 1
+    assert receipt.plastic_activation_fraction == pytest.approx(0.25)
+    assert receipt.phase_rejection_count == 1
+    assert receipt.contact_rejection_count == 1
+    assert receipt.activation_ceiling == "SIM_ONLY"
+
+
+def test_neural_torque_reset_clears_episode_receipt_state(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "actor.bin"
+    artifact_path.write_bytes(_artifact_bytes(output_bias=0.01))
+    policy = G1NeuralTorquePolicy(
+        load_g1_neural_torque_artifact(artifact_path),
+        expected_body_hash=_digest("body"),
+        expected_parent_policy_hash=_digest("parent"),
+    )
+    parent = np.zeros(29)
+    command = policy.command(_frame(), parent)
+    policy.note_applied(command)
+    assert policy.build_receipt().inference_count == 1
+
+    policy.reset()
+
+    with pytest.raises(ValueError, match="incomplete neural torque receipt"):
+        policy.build_receipt()

--- a/tests/simforge/test_g1_neural_torque.py
+++ b/tests/simforge/test_g1_neural_torque.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rosclaw.simforge.g1_neural_torque import (
+    G1_NEURAL_TORQUE_OBSERVATIONS,
+    G1NeuralTorquePolicy,
+    G1TeacherTorqueCollector,
+    G1TorqueControlFrame,
+    G1TorqueSafetyConfig,
+    G1TorqueSafetyProjector,
+    build_g1_neural_torque_observation,
+    load_g1_neural_torque_artifact,
+    serialize_g1_neural_torque_artifact,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import (
+    G1_DDS_JOINT_NAMES,
+    G1_HARD_TORQUE_LIMITS,
+)
+
+
+def _digest(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()
+
+
+def _frame(**changes: object) -> G1TorqueControlFrame:
+    values: dict[str, object] = {
+        "joint_position": np.zeros(29),
+        "joint_velocity": np.zeros(29),
+        "joint_lower_limits": np.full(29, -2.0),
+        "joint_upper_limits": np.full(29, 2.0),
+        "torso_quaternion_wxyz": np.asarray((1.0, 0.0, 0.0, 0.0)),
+        "pelvis_position": np.asarray((0.0, 0.0, 0.8)),
+        "ball_position": np.asarray((1.0, 0.1, 0.115)),
+        "ball_velocity": np.asarray((-0.2, 0.05, 0.0)),
+        "target_y_m": 0.75,
+        "target_z_m": 0.9,
+        "policy_phase": 0.25,
+        "left_contact": True,
+        "right_contact": False,
+    }
+    values.update(changes)
+    return G1TorqueControlFrame(**values)  # type: ignore[arg-type]
+
+
+def _artifact_bytes(
+    *,
+    safety: G1TorqueSafetyConfig | None = None,
+    output_bias: float = 0.0,
+) -> bytes:
+    resolved = safety or G1TorqueSafetyConfig(
+        maximum_projection_ratio=1.0,
+        maximum_parent_deviation_ratio=0.25,
+        warmup_steps=0,
+    )
+    observation_dim = len(G1_NEURAL_TORQUE_OBSERVATIONS)
+    hidden = 4
+    action_dim = len(G1_DDS_JOINT_NAMES)
+    limits = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float32) * resolved.torque_guard_scale
+    return serialize_g1_neural_torque_artifact(
+        body_hash=_digest("body"),
+        parent_policy_hash=_digest("parent"),
+        dataset_hash=_digest("dataset"),
+        hidden_dim=hidden,
+        observation_clip=8.0,
+        update_index=3,
+        safety=resolved,
+        tensors={
+            "observation_mean": np.zeros(observation_dim, dtype=np.float32),
+            "observation_std": np.ones(observation_dim, dtype=np.float32),
+            "action_limits": limits,
+            "actor.gru.weight_ih_l0": np.zeros((3 * hidden, observation_dim)),
+            "actor.gru.weight_hh_l0": np.zeros((3 * hidden, hidden)),
+            "actor.gru.bias_ih_l0": np.zeros(3 * hidden),
+            "actor.gru.bias_hh_l0": np.zeros(3 * hidden),
+            "actor.head.weight": np.zeros((2 * action_dim, hidden)),
+            "actor.head.bias": np.concatenate(
+                (
+                    np.full(action_dim, output_bias),
+                    np.zeros(action_dim),
+                )
+            ),
+        },
+    )
+
+
+def test_observation_contract_contains_raw_body_ball_phase_and_previous_torque() -> None:
+    previous = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=float) * 0.1
+
+    observation = build_g1_neural_torque_observation(_frame(), previous)
+
+    assert observation.shape == (len(G1_NEURAL_TORQUE_OBSERVATIONS),)
+    assert len(observation) == 102
+    assert observation[58:61] == pytest.approx((0.0, 0.0, -1.0))
+    assert observation[-29:] == pytest.approx(np.full(29, 0.1))
+
+
+def test_observation_rejects_nonfinite_proprioception() -> None:
+    position = np.zeros(29)
+    position[4] = np.nan
+
+    with pytest.raises(ValueError, match="joint position"):
+        build_g1_neural_torque_observation(
+            _frame(joint_position=position),
+            np.zeros(29),
+        )
+
+
+def test_safety_projector_limits_amplitude_rate_power_and_joint_boundary() -> None:
+    safety = G1TorqueSafetyConfig(
+        torque_guard_scale=0.70,
+        max_delta_ratio_per_step=0.05,
+        maximum_mechanical_power_w=100.0,
+        maximum_projection_ratio=1.0,
+    )
+    projector = G1TorqueSafetyProjector(safety)
+    frame = _frame(
+        joint_velocity=np.full(29, 5.0),
+    )
+
+    result = projector.project(
+        np.asarray(G1_HARD_TORQUE_LIMITS, dtype=float),
+        parent=np.zeros(29),
+        previous=np.zeros(29),
+        frame=frame,
+    )
+
+    assert not result.used_parent
+    assert result.maximum_limit_ratio <= 0.05 + 1e-9
+    assert result.mechanical_power_w <= 100.0 + 1e-8
+    assert result.projected_joint_count == 29
+
+    position = np.zeros(29)
+    position[0] = 1.99
+    boundary = projector.project(
+        np.asarray(G1_HARD_TORQUE_LIMITS, dtype=float),
+        parent=np.zeros(29),
+        previous=np.zeros(29),
+        frame=_frame(joint_position=position),
+    )
+    assert boundary.used_parent
+    assert boundary.reason == "joint_limit_guard"
+
+
+def test_safety_projector_falls_back_to_parent_on_nonfinite_or_overprojection() -> None:
+    projector = G1TorqueSafetyProjector(G1TorqueSafetyConfig(maximum_projection_ratio=0.0))
+    parent = np.linspace(-1.0, 1.0, 29)
+
+    nonfinite = projector.project(
+        np.full(29, np.nan),
+        parent=parent,
+        previous=np.zeros(29),
+        frame=_frame(),
+    )
+    overprojected = projector.project(
+        np.asarray(G1_HARD_TORQUE_LIMITS, dtype=float),
+        parent=parent,
+        previous=np.zeros(29),
+        frame=_frame(),
+    )
+
+    assert nonfinite.used_parent
+    assert nonfinite.reason is not None and nonfinite.reason.startswith("invalid_proposal")
+    assert overprojected.used_parent
+    assert overprojected.reason == "projection_ratio_exceeded"
+    assert nonfinite.torque == pytest.approx(parent)
+
+
+def test_artifact_roundtrip_and_numpy_actor_emit_direct_bounded_torque(tmp_path: Path) -> None:
+    payload = _artifact_bytes(output_bias=0.01)
+    path = tmp_path / "g1-neural-torque.bin"
+    path.write_bytes(payload)
+    artifact_hash = "sha256:" + hashlib.sha256(payload).hexdigest()
+
+    artifact = load_g1_neural_torque_artifact(
+        path,
+        expected_hash=artifact_hash,
+        expected_body_hash=_digest("body"),
+    )
+    policy = G1NeuralTorquePolicy(
+        artifact,
+        expected_body_hash=_digest("body"),
+        expected_parent_policy_hash=_digest("parent"),
+    )
+    torque = policy.command(_frame(), np.zeros(29))
+    policy.note_applied(torque)
+    receipt = policy.build_receipt()
+
+    assert torque.shape == (29,)
+    assert np.all(torque > 0.0)
+    assert receipt.inference_count == 1
+    assert receipt.learned_output_count == 1
+    assert receipt.direct_torque_output
+    assert receipt.activation_ceiling == "SIM_ONLY"
+    assert receipt.hardware_authorized is False
+    assert receipt.dds_opened is False
+    assert artifact.tensors["actor.head.bias"].flags.writeable is False
+
+
+def test_artifact_loader_rejects_tampering_and_non_sim_safety(tmp_path: Path) -> None:
+    payload = _artifact_bytes()
+    path = tmp_path / "candidate.bin"
+    path.write_bytes(payload + b"tampered")
+
+    with pytest.raises(ValueError, match="hash mismatch"):
+        load_g1_neural_torque_artifact(
+            path,
+            expected_hash="sha256:" + hashlib.sha256(payload).hexdigest(),
+        )
+    with pytest.raises(ValueError, match="SIM_ONLY"):
+        G1TorqueSafetyConfig(activation_ceiling="REAL")
+
+
+def test_teacher_collector_is_exact_pass_through_at_physics_rate() -> None:
+    collector = G1TeacherTorqueCollector()
+    collector.reset()
+    parent = np.linspace(-10.0, 10.0, 29)
+
+    command = collector.command(_frame(), parent)
+    collector.note_applied(command)
+    episode = collector.episode()
+
+    assert command == pytest.approx(parent)
+    assert episode.observations.shape == (1, 102)
+    assert episode.actions[0] == pytest.approx(parent)
+    assert episode.parent_actions[0] == pytest.approx(parent)

--- a/tests/simforge/test_g1_neural_torque_learning.py
+++ b/tests/simforge/test_g1_neural_torque_learning.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import hashlib
+from dataclasses import replace
 
 import numpy as np
 import pytest
 
 pytest.importorskip("torch")
 
+from rosclaw.collective.sources.motiondecode.motion_prior import (
+    G1_MOTION_PRIOR_FEATURES,
+    G1MotionPriorArtifact,
+)
 from rosclaw.simforge.g1_neural_torque import (
     G1_NEURAL_TORQUE_OBSERVATIONS,
     G1TeacherTorqueEpisode,
@@ -18,6 +23,7 @@ from rosclaw.simforge.g1_neural_torque_learning import (
     G1NeuralTorqueReplay,
     _quantized_export,
     online_replay,
+    recovery_online_replay,
     teacher_dataset_hash,
     teacher_replay,
 )
@@ -54,6 +60,41 @@ def _learner(seed: int = 3) -> G1ContinualTorqueActorCritic:
     )
 
 
+def _motion_prior(hidden_dim: int = 12) -> G1MotionPriorArtifact:
+    rng = np.random.default_rng(91)
+    feature_count = len(G1_MOTION_PRIOR_FEATURES)
+    tensors = {
+        "gru.weight_ih_l0": rng.normal(
+            0.0, 0.01, (3 * hidden_dim, feature_count)
+        ).astype(np.float32),
+        "gru.weight_hh_l0": rng.normal(0.0, 0.01, (3 * hidden_dim, hidden_dim)).astype(
+            np.float32
+        ),
+        "gru.bias_ih_l0": np.zeros(3 * hidden_dim, dtype=np.float32),
+        "gru.bias_hh_l0": np.zeros(3 * hidden_dim, dtype=np.float32),
+        "head.weight": np.full((feature_count, hidden_dim), 999.0, dtype=np.float32),
+        "head.bias": np.full(feature_count, 999.0, dtype=np.float32),
+        "observation_mean": np.zeros(feature_count, dtype=np.float32),
+        "observation_std": np.ones(feature_count, dtype=np.float32),
+    }
+    return G1MotionPriorArtifact(
+        artifact_hash=_digest("motion-prior"),
+        weights_hash=_digest("motion-prior-weights"),
+        pack_hash=_digest("motion-prior-pack"),
+        pilot_report_hash=_digest("motion-prior-pilot"),
+        body_hash=_digest("body"),
+        feature_names=G1_MOTION_PRIOR_FEATURES,
+        hidden_dim=hidden_dim,
+        sequence_length=8,
+        observation_mean=tensors["observation_mean"],
+        observation_std=tensors["observation_std"],
+        tensors=tensors,
+        source_truth_level="T4",
+        action_semantics="ABSENT",
+        activation_ceiling="SIM_ONLY_REPRESENTATION_INITIALIZATION",
+    )
+
+
 def test_behavior_cloning_learns_nonzero_direct_torque_and_exports_safe_actor(
     tmp_path,
 ) -> None:
@@ -84,6 +125,86 @@ def test_behavior_cloning_learns_nonzero_direct_torque_and_exports_safe_actor(
     assert np.all(np.abs(action) <= np.asarray(artifact.action_limits) + 1e-6)
     assert artifact.update_index == 0
     assert artifact.safety.activation_ceiling == "SIM_ONLY"
+
+
+def test_motion_prior_initializes_only_matching_sim_proprioceptive_gru() -> None:
+    learner = _learner(seed=17)
+    before = learner.actor_snapshot()
+    prior = _motion_prior()
+    learner.install_motion_prior(prior, expected_body_hash=_digest("body"))
+    learner.pretrain_behavior((_episode(1), _episode(2)), epochs=1, stride=2)
+    after = learner.actor_snapshot()
+
+    assert learner.motion_prior_artifact_hash == prior.artifact_hash
+    feature_count = len(G1_MOTION_PRIOR_FEATURES)
+    assert not np.array_equal(
+        after["gru.weight_ih_l0"][:, :feature_count],
+        before["gru.weight_ih_l0"][:, :feature_count],
+    )
+    assert not np.allclose(after["head.weight"], 999.0)
+    with pytest.raises(ValueError, match="before torque consolidation"):
+        learner.install_motion_prior(prior, expected_body_hash=_digest("body"))
+
+
+def test_motion_prior_rejects_body_mismatch() -> None:
+    learner = _learner()
+    with pytest.raises(ValueError, match="body hash"):
+        learner.install_motion_prior(_motion_prior(), expected_body_hash=_digest("other-body"))
+
+    incomplete = replace(
+        _motion_prior(),
+        feature_names=G1_MOTION_PRIOR_FEATURES[:-1],
+    )
+    with pytest.raises(ValueError, match="feature order"):
+        learner.install_motion_prior(incomplete, expected_body_hash=_digest("body"))
+
+
+def test_recovery_replay_aligns_500hz_policy_with_dense_50hz_physics() -> None:
+    episode = _episode(31, count=100)
+    trajectory = {
+        "policy_phase": np.full(10, 0.7),
+        "support_foot_slip": np.linspace(0.0, 0.05, 10),
+        "com_y_relative": np.linspace(0.0, 0.13, 10),
+        "left_foot_contact": np.ones(10),
+        "right_foot_contact": np.ones(10),
+    }
+    replay = recovery_online_replay(
+        episode,
+        trajectory=trajectory,
+        sequence_length=8,
+        recovery_score=2.0,
+        fell=False,
+        critical_failure=False,
+        projection_fallback_rate=0.0,
+        stride=10,
+    )
+
+    assert replay.count == 10
+    assert replay.partitions.tolist() == [0] * 10
+    assert replay.rewards[-1, 0] > replay.rewards[-2, 0]
+    assert replay.constraint_costs[-1, 0] == 1.0
+    assert replay.fall_costs[-1, 0] == 0.0
+    assert replay.terminals[-1, 0] == 1.0
+    with pytest.raises(ValueError, match="misaligned"):
+        recovery_online_replay(
+            episode,
+            trajectory={**trajectory, "policy_phase": np.full(9, 0.7)},
+            sequence_length=8,
+            recovery_score=0.0,
+            fell=False,
+            critical_failure=False,
+            projection_fallback_rate=0.0,
+        )
+    with pytest.raises(ValueError, match="non-numeric"):
+        recovery_online_replay(
+            episode,
+            trajectory={**trajectory, "policy_phase": np.full(10, "bad")},
+            sequence_length=8,
+            recovery_score=0.0,
+            fell=False,
+            critical_failure=False,
+            projection_fallback_rate=0.0,
+        )
 
 
 def test_actor_export_is_canonical_and_trust_region_is_bounded() -> None:

--- a/tests/simforge/test_g1_neural_torque_learning.py
+++ b/tests/simforge/test_g1_neural_torque_learning.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+
+from rosclaw.simforge.g1_neural_torque import (
+    G1_NEURAL_TORQUE_OBSERVATIONS,
+    G1TeacherTorqueEpisode,
+    load_g1_neural_torque_artifact,
+)
+from rosclaw.simforge.g1_neural_torque_learning import (
+    G1ContinualTorqueActorCritic,
+    G1NeuralTorqueLearnerConfig,
+    G1NeuralTorqueReplay,
+    _quantized_export,
+    online_replay,
+    teacher_dataset_hash,
+    teacher_replay,
+)
+from rosclaw.simforge.tasks.g1_goalforge.concepts import G1_HARD_TORQUE_LIMITS
+
+
+def _digest(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()
+
+
+def _episode(seed: int, *, count: int = 96) -> G1TeacherTorqueEpisode:
+    rng = np.random.default_rng(seed)
+    observation_dim = len(G1_NEURAL_TORQUE_OBSERVATIONS)
+    time = np.linspace(0.0, 2.0 * np.pi, count, dtype=np.float32)
+    observations = rng.normal(0.0, 0.05, (count, observation_dim)).astype(np.float32)
+    observations[:, 0] = np.sin(time)
+    observations[:, 29] = np.cos(time)
+    limits = np.asarray(G1_HARD_TORQUE_LIMITS, dtype=np.float32)
+    actions = np.zeros((count, 29), dtype=np.float32)
+    actions[:, 0] = 0.08 * limits[0] * np.sin(time)
+    actions[:, 1] = 0.04 * limits[1] * np.cos(time)
+    return G1TeacherTorqueEpisode(observations, actions, actions)
+
+
+def _learner(seed: int = 3) -> G1ContinualTorqueActorCritic:
+    return G1ContinualTorqueActorCritic(
+        G1NeuralTorqueLearnerConfig(
+            hidden_dim=12,
+            sequence_length=8,
+            batch_size=8,
+            device="cpu",
+            seed=seed,
+        )
+    )
+
+
+def test_behavior_cloning_learns_nonzero_direct_torque_and_exports_safe_actor(
+    tmp_path,
+) -> None:
+    learner = _learner()
+    training = (_episode(1), _episode(2))
+    validation = (_episode(4),)
+
+    metrics = learner.pretrain_behavior(
+        training,
+        validation=validation,
+        epochs=8,
+        stride=2,
+    )
+    payload = learner.artifact_bytes(
+        body_hash=_digest("body"),
+        parent_policy_hash=_digest("parent"),
+        dataset_hash=teacher_dataset_hash(training),
+    )
+    path = tmp_path / "actor.bin"
+    path.write_bytes(payload)
+    artifact = load_g1_neural_torque_artifact(path)
+    sequence = validation[0].observations[:8]
+    action = learner.deterministic_action(sequence)
+
+    assert metrics[-1].training_loss < metrics[0].training_loss
+    assert metrics[-1].finite
+    assert np.linalg.norm(action) > 0.0
+    assert np.all(np.abs(action) <= np.asarray(artifact.action_limits) + 1e-6)
+    assert artifact.update_index == 0
+    assert artifact.safety.activation_ceiling == "SIM_ONLY"
+
+
+def test_actor_export_is_canonical_and_trust_region_is_bounded() -> None:
+    learner = _learner(seed=13)
+    training = (_episode(1), _episode(2))
+    learner.pretrain_behavior(training, epochs=2, stride=2)
+    parent = learner.actor_snapshot()
+    proposal = {name: value.copy() for name, value in parent.items()}
+    first = next(iter(proposal))
+    proposal[first].flat[0] += 1e-4
+
+    assert np.array_equal(
+        _quantized_export(np.asarray((0.12345641,), dtype=np.float64)),
+        _quantized_export(np.asarray((0.12345642,), dtype=np.float64)),
+    )
+    learner.install_interpolated_actor(parent, proposal, fraction=0.0)
+    restored = learner.actor_snapshot()
+    assert all(np.array_equal(restored[name], parent[name]) for name in parent)
+    with pytest.raises(ValueError, match="fraction"):
+        learner.install_interpolated_actor(parent, proposal, fraction=1.01)
+
+
+def test_continual_actor_critic_uses_stale_and_boundary_only_for_critics() -> None:
+    learner = _learner(seed=5)
+    anchors = (_episode(1), _episode(2))
+    learner.pretrain_behavior(anchors, epochs=2, stride=2)
+    anchor_replay = teacher_replay(anchors, sequence_length=8, stride=4)
+    fresh_replay = online_replay(
+        _episode(7),
+        sequence_length=8,
+        task_score=2.0,
+        fell=False,
+        critical_failure=False,
+        projection_fallback_rate=0.0,
+        stride=4,
+    )
+    stale_replay = online_replay(
+        _episode(8),
+        sequence_length=8,
+        task_score=0.0,
+        fell=False,
+        critical_failure=False,
+        projection_fallback_rate=0.0,
+        policy_lag=2,
+        stride=4,
+    )
+    boundary_replay = online_replay(
+        _episode(9),
+        sequence_length=8,
+        task_score=-5.0,
+        fell=True,
+        critical_failure=True,
+        projection_fallback_rate=0.4,
+        stride=4,
+    )
+    replay = G1NeuralTorqueReplay.combine(
+        anchor_replay,
+        fresh_replay,
+        stale_replay,
+        boundary_replay,
+    )
+
+    update = learner.update(replay)
+
+    assert update.finite
+    assert update.actor_transition_count == fresh_replay.count
+    assert update.stale_actor_transition_count == stale_replay.count
+    assert update.anchor_transition_count == anchor_replay.count
+    assert update.critic_transition_count == replay.count
+    assert update.anchor_loss >= 0.0
+    assert update.ewc_loss >= 0.0
+
+
+def test_online_update_requires_fresh_plasticity_and_historical_stability() -> None:
+    learner = _learner()
+    anchors = (_episode(1),)
+    learner.pretrain_behavior(anchors, epochs=1, stride=2)
+    anchor_replay = teacher_replay(anchors, sequence_length=8, stride=4)
+    boundary = online_replay(
+        _episode(3),
+        sequence_length=8,
+        task_score=-3.0,
+        fell=True,
+        critical_failure=True,
+        projection_fallback_rate=1.0,
+        stride=4,
+    )
+
+    with pytest.raises(ValueError, match="fresh online transitions"):
+        learner.update(G1NeuralTorqueReplay.combine(anchor_replay, boundary))
+    critic_only = learner.update(
+        G1NeuralTorqueReplay.combine(anchor_replay, boundary),
+        update_actor=False,
+    )
+    assert critic_only.finite
+    assert not critic_only.actor_updated
+    assert critic_only.actor_transition_count == 0
+    with pytest.raises(ValueError, match="historical anchors"):
+        learner.update(
+            online_replay(
+                _episode(4),
+                sequence_length=8,
+                task_score=1.0,
+                fell=False,
+                critical_failure=False,
+                projection_fallback_rate=0.0,
+                stride=4,
+            )
+        )
+
+
+def test_full_checkpoint_restores_actor_critics_optimizers_and_ewc_state() -> None:
+    learner = _learner(seed=11)
+    anchors = (_episode(1), _episode(2))
+    learner.pretrain_behavior(anchors, epochs=2, stride=2)
+    replay = G1NeuralTorqueReplay.combine(
+        teacher_replay(anchors, sequence_length=8, stride=4),
+        online_replay(
+            _episode(5),
+            sequence_length=8,
+            task_score=1.0,
+            fell=False,
+            critical_failure=False,
+            projection_fallback_rate=0.0,
+            stride=4,
+        ),
+    )
+    learner.update(replay)
+    checkpoint = learner.checkpoint_bytes()
+    expected = learner.artifact_bytes(
+        body_hash=_digest("body"),
+        parent_policy_hash=_digest("parent"),
+        dataset_hash=teacher_dataset_hash(anchors),
+    )
+
+    recovered = _learner(seed=11)
+    recovered.restore_checkpoint(checkpoint)
+    actual = recovered.artifact_bytes(
+        body_hash=_digest("body"),
+        parent_policy_hash=_digest("parent"),
+        dataset_hash=teacher_dataset_hash(anchors),
+    )
+
+    assert recovered.update_index == learner.update_index
+    assert actual == expected
+    assert recovered.update(replay).finite


### PR DESCRIPTION
## Summary

Phase 8 turns the G1 football recovery work into a real SIM_ONLY data-driven control and self-evolution foundation.

- 102D proprioception/task context to GRU to 29 direct joint torques
- four independent A6000 behavior-cloning candidates, DAgger, constrained recurrent actor-critic, replay retention, physical trust regions, and rollback
- Collective Experience Plane with fail-closed source, license, semantic, and Body binding
- deterministic MotionDecode audit with clean continuous spans and explicit football-data shortage
- source-episode-disjoint 61D self-supervised G1 motion prior trained on four physical A6000 GPUs
- semantically limited GRU representation transfer; the motion prediction head can never become a torque head
- stable/plastic direct-torque actors gated by recovery phase, posture, contact, and warmup
- exact 500 Hz policy to 50 Hz MuJoCo dense recovery replay
- first-class `rosclaw collective source/ingest/prior build/prior train` CLI
- detailed Chinese implementation and experiment report

## Honest experiment result

- 400 audited episodes, 2,086,231 frames, 99.6577% weighted clean frames, 128,911 clean windows
- local MotionDecode snapshot has no football CSV, synchronized ball pose, torque, or reward labels; it is used only as a kinematic representation prior
- stability pack: 6,400 train and 1,600 held-out windows from 200 balance/recovery episodes
- all four A6000 workers pass the 2% representation gate; best held-out improvement is 7.303% over persistence
- online generation updates 612 fresh actor transitions, 3,820 critic transitions, and rehearses 2,596 anchors
- independent MuJoCo Validation finds no measurable recovery improvement over the parent
- final decision is `REJECTED`; no candidate promotion and no hardware authorization

The rejection is intentional: the code now closes the full data to learning to physics to gate loop without turning a lower loss into a false physical-performance claim.

## Validation

- targeted Phase 8 tests: 26 passed
- ruff: passed
- mypy: 928 source files passed
- portable report: validation, packaging, desktop/mobile browser verification, chart, source dialog, and zero-external-request checks passed
- full local pytest: 5,495 passed, 68 skipped, 27 deselected; 4 failures are the pre-existing optional LeRobot runtime configuration failures also present on main, and this branch does not modify those files

## Evidence and safety

- all execution is MuJoCo `SIM_ONLY`
- no ROS, DDS, Unitree SDK, or real robot was exercised
- no raw MotionDecode CSV, tensor pack, or trained weights are committed
- artifact activation is bound to Body, parent policy, source/data commitments, and safety receipts
- detailed report: `docs/validation/ROSCLAW_PHASE8_MOTIONDECODE_CONTINUAL_RECOVERY.md`
