### PR TITLE
seekdb: correct pyseekdb 1.4.0 repro to the real metadata-filtered triggers

### DIFF
--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -413,8 +413,10 @@ def _pyseekdb_compat_checks(
     matrix = {
         "validated": ["1.3.0"],
         "known_incompatible": {
-            "1.4.0": "embedded SQL generation broken (__pk_increment syntax "
-            "errors, empty hybrid_search results); use pyseekdb==1.3.0",
+            "1.4.0": "metadata-filtered search legs broken on embedded engine "
+            "(code=1064 __pk_increment, malformed FULL JOIN, code=1059 "
+            "identifier-too-long; unfiltered calls unaffected); "
+            "upstream: oceanbase/pyseekdb#251; use pyseekdb==1.3.0",
         },
     }
     try:

--- a/validation/ty1200/scripts/repro_pyseekdb_140.py
+++ b/validation/ty1200/scripts/repro_pyseekdb_140.py
@@ -1,30 +1,21 @@
 #!/usr/bin/env python3
-"""Minimal repro: pyseekdb 1.4.0 incompatibility with the embedded SeekDB engine.
+"""Minimal repro: pyseekdb 1.4.0 regressions on the embedded SeekDB engine.
 
-Observed on TY1200 (x86_64, glibc 2.35, Python 3.12.13, seekdb-lib 0.0.1.dev5,
-pylibseekdb 1.3.0.post3):
+CORRECTED (thanks to the reviewer on oceanbase/pyseekdb#251): the original
+version of this script used unfiltered calls which PASS on 1.4.0 — the real
+trigger is metadata-filtered search (rosclaw's calling pattern).
 
-  pyseekdb 1.3.0 + embedded engine -> all operations work.
-  pyseekdb 1.4.0 + embedded engine -> TWO failure classes:
+Verified first-hand matrix (Ubuntu 22.04 x86_64, Python 3.12.13,
+seekdb-lib 0.0.1.dev5, pylibseekdb 1.3.0.post3):
 
-  (a) ``get``/filtered queries raise::
+  case                                          1.3.0    1.4.0
+  T0 unfiltered get / BM25-only hybrid          OK       OK
+  T1 BM25 leg: where_document + metadata where  OK       code=1064 (__pk_increment)
+  T2 dual-leg RRF, both legs metadata-filtered  OK       malformed FULL JOIN SQL
+  T4 hybrid KNN leg + metadata where            OK       code=1059 (identifier too long)
+  T3/T5 plain query() + where (simple / $and)   OK       OK
 
-        pylibseekdb.SeekdbError: You have an error in your SQL syntax;
-        check the manual that corresponds to your OceanBase version for the
-        right syntax to use near 'DESC, `__pk_increment` LIMIT 5' at line 1
-        failed: code=1064
-
-  (b) ``hybrid_search`` with only the BM25 (query) leg returns empty lists
-      for every query, including substrings that exist in the documents.
-
-Run:
-
-    python -m venv /tmp/repro-venv && /tmp/repro-venv/bin/pip install \
-        "pyseekdb==1.4.0" seekdb seekdb-lib pylibseekdb
-    /tmp/repro-venv/bin/python validation/ty1200/scripts/repro_pyseekdb_140.py
-
-Expected with 1.3.0: prints "PASS". Expected with 1.4.0: prints the two
-failure classes above and exits 1.
+Exit code: 0 on a healthy SDK (all cases pass), 1 with failures listed.
 """
 
 from __future__ import annotations
@@ -35,50 +26,103 @@ import tempfile
 import pyseekdb
 from pyseekdb import HNSWConfiguration
 
+DOCS = ["joint limit exceeded in sandbox", "network retry succeeded"]
+META = [{"robot": "ur5e", "outcome": "failure"}, {"robot": "limo", "outcome": "failure"}]
+VEC = [[0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1]]
+
 
 def main() -> int:
     path = tempfile.mkdtemp(prefix="repro-140-")
-    client = pyseekdb.AdminClient(path=path)
-    client.create_database("repro")
+    admin = pyseekdb.AdminClient(path=path)
+    admin.create_database("repro")
     client = pyseekdb.Client(path=path, database="repro")
     coll = client.create_collection(
         "docs", configuration=HNSWConfiguration(dimension=4), embedding_function=None
     )
-    coll.add(
-        ids=["a", "b"],
-        embeddings=[[0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1]],
-        documents=["joint limit exceeded in sandbox", "network retry succeeded"],
-    )
+    coll.add(ids=["a", "b"], embeddings=VEC, documents=DOCS, metadatas=META)
 
     failures = []
 
-    # (a) filtered get()
-    try:
-        rows = coll.get(where={"robot": "ty1200"}, limit=5, include=["metadatas"])
-        print("get() ok:", (rows or {}).get("ids"))
-    except Exception as exc:  # noqa: BLE001
-        failures.append(f"get() raised: {type(exc).__name__}: {str(exc)[:160]}")
+    def check(name, fn, expect_ids):
+        try:
+            res = fn()
+            ids = (res or {}).get("ids")
+            status = "OK" if ids == expect_ids else f"WRONG ids={ids}"
+            if ids != expect_ids:
+                failures.append(f"{name}: expected {expect_ids}, got {ids}")
+        except Exception as exc:  # noqa: BLE001
+            status = f"FAIL {type(exc).__name__}: {str(exc)[:150]}"
+            failures.append(f"{name}: {status}")
+        print(f"  {name}: {status}")
 
-    # (b) BM25-only hybrid leg
-    try:
-        res = coll.hybrid_search(
-            query={"where_document": {"$contains": "joint"}, "n_results": 3},
+    # T1: BM25 leg with where_document + metadata where
+    check(
+        "T1 BM25 where_document + metadata where",
+        lambda: coll.hybrid_search(
+            query={
+                "where_document": {"$contains": "joint"},
+                "n_results": 3,
+                "where": {"robot": "ur5e"},
+            },
             n_results=3,
             include=["metadatas"],
-        )
-        ids = (res or {}).get("ids")
-        print("hybrid BM25 leg:", ids)
-        if not ids or ids == [[]]:
-            failures.append("hybrid_search BM25 leg returned empty for an existing substring")
-    except Exception as exc:  # noqa: BLE001
-        failures.append(f"hybrid_search raised: {type(exc).__name__}: {str(exc)[:160]}")
+        ),
+        [["a"]],
+    )
 
+    # T2: dual-leg RRF, both legs metadata-filtered
+    check(
+        "T2 dual-leg RRF both filtered",
+        lambda: coll.hybrid_search(
+            query={
+                "where_document": {"$contains": "joint"},
+                "n_results": 3,
+                "where": {"robot": "ur5e"},
+            },
+            knn={
+                "query_embeddings": [[0.1, 0.2, 0.3, 0.4]],
+                "n_results": 3,
+                "where": {"robot": "ur5e"},
+            },
+            rank={"rrf": {"rank_window_size": 5, "rank_constant": 60}},
+            n_results=3,
+            include=["metadatas"],
+        ),
+        [["a"]],
+    )
+
+    # T4: hybrid KNN leg + metadata where
+    check(
+        "T4 hybrid KNN leg + metadata where",
+        lambda: coll.hybrid_search(
+            knn={
+                "query_embeddings": [[0.1, 0.2, 0.3, 0.4]],
+                "n_results": 3,
+                "where": {"robot": "ur5e"},
+            },
+            n_results=3,
+            include=["metadatas"],
+        ),
+        [["a"]],
+    )
+
+    # Control: plain query with where — passes on both versions
+    check(
+        "T5 control: query() + where",
+        lambda: coll.query(
+            query_embeddings=[[0.1, 0.2, 0.3, 0.4]],
+            where={"robot": "ur5e"},
+            n_results=3,
+            include=["metadatas"],
+        ),
+        [["a"]],
+    )
+
+    version = getattr(pyseekdb, "__version__", "?")
     if failures:
-        print("\nREPRO FAILURES (pyseekdb", getattr(pyseekdb, "__version__", "?"), "):")
-        for f in failures:
-            print(" -", f)
+        print(f"\nREPRO FAILURES (pyseekdb {version}): {len(failures)} case(s)")
         return 1
-    print("PASS (pyseekdb", getattr(pyseekdb, "__version__", "?"), "works with embedded engine)")
+    print(f"\nPASS (pyseekdb {version} healthy on embedded engine)")
     return 0
 
 


### PR DESCRIPTION
## What

Correct the pyseekdb 1.4.0 repro after reviewer feedback on
oceanbase/pyseekdb#251, with first-hand verification in a 1.4.0 sandbox venv.

The original repro used unfiltered calls, which PASS on 1.4.0 (reviewer was
right). The real trigger is metadata-filtered search legs — rosclaw's calling
pattern.

## First-hand verified matrix (1.3.0 vs 1.4.0)

| case | 1.3.0 | 1.4.0 |
|---|---|---|
| unfiltered get / BM25-only hybrid | OK | OK |
| BM25 leg `where_document` + metadata `where` | OK | code=1064 `__pk_increment` |
| dual-leg RRF, both legs filtered | OK | malformed FULL JOIN |
| hybrid KNN leg + metadata `where` | OK | code=1059 identifier-too-long |
| plain `query()` + `where` (simple/`$and`) | OK | OK |

## Changes

- `validation/ty1200/scripts/repro_pyseekdb_140.py`: rewritten around the
  true triggers (T1/T2/T4) + a control case; prints PASS/FAIL per case and
  exits 1 on any failure. Verified: 3 failures on 1.4.0, all pass on 1.3.0.
- `storage/cli.py`: compat-matrix wording corrected to the real failure
  shape (metadata-filtered legs; unfiltered calls unaffected) + upstream
  issue reference.

Follow-up posted on the issue with the verified matrix:
https://github.com/oceanbase/pyseekdb/issues/251#issuecomment-5157386703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
