### PR TITLE
Connect AgentD real bodies to daemon proposals

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -25,8 +25,29 @@ rosclaw agentd start --port 8765
 #   /health /status /probe /missions /missions/{id}/turns
 ```
 
-`--mode REAL` 只是请求：缺 MissionGrant、真实身体、daemon REAL executor 时
-必须拒绝并列出缺口（fail closed）。
+`--mode REAL` 只是请求：创建 Mission 前必须存在 hash-valid 的真实身体、
+已加载并验签的 Robot Pack、在线 rosclawd 与对应 REAL executor；任一缺失都
+必须拒绝并列出缺口（fail closed）。MissionGrant 在具体动作提出后由用户批准，
+不会被错误地要求在 Mission 创建前预先存在。
+
+### 绑定真实身体（例如 LIMO）
+
+模型初始化后，在同一个 `~/.rosclaw/config.yaml` 的 `agent` 段绑定 Body：
+
+```yaml
+agent:
+  enabled: true
+  body_id: limo
+  default_mode: REAL
+  budgets:
+    physical_action_count: 3
+```
+
+`body_id` 由 Body Registry 解析；旧配置的 `sim_body_id` 仍用于 SIMULATION，
+但不会被当作真实 Body。真实身体上下文读取 EffectiveBody 的重算哈希，并从
+rosclawd 获取新鲜的控制面 Self 状态；daemon 断开、Body hash 漂移或 Robot
+Pack/执行器缺失时均停止推进。REAL Mission 还要求显式的
+`physical_action_count > 0`；默认值为 0，不会隐式获得真机动作预算。
 
 ## 架构落点
 
@@ -95,6 +116,14 @@ broker 侧，永不进入模型上下文）→ Agent REQUEST_ACTION 引用 grant
 Broker.verify 独立核验（principal/body hash/mode/risk/action_intent）→
 EXACT_ACTION 单次消费，重放即拒
 ```
+
+REAL 模式还有独立的物理边界确认：AgentD 校验 MissionGrant 后只调用
+`operator.proposal.create`。rosclawd 返回 public proposal（无 challenge、无
+permit、未派发），再由受信 Operator 进程审阅精确 ActionEnvelope 并决定。
+AgentD 不调用 proposal decision RPC，也不会因为拿到 MissionGrant 而自批。
+最终链路为：MissionGrant verify → daemon proposal → Operator decision → daemon
+Permit → executor → terminal Receipt。SHADOW/SIMULATION 仍直接返回各自证据域的
+回执，不能冒充 REAL 物理证据。
 
 攻击回归（全部拒绝并给出 reason_code）：unknown/revoked/expired/
 principal_mismatch/body_hash_changed/mode_mismatch/risk_above_ceiling/

--- a/src/rosclaw/agentd/action_channel.py
+++ b/src/rosclaw/agentd/action_channel.py
@@ -39,6 +39,13 @@ class ActionOutcome:
     verified: bool
 
 
+@dataclass(frozen=True)
+class ActionProposalOutcome:
+    request_id: str
+    action_id: str
+    state: str
+
+
 class DaemonActionChannel:
     def __init__(
         self,
@@ -52,15 +59,16 @@ class DaemonActionChannel:
         self._actor_id = actor_id
         self._body_id = body_id
         self._body_hash = body_hash
-        self._session_id: str | None = None
+        self._sessions_by_capability: dict[str, str] = {}
 
     async def _ensure_session(self, capability_id: str) -> str:
-        if self._session_id is not None:
-            return self._session_id
-        self._session_id = new_id("sess")
+        existing = self._sessions_by_capability.get(capability_id)
+        if existing is not None:
+            return existing
+        session_id = new_id("sess")
         await asyncio.to_thread(
             self._client.create_session,
-            session_id=self._session_id,
+            session_id=session_id,
             actor_id=self._actor_id,
             agent_framework="rosclaw-native",
             body_scope=[self._body_id],
@@ -68,17 +76,22 @@ class DaemonActionChannel:
             capability_scope=[capability_id],
             ttl_ms=30_000,
         )
-        return self._session_id
+        self._sessions_by_capability[capability_id] = session_id
+        return session_id
 
-    async def request_sim_action(
+    async def request_nonreal_action(
         self,
         *,
         capability_id: str,
         arguments: dict[str, Any],
         grant_id: str,
+        execution_mode: str = "SIMULATION",
         timeout_sec: float = 30.0,
     ) -> ActionOutcome:
-        """Submit a SIMULATION action and verify its receipt."""
+        """Submit a SIMULATION or SHADOW action and verify its receipt."""
+        mode = ExecutionMode(str(execution_mode).upper())
+        if mode not in {ExecutionMode.SIMULATION, ExecutionMode.SHADOW}:
+            raise ActionChannelError(f"non-real channel does not accept {mode.value}")
         try:
             session_id = await self._ensure_session(capability_id)
         except DaemonClientError as exc:
@@ -94,13 +107,13 @@ class DaemonActionChannel:
             body_snapshot_hash=self._body_hash,
             capability_id=capability_id,
             arguments=arguments,
-            execution_mode=ExecutionMode.SIMULATION,
+            execution_mode=mode,
             deadline_at=datetime.now(UTC) + timedelta(seconds=timeout_sec),
             authorization=AuthorizationContext(
                 principal_id="user:local:1000",
                 approved=True,
                 approval_id=grant_id,
-                scopes=["simulation"],
+                scopes=[mode.value.lower()],
             ),
             verification_policy=VerificationPolicy(
                 required_evidence=EvidenceLevel.TASK_VERIFIED,
@@ -120,6 +133,85 @@ class DaemonActionChannel:
             raise ActionChannelError(f"action did not finish: {exc.code}: {exc}") from exc
         receipt = await asyncio.to_thread(self._client.get_execution_receipt, action_id)
         return self._verify_outcome(action_id, status, receipt, envelope)
+
+    async def request_sim_action(
+        self,
+        *,
+        capability_id: str,
+        arguments: dict[str, Any],
+        grant_id: str,
+        timeout_sec: float = 30.0,
+    ) -> ActionOutcome:
+        """Backward-compatible SIMULATION entrypoint."""
+
+        return await self.request_nonreal_action(
+            capability_id=capability_id,
+            arguments=arguments,
+            grant_id=grant_id,
+            execution_mode="SIMULATION",
+            timeout_sec=timeout_sec,
+        )
+
+    async def request_real_proposal(
+        self,
+        *,
+        capability_id: str,
+        arguments: dict[str, Any],
+        grant_id: str,
+        grant_public_hash: str,
+        principal_id: str,
+        risk_tier: str,
+        display: dict[str, Any],
+        timeout_sec: float = 60.0,
+    ) -> ActionProposalOutcome:
+        """Create an exact daemon proposal without deciding or dispatching it."""
+
+        action_id = new_id("act")
+        envelope = ActionEnvelope(
+            action_id=action_id,
+            actor_id=self._actor_id,
+            agent_framework="rosclaw-native",
+            session_id=action_id,
+            body_id=self._body_id,
+            body_snapshot_hash=self._body_hash,
+            capability_id=capability_id,
+            arguments=arguments,
+            execution_mode=ExecutionMode.REAL,
+            risk_class=risk_tier.lower(),
+            deadline_at=datetime.now(UTC) + timedelta(seconds=timeout_sec + 60.0),
+            authorization=AuthorizationContext(
+                principal_id=principal_id,
+                approved=False,
+                approval_id=grant_id,
+                scopes=[],
+                provenance={"mission_grant_public_hash": grant_public_hash},
+            ),
+            verification_policy=VerificationPolicy(
+                required_evidence=EvidenceLevel.TASK_VERIFIED,
+                timeout_sec=timeout_sec,
+            ),
+        )
+        try:
+            created = await asyncio.to_thread(
+                self._client.create_operator_proposal,
+                envelope,
+                display=display,
+                ttl_sec=timeout_sec,
+            )
+        except DaemonClientError as exc:
+            raise ActionChannelError(
+                f"daemon rejected operator proposal: {exc.code}: {exc}"
+            ) from exc
+        proposal = created.get("proposal") or {}
+        if created.get("command_dispatched") is not False or created.get("permit_exposed") is not False:
+            raise ActionChannelError("daemon proposal response violated pending/no-permit invariant")
+        if not proposal.get("request_id") or not proposal.get("action_id"):
+            raise ActionChannelError("daemon proposal response omitted public identifiers")
+        return ActionProposalOutcome(
+            request_id=str(proposal.get("request_id", "")),
+            action_id=str(proposal.get("action_id", action_id)),
+            state=str(proposal.get("state", "UNKNOWN")),
+        )
 
     def _verify_outcome(
         self,
@@ -141,7 +233,8 @@ class DaemonActionChannel:
         trust = str(inner.get("trust_level", "UNKNOWN"))
         if trust == "SYNTHETIC":
             raise ActionChannelError("receipt is FIXTURE/SYNTHETIC — never usable as real evidence")
-        verified = state in ("FINISHED",) and trust == "SIMULATED"
+        expected_trust = "SIMULATED" if envelope.execution_mode is ExecutionMode.SIMULATION else "VERIFIED"
+        verified = state in ("FINISHED",) and trust == expected_trust
         return ActionOutcome(
             action_id=action_id,
             state=state,

--- a/src/rosclaw/agentd/config.py
+++ b/src/rosclaw/agentd/config.py
@@ -25,10 +25,18 @@ class AgentConfig:
     max_tool_rounds: int = 12
     max_input_tokens: int = 120_000
     dynamic_tool_limit: int = 12
+    physical_action_count: int = 0
     language: str = "zh-CN"
+    body_id: str | None = None
     sim_body_id: str = "sim/ur5e"
     profiles: list[ModelProfile] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def active_body_id(self) -> str:
+        """Return the configured body, preserving the legacy SIM default."""
+
+        return self.body_id or self.sim_body_id
 
     def to_policy(self) -> ModelPolicy:
         if not self.profiles:
@@ -68,6 +76,7 @@ def load_agent_config(path: Path | None = None) -> AgentConfig:
         _profile_from_dict(name, p or {}) for name, p in (models.get("profiles", {}) or {}).items()
     ]
     context = agent.get("context", {}) or {}
+    budgets = agent.get("budgets", {}) or {}
     return AgentConfig(
         enabled=bool(agent.get("enabled", True)),
         default_profile=str(agent.get("default_profile", "embodied_default")),
@@ -75,7 +84,9 @@ def load_agent_config(path: Path | None = None) -> AgentConfig:
         max_tool_rounds=int(agent.get("max_tool_rounds", 12)),
         max_input_tokens=int(context.get("max_input_tokens", 120_000)),
         dynamic_tool_limit=int(context.get("dynamic_tool_limit", 12)),
+        physical_action_count=int(budgets.get("physical_action_count", 0)),
         language=str(agent.get("language", "zh-CN")),
+        body_id=(str(agent["body_id"]) if agent.get("body_id") else None),
         sim_body_id=str(agent.get("sim_body_id", "sim/ur5e")),
         profiles=profiles,
         raw={
@@ -112,6 +123,7 @@ def write_agent_config(
         }
     )
     existing["agent"]["status"] = "CONFIGURED"
+    existing["agent"].setdefault("budgets", {"physical_action_count": 0})
     existing.setdefault(
         "team",
         {

--- a/src/rosclaw/agentd/handlers.py
+++ b/src/rosclaw/agentd/handlers.py
@@ -38,6 +38,7 @@ class ServiceIntentHandlers:
         manager: WorkerManager,
         actor_id: str,
         broker: OperatorBroker | None = None,
+        body_id: str = "sim/ur5e",
         body_hash: str = "",
         principal: str = "user:local:1000",
         mode: str = "SIMULATION",
@@ -46,6 +47,7 @@ class ServiceIntentHandlers:
         self._manager = manager
         self._actor_id = actor_id
         self._broker = broker
+        self._body_id = body_id
         self._body_hash = body_hash
         self._principal = principal
         self._mode = mode
@@ -121,7 +123,7 @@ class ServiceIntentHandlers:
             mission_id=decision.mission_id,
             task_id=payload.get("task_id"),
             principal=self._principal,
-            body_id=payload.get("body_id", "sim/ur5e"),
+            body_id=payload.get("body_id", self._body_id),
             effective_body_hash=self._body_hash,
             mode=self._mode,
             action_display=display,
@@ -180,10 +182,37 @@ class ServiceIntentHandlers:
         from rosclaw.agentd.action_channel import ActionChannelError
 
         try:
-            outcome = await channel.request_sim_action(
+            if self._mode == "REAL":
+                proposal = await channel.request_real_proposal(
+                    capability_id=capability,
+                    arguments=arguments,
+                    grant_id=grant.grant_id,
+                    grant_public_hash=grant.public_hash,
+                    principal_id=grant.principal,
+                    risk_tier=str(payload.get("risk_tier", "LOW")),
+                    display={
+                        "title": str(payload.get("title") or decision.summary or "真实动作请求"),
+                        "summary": str(payload.get("summary") or decision.summary or ""),
+                        "risk_tier": str(payload.get("risk_tier", "LOW")),
+                        "parameters": {
+                            "capability_id": capability,
+                            "arguments": arguments,
+                        },
+                        "mission_grant_public_hash": grant.public_hash,
+                    },
+                )
+                return (
+                    "REAL 动作已提交到 rosclawd Operator Broker，尚未执行："
+                    f"request_id={proposal.request_id[:24]}…, "
+                    f"action_id={proposal.action_id[:24]}…, state={proposal.state}。"
+                    "需要由受信 Operator 进程独立审阅并确认；Agent 未获得 permit，"
+                    "也没有自行授权。"
+                )
+            outcome = await channel.request_nonreal_action(
                 capability_id=capability,
                 arguments=arguments,
                 grant_id=grant.grant_id,
+                execution_mode=self._mode,
             )
         except ActionChannelError as exc:
             return f"动作派发/回执校验失败（fail closed）：{exc}"
@@ -193,8 +222,9 @@ class ServiceIntentHandlers:
                 f"trust={outcome.trust_level}）。提交不等于完成——不报告为成功。"
             )
         return (
-            f"动作已在 SIMULATION 完成并经回执验证：action_id={outcome.action_id[:20]}…, "
-            f"trust_level=SIMULATED（仿真证据，不可用于 REAL）。grant 已消费。"
+            f"动作已在 {self._mode} 完成并经回执验证："
+            f"action_id={outcome.action_id[:20]}…, trust_level={outcome.trust_level}。"
+            "非 REAL 证据不可用于证明真实物理执行；grant 已消费。"
         )
 
     async def team_coordinate(self, decision: DecisionV1) -> str:

--- a/src/rosclaw/agentd/runtime_sources.py
+++ b/src/rosclaw/agentd/runtime_sources.py
@@ -9,6 +9,8 @@ closed on any resolver error).
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
 
 from rosclaw.agentd.context.sources import (
     BodyFacts,
@@ -50,21 +52,26 @@ class SimBodySource:
 class ResolverBodySource:
     """Real body via rosclaw.body.BodyResolver. Fail closed on errors."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, workspace: Path | None = None, body_id: str | None = None) -> None:
         self._resolver = None
+        self._body_id = body_id
         try:
             from rosclaw.body.resolver import BodyResolver
 
-            self._resolver = BodyResolver()
+            self._resolver = BodyResolver(workspace=workspace, body_id=body_id)
         except Exception:  # noqa: BLE001 - absence means "no real body"
             self._resolver = None
 
     def get_body(self, body_id: str) -> BodyFacts | None:
         if self._resolver is None:
             return None
+        if self._body_id is not None and body_id != self._body_id:
+            return None
         try:
             effective = self._resolver.get_effective_body()
             body_hash = effective.compute_hash()
+            if effective.effective_body_hash and effective.effective_body_hash != body_hash:
+                return None
             summary = f"EffectiveBody {body_id} (hash {body_hash[:18]}…)"
             return BodyFacts(
                 body_id=body_id,
@@ -74,6 +81,52 @@ class ResolverBodySource:
             )
         except Exception:  # noqa: BLE001 - resolver failure must fail closed
             return None
+
+
+class DaemonSelfSource:
+    """Fresh control-plane Self facts for a real body.
+
+    This adapter deliberately reports only daemon-observed runtime health. It
+    does not fabricate pose, sensor, or task evidence when those observations
+    are unavailable.
+    """
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+        self._sequence = 0
+
+    def get_self(self, body_id: str) -> SelfFacts | None:
+        try:
+            status = self._client.get_runtime_status()
+        except Exception:  # noqa: BLE001 - daemon loss fails context compilation closed
+            return None
+        self._sequence += 1
+        running = bool(status.get("running")) and status.get("runtime_state") == "RUNNING"
+        recovery = bool((status.get("recovery") or {}).get("required"))
+        estop = bool(status.get("emergency_stop_latched"))
+        health = "OK" if running and not recovery and not estop else "DEGRADED"
+        public = {
+            "body_id": body_id,
+            "daemon_instance_id": status.get("daemon_instance_id"),
+            "runtime_state": status.get("runtime_state"),
+            "supervision_state": status.get("supervision_state"),
+            "emergency_stop_latched": estop,
+            "recovery_required": recovery,
+            "robot_pack": (status.get("robot_pack") or {}).get("pack_ref"),
+            "registered_executors": status.get("registered_executors") or [],
+            "sequence": self._sequence,
+        }
+        return SelfFacts(
+            self_snapshot_hash=content_hash("selfsnap", public),
+            sequence=self._sequence,
+            observed_at=datetime.now(UTC),
+            health=health,
+            summary=(
+                f"rosclawd runtime={public['runtime_state']} "
+                f"supervision={public['supervision_state']} health={health}; "
+                "pose and sensor evidence not asserted by this source"
+            ),
+        )
 
 
 class SimSelfSource:

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -28,7 +28,9 @@ from rosclaw.agentd.models.gateway import (
 )
 from rosclaw.agentd.runtime_sources import (
     ConfigConsentSource,
+    DaemonSelfSource,
     EmptyMemorySource,
+    ResolverBodySource,
     SimBodySource,
     SimSelfSource,
     StaticCapabilitySource,
@@ -37,6 +39,7 @@ from rosclaw.agentd.tools import SIM_BODY_TOOL, SIM_STATE_TOOL, BuiltinToolRegis
 from rosclaw.agentd.usage import UsageRecorder
 from rosclaw.contracts.agent.mission import (
     BodyBinding,
+    Budgets,
     ExecutionMode,
     Goal,
     MissionSessionV1,
@@ -113,14 +116,35 @@ class AgentService:
         from rosclaw.agentd.handlers import ServiceIntentHandlers
         from rosclaw.agentd.workers import NativeWorkerAdapter, WorkerManager, WorkerRegistry
 
+        self._body_id = config.active_body_id
+        self._daemon_client = None
+        daemon_socket = os.environ.get("ROSCLAW_DAEMON_SOCKET") or str(
+            rosclaw_home / "run" / "rosclawd.sock"
+        )
+        if Path(daemon_socket).exists():
+            from rosclaw.daemon.client import DaemonClient
+
+            self._daemon_client = DaemonClient(socket_path=daemon_socket)
         self._registry = WorkerRegistry(self._store.connection)
         self._registry.register_builtins(actor_id=self.actor_id)
-        self._body_source = SimBodySource(config.sim_body_id)
+        self._simulation_body = self._body_id.startswith("sim/")
+        if self._simulation_body:
+            self._body_source = SimBodySource(self._body_id)
+            self_source = SimSelfSource()
+        else:
+            self._body_source = ResolverBodySource(
+                workspace=rosclaw_home,
+                body_id=self._body_id,
+            )
+            self_source = DaemonSelfSource(self._daemon_client)
+        body = self._body_source.get_body(self._body_id)
         self._tools = BuiltinToolRegistry(
-            body_id=config.sim_body_id,
-            body_summary=self._body_source.get_body(config.sim_body_id).summary,  # type: ignore[union-attr]
+            body_id=self._body_id,
+            body_summary=body.summary if body else "configured body is unavailable",
         )
-        tool_names = [SIM_STATE_TOOL, SIM_BODY_TOOL]
+        tool_names = [SIM_BODY_TOOL]
+        if self._simulation_body:
+            tool_names.insert(0, SIM_STATE_TOOL)
         consent_source = ConfigConsentSource()
         from rosclaw.operator import OperatorBroker
 
@@ -131,12 +155,16 @@ class AgentService:
             SourceBundle(
                 constitution_text=load_prompt("native_agent_v1.md").text,
                 body=self._body_source,
-                self_source=SimSelfSource(),
+                self_source=self_source,
                 capabilities=StaticCapabilitySource(tool_names),
                 memory=EmptyMemorySource(),
                 organization=RegistryOrgSource(self._registry),
                 consent=BrokerConsentSource(consent_source, self._store.connection),
-                runtime_status_summary="agentd local; rosclawd not required in SIMULATION",
+                runtime_status_summary=(
+                    "agentd local; simulated body; rosclawd optional"
+                    if self._simulation_body
+                    else "agentd bound to a real body through rosclawd; physical evidence is daemon-owned"
+                ),
             ),
             max_input_tokens=config.max_input_tokens,
             dynamic_tool_limit=config.dynamic_tool_limit,
@@ -155,29 +183,25 @@ class AgentService:
             adapters={"native_inproc": NativeWorkerAdapter(self._gateway)},
             actor_id=self.actor_id,
         )
-        body = self._body_source.get_body(config.sim_body_id)
         self._handlers = ServiceIntentHandlers(
             registry=self._registry,
             manager=self._worker_manager,
             actor_id=self.actor_id,
             broker=self._broker,
+            body_id=self._body_id,
             body_hash=body.effective_body_hash if body else "",
             mode=config.default_mode,
         )
         # Daemon action channel (K3): only if a rosclawd socket is actually
         # reachable — otherwise request_action degrades honestly.
         self._action_channel = None
-        daemon_socket = os.environ.get("ROSCLAW_DAEMON_SOCKET") or str(
-            rosclaw_home / "run" / "rosclawd.sock"
-        )
-        if Path(daemon_socket).exists():
+        if self._daemon_client is not None:
             from rosclaw.agentd.action_channel import DaemonActionChannel
-            from rosclaw.daemon.client import DaemonClient
 
             self._action_channel = DaemonActionChannel(
-                DaemonClient(socket_path=daemon_socket),
+                self._daemon_client,
                 actor_id=self.actor_id,
-                body_id=config.sim_body_id,
+                body_id=self._body_id,
                 body_hash=body.effective_body_hash if body else "",
             )
             self._handlers._action_channel = self._action_channel
@@ -204,7 +228,7 @@ class AgentService:
 
     @property
     def actor_id(self) -> str:
-        safe = self._config.sim_body_id.replace("/", "_")
+        safe = self._body_id.replace("/", "_")
         return f"agent:rosclaw-native:{safe}"
 
     def _loop_for(self, mission_id: str) -> AgentLoop:
@@ -233,20 +257,45 @@ class AgentService:
         owner_principal: str = "user:local:1000",
     ) -> MissionSessionV1:
         requested_mode = ExecutionMode(mode or self._config.default_mode)
-        if requested_mode is not ExecutionMode.SIMULATION:
-            # --mode REAL is a *request*; enumerate the missing prerequisites
-            # instead of silently downgrading or upgrading (总纲 §8.2).
-            gaps = [
-                "no MissionGrant issued (Operator Broker not enabled)",
-                "no real body linked and verified (RobotPack + calibration)",
-                "rosclawd REAL executor not configured",
-            ]
+        body = self._body_source.get_body(self._body_id)
+        if body is None:
             raise ValidationError(
-                f"mode {requested_mode.value} requested but prerequisites are missing: "
-                + "; ".join(gaps)
+                f"body {self._body_id!r} is not linked, hash-valid, and available"
             )
-        body = self._body_source.get_body(self._config.sim_body_id)
-        assert body is not None
+        if requested_mode is not ExecutionMode.SIMULATION:
+            gaps: list[str] = []
+            if requested_mode is ExecutionMode.REAL and self._config.physical_action_count <= 0:
+                gaps.append("agent.budgets.physical_action_count must be greater than zero")
+            if self._simulation_body:
+                gaps.append("configured body is simulated, not a live BodyResolver body")
+            if self._daemon_client is None:
+                gaps.append("rosclawd socket is unavailable")
+            else:
+                try:
+                    status = self._daemon_client.get_runtime_status()
+                except Exception as exc:  # noqa: BLE001 - report an honest prerequisite gap
+                    gaps.append(f"rosclawd status unavailable: {exc}")
+                else:
+                    if not status.get("running"):
+                        gaps.append("rosclawd is not running")
+                    if status.get("robot_id") != self._body_id:
+                        gaps.append(
+                            f"rosclawd robot_id {status.get('robot_id')!r} != {self._body_id!r}"
+                        )
+                    pack = status.get("robot_pack") or {}
+                    if not pack.get("loaded") or pack.get("signature_status") != "valid":
+                        gaps.append("verified Robot Pack is not loaded")
+                    suffix = f":{requested_mode.value}"
+                    if not any(
+                        str(item).endswith(suffix)
+                        for item in status.get("registered_executors") or []
+                    ):
+                        gaps.append(f"no {requested_mode.value} executor is registered")
+            if gaps:
+                raise ValidationError(
+                    f"mode {requested_mode.value} requested but prerequisites are missing: "
+                    + "; ".join(gaps)
+                )
         return self._store.create_mission(
             owner_principal=owner_principal,
             goal=Goal(text=goal_text, language=self._config.language),
@@ -254,6 +303,7 @@ class AgentService:
                 body_id=body.body_id, effective_body_hash=body.effective_body_hash
             ),
             mode=requested_mode,
+            budgets=Budgets(physical_action_count=self._config.physical_action_count),
             actor_id=self.actor_id,
         )
 
@@ -268,6 +318,9 @@ class AgentService:
         if mission is None:
             raise ValidationError(f"unknown mission {mission_id!r}")
         async with self._lock:
+            if self._handlers is not None:
+                self._handlers._mode = mission.mode.value
+                self._handlers._principal = mission.owner_principal
             loop = self._loop_for(mission_id)
             return await loop.run_user_turn(
                 mission, text, now=datetime.now(UTC), on_text_delta=on_text_delta
@@ -335,6 +388,8 @@ class AgentService:
         return {
             "agent_enabled": self._config.enabled,
             "default_mode": self._config.default_mode,
+            "body_id": self._body_id,
+            "daemon_connected": self._daemon_client is not None,
             "profile": profile.name,
             "provider": profile.provider,
             "model": profile.model,

--- a/tests/agentd/test_k3_daemon_loop.py
+++ b/tests/agentd/test_k3_daemon_loop.py
@@ -21,7 +21,7 @@ from rosclaw.agentd.service import AgentService
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
 from rosclaw.core.runtime import Runtime, RuntimeConfig
 from rosclaw.daemon.client import DaemonClient
-from rosclaw.daemon.permits import PermitAuthority
+from rosclaw.daemon.ledger import DaemonLedger
 from rosclaw.daemon.server import RosclawDaemon
 from rosclaw.daemon.service import DaemonControlPlane
 from rosclaw.kernel.contracts import (
@@ -65,7 +65,15 @@ def daemon(tmp_path: Path):
     runtime.action_gateway.register_executor(
         SIM_CAPABILITY, ExecutionMode.SIMULATION, _sim_executor
     )
-    service = DaemonControlPlane(runtime=runtime, permits=PermitAuthority())
+    runtime.action_gateway.register_executor(SIM_CAPABILITY, ExecutionMode.SHADOW, _sim_executor)
+    ledger = DaemonLedger(
+        tmp_path / "state" / "ledger.sqlite3",
+        key_path=tmp_path / "state" / "ledger.key",
+    )
+    service = DaemonControlPlane(
+        runtime=runtime,
+        ledger=ledger,
+    )
     socket_path = tmp_path / "run" / "rosclawd.sock"
     daemon = RosclawDaemon(service=service, socket_path=socket_path)
     daemon.start()
@@ -75,6 +83,7 @@ def daemon(tmp_path: Path):
         yield client, socket_path
     finally:
         daemon.stop()
+        ledger.close()
 
 
 def _approval_decision(request) -> ModelTurnResultV1:
@@ -148,6 +157,26 @@ def _action_decision(request) -> ModelTurnResultV1:
 
 
 class TestK3SimActionLoop:
+    async def test_shadow_action_returns_verified_nonreal_receipt(self, daemon) -> None:
+        client, _socket_path = daemon
+        channel = DaemonActionChannel(
+            client,
+            actor_id="agent:rosclaw-native:sim_ur5e",
+            body_id="sim-ur5e",
+            body_hash="sha256:sim-body",
+        )
+
+        outcome = await channel.request_nonreal_action(
+            capability_id=SIM_CAPABILITY,
+            arguments={"joints": [0.0] * 6},
+            grant_id="grant_shadow",
+            execution_mode="SHADOW",
+        )
+
+        assert outcome.verified is True
+        assert outcome.trust_level == "VERIFIED"
+        assert outcome.receipt["receipt"]["evidence_domain"] == "SHADOW"
+
     async def test_full_loop_with_receipt(self, daemon, tmp_path: Path) -> None:
         client, socket_path = daemon
         config = load_agent_config(tmp_path / "config.yaml")
@@ -217,6 +246,36 @@ class TestReceiptVerification:
                 {"trust_level": "SYNTHETIC", "action": {"action_id": "act_1"}},
                 None,  # type: ignore[arg-type]
             )
+
+
+class TestRealProposalChannel:
+    async def test_real_request_creates_pending_proposal_without_dispatch(self, daemon) -> None:
+        client, _socket_path = daemon
+        channel = DaemonActionChannel(
+            client,
+            actor_id="agent:rosclaw-native:limo",
+            body_id="limo",
+            body_hash="sha256:body",
+        )
+        proposal = await channel.request_real_proposal(
+            capability_id="limo.play_tone",
+            arguments={"frequency_hz": 660, "duration_sec": 0.6},
+            grant_id="grant_public_only",
+            grant_public_hash="grantpub_hash",
+            principal_id="user:local:1000",
+            risk_tier="MEDIUM",
+            display={"title": "Play bounded tone", "risk_tier": "MEDIUM"},
+        )
+        status = client.get_runtime_status()
+        public = client.get_operator_proposal(proposal.request_id)
+
+        assert proposal.state == "CREATED"
+        assert public["proposal"]["state"] == "CREATED"
+        assert "challenge_nonce" not in public["proposal"]
+        assert "permit_id" not in str(public).lower()
+        assert public["permit_exposed"] is False
+        assert status["operator_proposals"]["created"] == 1
+        assert status["queue"]["FINISHED"] == 0
 
     def test_mismatched_receipt_action_rejected(self, tmp_path: Path) -> None:
         channel = DaemonActionChannel(

--- a/tests/agentd/test_service.py
+++ b/tests/agentd/test_service.py
@@ -16,6 +16,7 @@ import yaml
 
 from rosclaw.agentd.cli import main as agentd_main
 from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.context.sources import BodyFacts
 from rosclaw.agentd.models.gateway import MockModelGateway
 from rosclaw.agentd.models.profiles import mock_profile
 from rosclaw.agentd.onboarding import configure_model, doctor
@@ -74,6 +75,51 @@ class TestService:
         probe = await service.probe()
         assert probe.reachable and probe.tool_call_ok
 
+    async def test_real_mission_binds_verified_live_body_and_daemon(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class LiveBodySource:
+            def __init__(self, **_kwargs) -> None:
+                pass
+
+            def get_body(self, body_id: str) -> BodyFacts | None:
+                if body_id != "limo":
+                    return None
+                return BodyFacts(
+                    body_id="limo",
+                    effective_body_hash="body_live_hash",
+                    summary="verified live LIMO",
+                    calibrated=True,
+                )
+
+        class LiveDaemon:
+            def get_runtime_status(self) -> dict:
+                return {
+                    "running": True,
+                    "runtime_state": "RUNNING",
+                    "robot_id": "limo",
+                    "robot_pack": {"loaded": True, "signature_status": "valid"},
+                    "registered_executors": ["limo.play_tone:REAL"],
+                }
+
+        monkeypatch.setattr("rosclaw.agentd.service.ResolverBodySource", LiveBodySource)
+        config = load_agent_config(tmp_path / "missing.yaml")
+        config.body_id = "limo"
+        config.default_mode = "REAL"
+        config.physical_action_count = 3
+        gateway = MockModelGateway(mock_profile(), [_answer_turn])
+        live = AgentService(config, tmp_path, gateway=gateway)
+        live._daemon_client = LiveDaemon()
+
+        try:
+            mission = live.create_mission("播放巡检提示音", mode="REAL")
+
+            assert mission.body_binding.body_id == "limo"
+            assert mission.body_binding.effective_body_hash == "body_live_hash"
+            assert mission.mode.value == "REAL"
+        finally:
+            await live.close()
+
 
 class TestHttpApi:
     @pytest.fixture
@@ -97,7 +143,7 @@ class TestHttpApi:
     def test_real_mode_422_with_gaps(self, client) -> None:
         r = client.post("/missions", json={"goal": "搬箱子", "mode": "REAL"})
         assert r.status_code == 422
-        assert "MissionGrant" in r.json()["detail"]
+        assert "configured body is simulated" in r.json()["detail"]
 
     def test_console_served(self, client) -> None:
         r = client.get("/console")
@@ -106,6 +152,21 @@ class TestHttpApi:
 
 
 class TestOnboarding:
+    def test_loads_real_body_id_without_overwriting_legacy_sim_default(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "config.yaml"
+        path.write_text(
+            "agent:\n  body_id: limo\n  default_mode: REAL\n"
+            "  budgets:\n    physical_action_count: 3\n",
+            encoding="utf-8",
+        )
+        config = load_agent_config(path)
+
+        assert config.active_body_id == "limo"
+        assert config.sim_body_id == "sim/ur5e"
+        assert config.physical_action_count == 3
+
     def test_configure_writes_key_ref_only(self, tmp_path: Path) -> None:
         summary = configure_model(tmp_path, "kimi-code")
         assert summary["configured"]


### PR DESCRIPTION
## What changed

- bind AgentD missions to a configured real `body_id` through `BodyResolver`
- compile fresh daemon-owned Self facts without inventing pose or sensor evidence
- validate live Body, Robot Pack, daemon, executor, and explicit physical-action budget before REAL mission creation
- route REAL AgentD actions into the daemon Operator Proposal plane without exposing or self-issuing permits
- add direct SHADOW receipt handling while keeping SIMULATION compatibility
- document LIMO/live-body configuration and the dual-layer consent flow

## Why

The native Agent refactor contained the production body and daemon proposal primitives, but AgentService still hard-coded a simulated body and REQUEST_ACTION only dispatched SIMULATION. That left LIMO unable to act as ROSClaw's real body and left ADR-0007 unwired.

## Validation

- `pytest -q tests/agentd tests/contracts tests/architecture tests/operator tests/interaction tests/daemon/test_operator_proposals.py` — 225 passed, 1 skipped, 8 deselected
- focused K3 SIM/SHADOW/REAL proposal tests — 6 passed
- Ruff and compileall passed
- live LIMO SHADOW tone and initial-pose contracts completed with verified non-hardware receipts
