### PR TITLE
ADR-0007: dual-layer consent wiring (agentd grants ↔ daemon proposals)

### DIFF
--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -363,7 +363,7 @@ async def _chat_repl(service: AgentService, args: argparse.Namespace) -> int:
                 approve = text.startswith("/approve ")
                 request_id = text.split(maxsplit=1)[1].strip()
                 try:
-                    grant = service.decide_approval(
+                    grant = await service.decide_approval(
                         request_id, principal="user:local:1000", approve=approve
                     )
                 except Exception as exc:  # noqa: BLE001

--- a/src/rosclaw/agentd/consent_channel.py
+++ b/src/rosclaw/agentd/consent_channel.py
@@ -1,0 +1,174 @@
+"""Daemon consent channel (ADR-0007, K5 完整版).
+
+agentd 的认知层授权（ApprovalRequestV2/MissionGrant）与 daemon 的物理层
+consent plane（上游 #185 operator proposals）的桥：
+
+- ``create_proposal``：Agent 侧提交 proposal（**永不**附带 nonce/permit）；
+- ``decide``：operator 侧裁决（只有 daemon 服务 UID 能列出 nonce 与裁决；
+  same-UID 开发环境验证协议，生产必须 UID 分离）；
+- ACCEPT 后 daemon 内部签发 permit、以原 Agent UID 提交动作并监督到
+  终态 Receipt——agentd 只读回 public 状态与 receipt provenance。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from rosclaw.contracts.common import ValidationError, new_id
+from rosclaw.daemon.client import DaemonClient, DaemonClientError
+from rosclaw.kernel.contracts import (
+    ActionEnvelope,
+    EvidenceLevel,
+    ExecutionMode,
+    VerificationPolicy,
+)
+
+
+class ConsentChannelError(ValidationError):
+    """Proposal creation/decision/receipt failed (fail closed)."""
+
+
+class DaemonConsentChannel:
+    def __init__(
+        self,
+        client: DaemonClient,
+        *,
+        actor_id: str,
+        body_id: str,
+        body_hash: str,
+    ) -> None:
+        self._client = client
+        self._actor_id = actor_id
+        self._body_id = body_id
+        self._body_hash = body_hash
+        self._session_id: str | None = None
+
+    async def create_proposal(
+        self,
+        *,
+        capability_id: str,
+        arguments: dict[str, Any],
+        display: dict[str, Any],
+        execution_mode: str = "SIMULATION",
+        risk_class: str = "low",
+        ttl_sec: float = 60.0,
+    ) -> dict[str, Any]:
+        """Agent-side proposal. Returns the public view (no nonce, no permit)."""
+        envelope = ActionEnvelope(
+            action_id=new_id("act"),
+            actor_id=self._actor_id,
+            agent_framework="rosclaw-native",
+            # 与上游一致：proposal 不引用预建 session（daemon 会因会话
+            # 绑定语义拒绝 SESSION_ID_CONFLICT）；动作会话由 daemon 在
+            # 接受后自行建立与监督。
+            session_id=new_id("sess"),
+            body_id=self._body_id,
+            body_snapshot_hash=self._body_hash,
+            capability_id=capability_id,
+            arguments=arguments,
+            execution_mode=ExecutionMode(execution_mode),
+            risk_class=risk_class,
+            deadline_at=datetime.now(UTC) + timedelta(seconds=ttl_sec),
+            verification_policy=VerificationPolicy(
+                required_evidence=EvidenceLevel.DRIVER_CONFIRMED,
+                timeout_sec=ttl_sec,
+            ),
+        )
+        try:
+            created = await asyncio.to_thread(
+                self._client.create_operator_proposal,
+                envelope,
+                display=display,
+                ttl_sec=ttl_sec,
+            )
+        except DaemonClientError as exc:
+            raise ConsentChannelError(
+                f"operator.proposal.create failed: {exc.code}: {exc}"
+            ) from exc
+        proposal = created.get("proposal") or {}
+        if "challenge_nonce" in proposal:
+            raise ConsentChannelError(
+                "daemon leaked decision challenge to the agent view — refusing"
+            )
+        return proposal
+
+    async def decide(
+        self,
+        request_id: str,
+        *,
+        principal_id: str,
+        accept: bool,
+        channel: str = "rosclaw_console",
+        reason: str = "",
+        supervise_timeout_sec: float = 60.0,
+    ) -> dict[str, Any]:
+        """Operator-side decision. On ACCEPT the daemon issues the permit
+        internally, submits as the originating UID and supervises to a
+        terminal receipt."""
+        try:
+            pending = await asyncio.to_thread(self._client.list_pending_operator_proposals)
+        except DaemonClientError as exc:
+            raise ConsentChannelError(
+                f"operator pending list failed (operator UID required): {exc.code}: {exc}"
+            ) from exc
+        trusted = next(
+            (p for p in pending.get("proposals", []) if p.get("request_id") == request_id),
+            None,
+        )
+        if trusted is None:
+            raise ConsentChannelError(
+                f"no pending proposal {request_id!r} (decided, expired, or "
+                "invalidated by daemon restart)"
+            )
+        try:
+            decided = await asyncio.to_thread(
+                self._client.decide_operator_proposal,
+                request_id,
+                decision="ACCEPT" if accept else "DECLINE",
+                principal_id=principal_id,
+                challenge_nonce=trusted["challenge_nonce"],
+                action_intent_hash=trusted["action_intent_hash"],
+                channel=channel,
+                reason=reason or ("reviewed bounded action" if accept else "declined by operator"),
+            )
+        except DaemonClientError as exc:
+            raise ConsentChannelError(
+                f"operator.proposal.decide failed: {exc.code}: {exc}"
+            ) from exc
+        if not accept:
+            return decided
+        if decided.get("permit_exposed"):
+            raise ConsentChannelError(
+                "daemon exposed permit material in the decision result — refusing"
+            )
+        # Supervise to terminal (the daemon renews the lease; SIM finishes fast).
+        action_id = trusted.get("action_id")
+        if action_id:
+            try:
+                await asyncio.to_thread(
+                    self._client.wait_for_action,
+                    action_id,
+                    timeout_sec=supervise_timeout_sec,
+                )
+            except DaemonClientError as exc:
+                raise ConsentChannelError(
+                    f"accepted action did not terminate: {exc.code}: {exc}"
+                ) from exc
+        return decided
+
+    async def proposal(self, request_id: str) -> dict[str, Any]:
+        try:
+            result = await asyncio.to_thread(self._client.get_operator_proposal, request_id)
+        except DaemonClientError as exc:
+            raise ConsentChannelError(
+                f"operator.proposal.status failed: {exc.code}: {exc}"
+            ) from exc
+        return result.get("proposal") or {}
+
+    async def action_receipt(self, action_id: str) -> dict[str, Any]:
+        try:
+            return await asyncio.to_thread(self._client.get_execution_receipt, action_id)
+        except DaemonClientError as exc:
+            raise ConsentChannelError(f"action.receipt failed: {exc.code}: {exc}") from exc

--- a/src/rosclaw/agentd/handlers.py
+++ b/src/rosclaw/agentd/handlers.py
@@ -132,6 +132,46 @@ class ServiceIntentHandlers:
             expires_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat(),
         )
         self._broker.create_request(request)
+        # ADR-0007：daemon consent plane 只接受显式 REAL 动作的 proposal
+        # （PROPOSAL_REAL_ACTION_REQUIRED）。SIMULATION 走认知层 grant +
+        # action_channel；REAL 才需要 daemon proposal/permit。
+        consent = getattr(self, "_consent_channel", None)
+        proposal_note = ""
+        if consent is not None and self._mode == "REAL":
+            from rosclaw.agentd.consent_channel import ConsentChannelError
+
+            try:
+                proposal = await consent.create_proposal(
+                    capability_id=str(payload.get("capability_id", "sim.hold_position")),
+                    arguments=payload.get("arguments") or {},
+                    display=display.model_dump(mode="json"),
+                    execution_mode=self._mode,
+                    ttl_sec=600.0,
+                )
+                proposal_id = proposal.get("request_id")
+                action_id = proposal.get("action_id")
+                # Persist the linkage on the stored approval request.
+                self._broker._conn.execute(
+                    "UPDATE operator_requests SET request_json = ? WHERE request_id = ?",
+                    (
+                        request.model_copy(
+                            update={
+                                "daemon_proposal_id": proposal_id,
+                                "daemon_action_id": action_id,
+                            }
+                        ).model_dump_json(),
+                        request.request_id,
+                    ),
+                )
+                proposal_note = (
+                    f"\n物理层 daemon proposal {proposal_id} 已创建（nonce/permit "
+                    "仅在 operator 侧；批准即由 rosclawd 独立签发 permit 并提交）。"
+                )
+            except ConsentChannelError as exc:
+                proposal_note = (
+                    f"\n注意：daemon consent plane 不可用（{exc}），"
+                    "物理层未创建 proposal；动作将不会被派发。"
+                )
         return (
             f"已创建授权请求 {request.request_id}（EXACT_ACTION，10 分钟有效）：\n"
             f"【{display.title}】{display.summary}\n"
@@ -139,6 +179,7 @@ class ServiceIntentHandlers:
             f"失败处理：{display.failure_handling or '—'}\n"
             f"请确认：chat 中输入 /approve {request.request_id} 或 /deny {request.request_id}，"
             "或在 Console 的 Approvals 页操作。在你确认前我不会推进该动作。"
+            f"{proposal_note}"
         )
 
     # ------------------------------------------------------------------
@@ -168,6 +209,60 @@ class ServiceIntentHandlers:
             )
         except GrantDeniedError as exc:
             return f"授权校验失败（{exc.reason_code}）：{exc}。动作未提交。"
+        consent = getattr(self, "_consent_channel", None)
+        # ADR-0007 完整路径只在"该授权确实关联了 daemon proposal"时生效
+        # （REAL 模式）；否则回落到 SIM action_channel 或诚实无通道。
+        proposal_id = None
+        action_id = None
+        if consent is not None:
+            grant_row = self._broker._conn.execute(
+                "SELECT request_id FROM mission_grants WHERE grant_id = ?",
+                (grant.grant_id,),
+            ).fetchone()
+            approval_req = self._broker.get_request(grant_row["request_id"]) if grant_row else None
+            if approval_req is not None:
+                extras = approval_req.model_dump(mode="json")
+                proposal_id = getattr(approval_req, "daemon_proposal_id", None) or extras.get(
+                    "daemon_proposal_id"
+                )
+                action_id = getattr(approval_req, "daemon_action_id", None) or extras.get(
+                    "daemon_action_id"
+                )
+        if consent is not None and proposal_id:
+            from rosclaw.agentd.consent_channel import ConsentChannelError
+
+            try:
+                proposal = await consent.proposal(proposal_id)
+            except ConsentChannelError as exc:
+                return f"读取 daemon proposal 失败（fail closed）：{exc}"
+            state = proposal.get("state")
+            if state != "TERMINAL":
+                return (
+                    f"daemon proposal 尚未到终态（state={state}）。"
+                    "若批准时 operator 已裁决，receipt 应在数秒内可用；否则该 proposal "
+                    "可能已过期/失效。不报告为完成。"
+                )
+            if not action_id:
+                return "proposal 已终态但无 action_id，无法回读 receipt（fail closed）。"
+            try:
+                receipt = await consent.action_receipt(action_id)
+            except ConsentChannelError as exc:
+                return f"回执读取失败（fail closed）：{exc}"
+            inner = receipt.get("receipt") if isinstance(receipt.get("receipt"), dict) else receipt
+            trust = inner.get("trust_level", "UNKNOWN")
+            final_state = inner.get("final_state", "UNKNOWN")
+            provenance = (inner.get("authorization_decision") or {}).get("provenance") or {}
+            if trust == "SYNTHETIC":
+                return "回执为 FIXTURE/SYNTHETIC 证据——拒绝当作完成（fail closed）。"
+            if inner.get("action_id") not in (None, action_id):
+                return "回执 action 与请求不匹配——不报告为我们的动作（fail closed）。"
+            return (
+                f"动作已由 rosclawd consent plane 完成：state={final_state}, "
+                f"trust_level={trust}（SIMULATED 证据，不可用于 REAL）。"
+                f"授权来源：proposal {proposal_id[:20]}…, "
+                f"operator={provenance.get('operator_principal')}, "
+                f"channel={provenance.get('decision_channel')}。grant 已消费。"
+            )
         channel = getattr(self, "_action_channel", None)
         if channel is None:
             return (

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -164,14 +164,17 @@ class AgentService:
             body_hash=body.effective_body_hash if body else "",
             mode=config.default_mode,
         )
-        # Daemon action channel (K3): only if a rosclawd socket is actually
-        # reachable — otherwise request_action degrades honestly.
+        # Daemon action channel (K3) + consent channel (ADR-0007): only if a
+        # rosclawd socket is actually reachable — otherwise both degrade
+        # honestly.
         self._action_channel = None
+        self._consent_channel = None
         daemon_socket = os.environ.get("ROSCLAW_DAEMON_SOCKET") or str(
             rosclaw_home / "run" / "rosclawd.sock"
         )
         if Path(daemon_socket).exists():
             from rosclaw.agentd.action_channel import DaemonActionChannel
+            from rosclaw.agentd.consent_channel import DaemonConsentChannel
             from rosclaw.daemon.client import DaemonClient
 
             self._action_channel = DaemonActionChannel(
@@ -181,6 +184,13 @@ class AgentService:
                 body_hash=body.effective_body_hash if body else "",
             )
             self._handlers._action_channel = self._action_channel
+            self._consent_channel = DaemonConsentChannel(
+                DaemonClient(socket_path=daemon_socket),
+                actor_id=self.actor_id,
+                body_id=config.sim_body_id,
+                body_hash=body.effective_body_hash if body else "",
+            )
+            self._handlers._consent_channel = self._consent_channel
         # Team Fabric: enabled via config `team.enabled`. Local coordinator
         # in P0 (local_sim); ROS 2/Zenoh transports are later PRs.
         team_cfg = (config.raw.get("team") or {}) if config.raw else {}
@@ -290,8 +300,35 @@ class AgentService:
     def pending_approvals(self, mission_id: str | None = None):
         return self._broker.pending_requests(mission_id)
 
-    def decide_approval(self, request_id: str, *, principal: str, approve: bool):
-        return self._broker.decide(request_id, principal=principal, approve=approve)
+    async def decide_approval(self, request_id: str, *, principal: str, approve: bool):
+        """认知层裁决 +（有 consent channel 时）daemon proposal 物理层裁决。
+
+        ACCEPT 时 daemon 独立签发 permit、提交动作并监督到终态 receipt——
+        agentd 只是发起方与见证方，不持有 permit。
+        """
+        grant = self._broker.decide(request_id, principal=principal, approve=approve)
+        if self._consent_channel is not None:
+            request = self._broker.get_request(request_id)
+            proposal_id = getattr(request, "daemon_proposal_id", None) or (
+                request.model_dump(mode="json").get("daemon_proposal_id") if request else None
+            )
+            if proposal_id:
+                from rosclaw.agentd.consent_channel import ConsentChannelError
+
+                try:
+                    await self._consent_channel.decide(
+                        proposal_id,
+                        principal_id=principal,
+                        accept=approve,
+                        channel="rosclaw_console",
+                        reason="operator approved via rosclaw console",
+                    )
+                except ConsentChannelError as exc:
+                    # 认知层已裁决但物理层失败：如实报告，不伪造派发。
+                    raise ValidationError(
+                        f"agentd 授权已记录，但 daemon proposal 裁决失败（未派发）：{exc}"
+                    ) from exc
+        return grant
 
     def list_grants(self):
         rows = self._store.connection.execute(
@@ -491,7 +528,7 @@ def create_app(service: AgentService):
     @app.post("/approvals/{request_id}/decide")
     async def approvals_decide(request_id: str, payload: DecisionCreate) -> dict:
         try:
-            grant = service.decide_approval(
+            grant = await service.decide_approval(
                 request_id, principal=payload.principal, approve=payload.approve
             )
         except Exception as exc:  # noqa: BLE001

--- a/tests/agentd/test_consent_channel.py
+++ b/tests/agentd/test_consent_channel.py
@@ -1,0 +1,214 @@
+"""Daemon consent channel tests (ADR-0007, REAL 模式授权全链）。
+
+- proposal public view: no challenge_nonce / no permit material
+- ACCEPT → daemon 独立签 permit + 派发 + 终态 receipt + provenance
+- DECLINE → no dispatch; wrong nonce → fail closed
+- daemon restart invalidates pending proposals
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.consent_channel import (
+    ConsentChannelError,
+    DaemonConsentChannel,
+)
+from rosclaw.core.runtime import Runtime, RuntimeConfig
+from rosclaw.daemon.client import DaemonClient, DaemonRequestError
+from rosclaw.daemon.ledger import DaemonLedger
+from rosclaw.daemon.server import RosclawDaemon
+from rosclaw.daemon.service import DaemonControlPlane
+from rosclaw.kernel.contracts import (
+    ActionExecutionResult,
+    ActionState,
+    EvidenceLevel,
+    ExecutionMode,
+)
+
+REAL_CAPABILITY = "rh56.finger.move"
+
+
+def _real_executor(action) -> ActionExecutionResult:
+    return ActionExecutionResult(
+        final_state=ActionState.COMPLETED,
+        evidence_level=EvidenceLevel.DRIVER_CONFIRMED,
+        driver_ack={"ack": True},
+        verification_result={"verified": True},
+    )
+
+
+def _start_daemon(tmp_path: Path):
+    runtime = Runtime(
+        RuntimeConfig(
+            robot_id="rh56-test",
+            enable_firewall=False,
+            enable_memory=False,
+            enable_practice=False,
+            enable_skill_manager=False,
+            enable_knowledge=False,
+            enable_how=False,
+            enable_auto=False,
+            enable_provider=False,
+            enable_sense=False,
+            enable_event_persistence=False,
+            enable_tracing=False,
+        )
+    )
+    runtime.action_gateway.register_executor(REAL_CAPABILITY, ExecutionMode.REAL, _real_executor)
+    ledger_ctx = DaemonLedger(
+        tmp_path / "state" / "ledger.sqlite3", key_path=tmp_path / "state" / "ledger.key"
+    )
+    ledger = ledger_ctx.__enter__()
+    service = DaemonControlPlane(runtime=runtime, ledger=ledger)
+    socket_path = tmp_path / "run" / "rosclawd.sock"
+    daemon = RosclawDaemon(service=service, socket_path=socket_path)
+    daemon.start()
+    return daemon, socket_path, ledger_ctx
+
+
+@pytest.fixture
+def daemon(tmp_path: Path):
+    daemon, socket_path, ledger_ctx = _start_daemon(tmp_path)
+    client = DaemonClient(socket_path=socket_path, timeout_sec=5.0)
+    try:
+        yield client, socket_path
+    finally:
+        daemon.stop()
+        ledger_ctx.__exit__(None, None, None)
+
+
+def _channel(client: DaemonClient) -> DaemonConsentChannel:
+    return DaemonConsentChannel(client, actor_id="agent:test", body_id="rh56-test", body_hash="h")
+
+
+class TestRealConsentFlow:
+    async def test_accept_full_chain_with_provenance(self, daemon) -> None:
+        client, _ = daemon
+        channel = _channel(client)
+        proposal = await channel.create_proposal(
+            capability_id=REAL_CAPABILITY,
+            arguments={"finger": "index", "delta_raw": 20},
+            display={"title": "Move one finger", "risk_tier": "HIGH"},
+            execution_mode="REAL",
+            risk_class="high",
+            ttl_sec=60.0,
+        )
+        # Agent 视角：无 challenge、无 permit（K5 核心安全语义）。
+        assert "challenge_nonce" not in proposal
+        assert "permit" not in str(proposal).lower()
+        decided = await channel.decide(
+            proposal["request_id"],
+            principal_id="user:local:1000",
+            accept=True,
+            supervise_timeout_sec=15.0,
+        )
+        assert decided.get("command_dispatched") is True
+        assert decided.get("permit_exposed") is False
+        terminal = await channel.proposal(proposal["request_id"])
+        assert terminal.get("state") == "TERMINAL"
+        receipt = await channel.action_receipt(proposal["action_id"])
+        inner = receipt.get("receipt", receipt)
+        assert inner.get("final_state") == "COMPLETED"
+        provenance = (inner.get("authorization_decision") or {}).get("provenance") or {}
+        assert provenance.get("proposal_request_id") == proposal["request_id"]
+        assert provenance.get("operator_principal") == "user:local:1000"
+
+    async def test_decline_dispatches_nothing(self, daemon) -> None:
+        client, _ = daemon
+        channel = _channel(client)
+        proposal = await channel.create_proposal(
+            capability_id=REAL_CAPABILITY,
+            arguments={"finger": "index", "delta_raw": 20},
+            display={"title": "t", "risk_tier": "HIGH"},
+            execution_mode="REAL",
+            risk_class="high",
+            ttl_sec=60.0,
+        )
+        await channel.decide(proposal["request_id"], principal_id="user:local:1000", accept=False)
+        terminal = await channel.proposal(proposal["request_id"])
+        assert terminal.get("state") == "DECLINED"
+
+    async def test_wrong_nonce_fails_closed(self, daemon) -> None:
+        client, _ = daemon
+        channel = _channel(client)
+        proposal = await channel.create_proposal(
+            capability_id=REAL_CAPABILITY,
+            arguments={"finger": "index", "delta_raw": 20},
+            display={"title": "t", "risk_tier": "HIGH"},
+            execution_mode="REAL",
+            risk_class="high",
+            ttl_sec=60.0,
+        )
+        pending = client.list_pending_operator_proposals()["proposals"]
+        with pytest.raises(DaemonRequestError):
+            client.decide_operator_proposal(
+                proposal["request_id"],
+                decision="ACCEPT",
+                principal_id="user:local:1000",
+                challenge_nonce="forged-nonce",
+                action_intent_hash=pending[0]["action_intent_hash"],
+                channel="test",
+                reason="forgery attempt",
+            )
+        # 未被裁决，仍是 pending（被拒绝不会改变状态）。
+        still = await channel.proposal(proposal["request_id"])
+        assert still.get("state") in ("CREATED", "PRESENTED")
+
+    async def test_pending_after_decide_is_gone(self, daemon) -> None:
+        client, _ = daemon
+        channel = _channel(client)
+        proposal = await channel.create_proposal(
+            capability_id=REAL_CAPABILITY,
+            arguments={"finger": "index", "delta_raw": 20},
+            display={"title": "t", "risk_tier": "HIGH"},
+            execution_mode="REAL",
+            risk_class="high",
+            ttl_sec=60.0,
+        )
+        await channel.decide(proposal["request_id"], principal_id="user:local:1000", accept=True)
+        with pytest.raises(ConsentChannelError, match="no pending proposal"):
+            await channel.decide(
+                proposal["request_id"], principal_id="user:local:1000", accept=True
+            )
+
+
+class TestRestartInvalidation:
+    async def test_pending_invalidated_by_restart(self, tmp_path: Path) -> None:
+        daemon, socket_path, ledger_ctx = _start_daemon(tmp_path)
+        client = DaemonClient(socket_path=socket_path, timeout_sec=5.0)
+        channel = _channel(client)
+        proposal = await channel.create_proposal(
+            capability_id=REAL_CAPABILITY,
+            arguments={"finger": "index", "delta_raw": 20},
+            display={"title": "t", "risk_tier": "HIGH"},
+            execution_mode="REAL",
+            risk_class="high",
+            ttl_sec=300.0,
+        )
+        daemon.stop()
+        ledger_ctx.__exit__(None, None, None)
+        # Restart over the same ledger: the pending proposal is durably
+        # invalidated — it cannot be decided anymore (fail closed).
+        daemon2, socket_path2, ledger_ctx2 = _start_daemon(tmp_path)
+        client2 = DaemonClient(socket_path=socket_path2, timeout_sec=5.0)
+        channel2 = _channel(client2)
+        with pytest.raises(ConsentChannelError, match="no pending proposal"):
+            await channel2.decide(
+                proposal["request_id"], principal_id="user:local:1000", accept=True
+            )
+        # …并且账本里记录了 INVALIDATED 事件（可追溯）。
+        from rosclaw.daemon.ledger import DaemonLedger
+
+        with DaemonLedger(
+            tmp_path / "state" / "ledger.sqlite3",
+            key_path=tmp_path / "state" / "ledger.key",
+        ) as ledger:
+            events = ledger.events(
+                entity_kind="OPERATOR_PROPOSAL", entity_id=proposal["request_id"]
+            )
+        assert events[-1].event_type == "OPERATOR_PROPOSAL_INVALIDATED"
+        daemon2.stop()
+        ledger_ctx2.__exit__(None, None, None)

--- a/tests/agentd/test_k3_daemon_loop.py
+++ b/tests/agentd/test_k3_daemon_loop.py
@@ -21,7 +21,6 @@ from rosclaw.agentd.service import AgentService
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
 from rosclaw.core.runtime import Runtime, RuntimeConfig
 from rosclaw.daemon.client import DaemonClient
-from rosclaw.daemon.permits import PermitAuthority
 from rosclaw.daemon.server import RosclawDaemon
 from rosclaw.daemon.service import DaemonControlPlane
 from rosclaw.kernel.contracts import (
@@ -46,6 +45,8 @@ def _sim_executor(action) -> ActionExecutionResult:
 
 @pytest.fixture
 def daemon(tmp_path: Path):
+    from rosclaw.daemon.ledger import DaemonLedger
+
     runtime = Runtime(
         RuntimeConfig(
             robot_id="sim-ur5e",
@@ -65,16 +66,19 @@ def daemon(tmp_path: Path):
     runtime.action_gateway.register_executor(
         SIM_CAPABILITY, ExecutionMode.SIMULATION, _sim_executor
     )
-    service = DaemonControlPlane(runtime=runtime, permits=PermitAuthority())
-    socket_path = tmp_path / "run" / "rosclawd.sock"
-    daemon = RosclawDaemon(service=service, socket_path=socket_path)
-    daemon.start()
-    client = DaemonClient(socket_path=socket_path, timeout_sec=5.0)
-    client.arm_runtime("k3 test preflight")
-    try:
-        yield client, socket_path
-    finally:
-        daemon.stop()
+    with DaemonLedger(
+        tmp_path / "state" / "ledger.sqlite3", key_path=tmp_path / "state" / "ledger.key"
+    ) as ledger:
+        service = DaemonControlPlane(runtime=runtime, ledger=ledger)
+        socket_path = tmp_path / "run" / "rosclawd.sock"
+        daemon = RosclawDaemon(service=service, socket_path=socket_path)
+        daemon.start()
+        client = DaemonClient(socket_path=socket_path, timeout_sec=5.0)
+        client.arm_runtime("k3 test preflight")
+        try:
+            yield client, socket_path
+        finally:
+            daemon.stop()
 
 
 def _approval_decision(request) -> ModelTurnResultV1:
@@ -158,7 +162,7 @@ class TestK3SimActionLoop:
             r1 = await service.send_turn(mission.mission_id, "请求授权")
             assert r1.state.value == "WAIT_APPROVAL"
             pending = service.pending_approvals(mission.mission_id)
-            grant = service.decide_approval(
+            grant = await service.decide_approval(
                 pending[0].request_id, principal="user:local:1000", approve=True
             )
             _action_decision.grant_id = grant.grant_id
@@ -179,7 +183,7 @@ class TestK3SimActionLoop:
             mission = service.create_mission("daemon 不在线")
             await service.send_turn(mission.mission_id, "请求授权")
             pending = service.pending_approvals(mission.mission_id)
-            grant = service.decide_approval(
+            grant = await service.decide_approval(
                 pending[0].request_id, principal="user:local:1000", approve=True
             )
             _action_decision.grant_id = grant.grant_id

--- a/tests/agentd/test_kimi_live.py
+++ b/tests/agentd/test_kimi_live.py
@@ -298,7 +298,7 @@ async def test_k5_operator_consent_loop(tmp_path: Path) -> None:
         card = pending[0].action_display
         assert card.title and card.risk_tier in ("LOW", "MEDIUM", "HIGH", "CRITICAL")
 
-        grant = service.decide_approval(
+        grant = await service.decide_approval(
             pending[0].request_id, principal="user:local:1000", approve=True
         )
         assert grant is not None

--- a/tests/agentd/test_operator.py
+++ b/tests/agentd/test_operator.py
@@ -284,7 +284,7 @@ class TestApprovalLoop:
             assert r1.state.value == "WAIT_APPROVAL"
             pending = service.pending_approvals(mission.mission_id)
             assert len(pending) == 1
-            grant = service.decide_approval(
+            grant = await service.decide_approval(
                 pending[0].request_id, principal="user:local:1000", approve=True
             )
             assert grant is not None


### PR DESCRIPTION
## 概述

按 ADR-0007 完成 agentd 认知层授权与上游 #185 daemon consent plane 的接线（K5 完整版）。

### 内容

- `agentd/consent_channel.py`（DaemonConsentChannel）：proposal create（agent 视角**无 nonce/permit**）→ operator decide → daemon 独立签 permit、以原 Agent UID 派发并监督到终态 Receipt
- REQUEST_APPROVAL（REAL）同步创建 daemon proposal；/approve 同时完成认知层 grant 与物理层裁决；REQUEST_ACTION 读回终态 + receipt provenance（operator principal/decision channel/proposal id）
- SIMULATION 不走 proposal（daemon 仅接受 REAL proposal），维持 action_channel SIM executor 路径
- 实测协议约束：proposal 不引用预建 session（SESSION_ID_CONFLICT）、verification_policy 与 executor 证据等级匹配
- decide_approval 全链路 async 化

### 验证

- 新增 consent channel 测试 5 项（accept 全链含 provenance / decline / wrong-nonce / 重复裁决 / daemon 重启失效）
- agentd+daemon+operator 394 passed；K3 SIM 闭环回归通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)