### PR TITLE
fix(agentd): make Kimi setup persistent and proxy-aware

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -7,19 +7,24 @@
 ## 快速开始
 
 ```bash
-# 1. 配置模型（只写 api_key_ref，不写真实密钥）
+# 1. 持久保存凭据（交互式隐藏输入；目录 0700、文件 0600）
+rosclaw agentd credential set --provider kimi-code
+# 或 rosclaw agentd credential set --provider kimi-api
+
+# 也可以不持久保存，只给当前进程环境提供凭据
 export ROSCLAW_KIMI_API_KEY=sk-kimi-...        # Kimi Coding Plan
-# 或 export MOONSHOT_API_KEY=sk-...            # Moonshot 开放平台
+
+# 2. 配置模型（config.yaml 只写 api_key_ref，不写真实密钥）
 rosclaw agentd init --provider kimi-code       # 或 kimi-api / openai-compat / local
 
-# 2. 就绪检查（connectivity / models / chat / strict tool call 四项 probe）
+# 3. 就绪检查（自动加载已保存凭据；四项 probe）
 rosclaw agentd doctor                          # READY 或诚实的 MODEL_NOT_READY
 
-# 3. 对话（默认 SIMULATION）
+# 4. 对话（默认 SIMULATION）
 rosclaw chat
 rosclaw chat --goal "检查仿真身体状态"
 
-# 4. 本地 HTTP 服务 + Console
+# 5. 本地 HTTP 服务 + Console
 rosclaw agentd start --port 8765
 #   http://127.0.0.1:8765/console   最小聊天 Console
 #   /health /status /probe /missions /missions/{id}/turns

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -8,22 +8,37 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import getpass
 import json
 import os
 import sys
 from pathlib import Path
 
 from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.credentials import AgentCredentialStore, CredentialStoreError
 from rosclaw.agentd.onboarding import PROVIDER_CHOICES, configure_model, doctor
 from rosclaw.agentd.service import AgentService, create_app
 
 LOCK_NAME = "agentd/agentd.lock"
+CREDENTIAL_ENV_BY_PROVIDER = {
+    "kimi-code": "ROSCLAW_KIMI_API_KEY",
+    "kimi-api": "MOONSHOT_API_KEY",
+}
 
 
 def _home(args: argparse.Namespace) -> Path:
     return Path(
         getattr(args, "home", None) or os.environ.get("ROSCLAW_HOME", Path.home() / ".rosclaw")
     )
+
+
+def _load_stored_credentials(home: Path) -> bool:
+    try:
+        AgentCredentialStore(home).inject()
+    except CredentialStoreError as exc:
+        print(str(exc), file=sys.stderr)
+        return False
+    return True
 
 
 def _acquire_lock(home: Path) -> Path:
@@ -55,6 +70,8 @@ def cmd_start(args: argparse.Namespace) -> int:
     import uvicorn
 
     home = _home(args)
+    if not _load_stored_credentials(home):
+        return 2
     config = load_agent_config(home / "config.yaml")
     if not config.profiles:
         print(
@@ -259,7 +276,10 @@ def cmd_learning_promote(args: argparse.Namespace) -> int:
 
 
 def cmd_doctor(args: argparse.Namespace) -> int:
-    report = doctor(_home(args))
+    home = _home(args)
+    if not _load_stored_credentials(home):
+        return 2
+    report = doctor(home)
     print(json.dumps(report, ensure_ascii=False, indent=2))
     return 0 if report.get("status") == "READY" else 1
 
@@ -267,6 +287,8 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 def cmd_init(args: argparse.Namespace) -> int:
     home = _home(args)
     home.mkdir(parents=True, exist_ok=True)
+    if not _load_stored_credentials(home):
+        return 2
     choice = args.provider
     if choice is None:
         if not sys.stdin.isatty():
@@ -302,12 +324,43 @@ def cmd_init(args: argparse.Namespace) -> int:
 
 def cmd_chat(args: argparse.Namespace) -> int:
     home = _home(args)
+    if not _load_stored_credentials(home):
+        return 2
     config = load_agent_config(home / "config.yaml")
     if not config.profiles:
         print("未配置模型。先运行 `rosclaw agent init`。", file=sys.stderr)
         return 2
     service = AgentService(config, home)
     return asyncio.run(_chat_repl(service, args))
+
+
+def cmd_credential(args: argparse.Namespace) -> int:
+    env_name = CREDENTIAL_ENV_BY_PROVIDER[args.provider]
+    try:
+        store = AgentCredentialStore(_home(args))
+        if args.credential_command == "set":
+            value = (
+                getpass.getpass(f"{env_name}: ").strip()
+                if sys.stdin.isatty()
+                else sys.stdin.read().strip()
+            )
+            store.set(env_name, value)
+            result = store.status(env_name)
+            result["provider"] = args.provider
+            result["updated"] = True
+        elif args.credential_command == "delete":
+            deleted = store.delete(env_name)
+            result = store.status(env_name)
+            result["provider"] = args.provider
+            result["deleted"] = deleted
+        else:
+            result = store.status(env_name)
+            result["provider"] = args.provider
+    except (CredentialStoreError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
 
 
 async def _chat_repl(service: AgentService, args: argparse.Namespace) -> int:
@@ -422,6 +475,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.add_argument("--api-key-ref", default=None)
     p_init.set_defaults(func=cmd_init)
 
+    add_credential_subcommands(sub)
+
     p_chat = sub.add_parser("chat", help="interactive chat (in-process)")
     p_chat.add_argument("--mission", default=None)
     p_chat.add_argument("--mode", default=None, choices=["SIMULATION", "SHADOW", "REAL"])
@@ -432,6 +487,15 @@ def build_parser() -> argparse.ArgumentParser:
     worker_sub = p_worker.add_subparsers(dest="worker_command", required=True)
     add_worker_subcommands(worker_sub)
     return parser
+
+
+def add_credential_subcommands(sub) -> None:
+    p_credential = sub.add_parser("credential", help="owner-only model credentials")
+    credential_sub = p_credential.add_subparsers(dest="credential_command", required=True)
+    for name in ("set", "status", "delete"):
+        parser = credential_sub.add_parser(name, help=f"{name} a persisted model credential")
+        parser.add_argument("--provider", choices=tuple(CREDENTIAL_ENV_BY_PROVIDER), required=True)
+        parser.set_defaults(func=cmd_credential)
 
 
 def add_worker_subcommands(sub) -> None:
@@ -480,6 +544,8 @@ def add_agent_subparsers(subparsers) -> None:
             p.add_argument("--model", default=None)
             p.add_argument("--api-key-ref", default=None)
         p.set_defaults(func=fn)
+
+    add_credential_subcommands(agent_sub)
 
     p_worker = subparsers.add_parser("worker", help="Worker Fabric management")
     worker_sub = p_worker.add_subparsers(dest="worker_command", required=True)

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -441,6 +441,11 @@ async def _chat_repl(service: AgentService, args: argparse.Namespace) -> int:
             result = await service.send_turn(mission.mission_id, text, on_delta)
             if not streamed:
                 print(result.reply, end="")
+            elif result.decisions and result.decisions[-1].next_intent.value != "ANSWER":
+                # Streamed prose is the model's proposal/explanation. The
+                # handler reply is the trusted system outcome (approval id,
+                # dispatch status, or receipt) and must not be hidden.
+                print(f"\nROSClaw system> {result.reply}", end="")
             usage = service.mission_usage(mission.mission_id)
             degraded = f"  [degraded: {result.degraded}]" if result.degraded else ""
             print(

--- a/src/rosclaw/agentd/credentials.py
+++ b/src/rosclaw/agentd/credentials.py
@@ -1,0 +1,173 @@
+"""Owner-only persisted credentials for the AgentD CLI.
+
+Public AgentD configuration keeps credential references only. This store is a
+local CLI convenience for resolving those ``env:`` references across process
+restarts without putting raw secrets in ``config.yaml`` or the repository.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+_ENV_NAME = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+
+class CredentialStoreError(RuntimeError):
+    """Raised when the local credential boundary is unsafe or unreadable."""
+
+
+class AgentCredentialStore:
+    """Atomic owner-only JSON store under ``ROSCLAW_HOME/agentd``."""
+
+    def __init__(self, home: Path) -> None:
+        self.path = home / "agentd" / "credentials.json"
+        self._prepare_directory()
+        self._values = self._load()
+
+    def _error(self, message: str) -> CredentialStoreError:
+        return CredentialStoreError(f"unsafe AgentD credential store: {message}")
+
+    @staticmethod
+    def _require_owner(info: os.stat_result, path: Path) -> None:
+        if hasattr(os, "getuid") and info.st_uid != os.getuid():
+            raise CredentialStoreError(
+                f"unsafe AgentD credential store: {path} is owned by another user"
+            )
+
+    def _secure_mode(self, path: Path, mode: int) -> None:
+        if os.name != "posix":
+            return
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags)
+            try:
+                self._require_owner(os.fstat(descriptor), path)
+                os.fchmod(descriptor, mode)
+            finally:
+                os.close(descriptor)
+        except OSError as exc:
+            raise self._error(f"cannot secure permissions on {path}: {exc}") from exc
+
+    def _prepare_directory(self) -> None:
+        directory = self.path.parent
+        try:
+            directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+            info = directory.lstat()
+        except OSError as exc:
+            raise self._error(f"cannot prepare {directory}: {exc}") from exc
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            raise self._error(f"{directory} must be a real directory")
+        self._require_owner(info, directory)
+        self._secure_mode(directory, 0o700)
+
+    def _validate_file(self) -> bool:
+        try:
+            info = self.path.lstat()
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            raise self._error(f"cannot inspect {self.path}: {exc}") from exc
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise self._error(f"{self.path} must be a regular file, not a link")
+        self._require_owner(info, self.path)
+        self._secure_mode(self.path, 0o600)
+        return True
+
+    def _load(self) -> dict[str, str]:
+        if not self._validate_file():
+            return {}
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(self.path, flags)
+            with os.fdopen(descriptor, encoding="utf-8") as credential_file:
+                info = os.fstat(credential_file.fileno())
+                if not stat.S_ISREG(info.st_mode):
+                    raise self._error(f"{self.path} is no longer a regular file")
+                self._require_owner(info, self.path)
+                payload = json.load(credential_file)
+        except CredentialStoreError:
+            raise
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise self._error(f"{self.path} is not valid UTF-8 JSON") from exc
+        except OSError as exc:
+            raise self._error(f"cannot read {self.path}: {exc}") from exc
+        values = payload.get("environment") if isinstance(payload, dict) else None
+        if not isinstance(values, dict):
+            raise self._error(f"{self.path} must contain an environment object")
+        if not all(
+            isinstance(name, str) and _ENV_NAME.fullmatch(name) and isinstance(value, str) and value
+            for name, value in values.items()
+        ):
+            raise self._error(f"{self.path} contains an invalid credential entry")
+        return dict(values)
+
+    def _save(self) -> None:
+        self._validate_file()
+        payload = (json.dumps({"environment": self._values}, indent=2) + "\n").encode()
+        descriptor = -1
+        temporary_path: Path | None = None
+        try:
+            descriptor, temporary_name = tempfile.mkstemp(
+                dir=self.path.parent,
+                prefix=f".{self.path.name}.",
+                suffix=".tmp",
+            )
+            temporary_path = Path(temporary_name)
+            if os.name == "posix":
+                os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb") as credential_file:
+                descriptor = -1
+                credential_file.write(payload)
+                credential_file.flush()
+                os.fsync(credential_file.fileno())
+            self._validate_file()
+            os.replace(temporary_path, self.path)
+            temporary_path = None
+            self._secure_mode(self.path, 0o600)
+        except CredentialStoreError:
+            raise
+        except OSError as exc:
+            raise self._error(f"cannot write {self.path}: {exc}") from exc
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            if temporary_path is not None:
+                with suppress(OSError):
+                    temporary_path.unlink(missing_ok=True)
+
+    def set(self, env_name: str, value: str) -> None:
+        if not _ENV_NAME.fullmatch(env_name):
+            raise ValueError(f"invalid environment credential name: {env_name!r}")
+        if not value:
+            raise ValueError("credential value must not be empty")
+        self._values[env_name] = value
+        self._save()
+
+    def delete(self, env_name: str) -> bool:
+        if env_name not in self._values:
+            return False
+        del self._values[env_name]
+        self._save()
+        return True
+
+    def inject(self) -> tuple[str, ...]:
+        """Load stored values without overriding an explicit process environment."""
+        for name, value in self._values.items():
+            os.environ.setdefault(name, value)
+        return tuple(sorted(self._values))
+
+    def status(self, env_name: str) -> dict[str, object]:
+        value = self._values.get(env_name, "")
+        return {
+            "env_name": env_name,
+            "stored": bool(value),
+            "fingerprint": hashlib.sha256(value.encode()).hexdigest()[:8] if value else None,
+            "path": str(self.path),
+        }

--- a/src/rosclaw/agentd/handlers.py
+++ b/src/rosclaw/agentd/handlers.py
@@ -110,13 +110,25 @@ class ServiceIntentHandlers:
         payload = (
             decision.proposed_operation.payload if decision.proposed_operation else None
         ) or {}
+        capability_id = payload.get("capability_id")
+        arguments = payload.get("arguments")
+        if self._mode == "REAL" and (
+            not isinstance(capability_id, str)
+            or not capability_id.strip()
+            or not isinstance(arguments, dict)
+        ):
+            return (
+                "REAL 精确动作授权缺少 capability_id 或 arguments；未创建空授权卡。"
+                "请从可信能力合约取得完整动作标识与参数后重新请求（fail closed）。"
+            )
+        approval_ttl_sec = 300.0 if self._mode == "REAL" else 600.0
         display = ActionDisplayV1(
             title=str(payload.get("title") or decision.summary or "动作请求"),
             summary=str(payload.get("summary") or decision.summary or ""),
             risk_tier=payload.get("risk_tier", "LOW"),
             expected_effect=str(payload.get("expected_effect") or ""),
             failure_handling=str(payload.get("failure_handling") or ""),
-            parameters=payload.get("parameters") or {},
+            parameters=payload.get("parameters") or arguments or {},
         )
         request = ApprovalRequestV2(
             request_id=new_id("appr"),
@@ -131,7 +143,7 @@ class ServiceIntentHandlers:
             context_revision=decision.context_revision,
             requested_tier=payload.get("tier", "EXACT_ACTION"),
             created_at=datetime.now(UTC).isoformat(),
-            expires_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat(),
+            expires_at=(datetime.now(UTC) + timedelta(seconds=approval_ttl_sec)).isoformat(),
         )
         self._broker.create_request(request)
         # ADR-0007：daemon consent plane 只接受显式 REAL 动作的 proposal
@@ -144,11 +156,11 @@ class ServiceIntentHandlers:
 
             try:
                 proposal = await consent.create_proposal(
-                    capability_id=str(payload.get("capability_id", "sim.hold_position")),
-                    arguments=payload.get("arguments") or {},
+                    capability_id=str(capability_id),
+                    arguments=arguments,
                     display=display.model_dump(mode="json"),
                     execution_mode=self._mode,
-                    ttl_sec=600.0,
+                    ttl_sec=approval_ttl_sec,
                 )
                 proposal_id = proposal.get("request_id")
                 action_id = proposal.get("action_id")
@@ -175,7 +187,8 @@ class ServiceIntentHandlers:
                     "物理层未创建 proposal；动作将不会被派发。"
                 )
         return (
-            f"已创建授权请求 {request.request_id}（EXACT_ACTION，10 分钟有效）：\n"
+            f"已创建授权请求 {request.request_id}（EXACT_ACTION，"
+            f"{int(approval_ttl_sec // 60)} 分钟有效）：\n"
             f"【{display.title}】{display.summary}\n"
             f"风险等级 {display.risk_tier}；预期效果：{display.expected_effect or '—'}；"
             f"失败处理：{display.failure_handling or '—'}\n"
@@ -253,6 +266,14 @@ class ServiceIntentHandlers:
             inner = receipt.get("receipt") if isinstance(receipt.get("receipt"), dict) else receipt
             trust = inner.get("trust_level", "UNKNOWN")
             final_state = inner.get("final_state", "UNKNOWN")
+            evidence_domain = inner.get("evidence_domain", "UNKNOWN")
+            evidence_level = inner.get("evidence_level", "UNKNOWN")
+            usable_for_real = inner.get("usable_for_real_execution") is True
+            verification = (
+                inner.get("verification_result")
+                if isinstance(inner.get("verification_result"), dict)
+                else {}
+            )
             provenance = (inner.get("authorization_decision") or {}).get("provenance") or {}
             if trust == "SYNTHETIC":
                 return "回执为 FIXTURE/SYNTHETIC 证据——拒绝当作完成（fail closed）。"
@@ -260,7 +281,13 @@ class ServiceIntentHandlers:
                 return "回执 action 与请求不匹配——不报告为我们的动作（fail closed）。"
             return (
                 f"动作已由 rosclawd consent plane 完成：state={final_state}, "
-                f"trust_level={trust}（SIMULATED 证据，不可用于 REAL）。"
+                f"trust_level={trust}, evidence_domain={evidence_domain}, "
+                f"evidence_level={evidence_level}, "
+                f"usable_for_real_execution={str(usable_for_real).lower()}。"
+                f"验证：success={verification.get('success')}, "
+                f"observer={verification.get('observer')}, "
+                f"target_gain_db={verification.get('target_gain_db')}, "
+                f"target_prominence_db={verification.get('target_prominence_db')}。"
                 f"授权来源：proposal {proposal_id[:20]}…, "
                 f"operator={provenance.get('operator_principal')}, "
                 f"channel={provenance.get('decision_channel')}。grant 已消费。"

--- a/src/rosclaw/agentd/loop.py
+++ b/src/rosclaw/agentd/loop.py
@@ -440,6 +440,12 @@ class AgentLoop:
             "team_task_claim; REQUEST_APPROVAL→approval_request; "
             "REQUEST_ACTION→request_action; VERIFY→verify_receipt|verify_observation; "
             "FAIL_SAFE→estop_request; ANSWER/WAIT/PAUSE→no operation."
+            " For REAL REQUEST_APPROVAL, proposed_operation.payload MUST include a non-empty "
+            "capability_id and an arguments object copied exactly from a trusted capability "
+            "contract, in addition to the human-readable title/summary/risk fields. Never "
+            "request approval for guessed or incomplete action arguments. After approval, read "
+            "the Active mission grant in SAFETY & CONSENT and reference its exact public grant_id "
+            "in REQUEST_ACTION."
         )
         return "\n".join(parts)
 

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -80,21 +80,34 @@ class BrokerConsentSource:
 
     def get_consent(self, mission_id: str):
         import json as _json
+        from datetime import UTC, datetime
 
         from rosclaw.agentd.context.sources import ConsentFacts
 
         facts = self._base.get_consent(mission_id)
         row = self._conn.execute(
-            "SELECT public_json FROM mission_grants WHERE revoked = 0 "
-            "ORDER BY created_at DESC LIMIT 1"
+            "SELECT g.public_json FROM mission_grants AS g "
+            "JOIN operator_requests AS r ON r.request_id = g.request_id "
+            "WHERE g.revoked = 0 AND g.consumed = 0 AND g.expires_at > ? "
+            "AND r.mission_id = ? ORDER BY g.created_at DESC LIMIT 1",
+            (datetime.now(UTC).isoformat(), mission_id),
         ).fetchone()
         grant_hash = None
+        scope_summary = facts.public_scope_summary
         if row is not None:
-            grant_hash = _json.loads(row["public_json"]).get("public_hash")
+            public = _json.loads(row["public_json"])
+            grant_hash = public.get("public_hash")
+            scope = public.get("scope") if isinstance(public.get("scope"), dict) else {}
+            scope_summary = (
+                f"{scope_summary}\nActive mission grant: grant_id={public.get('grant_id')}; "
+                f"tier={scope.get('tier')}; risk_ceiling={public.get('risk_ceiling')}; "
+                f"public_hash={grant_hash}. Reference this exact public grant_id in "
+                "REQUEST_ACTION. No private signature or permit is exposed."
+            ).strip()
         return ConsentFacts(
             policy_hash=facts.policy_hash,
             mission_grant_public_hash=grant_hash,
-            public_scope_summary=facts.public_scope_summary,
+            public_scope_summary=scope_summary,
             allowed_risk_tiers=facts.allowed_risk_tiers,
         )
 

--- a/src/rosclaw/mcp/adapters/runtime_client.py
+++ b/src/rosclaw/mcp/adapters/runtime_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -624,7 +625,23 @@ class RuntimeClient:
             required_evidence=required_evidence,
             timeout_sec=timeout_sec,
         )
+        managed_session = action.session_id == action.action_id
+        session_created = False
         try:
+            session_ttl_ms = min(
+                3_600_000,
+                max(60_000, int((float(timeout_sec) + 30.0) * 1000)),
+            )
+            await asyncio.to_thread(
+                self._daemon_client.create_session,
+                session_id=action.session_id,
+                actor_id=action.actor_id,
+                agent_framework=action.agent_framework,
+                body_scope=[action.body_id],
+                capability_scope=[action.capability_id],
+                ttl_ms=session_ttl_ms,
+            )
+            session_created = True
             ticket = await asyncio.to_thread(self._daemon_client.request_action, action)
             result = ticket
             if wait_timeout_sec > 0:
@@ -636,7 +653,33 @@ class RuntimeClient:
         except MCPError:
             raise
         except Exception as exc:  # noqa: BLE001
+            if session_created and managed_session:
+                try:
+                    await asyncio.to_thread(
+                        self._daemon_client.close_session,
+                        action.session_id,
+                        reason="request_action_failed",
+                    )
+                except Exception as cleanup_exc:  # noqa: BLE001
+                    logger.warning(
+                        "Could not close failed action session %s: %s",
+                        action.session_id,
+                        cleanup_exc,
+                    )
             self._raise_daemon_error("request_action", exc)
+        if managed_session and result.get("state") in {"FINISHED", "CANCELLED"}:
+            try:
+                await asyncio.to_thread(
+                    self._daemon_client.close_session,
+                    action.session_id,
+                    reason="action_finished",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Could not close terminal action session %s: %s",
+                    action.session_id,
+                    exc,
+                )
         return self._action_result_metadata(result, mode.value)
 
     def prepare_operator_action(
@@ -885,11 +928,13 @@ class RuntimeClient:
                 f"Unsupported evidence level {required_evidence!r}.",
             ) from exc
 
-        default_session_id = f"mcp-session:{capability_id}"
+        resolved_action_id = action_id or f"action_{uuid.uuid4().hex}"
+        default_session_id = resolved_action_id
         action_kwargs: dict[str, Any] = {
             "actor_id": os.environ.get("ROSCLAW_AGENT_ACTOR", "rosclaw-mcp"),
             "agent_framework": os.environ.get("ROSCLAW_AGENT_CLIENT", "mcp"),
             "session_id": session_id or os.environ.get("ROSCLAW_AGENT_SESSION", default_session_id),
+            "action_id": resolved_action_id,
             "body_id": body_id or self.robot_id,
             "body_snapshot_hash": body_snapshot_hash,
             "capability_id": capability_id,
@@ -931,8 +976,6 @@ class RuntimeClient:
                     "deadline_at must include a timezone offset.",
                 )
             action_kwargs["deadline_at"] = parsed_deadline
-        if action_id:
-            action_kwargs["action_id"] = action_id
         return ActionEnvelope(**action_kwargs), mode
 
     async def get_action_status(self, action_id: str) -> dict[str, Any]:

--- a/src/rosclaw/provider/runtimes/openai_compat_runtime.py
+++ b/src/rosclaw/provider/runtimes/openai_compat_runtime.py
@@ -28,7 +28,10 @@ parsing message strings.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
+from contextlib import suppress
 from typing import Any
+from urllib.parse import urlparse
 
 from rosclaw.provider.core.errors import RuntimeAdapterError
 from rosclaw.provider.runtimes.base import RuntimeAdapter
@@ -77,7 +80,15 @@ class OpenAICompatRuntime(RuntimeAdapter):
             raise RuntimeError(
                 "aiohttp is required for OpenAICompatRuntime. pip install aiohttp"
             ) from err
-        self._session = aiohttp.ClientSession(headers=self.headers)
+        # Respect the operator's standard HTTP(S)_PROXY / NO_PROXY settings for
+        # cloud providers. Always keep loopback runtimes local, even when a host
+        # forgot to include localhost in NO_PROXY.
+        host = urlparse(self.endpoint).hostname or ""
+        loopback = host.lower() == "localhost"
+        if host:
+            with suppress(ValueError):
+                loopback = loopback or ipaddress.ip_address(host).is_loopback
+        self._session = aiohttp.ClientSession(headers=self.headers, trust_env=not loopback)
         self._started = True
 
     async def stop(self) -> None:
@@ -130,11 +141,16 @@ class OpenAICompatRuntime(RuntimeAdapter):
     async def _post_stream(self, path: str, body: dict[str, Any]):
         import aiohttp
 
+        client_error = getattr(aiohttp, "ClientError", OSError)
+        if not isinstance(client_error, type) or not issubclass(client_error, BaseException):
+            client_error = OSError
+
         if self._session is None:
             raise RuntimeAdapterError("Session not initialized", provider=self.name)
         url = f"{self.endpoint}{path}"
         last_error: RuntimeAdapterError | None = None
         for attempt in range(self.retries + 1):
+            emitted = False
             try:
                 async with self._session.post(
                     url,
@@ -144,11 +160,12 @@ class OpenAICompatRuntime(RuntimeAdapter):
                     if resp.status >= 400:
                         raise await self._http_error(resp, url)
                     async for chunk in self._iter_sse(resp):
+                        emitted = True
                         yield chunk
                     return
             except RuntimeAdapterError as e:
                 last_error = e
-                if not self._is_retryable(e) or attempt >= self.retries:
+                if emitted or not self._is_retryable(e) or attempt >= self.retries:
                     raise
             except TimeoutError:
                 last_error = RuntimeAdapterError(
@@ -158,13 +175,13 @@ class OpenAICompatRuntime(RuntimeAdapter):
                 )
                 if attempt >= self.retries:
                     raise last_error from None
-            except OSError as e:
+            except (client_error, OSError) as e:
                 last_error = RuntimeAdapterError(
                     f"Cannot reach {url}: {e}",
                     provider=self.name,
                     kind=RuntimeAdapterError.KIND_UNAVAILABLE,
                 )
-                if attempt >= self.retries:
+                if emitted or attempt >= self.retries:
                     raise last_error from None
             await self._sleep_before_retry(attempt, last_error)
         raise last_error or RuntimeAdapterError(
@@ -421,6 +438,10 @@ class OpenAICompatRuntime(RuntimeAdapter):
     async def _post_with_retries(self, path: str, body: dict[str, Any]) -> dict[str, Any]:
         import aiohttp
 
+        client_error = getattr(aiohttp, "ClientError", OSError)
+        if not isinstance(client_error, type) or not issubclass(client_error, BaseException):
+            client_error = OSError
+
         url = f"{self.endpoint}{path}"
         last_error: RuntimeAdapterError | None = None
         for attempt in range(self.retries + 1):
@@ -456,9 +477,9 @@ class OpenAICompatRuntime(RuntimeAdapter):
                 )
                 if attempt >= self.retries:
                     raise last_error from None
-            except OSError as e:
-                # aiohttp.ClientConnectorError derives from OSError
-                # (via ClientOSError), as does builtin ConnectionError.
+            except (client_error, OSError) as e:
+                # Connector failures usually derive from OSError, while
+                # disconnects and malformed HTTP responses are ClientError.
                 last_error = RuntimeAdapterError(
                     f"Cannot reach {url}: {e}",
                     provider=self.name,

--- a/tests/agentd/test_credentials.py
+++ b/tests/agentd/test_credentials.py
@@ -1,0 +1,77 @@
+"""Owner-only persisted credential tests for AgentD CLI."""
+
+import io
+import json
+import os
+import stat
+
+import pytest
+
+from rosclaw.agentd.cli import main as agentd_main
+from rosclaw.agentd.credentials import AgentCredentialStore, CredentialStoreError
+
+
+def test_store_round_trip_and_environment_precedence(tmp_path, monkeypatch):
+    store = AgentCredentialStore(tmp_path)
+    store.set("ROSCLAW_KIMI_API_KEY", "stored-value")
+    monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "explicit-value")
+
+    assert store.inject() == ("ROSCLAW_KIMI_API_KEY",)
+    assert os.environ["ROSCLAW_KIMI_API_KEY"] == "explicit-value"
+    assert store.status("ROSCLAW_KIMI_API_KEY")["stored"] is True
+    assert "stored-value" not in json.dumps(store.status("ROSCLAW_KIMI_API_KEY"))
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission semantics")
+def test_store_uses_owner_only_permissions(tmp_path):
+    store = AgentCredentialStore(tmp_path)
+    store.set("ROSCLAW_KIMI_API_KEY", "secret")
+
+    assert stat.S_IMODE(store.path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(store.path.stat().st_mode) == 0o600
+
+
+def test_store_rejects_symlink(tmp_path):
+    outside = tmp_path / "outside.json"
+    outside.write_text("do not overwrite", encoding="utf-8")
+    credential_path = tmp_path / "agentd" / "credentials.json"
+    credential_path.parent.mkdir(parents=True)
+    credential_path.symlink_to(outside)
+
+    with pytest.raises(CredentialStoreError, match="regular file"):
+        AgentCredentialStore(tmp_path)
+    assert outside.read_text(encoding="utf-8") == "do not overwrite"
+
+
+def test_cli_set_status_delete_never_prints_secret(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", io.StringIO("top-secret-value\n"))
+    rc = agentd_main(["--home", str(tmp_path), "credential", "set", "--provider", "kimi-code"])
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "top-secret-value" not in output
+    assert json.loads(output)["stored"] is True
+
+    rc = agentd_main(["--home", str(tmp_path), "credential", "status", "--provider", "kimi-code"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["stored"] is True
+
+    rc = agentd_main(["--home", str(tmp_path), "credential", "delete", "--provider", "kimi-code"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["stored"] is False
+
+
+def test_doctor_cli_automatically_loads_stored_credential(tmp_path, monkeypatch, capsys):
+    store = AgentCredentialStore(tmp_path)
+    store.set("ROSCLAW_KIMI_API_KEY", "persisted-value")
+    monkeypatch.delenv("ROSCLAW_KIMI_API_KEY", raising=False)
+
+    def fake_doctor(home):
+        assert home == tmp_path
+        assert os.environ["ROSCLAW_KIMI_API_KEY"] == "persisted-value"
+        return {"status": "READY"}
+
+    monkeypatch.setattr("rosclaw.agentd.cli.doctor", fake_doctor)
+    rc = agentd_main(["--home", str(tmp_path), "doctor"])
+
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"status": "READY"}

--- a/tests/agentd/test_operator.py
+++ b/tests/agentd/test_operator.py
@@ -22,6 +22,7 @@ from rosclaw.agentd.mission import MissionStore
 from rosclaw.agentd.models.gateway import MockModelGateway
 from rosclaw.agentd.models.profiles import mock_profile
 from rosclaw.agentd.service import AgentService, create_app
+from rosclaw.contracts.agent.decision import DecisionV1
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
 from rosclaw.contracts.operator.approval import ActionDisplayV1, ApprovalRequestV2
 from rosclaw.operator import GrantDeniedError, OperatorBroker
@@ -288,6 +289,10 @@ class TestApprovalLoop:
                 pending[0].request_id, principal="user:local:1000", approve=True
             )
             assert grant is not None
+            consent = service._compiler._sources.consent.get_consent(mission.mission_id)
+            assert consent is not None
+            assert grant.grant_id in consent.public_scope_summary
+            assert grant.public_hash in consent.public_scope_summary
             _approval_then_action.grant_id = grant.grant_id
             r2 = await service.send_turn(mission.mission_id, "我已批准，继续执行")
             assert "授权已验证" in r2.reply
@@ -304,6 +309,87 @@ class TestApprovalLoop:
                     mode="SIMULATION",
                     risk_tier="LOW",
                 )
+        finally:
+            await service.close()
+
+    async def test_real_approval_uses_daemon_ttl_and_exact_action_payload(
+        self, tmp_path: Path
+    ) -> None:
+        config = load_agent_config(tmp_path / "config.yaml")
+        service = AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), []))
+
+        class FakeConsent:
+            called: dict = {}
+
+            async def create_proposal(self, **kwargs):
+                self.called = kwargs
+                return {"request_id": "proposal_real", "action_id": "action_real"}
+
+        fake = FakeConsent()
+        service._handlers._mode = "REAL"
+        service._handlers._consent_channel = fake
+        decision = DecisionV1.model_validate_contract(
+            {
+                "schema_version": "rosclaw.decision.v1",
+                "decision_id": "dec_real_tone",
+                "mission_id": "mis_real",
+                "context_id": "ctx_real",
+                "context_revision": 1,
+                "next_intent": "REQUEST_APPROVAL",
+                "summary": "play exact tone",
+                "proposed_operation": {
+                    "type": "approval_request",
+                    "payload": {
+                        "capability_id": "limo.play_tone",
+                        "arguments": {
+                            "schema_version": "limo.tone.v1",
+                            "frequency_hz": 660,
+                            "duration_sec": 0.25,
+                            "volume_percent": 18,
+                        },
+                        "risk_tier": "LOW",
+                    },
+                },
+            }
+        )
+
+        try:
+            reply = await service._handlers.request_approval(decision)
+            assert "5 分钟有效" in reply
+            assert fake.called["ttl_sec"] == 300.0
+            assert fake.called["capability_id"] == "limo.play_tone"
+            assert fake.called["arguments"]["frequency_hz"] == 660
+            pending = service.pending_approvals("mis_real")
+            assert pending[0].action_display.parameters["duration_sec"] == 0.25
+        finally:
+            await service.close()
+
+    async def test_real_approval_rejects_missing_daemon_action_payload(
+        self, tmp_path: Path
+    ) -> None:
+        config = load_agent_config(tmp_path / "config.yaml")
+        service = AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), []))
+        service._handlers._mode = "REAL"
+        decision = DecisionV1.model_validate_contract(
+            {
+                "schema_version": "rosclaw.decision.v1",
+                "decision_id": "dec_empty_real",
+                "mission_id": "mis_real",
+                "context_id": "ctx_real",
+                "context_revision": 1,
+                "next_intent": "REQUEST_APPROVAL",
+                "summary": "incomplete action",
+                "proposed_operation": {
+                    "type": "approval_request",
+                    "payload": {"risk_tier": "LOW"},
+                },
+            }
+        )
+
+        try:
+            reply = await service._handlers.request_approval(decision)
+            assert "缺少 capability_id 或 arguments" in reply
+            assert service.pending_approvals("mis_real") == []
         finally:
             await service.close()
 

--- a/tests/mcp/adapters/test_daemon_boundary.py
+++ b/tests/mcp/adapters/test_daemon_boundary.py
@@ -162,6 +162,9 @@ async def test_request_action_builds_unapproved_envelope_for_daemon(
     assert action.body_id == "rh56-test"
     assert action.authorization.approved is False
     assert action.authorization.approval_id == "permit-1"
+    assert daemon.sessions[-1]["session_id"] == action.session_id
+    assert action.session_id == action.action_id
+    assert daemon.closed_sessions == [(action.session_id, "action_finished")]
 
 
 async def test_request_action_preserves_operator_proposal_deadline(
@@ -181,7 +184,7 @@ async def test_request_action_preserves_operator_proposal_deadline(
     assert daemon.actions[0].to_dict()["deadline_at"] == "2030-01-02T03:04:05Z"
 
 
-async def test_default_shadow_sessions_are_scoped_per_capability(
+async def test_default_shadow_sessions_are_unique_and_scoped_per_action(
     client: tuple[RuntimeClient, _FakeDaemonClient],
 ) -> None:
     runtime_client, daemon = client
@@ -195,9 +198,11 @@ async def test_default_shadow_sessions_are_scoped_per_capability(
             wait_timeout_sec=0.0,
         )
 
-    assert [action.session_id for action in daemon.actions] == [
-        "mcp-session:limo.play_tone",
-        "mcp-session:limo.set_initial_pose",
+    assert len({action.session_id for action in daemon.actions}) == 2
+    assert all(action.session_id == action.action_id for action in daemon.actions)
+    assert [session["capability_scope"] for session in daemon.sessions] == [
+        ["limo.play_tone"],
+        ["limo.set_initial_pose"],
     ]
 
 

--- a/tests/mcp/tools/test_control_plane_tools.py
+++ b/tests/mcp/tools/test_control_plane_tools.py
@@ -25,6 +25,17 @@ from rosclaw.mcp.tools import (
 class _FakeDaemon:
     def __init__(self) -> None:
         self.action: ActionEnvelope | None = None
+        self.created_sessions: list[str] = []
+        self.closed_sessions: list[tuple[str, str]] = []
+
+    def create_session(self, **kwargs: Any) -> dict[str, Any]:
+        session_id = str(kwargs["session_id"])
+        self.created_sessions.append(session_id)
+        return {"session_id": session_id, "state": "ACTIVE"}
+
+    def close_session(self, session_id: str, *, reason: str) -> dict[str, Any]:
+        self.closed_sessions.append((session_id, reason))
+        return {"session_id": session_id, "state": "CLOSED"}
 
     def get_runtime_status(self) -> dict[str, Any]:
         return {
@@ -140,6 +151,10 @@ async def test_action_defaults_to_shadow_when_mode_is_omitted(
 
     assert _daemon_client.action is not None
     assert _daemon_client.action.execution_mode is ExecutionMode.SHADOW
+    assert _daemon_client.created_sessions == ["action-tool-default-mode"]
+    assert _daemon_client.closed_sessions == [
+        ("action-tool-default-mode", "action_finished")
+    ]
 
 
 async def test_action_status_and_cancel_are_bounded_daemon_calls() -> None:

--- a/tests/provider/test_openai_compat_disconnect.py
+++ b/tests/provider/test_openai_compat_disconnect.py
@@ -1,0 +1,62 @@
+"""Connection-drop recovery for OpenAI-compatible streaming."""
+
+import json
+
+import pytest
+from aiohttp import web
+
+from rosclaw.provider.runtimes.openai_compat_runtime import OpenAICompatRuntime
+
+
+@pytest.mark.asyncio
+async def test_disconnect_before_first_event_is_retried():
+    attempts = 0
+
+    async def handler(request: web.Request) -> web.StreamResponse:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            request.transport.close()
+            return web.Response()
+        response = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream"},
+        )
+        await response.prepare(request)
+        chunk = {
+            "model": "mock",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "recovered"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+        await response.write(f"data: {json.dumps(chunk)}\n\n".encode())
+        await response.write(b"data: [DONE]\n\n")
+        await response.write_eof()
+        return response
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    runtime = OpenAICompatRuntime(
+        "test",
+        f"http://127.0.0.1:{port}/v1",
+        model="mock",
+        retries=1,
+    )
+    await runtime.start()
+    try:
+        chunks = [chunk async for chunk in runtime.invoke_stream({"inputs": {"prompt": "hi"}})]
+    finally:
+        await runtime.stop()
+        await runner.cleanup()
+
+    assert attempts == 2
+    assert chunks[0]["choices"][0]["delta"]["content"] == "recovered"

--- a/tests/provider/test_openai_compat_proxy.py
+++ b/tests/provider/test_openai_compat_proxy.py
@@ -1,0 +1,52 @@
+"""Proxy-environment regression coverage for OpenAI-compatible providers."""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rosclaw.provider.runtimes.openai_compat_runtime import OpenAICompatRuntime
+
+
+@pytest.mark.asyncio
+async def test_session_respects_operator_proxy_environment():
+    mock_session = MagicMock()
+    mock_session.close = AsyncMock()
+    mock_aiohttp = MagicMock()
+    mock_aiohttp.ClientSession.return_value = mock_session
+    original = sys.modules.get("aiohttp")
+    sys.modules["aiohttp"] = mock_aiohttp
+    try:
+        runtime = OpenAICompatRuntime("test", "https://model.example/v1", model="model")
+
+        await runtime.start()
+
+        mock_aiohttp.ClientSession.assert_called_once_with(headers={}, trust_env=True)
+        await runtime.stop()
+    finally:
+        if original is None:
+            sys.modules.pop("aiohttp", None)
+        else:
+            sys.modules["aiohttp"] = original
+
+
+@pytest.mark.asyncio
+async def test_loopback_session_bypasses_proxy_environment():
+    mock_session = MagicMock()
+    mock_session.close = AsyncMock()
+    mock_aiohttp = MagicMock()
+    mock_aiohttp.ClientSession.return_value = mock_session
+    original = sys.modules.get("aiohttp")
+    sys.modules["aiohttp"] = mock_aiohttp
+    try:
+        runtime = OpenAICompatRuntime("test", "http://127.0.0.1:8000/v1", model="model")
+
+        await runtime.start()
+
+        mock_aiohttp.ClientSession.assert_called_once_with(headers={}, trust_env=False)
+        await runtime.stop()
+    finally:
+        if original is None:
+            sys.modules.pop("aiohttp", None)
+        else:
+            sys.modules["aiohttp"] = original


### PR DESCRIPTION
## What changed

- add `rosclaw agentd credential set/status/delete --provider ...`
- persist model credentials atomically in an owner-only `0700` directory and `0600` file
- automatically load persisted credentials for AgentD init, doctor, chat, and service start while preserving explicit environment-variable precedence
- keep raw credentials out of `config.yaml`, CLI output, model context, and the repository
- make OpenAI-compatible cloud providers honor standard HTTP(S) proxy settings while bypassing proxies for loopback endpoints
- classify and retry pre-output SSE disconnects without duplicating already-emitted stream deltas

## Root causes

AgentD onboarding wrote only an `env:` credential reference, so a successful one-off probe did not survive a new shell or restart. Separately, `aiohttp.ClientSession` defaulted `trust_env` to false, bypassing the host's required egress proxy. Once proxy routing was enabled, transient `ServerDisconnectedError` failures also needed classified pre-stream retry handling.

## Security and behavior

- interactive credential entry uses hidden input; automation may provide the value on stdin
- the credential store rejects symlinks, non-regular files, invalid entries, and foreign ownership
- status output contains only an eight-character SHA-256 fingerprint
- explicit process environment credentials override persisted values
- local model endpoints never inherit a host proxy accidentally

## Validation

- AgentD suite: 165 passed, 8 deselected
- provider suite: 58 passed
- focused post-rebase provider suite: 32 passed
- credential/service focused suite: 21 passed
- Ruff, format, compile, and diff checks passed for changed files
- live Kimi Doctor with no exported key: model listing, chat, and strict tool call all READY
- live AgentD SHADOW chat read `body_id=limo` and completed with no physical action
