### PR TITLE
Model layer: cooldown/failover chain + two-level compaction

### DIFF
--- a/src/rosclaw/agentd/context/compact.py
+++ b/src/rosclaw/agentd/context/compact.py
@@ -1,0 +1,90 @@
+"""Conversation compaction (openharness 两级压缩的轻量版）.
+
+- **microcompact**：超阈值时先把旧 tool result 折叠为引用占位
+  （保留 system、首条 user 锚点与最近 N 条——zeroclaw trim_history 模式）；
+- **reactive compact**：模型返回 context-overflow 类错误时压缩并重试一次。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from rosclaw.agentd.context.tokens import estimate_tokens
+
+DEFAULT_MAX_MESSAGES = 50
+TOOL_RESULT_PLACEHOLDER = "[tool result compacted: see artifact refs in trusted context]"
+
+_OVERFLOW_MARKERS = (
+    "context length",
+    "context_length",
+    "prompt too long",
+    "prompt is too long",
+    "too long",
+    "context window",
+    "maximum context",
+    "too many tokens",
+    "string too long",
+)
+
+
+def is_context_overflow(kind: str, detail: str) -> bool:
+    if kind == "context_overflow":
+        return True
+    if kind not in ("http_error", "invalid_response", "stream_failed", "invoke_failed"):
+        return False
+    lowered = detail.lower()
+    return any(marker in lowered for marker in _OVERFLOW_MARKERS)
+
+
+def estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    total = 0
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, str):
+            total += estimate_tokens(content)
+        elif isinstance(content, list):
+            total += estimate_tokens(json.dumps(content, ensure_ascii=False))
+        if message.get("tool_calls"):
+            total += estimate_tokens(json.dumps(message["tool_calls"], ensure_ascii=False))
+    return total
+
+
+def microcompact(
+    messages: list[dict[str, Any]],
+    *,
+    keep_recent: int = 8,
+    max_messages: int = DEFAULT_MAX_MESSAGES,
+) -> tuple[list[dict[str, Any]], int]:
+    """折叠旧 tool result + 中段消息。返回 (新消息列表, 折叠数)。"""
+    if len(messages) <= max_messages:
+        compacted_tools, count = _compact_tool_results(messages, keep_recent)
+        return compacted_tools, count
+    # 保留首条 user 锚点 + 最近 max_messages-1 条。
+    anchor: list[dict[str, Any]] = []
+    rest = messages
+    if messages and messages[0].get("role") == "user":
+        anchor = [messages[0]]
+        rest = messages[1:]
+    trimmed = anchor + rest[-(max_messages - len(anchor)) :]
+    compacted_tools, count = _compact_tool_results(trimmed, keep_recent)
+    return compacted_tools, count + max(0, len(messages) - len(trimmed))
+
+
+def _compact_tool_results(
+    messages: list[dict[str, Any]], keep_recent: int
+) -> tuple[list[dict[str, Any]], int]:
+    boundary = max(0, len(messages) - keep_recent)
+    out: list[dict[str, Any]] = []
+    count = 0
+    for index, message in enumerate(messages):
+        if (
+            index < boundary
+            and message.get("role") == "tool"
+            and isinstance(message.get("content"), str)
+            and len(message["content"]) > 200
+        ):
+            message = {**message, "content": TOOL_RESULT_PLACEHOLDER}
+            count += 1
+        out.append(message)
+    return out, count

--- a/src/rosclaw/agentd/loop.py
+++ b/src/rosclaw/agentd/loop.py
@@ -252,6 +252,8 @@ class AgentLoop:
                     "cancelled_by_user",
                 )
                 return result
+            # 主动 microcompact：估算超阈值先折叠旧 tool result / 中段历史。
+            self._maybe_microcompact(result)
             request = ModelTurnRequest(
                 system_prompt=system_prompt,
                 messages=list(self._conversation),
@@ -264,10 +266,27 @@ class AgentLoop:
             try:
                 turn = await self._gateway.complete_stream(request, on_text_delta=on_text_delta)
             except ModelGatewayError as exc:
-                result.degraded = f"model_error: {exc.kind}"
-                result.reply = f"模型调用失败（{exc.kind}）：{exc}"
-                result.state = self._current_state(mission.mission_id)
-                return result
+                from rosclaw.agentd.context.compact import is_context_overflow, microcompact
+
+                if is_context_overflow(exc.kind, str(exc)):
+                    # Reactive compact（openharness 模式）：压缩后重试一次。
+                    self._conversation, _ = microcompact(self._conversation, keep_recent=4)
+                    request.messages = list(self._conversation)
+                    try:
+                        turn = await self._gateway.complete_stream(
+                            request, on_text_delta=on_text_delta
+                        )
+                        result.degraded = "reactive_compacted"
+                    except ModelGatewayError as exc2:
+                        result.degraded = f"model_error: {exc2.kind}"
+                        result.reply = f"模型调用失败（{exc2.kind}）：{exc2}"
+                        result.state = self._current_state(mission.mission_id)
+                        return result
+                else:
+                    result.degraded = f"model_error: {exc.kind}"
+                    result.reply = f"模型调用失败（{exc.kind}）：{exc}"
+                    result.state = self._current_state(mission.mission_id)
+                    return result
             result.model_turns += 1
             if not self._record_usage(mission.mission_id, turn, result):
                 # 预算超限（§4.2）：必须进入 WAIT_INPUT/SUSPENDED，不得继续
@@ -646,6 +665,20 @@ class AgentLoop:
         if mission is None:
             return MissionState.FAILED
         return mission.state
+
+    def _maybe_microcompact(self, result: LoopTurnResult) -> None:
+        """Proactive compaction when the conversation estimate exceeds 80%
+        of the configured input budget."""
+        from rosclaw.agentd.context.compact import (
+            estimate_messages_tokens,
+            microcompact,
+        )
+
+        budget = getattr(self._compiler, "_max_input_tokens", 120_000)
+        if estimate_messages_tokens(self._conversation) <= budget * 0.8:
+            return
+        self._conversation, folded = microcompact(self._conversation)
+        result.degraded = f"microcompacted:{folded}"
 
     def _safe_transition(
         self,

--- a/src/rosclaw/agentd/models/failover.py
+++ b/src/rosclaw/agentd/models/failover.py
@@ -1,0 +1,169 @@
+"""Cooldown tracking + ordered failover chain (picoclaw cooldown.go/fallback.go).
+
+规则（调研报告 §picoclaw/zeroclaw）：
+- 标准错误冷却 `min(1h, 1min * 5^(n-1))`，n 上限 3；billing/auth 类长冷却
+  （5h * 2^n 封顶 24h）；24h 无失败自动清零；成功即复位。
+- 冷却键用 profile 身份（provider/model/base_url），支持多 key 别名独立熔断。
+- format / auth / context_overflow 不重试（立即抛）；rate_limited / timeout /
+  unavailable / 5xx 进入下一个候选；最后候选也失败才抛。
+- 每候选 token-bucket RPM 限流：非末位拿不到令牌即跳过，末位才等待。
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+from rosclaw.agentd.models.gateway import (
+    ModelGateway,
+    ModelGatewayError,
+    ModelTurnRequest,
+)
+from rosclaw.agentd.models.policy import ModelProfile
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+
+#: 立即可判死刑的错误（重试只会烧钱）。
+NON_RETRYABLE_KINDS = frozenset(
+    {"format", "auth_error", "invalid_response", "context_overflow", "missing_credential"}
+)
+_BILLING_KINDS = frozenset({"billing", "payment_required"})
+
+
+@dataclass
+class _CooldownState:
+    failures: int = 0
+    billing_failures: int = 0
+    cooldown_until: float = 0.0
+    last_failure_at: float = 0.0
+
+
+class CooldownTracker:
+    def __init__(self, *, now=time.monotonic) -> None:
+        self._states: dict[str, _CooldownState] = {}
+        self._now = now
+
+    def in_cooldown(self, key: str) -> bool:
+        state = self._states.get(key)
+        if state is None:
+            return False
+        now = self._now()
+        # 24h 无失败自动清零。
+        if state.failures and now - state.last_failure_at > 24 * 3600:
+            self._states.pop(key, None)
+            return False
+        return now < state.cooldown_until
+
+    def record_failure(self, key: str, *, billing: bool = False) -> None:
+        state = self._states.setdefault(key, _CooldownState())
+        now = self._now()
+        state.last_failure_at = now
+        if billing:
+            state.billing_failures += 1
+            state.cooldown_until = now + min(
+                24 * 3600.0, 5 * 3600.0 * (2 ** (state.billing_failures - 1))
+            )
+        else:
+            state.failures = min(state.failures + 1, 3)
+            state.cooldown_until = now + min(3600.0, 60.0 * (5 ** (state.failures - 1)))
+
+    def record_success(self, key: str) -> None:
+        self._states.pop(key, None)
+
+
+@dataclass
+class TokenBucket:
+    """简单 RPM 令牌桶（每候选独立）。"""
+
+    rpm: int
+    _tokens: float = field(init=False)
+    _refilled_at: float = field(init=False, default=-1.0)
+
+    def __post_init__(self) -> None:
+        self._tokens = float(self.rpm)
+
+    def take(self, *, now: float) -> bool:
+        if self._refilled_at < 0:
+            self._refilled_at = now
+        elapsed = max(0.0, now - self._refilled_at)
+        self._tokens = min(float(self.rpm), self._tokens + elapsed * self.rpm / 60.0)
+        self._refilled_at = now
+        if self._tokens >= 1.0:
+            self._tokens -= 1.0
+            return True
+        return False
+
+
+class FailoverGateway:
+    """Ordered candidate chain with cooldown + RPM gating."""
+
+    def __init__(
+        self,
+        candidates: list[tuple[ModelProfile, ModelGateway]],
+        *,
+        cooldown: CooldownTracker | None = None,
+        rpm_limits: dict[str, int] | None = None,
+        now=time.monotonic,
+    ) -> None:
+        if not candidates:
+            raise ValueError("failover chain needs at least one candidate")
+        self._candidates = candidates
+        self._cooldown = cooldown or CooldownTracker(now=now)
+        self._now = now
+        self._buckets: dict[str, TokenBucket] = {
+            p.name: TokenBucket((rpm_limits or {}).get(p.name, 60)) for p, _ in candidates
+        }
+        self.profile = candidates[0][0]
+
+    def _key(self, profile: ModelProfile) -> str:
+        return f"{profile.provider}/{profile.model}/{profile.base_url}"
+
+    async def complete(self, request: ModelTurnRequest) -> ModelTurnResultV1:
+        return await self._attempt("complete", request, None)
+
+    async def complete_stream(
+        self, request: ModelTurnRequest, on_text_delta=None
+    ) -> ModelTurnResultV1:
+        return await self._attempt("complete_stream", request, on_text_delta)
+
+    async def _attempt(
+        self, method: str, request: ModelTurnRequest, on_text_delta
+    ) -> ModelTurnResultV1:
+        last_error: ModelGatewayError | None = None
+        for index, (profile, gateway) in enumerate(self._candidates):
+            key = self._key(profile)
+            is_last = index == len(self._candidates) - 1
+            if self._cooldown.in_cooldown(key):
+                continue
+            if not is_last and not self._buckets[profile.name].take(now=self._now()):
+                continue  # 非末位饱和即跳过；末位才阻塞等待
+            if is_last:
+                while not self._buckets[profile.name].take(now=self._now()):
+                    import asyncio
+
+                    await asyncio.sleep(0.05)
+            try:
+                fn = getattr(gateway, method)
+                if method == "complete_stream":
+                    result = await fn(request, on_text_delta=on_text_delta)
+                else:
+                    result = await fn(request)
+            except ModelGatewayError as exc:
+                last_error = exc
+                if exc.kind in NON_RETRYABLE_KINDS:
+                    raise
+                self._cooldown.record_failure(key, billing=exc.kind in _BILLING_KINDS)
+                continue
+            self._cooldown.record_success(key)
+            return result
+        raise last_error or ModelGatewayError("all_candidates_exhausted", "no usable profile")
+
+    async def probe(self):
+        # 探测首个非冷却候选。
+        for profile, gateway in self._candidates:
+            if not self._cooldown.in_cooldown(self._key(profile)):
+                return await gateway.probe()
+        return await self._candidates[-1][1].probe()
+
+    async def close(self) -> None:
+        for _, gateway in self._candidates:
+            await gateway.close()

--- a/src/rosclaw/agentd/models/policy.py
+++ b/src/rosclaw/agentd/models/policy.py
@@ -48,6 +48,16 @@ class ModelPolicy:
     def default(self) -> ModelProfile:
         return self._profiles[self._default]
 
+    def fallback_chain(
+        self, *, required: tuple[str, ...] = (CAP_STRUCTURED,)
+    ) -> list[ModelProfile]:
+        """Ordered failover candidates: default first, then other capable
+        profiles (stable name order). Cooldown/RPM gating happens in
+        FailoverGateway; this is just the static order."""
+        capable = [p for p in self._profiles.values() if set(required) <= set(p.capabilities)]
+        capable.sort(key=lambda p: (p.name != self._default, p.name))
+        return capable
+
     def select(
         self,
         *,

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -172,8 +172,13 @@ class AgentService:
         if gateway is not None:
             self._gateway: ModelGateway = gateway
         else:
+            from rosclaw.agentd.models.failover import FailoverGateway
+
             policy = config.to_policy()
-            self._gateway = OpenAICompatGateway(policy.default)
+            chain = policy.fallback_chain()
+            candidates = [(p, OpenAICompatGateway(p)) for p in chain]
+            # 单 profile 也走 FailoverGateway：统一的 cooldown/RPM 语义。
+            self._gateway = FailoverGateway(candidates)
         self._prompt = load_prompt("native_agent_v1.md")
         self._loops: dict[str, AgentLoop] = {}
         self._lock = asyncio.Lock()

--- a/tests/agentd/test_failover_compact.py
+++ b/tests/agentd/test_failover_compact.py
@@ -1,0 +1,183 @@
+"""Failover chain + compaction tests (model-layer leftovers).
+
+- cooldown: 标准错误 1m→5m→25m 递增、成功复位、24h 清零、billing 长冷却
+- failover: 非重试错误立即抛、rate_limited 跳下一个候选、冷却中跳过、
+  末位等待、RPM 限流
+- microcompact: 旧 tool result 折叠、中段裁剪保留锚点
+- reactive compact: context-overflow 错误 → 压缩重试成功
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.agentd.context.compact import (
+    is_context_overflow,
+    microcompact,
+)
+from rosclaw.agentd.models.failover import (
+    CooldownTracker,
+    FailoverGateway,
+    TokenBucket,
+)
+from rosclaw.agentd.models.gateway import MockModelGateway, ModelGatewayError
+from rosclaw.agentd.models.profiles import mock_profile
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+
+
+def _turn() -> ModelTurnResultV1:
+    return ModelTurnResultV1(
+        turn_id="t",
+        provider="mock",
+        model="m",
+        content="ok",
+        assistant_message={"role": "assistant", "content": "ok"},
+    )
+
+
+class TestCooldown:
+    def test_escalating_cooldown(self) -> None:
+        now = [0.0]
+        tracker = CooldownTracker(now=lambda: now[0])
+        tracker.record_failure("k")
+        assert tracker.in_cooldown("k")
+        now[0] = 59.0
+        assert tracker.in_cooldown("k")  # 1min first cooldown
+        now[0] = 61.0
+        assert not tracker.in_cooldown("k")
+        tracker.record_failure("k")
+        now[0] = 61.0 + 4 * 60
+        assert tracker.in_cooldown("k")  # 5min second cooldown
+        now[0] = 61.0 + 6 * 60
+        assert not tracker.in_cooldown("k")
+
+    def test_success_resets(self) -> None:
+        tracker = CooldownTracker()
+        tracker.record_failure("k")
+        tracker.record_success("k")
+        assert not tracker.in_cooldown("k")
+
+    def test_billing_long_cooldown(self) -> None:
+        now = [0.0]
+        tracker = CooldownTracker(now=lambda: now[0])
+        tracker.record_failure("k", billing=True)
+        now[0] = 3600.0
+        assert tracker.in_cooldown("k")  # billing: 5h first
+
+    def test_24h_auto_clear(self) -> None:
+        now = [0.0]
+        tracker = CooldownTracker(now=lambda: now[0])
+        tracker.record_failure("k")
+        now[0] = 25 * 3600.0
+        assert not tracker.in_cooldown("k")
+
+
+class TestFailover:
+    async def test_rate_limit_falls_to_next(self) -> None:
+        def fail(request):
+            raise ModelGatewayError("rate_limited", "429")
+
+        bad = MockModelGateway(mock_profile(name="bad", model="bad-model"), [fail])
+        good = MockModelGateway(mock_profile(name="good", model="good-model"), [_turn()])
+        gateway = FailoverGateway(
+            [(bad.profile, bad), (good.profile, good)],
+            now=__import__("time").monotonic,
+        )
+        from rosclaw.agentd.models.gateway import ModelTurnRequest
+
+        result = await gateway.complete(ModelTurnRequest(system_prompt="s", messages=[]))
+        assert result.content == "ok"
+        assert len(good.requests) == 1
+
+    async def test_non_retryable_raises_immediately(self) -> None:
+        def fail(request):
+            raise ModelGatewayError("auth_error", "401")
+
+        bad = MockModelGateway(mock_profile(name="bad", model="bad-model"), [fail])
+        good = MockModelGateway(mock_profile(name="good", model="good-model"), [_turn()])
+        gateway = FailoverGateway([(bad.profile, bad), (good.profile, good)])
+        from rosclaw.agentd.models.gateway import ModelTurnRequest
+
+        with pytest.raises(ModelGatewayError, match="auth_error"):
+            await gateway.complete(ModelTurnRequest(system_prompt="s", messages=[]))
+        assert len(good.requests) == 0  # 不重试也不轮换
+
+    async def test_cooldown_skips_candidate(self) -> None:
+        calls = []
+
+        def fail(request):
+            calls.append("fail")
+            raise ModelGatewayError("timeout", "slow")
+
+        bad = MockModelGateway(mock_profile(name="bad", model="bad-model"), [fail, fail, _turn()])
+        good = MockModelGateway(mock_profile(name="good", model="good-model"), [_turn(), _turn()])
+        gateway = FailoverGateway([(bad.profile, bad), (good.profile, good)])
+        from rosclaw.agentd.models.gateway import ModelTurnRequest
+
+        await gateway.complete(ModelTurnRequest(system_prompt="s", messages=[]))
+        # bad 已进入冷却，第二次直接跳过 bad 走 good。
+        await gateway.complete(ModelTurnRequest(system_prompt="s", messages=[]))
+        assert calls == ["fail"]
+        assert len(good.requests) == 2
+
+    def test_token_bucket(self) -> None:
+        bucket = TokenBucket(2)
+        assert bucket.take(now=0.0)
+        assert bucket.take(now=0.0)
+        assert not bucket.take(now=0.0)
+        assert bucket.take(now=31.0)  # 半分钟后补 1 个
+
+
+class TestCompaction:
+    def test_microcompact_folds_old_tool_results(self) -> None:
+        messages = [{"role": "user", "content": "开始"}]
+        for i in range(10):
+            messages.append({"role": "assistant", "content": None})
+            messages.append({"role": "tool", "tool_call_id": f"c{i}", "content": "X" * 500})
+        compacted, folded = microcompact(messages, keep_recent=4)
+        assert folded == 8
+        tool_contents = [m["content"] for m in compacted if m.get("role") == "tool"]
+        assert tool_contents[-1] == "X" * 500  # 最近的不动
+        assert "compacted" in tool_contents[0]
+
+    def test_trim_keeps_first_user_anchor(self) -> None:
+        messages = [{"role": "user", "content": "锚点"}] + [
+            {"role": "user", "content": f"m{i}"} for i in range(80)
+        ]
+        compacted, _ = microcompact(messages, max_messages=50)
+        assert compacted[0]["content"] == "锚点"
+        assert len(compacted) == 50
+
+    def test_overflow_detection(self) -> None:
+        assert is_context_overflow("http_error", "HTTP 400: prompt is too long")
+        assert is_context_overflow("invalid_response", "context_length_exceeded")
+        assert not is_context_overflow("rate_limited", "429")
+        assert not is_context_overflow("http_error", "HTTP 500 internal")
+
+
+class TestReactiveCompaction:
+    async def test_overflow_compact_and_retry(self) -> None:
+        from rosclaw.agentd.context.compact import microcompact as mc
+        from rosclaw.agentd.models.gateway import ModelTurnRequest
+
+        calls = []
+
+        def overflow_once(request):
+            calls.append(len(request.messages))
+            if len(calls) == 1:
+                raise ModelGatewayError("http_error", "HTTP 400: prompt too long")
+            return _turn()
+
+        gateway = MockModelGateway(mock_profile(), [overflow_once, overflow_once])
+        messages = [{"role": "user", "content": "锚点"}] + [
+            {"role": "tool", "tool_call_id": f"c{i}", "content": "Y" * 300} for i in range(20)
+        ]
+        request = ModelTurnRequest(system_prompt="s", messages=messages)
+        try:
+            await gateway.complete(request)
+            raise AssertionError("should have raised")
+        except ModelGatewayError as exc:
+            assert is_context_overflow(exc.kind, str(exc))
+            compacted, _ = mc(messages, keep_recent=4)
+            result = await gateway.complete(ModelTurnRequest(system_prompt="s", messages=compacted))
+            assert result.content == "ok"


### PR DESCRIPTION
## 概述

模型层遗留补齐（picoclaw cooldown.go/fallback.go、openharness 两级压缩、zeroclaw trim_history 的移植）。

### 内容

- `agentd/models/failover.py`：
  - CooldownTracker——1m/5m/25m 递增冷却、billing 长冷却（5h×2ⁿ 封顶 24h）、成功复位、24h 无失败清零、冷却键用配置身份
  - FailoverGateway——有序候选链；NON_RETRYABLE（format/auth/context_overflow/credential）立即抛；rate_limited/timeout/unavailable 跳下一候选；每候选 RPM 令牌桶（非末位饱和即跳、末位等待）
- `ModelPolicy.fallback_chain`：default 优先的有序候选
- service 所有 profile（含单 profile）统一走 FailoverGateway
- `agentd/context/compact.py`：microcompact（折叠旧 tool result + 保留首 user 锚点与最近 N 条）+ context-overflow 检测；AgentLoop：80% 输入预算主动压缩、overflow 错误反应式压缩+单次重试

### 验证

- 新增 12 项测试（冷却递增/复位/24h/billing、failover 三态、RPM 桶、microcompact 折叠/锚点、overflow 检测、反应式重试）
- agentd 182 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)