### PR TITLE
fix(robot-pack): preserve failed navigation evidence

### DIFF
--- a/src/rosclaw/robot_pack/runtime_loader.py
+++ b/src/rosclaw/robot_pack/runtime_loader.py
@@ -624,10 +624,7 @@ class _LimoFixedWorkerExecutor:
             )
         verification_error = self._validate_result(action, result)
         if verification_error is not None:
-            return _failed_result(
-                f"LIMO_{self.operation}_VERIFICATION_FAILED",
-                verification_error,
-            )
+            return self._verification_failure_result(action, result, verification_error)
         return self._success_result(action, result)
 
     def _validate_action(
@@ -680,6 +677,18 @@ class _LimoFixedWorkerExecutor:
         self, action: ActionEnvelope, result: dict[str, Any]
     ) -> ActionExecutionResult:
         raise NotImplementedError
+
+    def _verification_failure_result(
+        self,
+        action: ActionEnvelope,
+        result: dict[str, Any],
+        verification_error: str,
+    ) -> ActionExecutionResult:
+        del action, result
+        return _failed_result(
+            f"LIMO_{self.operation}_VERIFICATION_FAILED",
+            verification_error,
+        )
 
 
 class LimoNavigationExecutor(_LimoFixedWorkerExecutor):
@@ -919,6 +928,88 @@ class LimoNavigationExecutor(_LimoFixedWorkerExecutor):
                 "odom_translation_m": motion["odom_translation_m"],
                 "odom_rotation_rad": motion["odom_rotation_rad"],
             },
+        )
+
+    def _verification_failure_result(
+        self,
+        action: ActionEnvelope,
+        result: dict[str, Any],
+        verification_error: str,
+    ) -> ActionExecutionResult:
+        # A task-level verification failure does not erase a valid worker ACK.
+        # Preserve the fact that move_base accepted and completed the hardware
+        # dispatch, while still failing closed on the requested task predicate.
+        if (
+            result.get("protocol") != "rosclaw.limo.worker.v1"
+            or result.get("action_id") != action.action_id
+            or result.get("operation") != "NAVIGATE_TO_POSE"
+            or result.get("action_server") != "/move_base"
+            or result.get("accepted") is not True
+            or not isinstance(result.get("terminal_state"), int)
+            or isinstance(result.get("terminal_state"), bool)
+            or not isinstance(result.get("dispatched_wall_time"), (int, float))
+            or isinstance(result.get("dispatched_wall_time"), bool)
+        ):
+            return super()._verification_failure_result(action, result, verification_error)
+
+        motion = result.get("motion_evidence")
+        motion = motion if isinstance(motion, dict) else {}
+        observation = {
+            "kind": "navigation_verification_failed",
+            "target_pose": action.arguments["target_pose"],
+            "observed_final_pose": result.get("observed_final_pose"),
+            "preflight": result.get("preflight"),
+            "stopped_odometry": result.get("stopped_odometry"),
+            "map_to_base_after": result.get("map_to_base_after"),
+            "motion_evidence": motion,
+            "completed_wall_time": result.get("completed_wall_time"),
+        }
+        return ActionExecutionResult(
+            final_state=ActionState.FAILED,
+            evidence_level=EvidenceLevel.DRIVER_CONFIRMED,
+            policy_decision={
+                "allowed": True,
+                "policy": self.policy_name,
+                "reason": "bounded navigation dispatch was allowed; task verification failed",
+            },
+            authorization_decision={
+                "authorized": action.authorization.approved,
+                "approval_id": action.authorization.approval_id,
+            },
+            dispatch_result={
+                "accepted": True,
+                "adapter": self.instance.adapter.component_id,
+                "operation": "NAVIGATE_TO_POSE",
+                "action_server": "/move_base",
+                "terminal_state": result["terminal_state"],
+                "terminal_text": result.get("terminal_text"),
+                "movement_expected": motion.get("movement_expected"),
+                "motion_observed": motion.get("motion_observed"),
+            },
+            driver_ack={
+                "acknowledged": True,
+                "dispatched_wall_time": result["dispatched_wall_time"],
+            },
+            observations=[observation],
+            verification_result={
+                "success": False,
+                "predicate": verification_error,
+                "position_error_m": result.get("position_error_m"),
+                "yaw_error_rad": result.get("yaw_error_rad"),
+                "movement_expected": motion.get("movement_expected"),
+                "motion_observed": motion.get("motion_observed"),
+                "physical_motion_independently_observed": motion.get(
+                    "physical_motion_independently_observed"
+                ),
+                "odom_translation_m": motion.get("odom_translation_m"),
+                "odom_rotation_rad": motion.get("odom_rotation_rad"),
+            },
+            errors=[
+                {
+                    "code": "LIMO_NAVIGATION_VERIFICATION_FAILED",
+                    "message": verification_error,
+                }
+            ],
         )
 
 

--- a/tests/robot_pack/test_runtime_loader.py
+++ b/tests/robot_pack/test_runtime_loader.py
@@ -410,6 +410,47 @@ def test_limo_navigation_executor_rejects_success_without_expected_motion(
     assert result.final_state is ActionState.FAILED
     assert result.errors[0]["code"] == "LIMO_NAVIGATION_VERIFICATION_FAILED"
     assert "movement was not observed" in result.errors[0]["message"]
+    assert result.evidence_level is EvidenceLevel.DRIVER_CONFIRMED
+    assert result.dispatch_result["accepted"] is True
+    assert result.driver_ack["acknowledged"] is True
+    assert result.verification_result["success"] is False
+    assert result.observations[0]["motion_evidence"]["movement_expected"] is True
+
+
+def test_limo_navigation_executor_preserves_dispatch_when_pose_misses_tolerance(
+    tmp_path, monkeypatch
+) -> None:
+    instance, source = _limo_instance(tmp_path)
+    action = _limo_navigation_action(instance)
+    payload = _limo_navigation_worker_payload(action)
+    payload["yaw_error_rad"] = 0.08
+    action.arguments["goal_tolerance"]["yaw_rad"] = 0.05
+    monkeypatch.setattr(
+        "rosclaw.robot_pack.runtime_loader.subprocess.run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0, stdout=__import__("json").dumps(payload), stderr=""
+        ),
+    )
+
+    result = LimoNavigationExecutor(instance, adapter_source=source)(action)
+
+    assert result.final_state is ActionState.FAILED
+    assert result.evidence_level is EvidenceLevel.DRIVER_CONFIRMED
+    assert result.dispatch_result == {
+        "accepted": True,
+        "adapter": instance.adapter.component_id,
+        "operation": "NAVIGATE_TO_POSE",
+        "action_server": "/move_base",
+        "terminal_state": 3,
+        "terminal_text": "Goal reached.",
+        "movement_expected": True,
+        "motion_observed": True,
+    }
+    assert result.driver_ack == {"acknowledged": True, "dispatched_wall_time": 10.0}
+    assert result.observations[0]["kind"] == "navigation_verification_failed"
+    assert result.verification_result["success"] is False
+    assert result.verification_result["yaw_error_rad"] == 0.08
+    assert result.errors[0]["code"] == "LIMO_NAVIGATION_VERIFICATION_FAILED"
 
 
 def test_limo_navigation_executor_reports_goal_already_satisfied(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## What changed

- preserve a valid move_base dispatch acknowledgement when task-level navigation verification fails
- retain final pose, stop state, preflight, and odometry motion observations
- report DRIVER_CONFIRMED evidence instead of incorrectly claiming the command was never accepted
- keep malformed worker acknowledgements fail-closed

## Why

A real LIMO yaw goal reached move_base SUCCEEDED and physically moved the base, but missed a deliberately tight final tolerance. The receipt incorrectly collapsed that result to accepted=false and discarded the useful hardware evidence.

## Validation

- 43 focused Robot Pack and MCP boundary tests passed
- Ruff passed
- mypy passed
- new regression test covers a goal that dispatches and moves but misses requested yaw tolerance