### PR TITLE
seekdb: mark pyseekdb 1.4.0.post1 validated (upstream #251 fix verified)

### DIFF
--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -411,12 +411,13 @@ def _pyseekdb_compat_checks(
     """
     # (status, note) per SDK version range; keep in sync with pyproject pin.
     matrix = {
-        "validated": ["1.3.0"],
+        "validated": ["1.3.0", "1.4.0.post1"],
         "known_incompatible": {
             "1.4.0": "metadata-filtered search legs broken on embedded engine "
             "(code=1064 __pk_increment, malformed FULL JOIN, code=1059 "
             "identifier-too-long; unfiltered calls unaffected); "
-            "upstream: oceanbase/pyseekdb#251; use pyseekdb==1.3.0",
+            "upstream: oceanbase/pyseekdb#251; "
+            "fixed in 1.4.0.post1 — upgrade or use pyseekdb==1.3.0",
         },
     }
     try:

--- a/src/rosclaw/storage/seekdb_native.py
+++ b/src/rosclaw/storage/seekdb_native.py
@@ -104,13 +104,14 @@ def _warn_on_unvalidated_pyseekdb(pyseekdb: Any) -> None:
             return
     except Exception:  # noqa: BLE001
         return
-    validated = {"1.3.0"}
+    validated = {"1.3.0", "1.4.0.post1"}
     known_incompatible = {"1.4.0"}
     if installed in known_incompatible:
         logger.error(
             "pyseekdb %s is KNOWN-INCOMPATIBLE with the embedded SeekDB engine "
-            "(broken SQL generation: __pk_increment syntax errors, empty "
-            "hybrid results). Downgrade: pip install pyseekdb==1.3.0",
+            "(broken SQL generation on metadata-filtered search legs; "
+            "oceanbase/pyseekdb#251). Upgrade to 1.4.0.post1 or pin 1.3.0: "
+            "pip install 'pyseekdb==1.4.0.post1'",
             installed,
         )
     elif installed not in validated:

--- a/validation/ty1200/configs/seekdb/requirements-lock.txt
+++ b/validation/ty1200/configs/seekdb/requirements-lock.txt
@@ -7,6 +7,8 @@
 #       本文件锁定完整引擎组合 (SDK + 引擎绑定 + 推理依赖)。
 
 pyseekdb==1.3.0          # SDK client (pyproject seekdb extra pin)
+# 备选: pyseekdb==1.4.0.post1（#251 修复版，2026-08-03 全组合验收通过；
+#       1.4.0（无 post1）为 known-incompatible，禁止使用）
 pylibseekdb==1.3.0.post3 # 引擎原生绑定
 seekdb==0.0.1.dev5       # 嵌入式引擎包 (PyPI 当前唯一发布形态)
 seekdb-lib==0.0.1.dev5   # 引擎原生库


### PR DESCRIPTION
## What

Mark pyseekdb 1.4.0.post1 as validated in the compat matrix — the upstream
fix for oceanbase/pyseekdb#251, verified on TY1200.

## Verification (first-hand, sandbox venvs)

| SDK | Engine | T1 | T2 | T4 | control |
|---|---|---|---|---|---|
| 1.4.0 | pylibseekdb 1.3.0.post3 | 1064 | FULL JOIN | 1059 | OK |
| **1.4.0.post1** | pylibseekdb 1.3.0.post3 | **OK** | **OK** | **OK** | OK |
| **1.4.0.post1** | pylibseekdb 1.3.0 | **OK** | **OK** | **OK** | OK |

Plus rosclaw storage acceptance (the suite that originally failed on 1.4.0):
`test_seekdb_native_pr_mem3.py` + `test_versioned_collections.py`
**22/22 passed on 1.4.0.post1**.

## Changes

- `storage/cli.py`: matrix `validated` gains `1.4.0.post1`; the `1.4.0`
  known-incompatible entry now points at the fix.
- `storage/seekdb_native.py`: startup warning matrix updated; the
  incompatible-version message now recommends upgrading to 1.4.0.post1.
- `validation/ty1200/configs/seekdb/requirements-lock.txt`: documents
  1.4.0.post1 as the verified-fix alternative (1.4.0 without post1 remains
  forbidden).

Confirmed with upstream: https://github.com/oceanbase/pyseekdb/issues/251#issuecomment-5164987301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
