### PR TITLE
Tool/Capability Catalog (PR-05 per Pi TUI/Provider outline §7)

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -64,6 +64,7 @@ Pack/执行器缺失时均停止推进。REAL Mission 还要求显式的
 | `rosclaw.agentd.models` | ModelPolicy/Gateway：Kimi K3 等 OpenAI 兼容端点，严格工具 schema，流式聚合 |
 | `rosclaw.agentd.decisions` | DecisionValidator：DecisionV1 绑定当前 context revision |
 | `rosclaw.agentd.loop` | AgentLoop：显式状态机、工具循环、预算、崩溃恢复、决策块流式过滤 |
+| `rosclaw.agentd.tooling` | Tool/Capability Catalog（PR-05）：ToolDescriptorV2、ToolResolver 硬过滤+排序、MCP adapter、证据封装 |
 | `rosclaw.agentd.service` | AgentService + FastAPI 本地 API（含 SSE 流式 turn）+ 最小 Console |
 | `rosclaw.agentd.usage` | model_usage 持久化计量（每轮一行，聚合由查询计算） |
 
@@ -182,6 +183,35 @@ live 模型协调。3v3 联赛基准（T-SIM-2/3）属 PR-TF-075 后续范围。
   measured/verified_receipt/curated 事实形成 Memory/Know/How/Auto 候选，
   unverified/inferred 显式拒绝并记录；Darwin 晋升门 = 评测引用 + 人类
   principal，任何代码路径不能自动晋升。
+
+## Tool/Capability Catalog（PR-05）
+
+- **ToolDescriptorV2**（`rosclaw.tool_descriptor.v2`）在契约层强制：
+  `PHYSICAL_ACTION` 永远 `model_callable=false` 且必须声明
+  `requires_exact_action_grant=true`；OBSERVE 不得有副作用。违规构造直接
+  ValidationError（fail closed）。
+- **ToolResolver**：先确定性硬过滤（body 兼容 / mode / capability 在线 /
+  SelfSnapshot 新鲜 / permission / policy / 预算 / verifier / quarantine /
+  model_callable，全部可解释），再做相关性排序（语义、延迟、可靠性、
+  成本、新鲜度、证据等级）。安全条件永不进入模型评分；每轮注入 ≤12 个工具。
+- **MCP adapter**：`mcp_servers:` 配置的外部 MCP server（如 limo-ros-mcp）
+  经 stdio 发现工具；分类 fail-closed——`readOnlyHint` 且无动作动词 →
+  OBSERVE；动作动词 / destructive / 无注解歧义 → PHYSICAL_ACTION。
+  发现失败 → 整个 source 隔离（quarantine），聊天不中断、观测不伪造。
+- **证据封装**：每次观测产出 EvidenceEnvelope（timestamp/body/source/
+  evidence_class/freshness/artifact_ref），内容以 `<untrusted_input>` 包裹；
+  大输出落盘 artifact store（content-addressed），模型只见 ref+摘要。
+- 配置示例：
+
+```yaml
+mcp_servers:
+  - name: limo-ros-mcp
+    command: /usr/local/bin/limo-ros-mcp
+    args: ["--profile", "sim"]
+    env_refs: ["LIMO_MCP_TOKEN"]   # 只引用环境变量名，值不入文件
+    supported_modes: ["SIMULATION", "SHADOW"]
+    required_body_types: ["agilex-limo"]
+```
 
 ## 审计修复记录（对照总纲逐项审计后）
 

--- a/src/rosclaw/agentd/config.py
+++ b/src/rosclaw/agentd/config.py
@@ -32,6 +32,7 @@ class AgentConfig:
     body_id: str | None = None
     sim_body_id: str = "sim/ur5e"
     profiles: list[ModelProfile] = field(default_factory=list)
+    mcp_servers: list[dict[str, Any]] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -93,6 +94,7 @@ def load_agent_config(path: Path | None = None) -> AgentConfig:
         body_id=(str(agent["body_id"]) if agent.get("body_id") else None),
         sim_body_id=str(agent.get("sim_body_id", "sim/ur5e")),
         profiles=profiles,
+        mcp_servers=[dict(s or {}) for s in (data.get("mcp_servers", []) or [])],
         raw={
             "agent": agent,
             "models": models,

--- a/src/rosclaw/agentd/loop.py
+++ b/src/rosclaw/agentd/loop.py
@@ -260,7 +260,17 @@ class AgentLoop:
         candidate_tools = bundle.layers.capabilities.candidate_tools or []
         tools: list[StrictTool] = []
         if self._tools is not None and candidate_tools:
-            tools = self._tools.strict_tools(candidate_tools)
+            # PR-05: when the registry is catalog-backed, injection goes
+            # through resolver hard filters + relevance ranking (≤12).
+            resolve = getattr(self._tools, "resolve_tools", None)
+            if resolve is not None:
+                tools = resolve(
+                    candidate_tools,
+                    mode=mission.mode.value,
+                    task_hint=mission.goal.text if mission.goal else "",
+                )
+            else:
+                tools = self._tools.strict_tools(candidate_tools)
         if self._decision_protocol == "tool_call":
             from rosclaw.agentd.decisions.submit_tool import submit_decision_tool
 
@@ -552,28 +562,40 @@ class AgentLoop:
             )
             return True
         arguments = payload.get("arguments") or {}
+        error: str | None = None
         try:
             output = await self._tools.execute(tool_name, arguments)
             ok = True
         except Exception as exc:  # noqa: BLE001 - surfaced as data
             output = json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False)
+            error = f"{type(exc).__name__}: {exc}"
             ok = False
-        # 证据封装：时间戳/body/来源/证据类/freshness/artifact ref。
+        # PR-05 证据封装：EvidenceEnvelope（时间戳/body/来源/证据类/freshness/
+        # artifact ref/UNTRUSTED 包裹）；legacy registry 回退到旧格式。
         import hashlib
-        from datetime import UTC, datetime
 
         digest = hashlib.sha256(output.encode()).hexdigest()[:24]
         artifact_ref = f"artifact://observation/sha256:{digest}"
-        evidence_note = (
-            f"[observation — evidence]\n"
-            f"tool: {tool_name}\n"
-            f"timestamp: {datetime.now(UTC).isoformat()}\n"
-            f"body_id: {bundle.body_binding.body_id}\n"
-            f"source: native_tool\n"
-            f"evidence_class: measured\n"
-            f"artifact_ref: {artifact_ref}\n"
-            f"result: {output[:2000]}"
-        )
+        make_envelope = getattr(self._tools, "evidence_envelope", None)
+        if make_envelope is not None:
+            envelope = make_envelope(
+                tool_name, output, body_id=bundle.body_binding.body_id, error=error
+            )
+            evidence_note = envelope.render_for_model()
+            artifact_ref = envelope.artifact_ref or artifact_ref
+        else:
+            from datetime import UTC, datetime
+
+            evidence_note = (
+                f"[observation — evidence]\n"
+                f"tool: {tool_name}\n"
+                f"timestamp: {datetime.now(UTC).isoformat()}\n"
+                f"body_id: {bundle.body_binding.body_id}\n"
+                f"source: native_tool\n"
+                f"evidence_class: measured\n"
+                f"artifact_ref: {artifact_ref}\n"
+                f"result: {output[:2000]}"
+            )
         self._conversation.append(
             {"role": "tool", "tool_call_id": f"obs_{digest}", "content": evidence_note}
         )

--- a/src/rosclaw/agentd/runtime_sources.py
+++ b/src/rosclaw/agentd/runtime_sources.py
@@ -157,6 +157,47 @@ class StaticCapabilitySource:
         ]
 
 
+class CatalogCapabilitySource:
+    """Capability layer backed by the PR-05 ToolCatalog (dynamic, honest).
+
+    PHYSICAL_ACTION tools appear with permission="operator_only" so the model
+    knows the capability exists but can never call it directly — it must go
+    through REQUEST_APPROVAL → Operator grant → REQUEST_ACTION.
+    """
+
+    def __init__(self, catalog) -> None:  # ToolCatalog (avoid import cycle)
+        self._catalog = catalog
+
+    def list_capabilities(self, query: str, limit: int) -> list[CapabilityInfo]:
+        from rosclaw.contracts.agent.tool import ExecutionClass
+
+        infos: list[CapabilityInfo] = []
+        for d in self._catalog.list()[: limit * 2]:
+            if d.execution_class is ExecutionClass.PHYSICAL_ACTION:
+                infos.append(
+                    CapabilityInfo(
+                        name=d.tool_id,
+                        kind="physical_action",
+                        summary=(
+                            f"{d.description or d.tool_id} [PHYSICAL ACTION — never "
+                            "directly callable; requires Operator exact-action grant]"
+                        ),
+                        permission="operator_only",
+                    )
+                )
+            else:
+                quarantined = self._catalog.quarantine_reason(d.tool_id) is not None
+                infos.append(
+                    CapabilityInfo(
+                        name=d.tool_id,
+                        kind="tool",
+                        summary=d.description or f"tool {d.tool_id}",
+                        permission="denied" if quarantined else "granted",
+                    )
+                )
+        return infos
+
+
 class EmptyMemorySource:
     def retrieve(self, query: str, limit: int) -> list[MemoryItem]:
         return []

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -27,15 +27,15 @@ from rosclaw.agentd.models.gateway import (
     OpenAICompatGateway,
 )
 from rosclaw.agentd.runtime_sources import (
+    CatalogCapabilitySource,
     ConfigConsentSource,
     DaemonSelfSource,
     EmptyMemorySource,
     ResolverBodySource,
     SimBodySource,
     SimSelfSource,
-    StaticCapabilitySource,
 )
-from rosclaw.agentd.tools import SIM_BODY_TOOL, SIM_STATE_TOOL, BuiltinToolRegistry
+from rosclaw.agentd.tools import BuiltinToolRegistry
 from rosclaw.agentd.usage import UsageRecorder
 from rosclaw.contracts.agent.mission import (
     BodyBinding,
@@ -155,9 +155,43 @@ class AgentService:
             body_id=self._body_id,
             body_summary=body.summary if body else "configured body is unavailable",
         )
-        tool_names = [SIM_BODY_TOOL]
-        if self._simulation_body:
-            tool_names.insert(0, SIM_STATE_TOOL)
+        # PR-05: Tool/Capability Catalog — descriptors, resolver, evidence.
+        from rosclaw.agentd.tooling.artifact_result import ArtifactResultStore
+        from rosclaw.agentd.tooling.catalog import ToolCatalog
+        from rosclaw.agentd.tooling.catalog_registry import CatalogToolRegistry
+        from rosclaw.agentd.tooling.mcp_adapter import McpCapabilityAdapter, McpServerConfig
+        from rosclaw.agentd.tooling.native_tools import register_native_tools
+        from rosclaw.agentd.tooling.resolver import ToolResolver
+
+        self._tool_catalog = ToolCatalog()
+        register_native_tools(self._tool_catalog, self._tools, simulation=self._simulation_body)
+        self._artifact_store = ArtifactResultStore(db_dir)
+        self._tool_resolver = ToolResolver(self._tool_catalog)
+        self._tool_registry = CatalogToolRegistry(
+            self._tool_catalog,
+            self._tool_resolver,
+            artifact_store=self._artifact_store,
+            body_type=self._body_id,
+        )
+        self._mcp_adapters = [
+            McpCapabilityAdapter(
+                McpServerConfig(
+                    name=str(s.get("name", "")),
+                    command=str(s.get("command", "")),
+                    args=tuple(str(a) for a in s.get("args", []) or []),
+                    env_refs=tuple(str(r) for r in s.get("env_refs", []) or []),
+                    observation_tools=tuple(s.get("observation_tools", []) or ()),
+                    action_tools=tuple(s.get("action_tools", []) or ()),
+                    supported_modes=tuple(s.get("supported_modes", ("SIMULATION",)) or ()),
+                    required_body_types=tuple(s.get("required_body_types", []) or ()),
+                    timeout_ms=int(s.get("timeout_ms", 5000)),
+                ),
+                self._tool_catalog,
+            )
+            for s in self._config.mcp_servers
+            if s.get("name") and s.get("command")
+        ]
+        self._mcp_discovered = False
         consent_source = ConfigConsentSource()
         from rosclaw.operator import OperatorBroker
 
@@ -169,7 +203,7 @@ class AgentService:
                 constitution_text=load_prompt("native_agent_v1.md").text,
                 body=self._body_source,
                 self_source=self_source,
-                capabilities=StaticCapabilitySource(tool_names),
+                capabilities=CatalogCapabilitySource(self._tool_catalog),
                 memory=EmptyMemorySource(),
                 organization=RegistryOrgSource(self._registry),
                 consent=BrokerConsentSource(consent_source, self._store.connection),
@@ -321,7 +355,7 @@ class AgentService:
                 compiler=self._compiler,
                 gateway=self._gateway,
                 prompt=self._prompt,
-                tools=self._tools,
+                tools=self._tool_registry,
                 handlers=self._handlers,
                 actor_id=self.actor_id,
                 max_tool_rounds=self._config.max_tool_rounds,
@@ -439,6 +473,7 @@ class AgentService:
         mission = self._store.get_mission(mission_id)
         if mission is None:
             raise ValidationError(f"unknown mission {mission_id!r}")
+        await self._ensure_mcp_discovered()
         async with self._runner.lock_for(mission_id):
             if self._handlers is not None:
                 self._handlers._mode = mission.mode.value
@@ -450,6 +485,26 @@ class AgentService:
 
     def mission_usage(self, mission_id: str) -> dict:
         return self._usage.mission_totals(mission_id)
+
+    async def _ensure_mcp_discovered(self) -> None:
+        """Discover configured MCP servers once (PR-05); failures quarantine
+        the source honestly and never block the turn."""
+        if self._mcp_discovered:
+            return
+        self._mcp_discovered = True
+        for adapter in self._mcp_adapters:
+            try:
+                await adapter.discover()
+            except Exception:  # noqa: BLE001 - discovery must never break chat
+                self._tool_catalog.quarantine_source(adapter.source, "discovery_crashed")
+
+    @property
+    def tool_catalog(self):
+        return self._tool_catalog
+
+    @property
+    def tool_resolver(self):
+        return self._tool_resolver
 
     def conversation(self, mission_id: str) -> list[dict]:
         return self._store.conversation(mission_id)

--- a/src/rosclaw/agentd/tooling/__init__.py
+++ b/src/rosclaw/agentd/tooling/__init__.py
@@ -1,0 +1,23 @@
+"""Tool/Capability Catalog (PR-05, 大纲 §7).
+
+The catalog is the single seam between "capabilities that exist" and "tools
+the model may see". Deterministic hard filters (safety) run before any
+relevance ranking, and safety conditions never enter the model-facing score.
+"""
+
+from rosclaw.agentd.tooling.catalog import ToolCatalog
+from rosclaw.agentd.tooling.evidence import EvidenceEnvelope, wrap_observation
+from rosclaw.agentd.tooling.resolver import (
+    MAX_INJECTED_TOOLS,
+    FilterContext,
+    ToolResolver,
+)
+
+__all__ = [
+    "EvidenceEnvelope",
+    "FilterContext",
+    "MAX_INJECTED_TOOLS",
+    "ToolCatalog",
+    "ToolResolver",
+    "wrap_observation",
+]

--- a/src/rosclaw/agentd/tooling/artifact_result.py
+++ b/src/rosclaw/agentd/tooling/artifact_result.py
@@ -1,0 +1,35 @@
+"""Artifact result store (PR-05, 大纲 §7.5).
+
+Oversized tool outputs (ROS bags, images-as-metadata, long telemetry) are
+spilled to content-addressed files under the agentd home; the model only
+ever sees the ref + digest + head excerpt. Nothing is silently truncated.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+class ArtifactResultStore:
+    def __init__(self, root: Path) -> None:
+        self._root = root / "artifacts" / "observations"
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def put(self, content: str, *, prefix: str = "observation") -> str:
+        digest = hashlib.sha256(content.encode()).hexdigest()
+        path = self._root / f"{prefix}-{digest}.txt"
+        if not path.exists():
+            path.write_text(content, encoding="utf-8")
+        return f"artifact://{prefix}/sha256:{digest}"
+
+    def resolve(self, ref: str) -> str | None:
+        """Read back a stored artifact by ref; None if unknown (fail closed)."""
+        if not ref.startswith("artifact://") or "/sha256:" not in ref:
+            return None
+        prefix = ref[len("artifact://") :].split("/sha256:", 1)[0]
+        digest = ref.rsplit("/sha256:", 1)[1]
+        path = self._root / f"{prefix}-{digest}.txt"
+        if not path.exists():
+            return None
+        return path.read_text(encoding="utf-8")

--- a/src/rosclaw/agentd/tooling/catalog.py
+++ b/src/rosclaw/agentd/tooling/catalog.py
@@ -1,0 +1,106 @@
+"""Tool catalog — registration, quarantine, and guarded execution (PR-05).
+
+The catalog holds ToolDescriptorV2 entries plus the executor for each tool.
+Execution is guarded: PHYSICAL_ACTION tools raise immediately (they can only
+ever flow through the Operator grant path), and quarantined tools fail
+honestly instead of fabricating a result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from rosclaw.contracts.agent.tool import ExecutionClass, ToolDescriptorV2
+from rosclaw.contracts.common import ValidationError
+
+ToolExecutor = Callable[[dict[str, Any]], Awaitable[str]]
+
+
+class ToolNotCallableError(ValidationError):
+    """Raised when code tries to execute a tool the model must never call."""
+
+
+class ToolQuarantinedError(ValidationError):
+    """Raised when a tool/source is quarantined (health check failed)."""
+
+
+class ToolCatalog:
+    def __init__(self) -> None:
+        self._descriptors: dict[str, ToolDescriptorV2] = {}
+        self._executors: dict[str, ToolExecutor] = {}
+        self._quarantine: dict[str, str] = {}  # tool_id -> reason
+
+    def register(self, descriptor: ToolDescriptorV2, executor: ToolExecutor | None = None) -> None:
+        if descriptor.tool_id in self._descriptors:
+            raise ValidationError(f"tool {descriptor.tool_id!r} already registered")
+        self._descriptors[descriptor.tool_id] = descriptor
+        if executor is not None:
+            self._executors[descriptor.tool_id] = executor
+
+    def replace(self, descriptor: ToolDescriptorV2, executor: ToolExecutor | None = None) -> None:
+        """Idempotent re-registration (e.g. MCP reconnect re-discovery)."""
+        self._descriptors[descriptor.tool_id] = descriptor
+        if executor is not None:
+            self._executors[descriptor.tool_id] = executor
+
+    def get(self, tool_id: str) -> ToolDescriptorV2 | None:
+        return self._descriptors.get(tool_id)
+
+    def list(self, *, source: str | None = None) -> list[ToolDescriptorV2]:
+        items = sorted(self._descriptors.values(), key=lambda d: d.tool_id)
+        if source is not None:
+            items = [d for d in items if d.source == source]
+        return items
+
+    # -- quarantine -----------------------------------------------------------
+
+    def quarantine_tool(self, tool_id: str, reason: str) -> None:
+        self._quarantine[tool_id] = reason
+
+    def quarantine_source(self, source: str, reason: str) -> int:
+        count = 0
+        for d in self._descriptors.values():
+            if d.source == source:
+                self._quarantine[d.tool_id] = reason
+                count += 1
+        return count
+
+    def lift_quarantine(self, tool_id: str) -> None:
+        self._quarantine.pop(tool_id, None)
+
+    def lift_source_quarantine(self, source: str) -> int:
+        doomed = [tid for tid, d in self._descriptors.items() if d.source == source]
+        count = 0
+        for tid in doomed:
+            if tid in self._quarantine:
+                del self._quarantine[tid]
+                count += 1
+        return count
+
+    def quarantine_reason(self, tool_id: str) -> str | None:
+        return self._quarantine.get(tool_id)
+
+    # -- execution --------------------------------------------------------------
+
+    async def execute(self, tool_id: str, arguments: dict[str, Any]) -> str:
+        descriptor = self._descriptors.get(tool_id)
+        if descriptor is None:
+            raise ValidationError(f"tool {tool_id!r} not in catalog")
+        if descriptor.execution_class is ExecutionClass.PHYSICAL_ACTION:
+            raise ToolNotCallableError(
+                f"tool {tool_id!r} is PHYSICAL_ACTION — never directly executable; "
+                "it flows only through REQUEST_APPROVAL → Operator grant → rosclawd"
+            )
+        if not descriptor.model_callable:
+            raise ToolNotCallableError(f"tool {tool_id!r} is not model_callable")
+        reason = self._quarantine.get(tool_id)
+        if reason is not None:
+            raise ToolQuarantinedError(f"tool {tool_id!r} quarantined: {reason}")
+        executor = self._executors.get(tool_id)
+        if executor is None:
+            raise ValidationError(f"tool {tool_id!r} has no executor (source offline?)")
+        return await asyncio.wait_for(
+            executor(arguments), timeout=descriptor.timeout_ms / 1000.0
+        )

--- a/src/rosclaw/agentd/tooling/catalog_registry.py
+++ b/src/rosclaw/agentd/tooling/catalog_registry.py
@@ -1,0 +1,126 @@
+"""Catalog-backed ToolRegistry — the seam between the catalog and AgentLoop.
+
+Implements the loop's ``ToolRegistry`` protocol (``strict_tools`` /
+``execute``) and adds two PR-05 capabilities the loop prefers when present:
+
+* ``resolve_tools(...)`` — resolver hard filters + ranking before injection;
+* ``evidence_envelope(...)`` — the PR-05 evidence wrapper for observations.
+
+PHYSICAL_ACTION tools are structurally unable to leak through either path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rosclaw.agentd.models.gateway import StrictTool
+from rosclaw.agentd.tooling.artifact_result import ArtifactResultStore
+from rosclaw.agentd.tooling.catalog import ToolCatalog
+from rosclaw.agentd.tooling.evidence import EvidenceEnvelope, wrap_observation
+from rosclaw.agentd.tooling.resolver import FilterContext, ToolResolver
+from rosclaw.agentd.tooling.strict_schema import to_strict_tool
+from rosclaw.contracts.common import ValidationError
+
+
+class CatalogToolRegistry:
+    def __init__(
+        self,
+        catalog: ToolCatalog,
+        resolver: ToolResolver,
+        *,
+        artifact_store: ArtifactResultStore | None = None,
+        body_type: str = "",
+        online_capabilities: frozenset[str] = frozenset(),
+        granted_permissions: frozenset[str] = frozenset(),
+        policy_denied_tools: frozenset[str] = frozenset(),
+        self_snapshot_fresh: bool = True,
+    ) -> None:
+        self._catalog = catalog
+        self._resolver = resolver
+        self._artifact_store = artifact_store
+        self._body_type = body_type
+        self._online_capabilities = online_capabilities
+        self._granted_permissions = granted_permissions
+        self._policy_denied = policy_denied_tools
+        self._self_snapshot_fresh = self_snapshot_fresh
+
+    # -- loop ToolRegistry protocol ----------------------------------------------
+
+    def strict_tools(self, names: list[str]) -> list[StrictTool]:
+        """Legacy path: allowlist intersection only (no ranking)."""
+        tools: list[StrictTool] = []
+        for name in names:
+            descriptor = self._catalog.get(name)
+            if descriptor is None or not descriptor.model_callable:
+                continue
+            if self._catalog.quarantine_reason(name) is not None:
+                continue
+            tools.append(to_strict_tool(descriptor))
+        return tools
+
+    async def execute(self, name: str, arguments: dict[str, Any]) -> str:
+        return await self._catalog.execute(name, arguments)
+
+    # -- PR-05 extensions ---------------------------------------------------------
+
+    def resolve_tools(
+        self,
+        candidates: list[str],
+        *,
+        mode: str = "SIMULATION",
+        budget_exceeded: bool = False,
+        task_hint: str = "",
+    ) -> list[StrictTool]:
+        ctx = FilterContext(
+            body_type=self._body_type,
+            mode=mode,
+            online_capabilities=self._online_capabilities,
+            self_snapshot_fresh=self._self_snapshot_fresh,
+            granted_permissions=self._granted_permissions,
+            policy_denied_tools=self._policy_denied,
+            budget_exceeded=budget_exceeded,
+            task_hint=task_hint,
+        )
+        result = self._resolver.resolve(ctx, candidates=candidates or None)
+        return [to_strict_tool(d) for d in result.injected]
+
+    def excluded_reasons(
+        self,
+        candidates: list[str],
+        *,
+        mode: str = "SIMULATION",
+        budget_exceeded: bool = False,
+        task_hint: str = "",
+    ) -> dict[str, tuple[str, ...]]:
+        """Explainable audit view: why each candidate was not injected."""
+        ctx = FilterContext(
+            body_type=self._body_type,
+            mode=mode,
+            online_capabilities=self._online_capabilities,
+            self_snapshot_fresh=self._self_snapshot_fresh,
+            granted_permissions=self._granted_permissions,
+            policy_denied_tools=self._policy_denied,
+            budget_exceeded=budget_exceeded,
+            task_hint=task_hint,
+        )
+        result = self._resolver.resolve(ctx, candidates=candidates or None)
+        return {d.tool_id: d.reasons for d in result.excluded}
+
+    def evidence_envelope(
+        self,
+        tool_id: str,
+        output: str,
+        *,
+        body_id: str,
+        error: str | None = None,
+    ) -> EvidenceEnvelope:
+        descriptor = self._catalog.get(tool_id)
+        if descriptor is None:
+            raise ValidationError(f"tool {tool_id!r} not in catalog")
+        return wrap_observation(
+            descriptor,
+            output,
+            body_id=body_id,
+            artifact_store=self._artifact_store,
+            error=error,
+        )

--- a/src/rosclaw/agentd/tooling/descriptor.py
+++ b/src/rosclaw/agentd/tooling/descriptor.py
@@ -1,0 +1,45 @@
+"""Descriptor helpers (PR-05) — thin re-export of the ToolDescriptorV2 contract
+plus construction helpers, so callers never import the contracts package for
+day-to-day catalog work."""
+
+from __future__ import annotations
+
+from rosclaw.contracts.agent.tool import (
+    ExecutionClass,
+    ToolDescriptorV2,
+    ToolEvidenceClass,
+    ToolSideEffectClass,
+)
+
+
+def observation_descriptor(tool_id: str, *, source: str, **overrides) -> ToolDescriptorV2:
+    """Convenience constructor for a model-callable OBSERVE descriptor."""
+    return ToolDescriptorV2(
+        tool_id=tool_id,
+        source=source,
+        execution_class=ExecutionClass.OBSERVE,
+        **overrides,
+    )
+
+
+def physical_action_descriptor(tool_id: str, *, source: str, **overrides) -> ToolDescriptorV2:
+    """Convenience constructor for a PHYSICAL_ACTION descriptor (never model-callable)."""
+    return ToolDescriptorV2(
+        tool_id=tool_id,
+        source=source,
+        execution_class=ExecutionClass.PHYSICAL_ACTION,
+        side_effect_class=overrides.pop("side_effect_class", ToolSideEffectClass.REVERSIBLE),
+        model_callable=False,
+        requires_exact_action_grant=True,
+        **overrides,
+    )
+
+
+__all__ = [
+    "ExecutionClass",
+    "ToolDescriptorV2",
+    "ToolEvidenceClass",
+    "ToolSideEffectClass",
+    "observation_descriptor",
+    "physical_action_descriptor",
+]

--- a/src/rosclaw/agentd/tooling/evidence.py
+++ b/src/rosclaw/agentd/tooling/evidence.py
@@ -1,0 +1,99 @@
+"""Evidence wrapper for tool observations (PR-05, 大纲 §7.1).
+
+Every tool result that reaches the model is wrapped in an EvidenceEnvelope:
+timestamp, body, source, evidence class, freshness, and an artifact ref for
+oversized payloads. Tool output is *untrusted content* — the envelope text
+carries the same ``<untrusted_input>`` markers the ContextCompiler uses, so
+an observation can never masquerade as a system fact or an authorization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+
+from pydantic import Field
+
+from rosclaw.contracts.agent.tool import ToolDescriptorV2
+from rosclaw.contracts.common import ContractModel
+
+#: Outputs larger than this are spilled to the artifact store; the model sees
+#: the ref + a head excerpt, never a silent truncation.
+ARTIFACT_SPILL_BYTES = 8 * 1024
+
+UNTRUSTED_OPEN = '<untrusted_input source="{source}" trust="untrusted">\n'
+UNTRUSTED_CLOSE = "\n</untrusted_input>"
+
+
+class EvidenceEnvelope(ContractModel):
+    SCHEMA = "rosclaw.evidence_envelope.v1"
+
+    schema_version: str = "rosclaw.evidence_envelope.v1"
+    tool_id: str
+    ok: bool
+    timestamp: str
+    body_id: str
+    source: str
+    evidence_class: str
+    fresh: bool
+    artifact_ref: str | None = None
+    error: str | None = None
+    #: head excerpt when spilled to artifact store
+    content: str = Field(default="")
+    content_digest: str = ""
+
+    def render_for_model(self) -> str:
+        """Text injected into the conversation; untrusted-marked, honest."""
+        lines = [
+            "[observation — evidence]",
+            f"tool: {self.tool_id}",
+            f"timestamp: {self.timestamp}",
+            f"body_id: {self.body_id}",
+            f"source: {self.source}",
+            f"evidence_class: {self.evidence_class}",
+            f"fresh: {str(self.fresh).lower()}",
+        ]
+        if self.artifact_ref:
+            lines.append(f"artifact_ref: {self.artifact_ref}")
+        if not self.ok:
+            lines.append(f"error: {self.error or 'unknown'}")
+            lines.append("result: (no observation obtained — do not fabricate one)")
+        else:
+            lines.append("result:")
+        inner = "\n".join(lines)
+        if self.ok:
+            inner += "\n" + UNTRUSTED_OPEN.format(source=self.source) + self.content + UNTRUSTED_CLOSE
+        return inner
+
+
+def wrap_observation(
+    descriptor: ToolDescriptorV2,
+    output: str,
+    *,
+    body_id: str,
+    artifact_store=None,
+    error: str | None = None,
+) -> EvidenceEnvelope:
+    """Wrap a raw tool output in an evidence envelope (fail-honest on error)."""
+    ok = error is None
+    digest = hashlib.sha256(output.encode()).hexdigest()[:24]
+    artifact_ref: str | None = None
+    content = output
+    if ok and artifact_store is not None and len(output.encode()) > ARTIFACT_SPILL_BYTES:
+        artifact_ref = artifact_store.put(output, prefix="observation")
+        content = output[:2000] + f"\n… [完整输出 {len(output)} 字符已落盘 {artifact_ref}]"
+    elif ok:
+        artifact_ref = f"artifact://observation/sha256:{digest}"
+    return EvidenceEnvelope(
+        tool_id=descriptor.tool_id,
+        ok=ok,
+        timestamp=datetime.now(UTC).isoformat(),
+        body_id=body_id,
+        source=descriptor.source,
+        evidence_class=descriptor.evidence_class.value,
+        fresh=True,
+        artifact_ref=artifact_ref,
+        error=error,
+        content=content,
+        content_digest=digest,
+    )

--- a/src/rosclaw/agentd/tooling/mcp_adapter.py
+++ b/src/rosclaw/agentd/tooling/mcp_adapter.py
@@ -1,0 +1,200 @@
+"""MCP capability adapter (PR-05, 大纲 §7.5).
+
+Discovers tools from an external MCP server (e.g. ``limo-ros-mcp``) over
+stdio and classifies every one as OBSERVE or PHYSICAL_ACTION. Classification
+is fail-closed:
+
+* ``readOnlyHint: true`` (or explicit ``observation_tools`` config) → OBSERVE.
+* Explicit ``action_tools`` config, destructive/open-world annotations, or
+  action verb names → PHYSICAL_ACTION.
+* Anything ambiguous → PHYSICAL_ACTION (never model-callable).
+
+Any PHYSICAL_ACTION tool is registered with ``model_callable=False`` and
+``requires_exact_action_grant=True``: the model can see its descriptor in the
+capabilities layer but can never call it; it flows only through
+REQUEST_APPROVAL → Operator grant → rosclawd.
+
+Discovery/health failures quarantine the whole source honestly — a dead MCP
+server degrades the tool list, it never fabricates observations.
+
+Server auth material is referenced as ``env:VAR`` names only; the adapter
+reads values from the process environment at spawn time and never logs them.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from rosclaw.agentd.tooling.catalog import ToolCatalog
+from rosclaw.contracts.agent.tool import (
+    ExecutionClass,
+    ToolDescriptorV2,
+    ToolEvidenceClass,
+    ToolSideEffectClass,
+)
+from rosclaw.contracts.common import ValidationError
+
+#: action verb heuristic — names matching any of these are PHYSICAL_ACTION
+_ACTION_VERBS = re.compile(
+    r"(^|[._-])(play|move|set|write|publish|send|execute|exec|arm|disarm|drive|"
+    r"rotate|speak|sound|tone|stop|start|run|goto|navigate|grasp|release|actuate|"
+    r"command|control|reset|calibrate|dock|charge)($|[._-])",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class McpServerConfig:
+    """Static config for one external MCP server (from agentd YAML)."""
+
+    name: str
+    command: str
+    args: tuple[str, ...] = ()
+    #: env var NAMES to pass through (values read from process env at spawn)
+    env_refs: tuple[str, ...] = ()
+    observation_tools: tuple[str, ...] = ()
+    action_tools: tuple[str, ...] = ()
+    supported_modes: tuple[str, ...] = ("SIMULATION",)
+    required_body_types: tuple[str, ...] = ()
+    timeout_ms: int = 5000
+
+    def spawn_env(self) -> dict[str, str]:
+        env: dict[str, str] = {}
+        for ref in self.env_refs:
+            value = os.environ.get(ref)
+            if value:  # missing → simply not passed; never logged
+                env[ref] = value
+        return env
+
+
+@dataclass
+class DiscoveryReport:
+    server: str
+    ok: bool
+    tools: list[ToolDescriptorV2] = field(default_factory=list)
+    error: str | None = None
+
+
+class McpCapabilityAdapter:
+    """One adapter per external MCP server."""
+
+    def __init__(self, config: McpServerConfig, catalog: ToolCatalog) -> None:
+        self._config = config
+        self._catalog = catalog
+        self.source = f"mcp:{config.name}"
+
+    # -- classification ---------------------------------------------------------
+
+    def classify(self, tool_name: str, annotations: Any) -> ExecutionClass:
+        cfg = self._config
+        if tool_name in cfg.action_tools:
+            return ExecutionClass.PHYSICAL_ACTION
+        if tool_name in cfg.observation_tools:
+            return ExecutionClass.OBSERVE
+        read_only = bool(getattr(annotations, "readOnlyHint", False)) if annotations else False
+        destructive = (
+            bool(getattr(annotations, "destructiveHint", False)) if annotations else False
+        )
+        if destructive:
+            return ExecutionClass.PHYSICAL_ACTION
+        if read_only and not _ACTION_VERBS.search(tool_name):
+            return ExecutionClass.OBSERVE
+        if _ACTION_VERBS.search(tool_name):
+            return ExecutionClass.PHYSICAL_ACTION
+        # ambiguous → fail closed
+        return ExecutionClass.PHYSICAL_ACTION
+
+    # -- discovery ---------------------------------------------------------------
+
+    async def discover(self) -> DiscoveryReport:
+        """Connect, list tools, classify, and (re)register in the catalog."""
+        try:
+            from mcp import ClientSession, StdioServerParameters
+            from mcp.client.stdio import stdio_client
+        except ImportError as exc:  # pragma: no cover - mcp is a core dep
+            raise ValidationError(f"mcp package unavailable: {exc}") from exc
+
+        cfg = self._config
+        params = StdioServerParameters(
+            command=cfg.command, args=list(cfg.args), env=cfg.spawn_env() or None
+        )
+        report = DiscoveryReport(server=self.source, ok=False)
+        try:
+            async with (
+                stdio_client(params) as (read, write),
+                ClientSession(read, write) as session,
+            ):
+                await session.initialize()
+                listed = await session.list_tools()
+        except Exception as exc:  # noqa: BLE001 - surfaced as honest degradation
+            report.error = f"{type(exc).__name__}: {exc}"
+            self._catalog.quarantine_source(self.source, f"discovery_failed: {report.error}")
+            return report
+
+        self._catalog.lift_source_quarantine(self.source)
+        for tool in listed.tools:
+            execution_class = self.classify(tool.name, tool.annotations)
+            physical = execution_class is ExecutionClass.PHYSICAL_ACTION
+            descriptor = ToolDescriptorV2(
+                tool_id=tool.name,
+                source=self.source,
+                execution_class=execution_class,
+                side_effect_class=(
+                    ToolSideEffectClass.REVERSIBLE if physical else ToolSideEffectClass.NONE
+                ),
+                description=tool.description or "",
+                input_schema=dict(tool.inputSchema or {}),
+                supported_modes=list(cfg.supported_modes),
+                required_body_types=list(cfg.required_body_types),
+                freshness_ms=500 if not physical else None,
+                timeout_ms=cfg.timeout_ms,
+                evidence_class=ToolEvidenceClass.MEASURED,
+                verifier="schema+timestamp+frame",
+                idempotent=not physical,
+                model_callable=not physical,
+                requires_exact_action_grant=physical,
+            )
+            self._catalog.replace(descriptor, self._make_executor(tool.name))
+            report.tools.append(descriptor)
+        report.ok = True
+        return report
+
+    async def health_check(self) -> bool:
+        """Cheap liveness probe; failure quarantines the source (fail honest)."""
+        report = await self.discover()
+        return report.ok
+
+    # -- execution ---------------------------------------------------------------
+
+    def _make_executor(self, tool_name: str):
+        async def _exec(arguments: dict[str, Any]) -> str:
+            import json as _json
+
+            from mcp import ClientSession, StdioServerParameters
+            from mcp.client.stdio import stdio_client
+
+            cfg = self._config
+            params = StdioServerParameters(
+                command=cfg.command, args=list(cfg.args), env=cfg.spawn_env() or None
+            )
+            async with (
+                stdio_client(params) as (read, write),
+                ClientSession(read, write) as session,
+            ):
+                await session.initialize()
+                result = await session.call_tool(tool_name, arguments)
+            if result.isError:
+                text = " ".join(
+                    getattr(block, "text", "") for block in result.content
+                ).strip()
+                raise ValidationError(f"mcp tool {tool_name!r} error: {text or 'unknown'}")
+            parts = [getattr(block, "text", "") for block in result.content]
+            return _json.dumps(
+                {"tool": tool_name, "source": self.source, "content": parts},
+                ensure_ascii=False,
+            )
+
+        return _exec

--- a/src/rosclaw/agentd/tooling/native_tools.py
+++ b/src/rosclaw/agentd/tooling/native_tools.py
@@ -1,0 +1,73 @@
+"""Native tool adapter — registers the agentd's built-in P0 tools in the catalog.
+
+Wraps ``BuiltinToolRegistry`` so the existing sim tools flow through the same
+descriptor/resolver/evidence path as MCP-discovered capabilities.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rosclaw.agentd.tooling.catalog import ToolCatalog
+from rosclaw.agentd.tools import SIM_BODY_TOOL, SIM_STATE_TOOL, BuiltinToolRegistry
+from rosclaw.contracts.agent.tool import (
+    ExecutionClass,
+    ToolDescriptorV2,
+    ToolEvidenceClass,
+)
+
+NATIVE_SOURCE = "native:agentd"
+
+
+def register_native_tools(
+    catalog: ToolCatalog, registry: BuiltinToolRegistry, *, simulation: bool = True
+) -> None:
+    descriptors = [
+        ToolDescriptorV2(
+            tool_id=SIM_BODY_TOOL,
+            source=NATIVE_SOURCE,
+            execution_class=ExecutionClass.OBSERVE,
+            description="Read the bound body's static profile summary.",
+            input_schema={
+                "type": "object",
+                "properties": {"detail": {"type": "boolean"}},
+                "additionalProperties": False,
+            },
+            supported_modes=["SIMULATION", "SHADOW", "REAL"],
+            evidence_class=ToolEvidenceClass.CONFIGURED,
+            verifier="schema+configured-label",
+            reliability=1.0,
+            typical_latency_ms=1,
+        ),
+    ]
+    if simulation:
+        # The simulated live-state tool only exists for simulated bodies;
+        # for real bodies it is never registered (fail closed, not filtered).
+        descriptors.insert(
+            0,
+            ToolDescriptorV2(
+                tool_id=SIM_STATE_TOOL,
+                source=NATIVE_SOURCE,
+                execution_class=ExecutionClass.OBSERVE,
+                description=(
+                    "Read the SIMULATED body state (joints, health). "
+                    "Evidence class: simulated — never usable as REAL proof."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {"verbose": {"type": "boolean"}},
+                    "additionalProperties": False,
+                },
+                supported_modes=["SIMULATION", "SHADOW", "REAL"],
+                evidence_class=ToolEvidenceClass.SIMULATED,
+                verifier="schema+simulated-label",
+                reliability=1.0,
+                typical_latency_ms=1,
+            ),
+        )
+    for descriptor in descriptors:
+
+        async def _exec(arguments: dict[str, Any], _name: str = descriptor.tool_id) -> str:
+            return await registry.execute(_name, arguments)
+
+        catalog.register(descriptor, _exec)

--- a/src/rosclaw/agentd/tooling/resolver.py
+++ b/src/rosclaw/agentd/tooling/resolver.py
@@ -1,0 +1,153 @@
+"""ToolResolver — deterministic hard filters before any relevance ranking (大纲 §7.4).
+
+Hard filters (safety; a single failure excludes the tool, reasons are
+explainable and auditable):
+
+* body compatibility
+* mode allowlist
+* required capabilities online
+* SelfSnapshot freshness
+* permission granted
+* policy deny list
+* budget not exceeded
+* verifier present
+* not quarantined
+* model_callable
+
+Only then does relevance ranking run (semantic match, latency, reliability,
+cost, freshness, evidence level). Safety conditions NEVER enter the score —
+a high-scoring tool can never outrank a hard filter.
+
+At most ``MAX_INJECTED_TOOLS`` tools are injected into a model turn.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from rosclaw.agentd.tooling.catalog import ToolCatalog
+from rosclaw.contracts.agent.tool import ToolDescriptorV2
+
+MAX_INJECTED_TOOLS = 12
+
+
+@dataclass(frozen=True)
+class FilterContext:
+    """Everything the hard filters need; built by the service per turn."""
+
+    body_type: str = ""
+    mode: str = "SIMULATION"
+    online_capabilities: frozenset[str] = frozenset()
+    self_snapshot_fresh: bool = True
+    granted_permissions: frozenset[str] = frozenset()
+    policy_denied_tools: frozenset[str] = frozenset()
+    budget_exceeded: bool = False
+    #: semantic hint for ranking only (task text); never used by hard filters
+    task_hint: str = ""
+
+
+@dataclass(frozen=True)
+class FilterDecision:
+    tool_id: str
+    passed: bool
+    reasons: tuple[str, ...] = ()
+
+
+@dataclass
+class ResolutionResult:
+    injected: list[ToolDescriptorV2] = field(default_factory=list)
+    excluded: list[FilterDecision] = field(default_factory=list)
+
+
+class ToolResolver:
+    def __init__(self, catalog: ToolCatalog, *, max_injected: int = MAX_INJECTED_TOOLS) -> None:
+        self._catalog = catalog
+        self._max_injected = max_injected
+
+    # -- hard filters (safety) -------------------------------------------------
+
+    def hard_filter(self, descriptor: ToolDescriptorV2, ctx: FilterContext) -> FilterDecision:
+        reasons: list[str] = []
+        d = descriptor
+        if d.required_body_types and ctx.body_type not in d.required_body_types:
+            reasons.append(
+                f"body_incompatible: requires {sorted(d.required_body_types)}, have {ctx.body_type!r}"
+            )
+        if ctx.mode not in d.supported_modes:
+            reasons.append(f"mode_not_allowed: {ctx.mode} not in {sorted(d.supported_modes)}")
+        missing_caps = [c for c in d.required_capabilities if c not in ctx.online_capabilities]
+        if missing_caps:
+            reasons.append(f"capability_offline: {missing_caps}")
+        if d.freshness_ms is not None and not ctx.self_snapshot_fresh:
+            reasons.append("self_snapshot_stale: freshness-gated tool with stale SelfSnapshot")
+        if d.tool_id in ctx.policy_denied_tools:
+            reasons.append("policy_denied")
+        if ctx.granted_permissions:
+            # permission filter only binds when a permission set is configured
+            missing_perms = [
+                c for c in d.required_capabilities if c not in ctx.granted_permissions
+            ]
+            if missing_perms:
+                reasons.append(f"permission_not_granted: {missing_perms}")
+        if ctx.budget_exceeded and d.cost_hint > 0:
+            reasons.append("budget_exceeded")
+        if not d.verifier:
+            reasons.append("no_verifier")
+        quarantine = self._catalog.quarantine_reason(d.tool_id)
+        if quarantine is not None:
+            reasons.append(f"quarantined: {quarantine}")
+        if not d.model_callable:
+            reasons.append("not_model_callable")
+        return FilterDecision(tool_id=d.tool_id, passed=not reasons, reasons=tuple(reasons))
+
+    # -- relevance ranking (never safety) ---------------------------------------
+
+    @staticmethod
+    def _tokenize(text: str) -> set[str]:
+        return {t for t in re.split(r"[^a-zA-Z0-9_一-鿿]+", text.lower()) if len(t) > 1}
+
+    def score(self, descriptor: ToolDescriptorV2, ctx: FilterContext) -> float:
+        score = 0.0
+        if ctx.task_hint:
+            haystack = self._tokenize(f"{descriptor.tool_id} {descriptor.description}")
+            need = self._tokenize(ctx.task_hint)
+            if need:
+                score += 4.0 * len(haystack & need) / len(need)
+        score += 2.0 * descriptor.reliability
+        score += max(0.0, 1.0 - descriptor.typical_latency_ms / 5000.0)
+        score -= min(descriptor.cost_hint, 5.0) * 0.2
+        if descriptor.freshness_ms is not None and descriptor.freshness_ms <= 1000:
+            score += 0.5
+        evidence_rank = {"MEASURED": 1.0, "DERIVED": 0.7, "CONFIGURED": 0.5, "SIMULATED": 0.3}
+        score += evidence_rank.get(descriptor.evidence_class.value, 0.0)
+        return score
+
+    # -- resolve -----------------------------------------------------------------
+
+    def resolve(self, ctx: FilterContext, *, candidates: list[str] | None = None) -> ResolutionResult:
+        """Hard-filter the catalog (or a candidate subset), rank survivors, cap."""
+        pool = (
+            [d for d in (self._catalog.get(t) for t in candidates) if d is not None]
+            if candidates is not None
+            else self._catalog.list()
+        )
+        result = ResolutionResult()
+        survivors: list[ToolDescriptorV2] = []
+        for descriptor in pool:
+            decision = self.hard_filter(descriptor, ctx)
+            if decision.passed:
+                survivors.append(descriptor)
+            else:
+                result.excluded.append(decision)
+        survivors.sort(key=lambda d: (-self.score(d, ctx), d.tool_id))
+        result.injected = survivors[: self._max_injected]
+        for overflow in survivors[self._max_injected :]:
+            result.excluded.append(
+                FilterDecision(
+                    tool_id=overflow.tool_id,
+                    passed=False,
+                    reasons=(f"injection_cap: only {self._max_injected} tools per turn",),
+                )
+            )
+        return result

--- a/src/rosclaw/agentd/tooling/strict_schema.py
+++ b/src/rosclaw/agentd/tooling/strict_schema.py
@@ -1,0 +1,34 @@
+"""ToolDescriptorV2 → StrictTool conversion (model-facing schema).
+
+Only model-callable OBSERVE/COMPUTE tools may be converted; attempting to
+convert a PHYSICAL_ACTION descriptor raises (defense in depth on top of the
+contract validator and the resolver hard filter).
+"""
+
+from __future__ import annotations
+
+from rosclaw.agentd.models.gateway import StrictTool
+from rosclaw.contracts.agent.tool import ExecutionClass, ToolDescriptorV2
+from rosclaw.contracts.common import ValidationError
+
+
+def to_strict_tool(descriptor: ToolDescriptorV2) -> StrictTool:
+    if descriptor.execution_class is ExecutionClass.PHYSICAL_ACTION:
+        raise ValidationError(
+            f"tool {descriptor.tool_id!r}: PHYSICAL_ACTION can never become a model tool"
+        )
+    if not descriptor.model_callable:
+        raise ValidationError(f"tool {descriptor.tool_id!r}: not model_callable")
+    schema = dict(descriptor.input_schema) if descriptor.input_schema else {}
+    schema.setdefault("type", "object")
+    schema.setdefault("properties", {})
+    schema["additionalProperties"] = False
+    props = schema.get("properties", {})
+    # OpenAI strict convention: every property listed in required.
+    schema["required"] = list(props.keys())
+    description = descriptor.description or descriptor.tool_id
+    description += (
+        f" [evidence_class: {descriptor.evidence_class.value}; "
+        f"modes: {','.join(descriptor.supported_modes)}]"
+    )
+    return StrictTool(name=descriptor.tool_id, description=description, parameters=schema)

--- a/src/rosclaw/contracts/agent/tool.py
+++ b/src/rosclaw/contracts/agent/tool.py
@@ -1,0 +1,106 @@
+"""ToolDescriptorV2 — the catalog entry for every capability the Agent may see (大纲 §7.2).
+
+A descriptor is *metadata*, never an execution permit. Two hard invariants
+are enforced at the contract layer (fail closed):
+
+* ``PHYSICAL_ACTION`` tools are never ``model_callable`` — a physical action
+  only ever flows through ``Decision REQUEST_APPROVAL → Operator → Grant →
+  REQUEST_ACTION → rosclawd``.
+* ``requires_exact_action_grant=True`` implies ``model_callable=False``.
+
+No field of this contract may carry credentials; MCP server auth is always
+referenced as ``env:VAR`` on the *server* config, never on the descriptor.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from rosclaw.contracts.common import ContractModel, ValidationError
+
+
+class ExecutionClass(StrEnum):
+    """What kind of thing happens when this tool runs (大纲 §7.1)."""
+
+    OBSERVE = "OBSERVE"  # read-only observation; model-callable with evidence wrapping
+    COMPUTE = "COMPUTE"  # pure compute, no physical side effect; model-callable
+    PHYSICAL_ACTION = "PHYSICAL_ACTION"  # physical side effect; NEVER model-callable
+
+
+class ToolSideEffectClass(StrEnum):
+    NONE = "NONE"
+    REVERSIBLE = "REVERSIBLE"
+    IRREVERSIBLE = "IRREVERSIBLE"
+
+
+class ToolEvidenceClass(StrEnum):
+    MEASURED = "MEASURED"  # from a live sensor/ROS topic
+    SIMULATED = "SIMULATED"  # from simulation; never usable as REAL proof
+    CONFIGURED = "CONFIGURED"  # from static config/profile
+    DERIVED = "DERIVED"  # computed from other evidence
+
+
+class ToolDescriptorV2(ContractModel):
+    SCHEMA = "rosclaw.tool_descriptor.v2"
+
+    schema_version: Literal["rosclaw.tool_descriptor.v2"] = "rosclaw.tool_descriptor.v2"
+    tool_id: str = Field(min_length=1)
+    version: str = "1.0.0"
+    #: e.g. "native:agentd", "mcp:limo-ros-mcp"
+    source: str = Field(min_length=1)
+    execution_class: ExecutionClass = ExecutionClass.OBSERVE
+    side_effect_class: ToolSideEffectClass = ToolSideEffectClass.NONE
+    description: str = ""
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+    output_schema: dict[str, Any] = Field(default_factory=dict)
+    supported_modes: list[Literal["SIMULATION", "SHADOW", "REAL"]] = Field(
+        default_factory=lambda: ["SIMULATION"]
+    )
+    #: empty = body-agnostic
+    required_body_types: list[str] = Field(default_factory=list)
+    freshness_ms: int | None = Field(default=None, ge=0)
+    timeout_ms: int = Field(default=2000, gt=0)
+    risk_tier: Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"] = "LOW"
+    evidence_class: ToolEvidenceClass = ToolEvidenceClass.MEASURED
+    #: verifier id, e.g. "schema+timestamp+frame"; empty = no verifier
+    verifier: str = ""
+    idempotent: bool = True
+    model_callable: bool = True
+    requires_exact_action_grant: bool = False
+    #: reliability/latency/cost hints for resolver ranking (never for safety)
+    reliability: float = Field(default=0.5, ge=0.0, le=1.0)
+    typical_latency_ms: int = Field(default=100, ge=0)
+    cost_hint: float = Field(default=0.0, ge=0.0)
+    #: capability names this tool requires to be online (e.g. ROS topics)
+    required_capabilities: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _enforce_physical_action_invariants(self) -> ToolDescriptorV2:
+        if self.execution_class is ExecutionClass.PHYSICAL_ACTION and self.model_callable:
+            raise ValidationError(
+                f"tool {self.tool_id!r}: PHYSICAL_ACTION tools are never model_callable "
+                "(fail closed — physical actions flow only through Operator grant)"
+            )
+        if self.requires_exact_action_grant and self.model_callable:
+            raise ValidationError(
+                f"tool {self.tool_id!r}: requires_exact_action_grant implies "
+                "model_callable=False (fail closed)"
+            )
+        if self.execution_class is ExecutionClass.PHYSICAL_ACTION and not (
+            self.requires_exact_action_grant
+        ):
+            raise ValidationError(
+                f"tool {self.tool_id!r}: PHYSICAL_ACTION must declare "
+                "requires_exact_action_grant=True"
+            )
+        if self.side_effect_class is not ToolSideEffectClass.NONE and (
+            self.execution_class is ExecutionClass.OBSERVE
+        ):
+            raise ValidationError(
+                f"tool {self.tool_id!r}: OBSERVE tools must have side_effect_class=NONE; "
+                "reclassify as PHYSICAL_ACTION or COMPUTE"
+            )
+        return self

--- a/src/rosclaw/contracts/export.py
+++ b/src/rosclaw/contracts/export.py
@@ -15,6 +15,7 @@ from rosclaw.contracts.agent.decision import DecisionV1
 from rosclaw.contracts.agent.mission import MissionSessionV1
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
 from rosclaw.contracts.agent.task_graph import TaskGraphPatchV1, TaskGraphV1, TaskNodeV1
+from rosclaw.contracts.agent.tool import ToolDescriptorV2
 from rosclaw.contracts.common import ContractModel
 from rosclaw.contracts.operator.approval import ApprovalRequestV2
 from rosclaw.contracts.operator.grant import MissionGrantV1
@@ -44,6 +45,7 @@ ALL_CONTRACTS: dict[str, type[ContractModel]] = {
         SharedWorldDeltaV1,
         MissionGrantV1,
         ApprovalRequestV2,
+        ToolDescriptorV2,
     )
 }
 

--- a/tests/agentd/fixtures/limo_mcp_server.py
+++ b/tests/agentd/fixtures/limo_mcp_server.py
@@ -1,0 +1,55 @@
+"""LIMO-like MCP server fixture for PR-05 tests (real MCP protocol over stdio).
+
+Exposes:
+- ``limo.localization.get_pose`` — readOnlyHint=True → must classify OBSERVE
+- ``limo.speaker.play_tone`` — action verb, no readOnlyHint → PHYSICAL_ACTION
+- ``limo.misc.ambiguous`` — no annotations, no verb → fail-closed PHYSICAL_ACTION
+
+This is a REAL MCP server (mcp SDK, stdio transport), not a mock of the
+adapter — discovery and calls exercise the full JSON-RPC path.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+server = FastMCP("limo-ros-mcp-fixture")
+
+
+def _get_pose(frame: str = "map") -> str:
+    return (
+        f'{{"frame": "{frame}", "x": 1.25, "y": -0.5, "theta": 0.03, '
+        '"timestamp": "2026-08-03T00:00:00Z", "fresh": true}'
+    )
+
+
+def _play_tone(frequency_hz: int = 660, duration_sec: float = 0.25) -> str:
+    # A real action tool would side-effect the speaker; the fixture only
+    # reports the request. It must NEVER reach this point through the catalog.
+    return f'{{"played": true, "frequency_hz": {frequency_hz}, "duration_sec": {duration_sec}}}'
+
+
+def _ambiguous() -> str:
+    return '{"status": "ok"}'
+
+
+server.add_tool(
+    _get_pose,
+    name="limo.localization.get_pose",
+    description="Get the current LIMO localization pose (read-only observation).",
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
+server.add_tool(
+    _play_tone,
+    name="limo.speaker.play_tone",
+    description="Play a tone on the LIMO speaker (physical action).",
+)
+server.add_tool(
+    _ambiguous,
+    name="limo.misc.ambiguous",
+    description="A tool with no annotations at all.",
+)
+
+if __name__ == "__main__":
+    server.run()

--- a/tests/agentd/test_tooling.py
+++ b/tests/agentd/test_tooling.py
@@ -1,0 +1,578 @@
+"""PR-05 Tool/Capability Catalog tests (大纲 §7 + 补充文档 §10).
+
+- ToolDescriptorV2 contract invariants (fail closed)
+- Catalog guards: PHYSICAL_ACTION never executable, quarantine, timeout
+- ToolResolver hard filters (each reason) + explainability + ranking cap
+- Safety never enters model-facing scoring
+- MCP adapter: real stdio discovery against a LIMO-like fixture server,
+  fail-closed classification, fault-injection quarantine
+- Evidence wrapper: untrusted marking, artifact spill, honest errors
+- Exit condition: LIMO MCP observation usable, action not directly executable
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.tooling.artifact_result import ArtifactResultStore
+from rosclaw.agentd.tooling.catalog import (
+    ToolCatalog,
+    ToolNotCallableError,
+    ToolQuarantinedError,
+)
+from rosclaw.agentd.tooling.catalog_registry import CatalogToolRegistry
+from rosclaw.agentd.tooling.descriptor import physical_action_descriptor
+from rosclaw.agentd.tooling.evidence import ARTIFACT_SPILL_BYTES, wrap_observation
+from rosclaw.agentd.tooling.mcp_adapter import McpCapabilityAdapter, McpServerConfig
+from rosclaw.agentd.tooling.resolver import FilterContext, ToolResolver
+from rosclaw.agentd.tooling.strict_schema import to_strict_tool
+from rosclaw.contracts.agent.tool import (
+    ExecutionClass,
+    ToolDescriptorV2,
+    ToolSideEffectClass,
+)
+from rosclaw.contracts.common import ValidationError
+
+FIXTURE_SERVER = Path(__file__).parent / "fixtures" / "limo_mcp_server.py"
+
+
+def _obs(tool_id: str = "test.observe", **overrides) -> ToolDescriptorV2:
+    payload = {
+        "tool_id": tool_id,
+        "source": "test",
+        "execution_class": ExecutionClass.OBSERVE,
+        "verifier": "schema+timestamp",
+    }
+    payload.update(overrides)
+    return ToolDescriptorV2(**payload)
+
+
+class TestDescriptorInvariants:
+    def test_physical_action_never_model_callable(self) -> None:
+        with pytest.raises(ValidationError, match="never model_callable"):
+            ToolDescriptorV2(
+                tool_id="bad",
+                source="test",
+                execution_class=ExecutionClass.PHYSICAL_ACTION,
+                requires_exact_action_grant=True,
+                model_callable=True,
+            )
+
+    def test_grant_requirement_implies_not_callable(self) -> None:
+        with pytest.raises(ValidationError, match="model_callable=False"):
+            ToolDescriptorV2(
+                tool_id="bad",
+                source="test",
+                execution_class=ExecutionClass.OBSERVE,
+                requires_exact_action_grant=True,
+            )
+
+    def test_physical_action_must_require_grant(self) -> None:
+        with pytest.raises(ValidationError, match="requires_exact_action_grant"):
+            ToolDescriptorV2(
+                tool_id="bad",
+                source="test",
+                execution_class=ExecutionClass.PHYSICAL_ACTION,
+                model_callable=False,
+                side_effect_class=ToolSideEffectClass.REVERSIBLE,
+            )
+
+    def test_observe_cannot_have_side_effects(self) -> None:
+        with pytest.raises(ValidationError, match="side_effect_class=NONE"):
+            ToolDescriptorV2(
+                tool_id="bad",
+                source="test",
+                execution_class=ExecutionClass.OBSERVE,
+                side_effect_class=ToolSideEffectClass.REVERSIBLE,
+            )
+
+    def test_helper_constructs_valid_physical_action(self) -> None:
+        d = physical_action_descriptor("limo.speaker.play_tone", source="mcp:limo")
+        assert d.execution_class is ExecutionClass.PHYSICAL_ACTION
+        assert not d.model_callable and d.requires_exact_action_grant
+
+
+class TestCatalogGuards:
+    async def test_physical_action_not_executable(self) -> None:
+        catalog = ToolCatalog()
+        catalog.register(physical_action_descriptor("limo.speaker.play_tone", source="mcp:x"))
+        with pytest.raises(ToolNotCallableError, match="PHYSICAL_ACTION"):
+            await catalog.execute("limo.speaker.play_tone", {})
+
+    async def test_quarantined_tool_fails_honestly(self) -> None:
+        catalog = ToolCatalog()
+        catalog.register(_obs(), lambda args: _never_called(args))
+        catalog.quarantine_tool("test.observe", "health check failed")
+        with pytest.raises(ToolQuarantinedError, match="health check failed"):
+            await catalog.execute("test.observe", {})
+
+    async def test_unknown_tool_rejected(self) -> None:
+        catalog = ToolCatalog()
+        with pytest.raises(ValidationError, match="not in catalog"):
+            await catalog.execute("ghost", {})
+
+    async def test_duplicate_register_rejected_replace_ok(self) -> None:
+        catalog = ToolCatalog()
+        catalog.register(_obs())
+        with pytest.raises(ValidationError, match="already registered"):
+            catalog.register(_obs())
+        catalog.replace(_obs(description="v2"))
+        assert catalog.get("test.observe").description == "v2"
+
+    async def test_timeout_enforced(self) -> None:
+        import asyncio
+
+        async def slow(args):
+            await asyncio.sleep(5)
+            return "{}"
+
+        catalog = ToolCatalog()
+        catalog.register(_obs(timeout_ms=50), slow)
+        with pytest.raises(asyncio.TimeoutError):
+            await catalog.execute("test.observe", {})
+
+
+async def _never_called(args):  # pragma: no cover - guard
+    raise AssertionError("must not execute")
+
+
+class TestResolverHardFilters:
+    def _resolver_with(self, *descriptors: ToolDescriptorV2):
+        catalog = ToolCatalog()
+        for d in descriptors:
+            catalog.register(d, lambda args: _never_called(args))
+        return ToolResolver(catalog), catalog
+
+    def test_each_hard_filter_reason(self) -> None:
+        resolver, catalog = self._resolver_with(
+            _obs("t.body", required_body_types=["agilex-limo"]),
+            _obs("t.mode", supported_modes=["REAL"]),
+            _obs("t.caps", required_capabilities=["lidar.online"]),
+            _obs("t.fresh", freshness_ms=500),
+            _obs("t.policy"),
+            _obs("t.budget", cost_hint=1.0),
+            _obs("t.noverifier", verifier=""),
+            _obs("t.quar"),
+            _obs("t.ok"),
+        )
+        catalog.quarantine_tool("t.quar", "dead")
+        ctx = FilterContext(
+            body_type="other-robot",
+            mode="SIMULATION",
+            online_capabilities=frozenset(),
+            self_snapshot_fresh=False,
+            policy_denied_tools=frozenset({"t.policy"}),
+            budget_exceeded=True,
+        )
+        result = resolver.resolve(ctx)
+        assert [d.tool_id for d in result.injected] == ["t.ok"]
+        reasons = {d.tool_id: d.reasons for d in result.excluded}
+        assert "body_incompatible" in reasons["t.body"][0]
+        assert "mode_not_allowed" in reasons["t.mode"][0]
+        assert "capability_offline" in reasons["t.caps"][0]
+        assert "self_snapshot_stale" in reasons["t.fresh"][0]
+        assert "policy_denied" in reasons["t.policy"][0]
+        assert "budget_exceeded" in reasons["t.budget"][0]
+        assert "no_verifier" in reasons["t.noverifier"][0]
+        assert reasons["t.quar"][0].startswith("quarantined")
+
+    def test_permission_filter_binds_only_when_configured(self) -> None:
+        resolver, _ = self._resolver_with(_obs("t.perm", required_capabilities=["cam"]))
+        open_ctx = FilterContext(online_capabilities=frozenset({"cam"}))  # no permission set configured → not binding
+        assert resolver.resolve(open_ctx).injected[0].tool_id == "t.perm"
+        strict_ctx = FilterContext(
+            online_capabilities=frozenset({"cam"}),
+            granted_permissions=frozenset({"lidar"}),
+        )
+        result = resolver.resolve(strict_ctx)
+        assert not result.injected
+        assert "permission_not_granted" in result.excluded[0].reasons[0]
+
+    def test_physical_action_filtered_as_not_model_callable(self) -> None:
+        resolver, _ = self._resolver_with(
+            physical_action_descriptor("limo.speaker.play_tone", source="mcp:x")
+        )
+        result = resolver.resolve(FilterContext())
+        assert not result.injected
+        assert "not_model_callable" in result.excluded[0].reasons
+
+    def test_safety_never_in_score(self) -> None:
+        """A maximally-relevant, high-reliability tool still loses to filters."""
+        resolver, catalog = self._resolver_with(
+            _obs(
+                "pick red cube",
+                description="pick red cube grasp",
+                reliability=1.0,
+                typical_latency_ms=0,
+            )
+        )
+        catalog.quarantine_tool("pick red cube", "unsafe source")
+        ctx = FilterContext(task_hint="pick red cube")
+        result = resolver.resolve(ctx)
+        assert not result.injected, "score must never override quarantine"
+
+    def test_injection_cap_and_ranking(self) -> None:
+        descriptors = [
+            _obs(f"t.{i}", reliability=i / 20.0, typical_latency_ms=100 + i)
+            for i in range(20)
+        ]
+        resolver, _ = self._resolver_with(*descriptors)
+        result = resolver.resolve(FilterContext())
+        assert len(result.injected) == 12
+        scores = [d.reliability for d in result.injected]
+        assert scores == sorted(scores, reverse=True)
+        # overflow explained, not silently dropped
+        overflow = [d for d in result.excluded if d.reasons[0].startswith("injection_cap")]
+        assert len(overflow) == 8
+
+    def test_semantic_ranking_prefers_task_match(self) -> None:
+        resolver, _ = self._resolver_with(
+            _obs("limo.localization.get_pose", description="robot pose localization"),
+            _obs("camera.list", description="list cameras"),
+        )
+        ctx = FilterContext(task_hint="定位 pose 在哪里")
+        result = resolver.resolve(ctx)
+        assert result.injected[0].tool_id == "limo.localization.get_pose"
+
+
+class TestStrictSchema:
+    def test_observe_converts(self) -> None:
+        tool = to_strict_tool(
+            _obs(input_schema={"type": "object", "properties": {"f": {"type": "string"}}})
+        )
+        assert tool.parameters["additionalProperties"] is False
+        assert tool.parameters["required"] == ["f"]
+        assert "evidence_class" in tool.description
+
+    def test_physical_action_never_converts(self) -> None:
+        with pytest.raises(ValidationError, match="never become a model tool"):
+            to_strict_tool(physical_action_descriptor("x.act", source="mcp:x"))
+
+
+class TestMcpClassification:
+    def _adapter(self, **cfg) -> McpCapabilityAdapter:
+        return McpCapabilityAdapter(
+            McpServerConfig(name="limo", command="true", **cfg), ToolCatalog()
+        )
+
+    def test_action_verb_is_physical(self) -> None:
+        adapter = self._adapter()
+        assert adapter.classify("limo.speaker.play_tone", None) is ExecutionClass.PHYSICAL_ACTION
+        assert adapter.classify("limo.base.move_to", None) is ExecutionClass.PHYSICAL_ACTION
+
+    def test_readonly_annotation_is_observe(self) -> None:
+        from mcp.types import ToolAnnotations
+
+        adapter = self._adapter()
+        ann = ToolAnnotations(readOnlyHint=True)
+        assert adapter.classify("limo.localization.get_pose", ann) is ExecutionClass.OBSERVE
+        # action verb wins over readOnlyHint (suspicious combo → fail closed)
+        assert adapter.classify("limo.arm.set_pose", ann) is ExecutionClass.PHYSICAL_ACTION
+
+    def test_ambiguous_fails_closed(self) -> None:
+        adapter = self._adapter()
+        assert adapter.classify("limo.misc.unknown", None) is ExecutionClass.PHYSICAL_ACTION
+
+    def test_config_overrides(self) -> None:
+        adapter = self._adapter(
+            observation_tools=("custom.status",), action_tools=("custom.reset",)
+        )
+        assert adapter.classify("custom.status", None) is ExecutionClass.OBSERVE
+        assert adapter.classify("custom.reset", None) is ExecutionClass.PHYSICAL_ACTION
+
+    def test_destructive_annotation_is_physical(self) -> None:
+        from mcp.types import ToolAnnotations
+
+        adapter = self._adapter()
+        ann = ToolAnnotations(readOnlyHint=True, destructiveHint=True)
+        assert adapter.classify("x.y", ann) is ExecutionClass.PHYSICAL_ACTION
+
+
+class TestMcpDiscovery:
+    async def test_discover_limo_fixture(self, tmp_path: Path) -> None:
+        catalog = ToolCatalog()
+        adapter = McpCapabilityAdapter(
+            McpServerConfig(
+                name="limo-ros-mcp",
+                command=sys.executable,
+                args=(str(FIXTURE_SERVER),),
+                supported_modes=("SIMULATION", "SHADOW"),
+                required_body_types=("agilex-limo",),
+            ),
+            catalog,
+        )
+        report = await adapter.discover()
+        assert report.ok, report.error
+        by_id = {d.tool_id: d for d in report.tools}
+        pose = by_id["limo.localization.get_pose"]
+        tone = by_id["limo.speaker.play_tone"]
+        ambiguous = by_id["limo.misc.ambiguous"]
+        # 退出条件 1：observation 可用（model-callable OBSERVE）。
+        assert pose.execution_class is ExecutionClass.OBSERVE
+        assert pose.model_callable and not pose.requires_exact_action_grant
+        # 退出条件 2：action 不可被模型直接执行。
+        assert tone.execution_class is ExecutionClass.PHYSICAL_ACTION
+        assert not tone.model_callable and tone.requires_exact_action_grant
+        # 无注解工具 fail closed。
+        assert ambiguous.execution_class is ExecutionClass.PHYSICAL_ACTION
+
+        # observation 通过 catalog 真正执行（真实 MCP stdio 调用）。
+        output = await catalog.execute("limo.localization.get_pose", {"frame": "map"})
+        assert "1.25" in output and "map" in output
+        # action 即使显式执行也被 catalog 拒绝。
+        with pytest.raises(ToolNotCallableError):
+            await catalog.execute("limo.speaker.play_tone", {"frequency_hz": 440})
+
+        # resolver 只注入 observation。
+        resolver = ToolResolver(catalog)
+        result = resolver.resolve(
+            FilterContext(body_type="agilex-limo", mode="SIMULATION", task_hint="pose")
+        )
+        injected = {d.tool_id for d in result.injected}
+        assert "limo.localization.get_pose" in injected
+        assert "limo.speaker.play_tone" not in injected
+
+    async def test_dead_server_quarantines_source(self) -> None:
+        catalog = ToolCatalog()
+        adapter = McpCapabilityAdapter(
+            McpServerConfig(name="dead", command="/nonexistent/binary-xyz"),
+            catalog,
+        )
+        report = await adapter.discover()
+        assert not report.ok and report.error
+        # pre-registered tools from an earlier session get quarantined too
+        catalog.register(_obs("limo.old", source="mcp:dead"))
+        catalog.quarantine_source("mcp:dead", f"discovery_failed: {report.error}")
+        resolver = ToolResolver(catalog)
+        result = resolver.resolve(FilterContext())
+        assert not result.injected
+        assert result.excluded[0].reasons[0].startswith("quarantined")
+
+
+class TestEvidenceWrapper:
+    def test_ok_envelope_marks_untrusted(self, tmp_path: Path) -> None:
+        d = _obs("limo.localization.get_pose", source="mcp:limo")
+        env = wrap_observation(d, '{"x": 1.0}', body_id="limo/01")
+        text = env.render_for_model()
+        assert "<untrusted_input" in text and "</untrusted_input>" in text
+        assert "evidence_class: MEASURED" in text
+        assert env.artifact_ref and env.artifact_ref.startswith("artifact://observation/")
+
+    def test_large_output_spills_to_artifact_store(self, tmp_path: Path) -> None:
+        store = ArtifactResultStore(tmp_path)
+        d = _obs()
+        big = "X" * (ARTIFACT_SPILL_BYTES + 100)
+        env = wrap_observation(d, big, body_id="b", artifact_store=store)
+        assert len(env.content) < len(big)
+        assert env.artifact_ref is not None
+        assert store.resolve(env.artifact_ref) == big
+        assert store.resolve("artifact://observation/sha256:nonexistent") is None
+
+    def test_error_envelope_is_honest(self) -> None:
+        d = _obs()
+        env = wrap_observation(d, '{"error": "boom"}', body_id="b", error="TimeoutError: boom")
+        text = env.render_for_model()
+        assert not env.ok
+        assert "error: TimeoutError: boom" in text
+        assert "do not fabricate" in text
+        assert "<untrusted_input" not in text  # nothing trustworthy to wrap
+
+
+class TestCatalogRegistry:
+    async def test_registry_guards_and_envelope(self, tmp_path: Path) -> None:
+        catalog = ToolCatalog()
+        catalog.register(_obs("t.obs"), lambda args: _echo(args))
+        catalog.register(physical_action_descriptor("t.act", source="mcp:x"))
+        registry = CatalogToolRegistry(
+            catalog, ToolResolver(catalog), artifact_store=ArtifactResultStore(tmp_path)
+        )
+        # strict_tools never surfaces the physical action
+        names = [t.name for t in registry.strict_tools(["t.obs", "t.act"])]
+        assert names == ["t.obs"]
+        with pytest.raises(ToolNotCallableError):
+            await registry.execute("t.act", {})
+        env = registry.evidence_envelope("t.obs", "data", body_id="b")
+        assert env.ok and env.content == "data"
+
+    def test_resolve_tools_applies_filters(self, tmp_path: Path) -> None:
+        catalog = ToolCatalog()
+        catalog.register(_obs("t.sim", supported_modes=["SIMULATION"]))
+        catalog.register(_obs("t.real", supported_modes=["REAL"]))
+        registry = CatalogToolRegistry(catalog, ToolResolver(catalog))
+        sim_names = {t.name for t in registry.resolve_tools(["t.sim", "t.real"], mode="SIMULATION")}
+        assert sim_names == {"t.sim"}
+        excluded = registry.excluded_reasons(["t.sim", "t.real"], mode="SIMULATION")
+        assert "mode_not_allowed" in excluded["t.real"][0]
+
+
+async def _echo(args):
+    import json
+
+    return json.dumps(args)
+
+
+class TestServiceIntegration:
+    """退出条件：LIMO MCP observation 可用，action 不可被模型直接执行 ——
+    走 AgentService 全链路（真实 MCP stdio server + 真实 AgentLoop）。"""
+
+    def _service(self, tmp_path: Path, script):
+        import yaml as _yaml
+
+        from rosclaw.agentd.config import load_agent_config
+        from rosclaw.agentd.models.gateway import MockModelGateway
+        from rosclaw.agentd.models.profiles import mock_profile
+        from rosclaw.agentd.service import AgentService
+
+        (tmp_path / "config.yaml").write_text(
+            _yaml.safe_dump(
+                {
+                    "agent": {"enabled": True},
+                    "mcp_servers": [
+                        {
+                            "name": "limo-ros-mcp",
+                            "command": sys.executable,
+                            "args": [str(FIXTURE_SERVER)],
+                            "supported_modes": ["SIMULATION", "SHADOW"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        config = load_agent_config(tmp_path / "config.yaml")
+        return AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), script))
+
+    @staticmethod
+    def _script(req):
+        import json as _json
+
+        from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+
+        if not hasattr(TestServiceIntegration._script, "n"):
+            TestServiceIntegration._script.n = 0
+        TestServiceIntegration._script.n += 1
+        if TestServiceIntegration._script.n == 1:
+            decision = {
+                "next_intent": "OBSERVE",
+                "summary": "读取 LIMO 位姿",
+                "evidence_refs": [],
+                "proposed_operation": {
+                    "type": "observe",
+                    "payload": {
+                        "tool": "limo.localization.get_pose",
+                        "arguments": {"frame": "map"},
+                    },
+                },
+            }
+        else:
+            decision = {
+                "next_intent": "ANSWER",
+                "summary": "位姿 x=1.25（MEASURED 观测证据）",
+                "evidence_refs": ["artifact://observation/x"],
+            }
+        decision.update(
+            {
+                "schema_version": "rosclaw.decision.v1",
+                "decision_id": f"dec_{TestServiceIntegration._script.n}",
+                "mission_id": req.mission_id,
+                "context_id": req.context_id,
+                "context_revision": req.context_revision,
+            }
+        )
+        return ModelTurnResultV1(
+            turn_id="t",
+            provider="mock",
+            model="m",
+            content=f"```json\n{_json.dumps(decision)}\n```",
+            assistant_message={"role": "assistant", "content": "x"},
+            usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+        )
+
+    async def test_limo_observe_end_to_end(self, tmp_path: Path) -> None:
+        TestServiceIntegration._script.n = 0
+        service = self._service(tmp_path, [self._script] * 4)
+        try:
+            mission = service.create_mission("LIMO 观测闭环")
+            result = await service.send_turn(mission.mission_id, "看一下当前位姿")
+            # MCP 发现完成：descriptor 分类正确。
+            pose = service.tool_catalog.get("limo.localization.get_pose")
+            tone = service.tool_catalog.get("limo.speaker.play_tone")
+            assert pose is not None and pose.model_callable
+            assert tone is not None and not tone.model_callable
+            assert tone.requires_exact_action_grant
+            # OBSERVE 真正执行并进入证据封装。
+            assert result.tool_rounds >= 1
+            history = service.conversation(mission.mission_id)
+            obs = [m for m in history if "observation — evidence" in str(m.get("content"))]
+            assert obs, history
+            content = obs[0]["content"]
+            assert "limo.localization.get_pose" in content
+            assert "source: mcp:limo-ros-mcp" in content
+            assert "evidence_class: MEASURED" in content
+            assert "<untrusted_input" in content
+            assert "1.25" in content
+            # action tool 永不进入模型工具面。
+            from rosclaw.agentd.tooling.resolver import FilterContext
+
+            resolved = service.tool_resolver.resolve(FilterContext(mode="SIMULATION"))
+            injected = {d.tool_id for d in resolved.injected}
+            assert "limo.localization.get_pose" in injected
+            assert "limo.speaker.play_tone" not in injected
+        finally:
+            await service.close()
+
+    async def test_dead_mcp_server_degrades_honestly(self, tmp_path: Path) -> None:
+        import yaml as _yaml
+
+        from rosclaw.agentd.config import load_agent_config
+        from rosclaw.agentd.models.gateway import MockModelGateway
+        from rosclaw.agentd.models.profiles import mock_profile
+        from rosclaw.agentd.service import AgentService
+
+        (tmp_path / "config.yaml").write_text(
+            _yaml.safe_dump(
+                {
+                    "agent": {"enabled": True},
+                    "mcp_servers": [{"name": "dead", "command": "/nonexistent/bin-xyz"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        config = load_agent_config(tmp_path / "config.yaml")
+
+        def answer(req):
+            import json as _json
+
+            from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+
+            decision = {
+                "schema_version": "rosclaw.decision.v1",
+                "decision_id": "d1",
+                "mission_id": req.mission_id,
+                "context_id": req.context_id,
+                "context_revision": req.context_revision,
+                "next_intent": "ANSWER",
+                "summary": "ok",
+                "evidence_refs": [],
+            }
+            return ModelTurnResultV1(
+                turn_id="t",
+                provider="mock",
+                model="m",
+                content=f"```json\n{_json.dumps(decision)}\n```",
+                assistant_message={"role": "assistant", "content": "x"},
+                usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+            )
+
+        service = AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), [answer]))
+        try:
+            mission = service.create_mission("降级测试")
+            # 死亡的 MCP server 不得让聊天崩溃；native tools 仍可用。
+            result = await service.send_turn(mission.mission_id, "你好")
+            assert result.reply
+            assert service.tool_catalog.get("sim_get_state") is not None
+        finally:
+            await service.close()

--- a/tests/contracts/golden/rosclaw.tool_descriptor.v2.json
+++ b/tests/contracts/golden/rosclaw.tool_descriptor.v2.json
@@ -1,0 +1,186 @@
+{
+  "$defs": {
+    "ExecutionClass": {
+      "description": "What kind of thing happens when this tool runs (大纲 §7.1).",
+      "enum": [
+        "OBSERVE",
+        "COMPUTE",
+        "PHYSICAL_ACTION"
+      ],
+      "title": "ExecutionClass",
+      "type": "string"
+    },
+    "ToolEvidenceClass": {
+      "enum": [
+        "MEASURED",
+        "SIMULATED",
+        "CONFIGURED",
+        "DERIVED"
+      ],
+      "title": "ToolEvidenceClass",
+      "type": "string"
+    },
+    "ToolSideEffectClass": {
+      "enum": [
+        "NONE",
+        "REVERSIBLE",
+        "IRREVERSIBLE"
+      ],
+      "title": "ToolSideEffectClass",
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.tool_descriptor.v2",
+      "default": "rosclaw.tool_descriptor.v2",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "tool_id": {
+      "minLength": 1,
+      "title": "Tool Id",
+      "type": "string"
+    },
+    "version": {
+      "default": "1.0.0",
+      "title": "Version",
+      "type": "string"
+    },
+    "source": {
+      "minLength": 1,
+      "title": "Source",
+      "type": "string"
+    },
+    "execution_class": {
+      "$ref": "#/$defs/ExecutionClass",
+      "default": "OBSERVE"
+    },
+    "side_effect_class": {
+      "$ref": "#/$defs/ToolSideEffectClass",
+      "default": "NONE"
+    },
+    "description": {
+      "default": "",
+      "title": "Description",
+      "type": "string"
+    },
+    "input_schema": {
+      "additionalProperties": true,
+      "title": "Input Schema",
+      "type": "object"
+    },
+    "output_schema": {
+      "additionalProperties": true,
+      "title": "Output Schema",
+      "type": "object"
+    },
+    "supported_modes": {
+      "items": {
+        "enum": [
+          "SIMULATION",
+          "SHADOW",
+          "REAL"
+        ],
+        "type": "string"
+      },
+      "title": "Supported Modes",
+      "type": "array"
+    },
+    "required_body_types": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Required Body Types",
+      "type": "array"
+    },
+    "freshness_ms": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Freshness Ms"
+    },
+    "timeout_ms": {
+      "default": 2000,
+      "exclusiveMinimum": 0,
+      "title": "Timeout Ms",
+      "type": "integer"
+    },
+    "risk_tier": {
+      "default": "LOW",
+      "enum": [
+        "LOW",
+        "MEDIUM",
+        "HIGH",
+        "CRITICAL"
+      ],
+      "title": "Risk Tier",
+      "type": "string"
+    },
+    "evidence_class": {
+      "$ref": "#/$defs/ToolEvidenceClass",
+      "default": "MEASURED"
+    },
+    "verifier": {
+      "default": "",
+      "title": "Verifier",
+      "type": "string"
+    },
+    "idempotent": {
+      "default": true,
+      "title": "Idempotent",
+      "type": "boolean"
+    },
+    "model_callable": {
+      "default": true,
+      "title": "Model Callable",
+      "type": "boolean"
+    },
+    "requires_exact_action_grant": {
+      "default": false,
+      "title": "Requires Exact Action Grant",
+      "type": "boolean"
+    },
+    "reliability": {
+      "default": 0.5,
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Reliability",
+      "type": "number"
+    },
+    "typical_latency_ms": {
+      "default": 100,
+      "minimum": 0,
+      "title": "Typical Latency Ms",
+      "type": "integer"
+    },
+    "cost_hint": {
+      "default": 0.0,
+      "minimum": 0.0,
+      "title": "Cost Hint",
+      "type": "number"
+    },
+    "required_capabilities": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Required Capabilities",
+      "type": "array"
+    }
+  },
+  "required": [
+    "tool_id",
+    "source"
+  ],
+  "title": "rosclaw.tool_descriptor.v2",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.tool_descriptor.v2"
+}


### PR DESCRIPTION
## Summary

Implements PR-05 of the Pi TUI/Provider 实施大纲 (§7): the Tool/Capability Catalog that sits between "capabilities that exist" and "tools the model may see".

- **ToolDescriptorV2** (`rosclaw.tool_descriptor.v2`, golden schema): contract-level fail-closed invariants — `PHYSICAL_ACTION` is never `model_callable`, must declare `requires_exact_action_grant=True`; OBSERVE tools may not declare side effects.
- **ToolCatalog**: registration, source/tool quarantine, guarded execution (`ToolNotCallableError` for PHYSICAL_ACTION, per-tool timeout).
- **ToolResolver**: deterministic hard filters first (body compat / mode / capability online / SelfSnapshot freshness / permission / policy / budget / verifier / quarantine / model_callable — all explainable), relevance ranking second (semantic match, latency, reliability, cost, freshness, evidence level). Safety conditions never enter the model-facing score. ≤12 tools injected per turn.
- **McpCapabilityAdapter**: stdio discovery via official `mcp` SDK; fail-closed classification (`readOnlyHint` without action verbs → OBSERVE; action verbs / destructiveHint / ambiguity → PHYSICAL_ACTION); discovery failure quarantines the whole source honestly — chat degrades, observations are never fabricated. Server auth via `env:VAR` references only.
- **Evidence wrapper**: EvidenceEnvelope (timestamp/body/source/evidence_class/freshness/artifact_ref) with `<untrusted_input>` marking; oversized outputs spill to a content-addressed artifact store.
- **Wiring**: AgentService builds catalog/resolver/`CatalogToolRegistry`; AgentLoop injects resolved tools and wraps OBSERVE evidence; capabilities layer lists PHYSICAL_ACTION tools as `operator_only`.

## Reuse notes (per reuse-supplement requirements)

- direct dependency: official `mcp` Python SDK (already a core dep) for the MCP client — no hand-rolled JSON-RPC.
- behavior borrowed: resolver hard-filter-then-rank mirrors the worker scheduler's two-stage design (PR-WF); untrusted wrapping reuses the ContextCompiler convention.
- ROSClaw-specific: descriptor invariants, physical-action boundary, evidence envelope.
- deliberately not reused: no external agent framework's tool layer (boundary per ADR-0001).

## Exit condition

LIMO MCP observation is usable by the model; action is never directly executable — verified end-to-end against a real LIMO-like MCP stdio server (FastMCP fixture): `limo.localization.get_pose` is discovered as OBSERVE, executes through the catalog, and arrives as an untrusted evidence envelope; `limo.speaker.play_tone` is classified PHYSICAL_ACTION, never injected, and raises `ToolNotCallableError` even on explicit execution.

## Tests

- 32 new tests in `tests/agentd/test_tooling.py` (descriptor invariants, catalog guards, every hard-filter reason, ranking cap + safety-never-scored, MCP classification/discovery/quarantine, evidence spill, service-level LIMO e2e + dead-server degradation)
- Contract golden: `rosclaw.tool_descriptor.v2.json`
- Full regression: 6033 passed (only pre-existing environmental firstboot/lerobot failures excluded, reproduced on origin/main baseline)
- ruff + mypy clean