### PR TITLE
Close conversation/compact persistence gaps (reuse-supplement 批次A §3.3)

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -83,9 +83,23 @@ Pack/执行器缺失时均停止推进。REAL Mission 还要求显式的
   在流中被 `DecisionBlockFilter` 过滤，不打扰用户。
 - **会话连续性**：对话追加进 mission journal，重启后 `--mission` 恢复完整历史。
 
-已知未做（诚实清单）：跨 provider cooldown/failover 链、多 key 轮换、
-上下文 compaction（microcompact + LLM 摘要）——机制已在调研报告中选型
-（picoclaw cooldown、openharness 两级压缩），待后续阶段引入。
+已知未做（诚实清单）：多 key 轮换。
+
+## 持久化 Compaction（PR-07 + 批次 A）
+
+- **append-only journal**：canonical 对话事件永不删除；每条消息在
+  `append_conversation` 时获得稳定 `entry_id` + 单调 `seq`；
+  内部 journal 键（entry_id/seq/atomic_group）经 gateway sanitizer 净化，
+  永不越过 provider wire。
+- **持久化压缩**：Pi 算法切点（keepRecentTokens 倒序 + 边界对齐，不拆
+  tool_call/tool_result 对、不拆 `atomic_group` 物理原子组）；
+  `CompactionEntryV1` 记录 covered_entry_ids、covered_span_hash、
+  supersedes、prompt_version、provider/model、protected_groups；
+  手动 `/compact`、阈值自动压缩、overflow reactive 压缩全部走同一
+  持久化引擎（不原地改写内存列表，`_persisted_count` 始终对齐）。
+- **视图投影**：模型看到的是 journal 投影（summary marker + kept），
+  重启后从 journal + 最新 compaction 恢复相同 view；物理事实不依赖
+  摘要——每轮从权威存储重新编译。
 
 ## Worker Fabric（PR-WF-050/051/053，experimental）
 

--- a/src/rosclaw/agentd/context/compaction.py
+++ b/src/rosclaw/agentd/context/compaction.py
@@ -54,15 +54,22 @@ def estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
 
 
 def _turn_boundary_ok(messages: list[dict[str, Any]], cut: int) -> bool:
-    """切点不得切开 tool_call/tool_result 配对（§8.4）。"""
+    """切点不得切开 tool_call/tool_result 配对（§8.4），也不得切开
+    ``atomic_group`` 相同的物理原子组（批次 A：观测证据/授权卡/回执等
+    相关消息必须同侧）。"""
     if cut <= 0 or cut >= len(messages):
         return True
     left = messages[cut - 1]
+    right = messages[cut]
+    # 原子组：同组消息不得被切点分开。
+    left_group = left.get("atomic_group")
+    if left_group is not None and left_group == right.get("atomic_group"):
+        return False
     # 左侧是带 tool_calls 的 assistant，而右侧还有它的 tool result → 切断。
     if left.get("tool_calls"):
         return False
     # 右侧是 tool result，而其 assistant 在左侧 → 切断。
-    return messages[cut].get("role") not in _PAIR_ROLES
+    return right.get("role") not in _PAIR_ROLES
 
 
 def find_cut_point(messages: list[dict[str, Any]], *, keep_recent_tokens: int = 20_000) -> int:

--- a/src/rosclaw/agentd/loop.py
+++ b/src/rosclaw/agentd/loop.py
@@ -308,13 +308,16 @@ class AgentLoop:
             try:
                 turn = await self._gateway.complete_stream(request, on_text_delta=on_text_delta)
             except ModelGatewayError as exc:
-                from rosclaw.agentd.context.compact import is_context_overflow, microcompact
+                from rosclaw.agentd.context.compact import is_context_overflow
 
                 if is_context_overflow(exc.kind, str(exc)):
-                    # Reactive compact（openharness 模式）：压缩后重试一次。
+                    # Reactive compact：走持久化压缩（PR-07 引擎），绝不原地
+                    # 改写 self._conversation —— 那会让 _persisted_count 指向
+                    # 错误边界、新消息落不了盘（补充实施文档 §3.3）。
                     await self._emit(AgentEventType.COMPACTION_STARTED, {"reason": "overflow"})
-                    self._conversation, _ = microcompact(self._conversation, keep_recent=4)
-                    await self._emit(AgentEventType.COMPACTION_COMPLETED, {"reason": "overflow"})
+                    await self.compact_conversation(
+                        mission, reason="overflow", keep_recent_tokens=8_000
+                    )
                     request.messages = list(self._conversation)
                     try:
                         turn = await self._gateway.complete_stream(
@@ -597,7 +600,12 @@ class AgentLoop:
                 f"result: {output[:2000]}"
             )
         self._conversation.append(
-            {"role": "tool", "tool_call_id": f"obs_{digest}", "content": evidence_note}
+            {
+                "role": "tool",
+                "tool_call_id": f"obs_{digest}",
+                "content": evidence_note,
+                "atomic_group": f"obs_{digest}",
+            }
         )
         # context_revision += 1（权威存储，非内存计数）。
         self._store.bump_context_revision(mission.mission_id)
@@ -615,6 +623,7 @@ class AgentLoop:
                     "[observation] Fresh evidence attached above. Continue reasoning "
                     "with it and emit your next DecisionV1 when ready."
                 ),
+                "atomic_group": f"obs_{digest}",
             }
         )
         result.tool_rounds += 1
@@ -1056,6 +1065,13 @@ class AgentLoop:
         span = self._conversation[:cut]
         kept = self._conversation[cut:]
         summary = deterministic_summary(span, goal=mission.goal.text, focus=focus)
+        store = CompactionStore(self._store.connection)
+        previous = store.latest(mission.mission_id)
+        from rosclaw.contracts.common import content_hash
+
+        span_hash = content_hash("cmp_span", span)
+        covered_ids = [m["entry_id"] for m in span if m.get("entry_id")]
+        protected = sorted({m["atomic_group"] for m in span if m.get("atomic_group")})
         entry = CompactionEntryV1(
             compaction_id=new_id("cmp"),
             mission_id=mission.mission_id,
@@ -1070,8 +1086,14 @@ class AgentLoop:
             context_revision=mission.context_revision,
             summary_model="deterministic-fallback",
             usage={},
+            covered_entry_ids=covered_ids,
+            covered_span_hash=span_hash,
+            supersedes=previous.compaction_id if previous else None,
+            prompt_version=getattr(self._prompt, "version", "") or "",
+            provider=self._gateway.profile.provider,
+            model=self._gateway.profile.model,
+            protected_groups=protected,
         )
-        store = CompactionStore(self._store.connection)
         store.save(entry)
         # view = summary（untrusted）+ kept；canonical journal 追加 summary 消息。
         view = build_compaction_view(entry, kept)

--- a/src/rosclaw/agentd/mission/store.py
+++ b/src/rosclaw/agentd/mission/store.py
@@ -104,7 +104,20 @@ class MissionStore:
     # missions/task_nodes — chat text is never the source of truth)
     # ------------------------------------------------------------------
     def append_conversation(self, mission_id: str, messages: list[dict], *, actor_id: str) -> None:
+        """Append messages to the canonical journal.
+
+        Each message is stamped in place with a stable ``entry_id`` and
+        monotonic per-mission ``seq`` (补充实施文档 §3.3), so the caller's
+        in-memory view and the journal share message identity.
+        """
         with self._lock:
+            seq = self._conversation_length(mission_id)
+            stamped: list[dict] = []
+            for message in messages:
+                message.setdefault("entry_id", f"conv_{mission_id}_{seq}")
+                message.setdefault("seq", seq)
+                seq += 1
+                stamped.append(message)
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 self._append_event(
@@ -115,13 +128,21 @@ class MissionStore:
                     reason_code="conversation_turn",
                     actor_id=actor_id,
                     trace_id=None,
-                    payload={"messages": messages},
+                    payload={"messages": stamped},
                     idempotency_key=None,
                 )
                 self._conn.execute("COMMIT")
             except Exception:
                 self._conn.execute("ROLLBACK")
                 raise
+
+    def _conversation_length(self, mission_id: str) -> int:
+        total = 0
+        for event in self.events(mission_id):
+            if event["event_type"] == "rosclaw.agent.conversation.appended.v1":
+                payload = json.loads(event["payload_json"])
+                total += len(payload.get("messages") or [])
+        return total
 
     def conversation(self, mission_id: str) -> list[dict]:
         messages: list[dict] = []

--- a/src/rosclaw/agentd/models/gateway.py
+++ b/src/rosclaw/agentd/models/gateway.py
@@ -28,6 +28,16 @@ from rosclaw.contracts.common import ValidationError, new_id
 from rosclaw.provider.core.errors import RuntimeAdapterError
 from rosclaw.provider.runtimes.openai_compat_runtime import OpenAICompatRuntime
 
+#: Standard OpenAI chat message fields; anything else is internal bookkeeping.
+_WIRE_MESSAGE_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name"})
+
+
+def _sanitize_message(message: dict[str, Any]) -> dict[str, Any]:
+    """Strip internal journal keys before a message crosses the provider wire."""
+    if set(message) <= _WIRE_MESSAGE_KEYS:
+        return message
+    return {k: v for k, v in message.items() if k in _WIRE_MESSAGE_KEYS}
+
 
 class ModelGatewayError(Exception):
     """Model invocation failed in a classified, diagnosable way."""
@@ -162,7 +172,9 @@ class OpenAICompatGateway:
         for tool in request.tools:
             tool.validate()
         messages = [{"role": "system", "content": request.system_prompt}]
-        messages.extend(request.messages)
+        # Internal journal keys (entry_id/seq/atomic_group/source/ref …) are
+        # local bookkeeping; providers only accept standard message fields.
+        messages.extend(_sanitize_message(m) for m in request.messages)
         inputs: dict[str, Any] = {
             "messages": messages,
             "max_tokens": request.max_output_tokens,

--- a/src/rosclaw/contracts/agent/compaction.py
+++ b/src/rosclaw/contracts/agent/compaction.py
@@ -48,3 +48,16 @@ class CompactionEntryV1(ContractModel):
     context_revision: int = 0
     summary_model: str = "deterministic-fallback"
     usage: dict[str, Any] = Field(default_factory=dict)
+    # 批次 A（补充实施文档 §3.3/§8.10）：可审计的覆盖范围与来源。
+    #: 被压缩区间的 entry_id 列表（journal append 时稳定赋号）。
+    covered_entry_ids: list[str] = Field(default_factory=list)
+    #: 被压缩区间 canonical JSON 的内容 hash（审计对账用）。
+    covered_span_hash: str = ""
+    #: 被本条取代的上一条 compaction id。
+    supersedes: str | None = None
+    #: 生成摘要时的 prompt/provider/model（deterministic fallback 留空）。
+    prompt_version: str = ""
+    provider: str = ""
+    model: str = ""
+    #: 被压缩区间内受保护、不可拆的原子组标识（观测/授权/回执对等）。
+    protected_groups: list[str] = Field(default_factory=list)

--- a/tests/agentd/test_conversation_journal.py
+++ b/tests/agentd/test_conversation_journal.py
@@ -1,0 +1,223 @@
+"""批次 A 回归（补充实施文档 §3.3）：conversation journal 与 compact 持久化。
+
+- append_conversation 稳定赋 entry_id + 单调 seq
+- 内部 journal 键永不越过 provider wire（gateway sanitizer）
+- CompactionEntryV1 记录 covered_span_hash / covered_entry_ids / supersedes /
+  provider / model / protected_groups
+- find_cut_point 不拆 atomic_group
+- reactive overflow 走持久化压缩（不原地改写）→ 新消息仍落盘、重启一致
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.context.compaction import CompactionStore, find_cut_point
+from rosclaw.agentd.models.gateway import (
+    MockModelGateway,
+    ModelGatewayError,
+    _sanitize_message,
+)
+from rosclaw.agentd.models.profiles import mock_profile
+from rosclaw.agentd.service import AgentService
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+
+
+def _answer(request) -> ModelTurnResultV1:
+    decision = {
+        "schema_version": "rosclaw.decision.v1",
+        "decision_id": "d",
+        "mission_id": request.mission_id,
+        "context_id": request.context_id,
+        "context_revision": request.context_revision,
+        "next_intent": "ANSWER",
+        "summary": "ok",
+        "evidence_refs": [],
+    }
+    return ModelTurnResultV1(
+        turn_id="t",
+        provider="mock",
+        model="m",
+        content=f"```json\n{json.dumps(decision)}\n```",
+        assistant_message={"role": "assistant", "content": "x"},
+        usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+    )
+
+
+def _service(tmp_path: Path, script) -> AgentService:
+    config = load_agent_config(tmp_path / "config.yaml")
+    return AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), script))
+
+
+class TestStableEntryIds:
+    async def test_append_stamps_monotonic_entry_ids(self, tmp_path: Path) -> None:
+        service = _service(tmp_path, [_answer] * 10)
+        try:
+            mission = service.create_mission("entry id 测试")
+            await service.send_turn(mission.mission_id, "第一轮")
+            await service.send_turn(mission.mission_id, "第二轮")
+            history = service.store.conversation(mission.mission_id)
+            ids = [m.get("entry_id") for m in history]
+            seqs = [m.get("seq") for m in history]
+            assert all(ids), history
+            assert len(set(ids)) == len(ids), "entry_id 必须唯一"
+            assert seqs == sorted(seqs), "seq 必须单调"
+            # 重启后 id 不变（稳定身份）。
+            service2 = _service(tmp_path, [_answer] * 10)
+            history2 = service2.store.conversation(mission.mission_id)
+            assert [m.get("entry_id") for m in history2] == ids
+            await service2.close()
+        finally:
+            await service.close()
+
+
+class TestWireSanitizer:
+    def test_internal_keys_stripped(self) -> None:
+        msg = {
+            "role": "user",
+            "content": "hi",
+            "entry_id": "conv_mis_x_3",
+            "seq": 3,
+            "atomic_group": "obs_abc",
+            "source": "user",
+        }
+        assert _sanitize_message(msg) == {"role": "user", "content": "hi"}
+        standard = {"role": "assistant", "content": None, "tool_calls": []}
+        assert _sanitize_message(standard) is standard
+
+    async def test_model_requests_never_carry_journal_keys(self, tmp_path: Path) -> None:
+        """真实 OpenAICompatGateway._build_inputs（无网络）必须净化内部键。"""
+        from rosclaw.agentd.models.gateway import ModelTurnRequest, OpenAICompatGateway
+        from rosclaw.agentd.models.profiles import kimi_k3_profile
+
+        service = _service(tmp_path, [_answer] * 10)
+        try:
+            mission = service.create_mission("wire 净化")
+            await service.send_turn(mission.mission_id, "hello")
+            history = service.store.conversation(mission.mission_id)
+            assert any("entry_id" in m for m in history), "journal 必须带 entry_id"
+            import os
+
+            os.environ["ROSCLAW_TEST_DUMMY_KEY"] = "test-dummy-not-a-secret"
+            gateway = OpenAICompatGateway(
+                kimi_k3_profile(api_key_ref="env:ROSCLAW_TEST_DUMMY_KEY")
+            )
+            request = ModelTurnRequest(
+                system_prompt="sys",
+                messages=history,
+                tools=[],
+                max_output_tokens=16,
+                mission_id=mission.mission_id,
+                context_id="ctx",
+                context_revision=1,
+            )
+            wire = gateway._build_inputs(request)
+            for msg in wire["messages"]:
+                assert "entry_id" not in msg, msg
+                assert "seq" not in msg
+                assert "atomic_group" not in msg
+            await gateway.close()
+        finally:
+            await service.close()
+
+
+class TestCompactionAuditFields:
+    async def test_entry_records_coverage_and_supersedes(self, tmp_path: Path) -> None:
+        service = _service(tmp_path, [_answer] * 50)
+        try:
+            mission = service.create_mission("审计字段")
+            for i in range(4):
+                await service.send_turn(mission.mission_id, f"第 {i} 轮 {'长文本' * 100}")
+            await service.compact(mission.mission_id)
+            for i in range(4, 8):
+                await service.send_turn(mission.mission_id, f"第 {i} 轮 {'长文本' * 100}")
+            await service.compact(mission.mission_id)
+            store = CompactionStore(service.store.connection)
+            entries = store.list(mission.mission_id)
+            assert len(entries) == 2
+            first, second = entries
+            assert first.covered_span_hash.startswith("cmp_span_")
+            assert first.covered_entry_ids, "covered entry ids 必须记录"
+            assert first.provider == "mock" and first.model == "mock-model"
+            assert second.supersedes == first.compaction_id
+            # covered ids 确实来自 journal。
+            history = service.store.conversation(mission.mission_id)
+            journaled_ids = {m.get("entry_id") for m in history}
+            # marker 消息也带 entry_id；covered 的原始 id 已不在 view 中，
+            # 但 canonical journal（含 compact 前事件）里仍可审计。
+            assert all(eid.startswith("conv_") for eid in first.covered_entry_ids)
+            assert journaled_ids, "view 必须保留 entry_id"
+        finally:
+            await service.close()
+
+
+class TestAtomicGroupProtection:
+    def test_cut_never_splits_atomic_group(self) -> None:
+        messages = [{"role": "user", "content": "q " + "长" * 500}]
+        for i in range(8):
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": f"obs_{i}",
+                    "content": "证据 " + "长" * 500,
+                    "atomic_group": f"obs_{i}",
+                }
+            )
+            messages.append(
+                {
+                    "role": "user",
+                    "content": "continue",
+                    "atomic_group": f"obs_{i}",
+                }
+            )
+        cut = find_cut_point(messages, keep_recent_tokens=400)
+        if 0 < cut < len(messages):
+            left_group = messages[cut - 1].get("atomic_group")
+            right_group = messages[cut].get("atomic_group")
+            assert left_group != right_group or left_group is None, (
+                f"cut {cut} splits atomic group {left_group}"
+            )
+
+
+class TestReactiveOverflowPersistentCompaction:
+    async def test_overflow_compacts_persistently_and_keeps_persisting(
+        self, tmp_path: Path
+    ) -> None:
+        fired = {"done": False}
+
+        def overflow_then_answer(request) -> ModelTurnResultV1:
+            trigger = any(
+                "触发 overflow" in str(m.get("content") or "") for m in request.messages
+            )
+            if trigger and not fired["done"]:
+                fired["done"] = True
+                raise ModelGatewayError("http_error", "HTTP 400: prompt is too long")
+            return _answer(request)
+
+        service = _service(tmp_path, [overflow_then_answer] * 20)
+        try:
+            mission = service.create_mission("overflow 压缩")
+            for i in range(8):
+                await service.send_turn(mission.mission_id, f"第 {i} 轮 {'长文本' * 2000}")
+            # 触发 overflow → 持久化压缩 → 重试成功。
+            result = await service.send_turn(mission.mission_id, "触发 overflow 的一轮")
+            assert result.degraded == "reactive_compacted"
+            store = CompactionStore(service.store.connection)
+            entry = store.latest(mission.mission_id)
+            assert entry is not None and entry.reason == "overflow"
+            # §3.3 核心回归：压缩后新消息必须继续落盘。
+            await service.send_turn(mission.mission_id, "压缩后的新问题")
+            history = service.store.conversation(mission.mission_id)
+            assert any("压缩后的新问题" in str(m.get("content")) for m in history)
+            # 重启 view 一致。
+            service2 = _service(tmp_path, [_answer] * 5)
+            restored = service2.store.conversation(mission.mission_id)
+            assert [m.get("entry_id") for m in restored] == [
+                m.get("entry_id") for m in history
+            ]
+            assert any("压缩后的新问题" in str(m.get("content")) for m in restored)
+            await service2.close()
+        finally:
+            await service.close()


### PR DESCRIPTION
## Summary

Closes the P0 gaps flagged by rosclaw-native-agent-reuse-supplement §3.3 / 批次A against the merged PR-07 compaction engine.

- **Reactive overflow no longer rewrites the conversation in place.** Context-overflow now routes through the persistent compaction engine (`reason="overflow"`), so `_persisted_count` always points at the true unpersisted boundary — post-compact messages can never be silently dropped from the journal (regression test included).
- **Stable message identity.** `append_conversation` stamps each message in place with a stable `entry_id` + monotonic per-mission `seq`; restart restores identical identity. This is the foundation for later fork/tree/import work (批次F) which must reference journal entries deterministically.
- **Wire hygiene.** The model gateway sanitizes outgoing messages: internal journal keys (`entry_id`/`seq`/`atomic_group`) never cross to the provider.
- **Auditable compaction records.** CompactionEntryV1 gains `covered_entry_ids`, `covered_span_hash`, `supersedes`, `prompt_version`, `provider`/`model`, `protected_groups` (all optional → forward-compatible).
- **Physical atomic groups.** `find_cut_point` never splits messages sharing an `atomic_group`; observation evidence + its continuation are tagged as one group.
- **docs/AGENTD.md** consistency: removes the stale "compaction not done" claim (§3.3 point on docs drift) and documents the persistent design.

## Reuse notes

- behavior borrowed: Pi compaction cut-point algorithm (already merged in PR-07); this PR keeps the same algorithm and hardens persistence around it.
- ROSClaw-specific: entry identity, atomic groups, audit fields, wire sanitizer.
- deliberately not reused: Pi SessionManager/JSONL session tree (supplement forbids it as mission authority).

## Tests

- New `tests/agentd/test_conversation_journal.py` (6 tests): stable ids across restart, wire sanitizer (incl. real `OpenAICompatGateway._build_inputs`), compaction audit fields + supersedes chain, atomic-group cut protection, overflow → persistent compaction → keeps persisting → restart-identical view.
- Full regression: 6039 passed; ruff + mypy clean.