### PR TITLE
rosclaw-tui minimal full loop with pi-tui (reuse-supplement 批次C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ generated/
 # Agent/backup churn
 .backups/
 .agents/skills/rosclaw/.backups/
+node_modules/

--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -198,6 +198,25 @@ live 模型协调。3v3 联赛基准（T-SIM-2/3）属 PR-TF-075 后续范围。
   unverified/inferred 显式拒绝并记录；Darwin 晋升门 = 评测引用 + 人类
   principal，任何代码路径不能自动晋升。
 
+## rosclaw-tui（批次 C）
+
+- `packages/rosclaw-tui`：精确锁定 `@earendil-works/pi-tui@0.83.0`
+  （MIT，third_party/pi 有 NOTICE/LICENSE；lockfile 已提交），
+  Node >= 22.19。薄 Presenter + 纯函数 reducer + 命令路由——不复制
+  Pi interactive-mode.ts。
+- 数据流：`GET snapshot`（权威对齐）→ SSE `Last-Event-ID` 增量 →
+  reducer → 渲染效果；sequence 缺口自动重拉快照；event_id 去重；
+  agent.settled 停止 spinner。
+- 命令：`/help /hotkeys /quit /clear-screen /approve /deny /missions`
+  本地处理；`/compact /cancel /rename /archive /status /tools` 经
+  Batch B 控制 API；未知命令提示而不是发给模型。
+- 卡片：tool / worker / approval / receipt 结构化渲染；状态行常显
+  mode（REAL 红底）/body/mission/state/待批准数/阶段。
+- `rosclaw chat` 默认启动 TUI（进程内 uvicorn + exec node）；
+  Node/资源缺失时诚实回退 `rosclaw chat --basic`（input() 诊断模式）。
+- 边界由架构测试锁定：TUI 不得含模型客户端，pi 包必须精确锁定
+  （tests/architecture/test_pi_dependency_boundary.py）。
+
 ## UI 控制面（批次 B：命令/事件/快照/交互）
 
 - **命令是控制协议，不是聊天文本**：`/compact /cancel /rename /archive

--- a/packages/rosclaw-tui/package-lock.json
+++ b/packages/rosclaw-tui/package-lock.json
@@ -1,0 +1,106 @@
+{
+	"name": "rosclaw-tui",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "rosclaw-tui",
+			"version": "0.1.0",
+			"dependencies": {
+				"@earendil-works/pi-tui": "0.83.0",
+				"chalk": "^5.3.0"
+			},
+			"bin": {
+				"rosclaw-tui": "dist/main.js"
+			},
+			"devDependencies": {
+				"@types/node": "^22.10.0",
+				"typescript": "^5.7.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-tui": {
+			"version": "0.83.0",
+			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
+			"integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "22.20.1",
+			"resolved": "https://registry.npmmirror.com/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmmirror.com/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmmirror.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmmirror.com/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		}
+	}
+}

--- a/packages/rosclaw-tui/package.json
+++ b/packages/rosclaw-tui/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "rosclaw-tui",
+	"version": "0.1.0",
+	"private": true,
+	"description": "ROSClaw Native Agent terminal UI — pi-tui components + ROSClaw command routing + state reducer. Never executes tools, workers, or hardware.",
+	"type": "module",
+	"bin": {
+		"rosclaw-tui": "dist/main.js"
+	},
+	"engines": {
+		"node": ">=22.19.0"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"test": "npm run build && node --test dist/test/*.test.js",
+		"start": "node dist/main.js"
+	},
+	"dependencies": {
+		"@earendil-works/pi-tui": "0.83.0",
+		"chalk": "^5.3.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.0",
+		"typescript": "^5.7.0"
+	}
+}

--- a/packages/rosclaw-tui/src/app.ts
+++ b/packages/rosclaw-tui/src/app.ts
@@ -1,0 +1,330 @@
+/** rosclaw-tui app (批次 C)：薄 Presenter + reducer + 命令路由。
+ *
+ * 禁止复制 Pi interactive-mode.ts —— 这里只做：
+ * pi-tui 组件装配、SSE 消费、effect 渲染、命令路由。
+ * TUI 永远不执行工具/Worker/物理动作，不与模型直接通信。
+ */
+
+import {
+	Editor,
+	Markdown,
+	ProcessTerminal,
+	Text,
+	TUI,
+	matchesKey,
+} from "@earendil-works/pi-tui";
+import { AgentClient, idempotencyKey } from "./client/http.js";
+import { streamEvents } from "./client/sse.js";
+import { CommandRegistry } from "./commands/registry.js";
+import { HOTKEYS_TEXT, renderCard, statusLine } from "./components/render.js";
+import { chalk, editorTheme, markdownTheme, modeColor } from "./components/theme.js";
+import { reduce, shortId, type Effect } from "./state/reducer.js";
+import { initialState, type UiState } from "./state/types.js";
+
+export interface AppOptions {
+	baseUrl: string;
+	missionId: string;
+}
+
+export class RosclawTuiApp {
+	private tui!: TUI;
+	private editor!: Editor;
+	private statusText!: Text;
+	private state: UiState;
+	private client: AgentClient;
+	private registry = new CommandRegistry();
+	private deltaBuffer = "";
+	private abort = new AbortController();
+	private running = false;
+
+	constructor(private readonly options: AppOptions) {
+		this.client = new AgentClient(options.baseUrl);
+		this.state = initialState(options.missionId);
+	}
+
+	async start(): Promise<void> {
+		// 初始对齐：snapshot 是权威，SSE 是增量。
+		try {
+			const snap = await this.client.snapshot(this.options.missionId);
+			this.state.missionName = snap.name;
+			this.state.missionState = snap.state;
+			this.state.mode = snap.mode;
+			this.state.bodyId = snap.body_id;
+			this.state.lastSeq = snap.last_event_sequence;
+			this.state.turnInFlight = snap.turn_in_flight;
+			this.state.compactions = snap.compaction_count;
+			this.state.pendingApprovals = snap.pending_approvals.map((a) => ({
+				requestId: String(a.request_id ?? ""),
+				title: String(a.title ?? ""),
+				riskTier: String(a.risk_tier ?? "LOW"),
+				expiresAt: a.expires_at ? String(a.expires_at) : undefined,
+			}));
+		} catch (err) {
+			throw new Error(
+				`无法连接 AgentService（${this.options.baseUrl}）：${(err as Error).message}\n` +
+					"请先启动 rosclaw-agentd（rosclaw chat 会自动启动），或用 --url 指定地址。",
+			);
+		}
+		try {
+			const caps = await this.client.capabilities(this.options.missionId);
+			this.registry.loadRemote(caps.commands);
+		} catch {
+			// 老服务端没有 /v1/capabilities → 只用本地命令，诚实降级。
+		}
+
+		const terminal = new ProcessTerminal();
+		this.tui = new TUI(terminal);
+		this.statusText = new Text(this.statusString());
+		this.editor = new Editor(this.tui, editorTheme);
+		this.editor.onSubmit = (text) => {
+			void this.handleInput(text);
+		};
+
+		this.tui.addChild(
+			new Markdown(
+				`**ROSClaw Native Agent** — ${this.state.missionName}\n` +
+					`mode: ${this.state.mode} | body: ${this.state.bodyId}\n` +
+					"输入消息开始；/help 查看命令。TUI 只是客户端，权威状态在 AgentService。",
+				0,
+				0,
+				markdownTheme,
+			),
+		);
+		this.tui.addChild(this.statusText);
+		this.tui.addChild(this.editor);
+		this.tui.setFocus(this.editor);
+
+		this.tui.addInputListener((data) => {
+			if (matchesKey(data, "ctrl+c")) {
+				if (this.state.turnInFlight) {
+					void this.client.cancelTurn(this.options.missionId);
+					this.print(new Text(chalk.dim("已请求取消当前 turn（已派发动作不受影响）")));
+				} else {
+					this.print(new Text(chalk.dim("再按一次 Ctrl+C 退出；输入为空时 Ctrl+D 也可退出")));
+					this.confirmExit = true;
+					setTimeout(() => (this.confirmExit = false), 2000);
+					if (this.confirmExit && this.lastCtrlC) this.stop();
+					this.lastCtrlC = true;
+					setTimeout(() => (this.lastCtrlC = false), 2000);
+				}
+				return { consume: true };
+			}
+			if (matchesKey(data, "ctrl+d")) {
+				this.stop();
+				return { consume: true };
+			}
+			return undefined;
+		});
+
+		this.running = true;
+		this.tui.start();
+		void this.consumeEvents();
+	}
+
+	private confirmExit = false;
+	private lastCtrlC = false;
+
+	stop(): void {
+		this.running = false;
+		this.abort.abort();
+		this.tui.stop();
+	}
+
+	private statusString(): string {
+		const line = statusLine(this.state);
+		const phase = this.state.phase ? ` [${this.state.phase}…]` : "";
+		return modeColor(this.state.mode, line) + chalk.dim(phase);
+	}
+
+	private refreshStatus(): void {
+		this.statusText.setText?.(this.statusString());
+	}
+
+	/** 在 status bar 与 editor 之上插入一行（保持布局顺序）。 */
+	private print(component: Text | Markdown): void {
+		this.tui.removeChild(this.statusText);
+		this.tui.removeChild(this.editor);
+		this.tui.addChild(component);
+		this.tui.addChild(this.statusText);
+		this.tui.addChild(this.editor);
+		this.tui.setFocus(this.editor);
+	}
+
+	private applyEffects(effects: Effect[]): void {
+		for (const effect of effects) {
+			switch (effect.kind) {
+				case "append_markdown":
+					this.print(new Markdown(effect.text, 0, 0, markdownTheme));
+					break;
+				case "append_delta":
+					this.deltaBuffer += effect.text;
+					break;
+				case "flush_delta":
+					if (this.deltaBuffer.trim()) {
+						this.print(new Markdown(this.deltaBuffer, 0, 0, markdownTheme));
+					}
+					this.deltaBuffer = "";
+					break;
+				case "append_card":
+					this.print(new Text(renderCard(effect.card)));
+					break;
+				case "spinner":
+				case "spinner_stop":
+				case "status_refresh":
+					this.refreshStatus();
+					break;
+			}
+		}
+	}
+
+	private async consumeEvents(): Promise<void> {
+		const { baseUrl, missionId } = this.options;
+		const generator = streamEvents(baseUrl, missionId, {
+			signal: this.abort.signal,
+			onGap: () => {
+				// sequence 缺口：停止乐观渲染，拉权威快照对齐（§5.4）。
+				void this.resync();
+			},
+			onReconnect: () => {
+				this.state.reconnecting = true;
+				this.refreshStatus();
+			},
+		});
+		for await (const event of generator) {
+			this.state.reconnecting = false;
+			const effects = reduce(this.state, event);
+			this.applyEffects(effects);
+		}
+	}
+
+	private async resync(): Promise<void> {
+		try {
+			const snap = await this.client.snapshot(this.options.missionId);
+			this.state.missionState = snap.state;
+			this.state.mode = snap.mode;
+			this.state.turnInFlight = snap.turn_in_flight;
+			this.print(new Text(chalk.yellow("事件流出现缺口，已用权威快照重新对齐。")));
+			this.refreshStatus();
+		} catch {
+			// 快照也拉不到 → 等 SSE 重连
+		}
+	}
+
+	private async handleInput(raw: string): Promise<void> {
+		const text = raw.trim();
+		if (!text) return;
+		const route = this.registry.parse(text);
+		switch (route.kind) {
+			case "not_a_command":
+				this.print(new Text(chalk.cyan("> " + text)));
+				try {
+					await this.client.submitTurn(this.options.missionId, text);
+				} catch (err) {
+					this.print(new Text(chalk.red(`发送失败：${(err as Error).message}`)));
+				}
+				return;
+			case "unknown":
+				this.print(
+					new Text(
+						chalk.yellow(
+							`未知命令 /${route.name}。直接作为文本发送请去掉开头的 /，或 /help 查看命令。`,
+						),
+					),
+				);
+				return;
+			case "local":
+				await this.handleLocal(route.name, route.args);
+				return;
+			case "remote": {
+				if (route.spec.disabled_reason) {
+					this.print(new Text(chalk.yellow(`/${route.spec.name} 不可用：${route.spec.disabled_reason}`)));
+					return;
+				}
+				const args = this.parseRemoteArgs(route.spec.name, route.args);
+				const result = await this.client.command(
+					this.options.missionId,
+					route.spec.name,
+					args,
+					idempotencyKey(),
+				);
+				this.print(
+					new Text(
+						result.ok
+							? chalk.green(result.message || "ok")
+							: chalk.red(`${result.error_code}: ${result.message}`),
+					),
+				);
+				return;
+			}
+		}
+	}
+
+	private parseRemoteArgs(name: string, args: string): Record<string, unknown> {
+		if (name === "rename") return { name: args };
+		if (name === "compact") {
+			if (args === "dry-run") return { dry_run: true };
+			if (args.startsWith("focus ")) return { focus: args.slice(6) };
+			return {};
+		}
+		return {};
+	}
+
+	private async handleLocal(name: string, args: string): Promise<void> {
+		switch (name) {
+			case "help": {
+				const rows = this.registry
+					.all()
+					.filter((c) => !args || c.name === args)
+					.map((c) => {
+						const disabled = c.disabled ? chalk.yellow(`（不可用：${c.disabled}）`) : "";
+						return `/${c.name} ${c.hint}\n  ${c.description} [${c.owner}] ${disabled}`;
+					});
+				this.print(new Text(rows.join("\n") || "无匹配命令"));
+				return;
+			}
+			case "hotkeys":
+				this.print(new Text(HOTKEYS_TEXT));
+				return;
+			case "clear-screen":
+				process.stdout.write("\x1b[2J\x1b[H");
+				return;
+			case "quit": {
+				const active = this.state.workers.filter(
+					(w) => !["accepted", "failed", "expired"].includes(w.status),
+				);
+				if (active.length > 0) {
+					this.print(
+						new Text(
+							chalk.yellow(
+								`注意：${active.length} 个 WorkOrder 未终态。退出 TUI 不会停止已派发工作；` +
+									"权威状态保留在 AgentService。",
+							),
+						),
+					);
+				}
+				this.stop();
+				return;
+			}
+			case "approve":
+			case "deny": {
+				const item = this.state.pendingApprovals.find(
+					(a) => a.requestId === args || a.requestId.startsWith(args),
+				);
+				if (!item) {
+					this.print(new Text(chalk.yellow(`没有匹配的待批准请求：${args || "(空)"}`)));
+					return;
+				}
+				await this.client.decideApproval(item.requestId, name === "approve");
+				return;
+			}
+			case "missions": {
+				const missions = await this.client.listMissions();
+				const lines = missions.map(
+					(m) => `${m.mission_id}  ${String(m.state ?? "")}  ${String((m.goal as { text?: string })?.text ?? "").slice(0, 40)}`,
+				);
+				this.print(new Text(lines.join("\n") || "(无 Mission)"));
+				return;
+			}
+		}
+	}
+}

--- a/packages/rosclaw-tui/src/client/http.ts
+++ b/packages/rosclaw-tui/src/client/http.ts
@@ -1,0 +1,135 @@
+/** AgentService control API client (批次 C).
+ *
+ * The TUI only ever talks to the AgentService control plane — never to MCP,
+ * workers, modeld, or rosclawd.
+ */
+
+export interface CommandSpec {
+	name: string;
+	aliases: string[];
+	description: string;
+	argument_hint: string;
+	category: string;
+	owner: string;
+	availability: string[];
+	during_turn: boolean;
+	mutability: string;
+	confirmation: string;
+	required_capabilities: string[];
+	handler: string;
+	disabled_reason: string;
+}
+
+export interface CommandResult {
+	request_id: string;
+	command_name: string;
+	ok: boolean;
+	message: string;
+	data: Record<string, unknown>;
+	error_code: string;
+}
+
+export interface MissionSnapshot {
+	mission_id: string;
+	name: string;
+	goal_text: string;
+	state: string;
+	mode: string;
+	body_id: string;
+	context_id: string;
+	context_revision: number;
+	last_event_sequence: number;
+	turn_in_flight: boolean;
+	pending_approvals: Array<Record<string, unknown>>;
+	active_grants: Array<Record<string, unknown>>;
+	open_work_orders: Array<Record<string, unknown>>;
+	usage: Record<string, unknown>;
+	compaction_count: number;
+	tool_count: number;
+	captured_at: string;
+}
+
+export interface MissionInfo {
+	mission_id: string;
+	goal?: { text?: string };
+	state?: string;
+	mode?: string;
+	updated_at?: string;
+	[key: string]: unknown;
+}
+
+export class AgentClient {
+	constructor(private readonly baseUrl: string) {}
+
+	private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+		const res = await fetch(`${this.baseUrl}${path}`, {
+			method,
+			headers: body !== undefined ? { "content-type": "application/json" } : undefined,
+			body: body !== undefined ? JSON.stringify(body) : undefined,
+		});
+		if (!res.ok) {
+			const text = await res.text().catch(() => "");
+			throw new Error(`HTTP ${res.status} ${method} ${path}: ${text.slice(0, 200)}`);
+		}
+		return (await res.json()) as T;
+	}
+
+	health(): Promise<Record<string, unknown>> {
+		return this.request("GET", "/health");
+	}
+
+	listMissions(): Promise<MissionInfo[]> {
+		return this.request("GET", "/missions");
+	}
+
+	createMission(goal: string, mode?: string): Promise<{ mission_id: string }> {
+		return this.request("POST", "/missions", { goal, mode });
+	}
+
+	submitTurn(missionId: string, text: string): Promise<{ turn_id: string }> {
+		return this.request("POST", `/v2/missions/${missionId}/turns`, { text });
+	}
+
+	cancelTurn(missionId: string): Promise<unknown> {
+		return this.request("POST", `/v2/missions/${missionId}/cancel`, {});
+	}
+
+	capabilities(missionId: string): Promise<{ commands: CommandSpec[] }> {
+		return this.request("GET", `/v1/capabilities?mission_id=${missionId}`);
+	}
+
+	command(
+		missionId: string,
+		name: string,
+		args: Record<string, unknown>,
+		idempotencyKey: string,
+	): Promise<CommandResult> {
+		return this.request("POST", `/v1/missions/${missionId}/commands`, {
+			request_id: `req_${idempotencyKey}`,
+			idempotency_key: idempotencyKey,
+			command_name: name,
+			arguments: args,
+		});
+	}
+
+	snapshot(missionId: string): Promise<MissionSnapshot> {
+		return this.request("GET", `/v1/missions/${missionId}/snapshot`);
+	}
+
+	decideApproval(requestId: string, approve: boolean): Promise<Record<string, unknown>> {
+		return this.request("POST", `/approvals/${requestId}/decide`, {
+			approve,
+			principal: "user:local:1000",
+		});
+	}
+
+	pendingApprovals(missionId: string): Promise<Array<Record<string, unknown>>> {
+		return this.request("GET", `/approvals/pending?mission_id=${missionId}`);
+	}
+}
+
+let counter = 0;
+export function idempotencyKey(): string {
+	counter += 1;
+	return `tui_${Date.now().toString(36)}_${counter}`;
+}

--- a/packages/rosclaw-tui/src/client/sse.ts
+++ b/packages/rosclaw-tui/src/client/sse.ts
@@ -1,0 +1,116 @@
+/** SSE client with Last-Event-ID resume (批次 B/C §5.3).
+ *
+ * - Reconnects with backoff, preserving the last seen sequence.
+ * - Sequence gaps are surfaced via onGap so the consumer can stop
+ *   optimistic rendering and re-pull the authoritative snapshot.
+ * - Duplicate events are dropped by event_id.
+ */
+
+export interface AgentEvent {
+	event_id: string;
+	sequence: number;
+	mission_id: string;
+	turn_id?: string | null;
+	type: string;
+	visibility: string;
+	payload: Record<string, unknown>;
+	timestamp: string;
+}
+
+export interface SseOptions {
+	signal?: AbortSignal;
+	onGap?: (expected: number, got: number) => void;
+	onReconnect?: (attempt: number) => void;
+	maxAttempts?: number;
+}
+
+export async function* streamEvents(
+	baseUrl: string,
+	missionId: string,
+	options: SseOptions = {},
+): AsyncGenerator<AgentEvent> {
+	const seen = new Set<string>();
+	let lastSeq = 0;
+	let attempt = 0;
+	let emptyStreak = 0;
+	const maxAttempts = options.maxAttempts ?? 100;
+
+	while (attempt < maxAttempts && emptyStreak < 3) {
+		if (options.signal?.aborted) return;
+		const headers: Record<string, string> = { accept: "text/event-stream" };
+		if (lastSeq > 0) headers["last-event-id"] = String(lastSeq);
+		let res: Response;
+		try {
+			res = await fetch(`${baseUrl}/v2/missions/${missionId}/events`, { headers, signal: options.signal });
+		} catch {
+			attempt += 1;
+			options.onReconnect?.(attempt);
+			await sleep(Math.min(200 * attempt, 3000), options.signal);
+			continue;
+		}
+		if (!res.ok || !res.body) {
+			attempt += 1;
+			options.onReconnect?.(attempt);
+			await sleep(Math.min(200 * attempt, 3000), options.signal);
+			continue;
+		}
+		attempt = 0;
+		let yielded = 0;
+		const reader = res.body.getReader();
+		const decoder = new TextDecoder();
+		let buffer = "";
+		try {
+			for (;;) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+				let idx: number;
+				while ((idx = buffer.indexOf("\n\n")) !== -1) {
+					const frame = buffer.slice(0, idx);
+					buffer = buffer.slice(idx + 2);
+					const event = parseFrame(frame);
+					if (!event) continue;
+					if (seen.has(event.event_id)) continue; // 去重
+					seen.add(event.event_id);
+					if (lastSeq > 0 && event.sequence > lastSeq + 1) {
+						options.onGap?.(lastSeq + 1, event.sequence);
+					}
+					lastSeq = Math.max(lastSeq, event.sequence);
+					yielded += 1;
+					yield event;
+				}
+			}
+		} catch {
+			// connection dropped → reconnect with Last-Event-ID
+		}
+		// 连接正常结束但没有新事件：对 bounded replay（follow=false）这是
+		// 终止信号；连续空重连即退出，避免无限轮询。
+		emptyStreak = yielded === 0 ? emptyStreak + 1 : 0;
+		attempt += 1;
+		options.onReconnect?.(attempt);
+		await sleep(Math.min(200 * attempt, 3000), options.signal);
+	}
+}
+
+function parseFrame(frame: string): AgentEvent | null {
+	let data = "";
+	for (const line of frame.split("\n")) {
+		if (line.startsWith("data: ")) data += line.slice(6);
+	}
+	if (!data) return null;
+	try {
+		return JSON.parse(data) as AgentEvent;
+	} catch {
+		return null;
+	}
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		const timer = setTimeout(resolve, ms);
+		signal?.addEventListener("abort", () => {
+			clearTimeout(timer);
+			resolve();
+		}, { once: true });
+	});
+}

--- a/packages/rosclaw-tui/src/commands/registry.ts
+++ b/packages/rosclaw-tui/src/commands/registry.ts
@@ -1,0 +1,77 @@
+/** Command registry (批次 C，§5.1)：命令先解析、按 owner 路由，永不发给模型。 */
+
+import type { CommandSpec } from "../client/http.js";
+
+export type CommandRoute =
+	| { kind: "local"; name: string; args: string }
+	| { kind: "remote"; spec: CommandSpec; args: string }
+	| { kind: "unknown"; name: string; args: string }
+	| { kind: "not_a_command" };
+
+export interface LocalCommand {
+	name: string;
+	aliases: string[];
+	description: string;
+	argumentHint: string;
+}
+
+/** TUI 本地命令（LOCAL_UI owner）—— 不需要服务端。 */
+export const LOCAL_COMMANDS: LocalCommand[] = [
+	{ name: "help", aliases: ["h", "?"], description: "显示全部命令", argumentHint: "[command]" },
+	{ name: "hotkeys", aliases: [], description: "显示快捷键", argumentHint: "" },
+	{ name: "quit", aliases: ["q", "exit"], description: "退出 TUI（不停止已派发动作）", argumentHint: "" },
+	{ name: "clear-screen", aliases: ["cls"], description: "清屏（不清 Mission）", argumentHint: "" },
+	{ name: "approve", aliases: [], description: "批准授权请求", argumentHint: "<request_id>" },
+	{ name: "deny", aliases: [], description: "拒绝授权请求", argumentHint: "<request_id>" },
+	{ name: "missions", aliases: [], description: "列出 Mission", argumentHint: "" },
+];
+
+export class CommandRegistry {
+	private remote = new Map<string, CommandSpec>();
+
+	loadRemote(specs: CommandSpec[]): void {
+		this.remote.clear();
+		for (const spec of specs) this.remote.set(spec.name, spec);
+	}
+
+	remoteSpecs(): CommandSpec[] {
+		return [...this.remote.values()];
+	}
+
+	parse(input: string): CommandRoute {
+		if (!input.startsWith("/")) return { kind: "not_a_command" };
+		const [head, ...rest] = input.slice(1).split(/\s+/);
+		const args = rest.join(" ");
+		const name = head.toLowerCase();
+		const local = LOCAL_COMMANDS.find((c) => c.name === name || c.aliases.includes(name));
+		if (local) return { kind: "local", name: local.name, args };
+		const remote = this.remote.get(name);
+		if (remote) return { kind: "remote", spec: remote, args };
+		return { kind: "unknown", name, args };
+	}
+
+	all(): Array<{ name: string; description: string; owner: string; disabled?: string; hint: string }> {
+		const rows: Array<{
+			name: string;
+			description: string;
+			owner: string;
+			disabled?: string;
+			hint: string;
+		}> = LOCAL_COMMANDS.map((c) => ({
+			name: c.name,
+			description: c.description,
+			owner: "LOCAL_UI",
+			hint: c.argumentHint,
+		}));
+		for (const spec of this.remote.values()) {
+			rows.push({
+				name: spec.name,
+				description: spec.description,
+				owner: spec.owner,
+				disabled: spec.disabled_reason || undefined,
+				hint: spec.argument_hint,
+			});
+		}
+		return rows.sort((a, b) => a.name.localeCompare(b.name));
+	}
+}

--- a/packages/rosclaw-tui/src/components/render.ts
+++ b/packages/rosclaw-tui/src/components/render.ts
@@ -1,0 +1,51 @@
+/** Presentational helpers (pure, testable)：status line 与卡片文本。 */
+
+import type { CardModel } from "../state/reducer.js";
+import type { UiState } from "../state/types.js";
+
+export function statusLine(state: UiState): string {
+	const parts = [
+		`ROSClaw`,
+		state.missionName || state.missionId,
+		state.mode,
+	];
+	if (state.bodyId) parts.push(state.bodyId);
+	if (state.model) parts.push(`model=${state.model}`);
+	parts.push(`state=${state.missionState}`);
+	if (state.pendingApprovals.length > 0) parts.push(`待批准=${state.pendingApprovals.length}`);
+	if (state.workers.some((w) => !["accepted", "failed", "expired"].includes(w.status))) {
+		parts.push(`workers=${state.workers.filter((w) => !["accepted", "failed", "expired"].includes(w.status)).length}`);
+	}
+	if (state.compactions > 0) parts.push(`compactions=${state.compactions}`);
+	if (state.reconnecting) parts.push("reconnecting…");
+	if (state.degraded) parts.push(`degraded=${state.degraded}`);
+	return parts.join(" | ");
+}
+
+export function renderCard(card: CardModel): string {
+	const border = "─".repeat(Math.max(8, Math.min(60, visibleLen(card.title) + 4)));
+	const lines = [
+		`┌${border}┐`,
+		`│ ${card.title}`,
+		...card.lines.map((l) => `│ ${l}`),
+		`└${border}┘`,
+	];
+	return lines.join("\n");
+}
+
+function visibleLen(text: string): number {
+	let width = 0;
+	for (const ch of text) {
+		width += ch.charCodeAt(0) > 0xff ? 2 : 1;
+	}
+	return width;
+}
+
+export const HOTKEYS_TEXT = [
+	"Enter        发送 / 执行命令",
+	"Shift+Enter  换行（多行编辑）",
+	"Ctrl+C       turn 运行中：取消 turn；否则退出提示",
+	"Ctrl+D       输入为空时退出 TUI",
+	"↑ / ↓        历史输入",
+	"Tab          命令补全",
+].join("\n");

--- a/packages/rosclaw-tui/src/components/theme.ts
+++ b/packages/rosclaw-tui/src/components/theme.ts
@@ -1,0 +1,58 @@
+/** pi-tui themes (chalk-based, mirrors pi-tui test themes). */
+
+import { Chalk } from "chalk";
+import type { EditorTheme, MarkdownTheme, SelectListTheme } from "@earendil-works/pi-tui";
+
+const chalk = new Chalk({ level: 3 });
+
+export { chalk };
+
+export const selectListTheme: SelectListTheme = {
+	selectedPrefix: (text: string) => chalk.blue(text),
+	selectedText: (text: string) => chalk.bold(text),
+	description: (text: string) => chalk.dim(text),
+	scrollInfo: (text: string) => chalk.dim(text),
+	noMatch: (text: string) => chalk.dim(text),
+};
+
+export const markdownTheme: MarkdownTheme = {
+	heading: (text: string) => chalk.bold.cyan(text),
+	link: (text: string) => chalk.blue(text),
+	linkUrl: (text: string) => chalk.dim(text),
+	code: (text: string) => chalk.yellow(text),
+	codeBlock: (text: string) => chalk.green(text),
+	codeBlockBorder: (text: string) => chalk.dim(text),
+	quote: (text: string) => chalk.italic(text),
+	quoteBorder: (text: string) => chalk.dim(text),
+	hr: (text: string) => chalk.dim(text),
+	listBullet: (text: string) => chalk.cyan(text),
+	bold: (text: string) => chalk.bold(text),
+	italic: (text: string) => chalk.italic(text),
+	strikethrough: (text: string) => chalk.strikethrough(text),
+	underline: (text: string) => chalk.underline(text),
+};
+
+export const editorTheme: EditorTheme = {
+	borderColor: (text: string) => chalk.dim(text),
+	selectList: selectListTheme,
+};
+
+export function toneColor(tone: string, text: string): string {
+	switch (tone) {
+		case "ok":
+			return chalk.green(text);
+		case "warn":
+			return chalk.yellow(text);
+		case "error":
+			return chalk.red(text);
+		default:
+			return chalk.dim(text);
+	}
+}
+
+/** REAL 模式状态行：显眼但不刺眼的固定色（§6.3）。 */
+export function modeColor(mode: string, text: string): string {
+	if (mode === "REAL") return chalk.bgRed.white.bold(text);
+	if (mode === "SHADOW") return chalk.yellow(text);
+	return chalk.green(text);
+}

--- a/packages/rosclaw-tui/src/main.ts
+++ b/packages/rosclaw-tui/src/main.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/** rosclaw-tui entry (批次 C)。
+ *
+ * 用法：rosclaw-tui --url http://127.0.0.1:8787 --mission mis_x [--goal "新任务"]
+ * Python CLI（rosclaw chat）负责启动/发现 AgentService 后 exec 本入口。
+ */
+
+import { RosclawTuiApp } from "./app.js";
+import { AgentClient } from "./client/http.js";
+
+const REQUIRED_NODE = "22.19.0";
+
+function versionAtLeast(current: string, required: string): boolean {
+	const cur = current.split(".").map(Number);
+	const req = required.split(".").map(Number);
+	for (let i = 0; i < 3; i += 1) {
+		if ((cur[i] ?? 0) > (req[i] ?? 0)) return true;
+		if ((cur[i] ?? 0) < (req[i] ?? 0)) return false;
+	}
+	return true;
+}
+
+function parseArgs(argv: string[]): Record<string, string> {
+	const args: Record<string, string> = {};
+	for (let i = 0; i < argv.length; i += 1) {
+		if (argv[i].startsWith("--")) {
+			const key = argv[i].slice(2);
+			args[key] = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+		}
+	}
+	return args;
+}
+
+async function main(): Promise<void> {
+	if (!versionAtLeast(process.versions.node, REQUIRED_NODE)) {
+		console.error(
+			`rosclaw-tui 需要 Node >= ${REQUIRED_NODE}（当前 ${process.versions.node}）。\n` +
+				"请安装受支持的 Node 运行时；Python-only 安装可用 rosclaw chat --basic。",
+		);
+		process.exit(2);
+	}
+	const args = parseArgs(process.argv.slice(2));
+	const baseUrl = (args.url ?? "http://127.0.0.1:8787").replace(/\/$/, "");
+	const client = new AgentClient(baseUrl);
+
+	let missionId = args.mission;
+	if (!missionId && args.goal) {
+		const created = await client.createMission(args.goal, args.mode);
+		missionId = created.mission_id;
+	}
+	if (!missionId) {
+		const missions = await client.listMissions();
+		const active = missions.filter((m) => m.state !== "FAILED");
+		if (active.length === 0) {
+			console.error("没有可用 Mission。用 --goal \"任务目标\" 创建，或 rosclaw chat 引导创建。");
+			process.exit(2);
+		}
+		missionId = active[active.length - 1].mission_id;
+	}
+
+	const app = new RosclawTuiApp({ baseUrl, missionId });
+	try {
+		await app.start();
+	} catch (err) {
+		console.error((err as Error).message);
+		process.exit(1);
+	}
+}
+
+void main();

--- a/packages/rosclaw-tui/src/state/reducer.ts
+++ b/packages/rosclaw-tui/src/state/reducer.ts
@@ -1,0 +1,236 @@
+/** State reducer (批次 C)：AgentEventV2 → UiState + 渲染效果。
+ *
+ * 纯函数，可单测；TUI 只负责把 effects 画出来。
+ * agent.settled 是停止 spinner 的唯一可靠信号（§5.4）。
+ */
+
+import type { AgentEvent } from "../client/sse.js";
+import type { UiState } from "./types.js";
+
+export type Effect =
+	| { kind: "append_markdown"; text: string }
+	| { kind: "append_delta"; text: string }
+	| { kind: "flush_delta" }
+	| { kind: "append_card"; card: CardModel }
+	| { kind: "spinner"; label: string }
+	| { kind: "spinner_stop" }
+	| { kind: "status_refresh" };
+
+export interface CardModel {
+	cardType: "tool" | "worker" | "approval" | "receipt" | "info";
+	title: string;
+	lines: string[];
+	tone: "ok" | "warn" | "error" | "info";
+}
+
+const PHASE_BY_EVENT: Record<string, string> = {
+	"agent.started": "正在理解",
+	"context.compilation.started": "正在编译上下文",
+	"context.compilation.completed": "正在编译上下文",
+	"model.request.started": "正在调用模型",
+	"model.retry.scheduled": "正在重试",
+	"model.failover": "正在切换模型",
+	"tool.started": "正在调用工具",
+	"worker.started": "正在等待 Worker",
+	"approval.requested": "正在等待批准",
+	"action.dispatched": "正在执行/验证",
+	"verification.started": "正在执行/验证",
+	"compaction.started": "正在压缩上下文",
+};
+
+export function reduce(state: UiState, event: AgentEvent): Effect[] {
+	const effects: Effect[] = [];
+	const payload = event.payload ?? {};
+	state.lastSeq = Math.max(state.lastSeq, event.sequence);
+
+	const phase = PHASE_BY_EVENT[event.type];
+	if (phase) {
+		state.phase = phase;
+		effects.push({ kind: "spinner", label: phase });
+	}
+
+	switch (event.type) {
+		case "agent.started":
+			state.turnInFlight = true;
+			break;
+		case "agent.settled":
+			state.turnInFlight = false;
+			state.phase = "";
+			effects.push({ kind: "spinner_stop" });
+			effects.push({ kind: "flush_delta" });
+			break;
+		case "agent.failed":
+			state.turnInFlight = false;
+			effects.push({
+				kind: "append_card",
+				card: {
+					cardType: "info",
+					title: "Agent 失败",
+					lines: [String(payload.error ?? "unknown")],
+					tone: "error",
+				},
+			});
+			break;
+		case "model.text.delta":
+			effects.push({ kind: "append_delta", text: String(payload.text ?? "") });
+			break;
+		case "model.request.ended":
+			effects.push({ kind: "flush_delta" });
+			break;
+		case "mission.state.changed":
+			state.missionState = String(payload.to ?? state.missionState);
+			effects.push({ kind: "status_refresh" });
+			break;
+		case "mission.renamed":
+			state.missionName = String(payload.name ?? state.missionName);
+			effects.push({ kind: "status_refresh" });
+			break;
+		case "tool.started": {
+			const name = String(payload.name ?? payload.tool ?? "tool");
+			state.tools.push({ name, status: "running" });
+			effects.push({
+				kind: "append_card",
+				card: {
+					cardType: "tool",
+					title: `⚙ ${name}`,
+					lines: ["running…"],
+					tone: "info",
+				},
+			});
+			break;
+		}
+		case "tool.completed": {
+			const name = String(payload.name ?? payload.tool ?? "tool");
+			const ok = payload.ok !== false;
+			const run = state.tools.findLast((t) => t.name === name);
+			if (run) run.status = ok ? "completed" : "failed";
+			const lines = [ok ? "completed" : "failed"];
+			if (payload.artifact_ref) lines.push(`artifact: ${String(payload.artifact_ref)}`);
+			effects.push({
+				kind: "append_card",
+				card: {
+					cardType: "tool",
+					title: `⚙ ${name}`,
+					lines,
+					tone: ok ? "ok" : "error",
+				},
+			});
+			break;
+		}
+		case "worker.offered":
+		case "worker.claimed":
+		case "worker.started":
+		case "worker.submitted":
+		case "worker.verifying":
+		case "worker.accepted":
+		case "worker.failed":
+		case "worker.expired": {
+			const statusText = event.type.split(".")[1];
+			const orderId = String(payload.work_order_id ?? "");
+			const workerId = String(payload.worker_id ?? "");
+			const existing = state.workers.find((w) => w.workOrderId === orderId);
+			if (existing) existing.status = statusText;
+			else state.workers.push({ workOrderId: orderId, workerId, status: statusText });
+			const terminal = ["accepted", "failed", "expired"].includes(statusText);
+			effects.push({
+				kind: "append_card",
+				card: {
+					cardType: "worker",
+					title: `⛏ ${workerId || "worker"}`,
+					lines: [`order: ${orderId}`, `status: ${statusText}`],
+					tone: statusText === "accepted" ? "ok" : statusText === "failed" || statusText === "expired" ? "error" : "info",
+				},
+			});
+			if (terminal) effects.push({ kind: "status_refresh" });
+			break;
+		}
+		case "approval.requested": {
+			const item = {
+				requestId: String(payload.request_id ?? ""),
+				title: String(payload.title ?? "动作授权"),
+				riskTier: String(payload.risk_tier ?? "LOW"),
+				expiresAt: payload.expires_at ? String(payload.expires_at) : undefined,
+			};
+			state.pendingApprovals.push(item);
+			effects.push({
+				kind: "append_card",
+				card: {
+					cardType: "approval",
+					title: `🔐 授权请求 ${shortId(item.requestId)}`,
+					lines: [
+						item.title,
+						`风险等级: ${item.riskTier}`,
+						"输入 /approve " + shortId(item.requestId) + " 批准，/deny " + shortId(item.requestId) + " 拒绝",
+					],
+					tone: "warn",
+				},
+			});
+			effects.push({ kind: "status_refresh" });
+			break;
+		}
+		case "approval.decided": {
+			const requestId = String(payload.request_id ?? "");
+			state.pendingApprovals = state.pendingApprovals.filter((a) => a.requestId !== requestId);
+			effects.push({
+				kind: "append_card",
+				card: {
+					cardType: "approval",
+					title: `🔐 授权${payload.approved ? "已批准" : "已拒绝"}`,
+					lines: [shortId(requestId)],
+					tone: payload.approved ? "ok" : "error",
+				},
+			});
+			effects.push({ kind: "status_refresh" });
+			break;
+		}
+		case "action.receipt":
+		case "receipt.received":
+			effects.push({
+				kind: "append_card",
+				card: {
+					cardType: "receipt",
+					title: "🧾 执行回执",
+					lines: Object.entries(payload)
+						.slice(0, 6)
+						.map(([k, v]) => `${k}: ${typeof v === "string" ? v : JSON.stringify(v)}`),
+					tone: "ok",
+				},
+			});
+			break;
+		case "compaction.completed":
+			state.compactions += 1;
+			effects.push({
+				kind: "append_card",
+				card: {
+					cardType: "info",
+					title: "🗜 上下文已压缩",
+					lines: [
+						`reason: ${String(payload.reason ?? "")}`,
+						`tokens: ${String(payload.tokens_before ?? "?")} → ${String(payload.tokens_after ?? "?")}`,
+						"canonical journal 完整保留",
+					],
+					tone: "info",
+				},
+			});
+			break;
+		case "warning":
+			effects.push({
+				kind: "append_card",
+				card: { cardType: "info", title: "⚠ 警告", lines: [String(payload.message ?? "")], tone: "warn" },
+			});
+			break;
+		case "error":
+			effects.push({
+				kind: "append_card",
+				card: { cardType: "info", title: "✖ 错误", lines: [String(payload.error ?? "")], tone: "error" },
+			});
+			break;
+		default:
+			break;
+	}
+	return effects;
+}
+
+export function shortId(id: string): string {
+	return id.length > 14 ? id.slice(0, 14) : id;
+}

--- a/packages/rosclaw-tui/src/state/types.ts
+++ b/packages/rosclaw-tui/src/state/types.ts
@@ -1,0 +1,65 @@
+/** UI state (批次 C)：事件流的纯投影，不持有任何权威。 */
+
+export interface ApprovalItem {
+	requestId: string;
+	title: string;
+	riskTier: string;
+	expiresAt?: string;
+}
+
+export interface ToolRun {
+	name: string;
+	source?: string;
+	status: "proposed" | "running" | "completed" | "failed";
+	startedAt?: string;
+	durationMs?: number;
+	summary?: string;
+	artifactRef?: string;
+}
+
+export interface WorkerRun {
+	workOrderId: string;
+	workerId: string;
+	status: string;
+}
+
+export interface UiState {
+	missionId: string;
+	missionName: string;
+	missionState: string;
+	mode: string;
+	bodyId: string;
+	model: string;
+	profile: string;
+	turnInFlight: boolean;
+	/** 当前阶段（思考状态文案，§6.5 — 永不显示 chain-of-thought）。 */
+	phase: string;
+	lastSeq: number;
+	pendingApprovals: ApprovalItem[];
+	tools: ToolRun[];
+	workers: WorkerRun[];
+	compactions: number;
+	degraded: string;
+	reconnecting: boolean;
+}
+
+export function initialState(missionId: string): UiState {
+	return {
+		missionId,
+		missionName: "",
+		missionState: "IDLE",
+		mode: "SIMULATION",
+		bodyId: "",
+		model: "",
+		profile: "",
+		turnInFlight: false,
+		phase: "",
+		lastSeq: 0,
+		pendingApprovals: [],
+		tools: [],
+		workers: [],
+		compactions: 0,
+		degraded: "",
+		reconnecting: false,
+	};
+}

--- a/packages/rosclaw-tui/test/commands.test.ts
+++ b/packages/rosclaw-tui/test/commands.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CommandRegistry, LOCAL_COMMANDS } from "../src/commands/registry.js";
+import type { CommandSpec } from "../src/client/http.js";
+
+function spec(name: string, disabled = ""): CommandSpec {
+	return {
+		name,
+		aliases: [],
+		description: `${name} desc`,
+		argument_hint: "",
+		category: "mission",
+		owner: "MISSION_CONTROL",
+		availability: [],
+		during_turn: false,
+		mutability: "NONE",
+		confirmation: "NONE",
+		required_capabilities: [],
+		handler: `h.${name}`,
+		disabled_reason: disabled,
+	};
+}
+
+test("local commands route locally", () => {
+	const registry = new CommandRegistry();
+	assert.deepEqual(registry.parse("/help").kind, "local");
+	assert.deepEqual(registry.parse("/quit").kind, "local");
+	assert.deepEqual(registry.parse("/q").kind, "local");
+});
+
+test("remote commands route to control api", () => {
+	const registry = new CommandRegistry();
+	registry.loadRemote([spec("compact"), spec("rename")]);
+	const route = registry.parse("/compact dry-run");
+	assert.equal(route.kind, "remote");
+	if (route.kind === "remote") {
+		assert.equal(route.spec.name, "compact");
+		assert.equal(route.args, "dry-run");
+	}
+});
+
+test("unknown command is never sent to the model", () => {
+	const registry = new CommandRegistry();
+	const route = registry.parse("/estop");
+	assert.equal(route.kind, "unknown");
+});
+
+test("plain text is not a command", () => {
+	const registry = new CommandRegistry();
+	assert.equal(registry.parse("你好").kind, "not_a_command");
+});
+
+test("help lists local + remote with disabled reasons", () => {
+	const registry = new CommandRegistry();
+	registry.loadRemote([spec("compact", "turn 运行中不可用")]);
+	const all = registry.all();
+	assert.ok(all.length >= LOCAL_COMMANDS.length + 1);
+	const compact = all.find((c) => c.name === "compact");
+	assert.equal(compact?.disabled, "turn 运行中不可用");
+});

--- a/packages/rosclaw-tui/test/reducer.test.ts
+++ b/packages/rosclaw-tui/test/reducer.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { reduce, type Effect } from "../src/state/reducer.js";
+import { initialState } from "../src/state/types.js";
+import type { AgentEvent } from "../src/client/sse.js";
+
+function ev(type: string, payload: Record<string, unknown> = {}, sequence = 1): AgentEvent {
+	return {
+		event_id: `evt_${type}_${sequence}`,
+		sequence,
+		mission_id: "mis_x",
+		type,
+		visibility: "USER",
+		payload,
+		timestamp: "2026-08-03T00:00:00Z",
+	};
+}
+
+test("agent.settled stops spinner and flushes delta", () => {
+	let state = initialState("mis_x");
+	const effects: Effect[] = [];
+	for (const e of reduce(state, ev("agent.started", {}, 1))) effects.push(e);
+	assert.equal(state.turnInFlight, true);
+	for (const e of reduce(state, ev("model.text.delta", { text: "你好" }, 2))) effects.push(e);
+	for (const e of reduce(state, ev("agent.settled", {}, 3))) effects.push(e);
+	assert.equal(state.turnInFlight, false);
+	assert.ok(effects.some((e) => e.kind === "spinner_stop"));
+	assert.ok(effects.some((e) => e.kind === "flush_delta"));
+});
+
+test("approval card lifecycle", () => {
+	let state = initialState("mis_x");
+	reduce(state, ev("approval.requested", { request_id: "appr_1234567890abcdef", title: "播放提示音", risk_tier: "LOW" }, 1));
+	assert.equal(state.pendingApprovals.length, 1);
+	reduce(state, ev("approval.decided", { request_id: "appr_1234567890abcdef", approved: true }, 2));
+	assert.equal(state.pendingApprovals.length, 0);
+});
+
+test("worker lifecycle tracks terminal status", () => {
+	let state = initialState("mis_x");
+	reduce(state, ev("worker.offered", { work_order_id: "wo1", worker_id: "native" }, 1));
+	reduce(state, ev("worker.accepted", { work_order_id: "wo1", worker_id: "native" }, 2));
+	assert.equal(state.workers[0].status, "accepted");
+});
+
+test("phase label never exposes chain-of-thought", () => {
+	let state = initialState("mis_x");
+	const effects = reduce(state, ev("model.request.started", {}, 1));
+	const spinner = effects.find((e) => e.kind === "spinner");
+	assert.ok(spinner && spinner.kind === "spinner" && spinner.label.includes("模型"));
+});
+
+test("sequence tracking takes max", () => {
+	let state = initialState("mis_x");
+	reduce(state, ev("agent.started", {}, 5));
+	reduce(state, ev("agent.settled", {}, 3));
+	assert.equal(state.lastSeq, 5);
+});

--- a/packages/rosclaw-tui/test/sse.test.ts
+++ b/packages/rosclaw-tui/test/sse.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createServer, type Server } from "node:http";
+import { streamEvents, type AgentEvent } from "../src/client/sse.js";
+
+function sseFrame(seq: number, id: string, type: string): string {
+	return `id: ${seq}\ndata: ${JSON.stringify({
+		event_id: id,
+		sequence: seq,
+		mission_id: "mis_x",
+		type,
+		visibility: "USER",
+		payload: {},
+		timestamp: "t",
+	})}\n\n`;
+}
+
+async function withServer(
+	handler: (req: { headers: Record<string, unknown> }, res: {
+		writeHead: (code: number, headers?: Record<string, string>) => void;
+		write: (chunk: string) => void;
+		end: () => void;
+	}) => void,
+	fn: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+	const server: Server = createServer((req, res) => {
+		handler({ headers: req.headers }, res as never);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	const port = typeof address === "object" && address ? address.port : 0;
+	try {
+		await fn(`http://127.0.0.1:${port}`);
+	} finally {
+		server.closeAllConnections?.();
+		await new Promise((resolve) => server.close(resolve));
+	}
+}
+
+test("replays events and dedups by event_id", async () => {
+	await withServer(
+		(_req, res) => {
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			res.write(sseFrame(1, "evt_a", "agent.started"));
+			res.write(sseFrame(1, "evt_a", "agent.started")); // duplicate
+			res.write(sseFrame(2, "evt_b", "agent.settled"));
+			res.end();
+		},
+		async (baseUrl) => {
+			const events: AgentEvent[] = [];
+			for await (const e of streamEvents(baseUrl, "mis_x", { maxAttempts: 1 })) {
+				events.push(e);
+			}
+			assert.equal(events.length, 2);
+			assert.deepEqual(events.map((e) => e.event_id), ["evt_a", "evt_b"]);
+		},
+	);
+});
+
+test("reconnects with Last-Event-ID after a dropped connection", async () => {
+	let requestCount = 0;
+	const seenLastEventIds: string[] = [];
+	await withServer(
+		(req, res) => {
+			requestCount += 1;
+			seenLastEventIds.push(String(req.headers["last-event-id"] ?? ""));
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			if (requestCount === 1) {
+				res.write(sseFrame(1, "evt_a", "agent.started"));
+				res.end(); // drop
+			} else {
+				res.write(sseFrame(2, "evt_b", "agent.settled"));
+				res.end();
+			}
+		},
+		async (baseUrl) => {
+			const events: AgentEvent[] = [];
+			for await (const e of streamEvents(baseUrl, "mis_x", { maxAttempts: 3 })) {
+				events.push(e);
+			}
+			assert.deepEqual(events.map((e) => e.event_id), ["evt_a", "evt_b"]);
+			assert.equal(seenLastEventIds[1], "1", "second request must carry Last-Event-ID");
+		},
+	);
+});
+
+test("sequence gap triggers onGap", async () => {
+	await withServer(
+		(_req, res) => {
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			res.write(sseFrame(1, "evt_a", "agent.started"));
+			res.write(sseFrame(5, "evt_e", "agent.settled"));
+			res.end();
+		},
+		async (baseUrl) => {
+			const gaps: Array<[number, number]> = [];
+			for await (const _e of streamEvents(baseUrl, "mis_x", {
+				maxAttempts: 1,
+				onGap: (expected, got) => gaps.push([expected, got]),
+			})) {
+				// consume
+			}
+			assert.deepEqual(gaps, [[2, 5]]);
+		},
+	);
+});

--- a/packages/rosclaw-tui/tsconfig.json
+++ b/packages/rosclaw-tui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2023",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"outDir": "dist",
+		"rootDir": ".",
+		"strict": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"declaration": false,
+		"sourceMap": false,
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -373,7 +373,110 @@ def cmd_chat(args: argparse.Namespace) -> int:
         print("未配置模型。先运行 `rosclaw agent init`。", file=sys.stderr)
         return 2
     service = AgentService(config, home)
-    return asyncio.run(_chat_repl(service, args))
+    if getattr(args, "basic", False):
+        return asyncio.run(_chat_repl(service, args))
+    return _chat_tui(service, args)
+
+
+def _find_tui_runtime() -> tuple[str, str] | None:
+    """Locate (node ≥22.19, rosclaw-tui dist entry). None = unavailable."""
+    import shutil
+    import subprocess as _sp
+
+    candidates = [shutil.which("node"), "/usr/bin/node", "/usr/local/bin/node"]
+    node = None
+    for candidate in filter(None, candidates):
+        try:
+            out = _sp.check_output([candidate, "--version"], text=True, timeout=10).strip()
+            parts = [int(p) for p in out.lstrip("v").split(".")]
+            if parts >= [22, 19, 0]:
+                node = candidate
+                break
+        except Exception:  # noqa: BLE001 - probe next candidate
+            continue
+    if node is None:
+        return None
+    entry_env = os.environ.get("ROSCLAW_TUI_ENTRY")
+    repo_entry = (
+        Path(__file__).resolve().parents[3] / "packages" / "rosclaw-tui" / "dist" / "main.js"
+    )
+    entry = entry_env or (str(repo_entry) if repo_entry.exists() else None)
+    if not entry or not Path(entry).exists():
+        return None
+    return node, entry
+
+
+def _chat_tui(service: AgentService, args: argparse.Namespace) -> int:
+    """默认 chat：启动本地 AgentService HTTP + exec rosclaw-tui（批次 C）。
+
+    TUI 不可用（Node/资源缺失）时诚实降级到 --basic 并说明原因。
+    """
+    import subprocess as _sp
+    import threading
+
+    runtime = _find_tui_runtime()
+    if runtime is None:
+        print(
+            "rosclaw-tui 不可用（需要 Node >= 22.19 与已构建的 packages/rosclaw-tui；"
+            "见 rosclaw doctor）。回退到兼容模式 --basic。",
+            file=sys.stderr,
+        )
+        return asyncio.run(_chat_repl(service, args))
+    node, entry = runtime
+
+    mission = None
+    if args.mission:
+        mission = service.get_mission(args.mission)
+        if mission is None:
+            print(f"mission {args.mission} 不存在", file=sys.stderr)
+            return 2
+    else:
+        goal = args.goal or "ROSClaw chat session"
+        try:
+            mission = service.create_mission(goal, mode=args.mode)
+        except Exception as exc:  # noqa: BLE001
+            print(f"无法创建 mission：{exc}", file=sys.stderr)
+            return 2
+
+    import uvicorn
+
+    app = create_app(service)
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    # 等待 socket 就绪（最多 5s），拿不到端口就诚实降级。
+    import time
+
+    deadline = time.time() + 5.0
+    port = None
+    while time.time() < deadline:
+        if server.started and server.servers:
+            for srv in server.servers:
+                for sock in srv.sockets:
+                    port = sock.getsockname()[1]
+                    break
+        if port:
+            break
+        time.sleep(0.05)
+    if port is None:
+        print("AgentService HTTP 启动失败，回退到 --basic。", file=sys.stderr)
+        server.should_exit = True
+        return asyncio.run(_chat_repl(service, args))
+    try:
+        return _sp.call(
+            [
+                node,
+                entry,
+                "--url",
+                f"http://127.0.0.1:{port}",
+                "--mission",
+                mission.mission_id,
+            ]
+        )
+    finally:
+        server.should_exit = True
+        thread.join(timeout=3.0)
 
 
 def cmd_credential(args: argparse.Namespace) -> int:
@@ -651,6 +754,11 @@ def add_agent_subparsers(subparsers) -> None:
     p_chat.add_argument("--mission", default=None)
     p_chat.add_argument("--mode", default=None, choices=["SIMULATION", "SHADOW", "REAL"])
     p_chat.add_argument("--goal", default=None)
+    p_chat.add_argument(
+        "--basic",
+        action="store_true",
+        help="兼容/诊断模式：Python input() 行式 REPL（无 TUI）",
+    )
     p_chat.set_defaults(func=cmd_chat)
 
 

--- a/tests/architecture/test_pi_dependency_boundary.py
+++ b/tests/architecture/test_pi_dependency_boundary.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 REPO = Path(__file__).resolve().parents[2]
-NODE_ROOT = REPO / "node"
+NODE_ROOT = REPO / "packages"
 
 BANNED_NPM_PACKAGES = (
     "@earendil-works/pi-agent-core",
@@ -69,7 +69,7 @@ class TestNpmBoundary:
                         assert not version.startswith(("^", "~"))
 
     def test_lockfile_no_banned_packages(self) -> None:
-        lock = NODE_ROOT / "package-lock.json"
+        lock = REPO / "packages" / "rosclaw-tui" / "package-lock.json"
         if not lock.exists():
             pytest.skip("lockfile not created yet")
         data = json.loads(lock.read_text(encoding="utf-8"))
@@ -97,7 +97,7 @@ class TestRoleBoundaryStatements:
     """The TUI/modeld code (when it exists) must not cross its lane."""
 
     def test_modeld_never_touches_hardware_paths(self) -> None:
-        modeld = NODE_ROOT / "services" / "rosclaw-modeld"
+        modeld = NODE_ROOT / "rosclaw-modeld"
         if not modeld.exists():
             pytest.skip("modeld not created yet")
         banned = re.compile(r"rosclawd|/dev/tty|serialport|can-utils|gpio|robot-sdk", re.IGNORECASE)
@@ -108,7 +108,7 @@ class TestRoleBoundaryStatements:
             assert not banned.search(text), f"{path} references hardware paths"
 
     def test_tui_has_no_model_client(self) -> None:
-        tui = NODE_ROOT / "apps" / "rosclaw-tui"
+        tui = NODE_ROOT / "rosclaw-tui"
         if not tui.exists():
             pytest.skip("tui not created yet")
         banned = re.compile(r"openai|anthropic|/v1/chat/completions|pi-ai", re.IGNORECASE)

--- a/third_party/pi/LICENSE
+++ b/third_party/pi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Mario Zechner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/pi/NOTICE.md
+++ b/third_party/pi/NOTICE.md
@@ -1,0 +1,17 @@
+# Pi attribution (ADR-0008)
+
+ROSClaw depends on two npm packages from the Pi project (MIT License,
+Copyright (c) 2025 Mario Zechner):
+
+| Package | Version (exact pin) | Upstream commit | Use |
+|---|---|---|---|
+| `@earendil-works/pi-tui` | 0.83.0 | 0e633790c5a007f6d4bf35ba67ced457287c25ac | rosclaw-tui 终端组件（editor/markdown/select/loader/IME/CJK） |
+| `@earendil-works/pi-ai` | 0.83.0 | 0e633790c5a007f6d4bf35ba67ced457287c25ac | rosclaw-modeld Provider 目录与流式调用（批次 D 引入） |
+
+- 只使用包公开 exports；不 import 私有内部路径。
+- `pi-coding-agent` / `pi-agent-core` / Hermes / OpenCode 的 Agent 运行时
+  均被 ADR-0008 禁止进入生产路径（见
+  `tests/architecture/test_pi_dependency_boundary.py`）。
+- `packages/rosclaw-tui/package-lock.json` 已提交，升级依赖前必须先跑
+  upstream characterization tests。
+- LICENSE 原文见同目录 `LICENSE`。


### PR DESCRIPTION
## Summary

Batch C of the reuse-supplement: the mature terminal UI on top of the Batch B control/event layer.

- **packages/rosclaw-tui**: exact-pinned `@earendil-works/pi-tui@0.83.0` (MIT — `third_party/pi` holds NOTICE + LICENSE), committed `package-lock.json`, Node >= 22.19 (honest version check with guidance). Thin Presenter + pure reducer + command router; **Pi `interactive-mode.ts` is deliberately not copied** (supplement §14.11).
- **Data plane**: authoritative `MissionSnapshotV1` on start → SSE increment with standard `Last-Event-ID` resume → `event_id` dedup → sequence-gap detection triggers snapshot resync (no optimistic rendering across gaps) → `agent.settled` is the only spinner-stop signal.
- **Commands route by owner, never to the model** (§5.1): local (`/help /hotkeys /quit /clear-screen /approve /deny /missions`), remote via Batch B control API (`/compact /cancel /rename /archive /status /tools`); unknown commands show guidance instead of being sent as chat.
- **Cards & status**: tool / worker / approval / receipt cards (approval via `/approve <id>` — no口令 repetition); persistent status line with mode (REAL highlighted), body, mission state, pending approvals, current phase. No chain-of-thought is ever displayed — only the fixed phase labels from §6.5.
- **`rosclaw chat` defaults to the TUI** (in-process uvicorn + exec node); honest fallback to `rosclaw chat --basic` (the old `input()` REPL, now explicitly a compat/diagnostic mode) when Node >= 22.19 or the built assets are missing. Python `input()` is no longer the default chat (§14.5).
- **Boundary enforcement**: `tests/architecture/test_pi_dependency_boundary.py` now scans `packages/` — banned Pi agent runtimes absent, exact pins verified, lockfile clean, TUI contains no model client.

## Reuse notes

- direct dependency: `@earendil-works/pi-tui@0.83.0` (editor/IME/CJK/markdown/select/autocomplete) — the exact reuse the supplement mandates.
- behavior borrowed: Pi's settled/stop semantics, delta coalescing concept, snapshot+resume pattern.
- ROSClaw-specific: command owner routing (SAFETY_CONTROL excluded), approval flow via dedicated endpoint, snapshot watermark resync.
- deliberately not reused: pi-coding-agent, Pi AgentSession, Pi RPC protocol, Pi session JSONL.

## Tests

- 13 `node --test` tests: reducer (settled/approval/worker/phase/sequence), command routing (local/remote/unknown/not-a-command/disabled), SSE (dedup, Last-Event-ID reconnect, gap callback).
- Python: full agentd + architecture suites green; ruff + mypy clean.

## Notes for reviewers

Interactive IME/CJK acceptance (§12.1) requires a real terminal — the harness here validates logic headlessly; manual terminal acceptance is part of the PR-12 LIMO loop.