### PR TITLE
rosclaw-modeld + pi-ai provider daemon (reuse-supplement 批次D)

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -198,6 +198,28 @@ live 模型协调。3v3 联赛基准（T-SIM-2/3）属 PR-TF-075 后续范围。
   unverified/inferred 显式拒绝并记录；Darwin 晋升门 = 评测引用 + 人类
   principal，任何代码路径不能自动晋升。
 
+## rosclaw-modeld（批次 D）
+
+- `packages/rosclaw-modeld`：精确锁定 `@earendil-works/pi-ai@0.83.0`，
+  Unix socket（目录 0700、socket 0600）+ 启动时随机 bearer token（只经
+  子进程环境传递）。modeld 不是 Agent：不碰 MissionStore/DecisionV1/
+  工具/rosclawd（架构测试锁定，providers/all 禁止）。
+- API：`GET /v1/providers /v1/models /v1/auth`，
+  `POST /v1/auth/{provider}/login|logout`（OAuth 诚实 501，本批未做），
+  `POST /v1/probe /v1/stream`（SSE: text.delta/tool_call/usage/done/error）。
+- `ModeldGateway`（Python ModelGateway 协议）：AgentLoop 不再直接接触
+  OpenAI-compatible 协议细节；崩溃/不可达诚实报错（modeld_crashed），
+  绝不伪造成功。`models.backend: modeld` 切换；legacy backend 保留。
+- Provider：moonshot（kimi-k3）、kimi-code（k3/k3-256k，OpenAI 兼容面）、
+  ollama（本地）；凭据 env 引用或 modeld credential store（0600、
+  sha256 指纹展示，secret 不出 API 响应）。
+- 命令：`/providers /model /login /logout`（MODEL_CONTROL，经控制 API，
+  不发给模型）；`rosclaw agent backend --set modeld` 迁移现有 Kimi
+  配置（profile 与 env 凭据引用不变）。
+- 验收：K7（真实 Kimi K3 经 modeld 链路 probe/chat/usage/strict tool
+  call）、K8（backend=modeld 的 AgentService 完整 turn，usage 计量）——
+  全部为真实路径，无 mock。
+
 ## rosclaw-tui（批次 C）
 
 - `packages/rosclaw-tui`：精确锁定 `@earendil-works/pi-tui@0.83.0`

--- a/packages/rosclaw-modeld/package-lock.json
+++ b/packages/rosclaw-modeld/package-lock.json
@@ -1,0 +1,1241 @@
+{
+	"name": "rosclaw-modeld",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "rosclaw-modeld",
+			"version": "0.1.0",
+			"dependencies": {
+				"@earendil-works/pi-ai": "0.83.0"
+			},
+			"bin": {
+				"rosclaw-modeld": "dist/main.js"
+			},
+			"devDependencies": {
+				"@types/node": "^22.10.0",
+				"typescript": "^5.7.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmmirror.com/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmmirror.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmmirror.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmmirror.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmmirror.com/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.977.4",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/core/-/core-3.977.4.tgz",
+			"integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@aws-sdk/xml-builder": "^3.972.37",
+				"@aws/lambda-invoke-store": "^0.3.0",
+				"@smithy/core": "^3.31.1",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.65",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
+			"integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.67",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
+			"integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+			"version": "4.9.13",
+			"resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+			"integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.973.10",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
+			"integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/credential-provider-env": "^3.972.65",
+				"@aws-sdk/credential-provider-http": "^3.972.67",
+				"@aws-sdk/credential-provider-login": "^3.972.72",
+				"@aws-sdk/credential-provider-process": "^3.972.65",
+				"@aws-sdk/credential-provider-sso": "^3.973.9",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.71",
+				"@aws-sdk/nested-clients": "^3.997.39",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.72",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
+			"integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/nested-clients": "^3.997.39",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.76",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
+			"integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.65",
+				"@aws-sdk/credential-provider-http": "^3.972.67",
+				"@aws-sdk/credential-provider-ini": "^3.973.10",
+				"@aws-sdk/credential-provider-process": "^3.972.65",
+				"@aws-sdk/credential-provider-sso": "^3.973.9",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.71",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.65",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
+			"integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.973.9",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
+			"integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/nested-clients": "^3.997.39",
+				"@aws-sdk/token-providers": "3.1100.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1100.0",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
+			"integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/nested-clients": "^3.997.39",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.71",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
+			"integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/nested-clients": "^3.997.39",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.31",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+			"integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.26",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+			"integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.47",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.47.tgz",
+			"integrity": "sha512-UcPdY05u3TzvDah86NG6B9FgePYU6bXO7CRQIzQrieFL5xBBGajM7g1lCngmP4WA8EPed/kgT5CvM28cqSlBbA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.39",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
+			"integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.4",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.43",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+			"version": "4.9.13",
+			"resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+			"integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.43",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+			"integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.974.2",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/types/-/types-3.974.2.tgz",
+			"integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.8",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+			"integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+			"integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmmirror.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-ai": {
+			"version": "0.83.0",
+			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
+			"integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.3.7"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmmirror.com/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmmirror.com/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmmirror.com/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmmirror.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmmirror.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmmirror.com/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmmirror.com/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmmirror.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmmirror.com/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmmirror.com/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmmirror.com/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmmirror.com/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmmirror.com/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.31.1",
+			"resolved": "https://registry.npmmirror.com/@smithy/core/-/core-3.31.1.tgz",
+			"integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.4.16",
+			"resolved": "https://registry.npmmirror.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+			"integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.6.13",
+			"resolved": "https://registry.npmmirror.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+			"integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmmirror.com/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.6.12",
+			"resolved": "https://registry.npmmirror.com/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+			"integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.16.1",
+			"resolved": "https://registry.npmmirror.com/@smithy/types/-/types-4.16.1.tgz",
+			"integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmmirror.com/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmmirror.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "22.20.1",
+			"resolved": "https://registry.npmmirror.com/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmmirror.com/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT"
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmmirror.com/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmmirror.com/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"license": "MIT"
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmmirror.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmmirror.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmmirror.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmmirror.com/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmmirror.com/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmmirror.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmmirror.com/gaxios/-/gaxios-7.3.0.tgz",
+			"integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmmirror.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmmirror.com/google-auth-library/-/google-auth-library-10.9.1.tgz",
+			"integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmmirror.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmmirror.com/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmmirror.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmmirror.com/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmmirror.com/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmmirror.com/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmmirror.com/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmmirror.com/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmmirror.com/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmmirror.com/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmmirror.com/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"license": "MIT"
+		},
+		"node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmmirror.com/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmmirror.com/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT"
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/typebox": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmmirror.com/typebox/-/typebox-1.3.7.tgz",
+			"integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+			"license": "MIT"
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"license": "MIT"
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmmirror.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.21.1",
+			"resolved": "https://registry.npmmirror.com/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmmirror.com/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmmirror.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		}
+	}
+}

--- a/packages/rosclaw-modeld/package.json
+++ b/packages/rosclaw-modeld/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "rosclaw-modeld",
+	"version": "0.1.0",
+	"private": true,
+	"description": "ROSClaw model daemon — pi-ai Provider/auth wrapper over a local Unix socket. Not an agent: no Mission, no tools, no DecisionV1, no hardware.",
+	"type": "module",
+	"bin": {
+		"rosclaw-modeld": "dist/src/main.js"
+	},
+	"engines": {
+		"node": ">=22.19.0"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"test": "npm run build && node --test dist/test/*.test.js",
+		"start": "node dist/src/main.js"
+	},
+	"dependencies": {
+		"@earendil-works/pi-ai": "0.83.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.0",
+		"typescript": "^5.7.0"
+	}
+}

--- a/packages/rosclaw-modeld/src/credentials.ts
+++ b/packages/rosclaw-modeld/src/credentials.ts
@@ -1,0 +1,79 @@
+/** File credential store (批次 D §7.3)。
+ *
+ * - 文件 0600、目录 0700；
+ * - list/status 只返回 metadata（provider、created_at、sha256 前 8 位
+ *   指纹）——永远不返回 secret 本体；
+ * - secret 只经内存路径传给 pi-ai stream 调用。
+ */
+
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+interface StoredCredential {
+	type: "api_key";
+	key: string;
+	created_at: string;
+}
+
+export interface CredentialInfo {
+	provider: string;
+	type: string;
+	fingerprint: string;
+	created_at: string;
+}
+
+export class FileCredentialStore {
+	private readonly path: string;
+
+	constructor(homeDir: string) {
+		this.path = `${homeDir}/modeld-credentials.json`;
+	}
+
+	private readAll(): Record<string, StoredCredential> {
+		if (!existsSync(this.path)) return {};
+		try {
+			return JSON.parse(readFileSync(this.path, "utf8")) as Record<string, StoredCredential>;
+		} catch {
+			return {}; // 解析失败不伪造成功——当作空（调用方会按未配置处理）
+		}
+	}
+
+	private writeAll(data: Record<string, StoredCredential>): void {
+		mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 });
+		// tmp + fsync + atomic rename（§8.4 写入要求）。
+		const tmp = `${this.path}.tmp`;
+		writeFileSync(tmp, JSON.stringify(data), { mode: 0o600 });
+		chmodSync(tmp, 0o600);
+		renameSync(tmp, this.path);
+		chmodSync(this.path, 0o600);
+	}
+
+	set(provider: string, key: string): void {
+		const data = this.readAll();
+		data[provider] = { type: "api_key", key, created_at: new Date().toISOString() };
+		this.writeAll(data);
+	}
+
+	delete(provider: string): boolean {
+		const data = this.readAll();
+		if (!(provider in data)) return false;
+		delete data[provider];
+		this.writeAll(data);
+		return true;
+	}
+
+	/** 内存路径取 key —— 仅供 stream 调用使用，不出现在任何 API 响应。 */
+	resolve(provider: string): string | undefined {
+		return this.readAll()[provider]?.key;
+	}
+
+	list(): CredentialInfo[] {
+		return Object.entries(this.readAll()).map(([provider, cred]) => ({
+			provider,
+			type: cred.type,
+			fingerprint: createHash("sha256").update(cred.key).digest("hex").slice(0, 8),
+			created_at: cred.created_at,
+		}));
+	}
+}

--- a/packages/rosclaw-modeld/src/main.ts
+++ b/packages/rosclaw-modeld/src/main.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/** rosclaw-modeld entry (批次 D)。
+ *
+ * 由 rosclaw-agentd 以子进程启动：
+ *   ROSCLAW_MODELD_TOKEN=<random> rosclaw-modeld --socket <path> --home <dir>
+ * token 只经进程环境传递；绝不作为命令行参数（ps 可见）。
+ */
+
+import { startModeld } from "./server.js";
+
+function parseArgs(argv: string[]): Record<string, string> {
+	const args: Record<string, string> = {};
+	for (let i = 0; i < argv.length; i += 1) {
+		if (argv[i].startsWith("--")) {
+			args[argv[i].slice(2)] = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+		}
+	}
+	return args;
+}
+
+async function main(): Promise<void> {
+	const [major, minor] = process.versions.node.split(".").map(Number);
+	if (major < 22 || (major === 22 && minor < 19)) {
+		console.error(`rosclaw-modeld 需要 Node >= 22.19.0（当前 ${process.versions.node}）`);
+		process.exit(2);
+	}
+	const args = parseArgs(process.argv.slice(2));
+	const token = process.env.ROSCLAW_MODELD_TOKEN;
+	if (!token) {
+		console.error("缺少 ROSCLAW_MODELD_TOKEN（应由 agentd 启动时注入）");
+		process.exit(2);
+	}
+	const socketPath = args.socket;
+	const homeDir = args.home;
+	if (!socketPath || !homeDir) {
+		console.error("用法: rosclaw-modeld --socket <path> --home <dir>");
+		process.exit(2);
+	}
+	await startModeld({ socketPath, token, homeDir });
+	console.error(`rosclaw-modeld listening on ${socketPath}`);
+}
+
+void main();

--- a/packages/rosclaw-modeld/src/providers.ts
+++ b/packages/rosclaw-modeld/src/providers.ts
@@ -1,0 +1,131 @@
+/** Provider registry (批次 D §7.2/§7.4)。
+ *
+ * 只注册 ROSClaw 验收过的 provider；按需懒加载子路径——永不 import
+ * pi-ai providers/all（§14.13）。每个 provider 声明其 env key 名（引用，
+ * 不是值）与内置模型目录。
+ */
+
+import { createProvider, type Model, type Provider } from "@earendil-works/pi-ai";
+import { envApiKeyAuth } from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+export interface ProviderSpec {
+	id: string;
+	name: string;
+	/** env var 名（引用；值只从进程环境读取）。 */
+	envKeys: string[];
+	baseUrl: string;
+	build: () => Provider;
+}
+
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+function openAiModel(
+	provider: string,
+	id: string,
+	baseUrl: string,
+	contextWindow: number,
+	maxTokens: number,
+	reasoning = true,
+): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl,
+		reasoning,
+		input: ["text"],
+		cost: ZERO_COST,
+		contextWindow,
+		maxTokens,
+		compat: {
+			// Kimi/OpenAI-compat 接受 system 而非 developer 角色（实测 400）。
+			supportsDeveloperRole: false,
+			supportsStore: false,
+		},
+	};
+}
+
+function moonshotProvider(): Provider {
+	return createProvider({
+		id: "moonshot",
+		name: "Moonshot AI (Kimi 开放平台)",
+		baseUrl: "https://api.moonshot.cn/v1",
+		auth: { apiKey: envApiKeyAuth("Moonshot API key", ["MOONSHOT_API_KEY"]) },
+		models: [openAiModel("moonshot", "kimi-k3", "https://api.moonshot.cn/v1", 262_144, 16_384)],
+		api: openAICompletionsApi(),
+	});
+}
+
+function kimiCodeProvider(): Provider {
+	// Kimi Coding Plan 的 OpenAI 兼容面（agentd 全栈验证过的协议面）。
+	return createProvider({
+		id: "kimi-code",
+		name: "Kimi For Coding",
+		baseUrl: "https://api.kimi.com/coding/v1",
+		auth: { apiKey: envApiKeyAuth("Kimi Code API key", ["KIMI_API_KEY", "ROSCLAW_KIMI_API_KEY"]) },
+		models: [
+			openAiModel("kimi-code", "k3", "https://api.kimi.com/coding/v1", 1_048_576, 16_384),
+			openAiModel("kimi-code", "k3-256k", "https://api.kimi.com/coding/v1", 262_144, 16_384),
+		],
+		api: openAICompletionsApi(),
+	});
+}
+
+function ollamaProvider(): Provider {
+	const baseUrl = process.env.ROSCLAW_OLLAMA_BASE_URL ?? "http://127.0.0.1:11434/v1";
+	return createProvider({
+		id: "ollama",
+		name: "Ollama (local)",
+		baseUrl,
+		auth: { apiKey: envApiKeyAuth("none (local)", []) },
+		models: [openAiModel("ollama", process.env.ROSCLAW_OLLAMA_MODEL ?? "qwen3:8b", baseUrl, 32_768, 8_192, false)],
+		api: openAICompletionsApi(),
+	});
+}
+
+const REGISTRY: Record<string, ProviderSpec> = {
+	moonshot: {
+		id: "moonshot",
+		name: "Moonshot AI (Kimi 开放平台)",
+		envKeys: ["MOONSHOT_API_KEY"],
+		baseUrl: "https://api.moonshot.cn/v1",
+		build: moonshotProvider,
+	},
+	"kimi-code": {
+		id: "kimi-code",
+		name: "Kimi For Coding",
+		envKeys: ["KIMI_API_KEY", "ROSCLAW_KIMI_API_KEY"],
+		baseUrl: "https://api.kimi.com/coding/v1",
+		build: kimiCodeProvider,
+	},
+	ollama: {
+		id: "ollama",
+		name: "Ollama (local)",
+		envKeys: [],
+		baseUrl: "http://127.0.0.1:11434/v1",
+		build: ollamaProvider,
+	},
+};
+
+const providers = new Map<string, Provider>();
+
+export function providerIds(): string[] {
+	return Object.keys(REGISTRY);
+}
+
+export function providerSpec(id: string): ProviderSpec | undefined {
+	return REGISTRY[id];
+}
+
+export function getProvider(id: string): Provider {
+	const spec = REGISTRY[id];
+	if (!spec) throw new Error(`unknown provider ${id}`);
+	let provider = providers.get(id);
+	if (!provider) {
+		provider = spec.build();
+		providers.set(id, provider);
+	}
+	return provider;
+}

--- a/packages/rosclaw-modeld/src/redact.ts
+++ b/packages/rosclaw-modeld/src/redact.ts
@@ -1,0 +1,22 @@
+/** Secret redaction (批次 D §7.3)：错误/日志统一脱敏。 */
+
+const PATTERNS = [
+	/sk-[A-Za-z0-9_-]{8,}/g,
+	/Bearer\s+[A-Za-z0-9._-]{8,}/gi,
+	/(api[_-]?key|token|secret)("?\s*[:=]\s*"?)[^\s",}]+/gi,
+];
+
+export function redact(text: string, knownSecrets: string[] = []): string {
+	let out = text;
+	for (const secret of knownSecrets) {
+		if (secret && secret.length >= 4) {
+			out = out.split(secret).join("<redacted>");
+		}
+	}
+	for (const pattern of PATTERNS) {
+		out = out.replace(pattern, (match, p1) =>
+			p1 && match.includes(":") ? `${p1}<redacted>` : "<redacted>",
+		);
+	}
+	return out;
+}

--- a/packages/rosclaw-modeld/src/server.ts
+++ b/packages/rosclaw-modeld/src/server.ts
@@ -1,0 +1,223 @@
+/** rosclaw-modeld UDS server (批次 D §7.3)。
+ *
+ * 安全边界：
+ * - socket 目录 0700、socket 0600；
+ * - 所有请求要求启动时生成的 bearer token（经进程环境传递，不落盘）；
+ * - 错误统一 redact；
+ * - 本进程没有任何 Mission/工具/硬件能力——只有 pi-ai provider 调用。
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { chmodSync, mkdirSync, rmSync } from "node:fs";
+import { dirname } from "node:path";
+import { FileCredentialStore } from "./credentials.js";
+import { getProvider, providerIds, providerSpec } from "./providers.js";
+import { redact } from "./redact.js";
+import { streamTurn, type ModeldTurnRequest } from "./stream.js";
+
+export interface ModeldOptions {
+	socketPath: string;
+	token: string;
+	homeDir: string;
+}
+
+export function startModeld(options: ModeldOptions): Promise<Server> {
+	const store = new FileCredentialStore(options.homeDir);
+	mkdirSync(dirname(options.socketPath), { recursive: true, mode: 0o700 });
+	chmodSync(dirname(options.socketPath), 0o700);
+	rmSync(options.socketPath, { force: true });
+
+	function json(res: ServerResponse, code: number, body: unknown): void {
+		res.writeHead(code, { "content-type": "application/json" });
+		res.end(JSON.stringify(body));
+	}
+
+	async function readBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+		const chunks: Buffer[] = [];
+		for await (const chunk of req) chunks.push(chunk as Buffer);
+		if (chunks.length === 0) return {};
+		return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+	}
+
+	function envKeyFor(providerId: string): string | undefined {
+		const spec = providerSpec(providerId);
+		if (!spec) return undefined;
+		for (const name of spec.envKeys) {
+			const value = process.env[name];
+			if (value) return value;
+		}
+		return undefined;
+	}
+
+	const server = createServer(async (req, res) => {
+		try {
+			const auth = req.headers.authorization ?? "";
+			if (auth !== `Bearer ${options.token}`) {
+				json(res, 401, { error: "unauthorized" });
+				return;
+			}
+			const url = new URL(req.url ?? "/", "http://localhost");
+			const path = url.pathname;
+
+			if (req.method === "GET" && path === "/v1/providers") {
+				const stored = new Set(store.list().map((c) => c.provider));
+				json(res, 200, {
+					providers: providerIds().map((id) => {
+						const spec = providerSpec(id);
+						return {
+							id,
+							name: spec?.name ?? id,
+							base_url: spec?.baseUrl,
+							env_keys: spec?.envKeys ?? [],
+							auth: stored.has(id)
+								? "stored"
+								: envKeyFor(id)
+									? "env"
+									: (spec?.envKeys.length ?? 0) === 0
+										? "none_required"
+										: "missing",
+						};
+					}),
+				});
+				return;
+			}
+
+			if (req.method === "GET" && path === "/v1/models") {
+				const providerId = url.searchParams.get("provider") ?? "";
+				const provider = getProvider(providerId);
+				json(res, 200, {
+					models: provider.getModels().map((m) => ({
+						id: m.id,
+						provider: providerId,
+						context_window: m.contextWindow,
+						max_tokens: m.maxTokens,
+						reasoning: m.reasoning,
+					})),
+				});
+				return;
+			}
+
+			if (req.method === "GET" && path === "/v1/auth") {
+				json(res, 200, { credentials: store.list() });
+				return;
+			}
+
+			const loginMatch = path.match(/^\/v1\/auth\/([a-z0-9-]+)\/login$/);
+			if (req.method === "POST" && loginMatch) {
+				const providerId = loginMatch[1];
+				if (!providerSpec(providerId)) {
+					json(res, 404, { error: `unknown provider ${providerId}` });
+					return;
+				}
+				const body = await readBody(req);
+				if (body.mode === "oauth") {
+					json(res, 501, {
+						error: "oauth_not_implemented",
+						message: "OAuth 登录将在后续批次提供；请使用 API Key（mode=api_key）。",
+					});
+					return;
+				}
+				const key = String(body.api_key ?? "").trim();
+				if (!key) {
+					json(res, 400, { error: "missing api_key" });
+					return;
+				}
+				store.set(providerId, key);
+				json(res, 200, { ok: true, provider: providerId });
+				return;
+			}
+
+			const logoutMatch = path.match(/^\/v1\/auth\/([a-z0-9-]+)\/logout$/);
+			if (req.method === "POST" && logoutMatch) {
+				json(res, 200, { ok: true, deleted: store.delete(logoutMatch[1]) });
+				return;
+			}
+
+			if (req.method === "POST" && path === "/v1/probe") {
+				const body = await readBody(req);
+				const providerId = String(body.provider ?? "");
+				const modelId = String(body.model ?? "");
+				const apiKey = store.resolve(providerId) ?? envKeyFor(providerId);
+				if (!apiKey && (providerSpec(providerId)?.envKeys.length ?? 0) > 0) {
+					json(res, 200, { ok: false, error: "no_credential", message: "未配置凭据" });
+					return;
+				}
+				const provider = getProvider(providerId);
+				const model = provider.getModels().find((m) => m.id === modelId);
+				if (!model) {
+					json(res, 200, { ok: false, error: "unknown_model", message: modelId });
+					return;
+				}
+				const events = [];
+				for await (const event of streamTurn(
+					provider,
+					model,
+					{
+						provider: providerId,
+						model: modelId,
+						messages: [{ role: "user", content: "Reply with exactly: ok" }],
+						max_tokens: 8,
+					},
+					apiKey,
+					AbortSignal.timeout(30_000),
+				)) {
+					events.push(event);
+				}
+				const failed = events.find((e) => e.type === "error");
+				json(res, 200, {
+					ok: !failed,
+					error: failed ? (failed as { kind: string }).kind : undefined,
+					message: failed ? (failed as { message: string }).message : "probe ok",
+				});
+				return;
+			}
+
+			if (req.method === "POST" && path === "/v1/stream") {
+				const body = (await readBody(req)) as unknown as ModeldTurnRequest;
+				const providerId = String(body.provider ?? "");
+				const apiKey = store.resolve(providerId) ?? envKeyFor(providerId);
+				res.writeHead(200, {
+					"content-type": "text/event-stream",
+					"cache-control": "no-cache",
+				});
+				const send = (event: unknown) => {
+					res.write(`data: ${JSON.stringify(event)}\n\n`);
+				};
+				if (!apiKey && (providerSpec(providerId)?.envKeys.length ?? 0) > 0) {
+					send({ type: "error", kind: "no_credential", message: "未配置凭据" });
+					res.end();
+					return;
+				}
+				let provider;
+				let model;
+				try {
+					provider = getProvider(providerId);
+					model = provider.getModels().find((m) => m.id === String(body.model));
+					if (!model) throw new Error(`unknown model ${String(body.model)}`);
+				} catch (err) {
+					send({ type: "error", kind: "unknown_model", message: redact((err as Error).message) });
+					res.end();
+					return;
+				}
+				const abort = new AbortController();
+				req.on("close", () => abort.abort());
+				for await (const event of streamTurn(provider, model, body, apiKey, abort.signal)) {
+					send(event);
+				}
+				res.end();
+				return;
+			}
+
+			json(res, 404, { error: "not_found" });
+		} catch (err) {
+			json(res, 500, { error: redact((err as Error).message) });
+		}
+	});
+
+	return new Promise((resolve) => {
+		server.listen(options.socketPath, () => {
+			chmodSync(options.socketPath, 0o600);
+			resolve(server);
+		});
+	});
+}

--- a/packages/rosclaw-modeld/src/stream.ts
+++ b/packages/rosclaw-modeld/src/stream.ts
@@ -1,0 +1,163 @@
+/** ModelTurnRequest → pi-ai stream → modeld SSE 事件（批次 D §7.2/§7.3）。
+ *
+ * modeld 只做协议转换与转发：不解析 DecisionV1、不选工具、不维护状态。
+ */
+
+import type { Api, Context, Message, Model, Provider, Tool } from "@earendil-works/pi-ai";
+
+type AnyModel = Model<Api>;
+type AnyProvider = Provider<Api>;
+import { redact } from "./redact.js";
+
+export interface ModeldTurnRequest {
+	provider: string;
+	model: string;
+	system_prompt?: string;
+	messages: Array<Record<string, unknown>>;
+	tools?: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
+	max_tokens?: number;
+	reasoning_effort?: string;
+}
+
+export type ModeldEvent =
+	| { type: "text.delta"; text: string }
+	| { type: "tool_call"; call_id: string; name: string; arguments: Record<string, unknown> }
+	| { type: "usage"; input: number; output: number; total: number }
+	| { type: "done"; stop_reason: string; assistant_message: Record<string, unknown> }
+	| { type: "error"; kind: string; message: string };
+
+/** OpenAI chat 消息 → pi-ai Message（含 tool_calls / tool result 回填）。 */
+export function toPiMessages(raw: Array<Record<string, unknown>>): Message[] {
+	const out: Message[] = [];
+	const now = Date.now();
+	for (const msg of raw) {
+		const role = String(msg.role ?? "");
+		if (role === "user" || role === "system") {
+			out.push({ role: "user", content: String(msg.content ?? ""), timestamp: now });
+		} else if (role === "assistant") {
+			const content: Array<
+				{ type: "text"; text: string } | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
+			> = [];
+			if (msg.content) content.push({ type: "text", text: String(msg.content) });
+			for (const call of (msg.tool_calls as Array<Record<string, unknown>>) ?? []) {
+				const fn = (call.function ?? {}) as Record<string, unknown>;
+				let args: Record<string, unknown> = {};
+				try {
+					args = JSON.parse(String(fn.arguments ?? "{}")) as Record<string, unknown>;
+				} catch {
+					args = {};
+				}
+				content.push({
+					type: "toolCall",
+					id: String(call.id ?? ""),
+					name: String(fn.name ?? ""),
+					arguments: args,
+				});
+			}
+			out.push({
+				role: "assistant",
+				content,
+				api: "openai-completions",
+				provider: "unknown",
+				model: "unknown",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: ZERO_COST },
+				stopReason: "stop",
+				timestamp: now,
+			});
+		} else if (role === "tool") {
+			out.push({
+				role: "toolResult",
+				toolCallId: String(msg.tool_call_id ?? ""),
+				toolName: String(msg.name ?? "tool"),
+				content: [{ type: "text", text: String(msg.content ?? "") }],
+				isError: false,
+				timestamp: now,
+			});
+		}
+	}
+	return out;
+}
+
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+
+function toPiTools(raw: ModeldTurnRequest["tools"]): Tool[] {
+	return (raw ?? []).map((t) => ({
+		name: t.name,
+		description: t.description,
+		parameters: t.parameters as Tool["parameters"],
+	}));
+}
+
+export async function* streamTurn(
+	provider: AnyProvider,
+	model: AnyModel,
+	request: ModeldTurnRequest,
+	apiKey: string | undefined,
+	signal: AbortSignal,
+): AsyncGenerator<ModeldEvent> {
+	const context: Context = {
+		systemPrompt: request.system_prompt,
+		messages: toPiMessages(request.messages),
+		tools: toPiTools(request.tools),
+	};
+	try {
+		const stream = provider.stream(model, context, {
+			apiKey,
+			maxTokens: request.max_tokens,
+			signal,
+		});
+		for await (const event of stream) {
+			if (event.type === "text_delta") {
+				yield { type: "text.delta", text: event.delta };
+			} else if (event.type === "toolcall_end") {
+				yield {
+					type: "tool_call",
+					call_id: event.toolCall.id,
+					name: event.toolCall.name,
+					arguments: event.toolCall.arguments,
+				};
+			} else if (event.type === "done") {
+				const message = event.message;
+				yield {
+					type: "usage",
+					input: message.usage.input,
+					output: message.usage.output,
+					total: message.usage.totalTokens,
+				};
+				yield {
+					type: "done",
+					stop_reason: event.reason,
+					assistant_message: {
+						role: "assistant",
+						content: message.content
+							.filter((c) => c.type === "text")
+							.map((c) => (c as { text: string }).text)
+							.join(""),
+						tool_calls: message.content
+							.filter((c) => c.type === "toolCall")
+							.map((c) => {
+								const call = c as { id: string; name: string; arguments: Record<string, unknown> };
+								return {
+									id: call.id,
+									type: "function",
+									function: { name: call.name, arguments: JSON.stringify(call.arguments) },
+								};
+							}),
+					},
+				};
+			} else if (event.type === "error") {
+				yield {
+					type: "error",
+					kind: event.reason,
+					message: redact(event.error.errorMessage ?? "provider error", apiKey ? [apiKey] : []),
+				};
+			}
+		}
+	} catch (err) {
+		yield {
+			type: "error",
+			kind: "transport",
+			message: redact((err as Error).message, apiKey ? [apiKey] : []),
+		};
+	}
+}

--- a/packages/rosclaw-modeld/test/credentials.test.ts
+++ b/packages/rosclaw-modeld/test/credentials.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { FileCredentialStore } from "../src/credentials.js";
+
+test("store writes 0600 and lists fingerprints only", () => {
+	const dir = mkdtempSync(join(tmpdir(), "modeld-cred-"));
+	const store = new FileCredentialStore(dir);
+	store.set("moonshot", "sk-test-secret-value");
+	const mode = statSync(join(dir, "modeld-credentials.json")).mode & 0o777;
+	assert.equal(mode, 0o600);
+	const list = store.list();
+	assert.equal(list.length, 1);
+	assert.equal(list[0].provider, "moonshot");
+	assert.notEqual(list[0].fingerprint, "sk-test-secret-value");
+	assert.equal(JSON.stringify(list).includes("sk-test-secret-value"), false);
+	// resolve 只在内存路径返回 key。
+	assert.equal(store.resolve("moonshot"), "sk-test-secret-value");
+	assert.equal(store.delete("moonshot"), true);
+	assert.equal(store.resolve("moonshot"), undefined);
+});
+
+test("missing file reads as empty, never fabricates", () => {
+	const dir = mkdtempSync(join(tmpdir(), "modeld-cred-"));
+	const store = new FileCredentialStore(dir);
+	assert.deepEqual(store.list(), []);
+	assert.equal(store.resolve("moonshot"), undefined);
+});
+
+test("corrupt file reads as empty (fail honest)", () => {
+	const dir = mkdtempSync(join(tmpdir(), "modeld-cred-"));
+	const store = new FileCredentialStore(dir);
+	store.set("moonshot", "sk-x");
+	writeFileSync(join(dir, "modeld-credentials.json"), "not json");
+	assert.deepEqual(store.list(), []);
+});

--- a/packages/rosclaw-modeld/test/redact.test.ts
+++ b/packages/rosclaw-modeld/test/redact.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { redact } from "../src/redact.js";
+
+test("redacts known secrets verbatim", () => {
+	const key = "sk-kimi-abcdef1234567890";
+	assert.equal(redact(`Authorization failed for ${key}`, [key]), "Authorization failed for <redacted>");
+});
+
+test("redacts sk- patterns even when unknown", () => {
+	assert.equal(redact("token sk-abcdefghij leaked"), "token <redacted> leaked");
+});
+
+test("redacts bearer tokens and key=value shapes", () => {
+	assert.equal(redact("header Bearer abcdefgh12345"), "header <redacted>");
+	const out = redact('api_key="supersecretvalue"');
+	assert.ok(!out.includes("supersecretvalue"));
+});
+
+test("short strings are untouched", () => {
+	assert.equal(redact("plain error message"), "plain error message");
+});

--- a/packages/rosclaw-modeld/test/server.test.ts
+++ b/packages/rosclaw-modeld/test/server.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, statSync, existsSync } from "node:fs";
+import { request } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { startModeld } from "../src/server.js";
+
+const TOKEN = "test-token-123";
+
+async function uds(
+	socketPath: string,
+	method: string,
+	path: string,
+	body?: unknown,
+	token: string | null = TOKEN,
+): Promise<{ code: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const req = request(
+			{
+				socketPath,
+				method,
+				path,
+				headers: {
+					...(body ? { "content-type": "application/json" } : {}),
+					...(token ? { authorization: `Bearer ${token}` } : {}),
+				},
+			},
+			(res) => {
+				const chunks: Buffer[] = [];
+				res.on("data", (c) => chunks.push(c));
+				res.on("end", () => resolve({ code: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() }));
+			},
+		);
+		req.on("error", reject);
+		if (body) req.write(JSON.stringify(body));
+		req.end();
+	});
+}
+
+async function withModeld(fn: (socketPath: string, home: string) => Promise<void>): Promise<void> {
+	const home = mkdtempSync(join(tmpdir(), "modeld-test-"));
+	const socketPath = join(home, "run", "modeld.sock");
+	const server = await startModeld({ socketPath, token: TOKEN, homeDir: home });
+	try {
+		await fn(socketPath, home);
+	} finally {
+		server.close();
+	}
+}
+
+test("socket dir 0700 and socket 0600", async () => {
+	await withModeld(async (socketPath, home) => {
+		assert.equal(statSync(join(home, "run")).mode & 0o700, 0o700);
+		assert.equal(statSync(socketPath).mode & 0o777, 0o600);
+	});
+});
+
+test("requests without bearer token get 401", async () => {
+	await withModeld(async (socketPath) => {
+		const res = await uds(socketPath, "GET", "/v1/providers", undefined, null);
+		assert.equal(res.code, 401);
+	});
+});
+
+test("providers listed with auth status, never secrets", async () => {
+	await withModeld(async (socketPath) => {
+		const res = await uds(socketPath, "GET", "/v1/providers");
+		assert.equal(res.code, 200);
+		const body = JSON.parse(res.body);
+		const ids = body.providers.map((p: { id: string }) => p.id);
+		assert.ok(ids.includes("moonshot") && ids.includes("kimi-code") && ids.includes("ollama"));
+		assert.ok(!res.body.includes("sk-"));
+	});
+});
+
+test("login stores credential; auth lists fingerprint only; logout deletes", async () => {
+	await withModeld(async (socketPath) => {
+		const login = await uds(socketPath, "POST", "/v1/auth/moonshot/login", {
+			mode: "api_key",
+			api_key: "sk-test-value-12345",
+		});
+		assert.equal(login.code, 200);
+		const auth = await uds(socketPath, "GET", "/v1/auth");
+		const creds = JSON.parse(auth.body).credentials;
+		assert.equal(creds.length, 1);
+		assert.ok(!auth.body.includes("sk-test-value-12345"), "fingerprint only, no secret");
+		const logout = await uds(socketPath, "POST", "/v1/auth/moonshot/logout", {});
+		assert.equal(JSON.parse(logout.body).deleted, true);
+	});
+});
+
+test("oauth login honestly reports not-implemented", async () => {
+	await withModeld(async (socketPath) => {
+		const res = await uds(socketPath, "POST", "/v1/auth/moonshot/login", { mode: "oauth" });
+		assert.equal(res.code, 501);
+	});
+});
+
+test("stream without credential yields error event, never fabricates", async () => {
+	await withModeld(async (socketPath) => {
+		const res = await uds(socketPath, "POST", "/v1/stream", {
+			provider: "moonshot",
+			model: "kimi-k3",
+			messages: [{ role: "user", content: "hi" }],
+		});
+		assert.equal(res.code, 200);
+		assert.ok(res.body.includes("no_credential"));
+		assert.ok(!res.body.includes('"done"'));
+	});
+});
+
+test("unknown model yields error event", async () => {
+	await withModeld(async (socketPath) => {
+		const res = await uds(socketPath, "POST", "/v1/stream", {
+			provider: "ollama",
+			model: "no-such-model",
+			messages: [{ role: "user", content: "hi" }],
+		});
+		assert.ok(res.body.includes("unknown_model"));
+	});
+});
+
+test("models endpoint lists catalog", async () => {
+	await withModeld(async (socketPath) => {
+		const res = await uds(socketPath, "GET", "/v1/models?provider=kimi-code");
+		const models = JSON.parse(res.body).models;
+		assert.ok(models.some((m: { id: string }) => m.id === "k3"));
+	});
+});

--- a/packages/rosclaw-modeld/test/stream.test.ts
+++ b/packages/rosclaw-modeld/test/stream.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { toPiMessages } from "../src/stream.js";
+
+test("user and tool result round-trip", () => {
+	const messages = toPiMessages([
+		{ role: "user", content: "你好" },
+		{
+			role: "assistant",
+			content: null,
+			tool_calls: [
+				{ id: "c1", type: "function", function: { name: "sim_get_state", arguments: '{"verbose":true}' } },
+			],
+		},
+		{ role: "tool", tool_call_id: "c1", content: '{"ok":true}' },
+	]);
+	assert.equal(messages.length, 3);
+	assert.equal(messages[0].role, "user");
+	const assistant = messages[1];
+	assert.equal(assistant.role, "assistant");
+	if (assistant.role === "assistant") {
+		const call = assistant.content[0];
+		assert.equal(call.type, "toolCall");
+		if (call.type === "toolCall") {
+			assert.equal(call.name, "sim_get_state");
+			assert.deepEqual(call.arguments, { verbose: true });
+		}
+	}
+	const result = messages[2];
+	assert.equal(result.role, "toolResult");
+	if (result.role === "toolResult") {
+		assert.equal(result.toolCallId, "c1");
+	}
+});
+
+test("malformed tool arguments degrade to empty object, never throw", () => {
+	const messages = toPiMessages([
+		{
+			role: "assistant",
+			content: null,
+			tool_calls: [{ id: "c1", function: { name: "t", arguments: "not json" } }],
+		},
+	]);
+	const assistant = messages[0];
+	if (assistant.role === "assistant") {
+		const call = assistant.content[0];
+		if (call.type === "toolCall") assert.deepEqual(call.arguments, {});
+	}
+});

--- a/packages/rosclaw-modeld/tsconfig.json
+++ b/packages/rosclaw-modeld/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2023",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"outDir": "dist",
+		"rootDir": ".",
+		"strict": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"declaration": false,
+		"sourceMap": false,
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -508,6 +508,42 @@ def cmd_credential(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_backend(args: argparse.Namespace) -> int:
+    """查看/切换模型 backend（批次 D：Kimi 现有配置无需改动即可迁移）。"""
+    import yaml
+
+    home = _home(args)
+    config_path = home / "config.yaml"
+    data = {}
+    if config_path.exists():
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    models = data.setdefault("models", {})
+    current = models.get("backend", "legacy")
+    if not args.set:
+        print(json.dumps({"backend": current}, ensure_ascii=False))
+        return 0
+    if args.set == current:
+        print(f"backend 已是 {current}")
+        return 0
+    if args.set == "modeld":
+        from rosclaw.agentd.models.modeld_gateway import _find_modeld_runtime
+
+        if _find_modeld_runtime() is None:
+            print(
+                "rosclaw-modeld 不可用（需要 Node >= 22.19 与已构建的 "
+                "packages/rosclaw-modeld）。修复后再切换。",
+                file=sys.stderr,
+            )
+            return 2
+    models["backend"] = args.set
+    config_path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
+    print(
+        f"backend: {current} → {args.set}。"
+        "现有 profile 与 env 凭据引用保持不变；下一 turn 生效。"
+    )
+    return 0
+
+
 async def _chat_repl(service: AgentService, args: argparse.Namespace) -> int:
     mission = None
     if args.mission:
@@ -650,6 +686,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.set_defaults(func=cmd_init)
 
     add_credential_subcommands(sub)
+
+    p_backend = sub.add_parser("backend", help="model backend: legacy | modeld")
+    p_backend.add_argument("--set", choices=["legacy", "modeld"], default=None)
+    p_backend.set_defaults(func=cmd_backend)
 
     p_chat = sub.add_parser("chat", help="interactive chat (in-process)")
     p_chat.add_argument("--mission", default=None)

--- a/src/rosclaw/agentd/config.py
+++ b/src/rosclaw/agentd/config.py
@@ -32,6 +32,7 @@ class AgentConfig:
     body_id: str | None = None
     sim_body_id: str = "sim/ur5e"
     profiles: list[ModelProfile] = field(default_factory=list)
+    model_backend: str = "legacy"  # legacy | modeld（批次 D）
     mcp_servers: list[dict[str, Any]] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
 
@@ -94,6 +95,7 @@ def load_agent_config(path: Path | None = None) -> AgentConfig:
         body_id=(str(agent["body_id"]) if agent.get("body_id") else None),
         sim_body_id=str(agent.get("sim_body_id", "sim/ur5e")),
         profiles=profiles,
+        model_backend=str(models.get("backend", "legacy")),
         mcp_servers=[dict(s or {}) for s in (data.get("mcp_servers", []) or [])],
         raw={
             "agent": agent,

--- a/src/rosclaw/agentd/models/modeld_gateway.py
+++ b/src/rosclaw/agentd/models/modeld_gateway.py
@@ -1,0 +1,292 @@
+"""ModeldGateway — ModelGateway over rosclaw-modeld (批次 D §7.2).
+
+AgentLoop 不再直接依赖 OpenAI-compatible 协议细节：本 gateway 把
+ModelTurnRequest 转发给本地 modeld（UDS + bearer token），由 modeld 经
+pi-ai 完成 provider 差异、认证与流式调用。
+
+边界与失败语义：
+- token 在启动时随机生成，只经子进程环境传递；不落盘、不进日志。
+- modeld 崩溃/不可达 → ModelGatewayError（诚实失败，绝不伪造成功）。
+- 凭据按 profile.api_key_ref 的 env:VAR 由 *agentd 侧* 环境注入 modeld
+  子进程环境（modeld 自己读 env）；api_key_ref 的 *值* 永不出现在请求体。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from rosclaw.agentd.models.gateway import (
+    ModelGatewayError,
+    ModelProbeResult,
+    ModelTurnRequest,
+)
+from rosclaw.agentd.models.policy import ModelProfile
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1, ModelUsage, ToolCall
+from rosclaw.contracts.common import new_id
+
+#: provider 名映射：ModelProfile.provider → modeld provider id
+_PROVIDER_MAP = {
+    "kimi_cn": "moonshot",
+    "kimi_code": "kimi-code",
+    "moonshot": "moonshot",
+    "kimi-code": "kimi-code",
+    "ollama": "ollama",
+}
+
+
+def _find_modeld_runtime() -> tuple[str, str] | None:
+    """(node ≥22.19, modeld entry) — 与 CLI 的 TUI 探测同一语义。"""
+    candidates = [shutil.which("node"), "/usr/bin/node", "/usr/local/bin/node"]
+    node = None
+    for candidate in filter(None, candidates):
+        try:
+            out = subprocess.check_output([candidate, "--version"], text=True, timeout=10).strip()
+            if [int(p) for p in out.lstrip("v").split(".")] >= [22, 19, 0]:
+                node = candidate
+                break
+        except Exception:  # noqa: BLE001
+            continue
+    if node is None:
+        return None
+    entry_env = os.environ.get("ROSCLAW_MODELD_ENTRY")
+    repo_entry = (
+        Path(__file__).resolve().parents[4] / "packages" / "rosclaw-modeld" / "dist" / "src" / "main.js"
+    )
+    entry = entry_env or (str(repo_entry) if repo_entry.exists() else None)
+    if not entry or not Path(entry).exists():
+        return None
+    return node, entry
+
+
+class ModeldGateway:
+    """ModelGateway 协议实现（complete_stream/probe/close）。"""
+
+    def __init__(self, profile: ModelProfile, *, home: Path | None = None) -> None:
+        self.profile = profile
+        self._home = home or (Path.home() / ".rosclaw")
+        self._provider = _PROVIDER_MAP.get(profile.provider, profile.provider)
+        self._token = secrets.token_urlsafe(32)
+        self._proc: subprocess.Popen | None = None
+        self._socket_path = ""
+        self._session = None
+        self._last_error: str | None = None
+
+    # -- lifecycle ------------------------------------------------------------
+
+    async def _ensure_started(self) -> None:
+        if self._session is not None:
+            if self._proc is not None and self._proc.poll() is not None:
+                # modeld 崩溃：诚实报错，不假装修复（重启由下一次调用显式触发）。
+                self._last_error = f"modeld exited with code {self._proc.returncode}"
+                raise ModelGatewayError("modeld_crashed", self._last_error)
+            return
+        runtime = _find_modeld_runtime()
+        if runtime is None:
+            raise ModelGatewayError(
+                "modeld_unavailable",
+                "rosclaw-modeld runtime not found (need Node >= 22.19 and built "
+                "packages/rosclaw-modeld); use the legacy backend or run rosclaw doctor",
+            )
+        node, entry = runtime
+        home = self._home / "agentd" / "modeld"
+        home.mkdir(parents=True, exist_ok=True)
+        self._socket_path = str(home / "modeld.sock")
+        env = dict(os.environ)
+        env["ROSCLAW_MODELD_TOKEN"] = self._token
+        # profile 引用的 env key 若存在则随子进程环境传递（值不进命令行/文件）；
+        # 缺失时不拦——由 modeld 诚实报告 no_credential。
+        self._proc = subprocess.Popen(  # noqa: S603 - fixed entry, no shell
+            [node, entry, "--socket", self._socket_path, "--home", str(home)],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        import aiohttp
+
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if self._proc.poll() is not None:
+                raise ModelGatewayError(
+                    "modeld_crashed", f"modeld exited during startup (code {self._proc.returncode})"
+                )
+            if Path(self._socket_path).exists():
+                break
+            await asyncio.sleep(0.05)
+        else:
+            raise ModelGatewayError("modeld_timeout", "modeld did not create its socket in 10s")
+        connector = aiohttp.UnixConnector(path=self._socket_path)
+        self._session = aiohttp.ClientSession(
+            connector=connector, headers={"authorization": f"Bearer {self._token}"}
+        )
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+        if self._proc is not None and self._proc.poll() is None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+        self._proc = None
+
+    # -- management channel (commands: /providers /login /logout /model) ---------
+
+    async def manage(self, method: str, path: str, payload: dict | None = None) -> dict:
+        """管理面调用（/v1/providers、/v1/auth、/v1/models、login/logout）。
+
+        只返回 modeld 的公开 JSON——secret 永不经过此通道的响应。
+        """
+        await self._ensure_started()
+        try:
+            async with self._session.request(
+                method, f"http://localhost{path}", json=payload, timeout=30
+            ) as resp:
+                return await resp.json()  # type: ignore[no-any-return]
+        except ModelGatewayError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise ModelGatewayError(
+                "modeld_transport", f"management call failed: {type(exc).__name__}: {exc}"
+            ) from exc
+
+    # -- ModelGateway protocol --------------------------------------------------
+
+    async def probe(self) -> ModelProbeResult:
+        try:
+            await self._ensure_started()
+        except ModelGatewayError as exc:
+            return ModelProbeResult(reachable=False, error=f"{exc.kind}: {exc}")
+        try:
+            async with self._session.post(
+                "http://localhost/v1/probe",
+                json={"provider": self._provider, "model": self.profile.model},
+                timeout=35,
+            ) as resp:
+                body = await resp.json()
+        except Exception as exc:  # noqa: BLE001
+            return ModelProbeResult(reachable=False, error=f"transport: {exc}")
+        if body.get("ok"):
+            return ModelProbeResult(reachable=True, chat_ok=True, tool_call_ok=None)
+        return ModelProbeResult(
+            reachable=True, error=f"{body.get('error')}: {body.get('message')}"
+        )
+
+    async def complete(self, request: ModelTurnRequest) -> ModelTurnResultV1:
+        return await self.complete_stream(request, None)
+
+    async def complete_stream(
+        self, request: ModelTurnRequest, on_text_delta=None
+    ) -> ModelTurnResultV1:
+        await self._ensure_started()
+        started = time.monotonic()
+        payload: dict[str, Any] = {
+            "provider": self._provider,
+            "model": self.profile.model,
+            "system_prompt": request.system_prompt,
+            "messages": request.messages,
+            "max_tokens": request.max_output_tokens,
+            "tools": [t.to_openai()["function"] for t in request.tools],
+        }
+        effort = self.profile.vendor_parameters.get("reasoning_effort")
+        if effort:
+            payload["reasoning_effort"] = effort
+        content_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+        usage = ModelUsage()
+        finish_reason: str | None = None
+        assistant_message: dict[str, Any] = {}
+        try:
+            async with self._session.post(
+                "http://localhost/v1/stream",
+                json=payload,
+                timeout=self.profile.timeout_sec,
+            ) as resp:
+                buffer = ""
+                async for chunk in resp.content.iter_any():
+                    buffer += chunk.decode("utf-8", errors="replace")
+                    while "\n\n" in buffer:
+                        frame, buffer = buffer.split("\n\n", 1)
+                        data = ""
+                        for line in frame.splitlines():
+                            if line.startswith("data: "):
+                                data += line[6:]
+                        if not data:
+                            continue
+                        event = json.loads(data)
+                        etype = event.get("type")
+                        if etype == "text.delta":
+                            text = event.get("text", "")
+                            content_parts.append(text)
+                            if on_text_delta is not None:
+                                maybe = on_text_delta(text)
+                                if asyncio.iscoroutine(maybe):
+                                    await maybe
+                        elif etype == "tool_call":
+                            tool_calls.append(
+                                ToolCall(
+                                    call_id=event.get("call_id", ""),
+                                    name=event.get("name", ""),
+                                    arguments_json=json.dumps(
+                                        event.get("arguments") or {}, ensure_ascii=False
+                                    ),
+                                )
+                            )
+                        elif etype == "usage":
+                            usage = ModelUsage(
+                                prompt_tokens=int(event.get("input", 0)),
+                                completion_tokens=int(event.get("output", 0)),
+                                total_tokens=int(event.get("total", 0)),
+                            )
+                        elif etype == "done":
+                            finish_reason = event.get("stop_reason")
+                            assistant_message = event.get("assistant_message") or {}
+                        elif etype == "error":
+                            raise ModelGatewayError(
+                                str(event.get("kind", "provider_error")),
+                                str(event.get("message", "modeld stream error")),
+                            )
+        except ModelGatewayError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - transport/crash → honest error
+            raise ModelGatewayError(
+                "modeld_transport", f"modeld stream failed: {type(exc).__name__}: {exc}"
+            ) from exc
+        if finish_reason is None and not tool_calls and not content_parts:
+            raise ModelGatewayError("modeld_transport", "modeld stream ended without done event")
+        from rosclaw.agentd.usage import estimate_cost_microunits
+
+        usage = usage.model_copy(
+            update={
+                "cost_microunits": estimate_cost_microunits(
+                    prompt_tokens=usage.prompt_tokens,
+                    completion_tokens=usage.completion_tokens,
+                    price_input_per_mtok=self.profile.price_input_per_mtok_microunits,
+                    price_output_per_mtok=self.profile.price_output_per_mtok_microunits,
+                )
+            }
+        )
+        return ModelTurnResultV1(
+            turn_id=new_id("turn"),
+            mission_id=request.mission_id,
+            provider=self._provider,
+            model=self.profile.model,
+            profile=self.profile.name,
+            content="".join(content_parts),
+            tool_calls=tool_calls,
+            assistant_message=assistant_message,
+            finish_reason=finish_reason,
+            usage=usage,
+            latency_ms=int((time.monotonic() - started) * 1000),
+            context_id=request.context_id,
+            context_revision=request.context_revision,
+        )

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -230,7 +230,13 @@ class AgentService:
 
             policy = config.to_policy()
             chain = policy.fallback_chain()
-            candidates = [(p, OpenAICompatGateway(p)) for p in chain]
+            if config.model_backend == "modeld":
+                # 批次 D：AgentLoop 不再直接接触 OpenAI-compatible 协议细节。
+                from rosclaw.agentd.models.modeld_gateway import ModeldGateway
+
+                candidates = [(p, ModeldGateway(p, home=self._home)) for p in chain]
+            else:
+                candidates = [(p, OpenAICompatGateway(p)) for p in chain]
             # 单 profile 也走 FailoverGateway：统一的 cooldown/RPM 语义。
             self._gateway = FailoverGateway(candidates)
         self._prompt = load_prompt("native_agent_v1.md")
@@ -517,6 +523,96 @@ class AgentService:
     @property
     def tool_resolver(self):
         return self._tool_resolver
+
+    # -- modeld 管理面（批次 D：/providers /model /login /logout） ---------------
+    def _modeld_mgmt(self):
+        """共享的 modeld 管理通道（懒启动；runtime 缺失 → None）。"""
+        if getattr(self, "_modeld_mgmt_instance", None) is not None:
+            return self._modeld_mgmt_instance
+        from rosclaw.agentd.models.modeld_gateway import ModeldGateway, _find_modeld_runtime
+
+        if _find_modeld_runtime() is None:
+            return None
+        profile = (
+            self._config.to_policy().default
+            if self._config.profiles
+            else getattr(self._gateway, "profile", None)
+        )
+        if profile is None:
+            return None
+        self._modeld_mgmt_instance = ModeldGateway(profile, home=self._home)
+        return self._modeld_mgmt_instance
+
+    async def modeld_providers(self) -> dict:
+        mgmt = self._modeld_mgmt()
+        if mgmt is None:
+            return {"available": False, "providers": [], "error": "modeld runtime unavailable"}
+        try:
+            data = await mgmt.manage("GET", "/v1/providers")
+            data["available"] = True
+            return data
+        except Exception as exc:  # noqa: BLE001
+            return {"available": False, "providers": [], "error": str(exc)}
+
+    async def modeld_models(self, provider: str) -> dict:
+        mgmt = self._modeld_mgmt()
+        if mgmt is None:
+            return {"models": [], "error": "modeld runtime unavailable"}
+        return await mgmt.manage("GET", f"/v1/models?provider={provider}")
+
+    async def modeld_login(self, provider: str, api_key: str) -> dict:
+        """API key 登录：secret 只经内存进 modeld，不落 mission journal。"""
+        mgmt = self._modeld_mgmt()
+        if mgmt is None:
+            return {"ok": False, "error": "modeld runtime unavailable"}
+        return await mgmt.manage(
+            "POST", f"/v1/auth/{provider}/login", {"mode": "api_key", "api_key": api_key}
+        )
+
+    async def modeld_logout(self, provider: str) -> dict:
+        mgmt = self._modeld_mgmt()
+        if mgmt is None:
+            return {"ok": False, "error": "modeld runtime unavailable"}
+        return await mgmt.manage("POST", f"/v1/auth/{provider}/logout", {})
+
+    def current_model_label(self) -> str:
+        profile = self._gateway.profile
+        return f"{profile.provider}/{profile.model}（profile: {profile.name}）"
+
+    def switch_model(self, provider: str, model: str) -> dict:
+        """切换默认 profile 的 provider/model（内存态；持久化走 /settings）。
+
+        切换永不改变工具权限、Mission mode 或 grant（§8.5）。
+        """
+        if not self._config.profiles:
+            return {"ok": False, "error_code": "no_profiles", "message": "未配置模型"}
+        profile = self._config.to_policy().default
+        old = f"{profile.provider}/{profile.model}"
+        if self._config.model_backend != "modeld":
+            return {
+                "ok": False,
+                "error_code": "legacy_backend",
+                "message": (
+                    "legacy backend 的运行时在启动时绑定 endpoint，/model 暂不支持热切换；"
+                    "请设置 models.backend: modeld 后重试（Kimi 现有配置无需改动）"
+                ),
+            }
+        # modeld provider 名映射与 ModeldGateway 一致。
+        from rosclaw.agentd.models.modeld_gateway import _PROVIDER_MAP
+
+        mapped = _PROVIDER_MAP.get(provider, provider)
+        # profile 对象被 config / FailoverGateway candidates / 既有 AgentLoop
+        # 共享；frozen dataclass 的就地字段替换让"下一 turn 生效"在所有
+        # 引用点同时成立（当前 turn 不中断）。
+        object.__setattr__(profile, "provider", mapped)
+        object.__setattr__(profile, "model", model)
+        return {
+            "ok": True,
+            "message": (
+                f"模型已从 {old} 切换为 {mapped}/{model}（下一 turn 生效；"
+                "当前 turn 不中断；持久化配置修改将在 /settings 提供）"
+            ),
+        }
 
     def _record_worker_event(self, mission_id: str, to_status: str, payload: dict) -> None:
         """Sync bridge: WorkerManager transitions → AgentEventV2 (批次 B)."""

--- a/src/rosclaw/agentd/ui/command_service.py
+++ b/src/rosclaw/agentd/ui/command_service.py
@@ -192,6 +192,151 @@ class CommandService:
                 data={"tools": items},
             )
 
+        # -- MODEL_CONTROL（批次 D） -------------------------------------------
+
+        async def _providers(req: CommandRequestV1) -> CommandResultV1:
+            data = await service.modeld_providers()
+            providers = data.get("providers", [])
+            lines = [
+                f"{p['id']:14} {p.get('auth', '?'):14} {p.get('name', '')}"
+                for p in providers
+            ]
+            current = service.current_model_label()
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=bool(data.get("available", True)),
+                message=(
+                    f"当前模型：{current}\n" + "\n".join(lines)
+                    if lines
+                    else data.get("error", "modeld 不可用")
+                ),
+                data={"providers": providers, "current": current},
+            )
+
+        async def _model(req: CommandRequestV1) -> CommandResultV1:
+            target = str(req.arguments.get("target", "")).strip()
+            if not target:
+                data = await service.modeld_providers()
+                models: dict[str, list[str]] = {}
+                for p in data.get("providers", []):
+                    listing = await service.modeld_models(p["id"])
+                    models[p["id"]] = [m["id"] for m in listing.get("models", [])]
+                return CommandResultV1(
+                    request_id=req.request_id,
+                    command_name=req.command_name,
+                    ok=True,
+                    message=f"当前模型：{service.current_model_label()}",
+                    data={"models": models, "current": service.current_model_label()},
+                )
+            if "/" not in target:
+                return CommandResultV1(
+                    request_id=req.request_id,
+                    command_name=req.command_name,
+                    ok=False,
+                    error_code="invalid_arguments",
+                    message="/model 需要 <provider>/<model>，如 /model kimi-code/k3",
+                )
+            provider, _, model = target.partition("/")
+            result = service.switch_model(provider, model)
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=result.get("ok", False),
+                message=result.get("message", ""),
+                error_code=result.get("error_code", ""),
+            )
+
+        async def _login(req: CommandRequestV1) -> CommandResultV1:
+            provider = str(req.arguments.get("provider", "")).strip()
+            api_key = str(req.arguments.get("api_key", "")).strip()
+            if not provider or not api_key:
+                return CommandResultV1(
+                    request_id=req.request_id,
+                    command_name=req.command_name,
+                    ok=False,
+                    error_code="invalid_arguments",
+                    message="/login 需要 provider 与 api_key（TUI 会用 masked input 收集）",
+                )
+            result = await service.modeld_login(provider, api_key)
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=bool(result.get("ok")),
+                message=(
+                    f"已登录 {provider}（凭据存于 modeld credential store；不会进入对话）"
+                    if result.get("ok")
+                    else str(result.get("error", "login failed"))
+                ),
+            )
+
+        async def _logout(req: CommandRequestV1) -> CommandResultV1:
+            provider = str(req.arguments.get("provider", "")).strip()
+            if not provider:
+                return CommandResultV1(
+                    request_id=req.request_id,
+                    command_name=req.command_name,
+                    ok=False,
+                    error_code="invalid_arguments",
+                    message="/logout 需要 provider",
+                )
+            result = await service.modeld_logout(provider)
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=bool(result.get("ok", True)),
+                message=f"已登出 {provider}（活动 turn 不受影响，下一 turn 生效）",
+            )
+
+        self._register(
+            CommandSpecV1(
+                name="providers",
+                description="列出 Provider 与认证状态（不含 secret）",
+                category=CommandCategory.MODEL,
+                owner=CommandOwner.MODEL_CONTROL,
+                during_turn=True,
+                handler="model.providers",
+            ),
+            _providers,
+        )
+        self._register(
+            CommandSpecV1(
+                name="model",
+                description="查看或切换模型（切换不改变工具权限/Mission mode/grant）",
+                argument_hint="[<provider>/<model>]",
+                category=CommandCategory.MODEL,
+                owner=CommandOwner.MODEL_CONTROL,
+                mutability="CONTROL_STATE",
+                handler="model.select",
+            ),
+            _model,
+        )
+        self._register(
+            CommandSpecV1(
+                name="login",
+                description="Provider API key 登录（secret 不进对话）",
+                argument_hint="<provider>",
+                category=CommandCategory.MODEL,
+                owner=CommandOwner.MODEL_CONTROL,
+                mutability="PERSISTED",
+                handler="model.login",
+            ),
+            _login,
+        )
+        self._register(
+            CommandSpecV1(
+                name="logout",
+                description="Provider 登出",
+                argument_hint="<provider>",
+                category=CommandCategory.MODEL,
+                owner=CommandOwner.MODEL_CONTROL,
+                mutability="PERSISTED",
+                confirmation="CONFIRM",
+                handler="model.logout",
+            ),
+            _logout,
+        )
+
         self._register(
             CommandSpecV1(
                 name="compact",

--- a/tests/agentd/test_kimi_live.py
+++ b/tests/agentd/test_kimi_live.py
@@ -23,6 +23,8 @@ from pathlib import Path
 
 import pytest
 
+from rosclaw.agentd.models.modeld_gateway import _find_modeld_runtime as _find_runtime
+
 KEY = os.environ.get("ROSCLAW_KIMI_API_KEY", "")
 BASE_URL = os.environ.get("ROSCLAW_KIMI_BASE_URL", "https://api.kimi.com/coding/v1")
 
@@ -393,5 +395,93 @@ async def test_k6_team_coordination(tmp_path: Path) -> None:
         coord.member_lost(rows[0]["awardee"])
         after = service.store.connection.execute("SELECT status FROM team_tasks").fetchall()
         assert after[0]["status"] == "ANNOUNCED"
+    finally:
+        await service.close()
+
+
+
+@pytest.mark.skipif(_find_runtime() is None, reason="rosclaw-modeld runtime unavailable")
+async def test_k7_modeld_backend_live(tmp_path: Path) -> None:
+    """K7 (批次 D 验收)：真实 Kimi K3 经 rosclaw-modeld + pi-ai 全链路。
+
+    AgentLoop → ModeldGateway → modeld(UDS) → pi-ai → api.kimi.com。
+    无 mock：modeld 进程、UDS、provider 调用全部为真实路径。
+    """
+    from rosclaw.agentd.models.gateway import ModelTurnRequest, StrictTool
+    from rosclaw.agentd.models.modeld_gateway import ModeldGateway
+    from rosclaw.agentd.models.profiles import kimi_code_k3_profile
+
+    gateway = ModeldGateway(kimi_code_k3_profile(base_url=BASE_URL), home=tmp_path)
+    try:
+        probe = await gateway.probe()
+        assert probe.reachable and not probe.error, f"modeld probe failed: {probe.error}"
+        turn = await gateway.complete(
+            ModelTurnRequest(
+                system_prompt="Reply with exactly one word: ok",
+                messages=[{"role": "user", "content": "ping"}],
+                tools=[],
+                max_output_tokens=64,
+                mission_id="mis_k7",
+                context_id="ctx",
+                context_revision=1,
+            )
+        )
+        assert turn.content.strip(), "empty content from live model via modeld"
+        assert turn.usage.total_tokens > 0, "usage must be metered through modeld"
+        tool = StrictTool(
+            name="ping",
+            description="ping",
+            parameters={
+                "type": "object",
+                "properties": {"echo": {"type": "boolean"}},
+                "required": ["echo"],
+                "additionalProperties": False,
+            },
+        )
+        turn2 = await gateway.complete(
+            ModelTurnRequest(
+                system_prompt="Call the ping tool. No text answer.",
+                messages=[{"role": "user", "content": "ping"}],
+                tools=[tool],
+                tool_choice="required",
+                max_output_tokens=256,
+                mission_id="mis_k7",
+                context_id="ctx",
+                context_revision=1,
+            )
+        )
+        assert turn2.tool_calls, f"no tool calls via modeld: {turn2.content[:200]}"
+        assert turn2.tool_calls[0].name == "ping"
+    finally:
+        await gateway.close()
+
+
+@pytest.mark.skipif(_find_runtime() is None, reason="rosclaw-modeld runtime unavailable")
+async def test_k8_modeld_service_loop_live(tmp_path: Path) -> None:
+    """K8：backend=modeld 的 AgentService 完整 turn（决策协议经 modeld 链路）。"""
+    from rosclaw.agentd.config import load_agent_config
+    from rosclaw.agentd.service import AgentService
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "agent:\n  enabled: true\n  default_profile: embodied_default\n"
+        "models:\n  backend: modeld\n  profiles:\n    embodied_default:\n"
+        "      provider: kimi_code\n      model: k3\n"
+        f"      base_url: {BASE_URL}\n"
+        "      api_key_ref: env:ROSCLAW_KIMI_API_KEY\n"
+        "      capabilities: [llm.chat, llm.structured_decision, llm.tool_use]\n",
+        encoding="utf-8",
+    )
+    config = load_agent_config(config_path)
+    assert config.model_backend == "modeld"
+    service = AgentService(config, tmp_path)
+    try:
+        mission = service.create_mission("K8 modeld 全链路")
+        result = await service.send_turn(
+            mission.mission_id, "用一句话说明你现在处于什么模式（SIMULATION 还是 REAL）。"
+        )
+        assert result.reply.strip(), "empty reply through modeld backend"
+        usage = service.mission_usage(mission.mission_id)
+        assert usage.get("total_tokens", 0) > 0, "usage not metered"
     finally:
         await service.close()

--- a/tests/agentd/test_modeld_gateway.py
+++ b/tests/agentd/test_modeld_gateway.py
@@ -1,0 +1,199 @@
+"""批次 D：Python ModeldGateway 测试。
+
+- 真实 modeld 子进程（Node >= 22.19 时）：UDS 权限、bearer 认证、
+  无凭据诚实失败、崩溃诚实失败
+- legacy backend 下 /model 热切换被拒绝并给出迁移指引
+- MODEL_CONTROL 命令经 CommandService 路由（不发给模型）
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.models.gateway import MockModelGateway, ModelGatewayError, ModelTurnRequest
+from rosclaw.agentd.models.modeld_gateway import (
+    _PROVIDER_MAP,
+    ModeldGateway,
+    _find_modeld_runtime,
+)
+from rosclaw.agentd.models.profiles import kimi_code_k3_profile, mock_profile
+from rosclaw.agentd.service import AgentService
+
+NODE_AVAILABLE = _find_modeld_runtime() is not None
+requires_node = pytest.mark.skipif(not NODE_AVAILABLE, reason="node >= 22.19 or modeld not built")
+
+
+def _request() -> ModelTurnRequest:
+    return ModelTurnRequest(
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        max_output_tokens=16,
+        mission_id="mis_x",
+        context_id="ctx",
+        context_revision=1,
+    )
+
+
+@requires_node
+class TestModeldGateway:
+    async def test_probe_without_credential_is_honest(self, tmp_path: Path) -> None:
+        os.environ.pop("ROSCLAW_KIMI_API_KEY", None)
+        gateway = ModeldGateway(kimi_code_k3_profile(), home=tmp_path)
+        try:
+            probe = await gateway.probe()
+            assert probe.error
+            assert "no_credential" in probe.error or "missing" in probe.error.lower()
+        finally:
+            await gateway.close()
+
+    async def test_stream_without_credential_fails_closed(self, tmp_path: Path) -> None:
+        os.environ.pop("ROSCLAW_KIMI_API_KEY", None)
+        gateway = ModeldGateway(kimi_code_k3_profile(), home=tmp_path)
+        try:
+            with pytest.raises(ModelGatewayError, match="no_credential|missing"):
+                await gateway.complete(_request())
+        finally:
+            await gateway.close()
+
+    async def test_uds_permissions(self, tmp_path: Path) -> None:
+        gateway = ModeldGateway(kimi_code_k3_profile(), home=tmp_path)
+        try:
+            await gateway._ensure_started()
+            sock = Path(gateway._socket_path)
+            assert sock.exists()
+            assert (sock.stat().st_mode & 0o777) == 0o600
+            assert (sock.parent.stat().st_mode & 0o700) == 0o700
+        finally:
+            await gateway.close()
+
+    async def test_crash_is_honest(self, tmp_path: Path) -> None:
+        gateway = ModeldGateway(kimi_code_k3_profile(), home=tmp_path)
+        await gateway._ensure_started()
+        # 杀死 modeld：下一次调用必须诚实报 modeld_crashed，不得伪造成功。
+        gateway._proc.kill()
+        gateway._proc.wait(timeout=5)
+        with pytest.raises(ModelGatewayError, match="modeld_crashed"):
+            await gateway.complete(_request())
+        await gateway.close()
+
+    async def test_management_providers_no_secrets(self, tmp_path: Path) -> None:
+        gateway = ModeldGateway(kimi_code_k3_profile(), home=tmp_path)
+        try:
+            data = await gateway.manage("GET", "/v1/providers")
+            ids = {p["id"] for p in data["providers"]}
+            assert {"moonshot", "kimi-code", "ollama"} <= ids
+            import json as _json
+
+            assert "sk-" not in _json.dumps(data)
+        finally:
+            await gateway.close()
+
+    async def test_unauthorized_management_rejected(self, tmp_path: Path) -> None:
+        """无 token 直接打 modeld socket → 401（bearer 边界）。"""
+        import aiohttp
+
+        gateway = ModeldGateway(kimi_code_k3_profile(), home=tmp_path)
+        try:
+            await gateway._ensure_started()
+            connector = aiohttp.UnixConnector(path=gateway._socket_path)
+            async with (
+                aiohttp.ClientSession(connector=connector) as session,
+                session.get("http://localhost/v1/providers") as resp,
+            ):
+                assert resp.status == 401
+        finally:
+            await gateway.close()
+
+
+class TestProviderMapping:
+    def test_kimi_profiles_map(self) -> None:
+        assert _PROVIDER_MAP["kimi_cn"] == "moonshot"
+        assert _PROVIDER_MAP["kimi_code"] == "kimi-code"
+
+
+class TestModelCommands:
+    def _service(self, tmp_path: Path) -> AgentService:
+        config = load_agent_config(tmp_path / "config.yaml")
+        return AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), []))
+
+    async def test_legacy_backend_rejects_hot_switch(self, tmp_path: Path) -> None:
+        service = self._service(tmp_path)
+        try:
+            result = service.switch_model("kimi-code", "k3")
+            assert not result["ok"]
+            assert result["error_code"] in ("legacy_backend", "no_profiles")
+        finally:
+            await service.close()
+
+    @requires_node
+    async def test_providers_command_routes_to_modeld(self, tmp_path: Path) -> None:
+        from rosclaw.contracts.ui.commands import CommandRequestV1
+
+        service = self._service(tmp_path)
+        try:
+            result = await service.commands.execute(
+                CommandRequestV1(
+                    request_id="r1",
+                    idempotency_key="k1",
+                    command_name="providers",
+                    mission_id=None,
+                )
+            )
+            assert result.ok
+            ids = {p["id"] for p in result.data.get("providers", [])}
+            assert "kimi-code" in ids
+        finally:
+            await service.close()
+
+    @requires_node
+    async def test_login_logout_commands(self, tmp_path: Path) -> None:
+        from rosclaw.contracts.ui.commands import CommandRequestV1
+
+        service = self._service(tmp_path)
+        try:
+            login = await service.commands.execute(
+                CommandRequestV1(
+                    request_id="r2",
+                    idempotency_key="k2",
+                    command_name="login",
+                    arguments={"provider": "moonshot", "api_key": "sk-test-not-real"},
+                    mission_id=None,
+                )
+            )
+            assert login.ok
+            assert "sk-test-not-real" not in login.message
+            logout = await service.commands.execute(
+                CommandRequestV1(
+                    request_id="r3",
+                    idempotency_key="k3",
+                    command_name="logout",
+                    arguments={"provider": "moonshot"},
+                    mission_id=None,
+                )
+            )
+            assert logout.ok
+        finally:
+            await service.close()
+
+    async def test_login_requires_args(self, tmp_path: Path) -> None:
+        from rosclaw.contracts.ui.commands import CommandRequestV1
+
+        service = self._service(tmp_path)
+        try:
+            result = await service.commands.execute(
+                CommandRequestV1(
+                    request_id="r4",
+                    idempotency_key="k4",
+                    command_name="login",
+                    arguments={},
+                    mission_id=None,
+                )
+            )
+            assert not result.ok and result.error_code == "invalid_arguments"
+        finally:
+            await service.close()

--- a/tests/architecture/test_pi_dependency_boundary.py
+++ b/tests/architecture/test_pi_dependency_boundary.py
@@ -107,6 +107,20 @@ class TestRoleBoundaryStatements:
             text = path.read_text(encoding="utf-8")
             assert not banned.search(text), f"{path} references hardware paths"
 
+    def test_pi_ai_providers_all_never_imported(self) -> None:
+        """§14.13：pi-ai 必须按 provider 子路径懒加载，providers/all 会
+        eager-load 所有 SDK。"""
+        for package in NODE_ROOT.glob("rosclaw-*"):
+            for path in package.rglob("*.ts"):
+                if "node_modules" in path.parts or "dist" in path.parts:
+                    continue
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    stripped = line.strip()
+                    if stripped.startswith(("import ", "export ")) or "import(" in stripped:
+                        assert "providers/all" not in stripped, (
+                            f"{path} imports providers/all: {stripped}"
+                        )
+
     def test_tui_has_no_model_client(self) -> None:
         tui = NODE_ROOT / "rosclaw-tui"
         if not tui.exists():


### PR DESCRIPTION
## Summary

Batch D of the reuse-supplement: the model provider daemon wrapping pi-ai, plus the Python gateway that frees AgentLoop from OpenAI-compatible wire details.

- **packages/rosclaw-modeld**: exact-pinned `@earendil-works/pi-ai@0.83.0`; Unix socket (dir 0700, socket 0600) + per-boot random bearer token passed only via child-process env. **modeld is not an agent** — no MissionStore, no DecisionV1 parsing, no tool selection, no hardware access (architecture tests enforce, incl. a new `providers/all` import ban per §14.13).
- **API**: `GET /v1/providers /v1/models /v1/auth`, `POST /v1/auth/{provider}/login|logout` (OAuth honestly returns 501 this batch — never fake support), `POST /v1/probe`, `POST /v1/stream` (SSE: text.delta/tool_call/usage/done/error, errors redacted).
- **Providers**: moonshot (kimi-k3), kimi-code (k3/k3-256k — via the OpenAI-compatible surface the whole agentd stack is validated against), ollama (local). Credential store 0600, sha256-fingerprint listing, secrets never in responses. Kimi compat override discovered by live testing: `supportsDeveloperRole: false` (Kimi 400s on role 'developer').
- **Python ModeldGateway** (ModelGateway protocol): crash/transport failures raise honest `ModelGatewayError` (modeld_crashed/modeld_transport) — never fabricated success.
- **Config & migration**: `models.backend: legacy|modeld` (legacy preserved); `rosclaw agent backend --set modeld` flips the backend keeping every existing Kimi profile and env credential reference — no re-entering keys (§7.4).
- **Commands**: `/providers /model /login /logout` as MODEL_CONTROL via the Batch B control API — never sent to the model; `/model` hot-switch works on the modeld backend and honestly refuses on legacy (runtime binds endpoints at boot).

## Live acceptance (real Kimi K3, no mocks)

- **K7**: probe + chat + usage metering + strict tool call through AgentLoop→ModeldGateway→modeld(UDS)→pi-ai→api.kimi.com.
- **K8**: full AgentService turn on `backend: modeld` with durable usage metering.

## Reuse notes

- direct dependency: `@earendil-works/pi-ai@0.83.0` (provider streams, auth helpers, model catalog) — exactly the wheel the supplement says not to rebuild.
- behavior borrowed: provider/auth separation, lazy per-provider loading.
- ROSClaw-specific: UDS+bearer boundary, ModelGateway protocol bridge, provider map for existing Kimi profiles.
- deliberately not reused: pi-ai OAuth flows (501 this batch), providers/all, any provider SDK in Python.

## Tests

17 node --test (redact, credentials perms/fingerprint, stream mapping, server UDS/auth/providers/login/logout/stream-honesty) + 11 Python (UDS perms, bearer 401, honest no_credential, crash honesty, command routing, legacy guard) + 2 live integration (K7/K8). Full regression 6075 passed; ruff + mypy clean.