### PR TITLE
Full command surface via CommandRegistry (reuse-supplement 批次E)

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -198,6 +198,26 @@ live 模型协调。3v3 联赛基准（T-SIM-2/3）属 PR-TF-075 后续范围。
   unverified/inferred 显式拒绝并记录；Darwin 晋升门 = 评测引用 + 人类
   principal，任何代码路径不能自动晋升。
 
+## 命令面（批次 E）
+
+- 全部命令经 CommandService 注册表（spec + availability + disabled_reason
+  + 幂等）；未知命令不发给模型。
+- 执行/安全可见性：`/workers /worker inspect|enable|disable|probe`
+  （disable 有未终态订单时拒绝并提示 drain，写审计）、`/grants`（仅
+  public scope）、`/revoke`、`/body`、`/doctor`、`/mode`（禁止原地升级）、
+  `/context layers|compactions|refresh`、`/session`、`/new`、
+  `/retry`（无副作用才可重放）、`/failover`、`/thinking`、
+  `/scoped-models`。
+- Mission 资产：`/export`（.rcmission zip：manifest/conversation/events/
+  compactions/public-receipts/checksums，构造性脱敏）、`/import`
+  （magic/checksum/路径穿越/zip bomb/secret scan 全校验；只读归档导入，
+  不恢复任何授权效力）、`/share`（诚实指向 /export，不默认上传）。
+- 配置：`/settings`（白名单非安全键、tmp+fsync+rename 原子写、文件锁、
+  审计事件；安全域键永远拒绝）、`/reload`（prompts/workers/models 可
+  reload；policy/robot_pack/body/permits 等安全域永远拒绝）。
+- deferred：`/fork /clone /tree`（批次 F 双时间线）、`/copy`（TUI 本地
+  clipboard）、`/estop`（PR-11 专用通道）——不伪造存在。
+
 ## rosclaw-modeld（批次 D）
 
 - `packages/rosclaw-modeld`：精确锁定 `@earendil-works/pi-ai@0.83.0`，

--- a/src/rosclaw/agentd/models/failover.py
+++ b/src/rosclaw/agentd/models/failover.py
@@ -69,6 +69,20 @@ class CooldownTracker:
     def record_success(self, key: str) -> None:
         self._states.pop(key, None)
 
+    def status(self) -> dict[str, dict]:
+        """可展示的冷却状态（/failover 命令）：剩余秒数与失败计数。"""
+        now = self._now()
+        out: dict[str, dict] = {}
+        for key, state in self._states.items():
+            remaining = max(0.0, state.cooldown_until - now)
+            out[key] = {
+                "in_cooldown": remaining > 0,
+                "remaining_sec": int(remaining),
+                "failures": state.failures,
+                "billing_failures": state.billing_failures,
+            }
+        return out
+
 
 @dataclass
 class TokenBucket:
@@ -113,6 +127,14 @@ class FailoverGateway:
             p.name: TokenBucket((rpm_limits or {}).get(p.name, 60)) for p, _ in candidates
         }
         self.profile = candidates[0][0]
+
+    def failover_status(self) -> dict:
+        """/failover 命令的展示数据：候选、冷却、RPM 桶余量。"""
+        return {
+            "active": f"{self.profile.provider}/{self.profile.model}",
+            "candidates": [f"{p.provider}/{p.model}" for p, _ in self._candidates],
+            "cooldowns": self._cooldown.status(),
+        }
 
     def _key(self, profile: ModelProfile) -> str:
         return f"{profile.provider}/{profile.model}/{profile.base_url}"

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -199,6 +199,16 @@ class AgentService:
 
         self._commands = CommandService(self)
         self._interactions = InteractionService()
+        #: /scoped-models 快捷切换集合（内存态）。
+        self._scoped_models: set[str] = set()
+        # 批次 E：导出/导入/设置。
+        from rosclaw.agentd.ui.export_service import ExportService
+        from rosclaw.agentd.ui.import_service import ImportService
+        from rosclaw.agentd.ui.settings_service import SettingsService
+
+        self._exporter = ExportService(self)
+        self._importer = ImportService(self)
+        self._settings = SettingsService(self._home / "config.yaml")
         consent_source = ConfigConsentSource()
         from rosclaw.operator import OperatorBroker
 
@@ -644,6 +654,69 @@ class AgentService:
     @property
     def interactions(self):
         return self._interactions
+
+    @property
+    def scoped_models(self) -> set[str]:
+        return self._scoped_models
+
+    @property
+    def exporter(self):
+        return self._exporter
+
+    @property
+    def importer(self):
+        return self._importer
+
+    @property
+    def settings(self):
+        return self._settings
+
+    def reload_domains(self, domains: list[str]) -> dict:
+        """/reload（§8.15）：分域原子重载；安全域永远拒绝。
+
+        可 reload：prompts（prompt registry）、workers（pack 重新探活注册）、
+        models（modeld provider catalog refresh 提示）。
+        不可 reload：rosclawd Policy、Robot Pack 签名、Body 安全边界、
+        Permit、设备权限、REAL 风险上限。
+        """
+        results: dict[str, dict] = {}
+        for domain in domains:
+            if domain == "prompts":
+                from rosclaw.agentd.context.prompt_registry import load_prompt
+
+                try:
+                    self._prompt = load_prompt("native_agent_v1.md")
+                    results[domain] = {
+                        "ok": True,
+                        "detail": f"prompt v{self._prompt.version} hash={self._prompt.content_hash[:16]}（活跃 turn 不换 prompt，下一 turn 生效）",
+                    }
+                except Exception as exc:  # noqa: BLE001
+                    results[domain] = {"ok": False, "detail": f"{exc}（保持旧配置）"}
+            elif domain == "workers":
+                from rosclaw.agentd.workers.packs import ALL_PACKS, card_for_pack
+
+                refreshed = []
+                for pack in ALL_PACKS:
+                    try:
+                        self._registry.register(card_for_pack(pack), actor_id=self.actor_id)
+                        refreshed.append(pack.worker_id)
+                    except Exception as exc:  # noqa: BLE001
+                        results.setdefault(domain, {"ok": False, "detail": str(exc)})
+                else:
+                    results[domain] = {"ok": True, "detail": f"re-registered {len(refreshed)} packs"}
+            elif domain == "models":
+                results[domain] = {
+                    "ok": True,
+                    "detail": "modeld provider catalog 为启动时构建；/model 可切换，重启后重建。",
+                }
+            elif domain in ("policy", "robot_pack", "body", "permits", "permissions", "safety"):
+                results[domain] = {
+                    "ok": False,
+                    "detail": f"{domain} 属安全域，/reload 永不修改（走专用管理面）",
+                }
+            else:
+                results[domain] = {"ok": False, "detail": f"未知 reload 域 {domain!r}"}
+        return results
 
     def conversation(self, mission_id: str) -> list[dict]:
         return self._store.conversation(mission_id)

--- a/src/rosclaw/agentd/ui/command_service.py
+++ b/src/rosclaw/agentd/ui/command_service.py
@@ -35,6 +35,8 @@ class CommandService:
         self._specs: dict[str, CommandSpecV1] = {}
         self._idempotency: dict[str, CommandResultV1] = {}
         self._register_builtins()
+        _register_batch_e(service, self._register)
+        _register_batch_e2(service, self._register)
 
     # -- registry ----------------------------------------------------------------
 
@@ -406,3 +408,832 @@ class CommandService:
             ),
             _tools,
         )
+
+
+# ---------------------------------------------------------------------------
+# 批次 E：执行与安全可见性命令（workers/grants/body/doctor/mode/context/
+# session/new/retry/failover/thinking/scoped-models）
+# ---------------------------------------------------------------------------
+def _register_batch_e(service, register) -> None:  # noqa: C901 - 命令集合体
+    """注册批次 E 命令。register(spec, handler) 与 CommandService._register 同签名。"""
+
+    async def _workers(req: CommandRequestV1) -> CommandResultV1:
+        rows = []
+        for card in service._registry.list():
+            status = service._registry.status_of(card.worker_id) or "UNKNOWN"
+            rows.append(
+                {
+                    "worker_id": card.worker_id,
+                    "kind": card.kind.value,
+                    "status": status,
+                    "trust": card.trust.initial_level,
+                    "capabilities": [c.name for c in card.capabilities],
+                    "active_orders": len(
+                        service._worker_manager.active_orders_for_worker(card.worker_id)
+                    ),
+                }
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"{len(rows)} 个 worker",
+            data={"workers": rows},
+        )
+
+    async def _worker(req: CommandRequestV1) -> CommandResultV1:
+        sub = str(req.arguments.get("subcommand", "")).strip()
+        worker_id = str(req.arguments.get("worker_id", "")).strip()
+        if not worker_id:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="invalid_arguments",
+                message="/worker 需要 worker_id（inspect|enable|disable|probe）",
+            )
+        card = service._registry.get(worker_id)
+        if card is None:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="unknown_worker",
+                message=f"未知 worker {worker_id!r}",
+            )
+        if sub == "inspect":
+            data = card.model_dump(mode="json")
+            data["registry_status"] = service._registry.status_of(worker_id)
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message=f"{worker_id}: {data['registry_status']}",
+                data=data,
+            )
+        if sub == "enable":
+            service._registry.set_status(
+                worker_id, "ENABLED", actor_id=service.actor_id, reason="operator /worker enable"
+            )
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message=f"{worker_id} 已启用（写审计事件）",
+            )
+        if sub == "disable":
+            active = service._worker_manager.active_orders_for_worker(worker_id)
+            if active:
+                return CommandResultV1(
+                    request_id=req.request_id,
+                    command_name=req.command_name,
+                    ok=False,
+                    error_code="active_orders",
+                    message=(
+                        f"{worker_id} 有 {len(active)} 个未终态 WorkOrder；"
+                        "请先 /cancel 或等待 drain，不会被静默杀死。"
+                    ),
+                )
+            service._registry.set_status(
+                worker_id, "DISABLED", actor_id=service.actor_id, reason="operator /worker disable"
+            )
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message=f"{worker_id} 已停用（写审计事件）",
+            )
+        if sub == "probe":
+            from rosclaw.agentd.workers.packs import ALL_PACKS
+
+            pack = next((p for p in ALL_PACKS if p.worker_id == worker_id), None)
+            if pack is None:
+                return CommandResultV1(
+                    request_id=req.request_id,
+                    command_name=req.command_name,
+                    ok=True,
+                    message=f"{worker_id} 是内置 worker，无需外部二进制探活。",
+                )
+            ready, detail = service._probe_pack_sync(
+                pack.executable, pack.min_version, pack.install_hint
+            )
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=ready,
+                message=detail,
+                data={"ready": ready},
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=False,
+            error_code="invalid_arguments",
+            message=f"未知子命令 {sub!r}（inspect|enable|disable|probe）",
+        )
+
+    async def _grants(req: CommandRequestV1) -> CommandResultV1:
+        grants = [
+            {k: v for k, v in g.items() if k in (
+                "grant_id", "principal", "mode", "tier", "risk_ceiling",
+                "revoked", "consumed", "expires_at", "public_hash",
+            )}
+            for g in service.list_grants()
+        ]
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"{len(grants)} 个 grant（仅 public scope）",
+            data={"grants": grants},
+        )
+
+    async def _revoke(req: CommandRequestV1) -> CommandResultV1:
+        grant_id = str(req.arguments.get("grant_id", "")).strip()
+        if not grant_id:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="invalid_arguments",
+                message="/revoke 需要 grant_id（需要 Operator 身份）",
+            )
+        try:
+            service.revoke_grant(grant_id, principal=req.arguments.get("principal", "user:local:1000"))
+        except Exception as exc:  # noqa: BLE001
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="revoke_failed",
+                message=str(exc),
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"grant {grant_id} 已撤销",
+        )
+
+    async def _body(req: CommandRequestV1) -> CommandResultV1:
+        body = service._body_source.get_body(service._body_id)
+        if body is None:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="body_unavailable",
+                message="配置的 body 不可用（fail closed 显示，不伪造）",
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=body.summary,
+            data={
+                "body_id": body.body_id,
+                "effective_body_hash": body.effective_body_hash,
+                "calibrated": body.calibrated,
+                "issues": list(body.issues),
+            },
+        )
+
+    async def _doctor(req: CommandRequestV1) -> CommandResultV1:
+        from rosclaw.agentd.onboarding import doctor
+
+        report = doctor(service._home)
+        status = report.get("status", "UNKNOWN")
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=status if status == "READY" else f"{status}: {report.get('reason', '')}",
+            data=report,
+        )
+
+    async def _mode(req: CommandRequestV1) -> CommandResultV1:
+        mission = service.get_mission(req.mission_id or "")
+        if mission is None:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="unknown_mission",
+                message="未知 mission",
+            )
+        target = str(req.arguments.get("mode", "")).strip()
+        if target and target != mission.mode.value:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="mode_change_forbidden",
+                message=(
+                    f"当前 mode {mission.mode.value} 不能原地升级为 {target}；"
+                    "请创建新的 REAL Mission 或走 rebind/authorization 工作流（§8.18）。"
+                ),
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"当前 mode: {mission.mode.value}",
+            data={"mode": mission.mode.value},
+        )
+
+    async def _context(req: CommandRequestV1) -> CommandResultV1:
+        sub = str(req.arguments.get("subcommand", "layers")).strip()
+        from rosclaw.agentd.context.compaction import CompactionStore
+
+        store = CompactionStore(service.store.connection)
+        if sub == "compactions":
+            entries = store.list(req.mission_id or "")
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message=f"{len(entries)} 条 compaction 记录",
+                data={
+                    "compactions": [
+                        {
+                            "compaction_id": e.compaction_id,
+                            "reason": e.reason,
+                            "tokens_before": e.tokens_before,
+                            "tokens_after": e.tokens_after,
+                            "covered_span_hash": e.covered_span_hash,
+                            "supersedes": e.supersedes,
+                            "created_at": e.created_at,
+                        }
+                        for e in entries
+                    ]
+                },
+            )
+        if sub == "refresh":
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message="下一轮 turn 将重新编译观测与 ContextCompiler 输入（不代表允许动作）。",
+            )
+        loop = service._loops.get(req.mission_id or "")
+        bundle = getattr(loop, "_current_bundle", None) if loop else None
+        if bundle is None:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message="尚未编译上下文（发送第一条消息后可用 /context）。",
+                data={"compiled": False},
+            )
+        layers = {
+            name: {
+                "hash": getattr(bundle.layers, name).hash[:16],
+                "tokens": getattr(bundle.layers, name).token_estimate,
+            }
+            for name in (
+                "constitution", "embodiment", "dynamic_self", "capabilities",
+                "mission", "memory", "organization", "safety",
+            )
+        }
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=(
+                f"context {bundle.context_id} rev{bundle.context_revision}；"
+                f"compactions={store.count(req.mission_id or '')}"
+            ),
+            data={
+                "compiled": True,
+                "context_id": bundle.context_id,
+                "context_revision": bundle.context_revision,
+                "layers": layers,
+                "compaction_count": store.count(req.mission_id or ""),
+            },
+        )
+
+    async def _session(req: CommandRequestV1) -> CommandResultV1:
+        mission = service.get_mission(req.mission_id or "")
+        if mission is None:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="unknown_mission",
+                message="未知 mission",
+            )
+        meta = service.store.mission_meta(mission.mission_id)
+        usage = service.mission_usage(mission.mission_id)
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"{mission.mission_id} [{mission.state.value}/{mission.mode.value}]",
+            data={
+                "mission_id": mission.mission_id,
+                "name": meta["display_name"],
+                "goal": mission.goal.text,
+                "created_at": mission.created_at,
+                "updated_at": mission.updated_at,
+                "usage": usage,
+                "last_event_sequence": service._events.latest_sequence(mission.mission_id),
+                "archived": meta["archived"],
+            },
+        )
+
+    async def _new(req: CommandRequestV1) -> CommandResultV1:
+        goal = str(req.arguments.get("goal", "")).strip()
+        if not goal:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="invalid_arguments",
+                message="/new 需要 goal（默认 SIMULATION）",
+            )
+        mode = str(req.arguments.get("mode", "SIMULATION"))
+        try:
+            mission = service.create_mission(goal, mode=mode)
+        except Exception as exc:  # noqa: BLE001
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="create_failed",
+                message=str(exc),
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"已创建 Mission {mission.mission_id} [{mission.mode.value}]",
+            data={"mission_id": mission.mission_id, "mode": mission.mode.value},
+        )
+
+    async def _retry(req: CommandRequestV1) -> CommandResultV1:
+        mission_id = req.mission_id or ""
+        open_orders = [
+            o for o in service._worker_manager.orders_for_mission(mission_id)
+            if o.status not in ("ACCEPTED", "REJECTED", "EXPIRED", "CANCELLED", "FAILED")
+        ]
+        if open_orders:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="side_effects_pending",
+                message=(
+                    f"{len(open_orders)} 个 WorkOrder 未终态——/retry 不重放"
+                    "（§8.7：先 reconcile，不得简单重放）。"
+                ),
+            )
+        history = service.store.conversation(mission_id)
+        last_user = next(
+            (m for m in reversed(history)
+             if m.get("role") == "user" and not str(m.get("content", "")).startswith("[")),
+            None,
+        )
+        if last_user is None:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="nothing_to_retry",
+                message="没有可重试的用户消息。",
+            )
+        turn_id = await service.submit_turn_v2(mission_id, str(last_user["content"]))
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"已重新提交最后一条用户消息（turn {turn_id}）",
+            data={"turn_id": turn_id},
+        )
+
+    async def _failover(req: CommandRequestV1) -> CommandResultV1:
+        status_fn = getattr(service._gateway, "failover_status", None)
+        if status_fn is None:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message="当前 gateway 无 failover 链（单网关直连）。",
+            )
+        data = status_fn()
+        lines = [f"active: {data['active']}"] + [
+            f"  {c}" + (
+                f"  [cooldown {cd['remaining_sec']}s failures={cd['failures']}]"
+                if (cd := data["cooldowns"].get(c)) and cd["in_cooldown"] else ""
+            )
+            for c in data["candidates"]
+        ]
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message="\n".join(lines),
+            data=data,
+        )
+
+    async def _thinking(req: CommandRequestV1) -> CommandResultV1:
+        effort = str(req.arguments.get("effort", "")).strip()
+        if effort not in ("low", "high", "max"):
+            current = service._gateway.profile.vendor_parameters.get("reasoning_effort", "?")
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message=f"当前 reasoning effort: {current}（设置：/thinking low|high|max）",
+            )
+        profile = service._gateway.profile
+        params = dict(profile.vendor_parameters)
+        params["reasoning_effort"] = effort
+        object.__setattr__(profile, "vendor_parameters", params)
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"reasoning effort → {effort}（下一 turn 生效；Provider 不支持时无效）",
+        )
+
+    async def _scoped_models(req: CommandRequestV1) -> CommandResultV1:
+        sub = str(req.arguments.get("subcommand", "list")).strip()
+        target = str(req.arguments.get("target", "")).strip()
+        scoped = service.scoped_models
+        if sub == "add" and target:
+            scoped.add(target)
+        elif sub == "remove" and target:
+            scoped.discard(target)
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"scoped models: {sorted(scoped) or '(空)'}",
+            data={"scoped_models": sorted(scoped)},
+        )
+
+    register(
+        CommandSpecV1(
+            name="workers",
+            description="Worker registry：状态/能力/trust/在途订单",
+            category=CommandCategory.EXECUTION,
+            owner=CommandOwner.AGENT_CONTROL,
+            during_turn=True,
+            handler="workers.list",
+        ),
+        _workers,
+    )
+    register(
+        CommandSpecV1(
+            name="worker",
+            description="Worker inspect/enable/disable/probe（写审计；disable 先 drain）",
+            argument_hint="<inspect|enable|disable|probe> <worker_id>",
+            category=CommandCategory.EXECUTION,
+            owner=CommandOwner.AGENT_CONTROL,
+            mutability="CONTROL_STATE",
+            handler="workers.manage",
+        ),
+        _worker,
+    )
+    register(
+        CommandSpecV1(
+            name="grants",
+            description="当前 grants（仅 public scope/status）",
+            category=CommandCategory.SAFETY,
+            owner=CommandOwner.AGENT_CONTROL,
+            during_turn=True,
+            handler="grants.list",
+        ),
+        _grants,
+    )
+    register(
+        CommandSpecV1(
+            name="revoke",
+            description="撤销 grant（需要 Operator 身份）",
+            argument_hint="<grant_id>",
+            category=CommandCategory.SAFETY,
+            owner=CommandOwner.AGENT_CONTROL,
+            mutability="PERSISTED",
+            confirmation="CONFIRM",
+            handler="grants.revoke",
+        ),
+        _revoke,
+    )
+    register(
+        CommandSpecV1(
+            name="body",
+            description="EffectiveBody hash/校准/问题（refresh 不授权）",
+            category=CommandCategory.EXECUTION,
+            owner=CommandOwner.AGENT_CONTROL,
+            during_turn=True,
+            handler="body.show",
+        ),
+        _body,
+    )
+    register(
+        CommandSpecV1(
+            name="doctor",
+            description="agentd/modeld/Provider/MCP/Worker/rosclawd 就绪检查",
+            category=CommandCategory.HELP_UI,
+            owner=CommandOwner.AGENT_CONTROL,
+            during_turn=True,
+            handler="agent.doctor",
+        ),
+        _doctor,
+    )
+    register(
+        CommandSpecV1(
+            name="mode",
+            description="显示当前 Mission mode（不能原地升级）",
+            category=CommandCategory.SAFETY,
+            owner=CommandOwner.AGENT_CONTROL,
+            during_turn=True,
+            handler="mode.show",
+        ),
+        _mode,
+    )
+    register(
+        CommandSpecV1(
+            name="context",
+            description="上下文组成：layers/usage/compactions/refresh",
+            argument_hint="[layers|usage|compactions|refresh]",
+            category=CommandCategory.MISSION,
+            owner=CommandOwner.AGENT_CONTROL,
+            during_turn=True,
+            handler="context.show",
+        ),
+        _context,
+    )
+    register(
+        CommandSpecV1(
+            name="session",
+            description="Mission id/name/创建时间/用量/event seq",
+            category=CommandCategory.MISSION,
+            owner=CommandOwner.AGENT_CONTROL,
+            during_turn=True,
+            handler="session.show",
+        ),
+        _session,
+    )
+    register(
+        CommandSpecV1(
+            name="new",
+            description="创建新 Mission（默认 SIMULATION）",
+            argument_hint="<goal>",
+            category=CommandCategory.MISSION,
+            owner=CommandOwner.MISSION_CONTROL,
+            mutability="PERSISTED",
+            handler="mission.new",
+        ),
+        _new,
+    )
+    register(
+        CommandSpecV1(
+            name="retry",
+            description="重试最后一条无副作用的用户消息（不盲重放）",
+            category=CommandCategory.MODEL,
+            owner=CommandOwner.AGENT_CONTROL,
+            handler="turn.retry",
+        ),
+        _retry,
+    )
+    register(
+        CommandSpecV1(
+            name="failover",
+            description="模型候选/冷却/上次错误总览",
+            category=CommandCategory.MODEL,
+            owner=CommandOwner.MODEL_CONTROL,
+            during_turn=True,
+            handler="model.failover",
+        ),
+        _failover,
+    )
+    register(
+        CommandSpecV1(
+            name="thinking",
+            description="设置公开 reasoning effort（low|high|max）",
+            argument_hint="[low|high|max]",
+            category=CommandCategory.MODEL,
+            owner=CommandOwner.MODEL_CONTROL,
+            mutability="CONTROL_STATE",
+            handler="model.thinking",
+        ),
+        _thinking,
+    )
+    register(
+        CommandSpecV1(
+            name="scoped-models",
+            description="快捷切换模型集合（add/remove/list）",
+            argument_hint="[add|remove <provider/model>]",
+            category=CommandCategory.MODEL,
+            owner=CommandOwner.MODEL_CONTROL,
+            mutability="CONTROL_STATE",
+            handler="model.scoped",
+        ),
+        _scoped_models,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 批次 E（第二部分）：export/import/share/reload/settings
+# ---------------------------------------------------------------------------
+def _register_batch_e2(service, register) -> None:
+    async def _export(req: CommandRequestV1) -> CommandResultV1:
+        from pathlib import Path
+
+        mission_id = req.mission_id or ""
+        out = req.arguments.get("path")
+        path = Path(out) if out else service._home / "exports" / f"{mission_id}.rcmission"
+        try:
+            report = service.exporter.export_bundle(mission_id, path)
+        except Exception as exc:  # noqa: BLE001
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="export_failed",
+                message=str(exc),
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"已导出 {report['path']}（{report['bytes']} bytes，已脱敏）",
+            data=report,
+        )
+
+    async def _import(req: CommandRequestV1) -> CommandResultV1:
+        from pathlib import Path
+
+        raw = str(req.arguments.get("path", "")).strip()
+        if not raw:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="invalid_arguments",
+                message="/import 需要 bundle 路径",
+            )
+        try:
+            result = service.importer.import_bundle(Path(raw))
+        except Exception as exc:  # noqa: BLE001
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="import_refused",
+                message=str(exc),
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=(
+                f"已导入为只读 Mission {result['mission_id']}；"
+                "不恢复任何授权/Permit/审批效力。"
+            ),
+            data=result,
+        )
+
+    async def _share(req: CommandRequestV1) -> CommandResultV1:
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=False,
+            error_code="not_implemented",
+            message=(
+                "/share 第一版只支持本地脱敏导出：请用 /export 生成 .rcmission 后自行分发；"
+                "绝不默认上传 gist/云（§8.13）。"
+            ),
+        )
+
+    async def _reload(req: CommandRequestV1) -> CommandResultV1:
+        raw = str(req.arguments.get("domains", "")).strip()
+        domains = raw.split() if raw else ["prompts", "workers"]
+        results = service.reload_domains(domains)
+        lines = [f"{d}: {'ok' if r['ok'] else '拒绝'} — {r['detail']}" for d, r in results.items()]
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+
+        if req.mission_id:
+            await service._events.append(
+                req.mission_id,
+                AgentEventType.CONFIG_RELOADED,
+                {"domains": domains, "ok": all(r["ok"] for r in results.values())},
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=all(r["ok"] for r in results.values()),
+            message="\n".join(lines),
+            data=results,
+        )
+
+    async def _settings(req: CommandRequestV1) -> CommandResultV1:
+        key = str(req.arguments.get("key", "")).strip()
+        value = req.arguments.get("value")
+        if not key:
+            current = service.settings.get()
+            safe = {
+                k: v
+                for k, v in current.items()
+                if k in ("agent", "models") and "key" not in str(v).lower()
+            }
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message="settings（仅非安全键可写）",
+                data={"settings": safe},
+            )
+        if value is None:
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=True,
+                message=f"{key} = {service.settings.get_key(key)}",
+            )
+        try:
+            change = service.settings.set_key(key, value)
+        except Exception as exc:  # noqa: BLE001
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="settings_rejected",
+                message=str(exc),
+            )
+        if req.mission_id:
+            from rosclaw.contracts.agent.agent_event import AgentEventType
+
+            await service._events.append(
+                req.mission_id,
+                AgentEventType.CONFIG_RELOADED,
+                {"settings_key": key},
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=f"{key}: {change['old']} → {change['new']}（已原子写入并审计）",
+            data=change,
+        )
+
+    register(
+        CommandSpecV1(
+            name="export",
+            description="导出 .rcmission 脱敏 bundle（manifest/conversation/events/compactions/checksums）",
+            argument_hint="[path]",
+            category=CommandCategory.MISSION,
+            owner=CommandOwner.MISSION_CONTROL,
+            mutability="NONE",
+            handler="mission.export",
+        ),
+        _export,
+    )
+    register(
+        CommandSpecV1(
+            name="import",
+            description="导入 .rcmission（只读归档；不恢复任何授权效力）",
+            argument_hint="<path>",
+            category=CommandCategory.MISSION,
+            owner=CommandOwner.MISSION_CONTROL,
+            mutability="PERSISTED",
+            confirmation="CONFIRM",
+            handler="mission.import",
+        ),
+        _import,
+    )
+    register(
+        CommandSpecV1(
+            name="share",
+            description="分享（第一版仅本地脱敏导出，不默认上传）",
+            category=CommandCategory.MISSION,
+            owner=CommandOwner.MISSION_CONTROL,
+            handler="mission.share",
+        ),
+        _share,
+    )
+    register(
+        CommandSpecV1(
+            name="reload",
+            description="分域原子重载（prompts/workers/models；安全域永远拒绝）",
+            argument_hint="[domain ...]",
+            category=CommandCategory.EXECUTION,
+            owner=CommandOwner.AGENT_CONTROL,
+            mutability="CONTROL_STATE",
+            handler="agent.reload",
+        ),
+        _reload,
+    )
+    register(
+        CommandSpecV1(
+            name="settings",
+            description="查看/修改非安全设置（白名单键、原子写、审计）",
+            argument_hint="[<key> [<value>]]",
+            category=CommandCategory.HELP_UI,
+            owner=CommandOwner.AGENT_CONTROL,
+            mutability="PERSISTED",
+            handler="agent.settings",
+        ),
+        _settings,
+    )

--- a/src/rosclaw/agentd/ui/export_service.py
+++ b/src/rosclaw/agentd/ui/export_service.py
@@ -1,0 +1,125 @@
+"""Export service (批次 E §8.11)：.rcmission bundle + 脱敏。
+
+bundle 结构（zip）：
+    manifest.json / conversation.jsonl / mission-events.jsonl /
+    compactions.jsonl / public-receipts/ / checksums.txt
+
+默认排除：API key/OAuth token、Provider 请求头、Permit、daemon 私有
+ledger/challenge、grant 私签、原始 secret、外部 Worker 环境。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rosclaw.agentd.service import AgentService
+
+BUNDLE_MAGIC = "rcmission/1"
+MAX_BUNDLE_BYTES = 64 * 1024 * 1024
+
+_SECRET_RE = re.compile(
+    r"(sk-[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._-]{8,}"
+    r"|api[_-]?key[\"']?\s*[:=]\s*[\"']?[^\s\"',}]+)",
+    re.IGNORECASE,
+)
+
+
+def redact_text(text: str) -> str:
+    return _SECRET_RE.sub("<redacted>", text)
+
+
+class ExportService:
+    def __init__(self, service: AgentService) -> None:
+        self._service = service
+
+    def export_bundle(self, mission_id: str, out_path: Path) -> dict:
+        service = self._service
+        mission = service.get_mission(mission_id)
+        if mission is None:
+            from rosclaw.contracts.common import ValidationError
+
+            raise ValidationError(f"unknown mission {mission_id!r}")
+        from rosclaw.agentd.context.compaction import CompactionStore
+
+        meta = service.store.mission_meta(mission_id)
+        manifest = {
+            "magic": BUNDLE_MAGIC,
+            "exported_at": datetime.now(UTC).isoformat(),
+            "mission": {
+                "mission_id": mission_id,
+                "name": meta["display_name"],
+                "goal": mission.goal.text,
+                "mode": mission.mode.value,
+                "state": mission.state.value,
+                "created_at": mission.created_at,
+                "body_id": mission.body_binding.body_id,
+                "context_revision": mission.context_revision,
+            },
+            "redaction": "secrets/permits/private-signatures excluded by construction",
+        }
+        # canonical journal（含 entry_id/seq，fork/import 可引用）。
+        conversation = service.store.conversation(mission_id)
+        conv_lines = [
+            json.dumps(redact_text(json.dumps(m, ensure_ascii=False)), ensure_ascii=False)
+            for m in conversation
+        ]
+        events = service.events_replay(mission_id, after_sequence=0, limit=100_000)
+        event_lines = [
+            redact_text(json.dumps(e.model_dump(mode="json"), ensure_ascii=False))
+            for e in events
+        ]
+        compactions = [
+            e.model_dump(mode="json")
+            for e in CompactionStore(service.store.connection).list(mission_id)
+        ]
+        # 只含 public 字段的 grants（私签永不导出）。
+        public_grants = [
+            {k: v for k, v in g.items() if k in (
+                "grant_id", "principal", "mode", "tier", "risk_ceiling",
+                "revoked", "consumed", "expires_at", "public_hash",
+            )}
+            for g in service.list_grants()
+        ]
+
+        files: dict[str, str] = {
+            "manifest.json": json.dumps(manifest, ensure_ascii=False, indent=2),
+            "conversation.jsonl": "\n".join(conv_lines) + "\n",
+            "mission-events.jsonl": "\n".join(event_lines) + "\n",
+            "compactions.jsonl": "\n".join(
+                json.dumps(c, ensure_ascii=False) for c in compactions
+            )
+            + "\n",
+            "public-receipts/grants.json": json.dumps(
+                public_grants, ensure_ascii=False, indent=2
+            ),
+        }
+        checksums = "\n".join(
+            f"{hashlib.sha256(content.encode()).hexdigest()}  {name}"
+            for name, content in sorted(files.items())
+        )
+        files["checksums.txt"] = checksums + "\n"
+
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        total = sum(len(c.encode()) for c in files.values())
+        if total > MAX_BUNDLE_BYTES:
+            from rosclaw.contracts.common import ValidationError
+
+            raise ValidationError(f"bundle too large ({total} bytes)")
+        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for name, content in files.items():
+                zf.writestr(name, content)
+        return {
+            "path": str(out_path),
+            "bytes": out_path.stat().st_size,
+            "files": sorted(files),
+            "events": len(events),
+            "messages": len(conversation),
+            "compactions": len(compactions),
+        }

--- a/src/rosclaw/agentd/ui/import_service.py
+++ b/src/rosclaw/agentd/ui/import_service.py
@@ -1,0 +1,131 @@
+"""Import service (批次 E §8.12)：安全导入 .rcmission。
+
+硬规则：
+- magic/schema、大小、文件数、路径穿越、zip bomb 检查；
+- checksum 校验；
+- secret scan（含 secret 的 bundle 拒绝导入）；
+- 导入永远是 IMPORTED_READ_ONLY（archived）新 Mission——imported
+  Permit/grant/approval 永远无效，不恢复任何 authority；
+- 不执行任何导入的 shell/extension/prompt/code；
+- 不覆盖现有 Mission id。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rosclaw.agentd.ui.export_service import BUNDLE_MAGIC, redact_text  # noqa: F401
+from rosclaw.contracts.common import ValidationError
+
+if TYPE_CHECKING:
+    from rosclaw.agentd.service import AgentService
+
+MAX_FILES = 64
+MAX_TOTAL_BYTES = 64 * 1024 * 1024
+MAX_MEMBER_BYTES = 16 * 1024 * 1024
+REQUIRED = {"manifest.json", "conversation.jsonl", "checksums.txt"}
+_SECRET_SCAN = ("sk-", "Bearer ", "api_key\":", "private_key", "permit_secret")
+
+
+def _read_members(path: Path) -> dict[str, bytes]:
+    if not zipfile.is_zipfile(path):
+        raise ValidationError("not a zip file")
+    with zipfile.ZipFile(path) as zf:
+        infos = zf.infolist()
+        if len(infos) > MAX_FILES:
+            raise ValidationError(f"too many files ({len(infos)} > {MAX_FILES})")
+        members: dict[str, bytes] = {}
+        total = 0
+        for info in infos:
+            name = info.filename
+            # 路径穿越与绝对路径拒绝。
+            if name.startswith(("/", "\\")) or ".." in name.split("/"):
+                raise ValidationError(f"unsafe path {name!r}")
+            if info.file_size > MAX_MEMBER_BYTES:
+                raise ValidationError(f"member {name!r} too large (zip bomb guard)")
+            total += info.file_size
+            if total > MAX_TOTAL_BYTES:
+                raise ValidationError("bundle too large (zip bomb guard)")
+            members[name] = zf.read(name)
+    return members
+
+
+def _verify_checksums(members: dict[str, bytes]) -> None:
+    checksums = members["checksums.txt"].decode().splitlines()
+    for line in checksums:
+        if not line.strip():
+            continue
+        digest, _, name = line.partition("  ")
+        if name not in members:
+            raise ValidationError(f"checksum references missing file {name!r}")
+        actual = hashlib.sha256(members[name]).hexdigest()
+        if actual != digest.strip():
+            raise ValidationError(f"checksum mismatch for {name!r}")
+
+
+class ImportService:
+    def __init__(self, service: AgentService) -> None:
+        self._service = service
+
+    def preview(self, path: Path) -> dict:
+        members = _read_members(path)
+        if not set(members) >= REQUIRED:
+            raise ValidationError(f"missing required files: {REQUIRED - set(members)}")
+        _verify_checksums(members)
+        manifest = json.loads(members["manifest.json"].decode())
+        if manifest.get("magic") != BUNDLE_MAGIC:
+            raise ValidationError(f"bad magic {manifest.get('magic')!r}")
+        # secret scan：含 secret 形态的 bundle 拒绝导入。
+        for name, content in members.items():
+            text = content.decode(errors="replace")
+            for pattern in _SECRET_SCAN:
+                if pattern in text:
+                    raise ValidationError(f"secret-like content in {name} — import refused")
+        mission = manifest.get("mission", {})
+        return {
+            "mission_id": mission.get("mission_id"),
+            "goal": mission.get("goal"),
+            "mode": mission.get("mode"),
+            "exported_at": manifest.get("exported_at"),
+            "messages": len(members["conversation.jsonl"].decode().splitlines()),
+            "note": "导入后为只读归档 Mission；不恢复任何授权/Permit/审批效力。",
+        }
+
+    def import_bundle(self, path: Path) -> dict:
+        service = self._service
+        preview = self.preview(path)
+        members = _read_members(path)
+        manifest = json.loads(members["manifest.json"].decode())
+        src = manifest.get("mission", {})
+        # 新 Mission（永不复用导入的 mission_id）。
+        goal = f"[导入] {src.get('goal', 'imported mission')}"
+        mission = service.create_mission(goal, mode="SIMULATION")
+        service.archive_mission(mission.mission_id)  # IMPORTED_READ_ONLY
+        # 对话以导入证据形态进入 journal（untrusted 标记；不恢复 authority）。
+        lines = members["conversation.jsonl"].decode().splitlines()
+        messages = []
+        for line in lines:
+            if not line.strip():
+                continue
+            messages.append(
+                {
+                    "role": "artifact",
+                    "content": f"[imported from {src.get('mission_id')}] {line[:2000]}",
+                    "source": "import",
+                }
+            )
+        if messages:
+            service.store.append_conversation(
+                mission.mission_id, messages, actor_id=service.actor_id
+            )
+        return {
+            "mission_id": mission.mission_id,
+            "imported_from": preview["mission_id"],
+            "messages_imported": len(messages),
+            "read_only": True,
+            "authority_restored": False,
+        }

--- a/src/rosclaw/agentd/ui/settings_service.py
+++ b/src/rosclaw/agentd/ui/settings_service.py
@@ -1,0 +1,87 @@
+"""Settings service (批次 E §8.4)：分层、原子写、审计。
+
+- 只允许非安全键（白名单）：agent.language、agent.context.*、
+  models.backend、agent.default_mode(SIMULATION 除外——mode 升级永不
+  经 settings)。body/权限/预算/安全策略一律拒绝。
+- 写入：tmp + fsync + atomic rename + 文件锁；parse 失败保留旧配置。
+- 每次持久改变写审计事件（不含 secret 值——settings 本来就不收 secret）。
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from rosclaw.contracts.common import ValidationError
+
+#: 允许经 /settings 修改的键（点分路径 → 类型校验）。
+_ALLOWED_KEYS: dict[str, type] = {
+    "agent.language": str,
+    "agent.context.max_input_tokens": int,
+    "agent.context.dynamic_tool_limit": int,
+    "models.backend": str,
+}
+
+_FORBIDDEN_PREFIXES = ("agent.body", "agent.budgets", "agent.permissions", "agent.safety")
+
+
+class SettingsService:
+    def __init__(self, config_path: Path) -> None:
+        self._path = config_path
+
+    def get(self) -> dict[str, Any]:
+        if not self._path.exists():
+            return {}
+        return yaml.safe_load(self._path.read_text(encoding="utf-8")) or {}
+
+    def get_key(self, dotted: str) -> Any:
+        node: Any = self.get()
+        for part in dotted.split("."):
+            if not isinstance(node, dict) or part not in node:
+                return None
+            node = node[part]
+        return node
+
+    def set_key(self, dotted: str, value: Any) -> dict:
+        if dotted not in _ALLOWED_KEYS:
+            if dotted.startswith(_FORBIDDEN_PREFIXES):
+                raise ValidationError(
+                    f"{dotted} 属安全域，/settings 永不修改（走专用管理面）"
+                )
+            raise ValidationError(f"未知的 settings 键 {dotted!r}（白名单外）")
+        expected = _ALLOWED_KEYS[dotted]
+        if expected is int and isinstance(value, str) and value.isdigit():
+            value = int(value)
+        if not isinstance(value, expected):
+            raise ValidationError(f"{dotted} 需要 {expected.__name__}，得到 {type(value).__name__}")
+        if dotted == "models.backend" and value not in ("legacy", "modeld"):
+            raise ValidationError("models.backend 只能是 legacy|modeld")
+
+        data = self.get()
+        node = data
+        parts = dotted.split(".")
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+        old = node.get(parts[-1])
+        node[parts[-1]] = value
+        self._atomic_write(data)
+        return {"key": dotted, "old": old, "new": value}
+
+    def _atomic_write(self, data: dict) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(".yaml.tmp")
+        rendered = yaml.safe_dump(data, allow_unicode=True)
+        # parse-back 校验：渲染结果必须可解析，否则不动旧配置。
+        yaml.safe_load(rendered)
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.write(rendered)
+            fh.flush()
+            os.fsync(fh.fileno())
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, self._path)

--- a/src/rosclaw/agentd/workers/manager.py
+++ b/src/rosclaw/agentd/workers/manager.py
@@ -255,6 +255,15 @@ class WorkerManager:
         ).fetchone()
         return WorkOrderV1(**json.loads(row["order_json"])) if row else None
 
+    def active_orders_for_worker(self, worker_id: str) -> list[WorkOrderV1]:
+        """该 worker 名下未终态的 WorkOrder（/worker disable 的 drain 护栏）。"""
+        rows = self._conn.execute(
+            "SELECT order_json FROM work_orders WHERE worker_id = ? "
+            "AND status NOT IN ('ACCEPTED', 'REJECTED', 'EXPIRED', 'CANCELLED', 'FAILED')",
+            (worker_id,),
+        ).fetchall()
+        return [WorkOrderV1(**json.loads(r["order_json"])) for r in rows]
+
     def orders_for_mission(self, mission_id: str) -> list[WorkOrderV1]:
         rows = self._conn.execute(
             "SELECT order_json FROM work_orders WHERE mission_id = ? ORDER BY created_at",

--- a/tests/agentd/test_commands_batch_e.py
+++ b/tests/agentd/test_commands_batch_e.py
@@ -1,0 +1,205 @@
+"""批次 E（第一部分）命令测试：workers/grants/body/mode/context/session/
+new/retry/failover/thinking/scoped-models。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.models.gateway import MockModelGateway
+from rosclaw.agentd.models.profiles import mock_profile
+from rosclaw.agentd.service import AgentService
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+from rosclaw.contracts.ui.commands import CommandRequestV1
+
+
+def _answer(request) -> ModelTurnResultV1:
+    decision = {
+        "schema_version": "rosclaw.decision.v1",
+        "decision_id": "d",
+        "mission_id": request.mission_id,
+        "context_id": request.context_id,
+        "context_revision": request.context_revision,
+        "next_intent": "ANSWER",
+        "summary": "ok",
+        "evidence_refs": [],
+    }
+    return ModelTurnResultV1(
+        turn_id="t",
+        provider="mock",
+        model="m",
+        content=f"```json\n{json.dumps(decision)}\n```",
+        assistant_message={"role": "assistant", "content": "x"},
+        usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+    )
+
+
+def _service(tmp_path: Path) -> AgentService:
+    config = load_agent_config(tmp_path / "config.yaml")
+    return AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), [_answer] * 50))
+
+
+def _cmd(name: str, args: dict | None = None, mission_id: str | None = None, key: str = "k") -> CommandRequestV1:
+    return CommandRequestV1(
+        request_id=f"r_{key}",
+        idempotency_key=key,
+        command_name=name,
+        arguments=args or {},
+        mission_id=mission_id,
+    )
+
+
+class TestWorkerCommands:
+    async def test_workers_list_and_inspect(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            result = await service.commands.execute(_cmd("workers"))
+            assert result.ok and result.data["workers"]
+            ids = {w["worker_id"] for w in result.data["workers"]}
+            assert "worker:native:basic" in ids
+            inspect = await service.commands.execute(
+                _cmd("worker", {"subcommand": "inspect", "worker_id": "worker:native:basic"}, key="k2")
+            )
+            assert inspect.ok and inspect.data["registry_status"]
+            unknown = await service.commands.execute(
+                _cmd("worker", {"subcommand": "inspect", "worker_id": "ghost"}, key="k3")
+            )
+            assert not unknown.ok and unknown.error_code == "unknown_worker"
+        finally:
+            await service.close()
+
+    async def test_enable_disable_audit(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            disable = await service.commands.execute(
+                _cmd("worker", {"subcommand": "disable", "worker_id": "worker:native:basic"}, key="k4")
+            )
+            assert disable.ok
+            assert service._registry.status_of("worker:native:basic") == "DISABLED"
+            enable = await service.commands.execute(
+                _cmd("worker", {"subcommand": "enable", "worker_id": "worker:native:basic"}, key="k5")
+            )
+            assert enable.ok
+            assert service._registry.status_of("worker:native:basic") == "ENABLED"
+        finally:
+            await service.close()
+
+
+class TestGrantsCommands:
+    async def test_grants_empty_and_revoke_requires_id(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            result = await service.commands.execute(_cmd("grants"))
+            assert result.ok and result.data["grants"] == []
+            revoke = await service.commands.execute(_cmd("revoke", {}, key="k6"))
+            assert not revoke.ok and revoke.error_code == "invalid_arguments"
+            blob = json.dumps(result.data, ensure_ascii=False)
+            assert "signature" not in blob and "permit" not in blob.lower()
+        finally:
+            await service.close()
+
+
+class TestBodyDoctorMode:
+    async def test_body_honest(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            result = await service.commands.execute(_cmd("body"))
+            assert result.ok and result.data["body_id"]
+        finally:
+            await service.close()
+
+    async def test_doctor_structured(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            result = await service.commands.execute(_cmd("doctor"))
+            assert result.ok and ("status" in result.data or "ready" in result.data)
+        finally:
+            await service.close()
+
+    async def test_mode_display_and_no_inplace_upgrade(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("mode 测试")
+            show = await service.commands.execute(_cmd("mode", mission_id=mission.mission_id))
+            assert show.ok and show.data["mode"] == "SIMULATION"
+            upgrade = await service.commands.execute(
+                _cmd("mode", {"mode": "REAL"}, mission_id=mission.mission_id, key="k7")
+            )
+            assert not upgrade.ok and upgrade.error_code == "mode_change_forbidden"
+        finally:
+            await service.close()
+
+
+class TestContextSessionNew:
+    async def test_context_before_and_after_compile(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("context 测试")
+            before = await service.commands.execute(
+                _cmd("context", mission_id=mission.mission_id)
+            )
+            assert before.ok and before.data["compiled"] is False
+            await service.send_turn(mission.mission_id, "hi")
+            after = await service.commands.execute(
+                _cmd("context", mission_id=mission.mission_id, key="k8")
+            )
+            assert after.ok and after.data["compiled"] is True
+            assert "constitution" in after.data["layers"]
+            blob = json.dumps(after.data, ensure_ascii=False)
+            assert "sk-" not in blob
+        finally:
+            await service.close()
+
+    async def test_session_and_new(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            created = await service.commands.execute(_cmd("new", {"goal": "新任务"}))
+            assert created.ok and created.data["mission_id"].startswith("mis_")
+            session = await service.commands.execute(
+                _cmd("session", mission_id=created.data["mission_id"], key="k9")
+            )
+            assert session.ok and session.data["goal"] == "新任务"
+            assert session.data["archived"] is False
+            empty_goal = await service.commands.execute(_cmd("new", {}, key="k10"))
+            assert not empty_goal.ok
+        finally:
+            await service.close()
+
+
+class TestRetryFailoverThinking:
+    async def test_retry_rejects_nothing_and_resubmits(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("retry 测试")
+            nothing = await service.commands.execute(
+                _cmd("retry", mission_id=mission.mission_id)
+            )
+            assert not nothing.ok and nothing.error_code == "nothing_to_retry"
+            await service.send_turn(mission.mission_id, "请回答")
+            retry = await service.commands.execute(
+                _cmd("retry", mission_id=mission.mission_id, key="k11")
+            )
+            assert retry.ok and retry.data["turn_id"].startswith("turn_")
+            await service._turn_tasks[mission.mission_id]
+        finally:
+            await service.close()
+
+    async def test_failover_and_thinking(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            failover = await service.commands.execute(_cmd("failover"))
+            assert failover.ok
+            show = await service.commands.execute(_cmd("thinking", key="k12"))
+            assert show.ok
+            set_effort = await service.commands.execute(
+                _cmd("thinking", {"effort": "max"}, key="k13")
+            )
+            assert set_effort.ok
+            assert service._gateway.profile.vendor_parameters["reasoning_effort"] == "max"
+            scoped = await service.commands.execute(
+                _cmd("scoped-models", {"subcommand": "add", "target": "kimi-code/k3"}, key="k14")
+            )
+            assert scoped.ok and "kimi-code/k3" in scoped.data["scoped_models"]
+        finally:
+            await service.close()

--- a/tests/agentd/test_export_import_settings.py
+++ b/tests/agentd/test_export_import_settings.py
@@ -1,0 +1,218 @@
+"""批次 E（第二部分）测试：export/import/settings/reload。
+
+- export → import round trip（只读归档、不恢复授权）
+- 恶意 bundle：路径穿越、checksum 篡改、secret 内容、zip bomb 全拒绝
+- settings：白名单、安全域拒绝、原子写
+- reload：安全域拒绝、prompts/workers 成功
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.models.gateway import MockModelGateway
+from rosclaw.agentd.models.profiles import mock_profile
+from rosclaw.agentd.service import AgentService
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+from rosclaw.contracts.common import ValidationError
+from rosclaw.contracts.ui.commands import CommandRequestV1
+
+
+def _answer(request) -> ModelTurnResultV1:
+    decision = {
+        "schema_version": "rosclaw.decision.v1",
+        "decision_id": "d",
+        "mission_id": request.mission_id,
+        "context_id": request.context_id,
+        "context_revision": request.context_revision,
+        "next_intent": "ANSWER",
+        "summary": "ok",
+        "evidence_refs": [],
+    }
+    return ModelTurnResultV1(
+        turn_id="t",
+        provider="mock",
+        model="m",
+        content=f"```json\n{json.dumps(decision)}\n```",
+        assistant_message={"role": "assistant", "content": "x"},
+        usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+    )
+
+
+def _service(tmp_path: Path) -> AgentService:
+    config = load_agent_config(tmp_path / "config.yaml")
+    return AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), [_answer] * 50))
+
+
+def _cmd(name: str, args: dict | None = None, mission_id: str | None = None, key: str = "k") -> CommandRequestV1:
+    return CommandRequestV1(
+        request_id=f"r_{key}",
+        idempotency_key=key,
+        command_name=name,
+        arguments=args or {},
+        mission_id=mission_id,
+    )
+
+
+class TestExportImport:
+    async def test_round_trip_read_only(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("导出测试")
+            await service.send_turn(mission.mission_id, "你好")
+            out = tmp_path / "bundle.rcmission"
+            exported = await service.commands.execute(
+                _cmd("export", mission_id=mission.mission_id, args={"path": str(out)})
+            )
+            assert exported.ok and out.exists()
+            # bundle 内容：manifest 正确、无 secret 形态。
+            with zipfile.ZipFile(out) as zf:
+                names = set(zf.namelist())
+                assert {"manifest.json", "conversation.jsonl", "checksums.txt"} <= names
+                blob = b"".join(zf.read(n) for n in names).decode(errors="replace")
+            assert "sk-" not in blob
+            assert "permit_secret" not in blob and "private_signature" not in blob
+            manifest = json.loads(zipfile.ZipFile(out).read("manifest.json"))
+            assert manifest["magic"] == "rcmission/1"
+
+            # import：只读归档、不恢复任何授权。
+            imported = await service.commands.execute(
+                _cmd("import", args={"path": str(out)}, key="k2")
+            )
+            assert imported.ok
+            assert imported.data["read_only"] and imported.data["authority_restored"] is False
+            new_id = imported.data["mission_id"]
+            assert new_id != mission.mission_id
+            with pytest.raises(ValidationError, match="archived"):
+                await service.send_turn(new_id, "恢复？" )
+            assert service.list_grants() == []
+        finally:
+            await service.close()
+
+    async def test_malicious_bundles_refused(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            # 路径穿越
+            evil = tmp_path / "evil.rcmission"
+            with zipfile.ZipFile(evil, "w") as zf:
+                zf.writestr("../../etc/pwned", "x")
+            with pytest.raises(ValidationError, match="unsafe path"):
+                service.importer.preview(evil)
+
+            # checksum 篡改
+            mission = service.create_mission("源")
+            await service.send_turn(mission.mission_id, "hi")
+            good = tmp_path / "good.rcmission"
+            service.exporter.export_bundle(mission.mission_id, good)
+            tampered = tmp_path / "tampered.rcmission"
+            with zipfile.ZipFile(good) as zin, zipfile.ZipFile(tampered, "w") as zout:
+                for name in zin.namelist():
+                    content = zin.read(name)
+                    if name == "conversation.jsonl":
+                        content = b"tampered\n"
+                    zout.writestr(name, content)
+            with pytest.raises(ValidationError, match="checksum mismatch"):
+                service.importer.preview(tampered)
+
+            # secret 内容
+            secret_bundle = tmp_path / "secret.rcmission"
+            manifest = {"magic": "rcmission/1", "mission": {"goal": "x", "mission_id": "m"}}
+            files = {
+                "manifest.json": json.dumps(manifest),
+                "conversation.jsonl": '{"role":"user","content":"key sk-abcdefghij123"}\n',
+            }
+            checksums = "\n".join(
+                f"{hashlib.sha256(c.encode()).hexdigest()}  {n}" for n, c in sorted(files.items())
+            )
+            files["checksums.txt"] = checksums
+            with zipfile.ZipFile(secret_bundle, "w") as zf:
+                for n, c in files.items():
+                    zf.writestr(n, c)
+            with pytest.raises(ValidationError, match="secret-like"):
+                service.importer.preview(secret_bundle)
+
+            # 非 zip
+            notzip = tmp_path / "notzip.rcmission"
+            notzip.write_text("hello")
+            with pytest.raises(ValidationError, match="not a zip"):
+                service.importer.preview(notzip)
+        finally:
+            await service.close()
+
+    async def test_share_points_to_export(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            result = await service.commands.execute(_cmd("share"))
+            assert not result.ok and result.error_code == "not_implemented"
+            assert "/export" in result.message
+        finally:
+            await service.close()
+
+
+class TestSettings:
+    async def test_whitelist_and_atomic_write(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            set_ok = await service.commands.execute(
+                _cmd("settings", args={"key": "agent.language", "value": "zh-CN"})
+            )
+            assert set_ok.ok
+            assert service.settings.get_key("agent.language") == "zh-CN"
+            # 原子写结果可解析。
+            import yaml
+
+            data = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+            assert data["agent"]["language"] == "zh-CN"
+        finally:
+            await service.close()
+
+    async def test_safety_domain_and_unknown_key_rejected(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            safety = await service.commands.execute(
+                _cmd("settings", args={"key": "agent.budgets.physical_action_count", "value": "5"})
+            )
+            assert not safety.ok and "安全域" in safety.message
+            unknown = await service.commands.execute(
+                _cmd("settings", args={"key": "agent.telemetry.endpoint", "value": "x"}, key="k2")
+            )
+            assert not unknown.ok and unknown.error_code == "settings_rejected"
+        finally:
+            await service.close()
+
+
+class TestReload:
+    async def test_prompts_and_workers_reload(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("reload 测试")
+            result = await service.commands.execute(
+                _cmd("reload", args={"domains": "prompts workers"}, mission_id=mission.mission_id)
+            )
+            assert result.ok
+            assert result.data["prompts"]["ok"] and result.data["workers"]["ok"]
+            # config.reloaded 事件落 journal。
+            from rosclaw.contracts.agent.agent_event import AgentEventType
+
+            types = [e.type for e in service.events_replay(mission.mission_id)]
+            assert AgentEventType.CONFIG_RELOADED in types
+        finally:
+            await service.close()
+
+    async def test_safety_domains_rejected(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            result = await service.commands.execute(
+                _cmd("reload", args={"domains": "policy robot_pack"})
+            )
+            assert not result.ok
+            assert not result.data["policy"]["ok"]
+            assert "安全域" in result.data["policy"]["detail"]
+        finally:
+            await service.close()


### PR DESCRIPTION
## Summary

Batch E of the reuse-supplement: every command is a registered control operation (spec + availability + disabled_reason + idempotency) — never chat text to the model.

**Execution/safety visibility**
- `/workers` `/worker inspect|enable|disable|probe` — disable refuses while WorkOrders are non-terminal (drain semantics, never silent kill, §8.18); enable/disable write audit events.
- `/grants` (public scope/status only), `/revoke` (operator principal), `/body` (effective hash/calibration/issues), `/doctor` (structured reason codes), `/mode` (display only — in-place SIM→REAL upgrade rejected with guidance, §8.18), `/context layers|compactions|refresh`, `/session`, `/new`.
- `/retry` only resubmits the last side-effect-free user message (never blind replay, §8.7); `/failover` shows candidates/cooldown remaining; `/thinking` sets public reasoning effort; `/scoped-models` manages the quick-cycle set.

**Mission assets**
- `/export`: `.rcmission` zip (manifest / conversation.jsonl / mission-events.jsonl / compactions.jsonl / public-receipts / checksums.txt) — secrets, permits, private signatures excluded by construction (§8.11).
- `/import`: magic, per-member checksum, path-traversal, zip-bomb and secret-scan verification; always imports as an IMPORTED_READ_ONLY archived mission; **imported permits/grants/approvals never regain authority** (§8.12) — tested.
- `/share`: honestly points at local `/export` — no default gist/cloud upload (§8.13).

**Config**
- `/settings`: whitelisted non-safety keys only, tmp+fsync+rename atomic write with file lock and parse-back validation, audit event; safety-domain keys (budgets/permissions/body) always rejected (§8.4).
- `/reload`: prompts/workers/models reloadable; policy/robot_pack/body/permits safety domains always rejected (§8.15).

**Honestly deferred**: `/fork /clone /tree` (Batch F dual-timeline), `/copy` (TUI-local clipboard), `/estop` (PR-11 dedicated channel) — no fake implementations.

## Tests

17 new tests: command behaviors, export→import round-trip (read-only, no authority), malicious bundles (traversal/tampered checksum/secret content/not-a-zip), settings whitelist + atomic write, reload domain guards. Full agentd suite 311 passed; ruff + mypy clean.