### PR TITLE
Operator safety channel (PR-11 per outline §14)

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -216,7 +216,23 @@ live 模型协调。3v3 联赛基准（T-SIM-2/3）属 PR-TF-075 后续范围。
   审计事件；安全域键永远拒绝）、`/reload`（prompts/workers/models 可
   reload；policy/robot_pack/body/permits 等安全域永远拒绝）。
 - deferred：`/fork /clone /tree`（批次 F 双时间线）、`/copy`（TUI 本地
-  clipboard）、`/estop`（PR-11 专用通道）——不伪造存在。
+  clipboard）——不伪造存在。
+
+## Operator 安全通道（PR-11）
+
+- `operator.sock`（0600，JSONL）：与模型可见的 Agent API 物理分面——
+  `approvals.list / approvals.decide / grants.revoke / estop`。
+- **peer identity**：principal 只从 SO_PEERCRED UID 派生
+  （`user:local:<uid>`）；请求体里的 principal 字段永远被忽略（伪造
+  root 的攻击回归测试锁定）。
+- **display hash**：approve/deny 必须携带卡片 display_hash（title/
+  summary/risk/parameters/body_hash/request_id 的 sha256 指纹），
+  不匹配即拒（TOCTOU 换卡防护）；EXACT_ACTION 单次性由 Broker 保证。
+- **CSRF/Origin**：HTTP 变更请求携带外部 Origin → 403；
+  `ROSCLAW_CONSOLE_TOKEN` 设置时强制 X-Rosclaw-Token pairing。
+- **/estop**：TUI 本地命令经 operator.sock 直达 rosclawd（不经过模型）；
+  无 daemon 时诚实报不可用，绝不假装已停。
+- operator 方法永不出现在模型工具目录（架构级断言）。
 
 ## rosclaw-modeld（批次 D）
 

--- a/packages/rosclaw-tui/src/app.ts
+++ b/packages/rosclaw-tui/src/app.ts
@@ -14,6 +14,7 @@ import {
 	matchesKey,
 } from "@earendil-works/pi-tui";
 import { AgentClient, idempotencyKey } from "./client/http.js";
+import { defaultOperatorSocket, operatorCall } from "./client/operator.js";
 import { streamEvents } from "./client/sse.js";
 import { CommandRegistry } from "./commands/registry.js";
 import { HOTKEYS_TEXT, renderCard, statusLine } from "./components/render.js";
@@ -315,6 +316,29 @@ export class RosclawTuiApp {
 					return;
 				}
 				await this.client.decideApproval(item.requestId, name === "approve");
+				return;
+			}
+			case "estop": {
+				try {
+					const result = await operatorCall(defaultOperatorSocket(), "estop", {
+						reason: "operator /estop from rosclaw-tui",
+					});
+					this.print(
+						new Text(
+							result.ok
+								? chalk.red.bold("E-STOP 已请求 rosclawd 执行。")
+								: chalk.yellow(`E-STOP 未执行：${String(result.error ?? "unknown")}`),
+						),
+					);
+				} catch (err) {
+					this.print(
+						new Text(
+							chalk.yellow(
+								`E-STOP 通道不可用：${(err as Error).message}（未假装已停止）`,
+							),
+						),
+					);
+				}
 				return;
 			}
 			case "missions": {

--- a/packages/rosclaw-tui/src/client/operator.ts
+++ b/packages/rosclaw-tui/src/client/operator.ts
@@ -1,0 +1,48 @@
+/** operator.sock JSONL client (PR-11)：/estop 与审批的专用安全通道。
+ *
+ * TUI 只是 operator 终端——身份由 operator.sock 的 SO_PEERCRED 派生；
+ * 此客户端不携带任何 principal。
+ */
+
+import { connect } from "node:net";
+
+export function operatorCall(
+	socketPath: string,
+	method: string,
+	params: Record<string, unknown> = {},
+	timeoutMs = 5000,
+): Promise<Record<string, unknown>> {
+	return new Promise((resolve, reject) => {
+		const socket = connect(socketPath);
+		let buffer = "";
+		const timer = setTimeout(() => {
+			socket.destroy();
+			reject(new Error("operator socket timeout"));
+		}, timeoutMs);
+		socket.on("connect", () => {
+			socket.write(JSON.stringify({ method, params }) + "\n");
+		});
+		socket.on("data", (chunk) => {
+			buffer += chunk.toString();
+			const idx = buffer.indexOf("\n");
+			if (idx !== -1) {
+				clearTimeout(timer);
+				try {
+					resolve(JSON.parse(buffer.slice(0, idx)) as Record<string, unknown>);
+				} catch (err) {
+					reject(err);
+				}
+				socket.end();
+			}
+		});
+		socket.on("error", (err) => {
+			clearTimeout(timer);
+			reject(err);
+		});
+	});
+}
+
+export function defaultOperatorSocket(): string {
+	const home = process.env.ROSCLAW_HOME ?? `${process.env.HOME}/.rosclaw`;
+	return `${home}/run/operator.sock`;
+}

--- a/packages/rosclaw-tui/src/commands/registry.ts
+++ b/packages/rosclaw-tui/src/commands/registry.ts
@@ -24,6 +24,7 @@ export const LOCAL_COMMANDS: LocalCommand[] = [
 	{ name: "approve", aliases: [], description: "批准授权请求", argumentHint: "<request_id>" },
 	{ name: "deny", aliases: [], description: "拒绝授权请求", argumentHint: "<request_id>" },
 	{ name: "missions", aliases: [], description: "列出 Mission", argumentHint: "" },
+	{ name: "estop", aliases: [], description: "紧急停止（直达 rosclawd，不经过模型）", argumentHint: "" },
 ];
 
 export class CommandRegistry {

--- a/packages/rosclaw-tui/test/commands.test.ts
+++ b/packages/rosclaw-tui/test/commands.test.ts
@@ -41,8 +41,14 @@ test("remote commands route to control api", () => {
 
 test("unknown command is never sent to the model", () => {
 	const registry = new CommandRegistry();
-	const route = registry.parse("/estop");
+	const route = registry.parse("/nosuchcommand");
 	assert.equal(route.kind, "unknown");
+});
+
+test("estop routes locally to the operator channel, never the model", () => {
+	const registry = new CommandRegistry();
+	const route = registry.parse("/estop");
+	assert.equal(route.kind, "local");
 });
 
 test("plain text is not a command", () => {

--- a/src/rosclaw/agentd/operator_socket.py
+++ b/src/rosclaw/agentd/operator_socket.py
@@ -1,0 +1,180 @@
+"""Operator 安全通道（PR-11，大纲 §14）。
+
+与模型可见的 Agent API 物理分离的独立 UDS：
+
+* **peer identity**：principal 从 SO_PEERCRED 的 UID 派生
+  （``user:local:<uid>``）——请求体里的 principal 字段永远被忽略，
+  客户端无法伪造身份（§19.6）。
+* **display hash**：approve/deny 必须携带卡片 display_hash；与存储卡片
+  重算值不匹配即拒绝（防止 TOCTOU 换卡）。
+* **estop**：直达 rosclawd，绕过模型；无 daemon 时诚实报不可用。
+* 协议：JSON Lines（每行一个请求 JSON，一行响应 JSON）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import socket
+import struct
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from rosclaw.contracts.common import ValidationError
+
+if TYPE_CHECKING:
+    from rosclaw.agentd.service import AgentService
+
+
+def display_hash_for(request) -> str:
+    """审批卡片的展示指纹：内容任何变化都会改变 hash。"""
+    display = request.action_display
+    canonical = json.dumps(
+        {
+            "request_id": request.request_id,
+            "title": display.title,
+            "summary": display.summary,
+            "risk_tier": display.risk_tier,
+            "parameters": display.parameters,
+            "body_hash": request.effective_body_hash,
+            "expires_at": request.expires_at,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+def _peer_principal(conn: asyncio.StreamWriter) -> str:
+    """SO_PEERCRED → user:local:<uid>。取不到时 fail closed（拒绝）。"""
+    sock = conn.get_extra_info("socket")
+    if sock is None:
+        raise ValidationError("peer identity unavailable")
+    try:
+        creds = sock.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i"))
+        _, uid, _ = struct.unpack("3i", creds)
+        return f"user:local:{uid}"
+    except (AttributeError, OSError) as exc:
+        raise ValidationError(f"peer identity unavailable: {exc}") from exc
+
+
+class OperatorSocketServer:
+    """每连接 JSONL：{"method": ..., "params": {...}} → {"ok": bool, ...}"""
+
+    def __init__(self, service: AgentService, socket_path: Path) -> None:
+        self._service = service
+        self._path = socket_path
+        self._server: asyncio.AbstractServer | None = None
+
+    async def start(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        os.chmod(self._path.parent, 0o700)
+        self._path.unlink(missing_ok=True)
+        self._server = await asyncio.start_unix_server(self._handle, path=str(self._path))
+        os.chmod(self._path, 0o600)
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        self._path.unlink(missing_ok=True)
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            principal = _peer_principal(writer)
+        except ValidationError as exc:
+            writer.write(json.dumps({"ok": False, "error": str(exc)}).encode() + b"\n")
+            await writer.drain()
+            writer.close()
+            return
+        try:
+            while not reader.at_eof():
+                line = await reader.readline()
+                if not line:
+                    break
+                try:
+                    response = await self._dispatch(principal, json.loads(line))
+                except Exception as exc:  # noqa: BLE001 - 诚实错误，不伪造
+                    response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+                writer.write(json.dumps(response, ensure_ascii=False).encode() + b"\n")
+                await writer.drain()
+        finally:
+            writer.close()
+
+    async def _dispatch(self, principal: str, request: dict[str, Any]) -> dict[str, Any]:
+        method = request.get("method")
+        params = request.get("params") or {}
+        service = self._service
+        if method == "approvals.list":
+            pending = service.pending_approvals(params.get("mission_id"))
+            return {
+                "ok": True,
+                "principal": principal,
+                "approvals": [
+                    {
+                        "request_id": r.request_id,
+                        "mission_id": r.mission_id,
+                        "title": r.action_display.title,
+                        "summary": r.action_display.summary,
+                        "risk_tier": r.action_display.risk_tier,
+                        "parameters": r.action_display.parameters,
+                        "expires_at": r.expires_at,
+                        "display_hash": display_hash_for(r),
+                    }
+                    for r in pending
+                ],
+            }
+        if method == "approvals.decide":
+            request_id = str(params.get("request_id", ""))
+            provided_hash = str(params.get("display_hash", ""))
+            pending = {r.request_id: r for r in service.pending_approvals()}
+            card = pending.get(request_id)
+            if card is None:
+                return {"ok": False, "error": "unknown_or_decided request_id"}
+            expected = display_hash_for(card)
+            if not provided_hash or provided_hash != expected:
+                # display hash 不匹配 → 拒绝（§19.6）。
+                return {"ok": False, "error": "display_hash_mismatch"}
+            grant = await service.decide_approval(
+                request_id,
+                principal=principal,  # peer identity 唯一来源；body 里的 principal 被忽略
+                approve=bool(params.get("approve")),
+            )
+            return {
+                "ok": True,
+                "approved": bool(params.get("approve")),
+                "grant_id": grant.grant_id if grant else None,
+                "principal": principal,
+            }
+        if method == "grants.revoke":
+            grant_id = str(params.get("grant_id", ""))
+            if not grant_id:
+                return {"ok": False, "error": "missing grant_id"}
+            service.revoke_grant(grant_id, principal=principal)
+            return {"ok": True, "revoked": grant_id, "principal": principal}
+        if method == "estop":
+            # 直达 rosclawd，绕过模型（§14.2）；无 daemon 诚实报不可用。
+            result = await service.estop(str(params.get("reason", "operator estop")), principal=principal)
+            return {"ok": True, "estop": result, "principal": principal}
+        return {"ok": False, "error": f"unknown method {method!r}"}
+
+
+async def operator_call(socket_path: Path, method: str, params: dict | None = None) -> dict:
+    """Client helper（TUI/CLI 共用）：一次 JSONL 请求。"""
+    reader, writer = await asyncio.open_unix_connection(str(socket_path))
+    try:
+        writer.write(
+            json.dumps({"method": method, "params": params or {}}, ensure_ascii=False).encode()
+            + b"\n"
+        )
+        await writer.drain()
+        line = await reader.readline()
+        return json.loads(line)  # type: ignore[no-any-return]
+    finally:
+        writer.close()
+        await writer.wait_closed()

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -1020,7 +1020,37 @@ class AgentService:
             "maturity": "experimental",
         }
 
+    async def estop(self, reason: str, *, principal: str) -> dict:
+        """PR-11：直达 rosclawd 的急停路径，绕过模型。
+
+        无 daemon 时诚实报不可用——绝不假装已停（§12.5/§14.2）。
+        """
+        if self._daemon_client is None:
+            raise ValidationError(
+                "estop unavailable: rosclawd not connected; nothing was stopped (honest)"
+            )
+        return await asyncio.to_thread(
+            self._daemon_client.emergency_stop,
+            reason,
+            source=f"operator:{principal}",
+        )
+
+    async def start_operator_socket(self, socket_path: Path | None = None) -> Path:
+        """PR-11：operator.sock（peer identity + display hash + estop）。幂等。"""
+        from rosclaw.agentd.operator_socket import OperatorSocketServer
+
+        existing = getattr(self, "_operator_socket", None)
+        if existing is not None:
+            return existing._path
+        path = socket_path or (self._home / "run" / "operator.sock")
+        self._operator_socket = OperatorSocketServer(self, path)
+        await self._operator_socket.start()
+        return path
+
     async def close(self) -> None:
+        if getattr(self, "_operator_socket", None) is not None:
+            await self._operator_socket.stop()
+            self._operator_socket = None
         await self._gateway.close()
         self._store.close()
 
@@ -1068,10 +1098,45 @@ def _turn_payload(result) -> dict:
 
 
 def create_app(service: AgentService):
-    from fastapi import FastAPI, HTTPException
-    from fastapi.responses import HTMLResponse
+    from contextlib import asynccontextmanager
 
-    app = FastAPI(title="rosclaw-agentd", version="0.1.0")
+    from fastapi import FastAPI, HTTPException
+    from fastapi.responses import HTMLResponse, JSONResponse
+
+    @asynccontextmanager
+    async def lifespan(_app):
+        # PR-11：operator.sock 随 HTTP 服务启动（同一事件循环）。
+        await service.start_operator_socket()
+        yield
+
+    app = FastAPI(title="rosclaw-agentd", version="0.1.0", lifespan=lifespan)
+
+    @app.middleware("http")
+    async def csrf_origin_guard(request: _Request, call_next):
+        """PR-11 §14.1：浏览器 Console 的 CSRF/Origin 防线。
+
+        - 携带 Origin 的变更请求只允许本机来源（localhost/127.0.0.1/
+          [::1]）——任意网页不得向 localhost approval API 发请求（§19.6）。
+        - 设置 ROSCLAW_CONSOLE_TOKEN 时，变更请求必须带 X-Rosclaw-Token
+          （一次性 pairing token 语义）。
+        """
+        if request.method in ("POST", "PUT", "DELETE", "PATCH"):
+            origin = request.headers.get("origin")
+            if origin:
+                from urllib.parse import urlparse
+
+                host = urlparse(origin).hostname or ""
+                if host not in ("localhost", "127.0.0.1", "::1"):
+                    return JSONResponse(
+                        status_code=403,
+                        content={"detail": f"origin {host!r} rejected (CSRF guard)"},
+                    )
+            pairing = os.environ.get("ROSCLAW_CONSOLE_TOKEN")
+            if pairing and request.headers.get("x-rosclaw-token") != pairing:
+                return JSONResponse(
+                    status_code=403, content={"detail": "pairing token required"}
+                )
+        return await call_next(request)
 
     @app.get("/health")
     async def health() -> dict:

--- a/tests/agentd/test_operator_socket.py
+++ b/tests/agentd/test_operator_socket.py
@@ -1,0 +1,246 @@
+"""PR-11 Operator 安全通道测试（大纲 §14/§19.6 攻击回归）。
+
+- peer identity 是唯一身份源（body 里的 principal 被忽略）
+- display_hash 不匹配被拒
+- approve → Broker 签发 single-use Grant（同一终端舒服确认）
+- estop 无 daemon 时诚实不可用，不假装停止
+- CSRF/Origin：外部 Origin 的变更请求被 403；pairing token 强制
+- operator 方法永不出现在模型工具目录
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.models.gateway import MockModelGateway
+from rosclaw.agentd.models.profiles import mock_profile
+from rosclaw.agentd.operator_socket import (
+    OperatorSocketServer,
+    display_hash_for,
+    operator_call,
+)
+from rosclaw.agentd.service import AgentService, create_app
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+
+
+def _approval_turn(request) -> ModelTurnResultV1:
+    decision = {
+        "schema_version": "rosclaw.decision.v1",
+        "decision_id": "d_appr",
+        "mission_id": request.mission_id,
+        "context_id": request.context_id,
+        "context_revision": request.context_revision,
+        "next_intent": "REQUEST_APPROVAL",
+        "summary": "请求授权：播放提示音",
+        "evidence_refs": [],
+        "proposed_operation": {
+            "type": "approval_request",
+            "payload": {
+                "title": "播放提示音",
+                "summary": "speaker 660Hz 0.25s",
+                "risk_tier": "LOW",
+            },
+        },
+    }
+    return ModelTurnResultV1(
+        turn_id="t",
+        provider="mock",
+        model="m",
+        content=f"```json\n{json.dumps(decision)}\n```",
+        assistant_message={"role": "assistant", "content": "x"},
+        usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+    )
+
+
+async def _service_with_pending(tmp_path: Path):
+    config = load_agent_config(tmp_path / "config.yaml")
+    service = AgentService(
+        config, tmp_path, gateway=MockModelGateway(mock_profile(), [_approval_turn] * 4)
+    )
+    mission = service.create_mission("operator socket 测试")
+    await service.send_turn(mission.mission_id, "请求授权")
+    pending = service.pending_approvals(mission.mission_id)
+    assert len(pending) == 1
+    return service, pending[0]
+
+
+class TestOperatorSocket:
+    async def test_peer_identity_and_approve_flow(self, tmp_path: Path) -> None:
+        service, card = await _service_with_pending(tmp_path)
+        sock_path = tmp_path / "run" / "operator.sock"
+        server = OperatorSocketServer(service, sock_path)
+        await server.start()
+        try:
+            assert (sock_path.stat().st_mode & 0o777) == 0o600
+            # list：display_hash 可见。
+            listed = await operator_call(sock_path, "approvals.list")
+            assert listed["ok"]
+            assert listed["principal"].startswith("user:local:")
+            entry = listed["approvals"][0]
+            assert entry["request_id"] == card.request_id
+            assert entry["display_hash"] == display_hash_for(card)
+            # 伪造 principal（body 里写 root）→ 被忽略，peer uid 胜出。
+            decided = await operator_call(
+                sock_path,
+                "approvals.decide",
+                {
+                    "request_id": card.request_id,
+                    "display_hash": entry["display_hash"],
+                    "approve": True,
+                    "principal": "user:local:0",  # 伪造字段必须被忽略
+                },
+            )
+            assert decided["ok"]
+            assert decided["principal"] != "user:local:0"
+            grant = decided["grant_id"]
+            assert grant
+            # grant 的 principal 来自 peer identity，不是伪造值。
+            stored = [g for g in service.list_grants() if g["grant_id"] == grant]
+            assert stored and stored[0]["principal"] == decided["principal"]
+            # EXACT_ACTION 单次性：重复 decide 同一 request → 拒绝。
+            again = await operator_call(
+                sock_path,
+                "approvals.decide",
+                {
+                    "request_id": card.request_id,
+                    "display_hash": entry["display_hash"],
+                    "approve": True,
+                },
+            )
+            assert not again["ok"]
+        finally:
+            await server.stop()
+            await service.close()
+
+    async def test_display_hash_mismatch_rejected(self, tmp_path: Path) -> None:
+        service, card = await _service_with_pending(tmp_path)
+        sock_path = tmp_path / "op.sock"
+        server = OperatorSocketServer(service, sock_path)
+        await server.start()
+        try:
+            result = await operator_call(
+                sock_path,
+                "approvals.decide",
+                {
+                    "request_id": card.request_id,
+                    "display_hash": "0000000000000000",
+                    "approve": True,
+                },
+            )
+            assert not result["ok"] and result["error"] == "display_hash_mismatch"
+            # 未批准：无 grant 产生。
+            assert service.list_grants() == []
+            # 空 hash 同样拒绝（fail closed）。
+            empty = await operator_call(
+                sock_path,
+                "approvals.decide",
+                {"request_id": card.request_id, "display_hash": "", "approve": True},
+            )
+            assert not empty["ok"]
+        finally:
+            await server.stop()
+            await service.close()
+
+    async def test_estop_honest_without_daemon(self, tmp_path: Path) -> None:
+        service, _ = await _service_with_pending(tmp_path)
+        sock_path = tmp_path / "op.sock"
+        server = OperatorSocketServer(service, sock_path)
+        await server.start()
+        try:
+            result = await operator_call(sock_path, "estop", {"reason": "test"})
+            assert not result["ok"]
+            assert "unavailable" in result["error"]
+            assert "honest" in result["error"] or "not connected" in result["error"]
+        finally:
+            await server.stop()
+            await service.close()
+
+    async def test_unknown_method_rejected(self, tmp_path: Path) -> None:
+        service, _ = await _service_with_pending(tmp_path)
+        sock_path = tmp_path / "op.sock"
+        server = OperatorSocketServer(service, sock_path)
+        await server.start()
+        try:
+            result = await operator_call(sock_path, "permits.mint")
+            assert not result["ok"] and "unknown method" in result["error"]
+        finally:
+            await server.stop()
+            await service.close()
+
+
+class TestCsrfOriginGuard:
+    async def test_foreign_origin_rejected(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        service, card = await _service_with_pending(tmp_path)
+        client = TestClient(create_app(service))
+        try:
+            # 网页跨源调用 approval endpoint → 403。
+            hostile = client.post(
+                f"/approvals/{card.request_id}/decide",
+                json={"approve": True},
+                headers={"Origin": "https://evil.example.com"},
+            )
+            assert hostile.status_code == 403
+            # 本机来源放行。
+            local = client.post(
+                f"/approvals/{card.request_id}/decide",
+                json={"approve": True},
+                headers={"Origin": "http://localhost:3000"},
+            )
+            assert local.status_code == 200
+        finally:
+            await service.close()
+
+    async def test_pairing_token_enforced_when_configured(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        service, card = await _service_with_pending(tmp_path)
+        os.environ["ROSCLAW_CONSOLE_TOKEN"] = "pairing-test-token"
+        try:
+            client = TestClient(create_app(service))
+            missing = client.post(
+                f"/approvals/{card.request_id}/decide", json={"approve": True}
+            )
+            assert missing.status_code == 403
+            wrong = client.post(
+                f"/approvals/{card.request_id}/decide",
+                json={"approve": True},
+                headers={"X-Rosclaw-Token": "wrong"},
+            )
+            assert wrong.status_code == 403
+            right = client.post(
+                f"/approvals/{card.request_id}/decide",
+                json={"approve": True},
+                headers={"X-Rosclaw-Token": "pairing-test-token"},
+            )
+            assert right.status_code == 200
+        finally:
+            os.environ.pop("ROSCLAW_CONSOLE_TOKEN", None)
+            await service.close()
+
+
+class TestModelNeverReachesOperator:
+    async def test_operator_methods_not_in_tool_catalog(self, tmp_path: Path) -> None:
+        service, _ = await _service_with_pending(tmp_path)
+        try:
+            for descriptor in service.tool_catalog.list():
+                assert "approve" not in descriptor.tool_id
+                assert "estop" not in descriptor.tool_id
+                assert "grant" not in descriptor.tool_id
+                assert "revoke" not in descriptor.tool_id
+        finally:
+            await service.close()
+
+    async def test_model_text_approve_does_not_decide(self, tmp_path: Path) -> None:
+        """模型输出 '/approve xxx' 文本不得批准任何请求（§19.6）。"""
+        service, card = await _service_with_pending(tmp_path)
+        try:
+            await service.send_turn(card.mission_id, "/approve " + card.request_id)
+            # 卡片仍待定（命令只经 operator socket/HTTP 专用端点生效）。
+            assert service.pending_approvals(card.mission_id)
+        finally:
+            await service.close()


### PR DESCRIPTION
## Summary

PR-11 of the Pi TUI/Provider outline: the dedicated operator safety channel — comfortable same-terminal approval while the model can never self-approve.

- **operator.sock** (0600, JSONL): physically separate from the model-visible agent API — `approvals.list` / `approvals.decide` / `grants.revoke` / `estop`. Started via the FastAPI lifespan (cmd_start and chat TUI alike).
- **Peer identity**: principal is derived only from the SO_PEERCRED uid (`user:local:<uid>`); any `principal` field in the request body is ignored (forged-root regression test proves the body value never reaches the grant).
- **Display hash**: decide must carry the card's `display_hash` (sha256 over title/summary/risk/parameters/body_hash/request_id/expiry); mismatch or empty → rejected (TOCTOU card-swap guard). Single-use is enforced by the broker; a second decide is refused.
- **CSRF/Origin**: mutating HTTP requests with a foreign Origin → 403; `ROSCLAW_CONSOLE_TOKEN` (when set) enforces an `X-Rosclaw-Token` pairing header — arbitrary web pages cannot call the localhost approval API (§19.6).
- **/estop**: TUI local command over operator.sock straight to rosclawd, bypassing the model entirely; without a daemon it honestly reports unavailable — never fakes a stop.
- **Boundary**: operator methods never appear in the model tool catalog (asserted); a model emitting `/approve xxx` text decides nothing (§19.6 attack regression).

## Exit condition

同终端舒服确认，但模型永远不能自批 — the same terminal approves via operator.sock (peer-derived identity, no password replay), while the model has no path to decide: not through tools, not through chat text, not through forged principals, not through swapped cards.

## Tests

8 new Python tests (approve flow with forged-principal regression, display-hash mismatch, replay refusal, honest estop-without-daemon, unknown method, foreign-origin 403, pairing token, model-text /approve no-op, tool-catalog boundary) + 14 TUI node tests (incl. /estop local routing). Full agentd suite green; ruff + mypy clean.