### PR TITLE
LIMO full acceptance loop + arm64 release packaging (PR-12)

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -218,6 +218,30 @@ live 模型协调。3v3 联赛基准（T-SIM-2/3）属 PR-TF-075 后续范围。
 - deferred：`/fork /clone /tree`（批次 F 双时间线）、`/copy`（TUI 本地
   clipboard）——不伪造存在。
 
+## LIMO 完整闭环与发布打包（PR-12）
+
+- `rosclaw.limo.sim_mcp`：LIMO 仿真 MCP（观测 get_pose/health 为
+  readOnlyHint → OBSERVE；play_tone/set_initial_pose 为 PHYSICAL_ACTION）。
+- `SimActionChannel`（SIM 物理权威）：只在 EXACT_ACTION grant 验证消费
+  后执行；产出 SIMULATED receipt（evidence_domain=simulation、
+  usable_for_real_execution=false；无声学观测时诚实声明只证明驱动
+  执行）。观测与执行共享 `PersistentMcpClient` 持久会话（有状态身体
+  必须同进程）。
+- 验收（§18 C1–C10）：`bench/limo_acceptance.run_acceptance` ——
+  观测 → 授权卡 → operator.sock 批准（peer identity + display hash）→
+  SIM 执行 → receipt → 位姿验证 → practice candidate；SHADOW/REAL 无
+  daemon/硬件时诚实拒绝，绝不用 SIM 证据冒充。
+- K9 live：真实 Kimi K3 自行决策完成同一闭环（grant.consumed、
+  receipt.received、单次消费全部验证）。
+- 打包：`scripts/build_release.sh` → `dist/rosclaw-<ver>-linux-arm64.
+  tar.gz`（src + 已构建 packages + lockfiles + third_party 声明 +
+  manifest hash）；`scripts/release/install_release.sh`（venv + npm ci
+  重建 + 原子切换 current/previous，Node 缺失诚实降级）；
+  `rollback.sh`（manifest 校验后回切，失败版本保留排查）。
+- wire 约束：OpenAI 函数名不允许点号——工具 id 在 wire 上映射为
+  `__`（catalog 注册拒绝含 `__` 的原生 id 保证单射）；内部协议工具的
+  成功提交也必须回执 tool result（Kimi 拒绝悬空 tool_call）。
+
 ## Operator 安全通道（PR-11）
 
 - `operator.sock`（0600，JSONL）：与模型可见的 Agent API 物理分面——

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# PR-12：Linux arm64 发布包构建（诚实打包：不隐藏任何构建步骤）。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="$(cd "$REPO_ROOT" && python3 -c "import re; print(re.search(r'version = \"([^\"]+)\"', open('pyproject.toml').read()).group(1))")"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  aarch64) ARCH_NAME="arm64" ;;
+  x86_64)  ARCH_NAME="x64" ;;
+  *)       ARCH_NAME="$ARCH" ;;
+esac
+BUNDLE="rosclaw-${VERSION}-linux-${ARCH_NAME}"
+DIST_DIR="${REPO_ROOT}/dist"
+STAGE="${DIST_DIR}/${BUNDLE}"
+
+echo "==> building ${BUNDLE}"
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+
+# 1. Python 源码与元数据
+rsync -a --exclude '__pycache__' --exclude '*.pyc' \
+  "$REPO_ROOT/src" "$REPO_ROOT/pyproject.toml" "$REPO_ROOT/README.md" \
+  "$REPO_ROOT/LICENSE" "$STAGE/" 2>/dev/null || \
+  { cp -r "$REPO_ROOT/src" "$REPO_ROOT/pyproject.toml" "$REPO_ROOT/README.md" "$STAGE/"; }
+
+# 2. Node 包（预先构建 dist；lockfile 一并打包，安装侧 npm ci 可重现）
+for pkg in rosclaw-tui rosclaw-modeld; do
+  src_dir="$REPO_ROOT/packages/$pkg"
+  [ -d "$src_dir" ] || { echo "missing packages/$pkg" >&2; exit 1; }
+  if [ ! -d "$src_dir/dist/src" ]; then
+    echo "==> building packages/$pkg"
+    (cd "$src_dir" && npm ci --silent && npm run build --silent)
+  fi
+  mkdir -p "$STAGE/packages/$pkg"
+  cp -r "$src_dir/dist" "$src_dir/package.json" "$src_dir/package-lock.json" \
+        "$src_dir/tsconfig.json" "$STAGE/packages/$pkg/"
+  cp -r "$src_dir/src" "$STAGE/packages/$pkg/"
+done
+
+# 3. 第三方声明与安装脚本
+cp -r "$REPO_ROOT/third_party" "$STAGE/"
+cp "$REPO_ROOT/scripts/release/install_release.sh" "$STAGE/install.sh"
+cp "$REPO_ROOT/scripts/release/rollback.sh" "$STAGE/"
+chmod +x "$STAGE/install.sh" "$STAGE/rollback.sh"
+
+# 4. manifest（含各组件 hash 供回滚校验）
+python3 - "$STAGE" "$VERSION" "$ARCH_NAME" <<'PY'
+import hashlib, json, sys
+from pathlib import Path
+stage, version, arch = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+files = {}
+for path in sorted(stage.rglob("*")):
+    if path.is_file():
+        files[str(path.relative_to(stage))] = hashlib.sha256(path.read_bytes()).hexdigest()
+manifest = {
+    "product": "rosclaw",
+    "version": version,
+    "platform": f"linux-{arch}",
+    "files": files,
+}
+(stage / "manifest.json").write_text(json.dumps(manifest, indent=1))
+PY
+
+mkdir -p "$DIST_DIR"
+tar -C "$DIST_DIR" -czf "${DIST_DIR}/${BUNDLE}.tar.gz" "$BUNDLE"
+echo "==> ${DIST_DIR}/${BUNDLE}.tar.gz"

--- a/scripts/release/install_release.sh
+++ b/scripts/release/install_release.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# PR-12：发布包安装器（component installer）。
+# 用法：tar xzf rosclaw-<ver>-linux-arm64.tar.gz && cd rosclaw-<ver>-linux-arm64 && ./install.sh [--prefix DIR]
+set -euo pipefail
+
+PREFIX="${ROSCLAW_PREFIX:-$HOME/.local/share/rosclaw}"
+if [ "${1:-}" = "--prefix" ]; then PREFIX="$2"; fi
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT="$PREFIX/current"
+PREVIOUS="$PREFIX/previous"
+NEXT="$PREFIX/next-$RANDOM"
+
+echo "==> installing rosclaw to $PREFIX"
+mkdir -p "$PREFIX"
+cp -r "$SRC_DIR" "$NEXT"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1 ($2)" >&2; exit 2; }; }
+need python3 "3.11+"
+
+# Python 组件
+python3 -m venv "$NEXT/.venv"
+"$NEXT/.venv/bin/pip" install --quiet --upgrade pip
+"$NEXT/.venv/bin/pip" install --quiet "$NEXT"
+
+# Node 组件（TUI/modeld）：需要 Node >= 22.19；缺失时诚实降级说明
+NODE_OK=0
+for candidate in node /usr/bin/node /usr/local/bin/node; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    ver="$($candidate --version | tr -d 'v')"
+    major="${ver%%.*}"; rest="${ver#*.}"; minor="${rest%%.*}"
+    if [ "$major" -gt 22 ] || { [ "$major" -eq 22 ] && [ "$minor" -ge 19 ]; }; then
+      NODE_BIN="$candidate"; NODE_OK=1; break
+    fi
+  fi
+done
+if [ "$NODE_OK" = "1" ]; then
+  for pkg in rosclaw-tui rosclaw-modeld; do
+    (cd "$NEXT/packages/$pkg" && "$NODE_BIN" "$(command -v npm)" ci --silent && "$NODE_BIN" "$(command -v npm)" run build --silent)
+  done
+else
+  echo "WARN: Node >= 22.19 not found — rosclaw-tui/modeld 不可用；"
+  echo "      Python-only 安装完成（rosclaw chat --basic 与 legacy backend 可用）。"
+fi
+
+# CLI 入口链接
+mkdir -p "$PREFIX/bin"
+cat > "$PREFIX/bin/rosclaw" <<EOF2
+#!/usr/bin/env bash
+exec "$CURRENT/.venv/bin/python" -m rosclaw.entrypoint "\$@"
+EOF2
+chmod +x "$PREFIX/bin/rosclaw"
+
+# 原子切换 current；旧版本保留为 previous（rollback.sh 目标）。
+rm -rf "$PREFIX/previous.tmp"
+[ -e "$CURRENT" ] && mv "$CURRENT" "$PREFIX/previous.tmp" || true
+mv "$NEXT" "$CURRENT.new" && mv "$CURRENT.new" "$CURRENT"
+rm -rf "$PREVIOUS"
+[ -e "$PREFIX/previous.tmp" ] && mv "$PREFIX/previous.tmp" "$PREVIOUS" || true
+
+echo "==> installed. 加入 PATH: export PATH=\"$PREFIX/bin:\$PATH\""
+echo "==> 验证: rosclaw doctor；回滚: $PREFIX/current/rollback.sh"

--- a/scripts/release/rollback.sh
+++ b/scripts/release/rollback.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# PR-12：完整回滚——把 current 切回 previous（含校验）。
+set -euo pipefail
+
+PREFIX="${ROSCLAW_PREFIX:-$HOME/.local/share/rosclaw}"
+CURRENT="$PREFIX/current"
+PREVIOUS="$PREFIX/previous"
+
+[ -d "$PREVIOUS" ] || { echo "没有可回滚的 previous 版本。" >&2; exit 2; }
+# manifest 校验：回滚目标必须结构完整。
+[ -f "$PREVIOUS/manifest.json" ] || { echo "previous 缺 manifest.json，拒绝回滚。" >&2; exit 2; }
+
+mv "$CURRENT" "$PREFIX/failed-$(date +%Y%m%d%H%M%S)"
+mv "$PREVIOUS" "$CURRENT"
+echo "==> 已回滚到 previous（失败版本保留在 $PREFIX/failed-* 供排查）。"

--- a/src/rosclaw/agentd/bench/limo_acceptance.py
+++ b/src/rosclaw/agentd/bench/limo_acceptance.py
@@ -1,0 +1,348 @@
+"""LIMO 完整闭环验收（PR-12 §18）：SIMULATION 证据域的 C1–C10。
+
+驱动 TaskGraph：
+    T1 OBSERVE（定位/健康观测）
+    T3 REQUEST_APPROVAL → approve → REQUEST_ACTION（speaker.play_tone）
+    T4 REQUEST_APPROVAL → approve → REQUEST_ACTION（localization.set_initial_pose）
+    T5 VALIDATE（观测位姿对比目标）
+    T6 报告（含 §18.4 诚实声明）
+    T7 LEARN（practice candidate 证据）
+
+SHADOW/REAL 门控：无 rosclawd/真实硬件时明确拒绝并说明——绝不用 SIM
+证据冒充 SHADOW/REAL（§18.4、总纲 21 条）。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+LIMO_SIM_MCP = str(Path(__file__).resolve().parents[2] / "limo" / "sim_mcp.py")
+
+TONE_ARGS = {"frequency_hz": 660, "duration_sec": 0.6, "volume_percent": 18}
+POSE_ARGS = {"x": 0.0, "y": 0.0, "yaw": 0.0}
+
+
+@dataclass
+class AcceptanceReport:
+    checks: dict[str, bool] = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+    receipts: list[str] = field(default_factory=list)
+    grants: list[str] = field(default_factory=list)
+    practice_candidate: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        return all(self.checks.values())
+
+
+def limo_sim_mcp_server_config() -> dict:
+    """mcp_servers 配置项（SIMULATION 全证据域）。"""
+    return {
+        "name": "limo-sim",
+        "command": sys.executable,
+        "args": [LIMO_SIM_MCP],
+        "supported_modes": ["SIMULATION"],
+        "required_body_types": [],
+        "sim_executor": True,
+    }
+
+
+def acceptance_script(tone_args: dict | None = None, pose_args: dict | None = None):
+    """T1–T7 内容驱动的状态机脚本（OBSERVE 会在同一 turn 内续跑，不能按
+    调用次数推进——按会话内容判定当前阶段）。"""
+    tone = tone_args or TONE_ARGS
+    pose = pose_args or POSE_ARGS
+
+    def script(request):
+        import re
+
+        from rosclaw.agentd.models.gateway import ModelTurnResultV1
+
+        blob = json.dumps(request.messages, ensure_ascii=False)
+        prompt = request.system_prompt or ""
+        pose_observations = blob.count("tool: limo.localization.get_pose")
+        health_observed = "tool: limo.health" in blob
+        tone_card = "播放提示音" in blob
+        tone_receipt = "limo.speaker.play_tone" in blob and "SIM 执行器" in blob
+        pose_card = "设置地图初始位姿" in blob
+        pose_receipt = "limo.localization.set_initial_pose" in blob and "SIM 执行器" in blob
+        grant_match = re.search(r"grant_id=(grant_[a-z0-9]+)", prompt)
+        grant_id = grant_match.group(1) if grant_match else ""
+
+        if pose_observations == 0:
+            decision = {
+                "next_intent": "OBSERVE",
+                "summary": "读取 LIMO 定位位姿",
+                "proposed_operation": {
+                    "type": "observe",
+                    "payload": {
+                        "tool": "limo.localization.get_pose",
+                        "arguments": {"frame": "map"},
+                    },
+                },
+            }
+        elif not health_observed:
+            decision = {
+                "next_intent": "OBSERVE",
+                "summary": "读取 LIMO 健康状态",
+                "proposed_operation": {
+                    "type": "observe",
+                    "payload": {"tool": "limo.health", "arguments": {}},
+                },
+            }
+        elif not tone_card:
+            decision = {
+                "next_intent": "REQUEST_APPROVAL",
+                "summary": "请求授权：播放 660Hz 提示音",
+                "proposed_operation": {
+                    "type": "approval_request",
+                    "payload": {
+                        "capability_id": "limo.speaker.play_tone",
+                        "arguments": tone,
+                        "title": "播放提示音",
+                        "summary": (
+                            f"{tone['frequency_hz']}Hz {tone['duration_sec']}s "
+                            f"{tone['volume_percent']}%"
+                        ),
+                        "risk_tier": "LOW",
+                    },
+                },
+            }
+        elif not tone_receipt:
+            decision = {
+                "next_intent": "REQUEST_ACTION",
+                "summary": "执行已授权的扬声器动作",
+                "proposed_operation": {
+                    "type": "request_action",
+                    "payload": {
+                        "grant_id": grant_id,
+                        "capability_id": "limo.speaker.play_tone",
+                        "arguments": tone,
+                        "risk_tier": "LOW",
+                    },
+                },
+            }
+        elif not pose_card:
+            decision = {
+                "next_intent": "REQUEST_APPROVAL",
+                "summary": "请求授权：设置地图初始位姿",
+                "proposed_operation": {
+                    "type": "approval_request",
+                    "payload": {
+                        "capability_id": "limo.localization.set_initial_pose",
+                        "arguments": pose,
+                        "title": "设置地图初始位姿",
+                        "summary": f"x={pose['x']}, y={pose['y']}, yaw={pose['yaw']}",
+                        "risk_tier": "LOW",
+                    },
+                },
+            }
+        elif not pose_receipt:
+            decision = {
+                "next_intent": "REQUEST_ACTION",
+                "summary": "执行已授权的初始位姿设置",
+                "proposed_operation": {
+                    "type": "request_action",
+                    "payload": {
+                        "grant_id": grant_id,
+                        "capability_id": "limo.localization.set_initial_pose",
+                        "arguments": pose,
+                        "risk_tier": "LOW",
+                    },
+                },
+            }
+        elif pose_observations < 2:
+            decision = {
+                "next_intent": "OBSERVE",
+                "summary": "验证新位姿",
+                "proposed_operation": {
+                    "type": "observe",
+                    "payload": {
+                        "tool": "limo.localization.get_pose",
+                        "arguments": {"frame": "map"},
+                    },
+                },
+            }
+        else:
+            decision = {
+                "next_intent": "ANSWER",
+                "summary": (
+                    "LIMO 验收完成：扬声器与初始位姿动作均经 EXACT_ACTION 授权并由 "
+                    "SIM 执行器返回 COMPLETED receipt（SIMULATED 证据域）；"
+                    "新位姿 (0,0,0) 已在容差内验证。"
+                    "没有麦克风——扬声器只能确认驱动执行，不能独立证明声学效果（§18.4）。"
+                ),
+                "evidence_refs": [],
+            }
+        if decision["next_intent"] in ("REQUEST_APPROVAL", "REQUEST_ACTION"):
+            decision["verification"] = {
+                "schema_version": "rosclaw.decision_verification.v1",
+                "verifiers": ["deterministic:bounds"],
+            }
+        idx = blob.count("rosclaw.decision") + 1
+        decision.update(
+            {
+                "schema_version": "rosclaw.decision.v1",
+                "decision_id": f"dec_{idx}",
+                "mission_id": request.mission_id,
+                "context_id": request.context_id,
+                "context_revision": request.context_revision,
+                "evidence_refs": decision.get("evidence_refs", []),
+            }
+        )
+        return ModelTurnResultV1(
+            turn_id="t",
+            provider="mock",
+            model="m",
+            content=f"```json\n{json.dumps(decision, ensure_ascii=False)}\n```",
+            assistant_message={"role": "assistant", "content": "x"},
+            usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+        )
+
+    return script
+
+
+async def run_acceptance(home: Path, *, gateway=None) -> AcceptanceReport:
+    """SIMULATION 全链路验收（真实 MCP/审批/执行/receipt 路径）。"""
+    import yaml
+
+    from rosclaw.agentd.config import load_agent_config
+    from rosclaw.agentd.models.gateway import MockModelGateway
+    from rosclaw.agentd.models.profiles import mock_profile
+    from rosclaw.agentd.operator_socket import operator_call
+    from rosclaw.agentd.service import AgentService
+
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {"enabled": True},
+                "mcp_servers": [limo_sim_mcp_server_config()],
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = load_agent_config(home / "config.yaml")
+    script = acceptance_script()
+    service = AgentService(
+        config, home, gateway=gateway or MockModelGateway(mock_profile(), [script] * 40)
+    )
+    report = AcceptanceReport()
+    sock_path = await service.start_operator_socket()
+    try:
+        mission = service.create_mission("LIMO 验收：扬声器与定位")
+        report.checks["C1_body_bound"] = True
+        report.notes.append(f"body={mission.body_binding.body_id} hash={mission.body_binding.effective_body_hash[:16]}")
+
+        async def approve_pending() -> None:
+            """operator socket 审批当前待批卡片（peer identity + display hash）。"""
+            listed = await operator_call(sock_path, "approvals.list")
+            assert listed["approvals"], "expected a pending approval card"
+            entry = listed["approvals"][0]
+            decided = await operator_call(
+                sock_path,
+                "approvals.decide",
+                {
+                    "request_id": entry["request_id"],
+                    "display_hash": entry["display_hash"],
+                    "approve": True,
+                },
+            )
+            assert decided["ok"], f"approval failed: {decided}"
+            report.grants.append(decided["grant_id"])
+
+        # 状态驱动推进：每轮 turn 走到 WAIT_APPROVAL 就经 operator.sock
+        # 批准；直到最终验收报告出现（loop 在同一 turn 内可连续推进多步）。
+        last_reply = ""
+        for _step in range(14):
+            result = await service.send_turn(mission.mission_id, "继续执行验收流程")
+            last_reply = result.reply
+            if service.pending_approvals(mission.mission_id):
+                await approve_pending()
+                continue
+            if result.state.value == "FAILED":
+                raise AssertionError(f"mission failed at step {_step}: {result.reply[:300]}")
+            if "验收完成" in result.reply:
+                break
+        else:
+            raise AssertionError(f"acceptance did not converge; last reply: {last_reply[:300]}")
+
+        history = json.dumps(service.conversation(mission.mission_id), ensure_ascii=False)
+        report.checks["C2_observation_fresh"] = "observation" in history
+        report.checks["C3_tone_exact_action_approval"] = "播放提示音" in history
+        report.checks["C4_tone_terminal_receipt"] = (
+            "limo.speaker.play_tone" in history and "COMPLETED" in history
+        )
+        report.checks["C5_honest_no_acoustic_proof"] = "不能独立证明" in history
+        report.checks["C6_pose_exact_action_approval"] = "设置地图初始位姿" in history
+        report.checks["C7_pose_completed"] = (
+            "limo.localization.set_initial_pose" in history
+            and history.count("COMPLETED") >= 2
+        )
+        raw_contents = "\n".join(
+            str(m.get("content") or "") for m in service.conversation(mission.mission_id)
+        )
+        # 证据 envelope 内 MCP JSON 是转义的；两种形态都接受。
+        unescaped = raw_contents.replace('\\"', '"')
+        report.checks["C8_pose_within_tolerance"] = (
+            '"x": 0.0' in unescaped
+            and '"y": 0.0' in unescaped
+            and '"theta": 0.0' in unescaped
+        )
+        report.receipts.append("see mission journal (receipt.received events)")
+
+        # C9：所有 grant 单次消费（再次 verify 必拒）。
+        from rosclaw.operator import GrantDeniedError
+
+        single_use_ok = True
+        for grant in service.list_grants():
+            try:
+                service._broker.verify(
+                    grant["grant_id"],
+                    principal=grant["principal"],
+                    body_hash=mission.body_binding.effective_body_hash,
+                    mode="SIMULATION",
+                    risk_tier="LOW",
+                )
+                single_use_ok = False
+            except GrantDeniedError as exc:
+                single_use_ok = single_use_ok and exc.reason_code == "grant_consumed"
+        report.checks["C9_grants_single_use"] = single_use_ok
+
+        # C10：trace/receipt/verification 持久化。
+        events = service.events_replay(mission.mission_id)
+        types = {e.type.value for e in events}
+        report.checks["C10_trace_persisted"] = (
+            "receipt.received" in types and "grant.consumed" in types
+        )
+
+        # T7：practice candidate（学习证据，不自动晋升）。
+        from rosclaw.agentd.context.sources import EvidenceClass
+        from rosclaw.agentd.learning.pipeline import LearningPipeline
+
+        pipeline = LearningPipeline(service.store.connection, actor_id=service.actor_id)
+        receipt_ids = [e.event_id for e in events if e.type.value == "receipt.received"]
+        candidate = pipeline.propose(
+            kind="HOW",
+            title="LIMO 扬声器与定位验收流程",
+            content={
+                "scenario": "limo_tone_localization_acceptance",
+                "steps": ["observe", "approve+act tone", "approve+act pose", "validate"],
+                "evidence_domain": "simulation",
+            },
+            evidence_class=EvidenceClass.VERIFIED_RECEIPT,
+            evidence_refs=receipt_ids,
+            mission_id=mission.mission_id,
+            body_scope=mission.body_binding.body_id,
+        )
+        report.practice_candidate = candidate
+        report.checks["T7_practice_candidate"] = bool(candidate)
+
+        # T6 报告（用户可见诚实声明）。
+        report.notes.append(last_reply[:200])
+        report.checks["T6_report"] = "验收完成" in last_reply
+        return report
+    finally:
+        await service.close()

--- a/src/rosclaw/agentd/handlers.py
+++ b/src/rosclaw/agentd/handlers.py
@@ -394,7 +394,51 @@ class ServiceIntentHandlers:
                 evidence_ref=f"receipt://{action_id}",
             )
         channel = getattr(self, "_action_channel", None)
+        capability = str(payload.get("capability_id", "sim.hold_position"))
+        arguments = payload.get("arguments") or {}
         if channel is None:
+            # PR-12：无 daemon 时，SIMULATION 可经 SimActionChannel 在 SIM
+            # 身体上执行（SIMULATED receipt，永不证明 REAL）。
+            sim_channel = getattr(self, "_sim_channel", None)
+            if sim_channel is not None and self._mode == "SIMULATION":
+                from rosclaw.agentd.sim_executor import SimActionError
+
+                try:
+                    outcome = await sim_channel.execute(
+                        capability_id=capability,
+                        arguments=arguments,
+                        grant_id=grant.grant_id,
+                        mode=self._mode,
+                    )
+                except SimActionError as exc:
+                    return HandlerOutcome(text=f"SIM 执行失败（fail closed）：{exc}")
+                receipt = outcome.receipt
+                await self._emit(
+                    "receipt.received",
+                    decision.mission_id,
+                    {
+                        "action_id": outcome.action_id,
+                        "final_state": outcome.final_state,
+                        "trust_level": "SIMULATED",
+                        "verified": True,
+                        "evidence_domain": "simulation",
+                    },
+                )
+                effect_note = (
+                    "物理效果已由独立观测证明。"
+                    if receipt.get("physical_effect_proven")
+                    else "没有声学/物理观测——只能确认驱动执行，不能独立证明物理效果（§18.4）。"
+                )
+                return HandlerOutcome(
+                    text=(
+                        f"动作已由 SIM 执行器完成（{receipt['executor']}）："
+                        f"capability={capability}, final_state=COMPLETED, "
+                        "evidence_domain=simulation, usable_for_real_execution=false。"
+                        f"{effect_note}grant 已消费。"
+                    ),
+                    terminal_receipt=True,
+                    evidence_ref=f"receipt://{outcome.action_id}",
+                )
             return HandlerOutcome(
                 text=(
                     f"授权已验证（grant {grant.grant_id[:20]}…，EXACT_ACTION 已消费）。"
@@ -402,8 +446,6 @@ class ServiceIntentHandlers:
                     "这不是执行回执。"
                 )
             )
-        capability = str(payload.get("capability_id", "sim.hold_position"))
-        arguments = payload.get("arguments") or {}
         from rosclaw.agentd.action_channel import ActionChannelError
 
         try:

--- a/src/rosclaw/agentd/loop.py
+++ b/src/rosclaw/agentd/loop.py
@@ -414,6 +414,22 @@ class AgentLoop:
                                 context_revision=bundle.context_revision,
                             )
                             decision = DecisionV1.model_validate_contract(submitted)
+                            # Kimi/OpenAI 要求每个 tool_call_id 都有响应消息：
+                            # 内部协议工具也必须回执（标记为协议确认，不执行）。
+                            self._conversation.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": call.call_id,
+                                    "content": json.dumps(
+                                        {
+                                            "accepted": True,
+                                            "decision_id": decision.decision_id,
+                                            "note": "protocol tool: decision registered, not executed",
+                                        },
+                                        ensure_ascii=False,
+                                    ),
+                                }
+                            )
                         except Exception as exc:  # noqa: BLE001 - 回执错误继续修复
                             self._conversation.append(
                                 {
@@ -587,8 +603,10 @@ class AgentLoop:
                 }
             )
             return True
-        allowed = {t.name for t in self._tools.strict_tools([tool_name])}
-        if tool_name not in allowed:
+        from rosclaw.agentd.tooling.strict_schema import canonical_name
+
+        allowed = {canonical_name(t.name) for t in self._tools.strict_tools([tool_name])}
+        if canonical_name(tool_name) not in allowed:
             self._conversation.append(
                 {
                     "role": "user",

--- a/src/rosclaw/agentd/onboarding.py
+++ b/src/rosclaw/agentd/onboarding.py
@@ -109,14 +109,43 @@ async def probe_home(home: Path) -> ModelProbeResult:
         await gateway.close()
 
 
+def _component_report() -> dict:
+    """批次 D/E 与 PR-11 组件检查：Node、modeld、TUI 资产。"""
+    import shutil
+    import subprocess
+
+    node_version = None
+    node_ok = False
+    for candidate in filter(None, [shutil.which("node"), "/usr/bin/node", "/usr/local/bin/node"]):
+        try:
+            out = subprocess.check_output([candidate, "--version"], text=True, timeout=10).strip()
+            parts = [int(p) for p in out.lstrip("v").split(".")]
+            if parts >= [22, 19, 0]:
+                node_version, node_ok = out, True
+                break
+            node_version = node_version or out
+        except Exception:  # noqa: BLE001
+            continue
+    from rosclaw.agentd.cli import _find_tui_runtime
+    from rosclaw.agentd.models.modeld_gateway import _find_modeld_runtime
+
+    return {
+        "node": {"version": node_version, "ok": node_ok, "required": ">=22.19.0"},
+        "modeld": {"available": _find_modeld_runtime() is not None},
+        "tui": {"available": _find_tui_runtime() is not None},
+    }
+
+
 def doctor(home: Path) -> dict:
     """Honest agent readiness report. Never prints raw credentials."""
     config = load_agent_config(home / "config.yaml")
     report: dict = {
         "agent_enabled": config.enabled,
+        "model_backend": config.model_backend,
         "profiles": [p.name for p in config.profiles],
         "default_profile": config.default_profile if config.profiles else None,
     }
+    report["components"] = _component_report()
     if not config.profiles:
         report["status"] = "MODEL_NOT_READY"
         report["reason"] = "no model profile configured — run `rosclaw agent init`"

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -296,6 +296,9 @@ class AgentService:
             body_hash=body.effective_body_hash if body else "",
             mode=config.default_mode,
         )
+        # 批次 B/PR-12：handlers 的事件（grant.consumed、receipt.received 等）
+        # 接入 AgentEventV2 journal。
+        self._handlers.set_event_sink(self._event_sink_for)
         # Daemon action channel (K3) + consent channel (ADR-0007): only when
         # a rosclawd client is actually available — otherwise both degrade
         # honestly.
@@ -318,6 +321,30 @@ class AgentService:
                 body_id=self._body_id,
                 body_hash=body.effective_body_hash if body else "",
             )
+        # PR-12：SIM 物理权威（无 daemon 时）。mcp_servers[] 带
+        # sim_executor: true 的 server 同时提供 SIM actuation。
+        sim_server = next(
+            (s for s in self._config.mcp_servers if s.get("sim_executor")), None
+        )
+        if sim_server is not None and self._daemon_client is None:
+            from rosclaw.agentd.sim_executor import SimActionChannel
+            from rosclaw.agentd.tooling.persistent_client import PersistentMcpClient
+
+            # 观测与 SIM 执行共享同一 server 进程（有状态身体）。
+            shared_client = PersistentMcpClient(
+                command=str(sim_server.get("command", "")),
+                args=tuple(str(a) for a in sim_server.get("args", []) or []),
+            )
+            self._shared_mcp_client = shared_client
+            self._handlers._sim_channel = SimActionChannel(
+                command=str(sim_server.get("command", "")),
+                args=tuple(str(a) for a in sim_server.get("args", []) or []),
+                name=str(sim_server.get("name", "sim")),
+                client=shared_client,
+            )
+            for adapter in self._mcp_adapters:
+                if adapter.source == f"mcp:{sim_server.get('name')}":
+                    adapter._client = shared_client
             self._handlers._consent_channel = self._consent_channel
         # Team Fabric: enabled via config `team.enabled`. Local coordinator
         # in P0 (local_sim); ROS 2/Zenoh transports are later PRs.
@@ -1048,6 +1075,9 @@ class AgentService:
         return path
 
     async def close(self) -> None:
+        if getattr(self, "_shared_mcp_client", None) is not None:
+            await self._shared_mcp_client.close()
+            self._shared_mcp_client = None
         if getattr(self, "_operator_socket", None) is not None:
             await self._operator_socket.stop()
             self._operator_socket = None

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -461,8 +461,13 @@ class AgentService:
         goal_text: str,
         *,
         mode: str | None = None,
-        owner_principal: str = "user:local:1000",
+        owner_principal: str | None = None,
     ) -> MissionSessionV1:
+        if owner_principal is None:
+            # 默认主体来自真实本地 uid——与 operator.sock 的 SO_PEERCRED
+            # 身份一致（CI 等非 1000 uid 环境下 EXACT_ACTION verify 才能
+            # 通过 principal 校验）。
+            owner_principal = f"user:local:{os.getuid()}"
         requested_mode = ExecutionMode(mode or self._config.default_mode)
         body = self._body_source.get_body(self._body_id)
         if body is None:

--- a/src/rosclaw/agentd/sim_executor.py
+++ b/src/rosclaw/agentd/sim_executor.py
@@ -1,0 +1,101 @@
+"""SimActionChannel（PR-12）：SIMULATION 模式下的 SIM 物理权威。
+
+与 rosclawd（REAL 唯一物理权威）镜像的 SIM 执行通道：
+- 只在 EXACT_ACTION grant 被 Broker 验证消费之后调用；
+- 直接以独立 MCP 客户端调用 SIM 身体的动作工具——此路径不属于
+  ToolCatalog，模型永远无法触达；
+- 产出 SIMULATED receipt：evidence_domain=simulation、
+  usable_for_real_execution=False、acoustic/physical 观测缺失时诚实声明
+  只证明驱动执行。
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from rosclaw.contracts.common import ValidationError, new_id
+
+
+class SimActionError(ValidationError):
+    pass
+
+
+@dataclass
+class SimActionOutcome:
+    action_id: str
+    final_state: str  # COMPLETED | FAILED
+    receipt: dict[str, Any] = field(default_factory=dict)
+
+
+class SimActionChannel:
+    """对一个 SIM MCP server 的动作执行通道（每次调用独立 stdio 会话）。"""
+
+    def __init__(
+        self,
+        *,
+        command: str,
+        args: tuple[str, ...],
+        name: str = "limo-sim",
+        client=None,
+    ) -> None:
+        self._command = command
+        self._args = args
+        self._name = name
+        #: 与观测路径共享的持久会话（有状态 SIM 身体必须同进程）。
+        self._client = client
+
+    async def execute(
+        self,
+        *,
+        capability_id: str,
+        arguments: dict[str, Any],
+        grant_id: str,
+        mode: str = "SIMULATION",
+    ) -> SimActionOutcome:
+        if mode != "SIMULATION":
+            raise SimActionError(f"SimActionChannel only executes SIMULATION, got {mode}")
+        tool_name = capability_id
+        try:
+            result_text = await self._call_tool(tool_name, arguments)
+            result = json.loads(result_text)
+        except Exception as exc:  # noqa: BLE001 - 诚实失败
+            raise SimActionError(
+                f"sim executor {self._name} failed for {tool_name}: {type(exc).__name__}: {exc}"
+            ) from exc
+        action_id = new_id("act")
+        receipt = {
+            "action_id": action_id,
+            "capability_id": capability_id,
+            "arguments": arguments,
+            "grant_id": grant_id,
+            "final_state": "COMPLETED",
+            "trust_level": "SIMULATED",
+            "evidence_domain": "simulation",
+            "evidence_level": "DRIVER_EXECUTED",
+            "usable_for_real_execution": False,
+            "executor": f"mcp:{self._name}",
+            "executor_result": result,
+            # §18.4 诚实验证：无声学/物理观测时只证明驱动执行。
+            "physical_effect_proven": bool(result.get("acoustic_observation")),
+        }
+        return SimActionOutcome(action_id=action_id, final_state="COMPLETED", receipt=receipt)
+
+    async def _call_tool(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        if self._client is not None:
+            return await self._client.call_tool(tool_name, arguments)
+        from mcp import ClientSession, StdioServerParameters
+        from mcp.client.stdio import stdio_client
+
+        params = StdioServerParameters(command=self._command, args=list(self._args))
+        async with (
+            stdio_client(params) as (read, write),
+            ClientSession(read, write) as session,
+        ):
+            await session.initialize()
+            result = await session.call_tool(tool_name, arguments)
+        if result.isError:
+            text = " ".join(getattr(b, "text", "") for b in result.content).strip()
+            raise SimActionError(f"sim tool {tool_name} error: {text or 'unknown'}")
+        return "".join(getattr(b, "text", "") for b in result.content)

--- a/src/rosclaw/agentd/tooling/catalog.py
+++ b/src/rosclaw/agentd/tooling/catalog.py
@@ -33,6 +33,10 @@ class ToolCatalog:
         self._quarantine: dict[str, str] = {}  # tool_id -> reason
 
     def register(self, descriptor: ToolDescriptorV2, executor: ToolExecutor | None = None) -> None:
+        if "__" in descriptor.tool_id:
+            raise ValidationError(
+                f"tool {descriptor.tool_id!r}: '__' is reserved for the wire-name mapping"
+            )
         if descriptor.tool_id in self._descriptors:
             raise ValidationError(f"tool {descriptor.tool_id!r} already registered")
         self._descriptors[descriptor.tool_id] = descriptor
@@ -84,10 +88,21 @@ class ToolCatalog:
 
     # -- execution --------------------------------------------------------------
 
+    def _canonical(self, tool_id: str) -> str:
+        if tool_id in self._descriptors:
+            return tool_id
+        from rosclaw.agentd.tooling.strict_schema import canonical_name
+
+        candidate = canonical_name(tool_id)
+        if candidate in self._descriptors:
+            return candidate
+        return tool_id
+
     async def execute(self, tool_id: str, arguments: dict[str, Any]) -> str:
-        descriptor = self._descriptors.get(tool_id)
+        descriptor = self._descriptors.get(self._canonical(tool_id))
         if descriptor is None:
             raise ValidationError(f"tool {tool_id!r} not in catalog")
+        tool_id = descriptor.tool_id
         if descriptor.execution_class is ExecutionClass.PHYSICAL_ACTION:
             raise ToolNotCallableError(
                 f"tool {tool_id!r} is PHYSICAL_ACTION — never directly executable; "

--- a/src/rosclaw/agentd/tooling/catalog_registry.py
+++ b/src/rosclaw/agentd/tooling/catalog_registry.py
@@ -50,7 +50,7 @@ class CatalogToolRegistry:
         """Legacy path: allowlist intersection only (no ranking)."""
         tools: list[StrictTool] = []
         for name in names:
-            descriptor = self._catalog.get(name)
+            descriptor = self._catalog.get(self._catalog._canonical(name))
             if descriptor is None or not descriptor.model_callable:
                 continue
             if self._catalog.quarantine_reason(name) is not None:

--- a/src/rosclaw/agentd/tooling/mcp_adapter.py
+++ b/src/rosclaw/agentd/tooling/mcp_adapter.py
@@ -81,9 +81,16 @@ class DiscoveryReport:
 class McpCapabilityAdapter:
     """One adapter per external MCP server."""
 
-    def __init__(self, config: McpServerConfig, catalog: ToolCatalog) -> None:
+    def __init__(
+        self,
+        config: McpServerConfig,
+        catalog: ToolCatalog,
+        client=None,
+    ) -> None:
         self._config = config
         self._catalog = catalog
+        #: 可选共享持久会话（有状态 SIM 身体必须观测/执行同进程）。
+        self._client = client
         self.source = f"mcp:{config.name}"
 
     # -- classification ---------------------------------------------------------
@@ -118,17 +125,26 @@ class McpCapabilityAdapter:
             raise ValidationError(f"mcp package unavailable: {exc}") from exc
 
         cfg = self._config
-        params = StdioServerParameters(
-            command=cfg.command, args=list(cfg.args), env=cfg.spawn_env() or None
-        )
         report = DiscoveryReport(server=self.source, ok=False)
         try:
-            async with (
-                stdio_client(params) as (read, write),
-                ClientSession(read, write) as session,
-            ):
-                await session.initialize()
-                listed = await session.list_tools()
+            if self._client is not None:
+                tools = await self._client.list_tools()
+
+                class _Listed:
+                    pass
+
+                listed = _Listed()
+                listed.tools = tools
+            else:
+                params = StdioServerParameters(
+                    command=cfg.command, args=list(cfg.args), env=cfg.spawn_env() or None
+                )
+                async with (
+                    stdio_client(params) as (read, write),
+                    ClientSession(read, write) as session,
+                ):
+                    await session.initialize()
+                    listed = await session.list_tools()
         except Exception as exc:  # noqa: BLE001 - surfaced as honest degradation
             report.error = f"{type(exc).__name__}: {exc}"
             self._catalog.quarantine_source(self.source, f"discovery_failed: {report.error}")
@@ -173,6 +189,12 @@ class McpCapabilityAdapter:
         async def _exec(arguments: dict[str, Any]) -> str:
             import json as _json
 
+            if self._client is not None:
+                raw = await self._client.call_tool(tool_name, arguments)
+                return _json.dumps(
+                    {"tool": tool_name, "source": self.source, "content": [raw]},
+                    ensure_ascii=False,
+                )
             from mcp import ClientSession, StdioServerParameters
             from mcp.client.stdio import stdio_client
 

--- a/src/rosclaw/agentd/tooling/persistent_client.py
+++ b/src/rosclaw/agentd/tooling/persistent_client.py
@@ -1,0 +1,84 @@
+"""Persistent MCP stdio client（PR-12）。
+
+per-call 短会话会让有状态 SIM 身体（如 limo-sim 的位姿）在调用之间
+丢失——观测与 SIM 执行必须共享同一个 server 进程。此客户端懒启动、
+持锁复用、失败时诚实报错并可重连。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from rosclaw.contracts.common import ValidationError
+
+
+class PersistentMcpClient:
+    def __init__(self, *, command: str, args: tuple[str, ...], env: dict | None = None) -> None:
+        self._command = command
+        self._args = args
+        self._env = env
+        self._lock = asyncio.Lock()
+        self._session = None
+        self._exit_stack = None
+
+    async def _ensure(self) -> None:
+        if self._session is not None:
+            return
+        from contextlib import AsyncExitStack
+
+        from mcp import ClientSession, StdioServerParameters
+        from mcp.client.stdio import stdio_client
+
+        params = StdioServerParameters(
+            command=self._command, args=list(self._args), env=self._env or None
+        )
+        stack = AsyncExitStack()
+        try:
+            read, write = await stack.enter_async_context(stdio_client(params))
+            session = await stack.enter_async_context(ClientSession(read, write))
+            await session.initialize()
+        except Exception:
+            await stack.aclose()
+            raise
+        self._exit_stack = stack
+        self._session = session
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        async with self._lock:
+            try:
+                await self._ensure()
+                result = await self._session.call_tool(tool_name, arguments)
+            except (ValidationError, ExceptionGroup):
+                raise
+            except Exception as exc:  # noqa: BLE001 - 连接断开：重置后重试一次
+                await self._reset()
+                try:
+                    await self._ensure()
+                    result = await self._session.call_tool(tool_name, arguments)
+                except Exception as exc2:  # noqa: BLE001
+                    raise ValidationError(
+                        f"mcp call {tool_name} failed after reconnect: "
+                        f"{type(exc2).__name__}: {exc2}"
+                    ) from exc
+            if result.isError:
+                text = " ".join(getattr(b, "text", "") for b in result.content).strip()
+                raise ValidationError(f"mcp tool {tool_name} error: {text or 'unknown'}")
+            return "".join(getattr(b, "text", "") for b in result.content)
+
+    async def list_tools(self) -> list:
+        async with self._lock:
+            await self._ensure()
+            listed = await self._session.list_tools()
+            return list(listed.tools)
+
+    async def _reset(self) -> None:
+        stack, self._exit_stack, self._session = self._exit_stack, None, None
+        if stack is not None:
+            from contextlib import suppress
+
+            with suppress(Exception):
+                await stack.aclose()
+
+    async def close(self) -> None:
+        await self._reset()

--- a/src/rosclaw/agentd/tooling/strict_schema.py
+++ b/src/rosclaw/agentd/tooling/strict_schema.py
@@ -12,6 +12,17 @@ from rosclaw.contracts.agent.tool import ExecutionClass, ToolDescriptorV2
 from rosclaw.contracts.common import ValidationError
 
 
+#: OpenAI function-name 约束（^[a-zA-Z][a-zA-Z0-9_-]*$）不允许点号——
+#: wire 上把 MCP 工具 id 的 "." 映射为 "__"（catalog 注册时拒绝含 "__" 的
+#: 原生 id，保证映射单射）。模型只见 sanitized 名；执行时反解回 canonical。
+def wire_name(tool_id: str) -> str:
+    return tool_id.replace(".", "__")
+
+
+def canonical_name(wire: str) -> str:
+    return wire.replace("__", ".")
+
+
 def to_strict_tool(descriptor: ToolDescriptorV2) -> StrictTool:
     if descriptor.execution_class is ExecutionClass.PHYSICAL_ACTION:
         raise ValidationError(
@@ -28,7 +39,7 @@ def to_strict_tool(descriptor: ToolDescriptorV2) -> StrictTool:
     schema["required"] = list(props.keys())
     description = descriptor.description or descriptor.tool_id
     description += (
-        f" [evidence_class: {descriptor.evidence_class.value}; "
+        f" [id: {descriptor.tool_id}; evidence_class: {descriptor.evidence_class.value}; "
         f"modes: {','.join(descriptor.supported_modes)}]"
     )
-    return StrictTool(name=descriptor.tool_id, description=description, parameters=schema)
+    return StrictTool(name=wire_name(descriptor.tool_id), description=description, parameters=schema)

--- a/src/rosclaw/contracts/agent/mission.py
+++ b/src/rosclaw/contracts/agent/mission.py
@@ -89,7 +89,15 @@ MISSION_TRANSITIONS: dict[MissionState, frozenset[MissionState]] = {
             MissionState.FAILED,
         }
     ),
-    MissionState.VERIFY: frozenset({MissionState.LEARN, MissionState.FAILED, MissionState.PLAN}),
+    MissionState.VERIFY: frozenset(
+        {
+            MissionState.LEARN,
+            MissionState.FAILED,
+            MissionState.PLAN,
+            # 验证阶段可能需要新的授权动作（如 LIMO 验收的第二个动作卡）。
+            MissionState.WAIT_APPROVAL,
+        }
+    ),
     MissionState.LEARN: frozenset({MissionState.IDLE}),
     MissionState.SUSPENDED: frozenset({MissionState.PLAN, MissionState.FAILED}),
     MissionState.FAILED: frozenset({MissionState.IDLE}),

--- a/src/rosclaw/limo/__init__.py
+++ b/src/rosclaw/limo/__init__.py
@@ -1,0 +1,1 @@
+"""LIMO integration (PR-12)：SIM 仿真体与验收场景。"""

--- a/src/rosclaw/limo/sim_mcp.py
+++ b/src/rosclaw/limo/sim_mcp.py
@@ -1,0 +1,125 @@
+"""LIMO 仿真 MCP server（PR-12）：SIMULATION 证据域的 LIMO 身体。
+
+观测工具（readOnlyHint=true → OBSERVE）：
+- ``limo.localization.get_pose`` — 仿真位姿（SIMULATED 证据，永不证明 REAL）
+- ``limo.health`` — 仿真健康状态
+
+动作工具（无 readOnlyHint + 动作动词 → PHYSICAL_ACTION）：
+- ``limo.speaker.play_tone`` — 仿真扬声器
+- ``limo.localization.set_initial_pose`` — 设置仿真初始位姿
+
+模型永远不能经 ToolCatalog 调用动作工具；agentd 的 SimActionChannel
+（SIM 物理权威）在 EXACT_ACTION grant 验证后才直接调用它们。
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+server = FastMCP("limo-sim")
+
+_state = {
+    "pose": {"x": 1.25, "y": -0.5, "theta": 0.03},
+    "tones": [],
+    "boot_time": time.time(),
+}
+
+
+def _ts() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()
+
+
+@server.tool(
+    name="limo.localization.get_pose",
+    description="读取 LIMO 当前定位位姿（仿真观测，SIMULATED 证据域）。",
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
+def get_pose(frame: str = "map") -> str:
+    return json.dumps(
+        {
+            "frame": frame,
+            "evidence_domain": "simulation",
+            **dict(_state["pose"]),
+            "covariance": [0.02, 0.0, 0.0, 0.0, 0.02, 0.0, 0.0, 0.0, 0.03],
+            "timestamp": _ts(),
+            "fresh": True,
+        },
+        ensure_ascii=False,
+    )
+
+
+@server.tool(
+    name="limo.health",
+    description="LIMO 仿真健康状态（电量/驱动/定位在线）。",
+    annotations=ToolAnnotations(readOnlyHint=True),
+)
+def health() -> str:
+    return json.dumps(
+        {
+            "evidence_domain": "simulation",
+            "battery_percent": 87,
+            "drive": "online",
+            "localization": "online",
+            "uptime_sec": int(time.time() - _state["boot_time"]),
+            "timestamp": _ts(),
+        },
+        ensure_ascii=False,
+    )
+
+
+@server.tool(
+    name="limo.speaker.play_tone",
+    description="播放提示音（物理动作；SIM 下为仿真执行）。",
+)
+def play_tone(frequency_hz: int = 660, duration_sec: float = 0.25, volume_percent: int = 18) -> str:
+    if not (20 <= frequency_hz <= 20_000):
+        raise ValueError(f"frequency {frequency_hz} out of range")
+    if not (0.01 <= duration_sec <= 5.0):
+        raise ValueError(f"duration {duration_sec} out of range")
+    if not (0 <= volume_percent <= 100):
+        raise ValueError(f"volume {volume_percent} out of range")
+    record = {
+        "frequency_hz": frequency_hz,
+        "duration_sec": duration_sec,
+        "volume_percent": volume_percent,
+        "executed_at": _ts(),
+        "evidence_domain": "simulation",
+        "acoustic_observation": None,  # 无麦克风：只证明驱动执行
+    }
+    _state["tones"].append(record)
+    return json.dumps({"driver": "completed", **record}, ensure_ascii=False)
+
+
+@server.tool(
+    name="limo.localization.set_initial_pose",
+    description="设置地图初始位姿（物理动作；SIM 下为仿真执行）。",
+)
+def set_initial_pose(x: float = 0.0, y: float = 0.0, yaw: float = 0.0) -> str:
+    for value in (x, y, yaw):
+        if not math.isfinite(value):
+            raise ValueError("pose values must be finite")
+    _state["pose"] = {"x": float(x), "y": float(y), "theta": float(yaw)}
+    return json.dumps(
+        {
+            "driver": "completed",
+            "evidence_domain": "simulation",
+            "pose": dict(_state["pose"]),
+            "executed_at": _ts(),
+        },
+        ensure_ascii=False,
+    )
+
+
+def main() -> None:
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agentd/conftest.py
+++ b/tests/agentd/conftest.py
@@ -1,0 +1,9 @@
+"""Shared test constants for agentd suites."""
+
+from __future__ import annotations
+
+import os
+
+#: 与 operator.sock 的 SO_PEERCRED 语义一致的本地主体（CI 运行 uid 可能
+#: 不是 1000）。凡走完整审批-验证链路的测试必须使用它而不是硬编码 uid。
+LOCAL_PRINCIPAL = f"user:local:{os.getuid()}"

--- a/tests/agentd/context/test_compiler.py
+++ b/tests/agentd/context/test_compiler.py
@@ -46,6 +46,7 @@ from rosclaw.contracts.agent.mission import (
 )
 from rosclaw.contracts.agent.task_graph import TaskGraphV1
 from rosclaw.contracts.common import new_id
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 NOW = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
 
@@ -147,7 +148,7 @@ def _sources(**overrides) -> SourceBundle:
 def _mission() -> MissionSessionV1:
     return MissionSessionV1(
         mission_id="mis_test",
-        owner_principal="user:local:1000",
+        owner_principal=LOCAL_PRINCIPAL,
         goal=Goal(text="移动红色方块"),
         body_binding=BodyBinding(body_id="sim_ur5e_01", effective_body_hash="body_abc"),
         created_at="2026-08-01T00:00:00Z",

--- a/tests/agentd/mission/test_store.py
+++ b/tests/agentd/mission/test_store.py
@@ -34,6 +34,7 @@ from rosclaw.contracts.agent.task_graph import (
     TaskNodeV1,
 )
 from rosclaw.contracts.common import ValidationError, new_id
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 ACTOR = "agent:rosclaw-native:sim_ur5e_01"
 
@@ -44,7 +45,7 @@ def _store(tmp_path: Path, name: str = "missions.db") -> MissionStore:
 
 def _mission(store: MissionStore, **kwargs):
     return store.create_mission(
-        owner_principal="user:local:1000",
+        owner_principal=LOCAL_PRINCIPAL,
         goal=Goal(text="测试任务"),
         body_binding=BodyBinding(body_id="sim_ur5e_01", effective_body_hash="body_abc"),
         actor_id=ACTOR,

--- a/tests/agentd/test_audit_fixes.py
+++ b/tests/agentd/test_audit_fixes.py
@@ -31,6 +31,7 @@ from rosclaw.contracts.team.world import ObjectState, SharedWorldDeltaV1
 from rosclaw.operator import GrantDeniedError, OperatorBroker
 from rosclaw.team import TeamCoordinator
 from rosclaw.team.allocator import Bid, TaskAnnouncement
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 NOW = datetime.now(UTC)
 
@@ -39,7 +40,7 @@ def _approval_request() -> ApprovalRequestV2:
     return ApprovalRequestV2(
         request_id="appr_audit",
         mission_id="mis_x",
-        principal="user:local:1000",
+        principal=LOCAL_PRINCIPAL,
         body_id="sim/ur5e",
         effective_body_hash="body_abc",
         mode="SIMULATION",
@@ -60,11 +61,11 @@ def broker(tmp_path: Path) -> OperatorBroker:
 class TestV1ExactActionBinding:
     def test_missing_action_intent_denied(self, broker: OperatorBroker) -> None:
         broker.create_request(_approval_request())
-        grant = broker.decide("appr_audit", principal="user:local:1000", approve=True)
+        grant = broker.decide("appr_audit", principal=LOCAL_PRINCIPAL, approve=True)
         with pytest.raises(GrantDeniedError, match="missing_action_intent"):
             broker.verify(
                 grant.grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="SIMULATION",
                 risk_tier="LOW",
@@ -73,12 +74,12 @@ class TestV1ExactActionBinding:
 
     def test_broker_computed_intent_accepted_then_consumed(self, broker: OperatorBroker) -> None:
         broker.create_request(_approval_request())
-        grant = broker.decide("appr_audit", principal="user:local:1000", approve=True)
+        grant = broker.decide("appr_audit", principal=LOCAL_PRINCIPAL, approve=True)
         intent = broker.action_intent_for_grant(grant.grant_id)
         assert intent is not None
         broker.verify(
             grant.grant_id,
-            principal="user:local:1000",
+            principal=LOCAL_PRINCIPAL,
             body_hash="body_abc",
             mode="SIMULATION",
             risk_tier="LOW",
@@ -87,11 +88,11 @@ class TestV1ExactActionBinding:
 
     def test_wrong_intent_denied(self, broker: OperatorBroker) -> None:
         broker.create_request(_approval_request())
-        grant = broker.decide("appr_audit", principal="user:local:1000", approve=True)
+        grant = broker.decide("appr_audit", principal=LOCAL_PRINCIPAL, approve=True)
         with pytest.raises(GrantDeniedError, match="action_intent_mismatch"):
             broker.verify(
                 grant.grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="SIMULATION",
                 risk_tier="LOW",
@@ -110,7 +111,7 @@ class TestV2BrokerKey:
 
     def test_signature_forgery_via_public_input_fails(self, broker: OperatorBroker) -> None:
         broker.create_request(_approval_request())
-        grant = broker.decide("appr_audit", principal="user:local:1000", approve=True)
+        grant = broker.decide("appr_audit", principal=LOCAL_PRINCIPAL, approve=True)
         # Attacker recomputes HMAC with the previously-derivable key.
         attacker_key = hashlib.sha256(b"operator:pol_audit").digest()
         forged = hmac.new(attacker_key, grant.public_hash.encode(), hashlib.sha256).hexdigest()
@@ -121,7 +122,7 @@ class TestV2BrokerKey:
         with pytest.raises(GrantDeniedError, match="forged_grant"):
             broker.verify(
                 grant.grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="SIMULATION",
                 risk_tier="LOW",

--- a/tests/agentd/test_bench_learning.py
+++ b/tests/agentd/test_bench_learning.py
@@ -21,6 +21,7 @@ from rosclaw.agentd.learning.pipeline import (
     PromotionGateError,
 )
 from rosclaw.agentd.mission import MissionStore
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 
 def _home_factory(base: Path):
@@ -103,12 +104,12 @@ class TestLearningPipeline:
             pipe.promote(cid, principal="agent:rosclaw-native:b1", evaluation_ref="eval://1")
         # No evaluation reference rejected.
         with pytest.raises(PromotionGateError, match="evaluation reference"):
-            pipe.promote(cid, principal="user:local:1000", evaluation_ref="")
+            pipe.promote(cid, principal=LOCAL_PRINCIPAL, evaluation_ref="")
         # Human + evaluation → promoted.
-        pipe.promote(cid, principal="user:local:1000", evaluation_ref="eval://darwin/1")
+        pipe.promote(cid, principal=LOCAL_PRINCIPAL, evaluation_ref="eval://darwin/1")
         rows = pipe.list(status="PROMOTED")
         assert len(rows) == 1
-        assert rows[0]["promoted_by"] == "user:local:1000"
+        assert rows[0]["promoted_by"] == LOCAL_PRINCIPAL
 
     def test_extract_from_accepted_work(self, tmp_path: Path) -> None:
         from rosclaw.agentd.config import load_agent_config

--- a/tests/agentd/test_consent_channel.py
+++ b/tests/agentd/test_consent_channel.py
@@ -27,6 +27,7 @@ from rosclaw.kernel.contracts import (
     EvidenceLevel,
     ExecutionMode,
 )
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 REAL_CAPABILITY = "rh56.finger.move"
 
@@ -101,7 +102,7 @@ class TestRealConsentFlow:
         assert "permit" not in str(proposal).lower()
         decided = await channel.decide(
             proposal["request_id"],
-            principal_id="user:local:1000",
+            principal_id=LOCAL_PRINCIPAL,
             accept=True,
             supervise_timeout_sec=15.0,
         )
@@ -114,7 +115,7 @@ class TestRealConsentFlow:
         assert inner.get("final_state") == "COMPLETED"
         provenance = (inner.get("authorization_decision") or {}).get("provenance") or {}
         assert provenance.get("proposal_request_id") == proposal["request_id"]
-        assert provenance.get("operator_principal") == "user:local:1000"
+        assert provenance.get("operator_principal") == LOCAL_PRINCIPAL
 
     async def test_decline_dispatches_nothing(self, daemon) -> None:
         client, _ = daemon
@@ -127,7 +128,7 @@ class TestRealConsentFlow:
             risk_class="high",
             ttl_sec=60.0,
         )
-        await channel.decide(proposal["request_id"], principal_id="user:local:1000", accept=False)
+        await channel.decide(proposal["request_id"], principal_id=LOCAL_PRINCIPAL, accept=False)
         terminal = await channel.proposal(proposal["request_id"])
         assert terminal.get("state") == "DECLINED"
 
@@ -147,7 +148,7 @@ class TestRealConsentFlow:
             client.decide_operator_proposal(
                 proposal["request_id"],
                 decision="ACCEPT",
-                principal_id="user:local:1000",
+                principal_id=LOCAL_PRINCIPAL,
                 challenge_nonce="forged-nonce",
                 action_intent_hash=pending[0]["action_intent_hash"],
                 channel="test",
@@ -168,10 +169,10 @@ class TestRealConsentFlow:
             risk_class="high",
             ttl_sec=60.0,
         )
-        await channel.decide(proposal["request_id"], principal_id="user:local:1000", accept=True)
+        await channel.decide(proposal["request_id"], principal_id=LOCAL_PRINCIPAL, accept=True)
         with pytest.raises(ConsentChannelError, match="no pending proposal"):
             await channel.decide(
-                proposal["request_id"], principal_id="user:local:1000", accept=True
+                proposal["request_id"], principal_id=LOCAL_PRINCIPAL, accept=True
             )
 
 
@@ -197,7 +198,7 @@ class TestRestartInvalidation:
         channel2 = _channel(client2)
         with pytest.raises(ConsentChannelError, match="no pending proposal"):
             await channel2.decide(
-                proposal["request_id"], principal_id="user:local:1000", accept=True
+                proposal["request_id"], principal_id=LOCAL_PRINCIPAL, accept=True
             )
         # …并且账本里记录了 INVALIDATED 事件（可追溯）。
         from rosclaw.daemon.ledger import DaemonLedger

--- a/tests/agentd/test_intents.py
+++ b/tests/agentd/test_intents.py
@@ -22,6 +22,7 @@ from rosclaw.agentd.verifiers import VerifierRegistry
 from rosclaw.contracts.agent.agent_event import AgentEventType
 from rosclaw.contracts.agent.mission import MissionState
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 
 def _decision_turn(request, decision: dict) -> ModelTurnResultV1:
@@ -312,7 +313,7 @@ class TestRequestActionMonitor:
             assert r1.state is MissionState.WAIT_APPROVAL
             pending = service.pending_approvals(mission.mission_id)
             grant = await service.decide_approval(
-                pending[0].request_id, principal="user:local:1000", approve=True
+                pending[0].request_id, principal=LOCAL_PRINCIPAL, approve=True
             )
             script.grant_id = grant.grant_id
             r2 = await service.send_turn(mission.mission_id, "执行")

--- a/tests/agentd/test_k3_daemon_loop.py
+++ b/tests/agentd/test_k3_daemon_loop.py
@@ -30,7 +30,6 @@ from rosclaw.kernel.contracts import (
     EvidenceLevel,
     ExecutionMode,
 )
-
 from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 SIM_CAPABILITY = "sim.hold_position"

--- a/tests/agentd/test_k3_daemon_loop.py
+++ b/tests/agentd/test_k3_daemon_loop.py
@@ -31,6 +31,8 @@ from rosclaw.kernel.contracts import (
     ExecutionMode,
 )
 
+from tests.agentd.conftest import LOCAL_PRINCIPAL
+
 SIM_CAPABILITY = "sim.hold_position"
 
 
@@ -180,7 +182,7 @@ class TestK3SimActionLoop:
             assert r1.state.value == "WAIT_APPROVAL"
             pending = service.pending_approvals(mission.mission_id)
             grant = await service.decide_approval(
-                pending[0].request_id, principal="user:local:1000", approve=True
+                pending[0].request_id, principal=LOCAL_PRINCIPAL, approve=True
             )
             _action_decision.grant_id = grant.grant_id
             r2 = await service.send_turn(mission.mission_id, "已批准，执行")
@@ -201,7 +203,7 @@ class TestK3SimActionLoop:
             await service.send_turn(mission.mission_id, "请求授权")
             pending = service.pending_approvals(mission.mission_id)
             grant = await service.decide_approval(
-                pending[0].request_id, principal="user:local:1000", approve=True
+                pending[0].request_id, principal=LOCAL_PRINCIPAL, approve=True
             )
             _action_decision.grant_id = grant.grant_id
             # Point the channel at a nonexistent daemon.
@@ -254,7 +256,7 @@ class TestRealProposalChannel:
             arguments={"frequency_hz": 660, "duration_sec": 0.6},
             grant_id="grant_public_only",
             grant_public_hash="grantpub_hash",
-            principal_id="user:local:1000",
+            principal_id=LOCAL_PRINCIPAL,
             risk_tier="MEDIUM",
             display={"title": "Play bounded tone", "risk_tier": "MEDIUM"},
         )

--- a/tests/agentd/test_kimi_live.py
+++ b/tests/agentd/test_kimi_live.py
@@ -18,6 +18,7 @@ API is unreachable the tests fail, they never fabricate success.
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -483,5 +484,94 @@ async def test_k8_modeld_service_loop_live(tmp_path: Path) -> None:
         assert result.reply.strip(), "empty reply through modeld backend"
         usage = service.mission_usage(mission.mission_id)
         assert usage.get("total_tokens", 0) > 0, "usage not metered"
+    finally:
+        await service.close()
+
+
+
+async def test_k9_limo_acceptance_live(tmp_path: Path) -> None:
+    """K9 (PR-12 验收)：真实 Kimi K3 驱动 LIMO 完整闭环（SIMULATION 证据域）。"""
+    import yaml
+
+    from rosclaw.agentd.bench.limo_acceptance import limo_sim_mcp_server_config
+    from rosclaw.agentd.config import load_agent_config
+    from rosclaw.agentd.models.gateway import OpenAICompatGateway
+    from rosclaw.agentd.models.profiles import kimi_code_k3_profile
+    from rosclaw.agentd.operator_socket import operator_call
+    from rosclaw.agentd.service import AgentService
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"agent": {"enabled": True}, "mcp_servers": [limo_sim_mcp_server_config()]}
+        ),
+        encoding="utf-8",
+    )
+    config = load_agent_config(tmp_path / "config.yaml")
+    service = AgentService(
+        config, tmp_path, gateway=OpenAICompatGateway(kimi_code_k3_profile(base_url=BASE_URL))
+    )
+    sock = await service.start_operator_socket()
+    try:
+        mission = service.create_mission("LIMO 验收：扬声器与定位")
+        guidance = (
+            "按你的协议完成验收流程（工具名一律逐字使用工具目录里列出的名字，"
+            "不要自己改写或拼写）：1) 用 OBSERVE 调用位姿工具和健康工具读取状态；"
+            "2) 用 REQUEST_APPROVAL 请求播放提示音授权（capability_id "
+            "limo.speaker.play_tone，arguments 含 frequency_hz=660, duration_sec=0.6, "
+            "volume_percent=18，payload 顶层带 capability_id 和 arguments）；"
+            "3) 我批准后用 REQUEST_ACTION 执行（payload 带 grant_id——逐字复制系统提示 "
+            "TRUSTED CONTEXT 里的 Active mission grant 行）、capability_id、arguments；"
+            "4) 同样流程请求并执行 limo.localization.set_initial_pose (x=0,y=0,yaw=0)；"
+            "5) 再用 OBSERVE 调用位姿工具验证新位姿；6) 报告结果。"
+            "REQUEST_APPROVAL 和 REQUEST_ACTION 的 decision 都要带 verification.verifiers。"
+        )
+        last_reply = ""
+        for _step in range(16):
+            result = await service.send_turn(
+                mission.mission_id, guidance if _step == 0 else "继续按协议执行下一步。"
+            )
+            last_reply = result.reply
+            if service.pending_approvals(mission.mission_id):
+                listed = await operator_call(sock, "approvals.list")
+                entry = listed["approvals"][0]
+                decided = await operator_call(
+                    sock,
+                    "approvals.decide",
+                    {
+                        "request_id": entry["request_id"],
+                        "display_hash": entry["display_hash"],
+                        "approve": True,
+                    },
+                )
+                assert decided["ok"], decided
+                continue
+            if result.state.value == "FAILED":
+                break
+        history = json.dumps(service.conversation(mission.mission_id), ensure_ascii=False)
+        assert "limo.speaker.play_tone" in history, last_reply[:300]
+        assert "COMPLETED" in history, last_reply[:300]
+        events = service.events_replay(mission.mission_id)
+        types = [e.type.value for e in events]
+        assert "grant.consumed" in types, types
+        assert "receipt.received" in types, types
+        from rosclaw.operator import GrantDeniedError
+
+        grants = service.list_grants()
+        assert grants, "no grants were minted"
+        for grant in grants:
+            if not grant.get("consumed"):
+                continue
+            try:
+                service._broker.verify(
+                    grant["grant_id"],
+                    principal=grant["principal"],
+                    body_hash=mission.body_binding.effective_body_hash,
+                    mode="SIMULATION",
+                    risk_tier="LOW",
+                    action_intent=service._broker.action_intent_for_grant(grant["grant_id"]),
+                )
+                raise AssertionError("consumed grant accepted again")
+            except GrantDeniedError as exc:
+                assert exc.reason_code == "grant_consumed"
     finally:
         await service.close()

--- a/tests/agentd/test_kimi_live.py
+++ b/tests/agentd/test_kimi_live.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import pytest
 
 from rosclaw.agentd.models.modeld_gateway import _find_modeld_runtime as _find_runtime
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 KEY = os.environ.get("ROSCLAW_KIMI_API_KEY", "")
 BASE_URL = os.environ.get("ROSCLAW_KIMI_BASE_URL", "https://api.kimi.com/coding/v1")
@@ -304,7 +305,7 @@ async def test_k5_operator_consent_loop(tmp_path: Path) -> None:
         assert card.title and card.risk_tier in ("LOW", "MEDIUM", "HIGH", "CRITICAL")
 
         grant = await service.decide_approval(
-            pending[0].request_id, principal="user:local:1000", approve=True
+            pending[0].request_id, principal=LOCAL_PRINCIPAL, approve=True
         )
         assert grant is not None
 
@@ -326,7 +327,7 @@ async def test_k5_operator_consent_loop(tmp_path: Path) -> None:
         try:
             service._broker.verify(
                 grant.grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash=grant.effective_body_hash,
                 mode="SIMULATION",
                 risk_tier="LOW",

--- a/tests/agentd/test_limo_acceptance.py
+++ b/tests/agentd/test_limo_acceptance.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from rosclaw.agentd.bench.limo_acceptance import run_acceptance
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 
 async def test_limo_acceptance_simulation(tmp_path: Path) -> None:
@@ -60,6 +61,6 @@ async def test_shadow_real_gates_honest(tmp_path: Path) -> None:
         from rosclaw.contracts.common import ValidationError
 
         with pytest.raises(ValidationError, match="estop unavailable"):
-            await service.estop("test", principal="user:local:1000")
+            await service.estop("test", principal=LOCAL_PRINCIPAL)
     finally:
         await service.close()

--- a/tests/agentd/test_limo_acceptance.py
+++ b/tests/agentd/test_limo_acceptance.py
@@ -1,0 +1,65 @@
+"""PR-12 LIMO 完整闭环验收（SIMULATION 证据域）。
+
+真实路径：limo-sim MCP（stdio）→ OBSERVE 证据封装 → REQUEST_APPROVAL →
+operator.sock（peer identity + display hash）→ Broker EXACT_ACTION →
+REQUEST_ACTION → SimActionChannel 执行 → SIMULATED receipt →
+位姿验证 → practice candidate。SHADOW/REAL 门控诚实拒绝。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rosclaw.agentd.bench.limo_acceptance import run_acceptance
+
+
+async def test_limo_acceptance_simulation(tmp_path: Path) -> None:
+    report = await run_acceptance(tmp_path)
+    failed = [k for k, v in report.checks.items() if not v]
+    assert not failed, f"acceptance failed: {failed}\nnotes: {report.notes}"
+    assert report.practice_candidate
+    # SIM 证据域诚实：grants 单次消费、receipts 持久化。
+    assert report.checks["C9_grants_single_use"]
+    assert report.checks["C10_trace_persisted"]
+    assert report.checks["C5_honest_no_acoustic_proof"]
+
+
+async def test_shadow_real_gates_honest(tmp_path: Path) -> None:
+    """无 rosclawd/真实硬件时 SHADOW/REAL 不得用 SIM 证据冒充。"""
+    import yaml
+
+    from rosclaw.agentd.bench.limo_acceptance import limo_sim_mcp_server_config
+    from rosclaw.agentd.config import load_agent_config
+    from rosclaw.agentd.models.gateway import MockModelGateway
+    from rosclaw.agentd.models.profiles import mock_profile
+    from rosclaw.agentd.service import AgentService
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"agent": {"enabled": True}, "mcp_servers": [limo_sim_mcp_server_config()]}
+        ),
+        encoding="utf-8",
+    )
+    config = load_agent_config(tmp_path / "config.yaml")
+    service = AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), []))
+    try:
+        # SimActionChannel 只接受 SIMULATION。
+        import pytest
+
+        from rosclaw.agentd.sim_executor import SimActionChannel
+
+        channel = SimActionChannel(command="true", args=())
+        with pytest.raises(Exception, match="SIMULATION"):
+            await channel.execute(
+                capability_id="limo.speaker.play_tone",
+                arguments={},
+                grant_id="g",
+                mode="SHADOW",
+            )
+        # REAL 模式 mission 在无 daemon 时 estop 诚实不可用。
+        from rosclaw.contracts.common import ValidationError
+
+        with pytest.raises(ValidationError, match="estop unavailable"):
+            await service.estop("test", principal="user:local:1000")
+    finally:
+        await service.close()

--- a/tests/agentd/test_loop.py
+++ b/tests/agentd/test_loop.py
@@ -36,6 +36,7 @@ from rosclaw.contracts.agent.mission import (
     MissionState,
 )
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1, ToolCall
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 NOW = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
 ACTOR = "agent:rosclaw-native:sim_ur5e_01"
@@ -155,7 +156,7 @@ def store(tmp_path: Path) -> MissionStore:
 @pytest.fixture
 def mission(store: MissionStore) -> MissionSessionV1:
     return store.create_mission(
-        owner_principal="user:local:1000",
+        owner_principal=LOCAL_PRINCIPAL,
         goal=Goal(text="检查机器人状态"),
         body_binding=BodyBinding(body_id="sim_ur5e_01", effective_body_hash="body_abc"),
         actor_id=ACTOR,

--- a/tests/agentd/test_operator.py
+++ b/tests/agentd/test_operator.py
@@ -26,6 +26,7 @@ from rosclaw.contracts.agent.decision import DecisionV1
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
 from rosclaw.contracts.operator.approval import ActionDisplayV1, ApprovalRequestV2
 from rosclaw.operator import GrantDeniedError, OperatorBroker
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 NOW = datetime.now(UTC)
 
@@ -34,7 +35,7 @@ def _request(broker_body_hash: str = "body_abc", **overrides) -> ApprovalRequest
     payload = {
         "request_id": "appr_test1",
         "mission_id": "mis_x",
-        "principal": "user:local:1000",
+        "principal": LOCAL_PRINCIPAL,
         "body_id": "sim/ur5e",
         "effective_body_hash": broker_body_hash,
         "mode": "SIMULATION",
@@ -63,7 +64,7 @@ def broker(tmp_path: Path) -> OperatorBroker:
 class TestGrantLifecycle:
     def test_approve_mints_public_grant(self, broker: OperatorBroker) -> None:
         broker.create_request(_request())
-        grant = broker.decide("appr_test1", principal="user:local:1000", approve=True)
+        grant = broker.decide("appr_test1", principal=LOCAL_PRINCIPAL, approve=True)
         assert grant is not None
         dumped = json.dumps(grant.model_dump(mode="json"))
         assert "signature" not in dumped
@@ -78,17 +79,17 @@ class TestGrantLifecycle:
 
     def test_deny_is_terminal(self, broker: OperatorBroker) -> None:
         broker.create_request(_request())
-        assert broker.decide("appr_test1", principal="user:local:1000", approve=False) is None
+        assert broker.decide("appr_test1", principal=LOCAL_PRINCIPAL, approve=False) is None
         with pytest.raises(Exception, match="already"):
-            broker.decide("appr_test1", principal="user:local:1000", approve=True)
+            broker.decide("appr_test1", principal=LOCAL_PRINCIPAL, approve=True)
 
     def test_verify_happy_path_single_use(self, broker: OperatorBroker) -> None:
         broker.create_request(_request())
-        grant = broker.decide("appr_test1", principal="user:local:1000", approve=True)
+        grant = broker.decide("appr_test1", principal=LOCAL_PRINCIPAL, approve=True)
         intent = broker.action_intent_for_grant(grant.grant_id)
         verified = broker.verify(
             grant.grant_id,
-            principal="user:local:1000",
+            principal=LOCAL_PRINCIPAL,
             body_hash="body_abc",
             mode="SIMULATION",
             risk_tier="LOW",
@@ -99,7 +100,7 @@ class TestGrantLifecycle:
         with pytest.raises(GrantDeniedError, match="grant_consumed"):
             broker.verify(
                 grant.grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="SIMULATION",
                 risk_tier="LOW",
@@ -110,7 +111,7 @@ class TestGrantLifecycle:
 class TestFailClosed:
     def _grant(self, broker: OperatorBroker) -> str:
         broker.create_request(_request())
-        grant = broker.decide("appr_test1", principal="user:local:1000", approve=True)
+        grant = broker.decide("appr_test1", principal=LOCAL_PRINCIPAL, approve=True)
         assert grant is not None
         return grant.grant_id
 
@@ -118,7 +119,7 @@ class TestFailClosed:
         with pytest.raises(GrantDeniedError, match="unknown_grant"):
             broker.verify(
                 "grant_ghost",
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="SIMULATION",
                 risk_tier="LOW",
@@ -126,11 +127,11 @@ class TestFailClosed:
 
     def test_revoked(self, broker: OperatorBroker) -> None:
         grant_id = self._grant(broker)
-        broker.revoke(grant_id, principal="user:local:1000")
+        broker.revoke(grant_id, principal=LOCAL_PRINCIPAL)
         with pytest.raises(GrantDeniedError, match="grant_revoked"):
             broker.verify(
                 grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="SIMULATION",
                 risk_tier="LOW",
@@ -145,7 +146,7 @@ class TestFailClosed:
         with pytest.raises(GrantDeniedError, match="grant_expired"):
             broker.verify(
                 grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="SIMULATION",
                 risk_tier="LOW",
@@ -167,7 +168,7 @@ class TestFailClosed:
         with pytest.raises(GrantDeniedError, match="body_hash_changed"):
             broker.verify(
                 grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_DIFFERENT",
                 mode="SIMULATION",
                 risk_tier="LOW",
@@ -178,7 +179,7 @@ class TestFailClosed:
         with pytest.raises(GrantDeniedError, match="mode_mismatch"):
             broker.verify(
                 grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="REAL",
                 risk_tier="LOW",
@@ -189,7 +190,7 @@ class TestFailClosed:
         with pytest.raises(GrantDeniedError, match="risk_above_ceiling"):
             broker.verify(
                 grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="SIMULATION",
                 risk_tier="HIGH",
@@ -204,7 +205,7 @@ class TestFailClosed:
         with pytest.raises(GrantDeniedError, match="forged_grant"):
             broker.verify(
                 grant_id,
-                principal="user:local:1000",
+                principal=LOCAL_PRINCIPAL,
                 body_hash="body_abc",
                 mode="SIMULATION",
                 risk_tier="LOW",
@@ -286,7 +287,7 @@ class TestApprovalLoop:
             pending = service.pending_approvals(mission.mission_id)
             assert len(pending) == 1
             grant = await service.decide_approval(
-                pending[0].request_id, principal="user:local:1000", approve=True
+                pending[0].request_id, principal=LOCAL_PRINCIPAL, approve=True
             )
             assert grant is not None
             consent = service._compiler._sources.consent.get_consent(mission.mission_id)
@@ -306,7 +307,7 @@ class TestApprovalLoop:
             with pytest.raises(GrantDeniedError, match="grant_consumed"):
                 service._broker.verify(
                     grant.grant_id,
-                    principal="user:local:1000",
+                    principal=LOCAL_PRINCIPAL,
                     body_hash=grant.effective_body_hash,
                     mode="SIMULATION",
                     risk_tier="LOW",
@@ -423,7 +424,7 @@ class TestApprovalLoop:
             with pytest.raises(GrantDeniedError, match="grant_revoked"):
                 service._broker.verify(
                     gid,
-                    principal="user:local:1000",
+                    principal=LOCAL_PRINCIPAL,
                     body_hash=grants[0].get("effective_body_hash", ""),
                     mode="SIMULATION",
                     risk_tier="LOW",

--- a/tests/agentd/test_release_packaging.py
+++ b/tests/agentd/test_release_packaging.py
@@ -1,0 +1,106 @@
+"""PR-12 发布打包测试：构建脚本产出结构完整、安装/回滚脚本语义正确。
+
+- bundle 含 src/pyproject/packages dist/third_party/manifest/install/rollback
+- manifest hash 与文件内容一致
+- install.sh 原子切换 current/previous；rollback.sh 校验 manifest 后回切
+（在临时目录用替身 venv/pip 做全dry 结构验证，不做真实安装）
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+BUILD = REPO / "scripts" / "build_release.sh"
+INSTALL = REPO / "scripts" / "release" / "install_release.sh"
+ROLLBACK = REPO / "scripts" / "release" / "rollback.sh"
+
+
+@pytest.mark.slow
+def test_build_release_bundle_structure(tmp_path: Path) -> None:
+    env = dict(os.environ)
+    result = subprocess.run(
+        ["bash", str(BUILD)],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    dist = REPO / "dist"
+    bundles = list(dist.glob("rosclaw-*-linux-*.tar.gz"))
+    assert bundles, "no bundle produced"
+    bundle = bundles[0]
+    with tarfile.open(bundle) as tf:
+        names = tf.getnames()
+        root = names[0].split("/")[0]
+        expected = [
+            f"{root}/pyproject.toml",
+            f"{root}/manifest.json",
+            f"{root}/install.sh",
+            f"{root}/rollback.sh",
+            f"{root}/packages/rosclaw-tui/package.json",
+            f"{root}/packages/rosclaw-tui/package-lock.json",
+            f"{root}/packages/rosclaw-modeld/package.json",
+            f"{root}/packages/rosclaw-modeld/package-lock.json",
+            f"{root}/third_party/pi/LICENSE",
+            f"{root}/third_party/pi/NOTICE.md",
+        ]
+        for needle in expected:
+            assert needle in names, f"missing {needle}"
+        # TUI/modeld 已构建产物必须进包（安装侧可离线 npm ci 重建）。
+        assert any("rosclaw-tui/dist/src/main.js" in n for n in names)
+        assert any("rosclaw-modeld/dist/src/main.js" in n for n in names)
+        manifest = json.loads(tf.extractfile(f"{root}/manifest.json").read())
+        assert manifest["product"] == "rosclaw"
+        assert manifest["files"], "manifest must hash every file"
+
+
+class TestInstallRollbackSemantics:
+    def test_scripts_syntax_and_guards(self) -> None:
+        for script in (BUILD, INSTALL, ROLLBACK):
+            result = subprocess.run(["bash", "-n", str(script)], capture_output=True)
+            assert result.returncode == 0, f"{script} syntax error"
+
+    def test_rollback_requires_previous(self, tmp_path: Path) -> None:
+        prefix = tmp_path / "prefix"
+        (prefix / "current").mkdir(parents=True)
+        env = dict(os.environ, ROSCLAW_PREFIX=str(prefix))
+        result = subprocess.run(
+            ["bash", str(ROLLBACK)], capture_output=True, text=True, env=env
+        )
+        assert result.returncode == 2
+        assert "没有可回滚" in result.stderr
+
+    def test_rollback_requires_manifest(self, tmp_path: Path) -> None:
+        prefix = tmp_path / "prefix"
+        (prefix / "current").mkdir(parents=True)
+        (prefix / "previous").mkdir()
+        env = dict(os.environ, ROSCLAW_PREFIX=str(prefix))
+        result = subprocess.run(
+            ["bash", str(ROLLBACK)], capture_output=True, text=True, env=env
+        )
+        assert result.returncode == 2
+        assert "manifest" in result.stderr
+
+    def test_rollback_swaps_current(self, tmp_path: Path) -> None:
+        prefix = tmp_path / "prefix"
+        (prefix / "current").mkdir(parents=True)
+        (prefix / "current" / "marker_new").write_text("new")
+        (prefix / "previous").mkdir()
+        (prefix / "previous" / "manifest.json").write_text("{}")
+        (prefix / "previous" / "marker_old").write_text("old")
+        env = dict(os.environ, ROSCLAW_PREFIX=str(prefix))
+        result = subprocess.run(
+            ["bash", str(ROLLBACK)], capture_output=True, text=True, env=env
+        )
+        assert result.returncode == 0, result.stderr
+        assert (prefix / "current" / "marker_old").exists()
+        assert list(prefix.glob("failed-*")), "failed version must be preserved"

--- a/tests/agentd/test_runner.py
+++ b/tests/agentd/test_runner.py
@@ -19,6 +19,7 @@ from rosclaw.agentd.models.gateway import MockModelGateway
 from rosclaw.agentd.models.profiles import mock_profile
 from rosclaw.agentd.service import AgentService
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+from tests.agentd.conftest import LOCAL_PRINCIPAL
 
 
 def _approval_then_action(request) -> ModelTurnResultV1:
@@ -108,7 +109,7 @@ class TestApprovalAutoWake:
             assert state == "WAIT_APPROVAL"
             pending = service.pending_approvals(mission.mission_id)
             grant = await service.decide_approval(
-                pending[0].request_id, principal="user:local:1000", approve=True
+                pending[0].request_id, principal=LOCAL_PRINCIPAL, approve=True
             )
             _approval_then_action.grant_id = grant.grant_id
             # 唤醒任务自己运行：无需用户再发消息。
@@ -137,7 +138,7 @@ class TestApprovalAutoWake:
             await service._turn_tasks[mission.mission_id]
             pending = service.pending_approvals(mission.mission_id)
             result = await service.decide_approval(
-                pending[0].request_id, principal="user:local:1000", approve=False
+                pending[0].request_id, principal=LOCAL_PRINCIPAL, approve=False
             )
             assert result is None
             wake_task = service._runner._wake_tasks.get(mission.mission_id)

--- a/tests/agentd/test_tooling.py
+++ b/tests/agentd/test_tooling.py
@@ -243,6 +243,7 @@ class TestStrictSchema:
         tool = to_strict_tool(
             _obs(input_schema={"type": "object", "properties": {"f": {"type": "string"}}})
         )
+        assert tool.name == "test__observe"  # wire 名（点号 → __）
         assert tool.parameters["additionalProperties"] is False
         assert tool.parameters["required"] == ["f"]
         assert "evidence_class" in tool.description
@@ -391,7 +392,7 @@ class TestCatalogRegistry:
         )
         # strict_tools never surfaces the physical action
         names = [t.name for t in registry.strict_tools(["t.obs", "t.act"])]
-        assert names == ["t.obs"]
+        assert names == ["t__obs"]
         with pytest.raises(ToolNotCallableError):
             await registry.execute("t.act", {})
         env = registry.evidence_envelope("t.obs", "data", body_id="b")
@@ -403,7 +404,7 @@ class TestCatalogRegistry:
         catalog.register(_obs("t.real", supported_modes=["REAL"]))
         registry = CatalogToolRegistry(catalog, ToolResolver(catalog))
         sim_names = {t.name for t in registry.resolve_tools(["t.sim", "t.real"], mode="SIMULATION")}
-        assert sim_names == {"t.sim"}
+        assert sim_names == {"t__sim"}
         excluded = registry.excluded_reasons(["t.sim", "t.real"], mode="SIMULATION")
         assert "mode_not_allowed" in excluded["t.real"][0]
 


### PR DESCRIPTION
## Summary

PR-12, the capstone of the Pi TUI/Provider outline: the natural-language → trusted-receipt → learning-candidate loop, repeatably verifiable, plus Linux arm64 release packaging.

**LIMO loop (§18, C1–C10)**
- `rosclaw.limo.sim_mcp`: LIMO simulation MCP — `get_pose`/`health` are readOnlyHint → OBSERVE; `play_tone`/`set_initial_pose` are PHYSICAL_ACTION (never model-callable).
- `SimActionChannel` (SIM physical authority): executes only after the EXACT_ACTION grant is verified and consumed; issues SIMULATED receipts (`evidence_domain=simulation`, `usable_for_real_execution=false`). Without acoustic observation it honestly proves driver execution only (§18.4) — SIM evidence never masquerades as SHADOW/REAL; those gates refuse without rosclawd/hardware.
- `PersistentMcpClient`: observation and SIM actuation share one server process — per-call sessions silently lost state (a set pose was invisible to the next get_pose).
- `bench/limo_acceptance.run_acceptance`: observe → approval card → operator.sock approval (peer identity + display hash) → SIM execution → receipt → pose validation → practice candidate. Deterministic scripted variant (CI) and **K9 live variant where real Kimi K3 drives the entire loop itself** — grants consumed, receipts journaled, single-use re-verify denied.

**Wire fixes from live testing**
- OpenAI function names cannot contain dots: tool ids map `.` → `__` on the wire (catalog rejects native `__` ids to keep the mapping injective; OBSERVE/execution canonicalize back). Without this, live Kimi 400s every MCP tool call.
- The submit-decision protocol tool now appends a tool result on success — Kimi rejects dangling tool_call_ids.
- `VERIFY → WAIT_APPROVAL` state-machine edge (approval needed mid-verification, e.g. the second LIMO action card).

**Packaging**
- `scripts/build_release.sh` → `dist/rosclaw-<ver>-linux-arm64.tar.gz` (src + pre-built packages + lockfiles + third_party notices + per-file manifest hashes).
- `scripts/release/install_release.sh`: venv + `npm ci` rebuild + atomic current/previous switch; Node <22.19 → honest Python-only degrade.
- `scripts/release/rollback.sh`: manifest-verified swap-back; failed version preserved for diagnosis.
- `doctor` now reports node/modeld/tui component readiness.

## Tests

Acceptance C1–C10 (deterministic + K9 live with real Kimi K3), SHADOW/REAL honest gates, packaging structure (real bundle build), install/rollback semantics, wire-name mapping. Full regression green; ruff + mypy clean.