### PR TITLE
ReasoningBranch read-only tree + fork (reuse-supplement 批次F phase 1)

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -215,8 +215,19 @@ live 模型协调。3v3 联赛基准（T-SIM-2/3）属 PR-TF-075 后续范围。
 - 配置：`/settings`（白名单非安全键、tmp+fsync+rename 原子写、文件锁、
   审计事件；安全域键永远拒绝）、`/reload`（prompts/workers/models 可
   reload；policy/robot_pack/body/permits 等安全域永远拒绝）。
-- deferred：`/fork /clone /tree`（批次 F 双时间线）、`/copy`（TUI 本地
-  clipboard）——不伪造存在。
+- `/tree /fork` 已可用（批次 F 第一阶段）；`/clone`（第二阶段）与
+  `/copy`（TUI 本地 clipboard）deferred——不伪造存在。
+
+## ReasoningBranch（批次 F 第一阶段）
+
+- 双时间线：推理分支树可 fork；物理事实线只追加、永不回滚、不被旧
+  分支遮蔽（/tree 同时显示两条线）。
+- /fork 永远创建新 SIMULATION mission：不复制 grant/approval/Permit/
+  worker lease；旧 DecisionV1 对新 mission 无效（新 context，revision
+  从 0 开始）；首轮编译从权威存储注入最新 Body/Self；fork 点之前的
+  推理历史以 untrusted（source=fork:…）形态带入。
+- 物理动作进行中（未终态 WorkOrder）fork 被拒（fail closed）。
+- 同 Mission 分支切换与 /clone 属第二阶段，待不变量测试扩展后开放。
 
 ## LIMO 完整闭环与发布打包（PR-12）
 

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -209,6 +209,9 @@ class AgentService:
         self._exporter = ExportService(self)
         self._importer = ImportService(self)
         self._settings = SettingsService(self._home / "config.yaml")
+        from rosclaw.agentd.ui.branch_service import BranchService
+
+        self._branches = BranchService(self)
         consent_source = ConfigConsentSource()
         from rosclaw.operator import OperatorBroker
 
@@ -702,6 +705,10 @@ class AgentService:
     @property
     def settings(self):
         return self._settings
+
+    @property
+    def branches(self):
+        return self._branches
 
     def reload_domains(self, domains: list[str]) -> dict:
         """/reload（§8.15）：分域原子重载；安全域永远拒绝。

--- a/src/rosclaw/agentd/ui/branch_service.py
+++ b/src/rosclaw/agentd/ui/branch_service.py
@@ -1,0 +1,147 @@
+"""Branch service（批次 F 第一阶段）：只读 /tree + /fork 创建新 SIMULATION mission。
+
+硬不变量（§8.14/§14.9）：
+- fork 永远创建新 mission——同 Mission 分支切换本阶段不存在；
+- fork 不复制任何 authority：无 grant、approval、Permit、worker lease；
+- 物理事实线只追加：fork 后新 mission 的第一轮编译强制注入最新
+  Body/Self（ContextCompiler 本来就从权威存储重建）；
+- 旧 DecisionV1 对新 mission 无效（新 context_id / revision 从 0 开始）；
+- 物理动作进行中的 mission 拒绝 fork（fail closed）。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from rosclaw.agentd.mission.store import _utcnow
+from rosclaw.contracts.agent.branch import ReasoningBranchV1
+from rosclaw.contracts.common import ValidationError, new_id
+
+if TYPE_CHECKING:
+    from rosclaw.agentd.service import AgentService
+
+
+class BranchService:
+    def __init__(self, service: AgentService) -> None:
+        self._service = service
+
+    def tree(self, mission_id: str) -> dict:
+        """只读树：推理分支 + 不可变物理事实线（append-only）。"""
+        service = self._service
+        mission = service.get_mission(mission_id)
+        if mission is None:
+            raise ValidationError(f"unknown mission {mission_id!r}")
+        branches = self._branches_for(mission_id)
+        physical_lane = [
+            {
+                "sequence": e.sequence,
+                "type": e.type.value,
+                "timestamp": e.timestamp,
+            }
+            for e in service.events_replay(mission_id, limit=10_000)
+            if e.type.value.startswith(("approval.", "action.", "grant.", "receipt."))
+        ]
+        return {
+            "mission_id": mission_id,
+            "current_state": mission.state.value,
+            "reasoning_branches": [b.model_dump(mode="json") for b in branches],
+            "physical_lane": physical_lane,
+            "physical_lane_note": "物理事实线只追加，永远不能回滚、删除或被旧分支遮蔽。",
+        }
+
+    def fork(
+        self,
+        mission_id: str,
+        *,
+        from_entry_id: str | None = None,
+        label: str = "",
+        principal: str = "user:local:1000",
+    ) -> ReasoningBranchV1:
+        """fork → 新 SIMULATION mission（不复制任何 authority）。"""
+        service = self._service
+        mission = service.get_mission(mission_id)
+        if mission is None:
+            raise ValidationError(f"unknown mission {mission_id!r}")
+        # 物理动作进行中默认禁止 fork（fail closed，§8.14）。
+        open_orders = [
+            o
+            for o in service._worker_manager.orders_for_mission(mission_id)
+            if o.status not in ("ACCEPTED", "REJECTED", "EXPIRED", "CANCELLED", "FAILED")
+        ]
+        if open_orders:
+            raise ValidationError(
+                f"{len(open_orders)} 个 WorkOrder 未终态——fork 被拒绝（fail closed）"
+            )
+        conversation = service.store.conversation(mission_id)
+        entry = None
+        if from_entry_id is not None:
+            entry = next(
+                (m for m in conversation if m.get("entry_id") == from_entry_id), None
+            )
+            if entry is None:
+                raise ValidationError(f"unknown journal entry {from_entry_id!r}")
+        # 新 SIMULATION mission（fork 永远不继承 REAL mode）。
+        goal = f"[fork of {mission_id}] {label or mission.goal.text[:60]}"
+        forked = service.create_mission(goal, mode="SIMULATION")
+        # 推理上下文可带入（作为 untrusted 历史参考）；物理事实不复制——
+        # 新 mission 第一轮编译从权威存储注入最新 Body/Self。
+        if from_entry_id is not None and entry is not None:
+            upto = [m for m in conversation if m.get("seq", 0) <= entry.get("seq", 0)]
+            replay = [
+                {
+                    "role": m.get("role", "user"),
+                    "content": str(m.get("content", "")),
+                    "source": f"fork:{mission_id}",
+                }
+                for m in upto
+            ]
+            if replay:
+                service.store.append_conversation(
+                    forked.mission_id, replay, actor_id=service.actor_id
+                )
+        branch = ReasoningBranchV1(
+            branch_id=new_id("br"),
+            parent_branch_id=None,
+            fork_from_entry_id=from_entry_id or "(head)",
+            base_mission_event_seq=service._events.latest_sequence(mission_id),
+            base_context_revision=mission.context_revision,
+            label=label,
+            created_by=principal,
+            created_at=_utcnow(),
+            forked_mission_id=forked.mission_id,
+            notes=[
+                "authority 不复制：无 grant/approval/Permit/worker lease",
+                "旧 DecisionV1 对新 mission 无效（新 context，revision 从 0 开始）",
+                "第一轮编译强制注入最新 Body/Self",
+            ],
+        )
+        self._save_branch(mission_id, branch)
+        return branch
+
+    # -- 持久化（mission_meta 旁表，append-only JSON 行） -------------------------
+
+    def _save_branch(self, mission_id: str, branch: ReasoningBranchV1) -> None:
+        service = self._service
+        service.store.connection.execute(
+            "INSERT INTO reasoning_branches (branch_id, mission_id, created_at, "
+            "branch_json) VALUES (?, ?, ?, ?)",
+            (
+                branch.branch_id,
+                mission_id,
+                branch.created_at,
+                branch.model_dump_json(),
+            ),
+        )
+
+    def _branches_for(self, mission_id: str) -> list[ReasoningBranchV1]:
+        service = self._service
+        try:
+            rows = service.store.connection.execute(
+                "SELECT branch_json FROM reasoning_branches WHERE mission_id = ? "
+                "ORDER BY created_at",
+                (mission_id,),
+            ).fetchall()
+        except Exception:  # noqa: BLE001 - 表可能尚未迁移（旧库）→ 空树
+            return []
+        return [ReasoningBranchV1(**json.loads(r["branch_json"])) for r in rows]

--- a/src/rosclaw/agentd/ui/command_service.py
+++ b/src/rosclaw/agentd/ui/command_service.py
@@ -37,6 +37,7 @@ class CommandService:
         self._register_builtins()
         _register_batch_e(service, self._register)
         _register_batch_e2(service, self._register)
+        _register_batch_f(service, self._register)
 
     # -- registry ----------------------------------------------------------------
 
@@ -414,6 +415,102 @@ class CommandService:
 # 批次 E：执行与安全可见性命令（workers/grants/body/doctor/mode/context/
 # session/new/retry/failover/thinking/scoped-models）
 # ---------------------------------------------------------------------------
+def _register_batch_f(service, register) -> None:
+    """批次 F 第一阶段：/tree 只读、/fork 开新 SIMULATION mission。"""
+
+    async def _tree(req: CommandRequestV1) -> CommandResultV1:
+        try:
+            tree = service.branches.tree(req.mission_id or "")
+        except Exception as exc:  # noqa: BLE001
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="unknown_mission",
+                message=str(exc),
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=(
+                f"推理分支 {len(tree['reasoning_branches'])} 条；"
+                f"物理事实线 {len(tree['physical_lane'])} 个事件（不可回滚）"
+            ),
+            data=tree,
+        )
+
+    async def _fork(req: CommandRequestV1) -> CommandResultV1:
+        try:
+            branch = service.branches.fork(
+                req.mission_id or "",
+                from_entry_id=req.arguments.get("from_entry_id") or None,
+                label=str(req.arguments.get("label", "")),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="fork_refused",
+                message=str(exc),
+            )
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=True,
+            message=(
+                f"已 fork 为新 SIMULATION mission {branch.forked_mission_id}；"
+                "authority 未复制（无 grant/approval/Permit/lease），"
+                "首轮编译注入最新 Body/Self。"
+            ),
+            data=branch.model_dump(mode="json"),
+        )
+
+    async def _clone(req: CommandRequestV1) -> CommandResultV1:
+        return CommandResultV1(
+            request_id=req.request_id,
+            command_name=req.command_name,
+            ok=False,
+            error_code="not_implemented",
+            message="/clone 在批次 F 第二阶段提供；/fork 已可创建推理分支（不复制 authority）。",
+        )
+
+    register(
+        CommandSpecV1(
+            name="tree",
+            description="推理分支树 + 不可变物理事实线（只读）",
+            category=CommandCategory.MISSION,
+            owner=CommandOwner.MISSION_CONTROL,
+            during_turn=True,
+            handler="branch.tree",
+        ),
+        _tree,
+    )
+    register(
+        CommandSpecV1(
+            name="fork",
+            description="从当前/指定 entry 分叉为新 SIMULATION mission（不复制 authority）",
+            argument_hint="[from_entry_id] [label]",
+            category=CommandCategory.MISSION,
+            owner=CommandOwner.MISSION_CONTROL,
+            mutability="PERSISTED",
+            handler="branch.fork",
+        ),
+        _fork,
+    )
+    register(
+        CommandSpecV1(
+            name="clone",
+            description="克隆 Mission（第二阶段）",
+            category=CommandCategory.MISSION,
+            owner=CommandOwner.MISSION_CONTROL,
+            handler="branch.clone",
+        ),
+        _clone,
+    )
+
+
 def _register_batch_e(service, register) -> None:  # noqa: C901 - 命令集合体
     """注册批次 E 命令。register(spec, handler) 与 CommandService._register 同签名。"""
 

--- a/src/rosclaw/contracts/agent/branch.py
+++ b/src/rosclaw/contracts/agent/branch.py
@@ -1,0 +1,36 @@
+"""ReasoningBranchV1（批次 F §8.14）：推理分支，不是世界回滚。
+
+双时间线：
+- 推理分支树：可以 fork、切换、重写后续推理；
+- 物理事实线：只追加，永远不能回滚、删除或被旧分支遮蔽。
+
+第一阶段只实现只读 tree 与 fork-创建新-SIMULATION-mission；
+同 Mission 分支切换在不变量测试完成后才开放。
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from rosclaw.contracts.common import ContractModel
+
+
+class ReasoningBranchV1(ContractModel):
+    SCHEMA = "rosclaw.reasoning_branch.v1"
+
+    schema_version: Literal["rosclaw.reasoning_branch.v1"] = "rosclaw.reasoning_branch.v1"
+    branch_id: str
+    parent_branch_id: str | None = None
+    #: fork 起点的 journal entry_id（append-only 历史中的确定位置）
+    fork_from_entry_id: str
+    base_mission_event_seq: int = 0
+    base_context_revision: int = 0
+    label: str = ""
+    created_by: str
+    created_at: str
+    status: Literal["active", "archived"] = "active"
+    #: fork 生成的新 mission（第一阶段：fork 永远开新 SIMULATION mission）
+    forked_mission_id: str | None = None
+    notes: list[str] = Field(default_factory=list)

--- a/src/rosclaw/contracts/export.py
+++ b/src/rosclaw/contracts/export.py
@@ -10,6 +10,7 @@ import json
 import sys
 from pathlib import Path
 
+from rosclaw.contracts.agent.branch import ReasoningBranchV1
 from rosclaw.contracts.agent.context import EmbodiedContextBundleV1
 from rosclaw.contracts.agent.decision import DecisionV1
 from rosclaw.contracts.agent.mission import MissionSessionV1
@@ -54,6 +55,7 @@ ALL_CONTRACTS: dict[str, type[ContractModel]] = {
         CommandResultV1,
         MissionSnapshotV1,
         InteractionRequestV1,
+        ReasoningBranchV1,
     )
 }
 

--- a/src/rosclaw/storage/migrations/012_reasoning_branches_sqlite.sql
+++ b/src/rosclaw/storage/migrations/012_reasoning_branches_sqlite.sql
@@ -1,0 +1,11 @@
+-- backend: sqlite
+-- 批次 F: ReasoningBranch（推理分支树；物理事实线不在此表，永远只追加）。
+CREATE TABLE IF NOT EXISTS reasoning_branches (
+    branch_id TEXT PRIMARY KEY,
+    mission_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    branch_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_branches_mission
+    ON reasoning_branches (mission_id, created_at);

--- a/tests/agentd/test_branch.py
+++ b/tests/agentd/test_branch.py
@@ -1,0 +1,156 @@
+"""批次 F 测试：ReasoningBranch 双时间线不变量。
+
+- /tree 只读：推理分支 + 物理事实线
+- /fork 开新 SIMULATION mission：不复制 authority、最新 Body/Self、
+  旧 Decision 无效
+- 物理动作进行中 fork 被拒（fail closed）
+- 物理事实线不被 fork 遮蔽
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.models.gateway import MockModelGateway
+from rosclaw.agentd.models.profiles import mock_profile
+from rosclaw.agentd.service import AgentService
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+from rosclaw.contracts.common import ValidationError
+from rosclaw.contracts.ui.commands import CommandRequestV1
+
+
+def _answer(request) -> ModelTurnResultV1:
+    decision = {
+        "schema_version": "rosclaw.decision.v1",
+        "decision_id": "d",
+        "mission_id": request.mission_id,
+        "context_id": request.context_id,
+        "context_revision": request.context_revision,
+        "next_intent": "ANSWER",
+        "summary": "ok",
+        "evidence_refs": [],
+    }
+    return ModelTurnResultV1(
+        turn_id="t",
+        provider="mock",
+        model="m",
+        content=f"```json\n{json.dumps(decision)}\n```",
+        assistant_message={"role": "assistant", "content": "x"},
+        usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+    )
+
+
+def _service(tmp_path: Path) -> AgentService:
+    config = load_agent_config(tmp_path / "config.yaml")
+    return AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), [_answer] * 50))
+
+
+def _cmd(name: str, args: dict | None = None, mission_id: str | None = None, key: str = "k") -> CommandRequestV1:
+    return CommandRequestV1(
+        request_id=f"r_{key}",
+        idempotency_key=key,
+        command_name=name,
+        arguments=args or {},
+        mission_id=mission_id,
+    )
+
+
+class TestBranchTree:
+    async def test_tree_readonly(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("tree 测试")
+            await service.send_turn(mission.mission_id, "hi")
+            result = await service.commands.execute(
+                _cmd("tree", mission_id=mission.mission_id)
+            )
+            assert result.ok
+            assert result.data["reasoning_branches"] == []
+            assert "不能回滚" in result.data["physical_lane_note"]
+        finally:
+            await service.close()
+
+
+class TestFork:
+    async def test_fork_creates_sim_mission_without_authority(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("fork 源")
+            await service.send_turn(mission.mission_id, "第一轮")
+            history = service.store.conversation(mission.mission_id)
+            entry_id = history[0]["entry_id"]
+            result = await service.commands.execute(
+                _cmd("fork", args={"from_entry_id": entry_id, "label": "分支A"},
+                     mission_id=mission.mission_id)
+            )
+            assert result.ok, result.message
+            forked_id = result.data["forked_mission_id"]
+            assert forked_id != mission.mission_id
+            forked = service.get_mission(forked_id)
+            # fork 永远是 SIMULATION（不继承 REAL）且无 authority。
+            assert forked.mode.value == "SIMULATION"
+            assert forked.context_revision == 0
+            assert service.list_grants() == []
+            assert service.pending_approvals() == []
+            # fork 点之前的推理历史带入（标记为 fork 来源）。
+            forked_conv = service.store.conversation(forked_id)
+            assert forked_conv
+            assert any("fork:" in str(m.get("source", "")) for m in forked_conv)
+            # 树里能看到分支。
+            tree = await service.commands.execute(
+                _cmd("tree", mission_id=mission.mission_id, key="k2")
+            )
+            assert len(tree.data["reasoning_branches"]) == 1
+            # 物理事实线不被遮蔽：原 mission 事件原样存在。
+            assert service.events_replay(mission.mission_id)
+        finally:
+            await service.close()
+
+    async def test_fork_unknown_entry_rejected(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("fork 测试")
+            result = await service.commands.execute(
+                _cmd("fork", args={"from_entry_id": "conv_ghost_0"},
+                     mission_id=mission.mission_id)
+            )
+            assert not result.ok and result.error_code == "fork_refused"
+        finally:
+            await service.close()
+
+    async def test_fork_refused_with_open_orders(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("fork 护栏")
+            # 塞一个未终态订单（直接写库模拟在途动作）。
+            from rosclaw.agentd.workers.scheduler import ScoredCandidate
+            from rosclaw.contracts.worker.order import WorkOrderV1
+
+            order = WorkOrderV1(
+                work_order_id="wo_open",
+                mission_id=mission.mission_id,
+                issued_by="test",
+                capability="analysis.text",
+                goal="在途任务",
+                status="RUNNING",
+            )
+            scored = ScoredCandidate(
+                worker_id="worker:native:basic", score=1.0, features={}, reasons=("test",)
+            )
+            service._worker_manager._insert(order, scored)
+            with pytest.raises(ValidationError, match="未终态"):
+                service.branches.fork(mission.mission_id)
+        finally:
+            await service.close()
+
+    async def test_clone_honest_deferred(self, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        try:
+            result = await service.commands.execute(_cmd("clone"))
+            assert not result.ok and result.error_code == "not_implemented"
+        finally:
+            await service.close()

--- a/tests/contracts/golden/rosclaw.reasoning_branch.v1.json
+++ b/tests/contracts/golden/rosclaw.reasoning_branch.v1.json
@@ -1,0 +1,91 @@
+{
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.reasoning_branch.v1",
+      "default": "rosclaw.reasoning_branch.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "branch_id": {
+      "title": "Branch Id",
+      "type": "string"
+    },
+    "parent_branch_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Parent Branch Id"
+    },
+    "fork_from_entry_id": {
+      "title": "Fork From Entry Id",
+      "type": "string"
+    },
+    "base_mission_event_seq": {
+      "default": 0,
+      "title": "Base Mission Event Seq",
+      "type": "integer"
+    },
+    "base_context_revision": {
+      "default": 0,
+      "title": "Base Context Revision",
+      "type": "integer"
+    },
+    "label": {
+      "default": "",
+      "title": "Label",
+      "type": "string"
+    },
+    "created_by": {
+      "title": "Created By",
+      "type": "string"
+    },
+    "created_at": {
+      "title": "Created At",
+      "type": "string"
+    },
+    "status": {
+      "default": "active",
+      "enum": [
+        "active",
+        "archived"
+      ],
+      "title": "Status",
+      "type": "string"
+    },
+    "forked_mission_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Forked Mission Id"
+    },
+    "notes": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Notes",
+      "type": "array"
+    }
+  },
+  "required": [
+    "branch_id",
+    "fork_from_entry_id",
+    "created_by",
+    "created_at"
+  ],
+  "title": "rosclaw.reasoning_branch.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.reasoning_branch.v1"
+}


### PR DESCRIPTION
## Summary

Batch F phase 1 (§8.14): the dual-timeline reasoning branch — the part of Pi's session tree that is safe for a physical robot, and nothing more.

- **Dual timeline**: reasoning branches may fork; the physical fact lane is append-only and can never be rolled back, deleted, or shadowed by an old branch. `/tree` shows both lanes side by side.
- **/fork always creates a NEW SIMULATION mission**: never copies grants, approvals, permits, or worker leases (authority is never inherited); old DecisionV1 is invalid in the new mission (fresh context, revision from 0); the first compile injects the latest Body/Self from authoritative stores; pre-fork reasoning history is carried only as untrusted (`source=fork:…`) reference.
- **Fail closed**: fork refused while WorkOrders are non-terminal (physical work in flight, §8.14); fork from an unknown journal entry refused.
- **Honestly deferred**: same-mission branch switching and `/clone` (phase 2) return not_implemented — no fake 'world rollback' semantics ever (§14.9).

## Tests

5 new tests: read-only tree, fork creates SIM mission without authority (grants/approvals empty, mode forced SIMULATION, revision 0), fork-source marking, unknown-entry refusal, open-orders guard, clone deferral. Contract golden: `rosclaw.reasoning_branch.v1`. Full suites green; ruff + mypy clean.