### PR TITLE
Live K4/K5 robustness — protocol clarity + instruction extraction

### DIFF
--- a/src/rosclaw/agentd/decisions/submit_tool.py
+++ b/src/rosclaw/agentd/decisions/submit_tool.py
@@ -100,7 +100,16 @@ def submit_decision_tool() -> StrictTool:
             "INTERNAL PROTOCOL — conclude this cognitive step by submitting a "
             "ROSClaw DecisionV1. This is not an action and executes nothing: "
             "the host validates the decision. Call this exactly once when you "
-            "have finished reasoning; do not call physical tools with it."
+            "have finished reasoning; do not call physical tools with it. "
+            "Field rules: for action intents (HIRE_WORKER, TEAM_COORDINATE, "
+            "REQUEST_APPROVAL, REQUEST_ACTION, PLAN_PATCH) proposed_operation "
+            "is REQUIRED and must NOT be null — set proposed_operation.type "
+            "to the operation name (e.g. 'hire_worker', 'approval_request', "
+            "'request_action', 'team_task_claim', 'task_graph_patch') and put "
+            "its arguments in proposed_operation.payload. For ANSWER, OBSERVE, "
+            "WAIT, PAUSE, FAIL_SAFE, VERIFY proposed_operation may be null. "
+            "verification.verifiers is required for REQUEST_APPROVAL and "
+            "REQUEST_ACTION (e.g. ['deterministic:bounds'])."
         ),
         parameters=DECISION_SUBMIT_SCHEMA,
     )

--- a/src/rosclaw/agentd/handlers.py
+++ b/src/rosclaw/agentd/handlers.py
@@ -89,7 +89,7 @@ class ServiceIntentHandlers:
         ) or {}
         goal = str(payload.get("goal") or decision.summary or "子任务")
         capability = str(payload.get("capability") or "analysis.text")
-        instructions = str(payload.get("instructions") or "")
+        instructions = self._extract_instructions(payload)
         order = WorkOrderV1(
             work_order_id=new_id("wo"),
             mission_id=decision.mission_id,
@@ -157,6 +157,27 @@ class ServiceIntentHandlers:
             ),
             accepted=False,
         )
+
+    @staticmethod
+    def _extract_instructions(payload: dict) -> str:
+        """Worker 看不到主对话——instructions 必须自包含。模型可能把说明
+        嵌在不同层级；都找不到时以完整 payload 兜底（不丢上下文，让
+        worker 有据可依而不是空指令诚实失败）。"""
+        candidates = [
+            payload.get("instructions"),
+            (payload.get("work_order") or {}).get("instructions")
+            if isinstance(payload.get("work_order"), dict)
+            else None,
+            (payload.get("inputs") or {}).get("instructions")
+            if isinstance(payload.get("inputs"), dict)
+            else None,
+        ]
+        for candidate in candidates:
+            if candidate:
+                return str(candidate)
+        import json as _json
+
+        return _json.dumps(payload, ensure_ascii=False)
 
     # ------------------------------------------------------------------
     async def request_approval(self, decision: DecisionV1) -> HandlerOutcome:

--- a/tests/agentd/test_kimi_live.py
+++ b/tests/agentd/test_kimi_live.py
@@ -294,8 +294,10 @@ async def test_k5_operator_consent_loop(tmp_path: Path) -> None:
         mission = service.create_mission("授权闭环 K5")
         r1 = await service.send_turn(
             mission.mission_id,
-            "我想让仿真机械臂回到初始位。按你的协议，这需要先请求人类授权："
-            "请用 REQUEST_APPROVAL 决策创建授权请求，不要直接声称已执行。",
+            "我想让仿真机械臂保持初始位。可信能力契约是 sim.hold_position"
+            "（仿真保持位姿，arguments 可为空 {}）。按你的协议，这需要先请求人类授权："
+            "请用 REQUEST_APPROVAL 决策创建授权请求（payload 带 capability_id "
+            "sim.hold_position 和 arguments {}），不要直接声称已执行。",
         )
         pending = service.pending_approvals(mission.mission_id)
         assert pending, f"no approval request created; reply: {r1.reply[:300]}"


### PR DESCRIPTION
## Summary

Three small robustness fixes found by re-running the full K0–K9 live suite against real Kimi K3 after the big merges:

- **submit_decision tool description** now states field rules explicitly: `proposed_operation` is REQUIRED (never null) for action intents with the operation name in `.type` and arguments in `.payload`; `verification.verifiers` is required for REQUEST_APPROVAL/REQUEST_ACTION. Previously the nullable schema let the live model drift into FAIL_SAFE while misreading the requirements.
- **hire_worker instruction extraction**: accepts nested shapes (`instructions` / `work_order.instructions` / `inputs.instructions`) and falls back to the full payload instead of issuing an empty-instruction WorkOrder the native worker must honestly refuse (workers can't see the main conversation — instructions must be self-contained).
- **K5 test prompt** names the trusted capability contract (`sim.hold_position`) — post-PR-05 the model correctly refuses to invent actions without one, so the test must supply it.

## Live verification (real Kimi K3)

- K4: order created, log inlined into inputs.instructions, worker analyzed and root cause reported.
- K5: approval card created, grant verified, single-use enforced.

Full agentd suite 339 passed; ruff clean.