### PR TITLE
Conflict-review fixes + full-chain E2E suite

### DIFF
--- a/src/rosclaw/agentd/models/gateway.py
+++ b/src/rosclaw/agentd/models/gateway.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from collections.abc import Callable
@@ -285,7 +286,11 @@ class OpenAICompatGateway:
                     if piece:
                         content_parts.append(piece)
                         if on_text_delta is not None:
-                            on_text_delta(piece)
+                            # 回调可能是 async（runner 的事件总线）：不 await
+                            # 就会静默丢 delta 并留下 never-awaited 警告。
+                            maybe = on_text_delta(piece)
+                            if asyncio.iscoroutine(maybe):
+                                await maybe
                     reasoning_piece = delta.get("reasoning_content")
                     if reasoning_piece:
                         reasoning_parts.append(reasoning_piece)

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -1015,6 +1015,15 @@ class AgentService:
             )
         return grants
 
+    def principal_for_request(self, request_id: str) -> str:
+        """approval request 所属 mission 的 owner principal。"""
+        req = self._broker.get_request(request_id)
+        if req is not None:
+            mission = self._store.get_mission(req.mission_id)
+            if mission is not None:
+                return mission.owner_principal
+        return f"user:local:{os.getuid()}"
+
     def revoke_grant(self, grant_id: str, *, principal: str) -> None:
         self._broker.revoke(grant_id, principal=principal)
         import asyncio as _asyncio
@@ -1118,7 +1127,7 @@ class TurnCreate(_BaseModel):
 
 class DecisionCreate(_BaseModel):
     approve: bool
-    principal: str = "user:local:1000"
+    principal: str | None = None  # 缺省按 mission owner 解析（不再硬编码 uid）
 
 
 class CommandRequestCreate(_BaseModel):
@@ -1411,9 +1420,12 @@ def create_app(service: AgentService):
 
     @app.post("/approvals/{request_id}/decide")
     async def approvals_decide(request_id: str, payload: DecisionCreate) -> dict:
+        # principal 缺省按该请求的 mission owner 解析（loopback console；
+        # 强身份仍走 operator.sock 的 SO_PEERCRED）。
+        principal = payload.principal or service.principal_for_request(request_id)
         try:
             grant = await service.decide_approval(
-                request_id, principal=payload.principal, approve=payload.approve
+                request_id, principal=principal, approve=payload.approve
             )
         except Exception as exc:  # noqa: BLE001
             raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/src/rosclaw/agentd/tooling/persistent_client.py
+++ b/src/rosclaw/agentd/tooling/persistent_client.py
@@ -1,8 +1,13 @@
 """Persistent MCP stdio client（PR-12）。
 
 per-call 短会话会让有状态 SIM 身体（如 limo-sim 的位姿）在调用之间
-丢失——观测与 SIM 执行必须共享同一个 server 进程。此客户端懒启动、
-持锁复用、失败时诚实报错并可重连。
+丢失——观测与 SIM 执行必须共享同一个 server 进程。
+
+asyncio/anyio 的流是 loop-bound：HTTP server loop 与 CLI/测试 loop 可能
+不同，因此会话按 running loop 分键——同一 loop 内共享一个进程，跨 loop
+调用自动获得本 loop 的独立会话（状态一致性由 SIM 身体侧的同参数快照
+语义保证：limo-sim 这类快照式 server 每进程独立，但观测/执行在同一
+loop 内永远同进程）。
 """
 
 from __future__ import annotations
@@ -18,13 +23,25 @@ class PersistentMcpClient:
         self._command = command
         self._args = args
         self._env = env
-        self._lock = asyncio.Lock()
-        self._session = None
-        self._exit_stack = None
+        self._locks: dict[int, asyncio.Lock] = {}
+        self._sessions: dict[int, tuple[Any, Any]] = {}  # loop id -> (session, exit_stack)
 
-    async def _ensure(self) -> None:
-        if self._session is not None:
-            return
+    def _loop_key(self) -> int:
+        try:
+            return id(asyncio.get_running_loop())
+        except RuntimeError:
+            return 0
+
+    def _lock_for(self, key: int) -> asyncio.Lock:
+        if key not in self._locks:
+            self._locks[key] = asyncio.Lock()
+        return self._locks[key]
+
+    async def _ensure(self) -> Any:
+        key = self._loop_key()
+        entry = self._sessions.get(key)
+        if entry is not None:
+            return entry[0]
         from contextlib import AsyncExitStack
 
         from mcp import ClientSession, StdioServerParameters
@@ -41,21 +58,22 @@ class PersistentMcpClient:
         except Exception:
             await stack.aclose()
             raise
-        self._exit_stack = stack
-        self._session = session
+        self._sessions[key] = (session, stack)
+        return session
 
     async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> str:
-        async with self._lock:
+        key = self._loop_key()
+        async with self._lock_for(key):
             try:
-                await self._ensure()
-                result = await self._session.call_tool(tool_name, arguments)
-            except (ValidationError, ExceptionGroup):
+                session = await self._ensure()
+                result = await session.call_tool(tool_name, arguments)
+            except ValidationError:
                 raise
             except Exception as exc:  # noqa: BLE001 - 连接断开：重置后重试一次
-                await self._reset()
+                await self._reset(key)
                 try:
-                    await self._ensure()
-                    result = await self._session.call_tool(tool_name, arguments)
+                    session = await self._ensure()
+                    result = await session.call_tool(tool_name, arguments)
                 except Exception as exc2:  # noqa: BLE001
                     raise ValidationError(
                         f"mcp call {tool_name} failed after reconnect: "
@@ -67,18 +85,20 @@ class PersistentMcpClient:
             return "".join(getattr(b, "text", "") for b in result.content)
 
     async def list_tools(self) -> list:
-        async with self._lock:
-            await self._ensure()
-            listed = await self._session.list_tools()
+        key = self._loop_key()
+        async with self._lock_for(key):
+            session = await self._ensure()
+            listed = await session.list_tools()
             return list(listed.tools)
 
-    async def _reset(self) -> None:
-        stack, self._exit_stack, self._session = self._exit_stack, None, None
-        if stack is not None:
+    async def _reset(self, key: int) -> None:
+        entry = self._sessions.pop(key, None)
+        if entry is not None:
             from contextlib import suppress
 
             with suppress(Exception):
-                await stack.aclose()
+                await entry[1].aclose()
 
     async def close(self) -> None:
-        await self._reset()
+        for key in list(self._sessions):
+            await self._reset(key)

--- a/src/rosclaw/mcp/minimal_server.py
+++ b/src/rosclaw/mcp/minimal_server.py
@@ -23,7 +23,7 @@ import sys
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import TextContent, Tool, ToolAnnotations
 
 from rosclaw.agent_runtime.mcp_hub import MCPHub
 from rosclaw.core.event_bus import EventBus
@@ -49,13 +49,19 @@ class ROSClawMinimalMCPServer:
     def _register_handlers(self) -> None:
         @self.server.list_tools()
         async def list_tools() -> list[Tool]:
+            from rosclaw.agent.tool_catalog import MCP_TOOL_SAFETY_LEVELS
+
             tools = []
             for _name, spec in self.hub._tools.items():
+                level = MCP_TOOL_SAFETY_LEVELS.get(spec["name"], "")
                 tools.append(
                     Tool(
                         name=spec["name"],
                         description=spec["description"],
                         inputSchema=spec["inputSchema"],
+                        annotations=ToolAnnotations(
+                            readOnlyHint=level.startswith(("S0", "S2"))
+                        ),
                     )
                 )
             # Add system-level tools
@@ -78,14 +84,17 @@ class ROSClawMinimalMCPServer:
                 ]
 
     def _system_tools(self) -> list[Tool]:
+        read_only = ToolAnnotations(readOnlyHint=True)
         return [
             Tool(
                 name="system.list_robots",
+                annotations=read_only,
                 description="List all available robots in the e-URDF-Zoo registry",
                 inputSchema={"type": "object", "properties": {}},
             ),
             Tool(
                 name="system.list_providers",
+                annotations=read_only,
                 description="List all registered capability providers (llm, vlm, skill, critic, etc.)",
                 inputSchema={"type": "object", "properties": {}},
             ),
@@ -126,6 +135,7 @@ class ROSClawMinimalMCPServer:
             ),
             Tool(
                 name="system.query_memory",
+                annotations=read_only,
                 description="Query ROSClaw Memory for past experiences, failures, or success patterns",
                 inputSchema={
                     "type": "object",
@@ -146,6 +156,7 @@ class ROSClawMinimalMCPServer:
             ),
             Tool(
                 name="system.explain_failure",
+                annotations=read_only,
                 description="Explain the most recent failure and get recovery suggestions from Memory/How",
                 inputSchema={
                     "type": "object",
@@ -177,6 +188,7 @@ class ROSClawMinimalMCPServer:
             ),
             Tool(
                 name="system.get_version",
+                annotations=read_only,
                 description="Get ROSClaw version and system status",
                 inputSchema={"type": "object", "properties": {}},
             ),

--- a/src/rosclaw/mcp/ur5_server.py
+++ b/src/rosclaw/mcp/ur5_server.py
@@ -50,6 +50,7 @@ from mcp.types import (
     ImageContent,
     TextContent,
     Tool,
+    ToolAnnotations,
 )
 
 # ROSClaw imports
@@ -299,6 +300,7 @@ class UR5MCPServer:
             return [
                 Tool(
                     name="ur5_get_joint_states",
+                    annotations=ToolAnnotations(readOnlyHint=True),
                     description="Get current joint positions, velocities, and efforts",
                     inputSchema={"type": "object", "properties": {}},
                 ),
@@ -368,11 +370,13 @@ class UR5MCPServer:
                 ),
                 Tool(
                     name="ur5_get_limits",
+                    annotations=ToolAnnotations(readOnlyHint=True),
                     description="Get robot joint limits and safety parameters",
                     inputSchema={"type": "object", "properties": {}},
                 ),
                 Tool(
                     name="ur5_validate_trajectory",
+                    annotations=ToolAnnotations(readOnlyHint=True),
                     description="Validate trajectory through Digital Twin without executing",
                     inputSchema={
                         "type": "object",
@@ -629,9 +633,10 @@ def main():
     )
     args = parser.parse_args()
 
-    print("[UR5MCP] Starting ROSClaw UR5 MCP Server")
-    print(f"[UR5MCP] Robot IP: {args.robot_ip}")
-    print(f"[UR5MCP] Firewall Model: {args.firewall_model}")
+    # banner 必须走 stderr——stdout 属于 JSON-RPC 通道。
+    print("[UR5MCP] Starting ROSClaw UR5 MCP Server", file=sys.stderr)
+    print(f"[UR5MCP] Robot IP: {args.robot_ip}", file=sys.stderr)
+    print(f"[UR5MCP] Firewall Model: {args.firewall_model}", file=sys.stderr)
 
     server = UR5MCPServer(
         robot_ip=args.robot_ip,

--- a/tests/agentd/test_full_chain_e2e.py
+++ b/tests/agentd/test_full_chain_e2e.py
@@ -1,0 +1,353 @@
+"""全链路闭环深度测试（2026-08-04 复盘专项）。
+
+一次运行覆盖 Native Agent 全链路：
+init → doctor → service(+operator.sock+HTTP) → mission → LIMO 观测 →
+授权(operator.sock peer identity) → SIM 执行 → receipt → 验证 →
+worker 委派 → compaction+恢复 → export/import → fork/tree →
+modeld backend → ACP stdio → estop 诚实 → legacy MCP 观测 →
+崩溃恢复 → snapshot/SSE 一致性。
+
+全部为真实路径（真实 MCP stdio、真实 UDS、真实 modeld 子进程、真实
+ACP JSON-RPC），只有模型是 Mock（K 系列 live 测试覆盖真实模型）。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.models.gateway import MockModelGateway
+from rosclaw.agentd.models.profiles import mock_profile
+from rosclaw.agentd.service import AgentService, create_app
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+from tests.agentd.conftest import LOCAL_PRINCIPAL
+
+LIMO_SIM = str(Path(__file__).resolve().parents[2] / "src" / "rosclaw" / "limo" / "sim_mcp.py")
+
+TONE = {"frequency_hz": 660, "duration_sec": 0.6, "volume_percent": 18}
+
+
+def _chain_script(request) -> ModelTurnResultV1:
+    """内容驱动的全链路决策状态机（观测→授权→执行→验证→委派→回答）。"""
+    import re
+
+    blob = json.dumps(request.messages, ensure_ascii=False)
+    prompt = request.system_prompt or ""
+    pose_observed = "tool: limo.localization.get_pose" in blob
+    tone_card = "播放提示音" in blob
+    tone_receipt = "limo.speaker.play_tone" in blob and "SIM 执行器" in blob
+    worker_done = "Worker " in blob and "已完成并通过验证" in blob
+    grant = re.search(r"grant_id=(grant_[a-z0-9]+)", prompt)
+
+    if not pose_observed:
+        decision = {
+            "next_intent": "OBSERVE",
+            "summary": "读取 LIMO 位姿",
+            "proposed_operation": {
+                "type": "observe",
+                "payload": {"tool": "limo.localization.get_pose", "arguments": {"frame": "map"}},
+            },
+        }
+    elif not tone_card:
+        decision = {
+            "next_intent": "REQUEST_APPROVAL",
+            "summary": "请求授权：播放提示音",
+            "proposed_operation": {
+                "type": "approval_request",
+                "payload": {
+                    "capability_id": "limo.speaker.play_tone",
+                    "arguments": TONE,
+                    "title": "播放提示音",
+                    "summary": "660Hz 0.6s 18%",
+                    "risk_tier": "LOW",
+                },
+            },
+        }
+    elif not tone_receipt:
+        decision = {
+            "next_intent": "REQUEST_ACTION",
+            "summary": "执行扬声器动作",
+            "proposed_operation": {
+                "type": "request_action",
+                "payload": {
+                    "grant_id": grant.group(1) if grant else "",
+                    "capability_id": "limo.speaker.play_tone",
+                    "arguments": TONE,
+                    "risk_tier": "LOW",
+                },
+            },
+        }
+    elif not worker_done:
+        decision = {
+            "next_intent": "HIRE_WORKER",
+            "summary": "委派：分析验收日志",
+            "proposed_operation": {
+                "type": "create_work_order",
+                "payload": {
+                    "capability": "analysis.text",
+                    "goal": "分析验收日志并给出结论",
+                    "instructions": "分析以下日志并给出结论："
+                    "[INFO] tone executed; pose=(0,0,0) verified within tolerance.",
+                },
+            },
+        }
+    else:
+        decision = {
+            "next_intent": "ANSWER",
+            "summary": "全链路闭环完成：观测-授权-执行-回执-委派 全部验证",
+            "evidence_refs": [],
+        }
+    decision.update(
+        {
+            "schema_version": "rosclaw.decision.v1",
+            "decision_id": "dec_chain",
+            "mission_id": request.mission_id,
+            "context_id": request.context_id,
+            "context_revision": request.context_revision,
+            "evidence_refs": decision.get("evidence_refs", []),
+        }
+    )
+    if decision["next_intent"] in ("REQUEST_APPROVAL", "REQUEST_ACTION", "HIRE_WORKER"):
+        decision["verification"] = {
+            "schema_version": "rosclaw.decision_verification.v1",
+            "verifiers": ["deterministic:bounds"],
+        }
+    return ModelTurnResultV1(
+        turn_id="t",
+        provider="mock",
+        model="m",
+        content=f"```json\n{json.dumps(decision, ensure_ascii=False)}\n```",
+        assistant_message={"role": "assistant", "content": "x"},
+        usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+    )
+
+
+def _write_home(home: Path) -> None:
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {"enabled": True},
+                "mcp_servers": [
+                    {
+                        "name": "limo-sim",
+                        "command": sys.executable,
+                        "args": [LIMO_SIM],
+                        "supported_modes": ["SIMULATION"],
+                        "sim_executor": True,
+                    },
+                    {
+                        "name": "rosclaw-mcp",
+                        "command": sys.executable,
+                        "args": ["-m", "rosclaw.mcp.minimal_server"],
+                        "supported_modes": ["SIMULATION"],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestFullChainE2E:
+    async def test_complete_loop(self, tmp_path: Path) -> None:  # noqa: C901
+        home = tmp_path / "home"
+        home.mkdir()
+        _write_home(home)
+
+        # 1-2. init/doctor 层：配置可读、doctor 结构化。
+        config = load_agent_config(home / "config.yaml")
+        from rosclaw.agentd.onboarding import doctor
+
+        report = doctor(home)
+        assert "components" in report and "node" in report["components"]
+
+        service = AgentService(
+            config, home, gateway=MockModelGateway(mock_profile(), [_chain_script] * 60)
+        )
+        from rosclaw.agentd.operator_socket import operator_call
+
+        sock = await service.start_operator_socket()
+        service2 = None
+        try:
+            # 3. mission 创建（principal 与 uid 一致）。
+            mission = service.create_mission("全链路闭环")
+            assert mission.owner_principal == LOCAL_PRINCIPAL
+
+            # 4-8. 观测 → 授权 → 执行 → receipt（状态驱动推进）。
+            last_reply = ""
+            for _step in range(10):
+                result = await service.send_turn(mission.mission_id, "执行闭环流程")
+                last_reply = result.reply
+                if service.pending_approvals(mission.mission_id):
+                    listed = await operator_call(sock, "approvals.list")
+                    entry = listed["approvals"][0]
+                    decided = await operator_call(
+                        sock,
+                        "approvals.decide",
+                        {
+                            "request_id": entry["request_id"],
+                            "display_hash": entry["display_hash"],
+                            "approve": True,
+                        },
+                    )
+                    assert decided["ok"] and decided["principal"] == LOCAL_PRINCIPAL
+                    continue
+                if "全链路闭环完成" in last_reply:
+                    break
+                if result.state.value == "FAILED":
+                    raise AssertionError(f"chain failed: {last_reply[:300]}")
+            history = json.dumps(
+                service.conversation(mission.mission_id), ensure_ascii=False
+            )
+            assert "observation — evidence" in history
+            assert "limo.speaker.play_tone" in history and "COMPLETED" in history
+            assert "已完成并通过验证" in history, history[-500:]
+
+            # grant 单次消费 + receipt 事件落 journal。
+            events = service.events_replay(mission.mission_id)
+            types = [e.type.value for e in events]
+            assert "grant.consumed" in types and "receipt.received" in types
+            from rosclaw.operator import GrantDeniedError
+
+            grant = service.list_grants()[0]
+            with pytest.raises(GrantDeniedError, match="grant_consumed"):
+                service._broker.verify(
+                    grant["grant_id"],
+                    principal=grant["principal"],
+                    body_hash=mission.body_binding.effective_body_hash,
+                    mode="SIMULATION",
+                    risk_tier="LOW",
+                    action_intent=service._broker.action_intent_for_grant(grant["grant_id"]),
+                )
+
+            # 9. worker 委派已 ACCEPTED（归属链）。
+            orders = service._worker_manager.orders_for_mission(mission.mission_id)
+            assert orders and orders[0].status == "ACCEPTED"
+
+            # 10. compaction + 崩溃恢复：新 service 实例从 journal 恢复。
+            for i in range(4):
+                await service.send_turn(mission.mission_id, f"历史轮次 {i} {'长文本' * 100}")
+            await service.compact(mission.mission_id)
+            view_before = service.conversation(mission.mission_id)
+            await service.close()
+
+            service2 = AgentService(
+                config, home, gateway=MockModelGateway(mock_profile(), [_chain_script] * 20)
+            )
+            recovered = service2.conversation(mission.mission_id)
+            assert [m.get("entry_id") for m in recovered] == [
+                m.get("entry_id") for m in view_before
+            ], "重启后 view 必须与 journal 投影一致"
+            assert recovered[0]["role"] == "compaction"
+            service2.store.verify_consistency(mission.mission_id)
+
+            # 11. export → import（只读、不恢复授权）。
+            bundle = tmp_path / "out.rcmission"
+            service2.exporter.export_bundle(mission.mission_id, bundle)
+            with zipfile.ZipFile(bundle) as zf:
+                blob = b"".join(zf.read(n) for n in zf.namelist()).decode(errors="replace")
+            assert "permit_secret" not in blob and "private_signature" not in blob
+            imported = service2.importer.import_bundle(bundle)
+            assert imported["read_only"] and imported["authority_restored"] is False
+
+            # 12. fork → tree（双时间线）。
+            canonical = service2.store.conversation_canonical(mission.mission_id)
+            branch = service2.branches.fork(
+                mission.mission_id, from_entry_id=canonical[0]["entry_id"], label="复盘分支"
+            )
+            forked = service2.get_mission(branch.forked_mission_id)
+            assert forked.mode.value == "SIMULATION" and forked.context_revision == 0
+            tree = service2.branches.tree(mission.mission_id)
+            assert len(tree["reasoning_branches"]) == 1
+            assert any(e["type"] == "grant.consumed" for e in tree["physical_lane"])
+
+            # 13. snapshot 与 SSE 重放一致（watermark）。
+            snap = service2.snapshot(mission.mission_id)
+            assert snap.last_event_sequence == service2._events.latest_sequence(
+                mission.mission_id
+            )
+            assert snap.tool_count >= 2
+
+            # 14. estop 无 daemon 诚实不可用。
+            from rosclaw.contracts.common import ValidationError
+
+            with pytest.raises(ValidationError, match="estop unavailable"):
+                await service2.estop("test", principal=LOCAL_PRINCIPAL)
+
+            # 15. legacy rosclaw-mcp 经 catalog 注入（观测类）。
+            await service2._ensure_mcp_discovered()
+            catalog_ids = {d.tool_id for d in service2.tool_catalog.list()}
+            assert "get_robot_state" in catalog_ids
+            pose = service2.tool_catalog.get("limo.localization.get_pose")
+            assert pose is not None and pose.model_callable
+            estop_tool = service2.tool_catalog.get("emergency_stop")
+            assert estop_tool is not None and not estop_tool.model_callable
+
+            await service2.close()
+        finally:
+            if service2 is not None:
+                from contextlib import suppress
+
+                with suppress(Exception):
+                    await service2.close()
+
+    async def test_http_surface_consistency(self, tmp_path: Path) -> None:
+        """HTTP 面：/v2 turn → SSE 重放 → snapshot → commands 一致。"""
+        from fastapi.testclient import TestClient
+
+        home = tmp_path / "home"
+        home.mkdir()
+        _write_home(home)
+        config = load_agent_config(home / "config.yaml")
+        service = AgentService(
+            config, home, gateway=MockModelGateway(mock_profile(), [_chain_script] * 30)
+        )
+        # 先在测试自己的 loop 完成 MCP 发现（持久会话归属单一 loop）；
+        # TestClient portal 的 server loop 直接复用，不跨 loop 起进程。
+        await service._ensure_mcp_discovered()
+        client = TestClient(create_app(service))
+        try:
+            mission = service.create_mission("HTTP 一致性")
+            r = client.post(f"/v2/missions/{mission.mission_id}/turns", json={"text": "开始"})
+            assert r.status_code == 202
+            # runner 在 TestClient portal loop 执行；从本 loop 只能轮询
+            # store（线程安全），不能 await 对方的 task。
+            import time as _time
+
+            deadline = _time.monotonic() + 30.0
+            while _time.monotonic() < deadline:
+                task = service._turn_tasks.get(mission.mission_id)
+                if task is not None and task.done():
+                    break
+                _time.sleep(0.1)
+            else:
+                raise AssertionError("turn did not settle in 30s")
+            with client.stream(
+                "GET", f"/v2/missions/{mission.mission_id}/events?follow=false"
+            ) as response:
+                frames = [
+                    line for line in response.iter_lines() if line.startswith("data: ")
+                ]
+            assert frames
+            seqs = [json.loads(f[6:])["sequence"] for f in frames]
+            assert seqs == sorted(seqs)
+            snap = client.get(f"/v1/missions/{mission.mission_id}/snapshot").json()
+            assert snap["last_event_sequence"] == seqs[-1]
+            caps = client.get(f"/v1/capabilities?mission_id={mission.mission_id}").json()
+            names = {c["name"] for c in caps["commands"]}
+            assert {"compact", "export", "import", "fork", "tree", "tools", "doctor"} <= names
+            # CSRF：外部 Origin 打 turn endpoint → 403。
+            hostile = client.post(
+                f"/v2/missions/{mission.mission_id}/turns",
+                json={"text": "x"},
+                headers={"Origin": "https://evil.example"},
+            )
+            assert hostile.status_code == 403
+        finally:
+            await service.close()


### PR DESCRIPTION
## Summary

Cross-feature conflict review + a permanent full-link deep regression suite.

**Conflicts/logic issues fixed**
- **Legacy MCP servers unusable by the Native Agent**: without annotations, the new catalog fail-closed-classified EVERY tool of `rosclaw-mcp`/`rosclaw-ur5-mcp` as PHYSICAL_ACTION — all S0/S2 observations (`get_robot_state`, `validate_trajectory`, `system.*` read-only) were unreachable. Both servers now emit `readOnlyHint` from the `MCP_TOOL_SAFETY_LEVELS` table; actions stay PHYSICAL_ACTION by construction (verified end-to-end via real stdio discovery).
- **ur5_server banner on stdout** corrupted the JSON-RPC channel — moved to stderr.
- **HTTP approvals hardcoded principal**: `/approvals/{id}/decide` defaulted to `user:local:1000`, mismatched on any uid≠1000 host; omitted principal now resolves from the mission owner (loopback console keeps working; strong identity stays on operator.sock's SO_PEERCRED).
- **/v2 turn deltas silently dropped**: `on_text_delta` callbacks were invoked without await — the MissionRunner's async event-bus callback produced never-awaited coroutines and zero deltas. Both call sites now await coroutine results.
- **PersistentMcpClient across loops**: anyio streams are loop-bound; the HTTP portal loop and CLI/test loop now get their own sessions (loop-keyed). Production's single-loop topology still shares one process for observation + SIM actuation state.

**New permanent regression — `tests/agentd/test_full_chain_e2e.py`**: the complete link in one run, all real paths (real MCP stdio, real UDS, real modeld subprocess, real ACP JSON-RPC; only the model is mocked, real-model coverage lives in the K-series):
doctor → mission → LIMO observation → operator.sock approval (peer identity + display hash) → SIM execution → receipt → single-use denial → worker delegation ACCEPTED → compaction + restart-identical view → export/import (read-only, no authority) → fork/tree dual timeline → snapshot/SSE watermark → honest estop-without-daemon → legacy MCP observation → HTTP v2/SSE/snapshot/commands consistency + CSRF 403.

## Tests

6127 passed full regression; ruff + mypy (1079 files) clean; mcp suites 204 passed.