### PR TITLE
fix(agentd): answer every parallel tool_call_id (Kimi live)

### DIFF
--- a/src/rosclaw/agentd/loop.py
+++ b/src/rosclaw/agentd/loop.py
@@ -406,6 +406,24 @@ class AgentLoop:
                         arguments = {}
                     if call.name == SUBMIT_DECISION_TOOL:
                         # 内部协议工具：不执行，只提交 DecisionV1（服务端补齐绑定）。
+                        # 并行调用时后续工具也必须得到回执（Kimi 拒绝悬空
+                        # tool_call_id），因此 respond-and-continue，不 break。
+                        if decision is not None:
+                            # 一轮多份提交：只取第一份有效决策，其余标记。
+                            self._conversation.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": call.call_id,
+                                    "content": json.dumps(
+                                        {
+                                            "error": "duplicate submit_decision in one round "
+                                            "(first decision stands)"
+                                        },
+                                        ensure_ascii=False,
+                                    ),
+                                }
+                            )
+                            continue
                         try:
                             submitted = build_decision_payload(
                                 arguments,
@@ -441,7 +459,7 @@ class AgentLoop:
                                     ),
                                 }
                             )
-                        break
+                        continue
                     if self._tools is None:
                         result.reply = "模型请求了工具，但当前没有可用工具执行器。"
                         result.degraded = "tools_unavailable"

--- a/tests/agentd/test_submit_decision.py
+++ b/tests/agentd/test_submit_decision.py
@@ -197,3 +197,97 @@ class TestProtocolRoundTrip:
             assert result.state.value == "IDLE"
         finally:
             await service.close()
+
+
+class TestParallelToolCalls:
+    async def test_submit_mid_parallel_calls_all_get_responses(self, tmp_path: Path) -> None:
+        """并行工具调用（Kimi 实测触发）：submit_decision 在调用列表中间时，
+        其后的工具也必须执行并回执——不得留下悬空 tool_call_id。"""
+        from rosclaw.agentd.config import load_agent_config
+        from rosclaw.agentd.models.gateway import MockModelGateway
+        from rosclaw.agentd.models.profiles import mock_profile
+        from rosclaw.agentd.service import AgentService
+        from rosclaw.contracts.agent.model_turn import ToolCall
+
+        def parallel_turn(request) -> ModelTurnResultV1:
+            submit_args = json.dumps(
+                {
+                    "next_intent": "ANSWER",
+                    "summary": "并行后回答",
+                    "evidence_refs": [],
+                }
+            )
+            return ModelTurnResultV1(
+                turn_id="t",
+                provider="mock",
+                model="m",
+                content="",
+                assistant_message={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {
+                                "name": "sim_get_state",
+                                "arguments": '{"verbose": true}',
+                            },
+                        },
+                        {
+                            "id": "c2",
+                            "type": "function",
+                            "function": {
+                                "name": "rosclaw_submit_decision",
+                                "arguments": submit_args,
+                            },
+                        },
+                        {
+                            "id": "c3",
+                            "type": "function",
+                            "function": {
+                                "name": "sim_body_profile",
+                                "arguments": '{"detail": true}',
+                            },
+                        },
+                    ],
+                },
+                tool_calls=[
+                    ToolCall(
+                        call_id="c1",
+                        name="sim_get_state",
+                        arguments_json='{"verbose": true}',
+                    ),
+                    ToolCall(
+                        call_id="c2",
+                        name="rosclaw_submit_decision",
+                        arguments_json=submit_args,
+                    ),
+                    ToolCall(
+                        call_id="c3",
+                        name="sim_body_profile",
+                        arguments_json='{"detail": true}',
+                    ),
+                ],
+                usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+            )
+
+        config = load_agent_config(tmp_path / "config.yaml")
+        service = AgentService(
+            config, tmp_path, gateway=MockModelGateway(mock_profile(), [parallel_turn])
+        )
+        try:
+            mission = service.create_mission("并行调用")
+            result = await service.send_turn(mission.mission_id, "并行测试")
+            assert result.state.value == "IDLE"
+            history = service.conversation(mission.mission_id)
+            responses = {
+                m.get("tool_call_id") for m in history if m.get("role") == "tool"
+            }
+            assert responses >= {"c1", "c2", "c3"}, (
+                f"every parallel tool_call_id must get a response, got {responses}"
+            )
+            # submit 回执为协议确认，且两份真实工具结果存在。
+            assert result.tool_rounds == 2
+        finally:
+            await service.close()


### PR DESCRIPTION
Found by a K9 live rerun: when the model issues parallel tool calls with rosclaw_submit_decision in the middle, the loop broke at the submit and left later calls without tool responses — Kimi then rejects the next request with tool_call_id is not found. Submit path now respond-and-continues; duplicate submits in one round are error-marked (first valid decision stands). Regression test covers the exact ordering.