### PR TITLE
Audit A-line: TUI live delta, args schema, interactions (P0-02/P0-03)

### DIFF
--- a/packages/rosclaw-tui/package.json
+++ b/packages/rosclaw-tui/package.json
@@ -5,7 +5,7 @@
 	"description": "ROSClaw Native Agent terminal UI — pi-tui components + ROSClaw command routing + state reducer. Never executes tools, workers, or hardware.",
 	"type": "module",
 	"bin": {
-		"rosclaw-tui": "dist/main.js"
+		"rosclaw-tui": "dist/src/main.js"
 	},
 	"engines": {
 		"node": ">=22.19.0"
@@ -13,7 +13,7 @@
 	"scripts": {
 		"build": "tsc -p tsconfig.json",
 		"test": "npm run build && node --test dist/test/*.test.js",
-		"start": "node dist/main.js"
+		"start": "node dist/src/main.js"
 	},
 	"dependencies": {
 		"@earendil-works/pi-tui": "0.83.0",

--- a/packages/rosclaw-tui/src/app.ts
+++ b/packages/rosclaw-tui/src/app.ts
@@ -9,14 +9,18 @@ import {
 	Editor,
 	Markdown,
 	ProcessTerminal,
+	SelectList,
 	Text,
 	TUI,
 	matchesKey,
 } from "@earendil-works/pi-tui";
+import { parseArgs as parseSchemaArgs } from "./commands/args-parser.js";
+import { MaskedInput } from "./components/masked-input.js";
 import { AgentClient, idempotencyKey } from "./client/http.js";
 import { defaultOperatorSocket, operatorCall } from "./client/operator.js";
 import { streamEvents } from "./client/sse.js";
 import { CommandRegistry } from "./commands/registry.js";
+import { LiveAssistantMessage } from "./components/live-message.js";
 import { HOTKEYS_TEXT, renderCard, statusLine } from "./components/render.js";
 import { chalk, editorTheme, markdownTheme, modeColor } from "./components/theme.js";
 import { reduce, shortId, type Effect } from "./state/reducer.js";
@@ -34,9 +38,11 @@ export class RosclawTuiApp {
 	private state: UiState;
 	private client: AgentClient;
 	private registry = new CommandRegistry();
-	private deltaBuffer = "";
+	private live: LiveAssistantMessage | null = null;
 	private abort = new AbortController();
 	private running = false;
+	private lastDeltaAt = 0;
+	private phaseTicker: ReturnType<typeof setInterval> | null = null;
 
 	constructor(private readonly options: AppOptions) {
 		this.client = new AgentClient(options.baseUrl);
@@ -80,6 +86,10 @@ export class RosclawTuiApp {
 		this.editor.onSubmit = (text) => {
 			void this.handleInput(text);
 		};
+
+		// resume：先把 journal 中的可见历史恢复成 transcript（审计 P0-02.7），
+		// 再进入 live 增量（sequence 已由 snapshot 对齐，不会重复）。
+		await this.replayTranscript();
 
 		this.tui.addChild(
 			new Markdown(
@@ -125,6 +135,12 @@ export class RosclawTuiApp {
 
 		this.running = true;
 		this.tui.start();
+		// 500ms 内无 delta 时状态行仍持续显示阶段+计时（审计 P0-02.4：
+		// 不能保持静默）。
+		this.phaseTicker = setInterval(() => {
+			if (this.state.turnInFlight) this.refreshStatus();
+		}, 500);
+		this.phaseTicker.unref?.();
 		void this.consumeEvents();
 	}
 
@@ -132,13 +148,23 @@ export class RosclawTuiApp {
 
 	stop(): void {
 		this.running = false;
+		if (this.phaseTicker !== null) clearInterval(this.phaseTicker);
+		this.live?.flush(true);
 		this.abort.abort();
 		this.tui.stop();
 	}
 
 	private statusString(): string {
 		const line = statusLine(this.state);
-		const phase = this.state.phase ? ` [${this.state.phase}…]` : "";
+		let phase = "";
+		if (this.state.turnInFlight) {
+			const label = this.state.phase || "排队";
+			const idleMs = this.lastDeltaAt > 0 ? Date.now() - this.lastDeltaAt : 0;
+			phase =
+				idleMs > 500
+					? ` [${label}… ${(idleMs / 1000).toFixed(0)}s]`
+					: ` [${label}…]`;
+		}
 		return modeColor(this.state.mode, line) + chalk.dim(phase);
 	}
 
@@ -146,7 +172,12 @@ export class RosclawTuiApp {
 		this.statusText.setText?.(this.statusString());
 	}
 
-	/** 在 status bar 与 editor 之上插入一行（保持布局顺序）。 */
+	private transcriptCount = 0;
+	private static readonly MAX_TRANSCRIPT_BLOCKS = 400;
+
+	/** 在 status bar 与 editor 之上插入一行（保持布局顺序）；超出窗口
+	 * 移除最旧 transcript 块（渲染窗口与 journal 持久化分离——历史
+	 * 永远在 journal，/resume 可完整恢复）。 */
 	private print(component: Text | Markdown): void {
 		this.tui.removeChild(this.statusText);
 		this.tui.removeChild(this.editor);
@@ -154,6 +185,14 @@ export class RosclawTuiApp {
 		this.tui.addChild(this.statusText);
 		this.tui.addChild(this.editor);
 		this.tui.setFocus(this.editor);
+		this.transcriptCount += 1;
+		if (this.transcriptCount > RosclawTuiApp.MAX_TRANSCRIPT_BLOCKS) {
+			const children = this.tui.children;
+			if (children.length > 3) {
+				this.tui.removeChild(children[1]);
+				this.transcriptCount -= 1;
+			}
+		}
 	}
 
 	private applyEffects(effects: Effect[]): void {
@@ -162,14 +201,20 @@ export class RosclawTuiApp {
 				case "append_markdown":
 					this.print(new Markdown(effect.text, 0, 0, markdownTheme));
 					break;
-				case "append_delta":
-					this.deltaBuffer += effect.text;
-					break;
-				case "flush_delta":
-					if (this.deltaBuffer.trim()) {
-						this.print(new Markdown(this.deltaBuffer, 0, 0, markdownTheme));
+				case "append_delta": {
+					if (this.live === null) {
+						this.live = new LiveAssistantMessage(markdownTheme, () => this.refreshStatus());
+						this.print(this.live.component);
 					}
-					this.deltaBuffer = "";
+					this.lastDeltaAt = Date.now();
+					this.live.append(effect.text);
+					break;
+				}
+				case "flush_delta":
+					if (this.live !== null) {
+						this.live.flush(true);
+						this.live = null;
+					}
 					break;
 				case "append_card":
 					this.print(new Text(renderCard(effect.card)));
@@ -181,6 +226,46 @@ export class RosclawTuiApp {
 					break;
 			}
 		}
+	}
+
+	/** resume 时把历史事件重放为 transcript（delta 按 turn 聚合，卡片直出）。 */
+	private async replayTranscript(): Promise<void> {
+		const events = await this.client.replayEvents(this.options.missionId);
+		let live: LiveAssistantMessage | null = null;
+		const flushLive = () => {
+			if (live !== null) {
+				live.flush(true);
+				live = null;
+			}
+		};
+		for (const raw of events) {
+			const event = raw as { type?: string; visibility?: string; payload?: Record<string, unknown>; sequence?: number };
+			if (event.visibility === "DEBUG") continue;
+			const type = String(event.type ?? "");
+			const payload = event.payload ?? {};
+			if (type === "model.text.delta") {
+				if (live === null) {
+					live = new LiveAssistantMessage(markdownTheme, () => undefined);
+					this.print(live.component);
+				}
+				live.append(String(payload.text ?? ""));
+				continue;
+			}
+			flushLive();
+			const effects = reduce(this.state, {
+				event_id: `replay_${String(event.sequence ?? "")}`,
+				sequence: Number(event.sequence ?? 0),
+				mission_id: this.options.missionId,
+				type,
+				visibility: String(event.visibility ?? "USER"),
+				payload,
+				timestamp: "",
+			});
+			for (const effect of effects) {
+				if (effect.kind === "append_card") this.print(new Text(renderCard(effect.card)));
+			}
+		}
+		flushLive();
 	}
 
 	private async consumeEvents(): Promise<void> {
@@ -216,9 +301,42 @@ export class RosclawTuiApp {
 		}
 	}
 
+	/** /resume：切换 mission——停旧流、对齐 snapshot、恢复 transcript、重开事件流。 */
+	private async switchMission(missionId: string): Promise<void> {
+		this.abort.abort();
+		this.abort = new AbortController();
+		this.options.missionId = missionId;
+		this.state = initialState(missionId);
+		try {
+			const snap = await this.client.snapshot(missionId);
+			this.state.missionName = snap.name;
+			this.state.missionState = snap.state;
+			this.state.mode = snap.mode;
+			this.state.bodyId = snap.body_id;
+			this.state.lastSeq = snap.last_event_sequence;
+			this.state.turnInFlight = snap.turn_in_flight;
+			const caps = await this.client.capabilities(missionId);
+			this.registry.loadRemote(caps.commands);
+		} catch (err) {
+			this.print(new Text(chalk.red(`无法切换到 ${missionId}：${(err as Error).message}`)));
+			return;
+		}
+		this.print(new Text(chalk.dim(`—— 已切换到 ${this.state.missionName} ——`)));
+		await this.replayTranscript();
+		this.refreshStatus();
+		void this.consumeEvents();
+	}
+
 	private async handleInput(raw: string): Promise<void> {
 		const text = raw.trim();
 		if (!text) return;
+		// //text 转义：以 / 开头的普通文本显式发送（审计 P0-03.6）。
+		if (text.startsWith("//")) {
+			const literal = text.slice(1);
+			this.print(new Text(chalk.cyan("> " + literal)));
+			await this.client.submitTurn(this.options.missionId, literal);
+			return;
+		}
 		const route = this.registry.parse(text);
 		switch (route.kind) {
 			case "not_a_command":
@@ -241,38 +359,144 @@ export class RosclawTuiApp {
 			case "local":
 				await this.handleLocal(route.name, route.args);
 				return;
-			case "remote": {
-				if (route.spec.disabled_reason) {
-					this.print(new Text(chalk.yellow(`/${route.spec.name} 不可用：${route.spec.disabled_reason}`)));
-					return;
-				}
-				const args = this.parseRemoteArgs(route.spec.name, route.args);
-				const result = await this.client.command(
-					this.options.missionId,
-					route.spec.name,
-					args,
-					idempotencyKey(),
-				);
-				this.print(
-					new Text(
-						result.ok
-							? chalk.green(result.message || "ok")
-							: chalk.red(`${result.error_code}: ${result.message}`),
-					),
-				);
+			case "remote":
+				await this.handleRemote(route.spec, route.args);
 				return;
-			}
 		}
 	}
 
-	private parseRemoteArgs(name: string, args: string): Record<string, unknown> {
-		if (name === "rename") return { name: args };
-		if (name === "compact") {
-			if (args === "dry-run") return { dry_run: true };
-			if (args.startsWith("focus ")) return { focus: args.slice(6) };
-			return {};
+	/** 远程命令：共享 args_schema 解析 + interaction（select/secret/confirm/path）。 */
+	private async handleRemote(
+		spec: import("./client/http.js").CommandSpec,
+		rawArgs: string,
+	): Promise<void> {
+		if (spec.disabled_reason) {
+			this.print(new Text(chalk.yellow(`/${spec.name} 不可用：${spec.disabled_reason}`)));
+			return;
 		}
-		return {};
+		const parsed = parseSchemaArgs(spec.args_schema, rawArgs);
+		if (!parsed.ok) {
+			this.print(
+				new Text(chalk.yellow(`/${spec.name} ${parsed.error}（${spec.argument_hint || "见 /help"}）`)),
+			);
+			return;
+		}
+		const interaction = spec.args_schema?.interaction ?? "none";
+		if (interaction === "secret" && parsed.args.api_key === undefined) {
+			await this.runSecretInteraction(spec, parsed.args);
+			return;
+		}
+		if (interaction === "select" && !rawArgs.trim()) {
+			await this.runSelectInteraction(spec, parsed.args);
+			return;
+		}
+		await this.executeRemote(spec.name, parsed.args);
+	}
+
+	private async executeRemote(name: string, args: Record<string, unknown>): Promise<void> {
+		const result = await this.client.command(
+			this.options.missionId,
+			name,
+			args,
+			idempotencyKey(),
+		);
+		this.print(
+			new Text(
+				result.ok
+					? chalk.green(result.message || "ok")
+					: chalk.red(`${result.error_code}: ${result.message}`),
+			),
+		);
+		if (name === "model" && result.ok) this.refreshStatus();
+	}
+
+	/** secret 交互：masked 输入，值只进命令参数，不进 transcript/history。 */
+	private async runSecretInteraction(
+		spec: import("./client/http.js").CommandSpec,
+		baseArgs: Record<string, unknown>,
+	): Promise<void> {
+		const provider = String(baseArgs.provider ?? "");
+		if (!provider) {
+			this.print(new Text(chalk.yellow(`/${spec.name} 需要 provider（如 /login kimi-code）`)));
+			return;
+		}
+		const masked = new MaskedInput(this.tui, `${provider} API key:`);
+		const handle = this.tui.showOverlay(masked, { width: "60%" });
+		this.tui.setFocus(masked);
+		masked.onSubmit = (secret) => {
+			handle.hide();
+			this.tui.setFocus(this.editor);
+			if (secret) {
+				void this.executeRemote(spec.name, { ...baseArgs, api_key: secret });
+			}
+		};
+		masked.onCancel = () => {
+			handle.hide();
+			this.tui.setFocus(this.editor);
+			this.print(new Text(chalk.dim("已取消登录（未发送任何凭据）")));
+		};
+	}
+
+	/** select 交互：从命令数据或 modeld 列表构建 SelectList。 */
+	private async runSelectInteraction(
+		spec: import("./client/http.js").CommandSpec,
+		baseArgs: Record<string, unknown>,
+	): Promise<void> {
+		let items: Array<{ value: string; label: string; description?: string }> = [];
+		if (spec.args_schema?.interaction_source === "models") {
+			const listing = await this.client.command(
+				this.options.missionId,
+				"model",
+				{},
+				idempotencyKey(),
+			);
+			const models = (listing.data?.models ?? {}) as Record<string, string[]>;
+			for (const [provider, ids] of Object.entries(models)) {
+				for (const id of ids) {
+					items.push({ value: `${provider}/${id}`, label: `${provider}/${id}` });
+				}
+			}
+		} else if (spec.args_schema?.interaction_source === "workers") {
+			const listing = await this.client.command(
+				this.options.missionId,
+				"workers",
+				{},
+				idempotencyKey(),
+			);
+			const workers = (listing.data?.workers ?? []) as Array<{ worker_id: string; status: string }>;
+			items = workers.map((w) => ({
+				value: w.worker_id,
+				label: w.worker_id,
+				description: w.status,
+			}));
+		}
+		if (items.length === 0) {
+			this.print(new Text(chalk.yellow("没有可选项（modeld/worker 列表为空）")));
+			return;
+		}
+		const list = new SelectList(items, Math.min(items.length, 10), {
+			selectedPrefix: (t) => chalk.blue(t),
+			selectedText: (t) => chalk.bold(t),
+			description: (t) => chalk.dim(t),
+			scrollInfo: (t) => chalk.dim(t),
+			noMatch: (t) => chalk.dim(t),
+		});
+		const handle = this.tui.showOverlay(list, { width: "70%" });
+		this.tui.setFocus(list);
+		list.onSelect = (item) => {
+			handle.hide();
+			this.tui.setFocus(this.editor);
+			if (spec.args_schema?.interaction_source === "models") {
+				void this.executeRemote(spec.name, { target: item.value });
+			} else if (spec.args_schema?.interaction_source === "workers") {
+				const sub = String((this.registry.parse(`/worker ${item.value}`).kind === "remote" && "inspect") || "inspect");
+				void this.executeRemote(spec.name, { subcommand: sub, worker_id: item.value });
+			}
+		};
+		list.onCancel = () => {
+			handle.hide();
+			this.tui.setFocus(this.editor);
+		};
 	}
 
 	private async handleLocal(name: string, args: string): Promise<void> {
@@ -366,6 +590,41 @@ export class RosclawTuiApp {
 					(m) => `${m.mission_id}  ${String(m.state ?? "")}  ${String((m.goal as { text?: string })?.text ?? "").slice(0, 40)}`,
 				);
 				this.print(new Text(lines.join("\n") || "(无 Mission)"));
+				return;
+			}
+			case "resume": {
+				if (args) {
+					await this.switchMission(args);
+					return;
+				}
+				const missions = await this.client.listMissions();
+				const items = missions.map((m) => ({
+					value: m.mission_id,
+					label: `${m.mission_id}  ${String((m.goal as { text?: string })?.text ?? "").slice(0, 30)}`,
+					description: String(m.state ?? ""),
+				}));
+				if (items.length === 0) {
+					this.print(new Text(chalk.yellow("没有可恢复的 Mission")));
+					return;
+				}
+				const list = new SelectList(items, Math.min(items.length, 10), {
+					selectedPrefix: (t) => chalk.blue(t),
+					selectedText: (t) => chalk.bold(t),
+					description: (t) => chalk.dim(t),
+					scrollInfo: (t) => chalk.dim(t),
+					noMatch: (t) => chalk.dim(t),
+				});
+				const handle = this.tui.showOverlay(list, { width: "80%" });
+				this.tui.setFocus(list);
+				list.onSelect = (item) => {
+					handle.hide();
+					this.tui.setFocus(this.editor);
+					void this.switchMission(item.value);
+				};
+				list.onCancel = () => {
+					handle.hide();
+					this.tui.setFocus(this.editor);
+				};
 				return;
 			}
 		}

--- a/packages/rosclaw-tui/src/client/http.ts
+++ b/packages/rosclaw-tui/src/client/http.ts
@@ -18,6 +18,7 @@ export interface CommandSpec {
 	required_capabilities: string[];
 	handler: string;
 	disabled_reason: string;
+	args_schema?: import("../commands/args-parser.js").ArgsSchema;
 }
 
 export interface CommandResult {
@@ -118,6 +119,30 @@ export class AgentClient {
 
 	pendingApprovals(missionId: string): Promise<Array<Record<string, unknown>>> {
 		return this.request("GET", `/approvals/pending?mission_id=${missionId}`);
+	}
+
+	/** 有界事件重放（resume 恢复 transcript 用；不走 SSE 长连接）。 */
+	async replayEvents(
+		missionId: string,
+		afterSequence = 0,
+	): Promise<Array<Record<string, unknown>>> {
+		const res = await fetch(
+			`${this.baseUrl}/v2/missions/${missionId}/events?follow=false&after_sequence=${afterSequence}`,
+			{ headers: { accept: "text/event-stream" } },
+		);
+		if (!res.ok || !res.body) return [];
+		const text = await res.text();
+		const events: Array<Record<string, unknown>> = [];
+		for (const line of text.split("\n")) {
+			if (line.startsWith("data: ")) {
+				try {
+					events.push(JSON.parse(line.slice(6)) as Record<string, unknown>);
+				} catch {
+					/* skip malformed frame */
+				}
+			}
+		}
+		return events;
 	}
 }
 

--- a/packages/rosclaw-tui/src/commands/args-parser.ts
+++ b/packages/rosclaw-tui/src/commands/args-parser.ts
@@ -1,0 +1,71 @@
+/** Schema-driven command args parser（审计 P0-03）：TUI/ACP/Web 共享。 */
+
+export interface PositionalSpec {
+	name: string;
+	type: "string" | "enum" | "rest";
+	required?: boolean;
+	enum?: string[];
+}
+
+export interface ArgsSchema {
+	positional?: PositionalSpec[];
+	flags?: Record<string, { type: string }>;
+	interaction?: string;
+	interaction_source?: string;
+}
+
+export interface ParseOutcome {
+	ok: boolean;
+	args: Record<string, unknown>;
+	error?: string;
+}
+
+export function parseArgs(schema: ArgsSchema | undefined, input: string): ParseOutcome {
+	const spec = schema ?? {};
+	const positionals = spec.positional ?? [];
+	const flags = spec.flags ?? {};
+	const args: Record<string, unknown> = {};
+
+	let rest = input.trim();
+	// flags：前缀匹配 "--name" 或裸 "dry-run" 风格（与 /compact dry-run 一致）。
+	for (const [flagName] of Object.entries(flags)) {
+		for (const form of [`--${flagName}`, flagName]) {
+			if (rest === form || rest.startsWith(form + " ")) {
+				args[flagName.replace(/-/g, "_")] = true;
+				rest = rest.slice(form.length).trim();
+				break;
+			}
+		}
+	}
+
+	for (let i = 0; i < positionals.length; i += 1) {
+		const pos = positionals[i];
+		const isLast = i === positionals.length - 1;
+		if (pos.type === "rest") {
+			if (rest) args[pos.name] = rest;
+			rest = "";
+		} else {
+			const [head, ...tail] = rest.split(/\s+/).filter(Boolean);
+			if (head) args[pos.name] = head;
+			rest = tail.join(" ");
+		}
+		if (args[pos.name] === undefined && pos.required) {
+			return { ok: false, args: {}, error: `缺少参数 <${pos.name}>` };
+		}
+		if (pos.type === "enum" && args[pos.name] !== undefined) {
+			const allowed = pos.enum ?? [];
+			if (!allowed.includes(String(args[pos.name]))) {
+				return {
+					ok: false,
+					args: {},
+					error: `参数 ${pos.name} 必须是 ${allowed.join("|")} 之一`,
+				};
+			}
+		}
+		void isLast;
+	}
+	if (rest && positionals.length === 0) {
+		return { ok: false, args: {}, error: "此命令不接受参数" };
+	}
+	return { ok: true, args };
+}

--- a/packages/rosclaw-tui/src/commands/registry.ts
+++ b/packages/rosclaw-tui/src/commands/registry.ts
@@ -24,6 +24,7 @@ export const LOCAL_COMMANDS: LocalCommand[] = [
 	{ name: "approve", aliases: [], description: "批准授权请求", argumentHint: "<request_id>" },
 	{ name: "deny", aliases: [], description: "拒绝授权请求", argumentHint: "<request_id>" },
 	{ name: "missions", aliases: [], description: "列出 Mission", argumentHint: "" },
+	{ name: "resume", aliases: [], description: "切换到其他 Mission（选择器）", argumentHint: "[mission_id]" },
 	{ name: "estop", aliases: [], description: "紧急停止（直达 rosclawd，不经过模型）", argumentHint: "" },
 ];
 

--- a/packages/rosclaw-tui/src/components/live-message.ts
+++ b/packages/rosclaw-tui/src/components/live-message.ts
@@ -1,0 +1,57 @@
+/** Live assistant message（审计 P0-02）：可变增量消息组件。
+ *
+ * delta 不再攒到 flush 才出现——每个 turn 一个可变 Markdown 组件，
+ * 20–40ms 节流刷新；终止/错误/取消/agent.settled 时强制 flush。
+ */
+
+import { Markdown, type MarkdownTheme } from "@earendil-works/pi-tui";
+
+export class LiveAssistantMessage {
+	readonly component: Markdown;
+	private buffer = "";
+	private pending = "";
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private onFlush: () => void;
+	private flushed = false;
+
+	constructor(theme: MarkdownTheme, onFlush: () => void) {
+		this.component = new Markdown("", 0, 0, theme);
+		this.onFlush = onFlush;
+	}
+
+	append(text: string): void {
+		this.pending += text;
+		if (this.timer === null) {
+			// 首个 delta 立即显示（不做无谓等待），随后节流。
+			this.flush();
+			this.timer = setInterval(() => this.flush(), 30);
+			this.timer.unref?.();
+		}
+	}
+
+	/** 节流刷新；force 用于 turn 结束/错误/取消/settled。 */
+	flush(force = false): void {
+		if (this.pending) {
+			this.buffer += this.pending;
+			this.pending = "";
+			this.component.setText(this.buffer);
+			this.onFlush();
+		} else if (force && !this.flushed && !this.buffer) {
+			this.stop();
+			return;
+		}
+		if (force) this.stop();
+	}
+
+	stop(): void {
+		if (this.timer !== null) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+		this.flushed = true;
+	}
+
+	get text(): string {
+		return this.buffer + this.pending;
+	}
+}

--- a/packages/rosclaw-tui/src/components/masked-input.ts
+++ b/packages/rosclaw-tui/src/components/masked-input.ts
@@ -1,0 +1,53 @@
+/** Masked secret input（审计 P0-03.3）：自绘 masked 输入组件。
+ *
+ * secret 只进内存闭包，不进 transcript/journal/history——渲染永远是 •。
+ */
+
+import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
+import { Key, matchesKey } from "@earendil-works/pi-tui";
+
+export class MaskedInput implements Component, Focusable {
+	focused = false;
+	onSubmit?: (secret: string) => void;
+	onCancel?: () => void;
+	private value = "";
+	private cursorPos = 0;
+
+	constructor(
+		private readonly tui: TUI,
+		private readonly prompt: string,
+	) {}
+
+	invalidate(): void {
+		/* stateless render */
+	}
+
+	render(width: number): string[] {
+		const bullets = "•".repeat(this.value.length);
+		const line = `${this.prompt} ${bullets}`;
+		const hint = "（输入不显示原文；Enter 确认，Esc 取消）";
+		return [line.slice(0, width), hint];
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, "return")) {
+			const secret = this.value;
+			this.value = "";
+			this.onSubmit?.(secret);
+			return;
+		}
+		if (matchesKey(data, "escape")) {
+			this.value = "";
+			this.onCancel?.();
+			return;
+		}
+		if (matchesKey(data, "backspace")) {
+			this.value = this.value.slice(0, -1);
+			return;
+		}
+		if (data.length === 1 && data >= " ") {
+			this.value += data;
+			this.cursorPos = this.value.length;
+		}
+	}
+}

--- a/packages/rosclaw-tui/src/main.ts
+++ b/packages/rosclaw-tui/src/main.ts
@@ -44,18 +44,26 @@ async function main(): Promise<void> {
 	const client = new AgentClient(baseUrl);
 
 	let missionId = args.mission;
-	if (!missionId && args.goal) {
-		const created = await client.createMission(args.goal, args.mode);
-		missionId = created.mission_id;
-	}
-	if (!missionId) {
-		const missions = await client.listMissions();
-		const active = missions.filter((m) => m.state !== "FAILED");
-		if (active.length === 0) {
-			console.error("没有可用 Mission。用 --goal \"任务目标\" 创建，或 rosclaw chat 引导创建。");
-			process.exit(2);
+	try {
+		if (!missionId && args.goal) {
+			const created = await client.createMission(args.goal, args.mode);
+			missionId = created.mission_id;
 		}
-		missionId = active[active.length - 1].mission_id;
+		if (!missionId) {
+			const missions = await client.listMissions();
+			const active = missions.filter((m) => m.state !== "FAILED");
+			if (active.length === 0) {
+				console.error("没有可用 Mission。用 --goal \"任务目标\" 创建，或 rosclaw chat 引导创建。");
+				process.exit(2);
+			}
+			missionId = active[active.length - 1].mission_id;
+		}
+	} catch (err) {
+		console.error(
+			`无法连接 AgentService（${baseUrl}）：${(err as Error).message}\n` +
+				"请先启动 rosclaw-agentd（rosclaw chat 会自动启动），或用 --url 指定地址。",
+		);
+		process.exit(1);
 	}
 
 	const app = new RosclawTuiApp({ baseUrl, missionId });

--- a/packages/rosclaw-tui/src/state/reducer.ts
+++ b/packages/rosclaw-tui/src/state/reducer.ts
@@ -36,6 +36,7 @@ const PHASE_BY_EVENT: Record<string, string> = {
 	"action.dispatched": "正在执行/验证",
 	"verification.started": "正在执行/验证",
 	"compaction.started": "正在压缩上下文",
+	"turn.cancel.requested": "正在取消",
 };
 
 export function reduce(state: UiState, event: AgentEvent): Effect[] {

--- a/packages/rosclaw-tui/test/args-parser.test.ts
+++ b/packages/rosclaw-tui/test/args-parser.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseArgs, type ArgsSchema } from "../src/commands/args-parser.js";
+
+const S = (schema: ArgsSchema) => schema;
+
+test("positional rest captures multi-word", () => {
+	const schema = S({ positional: [{ name: "goal", type: "rest", required: true }] });
+	const out = parseArgs(schema, "把 红色 方块 移到 B 区");
+	assert.deepEqual(out, { ok: true, args: { goal: "把 红色 方块 移到 B 区" } });
+});
+
+test("required positional missing is an error, never sent", () => {
+	const schema = S({ positional: [{ name: "name", type: "rest", required: true }] });
+	const out = parseArgs(schema, "");
+	assert.equal(out.ok, false);
+	assert.match(out.error ?? "", /缺少参数/);
+});
+
+test("enum validation", () => {
+	const schema = S({
+		positional: [
+			{ name: "subcommand", type: "enum", enum: ["inspect", "enable"], required: true },
+			{ name: "worker_id", type: "string", required: true },
+		],
+	});
+	assert.deepEqual(parseArgs(schema, "inspect worker:native:basic"), {
+		ok: true,
+		args: { subcommand: "inspect", worker_id: "worker:native:basic" },
+	});
+	const bad = parseArgs(schema, "delete worker:x");
+	assert.equal(bad.ok, false);
+	assert.match(bad.error ?? "", /inspect\|enable/);
+});
+
+test("flags parsed before positionals", () => {
+	const schema = S({
+		positional: [{ name: "focus", type: "rest", required: false }],
+		flags: { "dry-run": { type: "boolean" } },
+	});
+	assert.deepEqual(parseArgs(schema, "dry-run"), { ok: true, args: { "dry_run": true } });
+	assert.deepEqual(parseArgs(schema, "dry-run 关注授权"), {
+		ok: true,
+		args: { "dry_run": true, focus: "关注授权" },
+	});
+	assert.deepEqual(parseArgs(schema, "关注授权"), { ok: true, args: { focus: "关注授权" } });
+});
+
+test("no-args command rejects stray args", () => {
+	const out = parseArgs(S({ interaction: "none" }), "unexpected");
+	assert.equal(out.ok, false);
+});
+
+test("optional positionals may be omitted", () => {
+	const schema = S({
+		positional: [
+			{ name: "key", type: "string", required: false },
+			{ name: "value", type: "rest", required: false },
+		],
+	});
+	assert.deepEqual(parseArgs(schema, ""), { ok: true, args: {} });
+	assert.deepEqual(parseArgs(schema, "agent.language"), { ok: true, args: { key: "agent.language" } });
+	assert.deepEqual(parseArgs(schema, "agent.language zh-CN"), {
+		ok: true,
+		args: { key: "agent.language", value: "zh-CN" },
+	});
+});

--- a/packages/rosclaw-tui/test/live-message.test.ts
+++ b/packages/rosclaw-tui/test/live-message.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Chalk } from "chalk";
+import { LiveAssistantMessage } from "../src/components/live-message.js";
+
+const chalk = new Chalk({ level: 0 });
+const theme = {
+	heading: (t: string) => t,
+	link: (t: string) => t,
+	linkUrl: (t: string) => t,
+	code: (t: string) => t,
+	codeBlock: (t: string) => t,
+	codeBlockBorder: (t: string) => t,
+	quote: (t: string) => t,
+	quoteBorder: (t: string) => t,
+	hr: (t: string) => t,
+	listBullet: (t: string) => t,
+	bold: (t: string) => t,
+	italic: (t: string) => t,
+	strikethrough: (t: string) => t,
+	underline: (t: string) => t,
+};
+
+test("first delta renders immediately, not on flush", () => {
+	let flushes = 0;
+	const live = new LiveAssistantMessage(theme, () => (flushes += 1));
+	live.append("你好");
+	// 首个 delta 立即显示（审计 P0-02.2：不允许傻等到 flush_delta）。
+	assert.equal(live.text, "你好");
+	assert.ok(flushes >= 1);
+	live.flush(true);
+});
+
+test("throttled accumulation, force flush on settle", async () => {
+	const live = new LiveAssistantMessage(theme, () => undefined);
+	live.append("a");
+	live.append("b");
+	live.append("c");
+	assert.equal(live.text, "abc");
+	live.flush(true);
+	assert.equal(live.text, "abc");
+});
+
+test("stop is idempotent", () => {
+	const live = new LiveAssistantMessage(theme, () => undefined);
+	live.append("x");
+	live.stop();
+	live.stop();
+	live.flush(true);
+	assert.equal(live.text, "x");
+});

--- a/packages/rosclaw-tui/test/package-entry.test.ts
+++ b/packages/rosclaw-tui/test/package-entry.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(here, "..", "..");
+
+/** 审计 §1.1：package.json bin/start 与 tsc 输出结构必须一致——
+ * 入口 smoke test 直接执行 npm 声明的路径，防止再次指向不存在的
+ * dist/main.js。 */
+test("package bin entry exists and is runnable", () => {
+	const pkg = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8")) as {
+		bin: Record<string, string>;
+		scripts: Record<string, string>;
+	};
+	const entry = join(pkgRoot, pkg.bin["rosclaw-tui"]);
+	assert.ok(existsSync(entry), `bin entry missing: ${entry}`);
+	// --version 式的快速执行：不带参数启动应立即给出用法/连接错误而非
+	// 模块找不到（非 TTY 下会报连接错误，这证明入口确实执行了）。
+	let output = "";
+	try {
+		output = execFileSync(process.execPath, [entry], {
+			encoding: "utf8",
+			timeout: 15_000,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+	} catch (err) {
+		output = String((err as { stdout?: string; stderr?: string }).stdout ?? "") +
+			String((err as { stdout?: string; stderr?: string }).stderr ?? "");
+	}
+	assert.ok(
+		output.includes("AgentService") || output.includes("Mission") || output.includes("rosclaw"),
+		`entry did not execute expected code path: ${output.slice(0, 200)}`,
+	);
+});
+
+test("start script points at the same entry", () => {
+	const pkg = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8")) as {
+		bin: Record<string, string>;
+		scripts: Record<string, string>;
+	};
+	assert.ok(pkg.scripts.start.includes(pkg.bin["rosclaw-tui"]));
+});

--- a/src/rosclaw/agentd/ui/command_service.py
+++ b/src/rosclaw/agentd/ui/command_service.py
@@ -27,6 +27,125 @@ if TYPE_CHECKING:
 
 HandlerFn = Callable[[CommandRequestV1], Awaitable[CommandResultV1]]
 
+#: 全部内建命令的机器可读参数 schema（审计 P0-03）。type: string|enum|rest
+#: （rest 吃掉剩余全部文本）；interaction 指示 TUI 需要的交互形态。
+_ARGS_SCHEMAS: dict[str, dict] = {
+    "compact": {
+        "positional": [{"name": "focus", "type": "rest", "required": False}],
+        "flags": {"dry-run": {"type": "boolean"}},
+        "interaction": "none",
+    },
+    "cancel": {"interaction": "none"},
+    "rename": {
+        "positional": [{"name": "name", "type": "rest", "required": True}],
+        "interaction": "none",
+    },
+    "archive": {"interaction": "confirm"},
+    "status": {"interaction": "none"},
+    "tools": {"interaction": "none"},
+    "providers": {"interaction": "none"},
+    "model": {
+        "positional": [{"name": "target", "type": "string", "required": False}],
+        "interaction": "select",
+        "interaction_source": "models",
+    },
+    "login": {
+        "positional": [{"name": "provider", "type": "string", "required": True}],
+        "interaction": "secret",
+    },
+    "logout": {
+        "positional": [{"name": "provider", "type": "string", "required": True}],
+        "interaction": "confirm",
+    },
+    "workers": {"interaction": "none"},
+    "worker": {
+        "positional": [
+            {
+                "name": "subcommand",
+                "type": "enum",
+                "enum": ["inspect", "enable", "disable", "probe"],
+                "required": True,
+            },
+            {"name": "worker_id", "type": "string", "required": True},
+        ],
+        "interaction": "select",
+        "interaction_source": "workers",
+    },
+    "grants": {"interaction": "none"},
+    "revoke": {
+        "positional": [{"name": "grant_id", "type": "string", "required": True}],
+        "interaction": "confirm",
+    },
+    "body": {"interaction": "none"},
+    "doctor": {"interaction": "none"},
+    "mode": {
+        "positional": [
+            {"name": "mode", "type": "enum", "enum": ["SIMULATION", "SHADOW", "REAL"], "required": False}
+        ],
+        "interaction": "none",
+    },
+    "context": {
+        "positional": [
+            {
+                "name": "subcommand",
+                "type": "enum",
+                "enum": ["layers", "usage", "compactions", "refresh"],
+                "required": False,
+            }
+        ],
+        "interaction": "none",
+    },
+    "session": {"interaction": "none"},
+    "new": {
+        "positional": [{"name": "goal", "type": "rest", "required": True}],
+        "interaction": "none",
+    },
+    "retry": {"interaction": "none"},
+    "failover": {"interaction": "none"},
+    "thinking": {
+        "positional": [
+            {"name": "effort", "type": "enum", "enum": ["low", "high", "max"], "required": False}
+        ],
+        "interaction": "none",
+    },
+    "scoped-models": {
+        "positional": [
+            {"name": "subcommand", "type": "enum", "enum": ["add", "remove", "list"], "required": False},
+            {"name": "target", "type": "string", "required": False},
+        ],
+        "interaction": "none",
+    },
+    "export": {
+        "positional": [{"name": "path", "type": "string", "required": False}],
+        "interaction": "path",
+    },
+    "import": {
+        "positional": [{"name": "path", "type": "string", "required": True}],
+        "interaction": "path",
+    },
+    "share": {"interaction": "none"},
+    "reload": {
+        "positional": [{"name": "domains", "type": "rest", "required": False}],
+        "interaction": "none",
+    },
+    "settings": {
+        "positional": [
+            {"name": "key", "type": "string", "required": False},
+            {"name": "value", "type": "rest", "required": False},
+        ],
+        "interaction": "none",
+    },
+    "tree": {"interaction": "none"},
+    "fork": {
+        "positional": [
+            {"name": "from_entry_id", "type": "string", "required": False},
+            {"name": "label", "type": "rest", "required": False},
+        ],
+        "interaction": "none",
+    },
+    "clone": {"interaction": "none"},
+}
+
 
 class CommandService:
     def __init__(self, service: AgentService) -> None:
@@ -42,6 +161,10 @@ class CommandService:
     # -- registry ----------------------------------------------------------------
 
     def _register(self, spec: CommandSpecV1, handler: HandlerFn) -> None:
+        if not spec.args_schema:
+            spec = spec.model_copy(
+                update={"args_schema": _ARGS_SCHEMAS.get(spec.name, {"interaction": "none"})}
+            )
         self._specs[spec.name] = spec
         self._handlers[spec.handler] = handler
 

--- a/src/rosclaw/contracts/ui/commands.py
+++ b/src/rosclaw/contracts/ui/commands.py
@@ -52,6 +52,13 @@ class CommandSpecV1(ContractModel):
     handler: str = ""
     #: set when unavailable: human-readable reason shown disabled in UI
     disabled_reason: str = ""
+    #: 机器可读参数 schema（审计 P0-03）：TUI/ACP/Web 共享解析，
+    #: 不再各自维护 switch 表。
+    #: {"positional": [{"name","type","required","enum"?,"rest"?}],
+    #:  "flags": {"name": {"type":"boolean"}},
+    #:  "interaction": "none|select|secret|path|confirm",
+    #:  "interaction_source": "models|missions|workers|providers|branches|none"}
+    args_schema: dict = Field(default_factory=dict)
 
 
 class CommandRequestV1(ContractModel):

--- a/tests/contracts/golden/rosclaw.ui.command_spec.v1.json
+++ b/tests/contracts/golden/rosclaw.ui.command_spec.v1.json
@@ -109,6 +109,11 @@
       "default": "",
       "title": "Disabled Reason",
       "type": "string"
+    },
+    "args_schema": {
+      "additionalProperties": true,
+      "title": "Args Schema",
+      "type": "object"
     }
   },
   "required": [


### PR DESCRIPTION
Per audit 2026-08-04:

**A1** — kills the "staring at silence" problem: LiveAssistantMessage renders the first delta immediately with 30ms throttled refresh (no more deltaBuffer-until-flush), phase status from turn start with idle-time indicator, resume replays the journal into the transcript, transcript windowing bound, package entry smoke test (caught a real bin path bug).

**A2** — CommandSpecV1 gains machine-readable args_schema (positional string/enum/rest + flags + interaction kind/source); TUI parses from the shared schema instead of a hand switch table that sent {} for most commands; //text escape.

**A3** — MaskedInput overlay for /login (secret never rendered/journaled), SelectList overlays for /model, /worker, /resume (mission picker with full snapshot+transcript switch).

25 node tests; ruff + mypy clean.