### PR TITLE
fix(skill): submit-catalog branches directly on the catalog for org members

### DIFF
--- a/src/rosclaw/skill/catalog.py
+++ b/src/rosclaw/skill/catalog.py
@@ -51,6 +51,67 @@ def _ensure_git_config(workdir: Path) -> None:
             _run(["git", "config", "--global", key, value], cwd=workdir)
 
 
+def _viewer_login() -> str:
+    """The gh-authenticated user's login."""
+    try:
+        return _run(["gh", "api", "user", "-q", ".login"]).stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Failed to get GitHub user login: {exc.stderr}") from exc
+
+
+def _viewer_can_push(repo: str) -> bool:
+    """True when the gh-authenticated user has push access to ``repo``.
+
+    Org members with write access should branch directly on the catalog
+    repo — the fork detour is for external contributors only.
+    """
+    try:
+        return (
+            _run(["gh", "api", f"repos/{repo}", "-q", ".permissions.push"]).stdout.strip() == "true"
+        )
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _parent_full_name(repo: str) -> str | None:
+    try:
+        parent = _run(["gh", "api", f"repos/{repo}", "-q", ".parent.full_name"]).stdout.strip()
+        return parent or None
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _fork_repo_for(catalog_repo: str, owner: str) -> str:
+    """The owner's fork of catalog_repo, forking only when none exists.
+
+    ``gh repo fork`` is NOT a reliable no-op across gh versions when the
+    fork already exists, and a fork's name is not guaranteed to equal the
+    upstream repo name (renamed forks) — look the fork up first, fork only
+    when absent, and never assume the name.
+    """
+    fork_name = catalog_repo.split("/")[-1]
+    candidate = f"{owner}/{fork_name}"
+    if _parent_full_name(candidate) == catalog_repo:
+        return candidate
+    try:
+        res = _run(["gh", "api", f"users/{owner}/repos?per_page=100", "-q", ".[].full_name"])
+        for full in res.stdout.splitlines():
+            if full != candidate and _parent_full_name(full) == catalog_repo:
+                return full
+    except subprocess.CalledProcessError:
+        pass
+    try:
+        _run(["gh", "repo", "fork", catalog_repo, "--clone=false", "--default-branch-only"])
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Failed to fork {catalog_repo}: {exc.stderr}") from exc
+    if _parent_full_name(candidate) == catalog_repo:
+        return candidate
+    raise RuntimeError(
+        f"Fork of {catalog_repo} not found for {owner} after forking — "
+        "check the fork's name and pass it explicitly."
+    )
+
+
 def submit_to_catalog(
     pkg: SkillPackage,
     *,
@@ -62,8 +123,10 @@ def submit_to_catalog(
     """Submit a local skill to the official catalog by opening a GitHub PR.
 
     This does **not** require ``ROSCLAW_ADMIN_API_KEY``. It requires only a
-    working ``gh`` CLI login (``gh auth login``) with permission to fork
-    ``ros-claw/skills``.
+    working ``gh`` CLI login (``gh auth login``).  When the authenticated
+    user has push access to the catalog repo (org members), the branch is
+    pushed directly to the catalog and the PR is same-repo; external
+    contributors go through their fork (created only when missing).
     """
     if pkg.skill is None:
         raise RuntimeError("skill.yaml not loaded")
@@ -102,29 +165,25 @@ def submit_to_catalog(
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp) / "skills"
 
-        # Fork the catalog repo (no-op if already forked).
+        # Org members with push access branch directly on the catalog;
+        # external contributors go through their fork.
+        direct = _viewer_can_push(catalog_repo)
+        if direct:
+            clone_repo = catalog_repo
+            pr_head = branch_name
+        else:
+            fork_owner = _viewer_login()
+            if not fork_owner:
+                raise RuntimeError("Could not determine GitHub login from `gh api user`.")
+            fork_repo = _fork_repo_for(catalog_repo, fork_owner)
+            clone_repo = fork_repo
+            pr_head = f"{fork_owner}:{branch_name}"
+
+        # Clone the working repo.
         try:
-            _run(["gh", "repo", "fork", catalog_repo, "--clone=false", "--default-branch-only"])
+            _run(["gh", "repo", "clone", clone_repo, str(workdir), "--", "--depth=1"])
         except subprocess.CalledProcessError as exc:
-            raise RuntimeError(f"Failed to fork {catalog_repo}: {exc.stderr}") from exc
-
-        # Determine the user's fork owner.
-        try:
-            viewer_res = _run(["gh", "api", "user", "-q", ".login"])
-            fork_owner = viewer_res.stdout.strip()
-        except subprocess.CalledProcessError as exc:
-            raise RuntimeError(f"Failed to get GitHub user login: {exc.stderr}") from exc
-
-        if not fork_owner:
-            raise RuntimeError("Could not determine GitHub login from `gh api user`.")
-
-        fork_repo = f"{fork_owner}/skills"
-
-        # Clone the fork.
-        try:
-            _run(["gh", "repo", "clone", fork_repo, str(workdir), "--", "--depth=1"])
-        except subprocess.CalledProcessError as exc:
-            raise RuntimeError(f"Failed to clone {fork_repo}: {exc.stderr}") from exc
+            raise RuntimeError(f"Failed to clone {clone_repo}: {exc.stderr}") from exc
 
         _ensure_git_config(workdir)
 
@@ -169,7 +228,8 @@ def submit_to_catalog(
         except subprocess.CalledProcessError as exc:
             raise RuntimeError(f"Failed to commit changes: {exc.stderr}") from exc
 
-        # Push the branch to the fork.
+        # Push the branch (origin = the catalog itself for org members,
+        # the fork for external contributors).
         env = os.environ.copy()
         env["GIT_ASKPASS"] = "echo"
         try:
@@ -189,7 +249,7 @@ def submit_to_catalog(
                     "--base",
                     base_branch,
                     "--head",
-                    f"{fork_owner}:{branch_name}",
+                    pr_head,
                     "--title",
                     f"Add {display_name} skill v{version}",
                     "--body",
@@ -206,7 +266,8 @@ def submit_to_catalog(
             "ok": True,
             "dry_run": False,
             "catalog_repo": catalog_repo,
-            "fork_repo": fork_repo,
+            "flow": "direct" if direct else "fork",
+            "fork_repo": None if direct else fork_repo,
             "branch": branch_name,
             "skill_name": f"{namespace}/{name}",
             "version": version,

--- a/src/rosclaw/skill/cli.py
+++ b/src/rosclaw/skill/cli.py
@@ -418,6 +418,7 @@ def cmd_skill_submit_catalog(args: argparse.Namespace) -> int:
             print("[ROSClaw] Submit to catalog: PR created")
             print(f"  skill: {result['skill_name']}")
             print(f"  version: {result['version']}")
+            print(f"  flow: {result.get('flow', 'fork')}")
             print(f"  PR: {result.get('pr_url', 'unknown')}")
     return 0
 

--- a/tests/skill/test_catalog.py
+++ b/tests/skill/test_catalog.py
@@ -1,0 +1,150 @@
+"""Tests for the submit-catalog direct-vs-fork flow selection.
+
+The 2026-08-04 incident: an org member's submission went through their
+personal fork (shaoxiang/skills) because submit_to_catalog forked
+unconditionally.  The catalog flow must branch directly on the catalog
+repo when the gh-authenticated user has push access, and fork only for
+external contributors — and fork only when none exists yet, without
+assuming the fork's name.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from rosclaw.skill import catalog as catalog_mod
+from rosclaw.skill.catalog import submit_to_catalog
+from rosclaw.skill.models import SkillPackage, SkillYaml
+
+
+def _make_pkg(tmp_path: Path, name: str = "demo_skill") -> SkillPackage:
+    root = tmp_path / name
+    root.mkdir()
+    (root / "skill.yaml").write_text("schema_version: rosclaw.skill.v1\n")
+    pkg = SkillPackage(root)
+    pkg.skill = SkillYaml.model_validate(
+        {
+            "schema_version": "rosclaw.skill.v1",
+            "kind": "Skill",
+            "metadata": {"name": name, "namespace": "ros-claw", "version": "1.0.0"},
+            "identity": {"skill_id": f"ros-claw/{name}", "package_name": f"ros-claw/{name}"},
+            "task": {"intent": name},
+            "execution": {"entrypoint": {"type": "behavior_tree", "file": "behavior_tree.xml"}},
+            "status": {},
+        }
+    )
+    return pkg
+
+
+class _Recorder:
+    """Dispatch fake subprocess results per command shape and record calls."""
+
+    def __init__(
+        self,
+        *,
+        can_push: bool,
+        viewer: str = "octocat",
+        parents: dict[str, str] | None = None,
+        user_repos: list[str] | None = None,
+    ):
+        self.can_push = can_push
+        self.viewer = viewer
+        self.parents = dict(parents or {})  # repo full_name -> its parent's full_name
+        self.user_repos = list(user_repos or [])
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, cwd=None, env=None):
+        self.calls.append(list(cmd))
+        out = ""
+        if cmd[:3] == ["gh", "api", "user"]:
+            out = self.viewer + "\n"
+        elif cmd[:2] == ["gh", "api"] and any("permissions.push" in c for c in cmd):
+            out = ("true" if self.can_push else "false") + "\n"
+        elif cmd[:2] == ["gh", "api"] and any("users/" in c and "repos" in c for c in cmd):
+            out = "\n".join(self.user_repos) + "\n"
+        elif cmd[:2] == ["gh", "api"] and any(".parent.full_name" in c for c in cmd):
+            repo = cmd[2].split("repos/")[-1]
+            if repo in self.parents:
+                out = self.parents[repo] + "\n"
+            else:
+                raise subprocess.CalledProcessError(1, cmd, "", "Not Found")
+        elif cmd[:3] == ["gh", "repo", "fork"]:
+            parent = cmd[3]
+            self.parents[f"{self.viewer}/{parent.split('/')[-1]}"] = parent  # fork now exists
+        elif cmd[:2] == ["gh", "pr"]:
+            out = "https://github.com/ros-claw/skills/pull/99\n"
+        return subprocess.CompletedProcess(cmd, 0, out, "")
+
+
+def _run_submit(pkg, recorder):
+    class _Report:
+        ok = True
+        errors: list[str] = []
+
+    with (
+        patch.object(catalog_mod, "_run", recorder),
+        patch.object(catalog_mod, "_has_gh", return_value=True),
+        patch.object(catalog_mod, "_gh_auth_status", return_value=True),
+        patch.object(catalog_mod, "validate_package", return_value=_Report()),
+    ):
+        return submit_to_catalog(pkg)
+
+
+def test_direct_flow_when_viewer_can_push(tmp_path):
+    rec = _Recorder(can_push=True)
+    result = _run_submit(_make_pkg(tmp_path), rec)
+    clones = [c for c in rec.calls if c[:3] == ["gh", "repo", "clone"]]
+    forks = [c for c in rec.calls if c[:3] == ["gh", "repo", "fork"]]
+    prs = [c for c in rec.calls if c[:3] == ["gh", "pr", "create"]]
+    assert result["flow"] == "direct"
+    assert result["fork_repo"] is None
+    assert clones and clones[0][3] == "ros-claw/skills"  # clones the catalog, not a fork
+    assert not forks  # never forks
+    assert prs and f"{rec.viewer}:" not in prs[0][prs[0].index("--head") + 1]
+
+
+def test_fork_flow_for_external_contributor(tmp_path):
+    rec = _Recorder(can_push=False, parents={"octocat/skills": "ros-claw/skills"})
+    result = _run_submit(_make_pkg(tmp_path), rec)
+    clones = [c for c in rec.calls if c[:3] == ["gh", "repo", "clone"]]
+    forks = [c for c in rec.calls if c[:3] == ["gh", "repo", "fork"]]
+    prs = [c for c in rec.calls if c[:3] == ["gh", "pr", "create"]]
+    assert result["flow"] == "fork"
+    assert result["fork_repo"] == "octocat/skills"
+    assert clones and clones[0][3] == "octocat/skills"
+    assert not forks  # fork already exists -> gh repo fork never called
+    assert prs and prs[0][prs[0].index("--head") + 1].startswith("octocat:")
+
+
+def test_fork_created_only_when_missing(tmp_path):
+    rec = _Recorder(can_push=False)  # no fork anywhere
+    result = _run_submit(_make_pkg(tmp_path), rec)
+    forks = [c for c in rec.calls if c[:3] == ["gh", "repo", "fork"]]
+    assert result["flow"] == "fork"
+    assert len(forks) == 1  # forked exactly once, after the lookup missed
+
+
+def test_renamed_fork_is_found_not_assumed(tmp_path):
+    # owner/skills exists but is NOT a fork of the catalog; the real fork
+    # was renamed to octocat/catalog-fork.
+    rec = _Recorder(
+        can_push=False,
+        parents={"octocat/skills": "someone/else", "octocat/catalog-fork": "ros-claw/skills"},
+        user_repos=["octocat/skills", "octocat/catalog-fork"],
+    )
+    result = _run_submit(_make_pkg(tmp_path), rec)
+    assert result["fork_repo"] == "octocat/catalog-fork"
+    clones = [c for c in rec.calls if c[:3] == ["gh", "repo", "clone"]]
+    assert clones and clones[0][3] == "octocat/catalog-fork"
+    forks = [c for c in rec.calls if c[:3] == ["gh", "repo", "fork"]]
+    assert not forks
+
+
+def test_viewer_can_push_false_on_api_error():
+    def boom(cmd, cwd=None, env=None):
+        raise subprocess.CalledProcessError(1, cmd, "", "rate limited")
+
+    with patch.object(catalog_mod, "_run", boom):
+        assert catalog_mod._viewer_can_push("ros-claw/skills") is False


### PR DESCRIPTION
## Summary

`rosclaw skill submit-catalog` forked the catalog repo **unconditionally**, so an org
member with write access to `ros-claw/skills` had submissions routed through a personal
fork — observed live on 2026-08-04 when an org upload cloned `shaoxiang/skills` and the
PR head became `shaoxiang:<branch>` despite `--catalog-repo ros-claw/skills`.

## The fix

- `_viewer_can_push(catalog_repo)` — checks `repos/{catalog}.permissions.push`.
- **Org members (push access)**: clone the catalog repo directly, push the branch to it,
  PR head is a same-repo branch. No fork is created or touched.
- **External contributors**: fork flow preserved, hardened —
  - the fork is *looked up*, never assumed to be `<user>/<repo>` (renamed forks are
    discovered by scanning the user's repos for one whose parent is the catalog);
  - `gh repo fork` runs only when no fork exists (it is not a reliable no-op across gh
    versions).
- Result dict gains `flow: direct|fork`; the CLI prints it.

## Validation

- New `tests/skill/test_catalog.py`: 5 tests (direct flow, external fork flow,
  fork-created-only-when-missing, renamed-fork discovery, can_push API-error path).
- `pytest tests/skill/`: 31 passed.  ruff check / ruff format / mypy: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)