### PR TITLE
fix(camera): D435iCapture.start escalation ladder, not reset-first

### DIFF
--- a/src/rosclaw/evolution/hardware/camera.py
+++ b/src/rosclaw/evolution/hardware/camera.py
@@ -1,16 +1,23 @@
-"""D435i capture with the field-proven wedge-safe lifecycle (PR-EVO-HW-2).
+"""D435i capture with the field-proven wedge-safe lifecycle (PR-EVO-HW-2,
+updated 2026-08-04 per the ros-claw/realsense_ops discipline).
 
 The D435i on this rig wedges when a pipeline starts on a device whose
 firmware state is stale (UVC GET_CUR -110 → USB disconnect, sometimes
-unrecoverable without a physical re-plug).  The proven-safe sequence is:
+unrecoverable without a physical re-plug).  The 2026-07 lesson was
+"hardware_reset FIRST, always"; the 2026-08 lesson is the other half of
+the story: each hardware_reset is a stress event, and ~20/day plus
+pipeline stop/start churn killed the xHCI host controller (NVDA8000:00,
+dmesg `Host halt failed, -110 → HC died`, 2026-08-03 — and AGAIN after a
+reboot on 2026-08-04).  The lifecycle is therefore the escalation ladder:
 
-    enumerate → hardware_reset FIRST → wait re-enumeration → ONE pipe.start
+    enumerate → plain pipe.start (no reset) → on failure ONLY:
+    ONE hardware_reset → wait re-enumeration → ONE retry
 
-and the forbidden moves are: plain pipe.start on a freshly-enumerated
-device, sysfs bus resets (kills the xHCI controller), and SIGTERM on a
-streaming pipeline.  ``D435iCapture`` implements exactly that lifecycle
-and nothing else.  pyrealsense2 is an optional dependency: its absence
-means "camera unavailable", never a mock.
+and the forbidden moves are: preventive hardware_reset, pipe.start retry
+loops on a wedged control channel, sysfs bus resets (kills the xHCI
+controller), and SIGTERM on a streaming pipeline.  ``D435iCapture``
+implements exactly that lifecycle and nothing else.  pyrealsense2 is an
+optional dependency: its absence means "camera unavailable", never a mock.
 """
 
 from __future__ import annotations
@@ -90,7 +97,14 @@ class D435iCapture:
         return devices
 
     def start(self, *, serial: str | None = None) -> dict[str, Any]:
-        """hardware_reset FIRST, wait re-enumeration, then ONE pipe.start."""
+        """Plain pipe.start FIRST; ONE hardware_reset only on actual failure.
+
+        hardware_reset is a full device re-enumeration — a stress event for
+        the host controller.  Reset churn (~20/day) plus pipeline stop/start
+        cycles killed xHCI host controllers twice on this rig (NVDA8000:00,
+        2026-08-03 and again 2026-08-04).  The escalation ladder: try the
+        plain start; only a real start failure earns the single reset.
+        """
         rs = self._rs()
         ctx = rs.context()
         devices = ctx.query_devices()
@@ -109,39 +123,48 @@ class D435iCapture:
             "firmware": target.get_info(rs.camera_info.firmware_version),
         }
 
-        # Field-proven wedge avoidance: reset FIRST, then one clean start.
-        target.hardware_reset()
-        deadline = time.monotonic() + REENUMERATE_TIMEOUT_S
-        reenumerated = None
-        while time.monotonic() < deadline:
-            time.sleep(1.0)
-            for dev in rs.context().query_devices():
-                if dev.get_info(rs.camera_info.serial_number) == identity["serial"]:
-                    reenumerated = dev
-                    break
-            if reenumerated is not None:
-                break
-        if reenumerated is None:
-            raise CameraUnavailableError(
-                "device did not re-enumerate after hardware_reset "
-                "(physical re-plug + 10s power drain required)"
-            )
-
-        config = rs.config()
-        config.enable_device(identity["serial"])
-        config.enable_stream(rs.stream.color, self.width, self.height, rs.format.bgr8, self.fps)
-        config.enable_stream(rs.stream.depth, self.width, self.height, rs.format.z16, self.fps)
-        self._pipeline = rs.pipeline()
-        try:
+        def _start_once() -> None:
+            config = rs.config()
+            config.enable_device(identity["serial"])
+            config.enable_stream(rs.stream.color, self.width, self.height, rs.format.bgr8, self.fps)
+            config.enable_stream(rs.stream.depth, self.width, self.height, rs.format.z16, self.fps)
+            self._pipeline = rs.pipeline()
             self._pipeline.start(config)
             # First frame must actually arrive — a timeout here is the
             # wedge signature; do NOT retry pipe.start (field notes).
             self._pipeline.wait_for_frames(FRAME_TIMEOUT_MS)
-        except Exception as exc:
+
+        try:
+            _start_once()
+        except Exception as first_exc:
             with suppress(Exception):
                 self._pipeline.stop()
             self._pipeline = None
-            raise CameraWedgeError(f"pipeline start wedged: {exc}") from exc
+            # Escalation rung 3: ONE hardware_reset after a real start
+            # failure, wait re-enumeration, ONE retry.  Never more.
+            target.hardware_reset()
+            deadline = time.monotonic() + REENUMERATE_TIMEOUT_S
+            reenumerated = None
+            while time.monotonic() < deadline:
+                time.sleep(1.0)
+                for dev in rs.context().query_devices():
+                    if dev.get_info(rs.camera_info.serial_number) == identity["serial"]:
+                        reenumerated = dev
+                        break
+                if reenumerated is not None:
+                    break
+            if reenumerated is None:
+                raise CameraUnavailableError(
+                    "device did not re-enumerate after hardware_reset "
+                    "(physical re-plug + 10s power drain required)"
+                ) from first_exc
+            try:
+                _start_once()
+            except Exception as exc:
+                with suppress(Exception):
+                    self._pipeline.stop()
+                self._pipeline = None
+                raise CameraWedgeError(f"pipeline start wedged: {exc}") from exc
         return {"session_id": self.session_id, **identity}
 
     # ------------------------------------------------------------------
@@ -189,7 +212,9 @@ def _as_array(frame: Any) -> Any:
         return None
 
 
-def write_artifacts(frame: CapturedFrame, directory: Path, *, prefix: str | None = None) -> dict[str, str]:
+def write_artifacts(
+    frame: CapturedFrame, directory: Path, *, prefix: str | None = None
+) -> dict[str, str]:
     """Persist color/depth artifacts; returns artifact:// refs.
 
     PNG via OpenCV when available, raw .npy otherwise — the artifact is

--- a/tests/evolution/hardware/test_camera_capture_start.py
+++ b/tests/evolution/hardware/test_camera_capture_start.py
@@ -1,0 +1,129 @@
+"""Tests for the D435iCapture.start escalation ladder (2026-08-04).
+
+The lifecycle changed from "hardware_reset FIRST, always" (the 2026-07
+wedge lesson) to the ladder (plain start -> ONE reset only on failure)
+after reset churn killed the xHCI host controller twice (2026-08-03/04).
+These tests pin the ladder: a healthy start must not reset at all, a
+failed start earns exactly one reset + one retry, and a still-wedged
+retry raises CameraWedgeError without further resets.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+from rosclaw.evolution.hardware.camera import (
+    CameraWedgeError,
+    D435iCapture,
+)
+
+
+class _FakeDevice:
+    def __init__(self, serial: str = "231122070092"):
+        self._serial = serial
+        self.resets = 0
+
+    def get_info(self, info):
+        name = getattr(info, "name", "")
+        if "serial" in str(info).lower() or "SERIAL" in name:
+            return self._serial
+        if "firmware" in str(info).lower():
+            return "5.17.0.10"
+        return "Intel RealSense D435I"
+
+    def hardware_reset(self):
+        self.resets += 1
+
+
+class _FakePipeline:
+    """Fails to start (or first-frame) until `failures_left` is exhausted."""
+
+    def __init__(self, rs_mod):
+        self._rs = rs_mod
+
+    def start(self, config):
+        if self._rs.failures_left > 0:
+            self._rs.failures_left -= 1
+            raise RuntimeError("get_xu(...). xioctl(UVCIOC_CTRL_QUERY) failed ... timed out")
+
+    def wait_for_frames(self, timeout_ms):
+        if self._rs.frame_failures_left > 0:
+            self._rs.frame_failures_left -= 1
+            raise RuntimeError("Frame didn't arrive")
+        return object()
+
+    def stop(self):
+        pass
+
+
+class _FakeContext:
+    def __init__(self, rs_mod):
+        self._rs = rs_mod
+
+    def query_devices(self):
+        return [self._rs.device]
+
+
+def _fake_rs(*, start_failures: int = 0, frame_failures: int = 0) -> types.ModuleType:
+    rs = types.ModuleType("pyrealsense2")
+    rs.device = _FakeDevice()
+    rs.failures_left = start_failures
+    rs.frame_failures_left = frame_failures
+    rs.context = lambda: _FakeContext(rs)
+    rs.pipeline = lambda: _FakePipeline(rs)
+    rs.config = lambda: types.SimpleNamespace(
+        enable_device=lambda s: None, enable_stream=lambda *a: None
+    )
+    rs.camera_info = types.SimpleNamespace(
+        name="name", serial_number="serial", firmware_version="fw"
+    )
+    rs.stream = types.SimpleNamespace(color="color", depth="depth")
+    rs.format = types.SimpleNamespace(bgr8="bgr8", z16="z16")
+    return rs
+
+
+def test_plain_start_success_never_resets():
+    rs = _fake_rs()
+    with patch.object(D435iCapture, "_rs", staticmethod(lambda: rs)):
+        cap = D435iCapture()
+        out = cap.start(serial="231122070092")
+    assert out["serial"] == "231122070092"
+    assert rs.device.resets == 0  # the whole point: no reset on a healthy start
+
+
+def test_failed_start_earns_exactly_one_reset_and_retry():
+    rs = _fake_rs(start_failures=1)
+    with (
+        patch.object(D435iCapture, "_rs", staticmethod(lambda: rs)),
+        patch("rosclaw.evolution.hardware.camera.time.sleep", lambda s: None),
+    ):
+        cap = D435iCapture()
+        cap.start(serial="231122070092")
+    assert rs.device.resets == 1  # one reset, then the retry succeeded
+
+
+def test_wedged_after_reset_raises_with_single_reset():
+    rs = _fake_rs(start_failures=5)
+    with (
+        patch.object(D435iCapture, "_rs", staticmethod(lambda: rs)),
+        patch("rosclaw.evolution.hardware.camera.time.sleep", lambda s: None),
+    ):
+        cap = D435iCapture()
+        with pytest.raises(CameraWedgeError):
+            cap.start(serial="231122070092")
+    assert rs.device.resets == 1  # never a second reset for the same incident
+
+
+def test_no_frame_after_start_counts_as_failure_and_uses_ladder():
+    rs = _fake_rs(frame_failures=1)
+    with (
+        patch.object(D435iCapture, "_rs", staticmethod(lambda: rs)),
+        patch("rosclaw.evolution.hardware.camera.time.sleep", lambda s: None),
+    ):
+        cap = D435iCapture()
+        out = cap.start(serial="231122070092")
+    assert rs.device.resets == 1
+    assert out["serial"] == "231122070092"


### PR DESCRIPTION
## Summary

`D435iCapture.start()` did `hardware_reset()` FIRST on every call — the 2026-07 wedge lesson. The 2026-08 lesson: each reset is a host stress event; churn (~20/day) plus pipeline stop/start cycles killed xHCI host controller NVDA8000:00 **twice** (2026-08-03, and again 2026-08-04 after a reboot): dmesg `Host halt failed, -110 → HC died`.

`start()` is now the escalation ladder from the ros-claw/realsense_ops skill (ros-claw/skills PR #7): plain `pipe.start()` first; ONE `hardware_reset` only after an actual start failure; one retry.

## Validation

- 4 new tests pin the ladder (no reset on healthy start / exactly one reset+retry / WedgeError without a second reset / first-frame timeout uses the ladder)
- `pytest tests/evolution/hardware/`: 93 passed; ruff/format/mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)