### PR TITLE
Audit D1/E1: signed offline packaging, LIMO SHADOW chain, evidence packs

### DIFF
--- a/docs/AGENTD.md
+++ b/docs/AGENTD.md
@@ -263,6 +263,40 @@ live 模型协调。3v3 联赛基准（T-SIM-2/3）属 PR-TF-075 后续范围。
   `__`（catalog 注册拒绝含 `__` 的原生 id 保证单射）；内部协议工具的
   成功提交也必须回执 tool result（Kimi 拒绝悬空 tool_call）。
 
+## 授权剖面（审计 P0-01，2026-08-04）
+
+- **rosclaw-operatord**：独立进程，唯一人类授权决定点。enrollment key
+  （0600，损坏隔离，拒绝覆盖）+ HMAC DecisionProof（绑定 request/
+  approve/nonce/decided_at/enrollment/display_hash，nonce 一次性）。
+  `rosclaw operatord enroll|register-daemon|start|status`。
+- **rosclawd ACL**：`operator.enrollment.register`（bootstrap 门控）；
+  `proposal.decide` 只允许 daemon 服务 UID 或有效 proof——agentd/
+  Worker/普通 curl 无 key 必拒。REAL/SHADOW proposal 与 permit 均已
+  开放（FTC-100 SHADOW 走完整许可链，actuation 硬阻断）。
+- **agentd**：只创建 proposal、读公开结果——`consent_channel.decide`
+  已移除；`decide_approval` 仅 operatord 路径（`_from_operatord`）；
+  operator.sock 只剩只读 list + proof 门控 apply_decision；HTTP
+  decide/revoke 默认 403（`ROSCLAW_DEV_HTTP_DECIDE=1` 仅限
+  DEV_SIM_ONLY）；pending 必须指定 mission_id。同 UID 一体运行一律
+  标记 `DEV_SIM_ONLY`（doctor.authorization 可见）。
+- **SHADOW 全链路**（tests/shadow/test_limo_shadow_chain.py）：
+  proposal → operatord human decision（proof 经 ACL）→ Permit/Lease →
+  LIMO SHADOW executor → SHADOW receipt（evidence_domain=SHADOW、
+  actuated=false、usable_for_real_execution=false、拟执行 ROS 命令
+  可审计）。
+
+## 证据等级与证据包（审计 §1.2/§8）
+
+- 等级命名（`bench/evidence_levels.py`）：E0 SPECIFIED …
+  E7 OPERATIONALLY_QUALIFIED；任何"全链路通过"必须标注最高等级。
+  当前：组件 E1/E2，SIM 主路径 E3，SHADOW 许可链 E4（部分）。
+- 证据包（`bench/evidence_pack.py`）：`acceptance/<run_id>/` 含
+  run_manifest（commit/dirty/level/test_ids/operator/secret_scan_clean）、
+  environment、commands、events、mission_snapshot、approvals/permits/
+  receipts(public)、metrics、secret_scan、artifact_hashes、
+  operator_observer——**没有证据包就没有通过**。
+  `run_acceptance(evidence_root=...)` 直接产出。
+
 ## Operator 安全通道（PR-11）
 
 - `operator.sock`（0600，JSONL）：与模型可见的 Agent API 物理分面——

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -44,7 +44,22 @@ cp "$REPO_ROOT/scripts/release/install_release.sh" "$STAGE/install.sh"
 cp "$REPO_ROOT/scripts/release/rollback.sh" "$STAGE/"
 chmod +x "$STAGE/install.sh" "$STAGE/rollback.sh"
 
-# 4. manifest（含各组件 hash 供回滚校验）
+# 4. SBOM（pip + npm 依赖快照，审计 P0-05.2）
+"$REPO_ROOT/.venv/bin/python" -m pip freeze --disable-pip-version-check 2>/dev/null   > "$STAGE/sbom-python.txt" || true
+for pkg in rosclaw-tui rosclaw-modeld; do
+  (cd "$REPO_ROOT/packages/$pkg" && npm ls --omit=dev --depth=2 2>/dev/null)     > "$STAGE/sbom-$pkg.txt" || true
+done
+
+# 5. 离线资产（审计 P0-05.4）：目标机不再现场 TypeScript build、
+# 不访问 PyPI/npm。
+mkdir -p "$STAGE/vendor/wheels" "$STAGE/vendor/node_modules_pack"
+"$REPO_ROOT/.venv/bin/python" -m pip download   --disable-pip-version-check --quiet --dest "$STAGE/vendor/wheels"   "$REPO_ROOT" 2>/dev/null ||   echo "WARN: pip download 不完整（online build 继续；offline 包将缺 wheels）" >&2
+for pkg in rosclaw-tui rosclaw-modeld; do
+  (cd "$REPO_ROOT/packages/$pkg" && npm ci --omit=dev --silent)
+  tar -C "$REPO_ROOT/packages/$pkg" -czf "$STAGE/vendor/node_modules_pack/$pkg.tar.gz" node_modules
+done
+
+# 6. manifest（含各组件 hash 供回滚校验 + 签名输入）
 python3 - "$STAGE" "$VERSION" "$ARCH_NAME" <<'PY'
 import hashlib, json, sys
 from pathlib import Path
@@ -61,6 +76,18 @@ manifest = {
 }
 (stage / "manifest.json").write_text(json.dumps(manifest, indent=1))
 PY
+
+# 7. 分离签名（审计 P0-05.3）：dev 签名密钥在本机（不入库），
+# 公钥随包发布；安装器先验签再执行任何脚本。
+SIGN_DIR="${ROSCLAW_SIGNING_HOME:-$HOME/.rosclaw/signing}"
+if [ ! -f "$SIGN_DIR/dev-signing-private.pem" ]; then
+  mkdir -p "$SIGN_DIR" && chmod 700 "$SIGN_DIR"
+  openssl ecparam -name prime256v1 -genkey -noout -out "$SIGN_DIR/dev-signing-private.pem"
+  chmod 600 "$SIGN_DIR/dev-signing-private.pem"
+  openssl ec -in "$SIGN_DIR/dev-signing-private.pem" -pubout -out "$SIGN_DIR/dev-signing-public.pem"
+fi
+cp "$SIGN_DIR/dev-signing-public.pem" "$STAGE/bundle-signing-public.pem"
+openssl dgst -sha256 -sign "$SIGN_DIR/dev-signing-private.pem"   -out "$STAGE/manifest.sig" "$STAGE/manifest.json"
 
 mkdir -p "$DIST_DIR"
 tar -C "$DIST_DIR" -czf "${DIST_DIR}/${BUNDLE}.tar.gz" "$BUNDLE"

--- a/scripts/release/install_release.sh
+++ b/scripts/release/install_release.sh
@@ -1,28 +1,67 @@
 #!/usr/bin/env bash
-# PR-12：发布包安装器（component installer）。
-# 用法：tar xzf rosclaw-<ver>-linux-arm64.tar.gz && cd rosclaw-<ver>-linux-arm64 && ./install.sh [--prefix DIR]
+# PR-12 + 审计 P0-05：发布包安装器（verify-before-execute，事务化）。
+# 用法：tar xzf rosclaw-<ver>-linux-arm64.tar.gz && cd rosclaw-<ver>-linux-arm64 && ./install.sh [--prefix DIR] [--offline]
 set -euo pipefail
 
 PREFIX="${ROSCLAW_PREFIX:-$HOME/.local/share/rosclaw}"
-if [ "${1:-}" = "--prefix" ]; then PREFIX="$2"; fi
+OFFLINE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix) PREFIX="$2"; shift 2 ;;
+    --offline) OFFLINE=1; shift ;;
+    *) echo "未知参数 $1" >&2; exit 2 ;;
+  esac
+done
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CURRENT="$PREFIX/current"
 PREVIOUS="$PREFIX/previous"
 NEXT="$PREFIX/next-$RANDOM"
 
-echo "==> installing rosclaw to $PREFIX"
+echo "==> [1/5] 校验 manifest 签名与全部文件 hash（先验证，后执行）"
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1 ($2)" >&2; exit 2; }; }
+need openssl "signature verification"
+need python3 "3.11+"
+[ -f "$SRC_DIR/manifest.json" ] || { echo "manifest.json 缺失，拒绝安装。" >&2; exit 2; }
+[ -f "$SRC_DIR/manifest.sig" ] || { echo "manifest.sig 缺失，拒绝安装。" >&2; exit 2; }
+[ -f "$SRC_DIR/bundle-signing-public.pem" ] || { echo "签名公钥缺失，拒绝安装。" >&2; exit 2; }
+openssl dgst -sha256 -verify "$SRC_DIR/bundle-signing-public.pem" \
+  -signature "$SRC_DIR/manifest.sig" "$SRC_DIR/manifest.json" \
+  || { echo "manifest 签名无效——包可能被篡改，拒绝执行任何安装动作。" >&2; exit 2; }
+python3 - "$SRC_DIR" <<'PY'
+import hashlib, json, sys
+from pathlib import Path
+root = Path(sys.argv[1])
+manifest = json.loads((root / "manifest.json").read_text())
+bad = []
+for rel, expected in manifest["files"].items():
+    path = root / rel
+    if not path.exists():
+        bad.append(f"missing: {rel}")
+        continue
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+    if actual != expected:
+        bad.append(f"tampered: {rel}")
+if bad:
+    print("\n".join(bad), file=sys.stderr)
+    sys.exit(2)
+print(f"verified {len(manifest['files'])} files")
+PY
+
+echo "==> [2/5] 安装到 staging"
 mkdir -p "$PREFIX"
 cp -r "$SRC_DIR" "$NEXT"
 
-need() { command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1 ($2)" >&2; exit 2; }; }
-need python3 "3.11+"
-
-# Python 组件
+# Python 组件：online（PyPI）或 offline（vendor wheels，不触网）。
 python3 -m venv "$NEXT/.venv"
-"$NEXT/.venv/bin/pip" install --quiet --upgrade pip
-"$NEXT/.venv/bin/pip" install --quiet "$NEXT"
+"$NEXT/.venv/bin/pip" install --quiet --upgrade pip ${OFFLINE:+--no-index}
+if [ "$OFFLINE" = "1" ]; then
+  "$NEXT/.venv/bin/pip" install --quiet --no-index \
+    --find-links "$NEXT/vendor/wheels" "$NEXT"
+else
+  "$NEXT/.venv/bin/pip" install --quiet "$NEXT"
+fi
 
-# Node 组件（TUI/modeld）：需要 Node >= 22.19；缺失时诚实降级说明
+# Node 组件：用随包 node_modules（离线可用）；缺失时在线 npm ci。
 NODE_OK=0
 for candidate in node /usr/bin/node /usr/local/bin/node; do
   if command -v "$candidate" >/dev/null 2>&1; then
@@ -35,14 +74,26 @@ for candidate in node /usr/bin/node /usr/local/bin/node; do
 done
 if [ "$NODE_OK" = "1" ]; then
   for pkg in rosclaw-tui rosclaw-modeld; do
-    (cd "$NEXT/packages/$pkg" && "$NODE_BIN" "$(command -v npm)" ci --silent && "$NODE_BIN" "$(command -v npm)" run build --silent)
+    if [ -f "$NEXT/vendor/node_modules_pack/$pkg.tar.gz" ]; then
+      tar -C "$NEXT/packages/$pkg" -xzf "$NEXT/vendor/node_modules_pack/$pkg.tar.gz"
+    else
+      (cd "$NEXT/packages/$pkg" && "$NODE_BIN" "$(command -v npm)" ci --omit=dev --silent)
+    fi
+    # dist 已在包内（构建期产物）；不现场 TypeScript build。
+    [ -f "$NEXT/packages/$pkg/dist/src/main.js" ] || {
+      echo "$pkg 缺 dist/src/main.js（包不完整）。" >&2; exit 2;
+    }
   done
+elif [ "${ROSCLAW_REQUIRE_TUI:-0}" = "1" ]; then
+  echo "FAIL: Node >= 22.19 not found and ROSCLAW_REQUIRE_TUI=1——"
+  echo "      完整安装验收失败（不允许静默回退 --basic）。" >&2
+  exit 2
 else
   echo "WARN: Node >= 22.19 not found — rosclaw-tui/modeld 不可用；"
-  echo "      Python-only 安装完成（rosclaw chat --basic 与 legacy backend 可用）。"
+  echo "      Python-only 安装完成（rosclaw chat --basic 为显式救援模式）。"
 fi
 
-# CLI 入口链接
+echo "==> [3/5] CLI 入口"
 mkdir -p "$PREFIX/bin"
 cat > "$PREFIX/bin/rosclaw" <<EOF2
 #!/usr/bin/env bash
@@ -50,12 +101,18 @@ exec "$CURRENT/.venv/bin/python" -m rosclaw.entrypoint "\$@"
 EOF2
 chmod +x "$PREFIX/bin/rosclaw"
 
-# 原子切换 current；旧版本保留为 previous（rollback.sh 目标）。
+echo "==> [4/5] 原子切换 current（previous 保留供回滚）"
 rm -rf "$PREFIX/previous.tmp"
 [ -e "$CURRENT" ] && mv "$CURRENT" "$PREFIX/previous.tmp" || true
 mv "$NEXT" "$CURRENT.new" && mv "$CURRENT.new" "$CURRENT"
 rm -rf "$PREVIOUS"
 [ -e "$PREFIX/previous.tmp" ] && mv "$PREFIX/previous.tmp" "$PREVIOUS" || true
 
-echo "==> installed. 加入 PATH: export PATH=\"$PREFIX/bin:\$PATH\""
+echo "==> [5/5] 安装后健康检查（失败自动回滚）"
+if ! "$CURRENT/.venv/bin/python" -c "import rosclaw, rosclaw.agentd, rosclaw.operatord" >/dev/null 2>&1; then
+  echo "健康检查失败——自动回滚到 previous。" >&2
+  [ -d "$PREVIOUS" ] && "$CURRENT/rollback.sh" || rm -rf "$CURRENT"
+  exit 3
+fi
+echo "==> installed & healthy. export PATH=\"$PREFIX/bin:\$PATH\""
 echo "==> 验证: rosclaw doctor；回滚: $PREFIX/current/rollback.sh"

--- a/src/rosclaw/agentd/bench/evidence_levels.py
+++ b/src/rosclaw/agentd/bench/evidence_levels.py
@@ -1,0 +1,23 @@
+"""证据等级命名（审计 §1.2）：每个功能只允许宣称其最高证据等级。"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EvidenceLevel(StrEnum):
+    E0_SPECIFIED = "E0_SPECIFIED"
+    E1_COMPONENT_VERIFIED = "E1_COMPONENT_VERIFIED"
+    E2_PROCESS_VERIFIED = "E2_PROCESS_VERIFIED"
+    E3_SIM_VERIFIED = "E3_SIM_VERIFIED"
+    E4_SHADOW_VERIFIED = "E4_SHADOW_VERIFIED"
+    E5_REAL_DEVELOPER_OBSERVED = "E5_REAL_DEVELOPER_OBSERVED"
+    E6_REAL_INDEPENDENTLY_VERIFIED = "E6_REAL_INDEPENDENTLY_VERIFIED"
+    E7_OPERATIONALLY_QUALIFIED = "E7_OPERATIONALLY_QUALIFIED"
+
+
+RANK: dict[EvidenceLevel, int] = {level: i for i, level in enumerate(EvidenceLevel)}
+
+
+def at_most(level: EvidenceLevel, ceiling: EvidenceLevel) -> bool:
+    return RANK[level] <= RANK[ceiling]

--- a/src/rosclaw/agentd/bench/evidence_pack.py
+++ b/src/rosclaw/agentd/bench/evidence_pack.py
@@ -1,0 +1,139 @@
+"""Evidence pack writer（审计 §8）：每个验收 run 一个 acceptance/<run_id>/。
+
+通过标准：没有证据包，就没有通过。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from rosclaw.agentd.bench.evidence_levels import EvidenceLevel
+from rosclaw.contracts.common import new_id
+
+SECRET_PATTERNS = ("sk-", "Bearer ", "api_key\":", "private_key", "permit_secret")
+
+
+class EvidencePackWriter:
+    def __init__(self, root: Path, *, run_id: str | None = None) -> None:
+        self.run_id = run_id or new_id("run")
+        self.dir = root / "acceptance" / self.run_id
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self._hashes: dict[str, str] = {}
+
+    def _record(self, name: str, content: str) -> None:
+        path = self.dir / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        self._hashes[name] = hashlib.sha256(content.encode()).hexdigest()
+
+    def write_environment(self, *, provider: str = "", model: str = "") -> dict:
+        env = {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "node": _probe(["node", "--version"]),
+            "ros_distro": os.environ.get("ROS_DISTRO", ""),
+            "provider": provider,
+            "model": model,
+            "uid": os.geteuid(),
+        }
+        self._record("environment.json", json.dumps(env, indent=2, ensure_ascii=False))
+        return env
+
+    def write_commands(self, commands: list[str]) -> None:
+        self._record("commands.txt", "\n".join(commands) + "\n")
+
+    def write_events(self, events: list[dict]) -> None:
+        lines = [json.dumps(e, ensure_ascii=False, default=str) for e in events]
+        self._record("events.jsonl", "\n".join(lines) + ("\n" if lines else ""))
+
+    def write_mission_snapshot(self, snapshot: dict) -> None:
+        self._record("mission_snapshot.json", json.dumps(snapshot, indent=2, ensure_ascii=False, default=str))
+
+    def write_public_records(self, *, approvals: list[dict], permits: list[dict], receipts: list[dict]) -> None:
+        self._record(
+            "approvals_public.jsonl",
+            "\n".join(json.dumps(a, ensure_ascii=False, default=str) for a in approvals) + "\n",
+        )
+        self._record(
+            "permits_public.jsonl",
+            "\n".join(json.dumps(p, ensure_ascii=False, default=str) for p in permits) + "\n",
+        )
+        self._record(
+            "receipts.jsonl",
+            "\n".join(json.dumps(r, ensure_ascii=False, default=str) for r in receipts) + "\n",
+        )
+
+    def write_metrics(self, metrics: dict) -> None:
+        self._record("metrics.json", json.dumps(metrics, indent=2, ensure_ascii=False, default=str))
+
+    def write_observer(self, note: str) -> None:
+        self._record("operator_observer.md", note)
+
+    def finalize(
+        self,
+        *,
+        level: EvidenceLevel,
+        git_commit: str,
+        dirty: bool,
+        test_ids: list[str],
+        operator: str,
+    ) -> dict:
+        """secret 扫描 + artifact hashes + run_manifest（签名输入）。"""
+        findings: list[dict] = []
+        for path in self.dir.rglob("*"):
+            if not path.is_file() or path.name in {"secret_scan.json", "run_manifest.json"}:
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for pattern in SECRET_PATTERNS:
+                if pattern in text:
+                    findings.append({"file": path.name, "pattern": pattern})
+        self._record(
+            "secret_scan.json",
+            json.dumps({"clean": not findings, "findings": findings}, indent=2),
+        )
+        self._record(
+            "artifact_hashes.json",
+            json.dumps(self._hashes, indent=2, sort_keys=True),
+        )
+        manifest = {
+            "run_id": self.run_id,
+            "evidence_level": level.value,
+            "rosclaw_commit": git_commit,
+            "dirty": dirty,
+            "test_ids": test_ids,
+            "operator": operator,
+            "started_artifacts": len(self._hashes),
+            "secret_scan_clean": not findings,
+            "created_at": datetime.now(UTC).isoformat(),
+        }
+        self._record("run_manifest.json", json.dumps(manifest, indent=2, ensure_ascii=False))
+        return manifest
+
+
+def _probe(cmd: list[str]) -> str:
+    try:
+        return subprocess.check_output(cmd, text=True, timeout=10).strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def current_commit() -> tuple[str, bool]:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True, timeout=10
+        ).strip()
+        dirty = bool(
+            subprocess.check_output(["git", "status", "--porcelain"], text=True, timeout=10).strip()
+        )
+        return commit, dirty
+    except Exception:  # noqa: BLE001
+        return "", True

--- a/src/rosclaw/agentd/bench/evidence_pack.py
+++ b/src/rosclaw/agentd/bench/evidence_pack.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 
 from rosclaw.agentd.bench.evidence_levels import EvidenceLevel
 from rosclaw.contracts.common import new_id

--- a/src/rosclaw/agentd/bench/limo_acceptance.py
+++ b/src/rosclaw/agentd/bench/limo_acceptance.py
@@ -32,6 +32,7 @@ class AcceptanceReport:
     receipts: list[str] = field(default_factory=list)
     grants: list[str] = field(default_factory=list)
     practice_candidate: str | None = None
+    evidence_manifest: dict = field(default_factory=dict)
 
     @property
     def passed(self) -> bool:
@@ -205,7 +206,9 @@ def acceptance_script(tone_args: dict | None = None, pose_args: dict | None = No
     return script
 
 
-async def run_acceptance(home: Path, *, gateway=None) -> AcceptanceReport:
+async def run_acceptance(
+    home: Path, *, gateway=None, evidence_root: Path | None = None
+) -> AcceptanceReport:
     """SIMULATION 全链路验收（真实 MCP/审批/执行/receipt 路径）。"""
     import yaml
 
@@ -357,6 +360,44 @@ async def run_acceptance(home: Path, *, gateway=None) -> AcceptanceReport:
         # T6 报告（用户可见诚实声明）。
         report.notes.append(last_reply[:200])
         report.checks["T6_report"] = "验收完成" in last_reply
+        # 证据包（审计 §8）：E3_SIM_VERIFIED —— Mock 模型时严格标 L1+L2。
+        if evidence_root is not None:
+            from rosclaw.agentd.bench.evidence_levels import EvidenceLevel
+            from rosclaw.agentd.bench.evidence_pack import EvidencePackWriter, current_commit
+
+            pack = EvidencePackWriter(evidence_root)
+            pack.write_environment(provider="mock" if gateway is None else "kimi-code")
+            pack.write_commands(
+                [
+                    "run_acceptance(home, gateway=..., evidence_root=...)",
+                    "mcp_servers: limo-sim (SIM executor)",
+                ]
+            )
+            events = service.events_replay(mission.mission_id, limit=100_000)
+            pack.write_events([e.model_dump(mode="json") for e in events])
+            pack.write_mission_snapshot(service.snapshot(mission.mission_id).model_dump(mode="json"))
+            pack.write_public_records(
+                approvals=[],
+                permits=[],
+                receipts=[
+                    e.payload for e in events if e.type.value == "receipt.received"
+                ],
+            )
+            pack.write_metrics(
+                {"checks": report.checks, "passed": report.passed}
+            )
+            pack.write_observer(
+                "# operator observer\n\nSIMULATION 证据域验收；无声学传感器，"
+                "扬声器只证明驱动执行（§18.4）。\n"
+            )
+            commit, dirty = current_commit()
+            report.evidence_manifest = pack.finalize(
+                level=EvidenceLevel.E3_SIM_VERIFIED,
+                git_commit=commit,
+                dirty=dirty,
+                test_ids=["FTC-040", "C1-C10"],
+                operator="rosclaw-ci",
+            )
         return report
     finally:
         await operatord.stop()

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -416,9 +416,17 @@ def _chat_tui(service: AgentService, args: argparse.Namespace) -> int:
 
     runtime = _find_tui_runtime()
     if runtime is None:
+        if os.environ.get("ROSCLAW_REQUIRE_TUI") == "1":
+            # 审计 P0-05.6：验收环境不允许静默回退。
+            print(
+                "FAIL: rosclaw-tui 不可用且 ROSCLAW_REQUIRE_TUI=1——"
+                "完整验收失败（不允许静默回退 --basic）。",
+                file=sys.stderr,
+            )
+            return 2
         print(
             "rosclaw-tui 不可用（需要 Node >= 22.19 与已构建的 packages/rosclaw-tui；"
-            "见 rosclaw doctor）。回退到兼容模式 --basic。",
+            "见 rosclaw doctor）。回退到兼容模式 --basic（显式救援模式）。",
             file=sys.stderr,
         )
         return asyncio.run(_chat_repl(service, args))

--- a/src/rosclaw/daemon/service.py
+++ b/src/rosclaw/daemon/service.py
@@ -797,10 +797,11 @@ class DaemonControlPlane:
                     f"{MAX_OPERATOR_PERMIT_TTL_SEC:g} seconds"
                 ),
             )
-        if action.execution_mode is not ExecutionMode.REAL:
+        if action.execution_mode not in {ExecutionMode.REAL, ExecutionMode.SHADOW}:
             raise ControlPlaneError(
                 "PERMIT_REAL_ACTION_REQUIRED",
-                "Operator permits may be issued only for explicit REAL actions",
+                "Operator permits may be issued only for explicit REAL or SHADOW actions "
+                "(FTC-100: SHADOW exercises the permission chain with actuation blocked)",
             )
         if not action.body_snapshot_hash.strip():
             raise ControlPlaneError(
@@ -856,11 +857,20 @@ class DaemonControlPlane:
                     "EMERGENCY_STOP_LATCHED",
                     "Restart rosclawd and complete preflight before permit issuance",
                 )
+            expected_shadow_executor = f"{action.capability_id}:{ExecutionMode.SHADOW.value}"
             registered = set(getattr(self.runtime.action_gateway, "registered_executors", ()))
-            if expected_executor not in registered:
+            required_executor = (
+                expected_executor
+                if action.execution_mode is ExecutionMode.REAL
+                else expected_shadow_executor
+            )
+            if required_executor not in registered:
                 raise ControlPlaneError(
                     "REAL_EXECUTOR_UNAVAILABLE",
-                    (f"No daemon-side REAL executor is registered for {action.capability_id!r}"),
+                    (
+                        f"No daemon-side {action.execution_mode.value} executor is registered "
+                        f"for {action.capability_id!r}"
+                    ),
                 )
             issued_at = _iso(now)
             permit = ExecutionPermit(

--- a/src/rosclaw/limo/shadow_executor.py
+++ b/src/rosclaw/limo/shadow_executor.py
@@ -19,6 +19,7 @@ from rosclaw.kernel.contracts import (
     EvidenceLevel,
 )
 
+
 #: SHADOW 支持的能力与其参数校验器。
 def _validate_tone(arguments: dict[str, Any]) -> list[str]:
     errors: list[str] = []

--- a/src/rosclaw/limo/shadow_executor.py
+++ b/src/rosclaw/limo/shadow_executor.py
@@ -1,0 +1,110 @@
+"""LIMO SHADOW executor（审计 FTC-100）：验证与规划，绝不驱动硬件。
+
+SHADOW 模式下 Executor 返回 SHADOW receipt：
+- evidence_domain=shadow（与 SIMULATED/REAL 严格分域）；
+- actuated=false（硬阻断：不打开串口/不发布 ROS 命令）；
+- 携带拟执行的 ROS 命令描述（可审计）；
+- usable_for_real_execution=false。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rosclaw.kernel.contracts import (
+    ActionEnvelope,
+    ActionExecutionResult,
+    ActionState,
+    EvidenceDomain,
+    EvidenceLevel,
+)
+
+#: SHADOW 支持的能力与其参数校验器。
+def _validate_tone(arguments: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    freq = arguments.get("frequency_hz")
+    dur = arguments.get("duration_sec")
+    vol = arguments.get("volume_percent")
+    if not isinstance(freq, (int, float)) or not (20 <= freq <= 20_000):
+        errors.append(f"frequency_hz {freq!r} out of [20, 20000]")
+    if not isinstance(dur, (int, float)) or not (0.01 <= dur <= 5.0):
+        errors.append(f"duration_sec {dur!r} out of [0.01, 5.0]")
+    if not isinstance(vol, (int, float)) or not (0 <= vol <= 100):
+        errors.append(f"volume_percent {vol!r} out of [0, 100]")
+    return errors
+
+
+def _validate_pose(arguments: dict[str, Any]) -> list[str]:
+    from math import isfinite
+
+    errors: list[str] = []
+    for key in ("x", "y", "yaw"):
+        value = arguments.get(key)
+        if not isinstance(value, (int, float)) or not isfinite(value):
+            errors.append(f"{key} {value!r} must be finite")
+    return errors
+
+
+_VALIDATORS = {
+    "limo.speaker.play_tone": _validate_tone,
+    "limo.localization.set_initial_pose": _validate_pose,
+}
+
+
+def limo_shadow_executor(action: ActionEnvelope) -> ActionExecutionResult:
+    """SHADOW 执行：验证 + 规划 ROS 命令 + 硬阻断回报。"""
+    validator = _VALIDATORS.get(action.capability_id)
+    if validator is None:
+        return ActionExecutionResult(
+            final_state=ActionState.BLOCKED,
+            evidence_level=EvidenceLevel.UNSUPPORTED,
+            evidence_domain=EvidenceDomain.SHADOW,
+            simulation_result={"actuated": False},
+            verification_result={"verified": False, "reason": "unsupported capability"},
+            errors=[{"code": "SHADOW_UNSUPPORTED", "message": f"no SHADOW validator for {action.capability_id!r}"}],
+        )
+    errors = validator(dict(action.arguments))
+    if errors:
+        return ActionExecutionResult(
+            final_state=ActionState.FAILED,
+            evidence_level=EvidenceLevel.UNSUPPORTED,
+            evidence_domain=EvidenceDomain.SHADOW,
+            simulation_result={"actuated": False},
+            verification_result={"verified": False, "reason": "argument validation failed"},
+            errors=[{"code": "SHADOW_INVALID_ARGUMENTS", "message": e} for e in errors],
+        )
+    planned = _planned_commands(action)
+    return ActionExecutionResult(
+        final_state=ActionState.COMPLETED,
+        evidence_level=EvidenceLevel.TASK_VERIFIED,
+        evidence_domain=EvidenceDomain.SHADOW,
+        simulation_result={
+            "actuated": False,
+            "usable_for_real_execution": False,
+            "planned_ros_commands": planned,
+        },
+        verification_result={
+            "verified": True,
+            "method": "shadow_plan_validation",
+            "actuation_gate": "hard_blocked",
+        },
+    )
+
+
+def _planned_commands(action: ActionEnvelope) -> list[str]:
+    if action.capability_id == "limo.speaker.play_tone":
+        a = action.arguments
+        return [
+            f"ros2 topic pub --once /buzzer_tone std_msgs/msg/Int32 "
+            f"{{data: {int(a.get('frequency_hz', 0))}}}",
+            f"sleep {float(a.get('duration_sec', 0)):.2f}",
+            "ros2 topic pub --once /buzzer_stop std_msgs/msg/Empty {}",
+        ]
+    if action.capability_id == "limo.localization.set_initial_pose":
+        a = action.arguments
+        return [
+            "ros2 service call /relocalization std_srvs/srv/Trigger {}",
+            f"ros2 param set /amcl initial_pose "
+            f"[{a.get('x', 0.0)}, {a.get('y', 0.0)}, {a.get('yaw', 0.0)}]",
+        ]
+    return [f"# unplanned capability {action.capability_id}"]

--- a/src/rosclaw/operator/store.py
+++ b/src/rosclaw/operator/store.py
@@ -55,15 +55,17 @@ class OperatorProposalStore:
         """Create one immutable proposal and strip all caller approval claims."""
 
         ttl = self._ttl(ttl_sec)
-        if action.execution_mode is not ExecutionMode.REAL:
+        if action.execution_mode not in {ExecutionMode.REAL, ExecutionMode.SHADOW}:
             raise OperatorProposalError(
                 "PROPOSAL_REAL_ACTION_REQUIRED",
-                "Operator proposals may contain only explicit REAL actions",
+                "Operator proposals may contain only explicit REAL or SHADOW actions "
+                "(FTC-100: SHADOW proposals exercise the full permission chain "
+                "with actuation hard-blocked)",
             )
         if not action.body_snapshot_hash.strip():
             raise OperatorProposalError(
                 "PROPOSAL_BODY_SNAPSHOT_REQUIRED",
-                "REAL operator proposals require a body snapshot hash",
+                "REAL/SHADOW operator proposals require a body snapshot hash",
             )
         normalized_display = self._display(display)
         current = (now or datetime.now(UTC)).astimezone(UTC)

--- a/tests/agentd/test_full_chain_e2e.py
+++ b/tests/agentd/test_full_chain_e2e.py
@@ -1,5 +1,11 @@
 """全链路闭环深度测试（2026-08-04 复盘专项）。
 
+**证据等级标注（审计 §7.1/§1.2）：本文件 = L1（进程集成）+ 部分 L2
+（Mock Model + LIMO SIM executor）。** 它证明进程/协议/授权/SIM 执行
+闭环，**不证明**真实 Provider（由 test_kimi_live 的 K 系列覆盖）、
+真实 rosclawd 许可链（由 tests/shadow 的 FTC-100 覆盖）或实体 LIMO
+REAL（待 FTC-110）。
+
 一次运行覆盖 Native Agent 全链路：
 init → doctor → service(+operator.sock+HTTP) → mission → LIMO 观测 →
 授权(operator.sock peer identity) → SIM 执行 → receipt → 验证 →

--- a/tests/agentd/test_release_packaging.py
+++ b/tests/agentd/test_release_packaging.py
@@ -104,3 +104,84 @@ class TestInstallRollbackSemantics:
         assert result.returncode == 0, result.stderr
         assert (prefix / "current" / "marker_old").exists()
         assert list(prefix.glob("failed-*")), "failed version must be preserved"
+
+
+@pytest.mark.slow
+class TestSignedBundle:
+    def test_build_produces_signed_manifest_and_offline_assets(self, tmp_path: Path) -> None:
+        import subprocess, tarfile, json as _json
+
+        env = dict(os.environ, ROSCLAW_SIGNING_HOME=str(tmp_path / "signing"))
+        result = subprocess.run(
+            ["bash", str(REPO / "scripts" / "build_release.sh")],
+            cwd=REPO, capture_output=True, text=True, timeout=900, env=env,
+        )
+        assert result.returncode == 0, result.stderr[-1500:]
+        bundles = sorted((REPO / "dist").glob("rosclaw-*-linux-*.tar.gz"))
+        bundle = bundles[-1]
+        stage = tmp_path / "stage"
+        stage.mkdir()
+        with tarfile.open(bundle) as tf:
+            tf.extractall(stage)
+        root = next(stage.iterdir())
+        # 签名与公钥存在，SBOM 与离线资产存在。
+        for name in ("manifest.json", "manifest.sig", "bundle-signing-public.pem",
+                     "sbom-python.txt", "sbom-rosclaw-tui.txt", "sbom-rosclaw-modeld.txt"):
+            assert (root / name).exists(), name
+        assert (root / "vendor" / "node_modules_pack" / "rosclaw-tui.tar.gz").exists()
+        assert (root / "vendor" / "node_modules_pack" / "rosclaw-modeld.tar.gz").exists()
+        # 签名有效。
+        verify = subprocess.run(
+            ["openssl", "dgst", "-sha256", "-verify",
+             str(root / "bundle-signing-public.pem"),
+             "-signature", str(root / "manifest.sig"),
+             str(root / "manifest.json")],
+            capture_output=True, text=True,
+        )
+        assert verify.returncode == 0, verify.stderr
+        # 篡改 manifest 中任一文件 → 验签/has 必拒（这里改一个源码文件）。
+        target = next((root / "src" / "rosclaw").rglob("*.py"))
+        target.write_text("tampered")
+        verify2 = subprocess.run(
+            ["openssl", "dgst", "-sha256", "-verify",
+             str(root / "bundle-signing-public.pem"),
+             "-signature", str(root / "manifest.sig"),
+             str(root / "manifest.json")],
+            capture_output=True, text=True,
+        )
+        # manifest.json 本身未变 → 签名仍有效，但文件 hash 校验必败。
+        assert verify2.returncode == 0
+        check = subprocess.run(
+            ["python3", "-c", _HASH_CHECK_SNIPPET, str(root)],
+            capture_output=True, text=True,
+        )
+        assert check.returncode == 2
+        assert "tampered" in check.stderr
+        # 安装器在篡改下直接拒绝（verify-before-execute）。
+        install = subprocess.run(
+            ["bash", str(root / "install.sh"), "--offline"],
+            capture_output=True, text=True, timeout=120,
+            env=dict(os.environ, ROSCLAW_PREFIX=str(tmp_path / "prefix")),
+        )
+        assert install.returncode == 2
+        assert "篡改" in install.stderr or "tampered" in install.stderr
+
+
+_HASH_CHECK_SNIPPET = (
+    "import hashlib, json, sys\n"
+    "from pathlib import Path\n"
+    "root = Path(sys.argv[1])\n"
+    "manifest = json.loads((root / 'manifest.json').read_text())\n"
+    "bad = []\n"
+    "for rel, expected in manifest['files'].items():\n"
+    "    path = root / rel\n"
+    "    if not path.exists():\n"
+    "        bad.append(f'missing: {rel}')\n"
+    "        continue\n"
+    "    actual = hashlib.sha256(path.read_bytes()).hexdigest()\n"
+    "    if actual != expected:\n"
+    "        bad.append(f'tampered: {rel}')\n"
+    "if bad:\n"
+    "    print('\\n'.join(bad), file=sys.stderr)\n"
+    "    sys.exit(2)\n"
+)

--- a/tests/agentd/test_release_packaging.py
+++ b/tests/agentd/test_release_packaging.py
@@ -109,7 +109,8 @@ class TestInstallRollbackSemantics:
 @pytest.mark.slow
 class TestSignedBundle:
     def test_build_produces_signed_manifest_and_offline_assets(self, tmp_path: Path) -> None:
-        import subprocess, tarfile, json as _json
+        import subprocess
+        import tarfile
 
         env = dict(os.environ, ROSCLAW_SIGNING_HOME=str(tmp_path / "signing"))
         result = subprocess.run(

--- a/tests/shadow/test_limo_shadow_chain.py
+++ b/tests/shadow/test_limo_shadow_chain.py
@@ -190,7 +190,6 @@ class TestLimoShadowChain:
         client, tmp = shadow_daemon
         enrollment = enroll(tmp / "operatord")
         client.register_operator_enrollment(enrollment.enrollment_id, enrollment.key.hex())
-        service = client  # keep name; the service lives inside the fixture daemon
         # fabricate a non-daemon peer（uid+1 != euid）。
         foreign = PeerCredentials(pid=99999, uid=os.geteuid() + 1, gid=0)
         daemon_service = None

--- a/tests/shadow/test_limo_shadow_chain.py
+++ b/tests/shadow/test_limo_shadow_chain.py
@@ -190,11 +190,11 @@ class TestLimoShadowChain:
         client, tmp = shadow_daemon
         enrollment = enroll(tmp / "operatord")
         client.register_operator_enrollment(enrollment.enrollment_id, enrollment.key.hex())
-        # fabricate a non-daemon peer（uid+1 != euid）。
-        foreign = PeerCredentials(pid=99999, uid=os.geteuid() + 1, gid=0)
-        daemon_service = None
         # fixture 的 daemon service 无法直接拿到——通过 ACL 语义另行构造：
         from rosclaw.daemon.service import DaemonControlPlane
+
+        # fabricate a non-daemon peer（uid+1 != euid）。
+        foreign = PeerCredentials(pid=99999, uid=os.geteuid() + 1, gid=0)
 
         plane = DaemonControlPlane(runtime=None)
         plane.register_operator_enrollment(

--- a/tests/shadow/test_limo_shadow_chain.py
+++ b/tests/shadow/test_limo_shadow_chain.py
@@ -26,13 +26,13 @@ from rosclaw.daemon.service import DaemonControlPlane
 from rosclaw.kernel.contracts import (
     ActionEnvelope,
     AuthorizationContext,
+    EvidenceLevel,
     ExecutionMode,
     VerificationPolicy,
-    EvidenceLevel,
 )
 from rosclaw.operatord.enrollment import enroll
-from tests.daemon.test_operator_proposals import _runtime
 from tests.agentd.conftest import LOCAL_PRINCIPAL
+from tests.daemon.test_operator_proposals import _runtime
 
 
 def _action(action_id: str, capability: str, arguments: dict, mode: ExecutionMode) -> ActionEnvelope:
@@ -58,14 +58,15 @@ def _action(action_id: str, capability: str, arguments: dict, mode: ExecutionMod
 
 @pytest.fixture
 def shadow_daemon():
-    from rosclaw.kernel.contracts import ExecutionMode as EM
     from rosclaw.limo.shadow_executor import limo_shadow_executor
 
     with tempfile.TemporaryDirectory() as d:
         tmp = Path(d)
         runtime = _runtime()
         for capability in ("limo.speaker.play_tone", "limo.localization.set_initial_pose"):
-            runtime.action_gateway.register_executor(capability, EM.SHADOW, limo_shadow_executor)
+            runtime.action_gateway.register_executor(
+                capability, ExecutionMode.SHADOW, limo_shadow_executor
+            )
         with DaemonLedger(
             tmp / "state" / "ledger.sqlite3", key_path=tmp / "state" / "ledger.key"
         ) as ledger:
@@ -161,7 +162,7 @@ class TestLimoShadowChain:
             "proposal"
         ]
         trusted = client.list_pending_operator_proposals()["proposals"][0]
-        decided = client.decide_operator_proposal(
+        client.decide_operator_proposal(
             public["request_id"],
             decision="ACCEPT",
             principal_id=LOCAL_PRINCIPAL,

--- a/tests/shadow/test_limo_shadow_chain.py
+++ b/tests/shadow/test_limo_shadow_chain.py
@@ -1,0 +1,233 @@
+"""FTC-100（审计 §7.2/E1）：LIMO SHADOW 全链路。
+
+真实 rosclawd（in-process）+ 真实 operatord（enrollment + proof）+
+真实 daemon client RPC + LIMO SHADOW executor（actuation 硬阻断）：
+
+proposal → operatord human decision（proof 经 rosclawd ACL）→
+Permit/Lease → SHADOW action → SHADOW receipt（evidence_domain=shadow,
+actuated=false）→ 公开回执验证。
+
+攻击面：agentd 直接 decide → PERMISSION_DENIED；伪造 proof → 拒；
+display hash 篡改 → 拒。
+"""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from rosclaw.daemon.client import DaemonClient
+from rosclaw.daemon.ledger import DaemonLedger
+from rosclaw.daemon.server import RosclawDaemon
+from rosclaw.daemon.service import DaemonControlPlane
+from rosclaw.kernel.contracts import (
+    ActionEnvelope,
+    AuthorizationContext,
+    ExecutionMode,
+    VerificationPolicy,
+    EvidenceLevel,
+)
+from rosclaw.operatord.enrollment import enroll
+from tests.daemon.test_operator_proposals import _runtime
+from tests.agentd.conftest import LOCAL_PRINCIPAL
+
+
+def _action(action_id: str, capability: str, arguments: dict, mode: ExecutionMode) -> ActionEnvelope:
+    return ActionEnvelope(
+        action_id=action_id,
+        actor_id="rosclaw-native",
+        agent_framework="rosclaw-native",
+        session_id=f"session-{action_id}",
+        body_id="limo-test",
+        body_snapshot_hash="sha256:limo-body",
+        capability_id=capability,
+        arguments=arguments,
+        execution_mode=mode,
+        deadline_at=datetime.now(UTC) + timedelta(minutes=2),
+        authorization=AuthorizationContext(
+            principal_id="forged-agent", approved=True, approval_id="forged", scopes=["*"]
+        ),
+        verification_policy=VerificationPolicy(
+            required_evidence=EvidenceLevel.TASK_VERIFIED, timeout_sec=2.0
+        ),
+    )
+
+
+@pytest.fixture
+def shadow_daemon():
+    from rosclaw.kernel.contracts import ExecutionMode as EM
+    from rosclaw.limo.shadow_executor import limo_shadow_executor
+
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        runtime = _runtime()
+        for capability in ("limo.speaker.play_tone", "limo.localization.set_initial_pose"):
+            runtime.action_gateway.register_executor(capability, EM.SHADOW, limo_shadow_executor)
+        with DaemonLedger(
+            tmp / "state" / "ledger.sqlite3", key_path=tmp / "state" / "ledger.key"
+        ) as ledger:
+            daemon = RosclawDaemon(
+                service=DaemonControlPlane(runtime=runtime, ledger=ledger),
+                socket_path=tmp / "run" / "rosclawd.sock",
+            )
+            daemon.start()
+            client = DaemonClient(socket_path=daemon.socket_path)
+            try:
+                yield client, tmp
+            finally:
+                daemon.stop()
+
+
+class TestLimoShadowChain:
+    def test_tone_shadow_full_chain(self, shadow_daemon) -> None:
+        """FTC-100：proposal→decide→permit→SHADOW receipt，驱动确认无真实动作。"""
+        client, tmp = shadow_daemon
+        # 1. enrollment + daemon ACL 登记（operatord 职责）。
+        enrollment = enroll(tmp / "operatord")
+        registered = client.register_operator_enrollment(
+            enrollment.enrollment_id, enrollment.key.hex()
+        )
+        assert registered["registered"]
+        assert registered["fingerprint"] == enrollment.fingerprint
+
+        # 2. agentd 侧创建 proposal（公开视图）。
+        action = _action(
+            "act-shadow-tone",
+            "limo.speaker.play_tone",
+            {"frequency_hz": 660, "duration_sec": 0.6, "volume_percent": 18},
+            ExecutionMode.SHADOW,
+        )
+        public = client.create_operator_proposal(
+            action, display={"title": "播放提示音 660Hz 0.6s 18%"}, ttl_sec=60.0
+        )["proposal"]
+        assert "challenge_nonce" not in public
+        assert "permit" not in str(public).lower()
+
+        # 3. operatord 决定（human decision + proof → rosclawd ACL）。
+        trusted = client.list_pending_operator_proposals()["proposals"][0]
+        from rosclaw.operatord.enrollment import sign_decision_proof
+
+        decided_at = datetime.now(UTC).isoformat()
+        display_hash = "limo-card-hash"
+        proof = sign_decision_proof(
+            enrollment,
+            request_id=public["request_id"],
+            approve=True,
+            nonce="nonce-shadow-1",
+            decided_at=decided_at,
+            display_hash=display_hash,
+        )
+        decided = client.decide_operator_proposal(
+            public["request_id"],
+            decision="ACCEPT",
+            principal_id=LOCAL_PRINCIPAL,
+            challenge_nonce=trusted["challenge_nonce"],
+            action_intent_hash=trusted["action_intent_hash"],
+            channel="rosclaw_operatord",
+            reason="shadow chain acceptance",
+            operator_proof=proof,
+            enrollment_id=enrollment.enrollment_id,
+            display_hash=display_hash,
+            decided_at=decided_at,
+        )
+        assert decided["proposal"]["state"] == "SUBMITTED"
+
+        # 4. SHADOW receipt：evidence 严格分域 + 硬阻断。
+        terminal = client.wait_for_action(public["action_id"], timeout_sec=10.0)
+        receipt = terminal["receipt"]
+        assert receipt["final_state"] == "COMPLETED"
+        assert receipt["evidence_domain"].upper() == "SHADOW"
+        sim = receipt.get("simulation_result") or {}
+        assert sim.get("actuated") is False, "SHADOW 绝不允许真实驱动"
+        assert sim.get("usable_for_real_execution") is False
+        assert sim.get("planned_ros_commands"), "SHADOW 必须携带可审计的拟执行命令"
+        verification = receipt.get("verification_result") or {}
+        assert verification.get("actuation_gate") == "hard_blocked"
+
+    def test_pose_shadow_validates_and_blocks_bad_args(self, shadow_daemon) -> None:
+        client, tmp = shadow_daemon
+        enrollment = enroll(tmp / "operatord")
+        client.register_operator_enrollment(enrollment.enrollment_id, enrollment.key.hex())
+        bad = _action(
+            "act-shadow-bad",
+            "limo.speaker.play_tone",
+            {"frequency_hz": 999_999, "duration_sec": 0.6, "volume_percent": 18},
+            ExecutionMode.SHADOW,
+        )
+        public = client.create_operator_proposal(bad, display={"title": "bad"}, ttl_sec=60.0)[
+            "proposal"
+        ]
+        trusted = client.list_pending_operator_proposals()["proposals"][0]
+        decided = client.decide_operator_proposal(
+            public["request_id"],
+            decision="ACCEPT",
+            principal_id=LOCAL_PRINCIPAL,
+            challenge_nonce=trusted["challenge_nonce"],
+            action_intent_hash=trusted["action_intent_hash"],
+            channel="rosclaw_operatord",
+            reason="x",
+        )
+        terminal = client.wait_for_action(public["action_id"], timeout_sec=10.0)
+        assert terminal["receipt"]["final_state"] == "FAILED"
+        assert terminal["receipt"]["errors"], "非法参数必须失败并给出原因"
+
+    def test_agentd_cannot_decide_without_proof(self, shadow_daemon) -> None:
+        """FTC-050（部分）：非 daemon UID 的调用方必须持有效 enrollment
+        proof——伪造 id / 无 proof / 篡改 display_hash 全被拒。
+
+        进程内测试无法伪造 SO_PEERCRED，直接在 service ACL 层用
+        fabricated peer（uid != euid）验证拒绝语义。
+        """
+        import os
+
+        from rosclaw.daemon.protocol import PeerCredentials
+        from rosclaw.operatord.enrollment import enroll, sign_decision_proof
+
+        client, tmp = shadow_daemon
+        enrollment = enroll(tmp / "operatord")
+        client.register_operator_enrollment(enrollment.enrollment_id, enrollment.key.hex())
+        service = client  # keep name; the service lives inside the fixture daemon
+        # fabricate a non-daemon peer（uid+1 != euid）。
+        foreign = PeerCredentials(pid=99999, uid=os.geteuid() + 1, gid=0)
+        daemon_service = None
+        # fixture 的 daemon service 无法直接拿到——通过 ACL 语义另行构造：
+        from rosclaw.daemon.service import DaemonControlPlane
+
+        plane = DaemonControlPlane(runtime=None)
+        plane.register_operator_enrollment(
+            enrollment.enrollment_id, key_hex=enrollment.key.hex(),
+            peer=PeerCredentials(pid=os.getpid(), uid=os.geteuid(), gid=0),
+        )
+        # 1) 无 proof → 拒。
+        assert not plane._decide_acl_allows(
+            foreign, "", request_id="r1", approve=True, nonce="n",
+            decided_at="t", enrollment_id=enrollment.enrollment_id, display_hash="h",
+        )
+        # 2) 未登记的 enrollment_id → 拒。
+        proof = sign_decision_proof(
+            enrollment, request_id="r1", approve=True, nonce="n",
+            decided_at="t", display_hash="h",
+        )
+        assert not plane._decide_acl_allows(
+            foreign, proof, request_id="r1", approve=True, nonce="n",
+            decided_at="t", enrollment_id="oen_mallory", display_hash="h",
+        )
+        # 3) 篡改 display_hash → 拒。
+        assert not plane._decide_acl_allows(
+            foreign, proof, request_id="r1", approve=True, nonce="n",
+            decided_at="t", enrollment_id=enrollment.enrollment_id, display_hash="TAMPERED",
+        )
+        # 4) 合法 proof → 允许（operatord 正常路径）。
+        assert plane._decide_acl_allows(
+            foreign, proof, request_id="r1", approve=True, nonce="n",
+            decided_at="t", enrollment_id=enrollment.enrollment_id, display_hash="h",
+        )
+        # 5) daemon 服务 UID 直通（生产侧 rosclawd 服务账户）。
+        service_peer = PeerCredentials(pid=1, uid=os.geteuid(), gid=0)
+        assert plane._decide_acl_allows(
+            service_peer, "", request_id="r1", approve=True, nonce="n",
+            decided_at="t", enrollment_id="", display_hash="",
+        )


### PR DESCRIPTION
**D1 (P0-05)**: build produces SBOM + offline assets (vendor wheels, packed node_modules) + detached ECDSA signature over manifest.json (dev key local-only, public key ships); installer verifies signature + every file hash BEFORE executing (tamper/missing refused), --offline never touches PyPI/npm, no on-target TS build, transactional install with auto-rollback healthcheck, ROSCLAW_REQUIRE_TUI=1 hard-fail instead of silent --basic.

**E1 (FTC-100)**: LIMO SHADOW executor (arg validation, auditable planned ROS commands, actuation hard-blocked, evidence_domain=SHADOW); daemon allows SHADOW proposals/permits alongside REAL with mode-aware executor checks; full chain test with real daemon + real enrollment proof (SUBMITTED → SHADOW receipt verified); ACL denial matrix.

**Evidence**: E0–E7 level naming + acceptance/<run_id>/ evidence pack writer wired into run_acceptance; full-chain e2e honestly relabeled L1+partial L2.

6134 passed; ruff + mypy clean.