### PR TITLE
Post-audit conflict fixes: operatord routing for REPL /approve + /revoke, modeld socket umask race

### DIFF
--- a/packages/rosclaw-modeld/package-lock.json
+++ b/packages/rosclaw-modeld/package-lock.json
@@ -11,7 +11,7 @@
 				"@earendil-works/pi-ai": "0.83.0"
 			},
 			"bin": {
-				"rosclaw-modeld": "dist/main.js"
+				"rosclaw-modeld": "dist/src/main.js"
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.0",

--- a/packages/rosclaw-modeld/src/server.ts
+++ b/packages/rosclaw-modeld/src/server.ts
@@ -250,7 +250,13 @@ export function startModeld(options: ModeldOptions): Promise<Server> {
 	});
 
 	return new Promise((resolve) => {
+		// umask 先行：socket 文件在 bind 时即 0600——listen 回调里的 chmod
+		// 晚于文件出现，等待方（Python gateway 轮询 exists）会在两者之间
+		// stat 到默认权限（负载相关的测试抖动 + 一个极小的时间窗）。
+		const previousUmask = process.umask(0o077);
+		server.once("error", () => process.umask(previousUmask));
 		server.listen(options.socketPath, () => {
+			process.umask(previousUmask);
 			chmodSync(options.socketPath, 0o600);
 			resolve(server);
 		});

--- a/packages/rosclaw-tui/package-lock.json
+++ b/packages/rosclaw-tui/package-lock.json
@@ -12,7 +12,7 @@
 				"chalk": "^5.3.0"
 			},
 			"bin": {
-				"rosclaw-tui": "dist/main.js"
+				"rosclaw-tui": "dist/src/main.js"
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.0",

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -569,7 +569,7 @@ async def _chat_repl(service: AgentService, args: argparse.Namespace) -> int:
     print(f"ROSClaw chat — mission {mission.mission_id} [{mission.mode.value}]")
     print(
         "输入消息开始对话；/state 查看状态；/approvals 待授权；"
-        "/approve|/deny <id> 决定授权；/compact [focus|--dry-run|--status]；"
+        "/approve|/deny <id> 经 operatord 决定授权；/compact [focus|--dry-run|--status]；"
         "/cancel 取消当前回合；/quit 退出。"
     )
     try:
@@ -615,6 +615,8 @@ async def _chat_repl(service: AgentService, args: argparse.Namespace) -> int:
                     )
                 continue
             if text == "/approvals":
+                from rosclaw.agentd.operator_socket import display_hash_for
+
                 pending = service.pending_approvals(mission.mission_id)
                 if not pending:
                     print("没有待处理的授权请求。")
@@ -622,23 +624,50 @@ async def _chat_repl(service: AgentService, args: argparse.Namespace) -> int:
                     d = req.action_display
                     print(
                         f"  {req.request_id} [{d.risk_tier}] {d.title}: {d.summary} "
-                        f"(expires {req.expires_at})"
+                        f"(expires {req.expires_at}) hash={display_hash_for(req)}"
                     )
                 continue
             if text.startswith("/approve ") or text.startswith("/deny "):
                 approve = text.startswith("/approve ")
                 request_id = text.split(maxsplit=1)[1].strip()
-                try:
-                    grant = await service.decide_approval(
-                        request_id, principal="user:local:1000", approve=approve
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    print(f"授权操作失败：{exc}")
+                # 审计 P0-01：REPL 不直接决定——决定经独立 rosclaw-operatord
+                # （enrollment proof + display hash 绑定），与 TUI 同一通道。
+                from rosclaw.agentd.operator_socket import display_hash_for, operator_call
+                from rosclaw.operatord.server import default_operatord_socket
+
+                target = next(
+                    (
+                        r
+                        for r in service.pending_approvals(mission.mission_id)
+                        if r.request_id == request_id
+                    ),
+                    None,
+                )
+                if target is None:
+                    print("没有找到该待批卡片（可能已过期或已被决定）。")
                     continue
-                if grant is not None:
+                sock = default_operatord_socket(_home(args))
+                if not sock.exists():
                     print(
-                        f"已批准并签发 grant {grant.grant_id}（public_hash "
-                        f"{grant.public_hash[:24]}…，EXACT_ACTION 单次有效）。"
+                        "授权决定已迁至独立 rosclaw-operatord（P0-01），本进程无权决定。\n"
+                        "请先运行：rosclaw operatord enroll && rosclaw operatord start"
+                    )
+                    continue
+                reply = await operator_call(
+                    sock,
+                    "approvals.decide",
+                    {
+                        "request_id": request_id,
+                        "display_hash": display_hash_for(target),
+                        "approve": approve,
+                    },
+                )
+                if not reply.get("ok"):
+                    print(f"授权操作失败：{reply.get('error', reply)}")
+                elif approve:
+                    print(
+                        f"已批准并签发 grant {reply.get('grant_id', '—')}"
+                        "（EXACT_ACTION 单次有效）。"
                     )
                 else:
                     print("已拒绝该授权请求。")

--- a/src/rosclaw/agentd/ui/command_service.py
+++ b/src/rosclaw/agentd/ui/command_service.py
@@ -782,8 +782,25 @@ def _register_batch_e(service, register) -> None:  # noqa: C901 - 命令集合�
                 error_code="invalid_arguments",
                 message="/revoke 需要 grant_id（需要 Operator 身份）",
             )
+        # 审计 P0-01：撤销与决定同属 operatord——agentd 不直接撤 grant，
+        # 经 operatord.sock（enrollment proof）转发，与 HTTP 403 口径一致。
+        from rosclaw.agentd.operator_socket import operator_call
+        from rosclaw.operatord.server import default_operatord_socket
+
+        sock = default_operatord_socket(service._home)
+        if not sock.exists():
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="operatord_unavailable",
+                message=(
+                    "撤销已迁至独立 rosclaw-operatord（P0-01），本进程无权撤销。"
+                    "请先运行：rosclaw operatord enroll && rosclaw operatord start"
+                ),
+            )
         try:
-            service.revoke_grant(grant_id, principal=req.arguments.get("principal", "user:local:1000"))
+            reply = await operator_call(sock, "grants.revoke", {"grant_id": grant_id})
         except Exception as exc:  # noqa: BLE001
             return CommandResultV1(
                 request_id=req.request_id,
@@ -792,11 +809,19 @@ def _register_batch_e(service, register) -> None:  # noqa: C901 - 命令集合�
                 error_code="revoke_failed",
                 message=str(exc),
             )
+        if not reply.get("ok"):
+            return CommandResultV1(
+                request_id=req.request_id,
+                command_name=req.command_name,
+                ok=False,
+                error_code="revoke_failed",
+                message=str(reply.get("error", reply)),
+            )
         return CommandResultV1(
             request_id=req.request_id,
             command_name=req.command_name,
             ok=True,
-            message=f"grant {grant_id} 已撤销",
+            message=f"grant {grant_id} 已撤销（经 operatord）",
         )
 
     async def _body(req: CommandRequestV1) -> CommandResultV1:


### PR DESCRIPTION
复审审计改动与旧功能的冲突面时发现三处问题，全部修复：

## 发现与修复

1. **REPL `/approve`/`/deny` 死命令（P0-01 冲突）**：`_chat_repl` 直接调 `service.decide_approval`（无 `_from_operatord`）——自 #217 起该路径必然抛错，命令名存实亡。改为与 TUI 同一通道：operatord.sock `approvals.decide`（display_hash 绑定 + operator_call）；operatord 未运行时给出明确接线指引。/approvals 列表补打印 display_hash 供人核对卡片。
2. **/revoke UI 命令面口径不一致（P0-01 冲突）**：HTTP `/grants/{id}/revoke` 已 403，但 CommandService `/revoke` 仍直连 `service.revoke_grant`——同一操作两个面两种策略。改为经 operatord.sock `grants.revoke`（enrollment proof 转发），operatord 缺席时诚实拒绝并指引。
3. **modeld UDS 权限竞态（flaky test_uds_permissions）**：`chmodSync(sock, 0o600)` 在 listen 回调里执行，晚于 socket 文件出现；Python gateway 轮询 `exists()` 会在两者之间 stat 到默认权限（负载相关抖动，全量回归抓到一次）。改为 listen 前 `process.umask(0o077)` 让 socket 创建即 0600，回调/出错路径恢复 umask（chmod 保留兜底）。

## 验证

- 全量回归 6154 passed（仅 8 个已知环境性失败：firstboot×4 + lerobot×4，origin/main 基线相同）
- test_uds_permissions 修复后连跑 8 次全绿；modeld 18/18、TUI 25/25 node 测试绿
- K0–K9 live 11/11（真实 Kimi K3 + 真实 operatord 决策链，947s）
- ruff clean；mypy 1090 files clean
- LIMO 验收 12/12 + E3 证据包 secret scan 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)