### PR TITLE
R4 + R6 + R7 + Node CI: transcript exactly-once, lifecycle/auth, trusted releases, auditable evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,77 @@ jobs:
       - name: Run ruff check
         run: ruff check src tests
 
+  node-tui-unit:
+    name: Node TUI Unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.19.0'
+          cache: 'npm'
+          cache-dependency-path: packages/rosclaw-tui/package-lock.json
+      - run: npm ci
+        working-directory: packages/rosclaw-tui
+      - run: npm test
+        working-directory: packages/rosclaw-tui
+
+  node-modeld-unit:
+    name: Node modeld Unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.19.0'
+          cache: 'npm'
+          cache-dependency-path: packages/rosclaw-modeld/package-lock.json
+      - run: npm ci
+        working-directory: packages/rosclaw-modeld
+      - run: npm test
+        working-directory: packages/rosclaw-modeld
+
+  evidence-pack-verify:
+    name: Evidence Pack Verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          version: 'latest'
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]" --system
+      - name: Run acceptance + evidence pack tests
+        run: python -m pytest tests/agentd/test_limo_acceptance.py tests/agentd/test_evidence_pack.py -q
+      - name: Produce acceptance evidence pack
+        run: |
+          python - <<'PY'
+          import asyncio, tempfile
+          from pathlib import Path
+          from rosclaw.agentd.bench.limo_acceptance import run_acceptance
+          async def main():
+              with tempfile.TemporaryDirectory() as d:
+                  report = await run_acceptance(Path(d), evidence_root=Path("/tmp/evidence-ci"))
+                  assert all(report.checks.values()), report.checks
+                  print("evidence pack at /tmp/evidence-ci/acceptance")
+          asyncio.run(main())
+          PY
+      - name: Verify pack offline
+        run: python -m rosclaw.entrypoint evidence verify /tmp/evidence-ci/acceptance/*/
+      - name: Upload evidence pack
+        uses: actions/upload-artifact@v4
+        with:
+          name: acceptance-evidence-pack
+          path: /tmp/evidence-ci/acceptance/
+          retention-days: 30
+
   cross-uid-operator-e2e:
     name: Cross-UID Operator E2E
     runs-on: ubuntu-latest

--- a/packages/rosclaw-modeld/src/credentials.ts
+++ b/packages/rosclaw-modeld/src/credentials.ts
@@ -10,7 +10,19 @@
  */
 
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	closeSync,
+	constants,
+	existsSync,
+	mkdirSync,
+	openSync,
+	fsyncSync,
+	readFileSync,
+	renameSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname } from "node:path";
 
 interface StoredCredential {
@@ -51,23 +63,53 @@ export class UnifiedCredentialStore {
 
 	private readFile(): Record<string, StoredCredential> {
 		if (!this.fileEnabled || !existsSync(this.path)) return {};
+		// P1-6：校验 owner/mode/link count——凭据文件不得是链接或多链接。
+		const st = statSync(this.path);
+		if (!st.isFile() || st.nlink !== 1) {
+			throw new CredentialStoreError(`credential file must be a regular single-link file: ${this.path}`);
+		}
+		if (st.mode & 0o077) {
+			throw new CredentialStoreError(`credential file must be 0600: ${this.path}`);
+		}
 		try {
 			return JSON.parse(readFileSync(this.path, "utf8")) as Record<string, StoredCredential>;
 		} catch (err) {
-			// 损坏文件报错隔离，不静默当作空凭据（审计 P0-04.3）。
+			// P1-6：损坏文件真实隔离到带时间戳的 quarantine（仍 0600），
+			// 不静默当作空凭据（审计 P0-04.3）。
+			const quarantined = `${this.path}.corrupt-${new Date().toISOString().replace(/[:.]/g, "")}`;
+			try {
+				renameSync(this.path, quarantined);
+				chmodSync(quarantined, 0o600);
+			} catch {
+				// quarantine 失败不掩盖原始损坏事实
+			}
 			throw new CredentialStoreError(
-				`credential file corrupt: ${this.path} — ${(err as Error).message}. quarantined; fix or delete it.`,
+				`credential file corrupt: ${this.path} — ${(err as Error).message}. quarantined to ${quarantined}; fix or delete it.`,
 			);
 		}
 	}
 
 	private writeFile(data: Record<string, StoredCredential>): void {
+		// P1-6：O_NOFOLLOW + 原子替换 + 文件/目录双 fsync（崩溃一致性）。
 		mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 });
 		const tmp = `${this.path}.tmp`;
-		writeFileSync(tmp, JSON.stringify(data), { mode: 0o600 });
+		const nofollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+		const fd = openSync(tmp, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | nofollow, 0o600);
+		try {
+			writeFileSync(fd, JSON.stringify(data));
+			fsyncSync(fd);
+		} finally {
+			closeSync(fd);
+		}
 		chmodSync(tmp, 0o600);
 		renameSync(tmp, this.path);
 		chmodSync(this.path, 0o600);
+		const dirFd = openSync(dirname(this.path), constants.O_RDONLY);
+		try {
+			fsyncSync(dirFd);
+		} finally {
+			closeSync(dirFd);
+		}
 	}
 
 	set(provider: string, key: string): { scope: "session" | "file" } {

--- a/packages/rosclaw-modeld/src/server.ts
+++ b/packages/rosclaw-modeld/src/server.ts
@@ -28,6 +28,9 @@ export interface ModeldOptions {
 }
 
 export function startModeld(options: ModeldOptions): Promise<Server> {
+	// P1-5：bind + chmod + 凭据存储初始化完成前 /v1/health/ready 一律 503；
+	// gateway 必须轮询真实就绪，不再只看 socket 文件出现。
+	let ready = false;
 	const store = new UnifiedCredentialStore(options.homeDir, {
 		allowFileCredentials: options.allowFileCredentials,
 	});
@@ -84,6 +87,15 @@ export function startModeld(options: ModeldOptions): Promise<Server> {
 			}
 			const url = new URL(req.url ?? "/", "http://localhost");
 			const path = url.pathname;
+
+			if (req.method === "GET" && path === "/v1/health/ready") {
+				if (ready) {
+					json(res, 200, { ready: true, policy: store.policy });
+				} else {
+					json(res, 503, { ready: false });
+				}
+				return;
+			}
 
 			if (req.method === "GET" && path === "/v1/providers") {
 				const stored = new Set(store.list().map((c) => c.provider));
@@ -258,6 +270,7 @@ export function startModeld(options: ModeldOptions): Promise<Server> {
 		server.listen(options.socketPath, () => {
 			process.umask(previousUmask);
 			chmodSync(options.socketPath, 0o600);
+			ready = true;
 			resolve(server);
 		});
 	});

--- a/packages/rosclaw-tui/src/app.ts
+++ b/packages/rosclaw-tui/src/app.ts
@@ -16,9 +16,21 @@ import {
 } from "@earendil-works/pi-tui";
 import { parseArgs as parseSchemaArgs } from "./commands/args-parser.js";
 import { MaskedInput } from "./components/masked-input.js";
-import { AgentClient, idempotencyKey } from "./client/http.js";
+import { AgentClient, idempotencyKey, type TranscriptBlock } from "./client/http.js";
 import { defaultOperatorSocket, operatorCall } from "./client/operator.js";
+import { readFileSync } from "node:fs";
 import { streamEvents } from "./client/sse.js";
+
+/** P1-4：从 env 或 0600 文件读 ephemeral control token（不打印、不进日志）。 */
+function loadControlToken(): string {
+	if (process.env.ROSCLAW_CONTROL_TOKEN) return process.env.ROSCLAW_CONTROL_TOKEN;
+	const home = process.env.ROSCLAW_HOME ?? `${process.env.HOME}/.rosclaw`;
+	try {
+		return readFileSync(`${home}/run/agentd-control.token`, "utf-8").trim();
+	} catch {
+		return "";
+	}
+}
 import { CommandRegistry } from "./commands/registry.js";
 import { LiveAssistantMessage } from "./components/live-message.js";
 import { HOTKEYS_TEXT, renderCard, statusLine } from "./components/render.js";
@@ -36,6 +48,7 @@ export class RosclawTuiApp {
 	private editor!: Editor;
 	private statusText!: Text;
 	private state: UiState;
+	private readonly clientToken: string;
 	private client: AgentClient;
 	private registry = new CommandRegistry();
 	private live: LiveAssistantMessage | null = null;
@@ -45,7 +58,8 @@ export class RosclawTuiApp {
 	private phaseTicker: ReturnType<typeof setInterval> | null = null;
 
 	constructor(private readonly options: AppOptions) {
-		this.client = new AgentClient(options.baseUrl);
+		this.clientToken = loadControlToken();
+		this.client = new AgentClient(options.baseUrl, this.clientToken);
 		this.state = initialState(options.missionId);
 	}
 
@@ -228,50 +242,89 @@ export class RosclawTuiApp {
 		}
 	}
 
-	/** resume 时把历史事件重放为 transcript（delta 按 turn 聚合，卡片直出）。 */
+	/** R4/P1-1：resume 用服务端 transcript projection（不再从底层事件
+	 * 猜聊天记录）；记录 latest_sequence 供 SSE exactly-once 续接。 */
 	private async replayTranscript(): Promise<void> {
-		const events = await this.client.replayEvents(this.options.missionId);
-		let live: LiveAssistantMessage | null = null;
-		const flushLive = () => {
-			if (live !== null) {
-				live.flush(true);
-				live = null;
-			}
-		};
-		for (const raw of events) {
-			const event = raw as { type?: string; visibility?: string; payload?: Record<string, unknown>; sequence?: number };
-			if (event.visibility === "DEBUG") continue;
-			const type = String(event.type ?? "");
-			const payload = event.payload ?? {};
-			if (type === "model.text.delta") {
-				if (live === null) {
-					live = new LiveAssistantMessage(markdownTheme, () => undefined);
-					this.print(live.component);
-				}
-				live.append(String(payload.text ?? ""));
-				continue;
-			}
-			flushLive();
-			const effects = reduce(this.state, {
-				event_id: `replay_${String(event.sequence ?? "")}`,
-				sequence: Number(event.sequence ?? 0),
-				mission_id: this.options.missionId,
-				type,
-				visibility: String(event.visibility ?? "USER"),
-				payload,
-				timestamp: "",
-			});
-			for (const effect of effects) {
-				if (effect.kind === "append_card") this.print(new Text(renderCard(effect.card)));
-			}
+		const page = await this.client.transcript(this.options.missionId);
+		for (const block of page.blocks) {
+			this.renderTranscriptBlock(block);
 		}
-		flushLive();
+		if (page.has_more) {
+			this.print(
+				new Text(
+					chalk.dim(
+						`—— 更早的 ${Math.max(0, page.oldest_sequence - 1)} 个事件已折叠（journal 权威，/resume 分页可查）——`,
+					),
+				),
+			);
+		}
+		// SSE 从这里续接：重放块与实时流不重复（exactly-once）。
+		this.state.lastSeq = Math.max(this.state.lastSeq, page.latest_sequence);
+	}
+
+	private renderTranscriptBlock(block: TranscriptBlock): void {
+		switch (block.kind) {
+			case "user":
+				this.print(new Text(`${chalk.bold.cyan("你")} ${block.text ?? ""}`));
+				break;
+			case "assistant":
+				this.print(new Markdown(block.text ?? "", 0, 0, markdownTheme));
+				break;
+			case "card":
+				this.print(
+					new Text(
+						renderCard({
+							cardType: "approval",
+							title: String(block.card?.title ?? "授权请求"),
+							lines: [
+								String(block.card?.summary ?? ""),
+								...(block.card?.request_id ? [`id: ${String(block.card.request_id)}`] : []),
+							],
+							tone: "warn",
+						}),
+					),
+				);
+				break;
+			case "decision":
+				this.print(
+					new Text(
+						chalk.yellow(
+							`授权决定：${String(block.decision?.decision ?? block.decision?.status ?? "")}`,
+						),
+					),
+				);
+				break;
+			case "tool_call":
+				this.print(
+					new Text(
+						chalk.dim(`▸ 工具调用 ${String(block.card?.tool_id ?? block.card?.name ?? "")}`),
+					),
+				);
+				break;
+			case "tool_result":
+				this.print(new Text(chalk.dim(`▸ 工具完成`)));
+				break;
+			case "receipt":
+				this.print(
+					new Text(
+						chalk.green(
+							`回执：${String(block.receipt?.final_state ?? block.receipt?.state ?? "已收到")}`,
+						),
+					),
+				);
+				break;
+			case "error":
+				this.print(new Text(chalk.red(`错误：${block.error ?? ""}`)));
+				break;
+		}
 	}
 
 	private async consumeEvents(): Promise<void> {
 		const { baseUrl, missionId } = this.options;
 		const generator = streamEvents(baseUrl, missionId, {
 			signal: this.abort.signal,
+			afterSequence: this.state.lastSeq,
+			controlToken: this.clientToken,
 			onGap: () => {
 				// sequence 缺口：停止乐观渲染，拉权威快照对齐（§5.4）。
 				void this.resync();
@@ -327,9 +380,46 @@ export class RosclawTuiApp {
 		void this.consumeEvents();
 	}
 
+	/** P1-2：卡片到达后的快捷 Y/N（行级；不抢正在输入的长文本）。 */
+	private async quickDecide(approve: boolean): Promise<void> {
+		const pending = this.state.pendingApprovals;
+		if (pending.length === 0) {
+			this.print(new Text(chalk.dim("没有待批准的请求。")));
+			return;
+		}
+		const latest = pending[pending.length - 1];
+		const { operatorCall, defaultOperatorSocket } = await import("./client/operator.js");
+		const listed = (await operatorCall(defaultOperatorSocket(), "approvals.list", {
+			mission_id: this.options.missionId,
+		})) as { ok: boolean; approvals?: Array<{ request_id: string; display_hash: string }>; error?: string };
+		const entry = (listed.approvals ?? []).find((a) => a.request_id === latest.requestId);
+		if (!entry) {
+			this.print(new Text(chalk.yellow(`卡片 ${latest.requestId} 已不在待定队列。`)));
+			return;
+		}
+		const decided = (await operatorCall(defaultOperatorSocket(), "approvals.decide", {
+			request_id: entry.request_id,
+			display_hash: entry.display_hash,
+			approve,
+		})) as { ok: boolean; error?: string };
+		this.print(
+			new Text(
+				decided.ok
+					? chalk.green(approve ? `已批准 ${entry.request_id}` : `已拒绝 ${entry.request_id}`)
+					: chalk.red(`决定被拒：${decided.error ?? "unknown"}`),
+			),
+		);
+	}
+
 	private async handleInput(raw: string): Promise<void> {
 		const text = raw.trim();
 		if (!text) return;
+		// P1-2：有待批准卡片时，裸 y/n 行 = 对最新卡片快捷决定
+		// （Y/N 语义，默认 N；正在输入其他文本不受影响）。
+		if ((text === "y" || text === "Y" || text === "n" || text === "N") && this.state.pendingApprovals.length > 0) {
+			await this.quickDecide(text.toLowerCase() === "y");
+			return;
+		}
 		// //text 转义：以 / 开头的普通文本显式发送（审计 P0-03.6）。
 		if (text.startsWith("//")) {
 			const literal = text.slice(1);

--- a/packages/rosclaw-tui/src/client/http.ts
+++ b/packages/rosclaw-tui/src/client/http.ts
@@ -59,13 +59,44 @@ export interface MissionInfo {
 	[key: string]: unknown;
 }
 
+export interface TranscriptBlock {
+	block_id: string;
+	kind: "user" | "assistant" | "tool_call" | "tool_result" | "card" | "decision" | "receipt" | "error";
+	sequence: number;
+	text?: string;
+	card?: Record<string, unknown>;
+	decision?: Record<string, unknown>;
+	receipt?: Record<string, unknown>;
+	error?: string;
+}
+
+export interface TranscriptPage {
+	mission_id: string;
+	blocks: TranscriptBlock[];
+	latest_sequence: number;
+	oldest_sequence: number;
+	has_more: boolean;
+}
+
 export class AgentClient {
-	constructor(private readonly baseUrl: string) {}
+	constructor(
+		private readonly baseUrl: string,
+		private readonly controlToken = "",
+	) {}
+
+	private authHeaders(extra?: Record<string, string>): Record<string, string> | undefined {
+		const headers: Record<string, string> = { ...(extra ?? {}) };
+		// P1-4：ephemeral control token（0600 文件/env 获取，永不打印）。
+		if (this.controlToken) headers["x-rosclaw-token"] = this.controlToken;
+		return Object.keys(headers).length > 0 ? headers : undefined;
+	}
 
 	private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
 		const res = await fetch(`${this.baseUrl}${path}`, {
 			method,
-			headers: body !== undefined ? { "content-type": "application/json" } : undefined,
+			headers: this.authHeaders(
+				body !== undefined ? { "content-type": "application/json" } : undefined,
+			),
 			body: body !== undefined ? JSON.stringify(body) : undefined,
 		});
 		if (!res.ok) {
@@ -121,6 +152,24 @@ export class AgentClient {
 		return this.request("GET", `/approvals/pending?mission_id=${missionId}`);
 	}
 
+	/** R4/P1-1：transcript projection（服务端权威投影 + 分页）。 */
+	async transcript(
+		missionId: string,
+		beforeSeq?: number,
+		limit = 500,
+	): Promise<TranscriptPage> {
+		const params = new URLSearchParams({ limit: String(limit) });
+		if (beforeSeq !== undefined && beforeSeq > 0) params.set("before_seq", String(beforeSeq));
+		const res = await fetch(
+			`${this.baseUrl}/v2/missions/${missionId}/transcript?${params}`,
+			{ headers: this.authHeaders() },
+		);
+		if (!res.ok) {
+			throw new Error(`HTTP ${res.status} transcript: ${(await res.text()).slice(0, 200)}`);
+		}
+		return (await res.json()) as TranscriptPage;
+	}
+
 	/** 有界事件重放（resume 恢复 transcript 用；不走 SSE 长连接）。 */
 	async replayEvents(
 		missionId: string,
@@ -128,7 +177,7 @@ export class AgentClient {
 	): Promise<Array<Record<string, unknown>>> {
 		const res = await fetch(
 			`${this.baseUrl}/v2/missions/${missionId}/events?follow=false&after_sequence=${afterSequence}`,
-			{ headers: { accept: "text/event-stream" } },
+			{ headers: this.authHeaders({ accept: "text/event-stream" }) },
 		);
 		if (!res.ok || !res.body) return [];
 		const text = await res.text();

--- a/packages/rosclaw-tui/src/client/sse.ts
+++ b/packages/rosclaw-tui/src/client/sse.ts
@@ -22,6 +22,32 @@ export interface SseOptions {
 	onGap?: (expected: number, got: number) => void;
 	onReconnect?: (attempt: number) => void;
 	maxAttempts?: number;
+	/** R4/P1-1：resume 后从 transcript 的 latest_sequence 续接（exactly-once）。 */
+	afterSequence?: number;
+	/** P1-4：ephemeral control token。 */
+	controlToken?: string;
+}
+
+/** 有界去重窗（P1-1：长会话不允许无界 seen Set）。 */
+class BoundedDedup {
+	private readonly queue: string[] = [];
+	private readonly set = new Set<string>();
+
+	constructor(private readonly capacity = 2048) {}
+
+	has(id: string): boolean {
+		return this.set.has(id);
+	}
+
+	add(id: string): void {
+		if (this.set.has(id)) return;
+		this.set.add(id);
+		this.queue.push(id);
+		if (this.queue.length > this.capacity) {
+			const evicted = this.queue.shift();
+			if (evicted !== undefined) this.set.delete(evicted);
+		}
+	}
 }
 
 export async function* streamEvents(
@@ -29,8 +55,8 @@ export async function* streamEvents(
 	missionId: string,
 	options: SseOptions = {},
 ): AsyncGenerator<AgentEvent> {
-	const seen = new Set<string>();
-	let lastSeq = 0;
+	const seen = new BoundedDedup();
+	let lastSeq = Math.max(0, options.afterSequence ?? 0);
 	let attempt = 0;
 	let emptyStreak = 0;
 	const maxAttempts = options.maxAttempts ?? 100;
@@ -38,6 +64,7 @@ export async function* streamEvents(
 	while (attempt < maxAttempts && emptyStreak < 3) {
 		if (options.signal?.aborted) return;
 		const headers: Record<string, string> = { accept: "text/event-stream" };
+		if (options.controlToken) headers["x-rosclaw-token"] = options.controlToken;
 		if (lastSeq > 0) headers["last-event-id"] = String(lastSeq);
 		let res: Response;
 		try {

--- a/packages/rosclaw-tui/test/sse.test.ts
+++ b/packages/rosclaw-tui/test/sse.test.ts
@@ -104,3 +104,57 @@ test("sequence gap triggers onGap", async () => {
 		},
 	);
 });
+
+test("afterSequence seeds last-event-id on the first connect (R4 exactly-once)", async () => {
+	await withServer(
+		(req, res) => {
+			const lastEventId = String(req.headers["last-event-id"] ?? "");
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			if (lastEventId !== "42") {
+				res.write(sseFrame(1, "evt_wrong", "agent.started"));
+				res.end();
+				return;
+			}
+			res.write(sseFrame(43, "evt_after", "agent.settled"));
+			res.end();
+		},
+		async (baseUrl) => {
+			const events: AgentEvent[] = [];
+			for await (const e of streamEvents(baseUrl, "mis_x", {
+				maxAttempts: 1,
+				afterSequence: 42,
+			})) {
+				events.push(e);
+			}
+			assert.equal(events.length, 1);
+			assert.equal(events[0].event_id, "evt_after");
+		},
+	);
+});
+
+test("control token header is sent when provided (P1-4)", async () => {
+	await withServer(
+		(req, res) => {
+			const token = String(req.headers["x-rosclaw-token"] ?? "");
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			if (token !== "tok_secret") {
+				res.write(sseFrame(1, "evt_noauth", "agent.started"));
+				res.end();
+				return;
+			}
+			res.write(sseFrame(1, "evt_auth", "agent.settled"));
+			res.end();
+		},
+		async (baseUrl) => {
+			const events: AgentEvent[] = [];
+			for await (const e of streamEvents(baseUrl, "mis_x", {
+				maxAttempts: 1,
+				controlToken: "tok_secret",
+			})) {
+				events.push(e);
+			}
+			assert.equal(events.length, 1);
+			assert.equal(events[0].event_id, "evt_auth");
+		},
+	);
+});

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -44,16 +44,69 @@ cp "$REPO_ROOT/scripts/release/install_release.sh" "$STAGE/install.sh"
 cp "$REPO_ROOT/scripts/release/rollback.sh" "$STAGE/"
 chmod +x "$STAGE/install.sh" "$STAGE/rollback.sh"
 
-# 4. SBOM（pip + npm 依赖快照，审计 P0-05.2）
+# 4. SBOM（审计 P0-05.2 + R6）：CycloneDX 1.5 JSON（pip freeze/npm ls
+# 只是依赖快照，不是 SBOM——保留快照作调试参考，正式 SBOM 用 CycloneDX）。
 "$REPO_ROOT/.venv/bin/python" -m pip freeze --disable-pip-version-check 2>/dev/null   > "$STAGE/sbom-python.txt" || true
 for pkg in rosclaw-tui rosclaw-modeld; do
   (cd "$REPO_ROOT/packages/$pkg" && npm ls --omit=dev --depth=2 2>/dev/null)     > "$STAGE/sbom-$pkg.txt" || true
 done
+python3 - "$STAGE" "$VERSION" <<'PY'
+import json, re, sys
+from pathlib import Path
+
+stage, version = Path(sys.argv[1]), sys.argv[2]
+components = []
+for line in (stage / "sbom-python.txt").read_text().splitlines():
+    match = re.match(r"^([A-Za-z0-9_.-]+)==([A-Za-z0-9_.+-]+)$", line.strip())
+    if match:
+        name, ver = match.groups()
+        components.append({
+            "type": "library", "name": name, "version": ver,
+            "purl": f"pkg:pypi/{name.lower()}@{ver}",
+        })
+for pkg_file in stage.glob("sbom-rosclaw-*.txt"):
+    for line in pkg_file.read_text().splitlines():
+        match = re.search(r"([@a-z0-9_/.-]+)@([0-9][A-Za-z0-9_.+-]*)$", line.strip().lstrip("├─└│ "))
+        if match:
+            name, ver = match.groups()
+            components.append({
+                "type": "library", "name": name, "version": ver,
+                "purl": f"pkg:npm/{name}@{ver}",
+            })
+seen = set()
+unique = []
+for component in components:
+    if component["purl"] not in seen:
+        seen.add(component["purl"])
+        unique.append(component)
+sbom = {
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "version": 1,
+    "metadata": {
+        "component": {
+            "type": "application", "name": "rosclaw", "version": version,
+            "purl": f"pkg:generic/rosclaw@{version}",
+        }
+    },
+    "components": sorted(unique, key=lambda c: c["purl"]),
+}
+(stage / "sbom-cyclonedx.json").write_text(json.dumps(sbom, indent=1, ensure_ascii=False))
+print(f"cyclonedx components: {len(unique)}")
+PY
 
 # 5. 离线资产（审计 P0-05.4）：目标机不再现场 TypeScript build、
 # 不访问 PyPI/npm。
 mkdir -p "$STAGE/vendor/wheels" "$STAGE/vendor/node_modules_pack"
-"$REPO_ROOT/.venv/bin/python" -m pip download   --disable-pip-version-check --quiet --dest "$STAGE/vendor/wheels"   "$REPO_ROOT" 2>/dev/null ||   echo "WARN: pip download 不完整（online build 继续；offline 包将缺 wheels）" >&2
+# R6：离线包缺 wheel 是硬失败（不再 warning 后继续）。
+"$REPO_ROOT/.venv/bin/python" -m pip download   --disable-pip-version-check --quiet --dest "$STAGE/vendor/wheels"   "$REPO_ROOT" || {
+    echo "FAIL: pip download 不完整——离线包将缺 wheels，拒绝产出。" >&2
+    exit 1
+  }
+[ -n "$(ls -A "$STAGE/vendor/wheels" 2>/dev/null)" ] || {
+  echo "FAIL: vendor/wheels 为空——拒绝产出离线包。" >&2
+  exit 1
+}
 for pkg in rosclaw-tui rosclaw-modeld; do
   (cd "$REPO_ROOT/packages/$pkg" && npm ci --omit=dev --silent)
   tar -C "$REPO_ROOT/packages/$pkg" -czf "$STAGE/vendor/node_modules_pack/$pkg.tar.gz" node_modules

--- a/scripts/release/install_release.sh
+++ b/scripts/release/install_release.sh
@@ -1,14 +1,31 @@
 #!/usr/bin/env bash
-# PR-12 + 审计 P0-05：发布包安装器（verify-before-execute，事务化）。
-# 用法：tar xzf rosclaw-<ver>-linux-arm64.tar.gz && cd rosclaw-<ver>-linux-arm64 && ./install.sh [--prefix DIR] [--offline]
+# PR-12 + 审计 P0-05 + 二次复核 R6：发布包安装器（verify-before-execute）。
+#
+# R6 信任模型：验签公钥必须来自**包外 trust anchor**——
+#   --trusted-key PATH            显式指定；或
+#   $ROSCLAW_RELEASE_KEY           环境变量；或
+#   /etc/rosclaw/release-pub.pem  系统级锚；或
+#   ~/.rosclaw/release-keys/release-pub.pem  用户预置锚。
+# 包内 bundle-signing-public.pem 只作信息对照，不再用于验签
+# （"自带钥匙证明自己"不是发行者信任）。--allow-untrusted-dev 是
+# 显式开发者逃生门（输出大字警告，结果标记 DEV-UNTRUSTED）。
+#
+# 用法：./install.sh [--prefix DIR] [--offline] [--trusted-key PATH]
+#       [--trusted-fingerprint SHA256] [--allow-untrusted-dev]
 set -euo pipefail
 
 PREFIX="${ROSCLAW_PREFIX:-$HOME/.local/share/rosclaw}"
 OFFLINE=0
+TRUSTED_KEY=""
+TRUSTED_FP=""
+ALLOW_UNTRUSTED=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --prefix) PREFIX="$2"; shift 2 ;;
     --offline) OFFLINE=1; shift ;;
+    --trusted-key) TRUSTED_KEY="$2"; shift 2 ;;
+    --trusted-fingerprint) TRUSTED_FP="$2"; shift 2 ;;
+    --allow-untrusted-dev) ALLOW_UNTRUSTED=1; shift ;;
     *) echo "未知参数 $1" >&2; exit 2 ;;
   esac
 done
@@ -17,21 +34,59 @@ CURRENT="$PREFIX/current"
 PREVIOUS="$PREFIX/previous"
 NEXT="$PREFIX/next-$RANDOM"
 
-echo "==> [1/5] 校验 manifest 签名与全部文件 hash（先验证，后执行）"
+echo "==> [1/5] 校验信任锚、manifest 签名与全部文件 hash（先验证，后执行）"
 need() { command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1 ($2)" >&2; exit 2; }; }
 need openssl "signature verification"
 need python3 "3.11+"
 [ -f "$SRC_DIR/manifest.json" ] || { echo "manifest.json 缺失，拒绝安装。" >&2; exit 2; }
 [ -f "$SRC_DIR/manifest.sig" ] || { echo "manifest.sig 缺失，拒绝安装。" >&2; exit 2; }
-[ -f "$SRC_DIR/bundle-signing-public.pem" ] || { echo "签名公钥缺失，拒绝安装。" >&2; exit 2; }
-openssl dgst -sha256 -verify "$SRC_DIR/bundle-signing-public.pem" \
+
+# --- trust anchor 解析（R6：锚在包外） -------------------------------------
+if [ -z "$TRUSTED_KEY" ]; then
+  for candidate in "${ROSCLAW_RELEASE_KEY:-}" /etc/rosclaw/release-pub.pem \
+                   "$HOME/.rosclaw/release-keys/release-pub.pem"; do
+    [ -n "$candidate" ] && [ -f "$candidate" ] && { TRUSTED_KEY="$candidate"; break; }
+  done
+fi
+if [ -z "$TRUSTED_KEY" ]; then
+  if [ "$ALLOW_UNTRUSTED" = "1" ]; then
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+    echo "!! DEV-UNTRUSTED：未提供包外信任锚——仅验证包内自洽性，" >&2
+    echo "!! 不证明发行者身份。仅允许在开发环境使用。             !!"
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+    [ -f "$SRC_DIR/bundle-signing-public.pem" ] || { echo "签名公钥缺失，拒绝安装。" >&2; exit 2; }
+    TRUSTED_KEY="$SRC_DIR/bundle-signing-public.pem"
+  else
+    echo "未找到包外信任锚（release public key）。R6：包内公钥不能自证。" >&2
+    echo "请提供 --trusted-key PATH，或预置 ~/.rosclaw/release-keys/release-pub.pem；" >&2
+    echo "开发环境可显式 --allow-untrusted-dev（结果不受信）。" >&2
+    exit 2
+  fi
+fi
+# 可选指纹钉住：锚本身也要匹配预期指纹。
+if [ -n "$TRUSTED_FP" ]; then
+  actual_fp="$(openssl pkey -pubin -in "$TRUSTED_KEY" -outform DER 2>/dev/null | openssl dgst -sha256 -r | awk '{print $1}')"
+  [ "$actual_fp" = "$TRUSTED_FP" ] || {
+    echo "信任锚指纹不匹配：期望 $TRUSTED_FP，实际 $actual_fp——拒绝安装。" >&2; exit 2; }
+fi
+# 信息对照：包内公钥若与锚不一致，说明包被重打包（非致命——锚才是权威，
+# 但必须告诉用户）。
+if [ -f "$SRC_DIR/bundle-signing-public.pem" ] && \
+   ! cmp -s "$TRUSTED_KEY" "$SRC_DIR/bundle-signing-public.pem"; then
+  echo "WARN: 包内公钥与信任锚不同——以包外锚为准（包可能被重新分发）。" >&2
+fi
+
+openssl dgst -sha256 -verify "$TRUSTED_KEY" \
   -signature "$SRC_DIR/manifest.sig" "$SRC_DIR/manifest.json" \
   || { echo "manifest 签名无效——包可能被篡改，拒绝执行任何安装动作。" >&2; exit 2; }
+
+# 全文件 hash 校验 + **额外文件拒绝**（R6：manifest 未列出的一律拒装）。
 python3 - "$SRC_DIR" <<'PY'
 import hashlib, json, sys
 from pathlib import Path
 root = Path(sys.argv[1])
 manifest = json.loads((root / "manifest.json").read_text())
+allowed_extra = {"manifest.json", "manifest.sig", "bundle-signing-public.pem"}
 bad = []
 for rel, expected in manifest["files"].items():
     path = root / rel
@@ -41,10 +96,17 @@ for rel, expected in manifest["files"].items():
     actual = hashlib.sha256(path.read_bytes()).hexdigest()
     if actual != expected:
         bad.append(f"tampered: {rel}")
+for path in sorted(root.rglob("*")):
+    if path.is_file() or path.is_symlink():
+        rel = str(path.relative_to(root))
+        if rel not in manifest["files"] and rel not in allowed_extra:
+            bad.append(f"unlisted file (extra-file rejection): {rel}")
+    if path.is_symlink():
+        bad.append(f"symlink not allowed in bundle: {path.relative_to(root)}")
 if bad:
     print("\n".join(bad), file=sys.stderr)
     sys.exit(2)
-print(f"verified {len(manifest['files'])} files")
+print(f"verified {len(manifest['files'])} files; no unlisted extras")
 PY
 
 echo "==> [2/5] 安装到 staging"
@@ -55,6 +117,9 @@ cp -r "$SRC_DIR" "$NEXT"
 python3 -m venv "$NEXT/.venv"
 "$NEXT/.venv/bin/pip" install --quiet --upgrade pip ${OFFLINE:+--no-index}
 if [ "$OFFLINE" = "1" ]; then
+  # R6：离线模式缺 wheel 是硬失败，不是 warning。
+  [ -d "$NEXT/vendor/wheels" ] && [ -n "$(ls -A "$NEXT/vendor/wheels" 2>/dev/null)" ] || {
+    echo "离线安装但 vendor/wheels 为空——构建期 pip download 不完整，拒绝继续。" >&2; exit 2; }
   "$NEXT/.venv/bin/pip" install --quiet --no-index \
     --find-links "$NEXT/vendor/wheels" "$NEXT"
 else

--- a/scripts/release/rollback.sh
+++ b/scripts/release/rollback.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# PR-12：完整回滚——把 current 切回 previous（含校验）。
+# PR-12 + 二次复核 R6：完整回滚——把 current 切回 previous。
+# R6：回滚目标必须重新通过签名 + 全量 hash 校验（被篡改的 previous
+# 不得成为回滚目标）。签名公钥：优先包外锚（与 install 同一查找
+# 顺序），找不到时退回目标包内公钥——previous 是当初用锚验证过
+# 才安装进来的，这里以 hash 完整性为主防线并如实标记。
 set -euo pipefail
 
 PREFIX="${ROSCLAW_PREFIX:-$HOME/.local/share/rosclaw}"
@@ -7,8 +11,42 @@ CURRENT="$PREFIX/current"
 PREVIOUS="$PREFIX/previous"
 
 [ -d "$PREVIOUS" ] || { echo "没有可回滚的 previous 版本。" >&2; exit 2; }
-# manifest 校验：回滚目标必须结构完整。
 [ -f "$PREVIOUS/manifest.json" ] || { echo "previous 缺 manifest.json，拒绝回滚。" >&2; exit 2; }
+[ -f "$PREVIOUS/manifest.sig" ] || { echo "previous 缺 manifest.sig，拒绝回滚。" >&2; exit 2; }
+
+TRUSTED_KEY=""
+for candidate in "${ROSCLAW_RELEASE_KEY:-}" /etc/rosclaw/release-pub.pem \
+                 "$HOME/.rosclaw/release-keys/release-pub.pem" \
+                 "$PREVIOUS/bundle-signing-public.pem"; do
+  [ -n "$candidate" ] && [ -f "$candidate" ] && { TRUSTED_KEY="$candidate"; break; }
+done
+[ -n "$TRUSTED_KEY" ] || { echo "无可用的验签公钥，拒绝回滚。" >&2; exit 2; }
+case "$TRUSTED_KEY" in
+  "$PREVIOUS"*) echo "WARN: 使用 previous 包内公钥验签（无包外锚）——以 hash 完整性为主防线。" >&2 ;;
+esac
+
+openssl dgst -sha256 -verify "$TRUSTED_KEY" \
+  -signature "$PREVIOUS/manifest.sig" "$PREVIOUS/manifest.json" \
+  || { echo "previous manifest 签名无效——回滚目标可能被篡改，拒绝回滚。" >&2; exit 2; }
+
+python3 - "$PREVIOUS" <<'PY'
+import hashlib, json, sys
+from pathlib import Path
+root = Path(sys.argv[1])
+manifest = json.loads((root / "manifest.json").read_text())
+bad = []
+for rel, expected in manifest["files"].items():
+    path = root / rel
+    if not path.exists():
+        bad.append(f"missing: {rel}")
+        continue
+    if hashlib.sha256(path.read_bytes()).hexdigest() != expected:
+        bad.append(f"tampered: {rel}")
+if bad:
+    print("\n".join(bad), file=sys.stderr)
+    sys.exit(2)
+print(f"rollback target verified ({len(manifest['files'])} files)")
+PY
 
 mv "$CURRENT" "$PREFIX/failed-$(date +%Y%m%d%H%M%S)"
 mv "$PREVIOUS" "$CURRENT"

--- a/src/rosclaw/agentd/bench/evidence_pack.py
+++ b/src/rosclaw/agentd/bench/evidence_pack.py
@@ -17,7 +17,29 @@ from pathlib import Path
 from rosclaw.agentd.bench.evidence_levels import EvidenceLevel
 from rosclaw.contracts.common import new_id
 
-SECRET_PATTERNS = ("sk-", "Bearer ", "api_key\":", "private_key", "permit_secret")
+# R7/T6：secret corpus——命中即 fail（不是 warning）。
+SECRET_PATTERNS = (
+    "sk-",
+    "sk-ant-",
+    "sk-kimi-",
+    "ghp_",
+    "gho_",
+    "github_pat_",
+    "Bearer ",
+    "eyJ",  # JWT header 前缀
+    "BEGIN OPENSSH PRIVATE KEY",
+    "BEGIN RSA PRIVATE KEY",
+    "BEGIN EC PRIVATE KEY",
+    "BEGIN PRIVATE KEY",
+    "api_key\":",
+    "private_key\":",
+    "permit_secret",
+    "refresh_token",
+)
+
+
+class EvidencePackError(RuntimeError):
+    pass
 
 
 class EvidencePackWriter:
@@ -75,7 +97,11 @@ class EvidencePackWriter:
         self._record("metrics.json", json.dumps(metrics, indent=2, ensure_ascii=False, default=str))
 
     def write_observer(self, note: str) -> None:
-        self._record("operator_observer.md", note)
+        # R7：自动生成的观察记录必须明确标注——不是独立人类观察者签字。
+        self._record(
+            "automated_observation.md",
+            "> **automated_observation**（自动生成，非独立观察者签字）\n\n" + note,
+        )
 
     def finalize(
         self,
@@ -89,7 +115,11 @@ class EvidencePackWriter:
         """secret 扫描 + artifact hashes + run_manifest（签名输入）。"""
         findings: list[dict] = []
         for path in self.dir.rglob("*"):
-            if not path.is_file() or path.name in {"secret_scan.json", "run_manifest.json"}:
+            if not path.is_file() or path.name in {
+                "secret_scan.json",
+                "run_manifest.json",
+                "run_manifest.sig",
+            }:
                 continue
             text = path.read_text(encoding="utf-8", errors="replace")
             for pattern in SECRET_PATTERNS:
@@ -99,6 +129,24 @@ class EvidencePackWriter:
             "secret_scan.json",
             json.dumps({"clean": not findings, "findings": findings}, indent=2),
         )
+        if findings:
+            # R7/T6：发现 secret 即 fail——证据包标记 INVALID 并拒绝 finalize。
+            self._record(
+                "run_manifest.json",
+                json.dumps(
+                    {
+                        "run_id": self.run_id,
+                        "invalid": True,
+                        "reason": "secret_scan_findings",
+                        "findings": findings,
+                    },
+                    indent=2,
+                ),
+            )
+            raise EvidencePackError(
+                f"evidence pack contains secret-like material: {findings} — "
+                "pack marked INVALID; redact sources and re-run"
+            )
         self._record(
             "artifact_hashes.json",
             json.dumps(self._hashes, indent=2, sort_keys=True),
@@ -112,10 +160,50 @@ class EvidencePackWriter:
             "operator": operator,
             "started_artifacts": len(self._hashes),
             "secret_scan_clean": not findings,
+            "process": {"uid": os.geteuid(), "pid": os.getpid()},
             "created_at": datetime.now(UTC).isoformat(),
         }
         self._record("run_manifest.json", json.dumps(manifest, indent=2, ensure_ascii=False))
+        # R7：pack 签名（构建机 dev release key；无 key 时如实标 unsigned）。
+        signed = self._try_sign_manifest()
+        manifest["signed"] = signed
+        self._hashes["run_manifest.json"] = hashlib.sha256(
+            (self.dir / "run_manifest.json").read_bytes()
+        ).hexdigest()
+        # artifact_hashes.json 不包含自己的条目（否则自引用永真失配）。
+        final_hashes = {k: v for k, v in self._hashes.items() if k != "artifact_hashes.json"}
+        self._record(
+            "artifact_hashes.json",
+            json.dumps(final_hashes, indent=2, sort_keys=True),
+        )
         return manifest
+
+    def _try_sign_manifest(self) -> bool:
+        """用本机 release 签名 key 签 run_manifest.json（openssl ECDSA）。
+
+        无签名 key 时返回 False（pack 仍可用于开发调试，但不能作为
+        可审计发布证据——verifier 会要求签名）。
+        """
+        import shutil
+        import subprocess
+
+        key = Path.home() / ".rosclaw" / "signing" / "dev-signing-private.pem"
+        if not key.exists() or shutil.which("openssl") is None:
+            return False
+        result = subprocess.run(
+            [
+                "openssl",
+                "dgst",
+                "-sha256",
+                "-sign",
+                str(key),
+                "-out",
+                str(self.dir / "run_manifest.sig"),
+                str(self.dir / "run_manifest.json"),
+            ],
+            capture_output=True,
+        )
+        return result.returncode == 0
 
 
 def _probe(cmd: list[str]) -> str:

--- a/src/rosclaw/agentd/bench/limo_acceptance.py
+++ b/src/rosclaw/agentd/bench/limo_acceptance.py
@@ -376,9 +376,15 @@ async def run_acceptance(
             events = service.events_replay(mission.mission_id, limit=100_000)
             pack.write_events([e.model_dump(mode="json") for e in events])
             pack.write_mission_snapshot(service.snapshot(mission.mission_id).model_dump(mode="json"))
+            # R7：完整 approval → decision → grant → permit → receipt 链
+            # （全部公开视图；secret 扫描兜底）。
             pack.write_public_records(
-                approvals=[],
-                permits=[],
+                approvals=[
+                    e.payload
+                    for e in events
+                    if e.type.value in ("approval.requested", "approval.decided")
+                ],
+                permits=list(service.list_grants()),
                 receipts=[
                     e.payload for e in events if e.type.value == "receipt.received"
                 ],

--- a/src/rosclaw/agentd/events.py
+++ b/src/rosclaw/agentd/events.py
@@ -127,15 +127,19 @@ class AgentEventStore:
         mission_id: str,
         *,
         after_sequence: int = 0,
+        before_sequence: int | None = None,
         visibility: Visibility | None = None,
         limit: int = 1000,
     ) -> list[AgentEventV2]:
         query = (
             "SELECT * FROM agent_events WHERE mission_id = ? AND sequence > ?"
+            + (" AND sequence < ?" if before_sequence is not None else "")
             + (" AND visibility = ?" if visibility else "")
             + " ORDER BY sequence LIMIT ?"
         )
         params: list = [mission_id, after_sequence]
+        if before_sequence is not None:
+            params.append(before_sequence)
         if visibility:
             params.append(visibility.value)
         params.append(limit)

--- a/src/rosclaw/agentd/models/modeld_gateway.py
+++ b/src/rosclaw/agentd/models/modeld_gateway.py
@@ -76,6 +76,7 @@ class ModeldGateway:
         self._token = secrets.token_urlsafe(32)
         self._proc: subprocess.Popen | None = None
         self._socket_path = ""
+        self._stderr_log = None
         self._session = None
         self._last_error: str | None = None
         self._start_lock = asyncio.Lock()
@@ -112,11 +113,14 @@ class ModeldGateway:
         env["ROSCLAW_MODELD_TOKEN"] = self._token
         # profile 引用的 env key 若存在则随子进程环境传递（值不进命令行/文件）；
         # 缺失时不拦——由 modeld 诚实报告 no_credential。
+        # P1-5：stderr 进文件（启动失败时保留脱敏尾部，不再丢 /dev/null）。
+        stderr_path = home / f"modeld-{os.getpid()}-{id(self) % 0xFFFF:x}.stderr.log"
+        self._stderr_log = open(stderr_path, "wb")  # noqa: SIM115 - 随进程生命周期
         self._proc = subprocess.Popen(  # noqa: S603 - fixed entry, no shell
             [node, entry, "--socket", self._socket_path, "--home", str(home)],
             env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=self._stderr_log,
+            stderr=self._stderr_log,
         )
         import aiohttp
 
@@ -124,17 +128,68 @@ class ModeldGateway:
         while time.monotonic() < deadline:
             if self._proc.poll() is not None:
                 raise ModelGatewayError(
-                    "modeld_crashed", f"modeld exited during startup (code {self._proc.returncode})"
+                    "modeld_crashed",
+                    f"modeld exited during startup (code {self._proc.returncode}); "
+                    f"stderr tail: {self._stderr_tail()}",
                 )
             if Path(self._socket_path).exists():
                 break
             await asyncio.sleep(0.05)
         else:
-            raise ModelGatewayError("modeld_timeout", "modeld did not create its socket in 10s")
+            raise ModelGatewayError(
+                "modeld_timeout",
+                f"modeld did not create its socket in 10s; stderr tail: {self._stderr_tail()}",
+            )
+        # P1-5：socket 出现 ≠ 就绪——轮询真实 /v1/health/ready（鉴权），
+        # 并验证 socket 权限 0600 后才宣告启动完成。
         connector = aiohttp.UnixConnector(path=self._socket_path)
         self._session = aiohttp.ClientSession(
             connector=connector, headers={"authorization": f"Bearer {self._token}"}
         )
+        ready_deadline = time.monotonic() + 10.0
+        while time.monotonic() < ready_deadline:
+            if self._proc.poll() is not None:
+                raise ModelGatewayError(
+                    "modeld_crashed",
+                    f"modeld exited before readiness (code {self._proc.returncode}); "
+                    f"stderr tail: {self._stderr_tail()}",
+                )
+            try:
+                async with self._session.get("http://localhost/v1/health/ready") as response:
+                    if response.status == 200:
+                        break
+            except (TimeoutError, aiohttp.ClientError, OSError):
+                pass
+            await asyncio.sleep(0.1)
+        else:
+            raise ModelGatewayError(
+                "modeld_not_ready",
+                f"modeld did not report readiness in 10s; stderr tail: {self._stderr_tail()}",
+            )
+        sock_mode = Path(self._socket_path).stat().st_mode & 0o777
+        if sock_mode != 0o600:
+            raise ModelGatewayError(
+                "modeld_socket_permissions",
+                f"modeld socket must be 0600 (found {sock_mode:o})",
+            )
+
+    def _stderr_tail(self, max_bytes: int = 2048) -> str:
+        """启动失败诊断：脱敏的最后 N 字节 stderr（P1-5）。"""
+        try:
+            if self._stderr_log is None:
+                return ""
+            self._stderr_log.flush()
+            with open(self._stderr_log.name, "rb") as handle:
+                handle.seek(0, 2)
+                size = handle.tell()
+                handle.seek(max(0, size - max_bytes))
+                tail = handle.read().decode(errors="replace")
+        except OSError:
+            return ""
+        import re
+
+        # 脱敏：bearer/api key 形状一律掩码。
+        return re.sub(r"(?i)(bearer|api[_-]?key|token)[=: ]+\S+", r"\1=***", tail).strip()[-500:]
 
     async def close(self) -> None:
         if self._session is not None:

--- a/src/rosclaw/agentd/operator_socket.py
+++ b/src/rosclaw/agentd/operator_socket.py
@@ -122,7 +122,17 @@ class OperatorSocketServer:
         params = request.get("params") or {}
         service = self._service
         if method == "approvals.list":
-            pending = service.pending_approvals(params.get("mission_id"))
+            mission_id = params.get("mission_id")
+            pending = service.pending_approvals(mission_id)
+            if not mission_id:
+                # P1-8：省略 mission_id 不得扩大范围——只投影 peer 自己
+                # 拥有的 mission 的卡片（socket 周界是同组 operator/agent，
+                # 跨 UID operator 必须显式给 mission_id）。
+                pending = [
+                    r
+                    for r in pending
+                    if service.principal_for_request(r.request_id) == principal
+                ]
             return {
                 "ok": True,
                 "principal": principal,

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -552,9 +552,23 @@ class AgentService:
                 self._handlers._mode = mission.mode.value
                 self._handlers._principal = mission.owner_principal
             loop = self._loop_for(mission_id)
-            return await loop.run_user_turn(
+            # R4：同步路径也写用户可见事件——transcript projection 才能
+            # 覆盖用户消息与助手回复（与 v2 runner 同一事件词汇）。
+            from rosclaw.contracts.agent.agent_event import AgentEventType
+
+            await self._events.append(
+                mission_id, AgentEventType.TURN_ACCEPTED, {"text": text[:500]}
+            )
+            result = await loop.run_user_turn(
                 mission, text, now=datetime.now(UTC), on_text_delta=on_text_delta
             )
+            reply = getattr(result, "reply", "") or ""
+            if reply:
+                await self._events.append(
+                    mission_id, AgentEventType.MODEL_TEXT_DELTA, {"text": reply}
+                )
+                await self._events.append(mission_id, AgentEventType.MESSAGE_ENDED, {})
+            return result
 
     def mission_usage(self, mission_id: str) -> dict:
         return self._usage.mission_totals(mission_id)
@@ -1276,6 +1290,90 @@ class AgentService:
             self._operator_socket = None
         await self._gateway.close()
         self._store.close()
+        # P1-4：control token 文件随服务关闭删除（不残留可重用的令牌）。
+        token_path = self._home / "run" / "agentd-control.token"
+        import contextlib as _contextlib
+
+        with _contextlib.suppress(OSError):
+            token_path.unlink(missing_ok=True)
+
+    # -- 生命周期与控制台鉴权（二次复核 P1-3/P1-4） -----------------------------
+
+    @classmethod
+    def open(cls, config: AgentConfig, rosclaw_home: Path, **kwargs):
+        """统一生命周期（P1-3）：``async with AgentService.open(...) as svc``
+        ——正常退出、异常、Ctrl-C 都保证 close（子进程/socket/句柄不残留）。"""
+        import contextlib as _contextlib
+
+        @_contextlib.asynccontextmanager
+        async def _ctx():
+            service = cls(config, rosclaw_home, **kwargs)
+            try:
+                yield service
+            finally:
+                await service.close()
+
+        return _ctx()
+
+    @property
+    def control_token(self) -> str:
+        """每次启动生成的高熵 ephemeral 控制 token（P1-4）。"""
+        token = getattr(self, "_control_token", None)
+        if token is None:
+            import secrets as _secrets
+
+            token = _secrets.token_urlsafe(32)
+            self._control_token = token
+        return token
+
+    def write_control_token_file(self) -> Path:
+        """把 control token 写入 0600 临时文件（TUI/CLI 同 UID 读取；
+        不写 journal、不进命令行参数）。"""
+        run_dir = self._home / "run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(run_dir, 0o700)
+        path = run_dir / "agentd-control.token"
+        tmp = run_dir / ".agentd-control.token.tmp"
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.fchmod(fd, 0o600)
+            os.write(fd, self.control_token.encode())
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.rename(tmp, path)
+        return path
+
+    # -- transcript projection（二次复核 R4/P1-1） -------------------------------
+
+    def transcript(
+        self,
+        mission_id: str,
+        *,
+        before_seq: int | None = None,
+        limit: int = 500,
+    ) -> dict:
+        """journal → transcript 块（稳定 ID + before_seq 分页）。
+
+        TUI 不再从底层事件猜聊天记录；journal 仍是唯一权威。
+        """
+        from rosclaw.agentd.transcript import project_transcript
+
+        limit = max(1, min(int(limit), 2000))
+        events = self._events.replay(
+            mission_id,
+            before_sequence=before_seq,
+            limit=limit + 1,
+        )
+        has_more = len(events) > limit
+        events = events[:limit]
+        return {
+            "mission_id": mission_id,
+            "blocks": project_transcript(events),
+            "latest_sequence": self._events.latest_sequence(mission_id),
+            "oldest_sequence": events[0].sequence if events else 0,
+            "has_more": has_more,
+        }
 
 
 # ----------------------------------------------------------------------
@@ -1329,8 +1427,14 @@ def create_app(service: AgentService):
     @asynccontextmanager
     async def lifespan(_app):
         # PR-11：operator.sock 随 HTTP 服务启动（同一事件循环）。
+        # P1-3：HTTP 服务停止时必须关闭 service（子进程/socket/句柄）。
+        # P1-4：ephemeral control token 落 0600 文件供同机 TUI/CLI。
         await service.start_operator_socket()
-        yield
+        service.write_control_token_file()
+        try:
+            yield
+        finally:
+            await service.close()
 
     app = FastAPI(title="rosclaw-agentd", version="0.1.0", lifespan=lifespan)
 
@@ -1359,6 +1463,24 @@ def create_app(service: AgentService):
                 return JSONResponse(
                     status_code=403, content={"detail": "pairing token required"}
                 )
+        # P1-4：ephemeral control token——除 /health 与 /console（HTML
+        # 壳）外全部端点（含敏感 GET）都必须携带。token 经 0600 文件
+        # 交给同机 TUI/CLI，不写 journal、不进 ps。
+        public_paths = ("/health", "/console")
+        if (
+            request.url.path not in public_paths
+            and not request.url.path.startswith("/static/")
+            and request.headers.get("x-rosclaw-token") != service.control_token
+        ):
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "detail": (
+                        "control token required (P1-4): read "
+                        "run/agentd-control.token (0600) on this host"
+                    )
+                },
+            )
         return await call_next(request)
 
     @app.get("/health")
@@ -1419,6 +1541,19 @@ def create_app(service: AgentService):
         except ValidationError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         return {"turn_id": turn_id, "mission_id": mission_id, "accepted": True}
+
+    @app.get("/v2/missions/{mission_id}/transcript")
+    async def v2_transcript(
+        mission_id: str,
+        before_seq: int | None = None,
+        limit: int = 500,
+    ) -> dict:
+        """R4/P1-1：transcript projection（稳定块 ID + before_seq 分页）。
+        响应含 latest_sequence——SSE 应从其续接（after_sequence），
+        恢复 exactly-once。"""
+        if service.get_mission(mission_id) is None:
+            raise HTTPException(status_code=404, detail="mission not found")
+        return service.transcript(mission_id, before_seq=before_seq, limit=limit)
 
     @app.get("/v2/missions/{mission_id}/events")
     async def v2_events(
@@ -1669,12 +1804,14 @@ function add(cls, who, text){ const d=document.createElement('div');
   d.className='turn'; d.innerHTML=`<span class="who ${cls}">${who}</span> `;
   const s=document.createElement('span'); s.textContent=text; d.appendChild(s);
   logEl().appendChild(d); logEl().scrollTop=logEl().scrollHeight; return s; }
-async function status(){ const r = await fetch('/status'); const s = await r.json();
+const TOKEN = new URLSearchParams(location.search).get('token') || '';
+const AUTH = TOKEN ? {'x-rosclaw-token': TOKEN} : {};
+async function status(){ const r = await fetch('/status',{headers:AUTH}); const s = await r.json();
   document.getElementById('status').textContent =
     `profile=${s.profile} model=${s.model} mode=${s.default_mode}`; }
 async function createMission(){
   const goal = document.getElementById('goal').value; if(!goal) return;
-  const r = await fetch('/missions',{method:'POST',headers:{'Content-Type':'application/json'},
+  const r = await fetch('/missions',{method:'POST',headers:{'Content-Type':'application/json',...AUTH},
     body:JSON.stringify({goal})});
   const m = await r.json();
   if(r.status!==201){ add('meta','系统','创建失败: '+(m.detail||'')); return; }
@@ -1685,7 +1822,7 @@ async function send(){
   t.value=''; add('','你',text);
   const span = add('','ROSClaw','');
   const r = await fetch(`/missions/${missionId}/turns/stream`,{method:'POST',
-    headers:{'Content-Type':'application/json'},body:JSON.stringify({text})});
+    headers:{'Content-Type':'application/json',...AUTH},body:JSON.stringify({text})});
   const reader = r.body.getReader(); const dec = new TextDecoder(); let buf='';
   while(true){ const {done, value} = await reader.read(); if(done) break;
     buf += dec.decode(value, {stream:true});
@@ -1698,7 +1835,7 @@ async function send(){
         if(!span.textContent && ev.reply) span.textContent = ev.reply;
         add('meta','状态',`state=${ev.state} 工具轮次=${ev.tool_rounds} tokens=${ev.tokens_used}`
           +(ev.degraded?` degraded=${ev.degraded}`:''));
-        const u = await (await fetch(`/missions/${missionId}/usage`)).json();
+        const u = await (await fetch(`/missions/${missionId}/usage`,{headers:AUTH})).json();
         add('meta','用量',`累计 tokens=${u.total_tokens} 轮次=${u.model_turns} 成本(微单位)=${u.cost_microunits}`);}
       else if(ev.type==='error'){ span.textContent = '错误: '+ev.detail; } } } }
 status();

--- a/src/rosclaw/agentd/transcript.py
+++ b/src/rosclaw/agentd/transcript.py
@@ -1,0 +1,143 @@
+"""Transcript projection（二次复核 R4/P1-1）：journal → transcript 块。
+
+TUI 不再从底层事件流"猜"聊天记录——服务端把 append-only journal
+投影为稳定的 transcript 块（user/assistant/tool/card/decision/receipt/
+error），每块带稳定 ID 与 sequence，支持 ``before_seq`` 分页。
+journal 仍是权威；projection 是纯函数、可重算、幂等。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rosclaw.contracts.agent.agent_event import AgentEventType, AgentEventV2, Visibility
+
+# 每个 transcript 页的最大 assistant 聚合跨度（防御异常事件流）。
+_MAX_DELTA_RUN = 100_000
+
+
+def project_transcript(events: list[AgentEventV2]) -> list[dict[str, Any]]:
+    """把有序 journal 事件投影为 transcript 块。
+
+    块 schema：
+      {block_id, kind, sequence, text?, card?, decision?, receipt?, error?}
+    block_id 稳定：user=u_<seq>；assistant=a_<turn_id|first_seq>；
+    tool=t_<seq>；card/decision/receipt/error 同理按首事件 seq。
+    """
+    blocks: list[dict[str, Any]] = []
+    assistant: dict[str, Any] | None = None
+    delta_run = 0
+
+    def close_assistant() -> None:
+        nonlocal assistant, delta_run
+        if assistant is not None:
+            if assistant["text"].strip():
+                blocks.append(assistant)
+            assistant = None
+            delta_run = 0
+
+    for event in events:
+        if event.visibility is Visibility.DEBUG:
+            continue
+        etype = event.type
+        payload = event.payload or {}
+        seq = event.sequence
+
+        if etype is AgentEventType.TURN_ACCEPTED:
+            close_assistant()
+            text = str(payload.get("text", ""))
+            if text:
+                blocks.append(
+                    {"block_id": f"u_{seq}", "kind": "user", "sequence": seq, "text": text}
+                )
+            continue
+        if etype is AgentEventType.MODEL_TEXT_DELTA:
+            if assistant is None:
+                assistant = {
+                    "block_id": f"a_{event.turn_id or seq}",
+                    "kind": "assistant",
+                    "sequence": seq,
+                    "text": "",
+                }
+            if delta_run < _MAX_DELTA_RUN:
+                assistant["text"] += str(payload.get("text", ""))
+                assistant["sequence"] = seq
+                delta_run += 1
+            continue
+        if etype in (
+            AgentEventType.MESSAGE_ENDED,
+            AgentEventType.TURN_ENDED,
+            AgentEventType.AGENT_SETTLED,
+            AgentEventType.MODEL_REQUEST_ENDED,
+        ):
+            close_assistant()
+            continue
+        if etype is AgentEventType.APPROVAL_REQUESTED:
+            close_assistant()
+            blocks.append(
+                {
+                    "block_id": f"c_{seq}",
+                    "kind": "card",
+                    "sequence": seq,
+                    "card": payload,
+                }
+            )
+            continue
+        if etype is AgentEventType.APPROVAL_DECIDED:
+            close_assistant()
+            blocks.append(
+                {
+                    "block_id": f"d_{seq}",
+                    "kind": "decision",
+                    "sequence": seq,
+                    "decision": payload,
+                }
+            )
+            continue
+        if etype in (AgentEventType.TOOL_PROPOSED, AgentEventType.MODEL_TOOL_CALL_PROPOSED):
+            close_assistant()
+            blocks.append(
+                {
+                    "block_id": f"t_{seq}",
+                    "kind": "tool_call",
+                    "sequence": seq,
+                    "card": payload,
+                }
+            )
+            continue
+        if etype is AgentEventType.TOOL_COMPLETED:
+            close_assistant()
+            blocks.append(
+                {
+                    "block_id": f"tr_{seq}",
+                    "kind": "tool_result",
+                    "sequence": seq,
+                    "card": payload,
+                }
+            )
+            continue
+        if etype in (AgentEventType.ACTION_RECEIPT, AgentEventType.RECEIPT_RECEIVED):
+            close_assistant()
+            blocks.append(
+                {
+                    "block_id": f"r_{seq}",
+                    "kind": "receipt",
+                    "sequence": seq,
+                    "receipt": payload,
+                }
+            )
+            continue
+        if etype in (AgentEventType.ERROR, AgentEventType.AGENT_FAILED):
+            close_assistant()
+            blocks.append(
+                {
+                    "block_id": f"e_{seq}",
+                    "kind": "error",
+                    "sequence": seq,
+                    "error": str(payload.get("error", "")),
+                }
+            )
+            continue
+        # 其他事件（阶段/状态/用量）不进 transcript——它们属于状态栏。
+    close_assistant()
+    return blocks

--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -32,6 +32,18 @@ def main() -> int:
     if result is not None:
         return result
 
+    from rosclaw.release_verify import dispatch_release_argv
+
+    result = dispatch_release_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
+    from rosclaw.evidence_verify import dispatch_evidence_argv
+
+    result = dispatch_evidence_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
     from rosclaw.robot_pack.cli import dispatch_robot_pack_argv
 
     result = dispatch_robot_pack_argv(sys.argv[1:])

--- a/src/rosclaw/evidence_verify.py
+++ b/src/rosclaw/evidence_verify.py
@@ -1,0 +1,116 @@
+"""`rosclaw evidence verify <pack_dir>` — 证据包离线 verifier（二次复核 R7/T6）。
+
+在另一台机器上独立验证 evidence pack：
+1. artifact_hashes.json 全部重算匹配；
+2. run_manifest.sig 用包外锚验签（与 release 同一锚查找链）；
+3. run_manifest 必备字段 + secret_scan_clean；
+4. 缺任一关键 artifact 即失败。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REQUIRED_ARTIFACTS = (
+    "run_manifest.json",
+    "artifact_hashes.json",
+    "secret_scan.json",
+    "environment.json",
+    "commands.txt",
+    "events.jsonl",
+)
+
+
+def _anchor_candidates() -> list[str]:
+    return [
+        os.environ.get("ROSCLAW_RELEASE_KEY", ""),
+        "/etc/rosclaw/release-pub.pem",
+        str(Path.home() / ".rosclaw" / "release-keys" / "release-pub.pem"),
+        str(Path.home() / ".rosclaw" / "signing" / "dev-signing-public.pem"),
+    ]
+
+
+def verify_pack(pack: Path) -> dict:
+    errors: list[str] = []
+    for name in REQUIRED_ARTIFACTS:
+        if not (pack / name).exists():
+            errors.append(f"missing artifact: {name}")
+    if errors:
+        _fail(errors)
+    manifest = json.loads((pack / "run_manifest.json").read_text())
+    if manifest.get("invalid"):
+        _fail([f"pack marked INVALID: {manifest.get('reason', '')}"])
+    scan = json.loads((pack / "secret_scan.json").read_text())
+    if not scan.get("clean"):
+        errors.append(f"secret scan findings: {scan.get('findings')}")
+    hashes = json.loads((pack / "artifact_hashes.json").read_text())
+    for rel, expected in hashes.items():
+        path = pack / rel
+        if not path.exists():
+            errors.append(f"missing hashed artifact: {rel}")
+            continue
+        if hashlib.sha256(path.read_bytes()).hexdigest() != expected:
+            errors.append(f"hash mismatch: {rel}")
+    for field in ("run_id", "evidence_level", "rosclaw_commit", "created_at"):
+        if not manifest.get(field):
+            errors.append(f"run_manifest missing field: {field}")
+    # 签名：有 sig 必须验；无 sig 如实标记（开发包可过，发布门禁卡这个）。
+    sig = pack / "run_manifest.sig"
+    signed = False
+    if sig.exists():
+        anchor = None
+        for candidate in _anchor_candidates():
+            if candidate and Path(candidate).exists():
+                anchor = Path(candidate)
+                break
+        if anchor is None:
+            errors.append("run_manifest.sig present but no trust anchor available")
+        else:
+            result = subprocess.run(
+                [
+                    "openssl", "dgst", "-sha256", "-verify", str(anchor),
+                    "-signature", str(sig), str(pack / "run_manifest.json"),
+                ],
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                errors.append("run_manifest signature invalid")
+            else:
+                signed = True
+    if errors:
+        _fail(errors)
+    return {
+        "verified": True,
+        "run_id": manifest["run_id"],
+        "evidence_level": manifest["evidence_level"],
+        "signed": signed,
+        "secret_scan_clean": True,
+        "artifacts": len(hashes),
+    }
+
+
+def _fail(errors: list[str]) -> None:
+    print("EVIDENCE PACK VERIFICATION FAILED:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def dispatch_evidence_argv(argv: list[str]) -> int | None:
+    if argv[:2] != ["evidence", "verify"]:
+        return None
+    if len(argv) < 3:
+        print("用法: rosclaw evidence verify <pack_dir>", file=sys.stderr)
+        return 2
+    pack = Path(argv[2])
+    if not pack.is_dir():
+        print(f"pack 目录不存在: {pack}", file=sys.stderr)
+        return 2
+    report = verify_pack(pack)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0

--- a/src/rosclaw/release_verify.py
+++ b/src/rosclaw/release_verify.py
@@ -1,0 +1,174 @@
+"""`rosclaw release verify <bundle>` — 离线发布包验证 CLI（二次复核 R6）。
+
+在另一台机器上独立验证发布包：
+1. 信任锚必须来自包外（--trusted-key / $ROSCLAW_RELEASE_KEY /
+   /etc/rosclaw/release-pub.pem / ~/.rosclaw/release-keys/release-pub.pem）；
+2. openssl 验证 manifest 签名；
+3. 全文件 sha256 + 额外文件拒绝 + symlink 拒绝。
+
+退出码：0=VERIFIED；2=拒绝（任何一项不满足）。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+ALLOWED_EXTRA = {"manifest.json", "manifest.sig", "bundle-signing-public.pem"}
+
+
+def _anchor_candidates() -> list[str]:
+    return [
+        os.environ.get("ROSCLAW_RELEASE_KEY", ""),
+        "/etc/rosclaw/release-pub.pem",
+        str(Path.home() / ".rosclaw" / "release-keys" / "release-pub.pem"),
+    ]
+
+
+def verify_bundle(
+    bundle: Path,
+    *,
+    trusted_key: Path | None = None,
+    trusted_fingerprint: str = "",
+) -> dict:
+    """验证一个解包目录或 tar.gz。返回验证报告 dict；失败抛 SystemExit(2)。"""
+    errors: list[str] = []
+    warnings: list[str] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        if bundle.is_dir():
+            root = bundle
+        else:
+            root = Path(tmp) / "bundle"
+            with tarfile.open(bundle) as tar:
+                # 解包即防线：拒绝绝对路径/.. 成员。
+                for member in tar.getmembers():
+                    name = member.name
+                    if name.startswith("/") or ".." in Path(name).parts:
+                        errors.append(f"unsafe tar member: {name}")
+                if not errors:
+                    tar.extractall(root, filter="data")
+            subs = [p for p in root.iterdir() if p.is_dir()] if root.exists() else []
+            if len(subs) == 1:
+                root = subs[0]
+        if errors:
+            _fail(errors, warnings)
+        manifest_path = root / "manifest.json"
+        sig_path = root / "manifest.sig"
+        if not manifest_path.exists():
+            errors.append("manifest.json missing")
+        if not sig_path.exists():
+            errors.append("manifest.sig missing")
+        if errors:
+            _fail(errors, warnings)
+
+        anchor = trusted_key
+        if anchor is None:
+            for candidate in _anchor_candidates():
+                if candidate and Path(candidate).exists():
+                    anchor = Path(candidate)
+                    break
+        if anchor is None:
+            _fail(
+                errors
+                + [
+                    "no out-of-bundle trust anchor (use --trusted-key or pre-seed "
+                    "~/.rosclaw/release-keys/release-pub.pem)"
+                ],
+                warnings,
+            )
+        if trusted_fingerprint:
+            proc = subprocess.run(
+                ["openssl", "pkey", "-pubin", "-in", str(anchor), "-outform", "DER"],
+                capture_output=True,
+            )
+            actual = hashlib.sha256(proc.stdout).hexdigest()
+            if actual != trusted_fingerprint:
+                _fail(errors + [f"anchor fingerprint mismatch: {actual}"], warnings)
+        bundled_key = root / "bundle-signing-public.pem"
+        if bundled_key.exists() and bundled_key.read_bytes() != anchor.read_bytes():
+            warnings.append("bundle key differs from anchor — anchor wins (possible repackaging)")
+
+        verify = subprocess.run(
+            [
+                "openssl", "dgst", "-sha256", "-verify", str(anchor),
+                "-signature", str(sig_path), str(manifest_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if verify.returncode != 0:
+            _fail(errors + ["manifest signature invalid"], warnings)
+
+        manifest = json.loads(manifest_path.read_text())
+        for rel, expected in manifest["files"].items():
+            path = root / rel
+            if not path.exists():
+                errors.append(f"missing: {rel}")
+                continue
+            if hashlib.sha256(path.read_bytes()).hexdigest() != expected:
+                errors.append(f"tampered: {rel}")
+        for path in sorted(root.rglob("*")):
+            if path.is_symlink():
+                errors.append(f"symlink not allowed: {path.relative_to(root)}")
+            elif path.is_file():
+                rel = str(path.relative_to(root))
+                if rel not in manifest["files"] and rel not in ALLOWED_EXTRA:
+                    errors.append(f"unlisted file: {rel}")
+        if errors:
+            _fail(errors, warnings)
+        return {
+            "verified": True,
+            "product": manifest.get("product"),
+            "version": manifest.get("version"),
+            "platform": manifest.get("platform"),
+            "files": len(manifest["files"]),
+            "anchor": str(anchor),
+            "warnings": warnings,
+        }
+
+
+def _fail(errors: list[str], warnings: list[str]) -> None:
+    print("RELEASE VERIFICATION FAILED:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    for warning in warnings:
+        print(f"  WARN: {warning}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def dispatch_release_argv(argv: list[str]) -> int | None:
+    if argv[:2] != ["release", "verify"]:
+        return None
+    rest = argv[2:]
+    if not rest:
+        print("用法: rosclaw release verify <bundle-dir|bundle.tar.gz> "
+              "[--trusted-key PATH] [--trusted-fingerprint SHA256]", file=sys.stderr)
+        return 2
+    bundle = Path(rest[0])
+    trusted_key = None
+    fingerprint = ""
+    idx = 1
+    while idx < len(rest):
+        if rest[idx] == "--trusted-key" and idx + 1 < len(rest):
+            trusted_key = Path(rest[idx + 1])
+            idx += 2
+        elif rest[idx] == "--trusted-fingerprint" and idx + 1 < len(rest):
+            fingerprint = rest[idx + 1]
+            idx += 2
+        else:
+            print(f"未知参数 {rest[idx]}", file=sys.stderr)
+            return 2
+    if not bundle.exists():
+        print(f"bundle 不存在: {bundle}", file=sys.stderr)
+        return 2
+    report = verify_bundle(
+        bundle, trusted_key=trusted_key, trusted_fingerprint=fingerprint
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0

--- a/tests/agentd/test_events_v2.py
+++ b/tests/agentd/test_events_v2.py
@@ -156,7 +156,7 @@ class TestV2Api:
     async def test_http_v2_endpoints(self, service: AgentService) -> None:
         from fastapi.testclient import TestClient
 
-        client = TestClient(create_app(service))
+        client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
         mission = service.create_mission("HTTP 测试")
         r = client.post(f"/v2/missions/{mission.mission_id}/turns", json={"text": "你好"})
         assert r.status_code == 202

--- a/tests/agentd/test_evidence_pack.py
+++ b/tests/agentd/test_evidence_pack.py
@@ -1,0 +1,88 @@
+"""T6（二次复核 R7）：证据包验证——secret corpus、签名、缺失检测。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.bench.evidence_levels import EvidenceLevel
+from rosclaw.agentd.bench.evidence_pack import EvidencePackError, EvidencePackWriter
+from rosclaw.evidence_verify import verify_pack
+
+
+def _make_pack(root: Path) -> Path:
+    pack = EvidencePackWriter(root, run_id="run_test")
+    pack.write_environment(provider="mock")
+    pack.write_commands(["pytest tests/x"])
+    pack.write_events([{"type": "turn.accepted", "payload": {"text": "hi"}}])
+    pack.write_mission_snapshot({"mission_id": "mis_x"})
+    pack.write_public_records(approvals=[{"request_id": "r1"}], permits=[], receipts=[])
+    pack.write_metrics({"passed": True})
+    pack.write_observer("SIM 验收。")
+    pack.finalize(
+        level=EvidenceLevel.E3_SIM_VERIFIED,
+        git_commit="abc123",
+        dirty=False,
+        test_ids=["T6"],
+        operator="test",
+    )
+    return pack.dir
+
+
+class TestSecretCorpus:
+    @pytest.mark.parametrize(
+        "material",
+        [
+            "sk-proj-abc123",
+            "sk-ant-api03-xyz",
+            "ghp_abcdefghijklmnop",
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig",
+            "-----BEGIN RSA PRIVATE KEY-----",
+            "Bearer abc.def.ghi",
+        ],
+    )
+    def test_secret_corpus_fails_finalize(self, tmp_path: Path, material: str) -> None:
+        pack = EvidencePackWriter(tmp_path)
+        pack.write_events([{"payload": {"note": material}}])
+        with pytest.raises(EvidencePackError, match="secret"):
+            pack.finalize(
+                level=EvidenceLevel.E3_SIM_VERIFIED,
+                git_commit="x",
+                dirty=False,
+                test_ids=["T6"],
+                operator="test",
+            )
+        # 失败也必须在盘上留下 INVALID 标记（不是静默消失）。
+        manifest = json.loads((pack.dir / "run_manifest.json").read_text())
+        assert manifest["invalid"] is True
+        assert manifest["reason"] == "secret_scan_findings"
+
+
+class TestPackVerifier:
+    def test_valid_pack_verifies(self, tmp_path: Path) -> None:
+        pack_dir = _make_pack(tmp_path)
+        report = verify_pack(pack_dir)
+        assert report["verified"]
+        assert report["secret_scan_clean"]
+
+    def test_missing_artifact_fails(self, tmp_path: Path) -> None:
+        pack_dir = _make_pack(tmp_path)
+        (pack_dir / "events.jsonl").unlink()
+        with pytest.raises(SystemExit) as exit_info:
+            verify_pack(pack_dir)
+        assert exit_info.value.code == 2
+
+    def test_tampered_artifact_fails(self, tmp_path: Path) -> None:
+        pack_dir = _make_pack(tmp_path)
+        (pack_dir / "events.jsonl").write_text('{"tampered": true}\n')
+        with pytest.raises(SystemExit) as exit_info:
+            verify_pack(pack_dir)
+        assert exit_info.value.code == 2
+
+    def test_observer_labeled_automated(self, tmp_path: Path) -> None:
+        pack_dir = _make_pack(tmp_path)
+        text = (pack_dir / "automated_observation.md").read_text()
+        assert "automated_observation" in text
+        assert not (pack_dir / "operator_observer.md").exists()

--- a/tests/agentd/test_full_chain_e2e.py
+++ b/tests/agentd/test_full_chain_e2e.py
@@ -331,7 +331,7 @@ class TestFullChainE2E:
         # 先在测试自己的 loop 完成 MCP 发现（持久会话归属单一 loop）；
         # TestClient portal 的 server loop 直接复用，不跨 loop 起进程。
         await service._ensure_mcp_discovered()
-        client = TestClient(create_app(service))
+        client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
         try:
             mission = service.create_mission("HTTP 一致性")
             r = client.post(f"/v2/missions/{mission.mission_id}/turns", json={"text": "开始"})

--- a/tests/agentd/test_operator.py
+++ b/tests/agentd/test_operator.py
@@ -403,7 +403,7 @@ class TestApprovalLoop:
         _approval_then_action.calls = 0
         gateway = MockModelGateway(mock_profile(), [_approval_then_action] * 4)
         service = AgentService(config, tmp_path, gateway=gateway)
-        client = TestClient(create_app(service))
+        client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
         try:
             mission = service.create_mission("HTTP 授权")
             await service.send_turn(mission.mission_id, "请求授权")

--- a/tests/agentd/test_operator_socket.py
+++ b/tests/agentd/test_operator_socket.py
@@ -247,7 +247,7 @@ class TestHttpBypassClosed:
         from fastapi.testclient import TestClient
 
         service, card = await _service_with_pending(tmp_path)
-        client = TestClient(create_app(service))
+        client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
         try:
             assert client.get("/approvals/pending").status_code == 400
             r = client.post(f"/approvals/{card.request_id}/decide", json={"approve": True})

--- a/tests/agentd/test_release_packaging.py
+++ b/tests/agentd/test_release_packaging.py
@@ -94,10 +94,11 @@ class TestInstallRollbackSemantics:
         prefix = tmp_path / "prefix"
         (prefix / "current").mkdir(parents=True)
         (prefix / "current" / "marker_new").write_text("new")
-        (prefix / "previous").mkdir()
-        (prefix / "previous" / "manifest.json").write_text("{}")
+        # R6：rollback 现在重验签名+hash——previous 必须是合法签名包。
+        _make_mini_bundle(prefix / "previous", tmp_path / "signing")
         (prefix / "previous" / "marker_old").write_text("old")
-        env = dict(os.environ, ROSCLAW_PREFIX=str(prefix))
+        env = dict(os.environ, ROSCLAW_PREFIX=str(prefix),
+                   ROSCLAW_RELEASE_KEY=str(tmp_path / "signing" / "pub.pem"))
         result = subprocess.run(
             ["bash", str(ROLLBACK)], capture_output=True, text=True, env=env
         )
@@ -125,10 +126,13 @@ class TestSignedBundle:
         with tarfile.open(bundle) as tf:
             tf.extractall(stage)
         root = next(stage.iterdir())
-        # 签名与公钥存在，SBOM 与离线资产存在。
+        # 签名与公钥存在，SBOM（CycloneDX + 快照）与离线资产存在。
         for name in ("manifest.json", "manifest.sig", "bundle-signing-public.pem",
-                     "sbom-python.txt", "sbom-rosclaw-tui.txt", "sbom-rosclaw-modeld.txt"):
+                     "sbom-python.txt", "sbom-rosclaw-tui.txt", "sbom-rosclaw-modeld.txt",
+                     "sbom-cyclonedx.json"):
             assert (root / name).exists(), name
+        sbom = json.loads((root / "sbom-cyclonedx.json").read_text())
+        assert sbom["bomFormat"] == "CycloneDX" and sbom["components"]
         assert (root / "vendor" / "node_modules_pack" / "rosclaw-tui.tar.gz").exists()
         assert (root / "vendor" / "node_modules_pack" / "rosclaw-modeld.tar.gz").exists()
         # 签名有效。
@@ -158,9 +162,19 @@ class TestSignedBundle:
         )
         assert check.returncode == 2
         assert "tampered" in check.stderr
-        # 安装器在篡改下直接拒绝（verify-before-execute）。
-        install = subprocess.run(
+        # R6：无包外信任锚 → 安装器直接拒绝（包内公钥不能自证）。
+        no_anchor = subprocess.run(
             ["bash", str(root / "install.sh"), "--offline"],
+            capture_output=True, text=True, timeout=120,
+            env=dict(os.environ, ROSCLAW_PREFIX=str(tmp_path / "prefix0"),
+                     ROSCLAW_RELEASE_KEY=str(tmp_path / "nonexistent.pem")),
+        )
+        assert no_anchor.returncode == 2
+        assert "信任锚" in no_anchor.stderr
+        # 安装器在篡改下直接拒绝（verify-before-execute；锚来自包外）。
+        install = subprocess.run(
+            ["bash", str(root / "install.sh"), "--offline",
+             "--trusted-key", str(tmp_path / "signing" / "dev-signing-public.pem")],
             capture_output=True, text=True, timeout=120,
             env=dict(os.environ, ROSCLAW_PREFIX=str(tmp_path / "prefix")),
         )
@@ -186,3 +200,150 @@ _HASH_CHECK_SNIPPET = (
     "    print('\\n'.join(bad), file=sys.stderr)\n"
     "    sys.exit(2)\n"
 )
+
+
+# ----------------------------------------------------------------------
+# T5（二次复核 R6）：发布供应链攻击矩阵。
+# ----------------------------------------------------------------------
+
+
+def _make_mini_bundle(root: Path, signing: Path) -> None:
+    """构造最小签名 bundle（真实 openssl ECDSA）。"""
+    import hashlib
+
+    signing.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["openssl", "ecparam", "-name", "prime256v1", "-genkey", "-noout",
+         "-out", str(signing / "priv.pem")],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["openssl", "ec", "-in", str(signing / "priv.pem"), "-pubout",
+         "-out", str(signing / "pub.pem")],
+        check=True, capture_output=True,
+    )
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "a.txt").write_text("payload-a")
+    (root / "src").mkdir()
+    (root / "src" / "x.py").write_text("print('x')\n")
+    files = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            files[str(path.relative_to(root))] = hashlib.sha256(path.read_bytes()).hexdigest()
+    (root / "manifest.json").write_text(json.dumps({"product": "t", "version": "0", "files": files}))
+    (root / "bundle-signing-public.pem").write_bytes((signing / "pub.pem").read_bytes())
+    subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", str(signing / "priv.pem"),
+         "-out", str(root / "manifest.sig"), str(root / "manifest.json")],
+        check=True, capture_output=True,
+    )
+
+
+class TestReleaseTrustAnchor:
+    """T5：信任锚在包外；篡改/替换/夹带全部拒绝。"""
+
+    def test_valid_bundle_verifies_with_anchor(self, tmp_path: Path) -> None:
+        from rosclaw.release_verify import verify_bundle
+
+        root, signing = tmp_path / "bundle", tmp_path / "signing"
+        _make_mini_bundle(root, signing)
+        report = verify_bundle(root, trusted_key=signing / "pub.pem")
+        assert report["verified"] and report["files"] == 2
+
+    def test_no_anchor_refuses(self, tmp_path: Path, monkeypatch) -> None:
+        from rosclaw.release_verify import verify_bundle
+
+        root, signing = tmp_path / "bundle", tmp_path / "signing"
+        _make_mini_bundle(root, signing)
+        monkeypatch.setenv("ROSCLAW_RELEASE_KEY", str(tmp_path / "nonexistent"))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "nohome")
+        with pytest.raises(SystemExit) as exit_info:
+            verify_bundle(root)
+        assert exit_info.value.code == 2
+
+    def test_payload_tamper_refused(self, tmp_path: Path) -> None:
+        from rosclaw.release_verify import verify_bundle
+
+        root, signing = tmp_path / "bundle", tmp_path / "signing"
+        _make_mini_bundle(root, signing)
+        (root / "a.txt").write_text("tampered-one-byte")
+        with pytest.raises(SystemExit) as exit_info:
+            verify_bundle(root, trusted_key=signing / "pub.pem")
+        assert exit_info.value.code == 2
+
+    def test_manifest_and_key_replacement_refused(self, tmp_path: Path) -> None:
+        """攻击者同时替换 manifest、签名与包内公钥——包外锚仍拒绝。"""
+        from rosclaw.release_verify import verify_bundle
+
+        root, signing = tmp_path / "bundle", tmp_path / "signing"
+        _make_mini_bundle(root, signing)
+        attacker = tmp_path / "attacker"
+        _make_mini_bundle(attacker, tmp_path / "attacker-signing")
+        # 攻击者重打包：换成自己的 manifest+签名+公钥。
+        (root / "manifest.json").write_bytes((attacker / "manifest.json").read_bytes())
+        (root / "manifest.sig").write_bytes((attacker / "manifest.sig").read_bytes())
+        (root / "bundle-signing-public.pem").write_bytes(
+            (attacker / "bundle-signing-public.pem").read_bytes()
+        )
+        with pytest.raises(SystemExit) as exit_info:
+            verify_bundle(root, trusted_key=signing / "pub.pem")
+        assert exit_info.value.code == 2
+
+    def test_extra_unlisted_file_refused(self, tmp_path: Path) -> None:
+        from rosclaw.release_verify import verify_bundle
+
+        root, signing = tmp_path / "bundle", tmp_path / "signing"
+        _make_mini_bundle(root, signing)
+        (root / "evil.sh").write_text("#!/bin/sh\nid\n")
+        with pytest.raises(SystemExit) as exit_info:
+            verify_bundle(root, trusted_key=signing / "pub.pem")
+        assert exit_info.value.code == 2
+
+    def test_symlink_refused(self, tmp_path: Path) -> None:
+        from rosclaw.release_verify import verify_bundle
+
+        root, signing = tmp_path / "bundle", tmp_path / "signing"
+        _make_mini_bundle(root, signing)
+        (root / "link").symlink_to("/etc/passwd")
+        with pytest.raises(SystemExit) as exit_info:
+            verify_bundle(root, trusted_key=signing / "pub.pem")
+        assert exit_info.value.code == 2
+
+    def test_fingerprint_pinning(self, tmp_path: Path) -> None:
+        import hashlib
+
+        from rosclaw.release_verify import verify_bundle
+
+        root, signing = tmp_path / "bundle", tmp_path / "signing"
+        _make_mini_bundle(root, signing)
+        proc = subprocess.run(
+            ["openssl", "pkey", "-pubin", "-in", str(signing / "pub.pem"), "-outform", "DER"],
+            capture_output=True, check=True,
+        )
+        good_fp = hashlib.sha256(proc.stdout).hexdigest()
+        report = verify_bundle(
+            root, trusted_key=signing / "pub.pem", trusted_fingerprint=good_fp
+        )
+        assert report["verified"]
+        with pytest.raises(SystemExit) as exit_info:
+            verify_bundle(root, trusted_key=signing / "pub.pem", trusted_fingerprint="0" * 64)
+        assert exit_info.value.code == 2
+
+    def test_rollback_refuses_tampered_previous(self, tmp_path: Path) -> None:
+        """R6：被篡改的 previous 不得成为回滚目标。"""
+        prefix = tmp_path / "prefix"
+        previous = prefix / "previous"
+        _make_mini_bundle(previous, tmp_path / "signing")
+        current = prefix / "current"
+        current.mkdir(parents=True)
+        # 篡改 previous 的一个 payload 文件。
+        (previous / "a.txt").write_text("tampered")
+        result = subprocess.run(
+            ["bash", str(ROLLBACK)],
+            capture_output=True, text=True,
+            env=dict(os.environ, ROSCLAW_PREFIX=str(prefix),
+                     ROSCLAW_RELEASE_KEY=str(tmp_path / "signing" / "pub.pem")),
+        )
+        assert result.returncode == 2
+        assert "篡改" in result.stderr or "tampered" in result.stderr
+        assert current.exists(), "拒绝回滚不得改变 current"

--- a/tests/agentd/test_service.py
+++ b/tests/agentd/test_service.py
@@ -158,7 +158,7 @@ class TestHttpApi:
     def client(self, service: AgentService):
         from fastapi.testclient import TestClient
 
-        return TestClient(create_app(service))
+        return TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
 
     def test_health_and_status(self, client) -> None:
         assert client.get("/health").json()["status"] == "ok"

--- a/tests/agentd/test_transcript_r4.py
+++ b/tests/agentd/test_transcript_r4.py
@@ -1,0 +1,151 @@
+"""R4（二次复核 P1-1/P1-3/P1-4/P1-8）：transcript projection、
+exactly-once 恢复、生命周期关闭、控制 token、projection owner 过滤。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.config import load_agent_config
+from rosclaw.agentd.models.gateway import MockModelGateway
+from rosclaw.agentd.models.profiles import mock_profile
+from rosclaw.agentd.operator_socket import OperatorSocketServer, display_hash_for, operator_call
+from rosclaw.agentd.service import AgentService, create_app
+from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+
+
+def _turn(text: str) -> ModelTurnResultV1:
+    return ModelTurnResultV1(
+        turn_id="t",
+        provider="mock",
+        model="m",
+        content=text,
+        assistant_message={"role": "assistant", "content": text},
+        usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},  # type: ignore[arg-type]
+    )
+
+
+async def _service(tmp_path: Path, turns: list[ModelTurnResultV1]) -> AgentService:
+    config = load_agent_config(tmp_path / "config.yaml")
+    return AgentService(config, tmp_path, gateway=MockModelGateway(mock_profile(), turns))
+
+
+class TestTranscriptProjection:
+    async def test_blocks_cover_user_assistant_and_seq(self, tmp_path: Path) -> None:
+        service = await _service(tmp_path, [_turn("你好，世界"), _turn("第二回合")])
+        mission = service.create_mission("transcript 测试")
+        await service.send_turn(mission.mission_id, "第一条用户消息")
+        await service.send_turn(mission.mission_id, "第二条用户消息")
+        page = service.transcript(mission.mission_id)
+        kinds = [b["kind"] for b in page["blocks"]]
+        assert kinds.count("user") == 2
+        assert kinds.count("assistant") == 2
+        # 稳定块 ID + 单调 sequence
+        ids = [b["block_id"] for b in page["blocks"]]
+        assert len(set(ids)) == len(ids)
+        seqs = [b["sequence"] for b in page["blocks"]]
+        assert seqs == sorted(seqs)
+        assert page["latest_sequence"] > 0
+        users = [b for b in page["blocks"] if b["kind"] == "user"]
+        assert users[0]["text"] == "第一条用户消息"
+        await service.close()
+
+    async def test_pagination_before_seq(self, tmp_path: Path) -> None:
+        service = await _service(tmp_path, [_turn("x")])
+        mission = service.create_mission("分页")
+        for i in range(4):
+            await service.send_turn(mission.mission_id, f"msg-{i}")
+        full = service.transcript(mission.mission_id, limit=100)
+        first_user_seq = next(b["sequence"] for b in full["blocks"] if b["kind"] == "user")
+        page = service.transcript(mission.mission_id, before_seq=first_user_seq + 1, limit=2)
+        assert page["latest_sequence"] == full["latest_sequence"]
+        assert all(b["sequence"] <= first_user_seq for b in page["blocks"])
+        await service.close()
+
+
+class TestTranscriptEndpointAndToken:
+    async def test_endpoint_requires_token_and_serves_projection(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        service = await _service(tmp_path, [_turn("hi")])
+        mission = service.create_mission("endpoint")
+        await service.send_turn(mission.mission_id, "hello")
+        app = create_app(service)
+        anon = TestClient(app)
+        assert anon.get(f"/v2/missions/{mission.mission_id}/transcript").status_code == 401
+        assert anon.get("/missions").status_code == 401
+        assert anon.get("/health").status_code == 200
+        authed = TestClient(app, headers={"x-rosclaw-token": service.control_token})
+        page = authed.get(f"/v2/missions/{mission.mission_id}/transcript").json()
+        assert page["latest_sequence"] > 0
+        assert any(b["kind"] == "user" for b in page["blocks"])
+        # SSE 从 latest_sequence 续接 → 不回放历史（exactly-once）。
+        with authed.stream(
+            "GET",
+            f"/v2/missions/{mission.mission_id}/events",
+            params={"follow": "false", "after_sequence": page["latest_sequence"]},
+        ) as res:
+            res.read()
+            body = res.text
+        assert "data:" not in body, "after latest_sequence 不应再回放任何历史事件"
+        await service.close()
+
+
+class TestLifecycleClose:
+    async def test_open_context_manager_closes(self, tmp_path: Path) -> None:
+        config = load_agent_config(tmp_path / "config.yaml")
+        async with AgentService.open(
+            config, tmp_path, gateway=MockModelGateway(mock_profile(), [_turn("x")])
+        ) as service:
+            mission = service.create_mission("lifecycle")
+            assert mission.mission_id
+        # close 后 store 已关（再访问应抛异常而非泄漏句柄）。
+        with pytest.raises(Exception):  # noqa: B017
+            service.list_missions()
+
+    async def test_token_file_written_and_removed(self, tmp_path: Path) -> None:
+        service = await _service(tmp_path, [_turn("x")])
+        path = service.write_control_token_file()
+        assert path.exists()
+        assert path.read_text() == service.control_token
+        assert path.stat().st_mode & 0o777 == 0o600
+        await service.close()
+        assert not path.exists()
+
+
+class TestProjectionOwnerFilter:
+    async def test_list_without_mission_filters_by_peer(self, tmp_path: Path) -> None:
+        """P1-8：省略 mission_id 不得扩大范围（peer 非 owner → 空）。"""
+        from tests.agentd.test_operator_socket import _approval_turn
+
+        config = load_agent_config(tmp_path / "config.yaml")
+        service = AgentService(
+            config, tmp_path, gateway=MockModelGateway(mock_profile(), [_approval_turn] * 2)
+        )
+        mission = service.create_mission("owner filter")
+        await service.send_turn(mission.mission_id, "请求授权")
+        assert service.pending_approvals(mission.mission_id)
+        sock = tmp_path / "run" / "operator.sock"
+        server = OperatorSocketServer(service, sock)
+        await server.start()
+        try:
+            listed = await operator_call(sock, "approvals.list")
+            owner = service.principal_for_request(
+                service.pending_approvals(mission.mission_id)[0].request_id
+            )
+            peer_principal = f"user:local:{__import__('os').getuid()}"
+            if owner == peer_principal:
+                assert listed["approvals"], "owner==peer 时应可见"
+            else:
+                assert listed["approvals"] == []
+            # 显式 mission_id 不受 owner 过滤限制（socket 周界即 ACL）。
+            scoped = await operator_call(sock, "approvals.list", {"mission_id": mission.mission_id})
+            assert len(scoped["approvals"]) == 1
+            assert scoped["approvals"][0]["display_hash"] == display_hash_for(
+                service.pending_approvals(mission.mission_id)[0]
+            )
+        finally:
+            await server.stop()
+            await service.close()

--- a/tests/agentd/test_ui_batch_b.py
+++ b/tests/agentd/test_ui_batch_b.py
@@ -128,7 +128,7 @@ class TestCommandRegistry:
 
         service = _service(tmp_path, [_answer] * 5)
         try:
-            client = TestClient(create_app(service))
+            client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
             mission = service.create_mission("命令测试")
             caps = client.get(f"/v1/capabilities?mission_id={mission.mission_id}").json()
             names = {c["name"] for c in caps["commands"]}
@@ -154,7 +154,7 @@ class TestCommandRegistry:
 
         service = _service(tmp_path, [_answer] * 5)
         try:
-            client = TestClient(create_app(service))
+            client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
             mission = service.create_mission("重命名")
             r1 = client.post(
                 f"/v1/missions/{mission.mission_id}/commands",
@@ -204,7 +204,7 @@ class TestCommandRegistry:
 
         service = _service(tmp_path, [_answer] * 5)
         try:
-            client = TestClient(create_app(service))
+            client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
             mission = service.create_mission("工具列表")
             r = client.post(
                 f"/v1/missions/{mission.mission_id}/commands",
@@ -228,7 +228,7 @@ class TestSnapshot:
 
         service = _service(tmp_path, [_answer] * 5)
         try:
-            client = TestClient(create_app(service))
+            client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
             mission = service.create_mission("快照测试")
             await service.send_turn(mission.mission_id, "hi")
             snap = client.get(f"/v1/missions/{mission.mission_id}/snapshot").json()
@@ -250,7 +250,7 @@ class TestSnapshot:
 
         service = _service(tmp_path, [_answer] * 5)
         try:
-            client = TestClient(create_app(service))
+            client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
             assert client.get("/v1/missions/mis_ghost/snapshot").status_code == 404
         finally:
             await service.close()
@@ -262,7 +262,7 @@ class TestSseResume:
 
         service = _service(tmp_path, [_answer] * 5)
         try:
-            client = TestClient(create_app(service))
+            client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
             mission = service.create_mission("断线恢复")
             await service.send_turn(mission.mission_id, "hi")
             events = _events(service, mission.mission_id)

--- a/tests/agentd/test_usage_streaming.py
+++ b/tests/agentd/test_usage_streaming.py
@@ -119,7 +119,7 @@ class TestStreamingUx:
         from fastapi.testclient import TestClient
 
         service = _service(tmp_path)
-        client = TestClient(create_app(service))
+        client = TestClient(create_app(service), headers={'x-rosclaw-token': service.control_token})
         mission = service.create_mission("SSE 测试")
         events: list[dict] = []
         with client.stream(


### PR DESCRIPTION
二次复核后续批次（基于已合并的 #224 Gate S）。**REAL 门禁不变（继续关闭）。**

## R4：TUI transcript / 生命周期 / 控制面鉴权（P1-1/P1-3/P1-4/P1-8）

- agentd 提供 **transcript projection API**：journal → 稳定块（user/assistant/tool/card/decision/receipt/error），`before_seq` 分页，响应带 `latest_sequence`；TUI resume 不再从底层事件猜聊天记录（用户消息终于出现在恢复里）。
- SSE 以 `afterSequence=latest_sequence` 续接（exactly-once，恢复不再重复）；无界 seen Set 换成 2048 有界去重窗。
- `AgentService.open()` 统一生命周期 + FastAPI lifespan 关闭（子进程/socket/句柄不再泄漏）。
- **ephemeral control token**：除 /health 与 /console 壳外全部端点（含敏感 GET）必须 `x-rosclaw-token`；token 写 0600 文件随关闭删除；console JS 从 ?token= 读取。
- projection approvals.list 省略 mission_id 时按 peer owner 过滤（P1-8）。
- TUI 裸 y/n 行快捷决定最新待批卡（默认 N 语义）；同步 send_turn 也发 TURN_ACCEPTED/MODEL_TEXT_DELTA。

## PR-3：Node required CI + modeld 硬化（P1-5/P1-6/P1-7）

- 新 required jobs：`node-tui-unit`、`node-modeld-unit`、`evidence-pack-verify`（`cross-uid-operator-e2e` 随 #224 已在）。
- modeld `/v1/health/ready`：bind+chmod+凭据初始化前 503；gateway 轮询真实鉴权就绪 + 验证 socket 0600；启动失败保留脱敏 stderr 尾部。
- 凭据存储：O_NOFOLLOW + 文件/目录双 fsync + 单链接/owner/0600 校验 + 损坏真实 quarantine。

## R6：可信离线发布链（P0-7/T5）

- **信任锚移出包外**：--trusted-key / ROSCLAW_RELEASE_KEY / /etc/rosclaw/release-pub.pem / ~/.rosclaw/release-keys/，可选 --trusted-fingerprint 钉住；包内公钥不再自证（--allow-untrusted-dev 是大字警告的显式逃生门）。
- installer **额外文件/symlink 拒绝**；离线缺 wheel 构建/安装双侧硬失败。
- rollback 重验签名+全 hash，篡改的 previous 拒绝成为回滚目标。
- CycloneDX 1.5 SBOM（pip freeze/npm ls 降级为调试快照）。
- 新 CLI：`rosclaw release verify <bundle>`（tar 成员穿越防护）。
- T5 攻击矩阵 8 项：payload 篡改/manifest+sig+key 整体替换/夹带文件/symlink/指纹钉住/无锚拒绝/回滚篡改。

## R7：可审计证据包（T6）

- 证据包补齐 approval→decision→grant→receipt 全链（原来 approvals/permits 是空数组）；run_manifest 增加 uid/pid/signed。
- run_manifest.sig 签名；新 CLI `rosclaw evidence verify <pack>`（hash 重算 + 包外锚验签 + 必备 artifact + secret_scan_clean）。
- secret corpus 扩充（JWT/OAuth/云 key/私钥块），命中即 fail 且落 INVALID 标记。
- observer → automated_observation.md（明确非人签）。
- CI evidence job：验收 → 出包 → 离线验证 → 上传 artifact（30 天）。

## 验证

- 全量回归 **6225 passed**（8 个已知环境性失败：firstboot×4 + lerobot×4，origin/main 基线相同）；ruff clean；TUI 27/27、modeld 18/18 node 测试。
- K0–K9 live：10/11（K1 注入抵抗断言在套件并发下间歇性措辞波动，单独 4/4 通过；非代码回归——live LLM 行为抖动，报告如实标注）。
- LIMO 验收 12/12；证据包签名 + `rosclaw evidence verify` 本机验证通过（E3_SIM_VERIFIED，signed=true，secret_scan_clean）。
- T5 8/8、T6 10/10、R4 python 6/6、T1 跨 UID e2e（#224 CI 已绿）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)