### PR TITLE
PR-PNA-6: session lifecycle mapping (new/fork/resume/tree binding rules)

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -8,6 +8,13 @@
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { bridgeCall } from "../bridge/bridge-client.js";
+import {
+	handleSessionStart,
+	sessionIdOf,
+	shouldCancelSwitch,
+	shouldCancelTree,
+	type LifecycleDeps,
+} from "../session/lifecycle.js";
 import { defaultOperatorSocket, operatorCall } from "../bridge/operatord-client.js";
 import { ApprovalCardComponent } from "../ui/approval-card.js";
 import { fetchEmbodiedContext, renderTrustedContext } from "./context-injection.js";
@@ -214,7 +221,39 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			}
 		});
 
-		// -- 生命周期观察（PNA-6 在此强制"新 SIM Mission + 不复制 authority"） -------
+		// -- Session 生命周期映射（PNA-6，规格 §13） ------------------------------
+		const lifecycle: LifecycleDeps = {
+			rosclawHome: options.rosclawHome,
+			getMissionId: () => options.missionId,
+			setMissionId: (missionId) => {
+				options.missionId = missionId;
+			},
+			notify: (message, type) => undefined,
+		};
+		pi.on("session_start", async (event, ctx) => {
+			lifecycle.notify = (message, type) => ctx.ui.notify(message, type);
+			try {
+				await handleSessionStart(lifecycle, event.reason, sessionIdOf(ctx));
+			} catch (err) {
+				ctx.ui.notify(`session 绑定异常：${(err as Error).message}`, "error");
+			}
+		});
+		pi.on("session_before_switch", async (event, ctx) => {
+			lifecycle.notify = (message, type) => ctx.ui.notify(message, type);
+			const veto = await shouldCancelSwitch(lifecycle, sessionIdOf(ctx));
+			return veto ? { cancel: true } : undefined;
+		});
+		pi.on("session_before_tree", async (_event, ctx) => {
+			lifecycle.notify = (message, type) => ctx.ui.notify(message, type);
+			const veto = await shouldCancelTree(lifecycle);
+			if (veto) {
+				ctx.ui.notify(veto, "warning");
+				return { cancel: true };
+			}
+			return undefined;
+		});
+		// fork：authority 结构性不复制（grant/permit 只在 agentd）；
+		// 新 mission 绑定在 session_start(reason=fork) 完成。
 		pi.on("session_before_fork", async () => {
 			return undefined;
 		});

--- a/packages/rosclaw-agent/src/session/lifecycle.ts
+++ b/packages/rosclaw-agent/src/session/lifecycle.ts
@@ -1,0 +1,134 @@
+/** Session 生命周期映射（PNA-6，规格 §13）。
+ *
+ * - session_start(reason=new|fork)：创建新 SIM Mission 并绑定（fork 记录
+ *   来源 mission，authority 永不复制——authority 只存 agentd，Pi session
+ *   里没有可复制的授权材料，结构性保证）；
+ * - session_before_switch(resume)：目标 session 无绑定 → 自动新建
+ *   SIM Mission 绑定（NEEDS_BINDING 的安全默认）；绑定 mission 已归档
+ *   → 同样新建绑定；旧 binding 保持只读历史；
+ * - session_before_tree：有进行中动作/待决授权 → veto（fail closed，
+ *   规格 §13.5：tree 不得回滚物理 lane）。
+ */
+
+import { bridgeCall } from "../bridge/bridge-client.js";
+
+export type BridgeCallFn = (
+	home: string,
+	method: string,
+	params?: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+export interface LifecycleDeps {
+	rosclawHome: string;
+	/** 启动时绑定的 mission（--mission）；hook 内新绑定会更新它。 */
+	getMissionId: () => string | undefined;
+	setMissionId: (missionId: string) => void;
+	notify: (message: string, type?: "info" | "warning" | "error") => void;
+	call?: BridgeCallFn;
+}
+
+export function sessionIdOf(ctx: {
+	sessionManager?: { getSessionId?: () => string };
+}): string {
+	return ctx.sessionManager?.getSessionId?.() ?? "";
+}
+
+export async function handleSessionStart(
+	deps: LifecycleDeps,
+	reason: string,
+	sessionId: string,
+): Promise<void> {
+	const call = deps.call ?? bridgeCall;
+	if (reason !== "new" && reason !== "fork") return;
+	const sourceMissionId = deps.getMissionId();
+	const created = await call(deps.rosclawHome, "pi.mission.create", {
+		goal: reason === "fork" ? `fork of ${sourceMissionId ?? "session"}` : "pi session",
+		mode: "SIMULATION",
+	});
+	if (!created.ok) {
+		deps.notify(`新建 Mission 失败：${String(created.error ?? "")}`, "error");
+		return;
+	}
+	const missionId = String(created.mission_id);
+	const bound = await call(deps.rosclawHome, "pi.session.bind", {
+		pi_session_id: sessionId,
+		mission_id: missionId,
+	});
+	if (!bound.ok) {
+		deps.notify(
+			`绑定失败 [${String(bound.code ?? "")}]：${String(bound.error ?? "")}`,
+			"error",
+		);
+		return;
+	}
+	deps.setMissionId(missionId);
+	deps.notify(
+		reason === "fork"
+			? `已 fork：新 SIM Mission ${missionId}（authority 不复制，来源 ${sourceMissionId ?? "—"} 仅作只读历史）`
+			: `新 Mission ${missionId}（SIMULATION）`,
+		"info",
+	);
+}
+
+export async function shouldCancelSwitch(
+	deps: LifecycleDeps,
+	targetSessionId: string,
+): Promise<string | null> {
+	// resume/switch 前置检查。返回 veto 原因；null=放行（可能已完成新绑定）。
+	const call = deps.call ?? bridgeCall;
+	const looked = await call(deps.rosclawHome, "pi.session.binding.get", {
+		pi_session_id: targetSessionId,
+	});
+	if (!looked.ok) return `绑定查询失败：${String(looked.error ?? "")}`;
+	const binding = looked.binding as { mission_id?: string } | null;
+	if (binding && !looked.mission_archived) {
+		deps.setMissionId(String(binding.mission_id));
+		return null;
+	}
+	// 绑定丢失或 mission 已归档：不猜——新建 SIM Mission 绑定（NEEDS_BINDING
+	// 的安全默认；规格 §13.3）。
+	const created = await call(deps.rosclawHome, "pi.mission.create", {
+		goal: `resume rebind (${targetSessionId.slice(0, 8)})`,
+		mode: "SIMULATION",
+	});
+	if (!created.ok) return `绑定丢失且新建 Mission 失败：${String(created.error ?? "")}`;
+	const bound = await call(deps.rosclawHome, "pi.session.bind", {
+		pi_session_id: targetSessionId,
+		mission_id: String(created.mission_id),
+	});
+	if (!bound.ok) return `rebind 失败：${String(bound.error ?? "")}`;
+	deps.setMissionId(String(created.mission_id));
+	deps.notify(
+		binding
+			? "原 Mission 已归档——已新建 SIM Mission 绑定（旧记录只读保留）"
+			: "该 session 无 Mission 绑定——已新建 SIM Mission 绑定",
+		"warning",
+	);
+	return null;
+}
+
+export async function shouldCancelTree(deps: LifecycleDeps): Promise<string | null> {
+	// tree navigation 前置：进行中动作/待决授权 → veto（§13.5 fail closed）。
+	const missionId = deps.getMissionId();
+	if (!missionId) return null;
+	const call = deps.call ?? bridgeCall;
+	try {
+		const ctxResponse = await call(deps.rosclawHome, "pi.context", {
+			mission_id: missionId,
+		});
+		if (!ctxResponse.ok) return null; // context 拉不到由注入层标 stale；tree 不背锅
+		const context = ctxResponse.context as {
+			pending_approvals?: unknown[];
+			active_actions?: unknown[];
+		};
+		if ((context.pending_approvals ?? []).length > 0) {
+			return "有待决授权——先完成 reconciliation 再切换认知路径";
+		}
+		if ((context.active_actions ?? []).length > 0) {
+			return "有进行中的真实动作——tree navigation fail closed（§13.5）";
+		}
+	} catch {
+		return null;
+	}
+	return null;
+}

--- a/packages/rosclaw-agent/test/lifecycle.test.ts
+++ b/packages/rosclaw-agent/test/lifecycle.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	handleSessionStart,
+	shouldCancelSwitch,
+	shouldCancelTree,
+	type LifecycleDeps,
+} from "../src/session/lifecycle.js";
+
+function fakeBridge(responses: Record<string, Record<string, unknown>>) {
+	const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+	const call = async (_home: string, method: string, params: Record<string, unknown> = {}) => {
+		calls.push({ method, params });
+		return responses[method] ?? { ok: false, error: `no stub for ${method}` };
+	};
+	return { calls, call };
+}
+
+function deps(call: LifecycleDeps["call"], missionId?: string) {
+	const notes: string[] = [];
+	const d: LifecycleDeps = {
+		rosclawHome: "/tmp/rh",
+		getMissionId: () => missionId,
+		setMissionId: (id) => {
+			missionId = id;
+		},
+		notify: (message) => notes.push(message),
+		call,
+	};
+	return { deps: d, notes, getMission: () => missionId };
+}
+
+test("new/fork creates SIM mission and binds; fork never copies authority", async () => {
+	const { calls, call } = fakeBridge({
+		"pi.mission.create": { ok: true, mission_id: "mis_new", mode: "SIMULATION" },
+		"pi.session.bind": { ok: true, binding: { binding_id: "psb_1" }, lease_token: "t" },
+	});
+	const { deps: d, getMission } = deps(call, "mis_old");
+	await handleSessionStart(d, "fork", "pi_sess_2");
+	assert.equal(getMission(), "mis_new");
+	const create = calls.find((c) => c.method === "pi.mission.create");
+	assert.equal(create?.params.mode, "SIMULATION", "fork 强制 SIM");
+	// 绑定请求不含任何 authority 字段（结构性不复制）。
+	const bind = calls.find((c) => c.method === "pi.session.bind");
+	assert.deepEqual(Object.keys(bind?.params ?? {}).sort(), ["mission_id", "pi_session_id"]);
+});
+
+test("resume with healthy binding just reattaches", async () => {
+	const { call } = fakeBridge({
+		"pi.session.binding.get": {
+			ok: true,
+			binding: { mission_id: "mis_kept" },
+			mission_archived: false,
+		},
+	});
+	const { deps: d, getMission } = deps(call, undefined);
+	const veto = await shouldCancelSwitch(d, "pi_sess_old");
+	assert.equal(veto, null);
+	assert.equal(getMission(), "mis_kept");
+});
+
+test("resume without binding creates a fresh SIM binding (never guesses)", async () => {
+	const { calls, call } = fakeBridge({
+		"pi.session.binding.get": { ok: true, binding: null },
+		"pi.mission.create": { ok: true, mission_id: "mis_fresh" },
+		"pi.session.bind": { ok: true },
+	});
+	const { deps: d, getMission, notes } = deps(call, undefined);
+	const veto = await shouldCancelSwitch(d, "pi_sess_lost");
+	assert.equal(veto, null);
+	assert.equal(getMission(), "mis_fresh");
+	assert.ok(notes.some((n) => n.includes("无 Mission 绑定")));
+	assert.ok(calls.some((c) => c.method === "pi.mission.create"));
+});
+
+test("archived mission rebinds to a fresh SIM mission", async () => {
+	const { call } = fakeBridge({
+		"pi.session.binding.get": {
+			ok: true,
+			binding: { mission_id: "mis_archived" },
+			mission_archived: true,
+		},
+		"pi.mission.create": { ok: true, mission_id: "mis_new2" },
+		"pi.session.bind": { ok: true },
+	});
+	const { deps: d, getMission, notes } = deps(call, undefined);
+	const veto = await shouldCancelSwitch(d, "pi_sess_arch");
+	assert.equal(veto, null);
+	assert.equal(getMission(), "mis_new2");
+	assert.ok(notes.some((n) => n.includes("已归档")));
+});
+
+test("tree navigation vetoed with pending approvals or active actions", async () => {
+	const { call } = fakeBridge({
+		"pi.context": {
+			ok: true,
+			context: { pending_approvals: [{ request_id: "r1" }], active_actions: [] },
+		},
+	});
+	const { deps: d } = deps(call, "mis_x");
+	assert.ok((await shouldCancelTree(d))?.includes("待决授权"));
+
+	const { call: call2 } = fakeBridge({
+		"pi.context": {
+			ok: true,
+			context: { pending_approvals: [], active_actions: [{ id: "a1" }] },
+		},
+	});
+	const { deps: d2 } = deps(call2, "mis_x");
+	assert.ok((await shouldCancelTree(d2))?.includes("fail closed"));
+
+	const { call: call3 } = fakeBridge({
+		"pi.context": { ok: true, context: { pending_approvals: [], active_actions: [] } },
+	});
+	const { deps: d3 } = deps(call3, "mis_x");
+	assert.equal(await shouldCancelTree(d3), null);
+});

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -167,6 +167,31 @@ class PiBridgeServer:
             except ValueError as exc:
                 return {"ok": False, "error": str(exc), "code": "CONTEXT_UNAVAILABLE"}
             return {"ok": True, "context": envelope.model_dump(mode="json")}
+        if method == "pi.mission.create":
+            # PNA-6（规格 §13）：/new /fork 的新 Mission——fork 强制
+            # SIMULATION，authority（grant/permit/approval）永不复制。
+            goal = str(params.get("goal", "")) or "ROSClaw pi session"
+            mode = str(params.get("mode", "SIMULATION")).upper()
+            if mode != "SIMULATION":
+                return {
+                    "ok": False,
+                    "error": "pi sessions may only create SIMULATION missions",
+                    "code": "MODE_FORBIDDEN",
+                }
+            mission = service.create_mission(goal, mode="SIMULATION")
+            return {"ok": True, "mission_id": mission.mission_id,
+                    "mode": mission.mode.value}
+        if method == "pi.session.binding.get":
+            binding = self._bindings.binding_for_session(str(params.get("pi_session_id", "")))
+            if binding is None:
+                return {"ok": True, "binding": None}
+            mission = service.get_mission(binding.mission_id)
+            return {
+                "ok": True,
+                "binding": binding.model_dump(mode="json"),
+                "mission_state": mission.state.value if mission else "MISSING",
+                "mission_archived": service.mission_archived(binding.mission_id),
+            }
         if method == "pi.worker.status":
             # PNA-4：Worker 状态投影（原位更新 UI 用；只读）。
             mission_id = str(params.get("mission_id", ""))

--- a/tests/agentd/test_pi_bridge.py
+++ b/tests/agentd/test_pi_bridge.py
@@ -175,3 +175,36 @@ class TestPiBridge:
         finally:
             await server.stop()
             await service.close()
+
+
+class TestLifecycleBridgeMethods:
+    async def test_mission_create_forces_sim_and_binding_get(self, tmp_path: Path) -> None:
+        service, server, sock = await _bridge(tmp_path)
+        try:
+            token = service.control_token
+            # fork/新建只允许 SIMULATION（规格 §13.2/§13.4）。
+            created = await operator_call(
+                sock, "pi.mission.create", {"token": token, "goal": "fork test", "mode": "REAL"}
+            )
+            assert not created["ok"] and created["code"] == "MODE_FORBIDDEN"
+            ok = await operator_call(
+                sock, "pi.mission.create", {"token": token, "goal": "fork test"}
+            )
+            assert ok["ok"] and ok["mode"] == "SIMULATION"
+            # binding.get：未绑定 → null；绑定后 → 返回绑定 + mission 状态。
+            missing = await operator_call(
+                sock, "pi.session.binding.get", {"token": token, "pi_session_id": "pi_x"}
+            )
+            assert missing["ok"] and missing["binding"] is None
+            await operator_call(
+                sock, "pi.session.bind",
+                {"token": token, "pi_session_id": "pi_x", "mission_id": ok["mission_id"]},
+            )
+            found = await operator_call(
+                sock, "pi.session.binding.get", {"token": token, "pi_session_id": "pi_x"}
+            )
+            assert found["binding"]["mission_id"] == ok["mission_id"]
+            assert found["mission_state"]
+        finally:
+            await server.stop()
+            await service.close()


### PR DESCRIPTION
重构规格 §13 批次。默认 engine 仍 legacy；REAL 门禁不变。

## Scope
- `session_start(new|fork)`：新建 SIM Mission 并绑定；fork 记来源 mission（只读历史）；**authority 结构性不复制**（grant/permit 只存 agentd，Pi session 里没有任何授权材料可复制）。
- `session_before_switch(resume)`：健康绑定直接重连；绑定丢失/mission 归档 → 不猜——新建 SIM 绑定（NEEDS_BINDING 安全默认）+ 明确提示。
- `session_before_tree`：有待决授权/进行中动作 → veto（fail closed；tree 永不回滚物理 lane）。
- 桥新增 `pi.mission.create`（仅 SIMULATION，否则 MODE_FORBIDDEN）与 `pi.session.binding.get`。

## 验证
- 生命周期 hook 矩阵 6 项 node 测试（fork 强制 SIM/authority 不复制/归档重绑/tree veto）；bridge 方法 python 测试；pi 套件全绿；ruff clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)