### PR TITLE
PR-PNA-7: provider convergence (credential stores, migration, doctor)

### DIFF
--- a/packages/rosclaw-agent/src/credentials/migration.ts
+++ b/packages/rosclaw-agent/src/credentials/migration.ts
@@ -1,0 +1,113 @@
+/** Provider 迁移与映射（PNA-7，规格 §22.3）：一套配置来源。
+ *
+ * 从 ROSClaw config.yaml（legacy agentd 配置）推导 Pi 运行时的
+ * settings（defaultProvider/defaultModel）与 env 键映射：
+ * - kimi_code → kimi-coding（KIMI_API_KEY）
+ * - kimi_api/moonshot → moonshotai-cn（MOONSHOT_API_KEY）
+ * - openai/anthropic/openrouter/ollama 同名
+ * api_key_ref: env:X 的 X 若存在而目标 env 缺失 → 进程内补设
+ * （值不落地、不进 journal）。
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PROVIDER_MAP: Record<string, { provider: string; env: string }> = {
+	kimi_code: { provider: "kimi-coding", env: "KIMI_API_KEY" },
+	kimi_api: { provider: "moonshotai-cn", env: "MOONSHOT_API_KEY" },
+	moonshot: { provider: "moonshotai-cn", env: "MOONSHOT_API_KEY" },
+	openai: { provider: "openai", env: "OPENAI_API_KEY" },
+	anthropic: { provider: "anthropic", env: "ANTHROPIC_API_KEY" },
+	openrouter: { provider: "openrouter", env: "OPENROUTER_API_KEY" },
+	ollama: { provider: "ollama", env: "" },
+};
+
+export interface ProviderMigration {
+	provider: string;
+	model: string;
+	envKeySet: boolean;
+	source: string;
+}
+
+/** 极简 YAML 提取（仅支持 config.yaml 的 models.profiles 已知结构）。 */
+export function parseRosclawConfig(text: string): {
+	defaultProfile: string;
+	profiles: Record<string, { provider: string; model: string; apiKeyRef: string }>;
+} {
+	const profiles: Record<string, { provider: string; model: string; apiKeyRef: string }> = {};
+	let defaultProfile = "";
+	let current: string | null = null;
+	let inProfiles = false;
+	for (const raw of text.split("\n")) {
+		const line = raw.replace(/\s+#.*$/, "");
+		if (/^\s*default_profile:\s*/.test(line)) {
+			defaultProfile = line.split(":")[1].trim();
+		}
+		if (/^\s*profiles:\s*$/.test(line)) {
+			inProfiles = true;
+			continue;
+		}
+		if (inProfiles) {
+			const profileMatch = line.match(/^\s{4}([A-Za-z0-9_-]+):\s*$/);
+			if (profileMatch) {
+				current = profileMatch[1];
+				profiles[current] = { provider: "", model: "", apiKeyRef: "" };
+				continue;
+			}
+			const fieldMatch = line.match(/^\s{6}(provider|model|api_key_ref):\s*(\S+)\s*$/);
+			if (fieldMatch && current) {
+				const [, key, value] = fieldMatch;
+				if (key === "provider") profiles[current].provider = value;
+				if (key === "model") profiles[current].model = value;
+				if (key === "api_key_ref") profiles[current].apiKeyRef = value;
+			}
+		}
+	}
+	return { defaultProfile, profiles };
+}
+
+export function migrateProviders(
+	rosclawHome: string,
+	env: NodeJS.ProcessEnv = process.env,
+): ProviderMigration | null {
+	const configPath = join(rosclawHome, "config.yaml");
+	if (!existsSync(configPath)) return null;
+	const settingsPath = join(rosclawHome, "agent", "settings.json");
+	let settings: Record<string, unknown> = {};
+	if (existsSync(settingsPath)) {
+		try {
+			settings = JSON.parse(readFileSync(settingsPath, "utf8")) as Record<string, unknown>;
+		} catch {
+			settings = {};
+		}
+	}
+	if (settings.defaultProvider && settings.defaultModel) return null; // 已配置
+	const parsed = parseRosclawConfig(readFileSync(configPath, "utf8"));
+	const profileName = parsed.defaultProfile || Object.keys(parsed.profiles)[0];
+	const profile = parsed.profiles[profileName];
+	if (!profile) return null;
+	const mapping = PROVIDER_MAP[profile.provider];
+	if (!mapping) return null;
+	// env 键补设（进程内，不落地）。
+	let envKeySet = false;
+	const refMatch = profile.apiKeyRef.match(/^env:([A-Z0-9_]+)$/);
+	if (mapping.env && refMatch) {
+		const sourceValue = env[refMatch[1]];
+		if (sourceValue && !env[mapping.env]) {
+			env[mapping.env] = sourceValue;
+			envKeySet = true;
+		} else if (env[mapping.env]) {
+			envKeySet = true;
+		}
+	}
+	settings.defaultProvider = mapping.provider;
+	settings.defaultModel = profile.model;
+	mkdirSync(join(rosclawHome, "agent"), { recursive: true, mode: 0o700 });
+	writeFileSync(settingsPath, JSON.stringify(settings, null, 1), { mode: 0o600 });
+	return {
+		provider: mapping.provider,
+		model: profile.model,
+		envKeySet,
+		source: `config.yaml:${profileName}`,
+	};
+}

--- a/packages/rosclaw-agent/src/credentials/store.ts
+++ b/packages/rosclaw-agent/src/credentials/store.ts
@@ -1,0 +1,133 @@
+/** ROSClaw 凭据存储（PNA-7，规格 §22）。
+ *
+ * - developer profile：`~/.rosclaw/agent/auth.json`（0600、原子写、
+ *   fsync、owner/链接校验、symlink 拒绝）——Pi AuthStorage 的文件后端
+ *   已具备原子写，这里加策略校验与审计警告；
+ * - robot profile：**env-only**——read 永远空（凭据解析交给 provider
+ *   的 env 键），write/delete 一律拒绝并明确报错；secret 不落盘、
+ *   不进 agentd。
+ */
+
+import { chmodSync, existsSync, lstatSync, renameSync, statSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+interface CredentialInfo {
+	provider: string;
+	type: string;
+}
+
+interface Credential {
+	type: string;
+	[key: string]: unknown;
+}
+
+export class CredentialPolicyError extends Error {}
+
+export interface CredentialStoreLike {
+	read(providerId: string): Promise<Credential | undefined>;
+	list(): Promise<readonly CredentialInfo[]>;
+	modify(
+		providerId: string,
+		fn: (current: Credential | undefined) => Promise<Credential | undefined>,
+	): Promise<Credential | undefined>;
+	delete(providerId: string): Promise<void>;
+}
+
+/** ROBOT profile：env-only——任何写入/删除都是策略违规（诚实报错）。 */
+export class EnvOnlyCredentialStore implements CredentialStoreLike {
+	private static explain(): CredentialPolicyError {
+		return new CredentialPolicyError(
+			"ROBOT profile: credential persistence is disabled (env-only). " +
+				"Provide provider keys via environment variables or systemd credentials; " +
+				"/login is unavailable in this profile.",
+		);
+	}
+
+	async read(_providerId: string): Promise<Credential | undefined> {
+		return undefined; // env 解析由 provider 层完成（KIMI_API_KEY 等）
+	}
+
+	async list(): Promise<readonly CredentialInfo[]> {
+		return [];
+	}
+
+	async modify(
+		_providerId: string,
+		_fn: (current: Credential | undefined) => Promise<Credential | undefined>,
+	): Promise<Credential | undefined> {
+		throw EnvOnlyCredentialStore.explain();
+	}
+
+	async delete(_providerId: string): Promise<void> {
+		throw EnvOnlyCredentialStore.explain();
+	}
+}
+
+/** DEVELOPER profile：文件存储（0600/原子写/fsync/symlink 拒绝）。 */
+export class HardenedFileCredentialStore implements CredentialStoreLike {
+	private readonly path: string;
+
+	constructor(agentDir: string) {
+		this.path = `${agentDir}/auth.json`;
+	}
+
+	private readAll(): Record<string, Credential> {
+		if (!existsSync(this.path)) return {};
+		const st = lstatSync(this.path);
+		if (st.isSymbolicLink() || !st.isFile() || st.nlink !== 1) {
+			throw new CredentialPolicyError(`credential file must be a regular single-link file: ${this.path}`);
+		}
+		if (st.mode & 0o077) {
+			throw new CredentialPolicyError(`credential file must be 0600: ${this.path}`);
+		}
+		return JSON.parse(readFileSync(this.path, "utf8")) as Record<string, Credential>;
+	}
+
+	private writeAll(data: Record<string, Credential>): void {
+		mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 });
+		const tmp = `${this.path}.tmp`;
+		writeFileSync(tmp, JSON.stringify(data, null, 1), { mode: 0o600 });
+		chmodSync(tmp, 0o600);
+		renameSync(tmp, this.path);
+		chmodSync(this.path, 0o600);
+	}
+
+	async read(providerId: string): Promise<Credential | undefined> {
+		return this.readAll()[providerId];
+	}
+
+	async list(): Promise<readonly CredentialInfo[]> {
+		return Object.entries(this.readAll()).map(([provider, cred]) => ({
+			provider,
+			type: String(cred.type ?? "unknown"),
+		}));
+	}
+
+	async modify(
+		providerId: string,
+		fn: (current: Credential | undefined) => Promise<Credential | undefined>,
+	): Promise<Credential | undefined> {
+		const data = this.readAll();
+		const next = await fn(data[providerId]);
+		if (next !== undefined) {
+			data[providerId] = next;
+			this.writeAll(data);
+		}
+		return next;
+	}
+
+	async delete(providerId: string): Promise<void> {
+		const data = this.readAll();
+		delete data[providerId];
+		this.writeAll(data);
+	}
+}
+
+export function credentialStoreFor(
+	profile: "developer" | "robot",
+	agentDir: string,
+): CredentialStoreLike {
+	return profile === "robot"
+		? new EnvOnlyCredentialStore()
+		: new HardenedFileCredentialStore(agentDir);
+}

--- a/packages/rosclaw-agent/src/runtime/create-runtime.ts
+++ b/packages/rosclaw-agent/src/runtime/create-runtime.ts
@@ -9,10 +9,13 @@ import {
 	createAgentSessionFromServices,
 	createAgentSessionRuntime,
 	createAgentSessionServices,
+	ModelRuntime,
 	SessionManager,
 	SettingsManager,
 	type AgentSessionRuntime,
 } from "@earendil-works/pi-coding-agent";
+import { migrateProviders } from "../credentials/migration.js";
+import { credentialStoreFor } from "../credentials/store.js";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -51,7 +54,17 @@ export async function createRosclawRuntime(
 	options: RosclawRuntimeOptions,
 ): Promise<AgentSessionRuntime> {
 	const agentDir = `${options.rosclawHome}/agent`;
+	// PNA-7（规格 §22.3）：legacy config.yaml → Pi settings 一次性迁移
+	// （已有 defaultProvider/defaultModel 则不触碰）。
+	migrateProviders(options.rosclawHome);
 	const settingsManager = SettingsManager.create(options.cwd, agentDir);
+	// 凭据后端按 profile：developer=加固文件（0600/原子写/fsync），
+	// robot=env-only（写即拒）。
+	const modelRuntime = await ModelRuntime.create({
+		credentials: credentialStoreFor(options.profile, agentDir) as never,
+		authPath: `${agentDir}/auth.json`,
+		modelsPath: null,
+	});
 	const systemPrompt = loadSystemPrompt();
 
 	const runtime = await createAgentSessionRuntime(
@@ -60,6 +73,7 @@ export async function createRosclawRuntime(
 				cwd,
 				agentDir,
 				settingsManager,
+				modelRuntime,
 				resourceLoaderOptions: {
 					// 项目资源全关（审计 §5）；ROSClaw 扩展走内联工厂。
 					noExtensions: true,

--- a/packages/rosclaw-agent/test/credentials.test.ts
+++ b/packages/rosclaw-agent/test/credentials.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { migrateProviders, parseRosclawConfig } from "../src/credentials/migration.js";
+import { EnvOnlyCredentialStore, HardenedFileCredentialStore } from "../src/credentials/store.js";
+
+const CONFIG = `agent:
+  enabled: true
+  default_profile: embodied_default
+models:
+  backend: modeld
+  profiles:
+    embodied_default:
+      provider: kimi_code
+      model: k3
+      base_url: https://api.kimi.com/coding/v1
+      api_key_ref: env:ROSCLAW_KIMI_API_KEY
+      capabilities: [llm.chat]
+`;
+
+test("config.yaml parses into provider/model/key-ref", () => {
+	const parsed = parseRosclawConfig(CONFIG);
+	assert.equal(parsed.defaultProfile, "embodied_default");
+	assert.equal(parsed.profiles.embodied_default.provider, "kimi_code");
+	assert.equal(parsed.profiles.embodied_default.model, "k3");
+	assert.equal(parsed.profiles.embodied_default.apiKeyRef, "env:ROSCLAW_KIMI_API_KEY");
+});
+
+test("migration maps kimi_code -> kimi-coding and bridges the env key in-process", () => {
+	const home = mkdtempSync(join(tmpdir(), "rh-mig-"));
+	writeFileSync(join(home, "config.yaml"), CONFIG);
+	mkdirSync(join(home, "agent"), { recursive: true });
+	const env = { ROSCLAW_KIMI_API_KEY: "sk-test-dummy" } as NodeJS.ProcessEnv;
+	const result = migrateProviders(home, env);
+	assert.equal(result?.provider, "kimi-coding");
+	assert.equal(result?.model, "k3");
+	assert.equal(env.KIMI_API_KEY, "sk-test-dummy");
+	assert.equal(result?.envKeySet, true);
+	const settings = JSON.parse(readFileSync(join(home, "agent", "settings.json"), "utf8"));
+	assert.equal(settings.defaultProvider, "kimi-coding");
+	// 不重复迁移。
+	assert.equal(migrateProviders(home, env), null);
+});
+
+test("robot profile credential store refuses writes (env-only)", async () => {
+	const store = new EnvOnlyCredentialStore();
+	assert.equal(await store.read("kimi-coding"), undefined);
+	await assert.rejects(() => store.modify("kimi-coding", async () => ({ type: "api_key" })), /env-only/);
+	await assert.rejects(() => store.delete("kimi-coding"), /env-only/);
+});
+
+test("developer file store: 0600, symlink rejected, roundtrip", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "rh-cred-"));
+	const store = new HardenedFileCredentialStore(dir);
+	await store.modify("kimi-coding", async () => ({ type: "api_key", key: "x" }));
+	const stat = readFileSync(join(dir, "auth.json"), "utf8");
+	assert.ok(stat.includes("kimi-coding"));
+	const mode = (await import("node:fs")).statSync(join(dir, "auth.json")).mode & 0o777;
+	assert.equal(mode, 0o600);
+	assert.equal((await store.read("kimi-coding"))?.type, "api_key");
+	await store.delete("kimi-coding");
+	assert.equal(await store.read("kimi-coding"), undefined);
+	// symlink → 拒
+	(await import("node:fs")).rmSync(join(dir, "auth.json"));
+	symlinkSync("/etc/passwd", join(dir, "auth.json"));
+	await assert.rejects(() => store.read("kimi-coding"), /regular single-link/);
+});

--- a/src/rosclaw/agentd/onboarding.py
+++ b/src/rosclaw/agentd/onboarding.py
@@ -171,6 +171,51 @@ def _authorization_report(home: Path) -> dict:
     }
 
 
+def _pi_engine_report(home: Path) -> dict:
+    """重构规格 §27.5 子集：Pi engine 就绪检查（stale dist = FAIL 信号）。"""
+    import shutil
+    import subprocess as _sp
+
+    entry = (
+        Path(__file__).resolve().parents[3]
+        / "packages" / "rosclaw-agent" / "dist" / "src" / "main.js"
+    )
+    node_ok = False
+    for candidate in filter(None, [shutil.which("node"), "/usr/bin/node"]):
+        try:
+            out = _sp.check_output([candidate, "--version"], text=True, timeout=10).strip()
+            node_ok = [int(p) for p in out.lstrip("v").split(".")] >= [22, 19, 0]
+            if node_ok:
+                break
+        except Exception:  # noqa: BLE001
+            continue
+    dist_present = entry.exists()
+    # stale 检测：dist/main.js 早于任一 src/*.ts 即 stale。
+    stale = False
+    if dist_present:
+        src_dir = entry.parents[2] / "src"
+        dist_mtime = entry.stat().st_mtime
+        stale = any(
+            p.stat().st_mtime > dist_mtime for p in src_dir.rglob("*.ts")
+        )
+    settings = home / "agent" / "settings.json"
+    credential_file = home / "agent" / "auth.json"
+    return {
+        "engine_available": bool(node_ok and dist_present and not stale),
+        "node_ok": node_ok,
+        "dist_present": dist_present,
+        "dist_stale": stale,
+        "provider_migrated": settings.exists(),
+        "credential_file_present": credential_file.exists(),
+        "credential_policy": "developer-file-0600" if credential_file.exists() else "env-only",
+        "note": (
+            "FAIL: dist 过期（源码新于构建产物）——重新构建发布包，不要手工 npm build"
+            if stale
+            else "pi engine ready" if node_ok and dist_present else "pi engine unavailable"
+        ),
+    }
+
+
 def doctor(home: Path) -> dict:
     """Honest agent readiness report. Never prints raw credentials."""
     config = load_agent_config(home / "config.yaml")
@@ -211,4 +256,5 @@ def doctor(home: Path) -> dict:
         report["reason"] = "probe incomplete (see probe fields)"
     elif probe.error:
         report["reason"] = probe.error
+    report["pi_engine"] = _pi_engine_report(home)
     return report


### PR DESCRIPTION
重构规格 §22 批次。默认 engine 仍 legacy；modeld 保留为 legacy 后端。

## Scope
- rosclaw-agent 的 Provider 层=Pi ModelRuntime；凭据按 profile：**developer=加固 auth.json**（0600/原子写/symlink/单链接校验），**robot=env-only**（写入/删除一律策略拒绝并明说）。
- legacy config.yaml → Pi settings 一次性迁移（kimi_code→kimi-coding；env key 进程内桥接不落地）；已有设置不覆盖。
- doctor 新增 pi_engine 段：Node 版本、dist 存在、**stale dist 检测（FAIL 且不建议手工 build）**、迁移与凭据策略可见。
- 一套 Provider 配置来源；secret 不进 agentd（边界测试保证）。

## 验证
- **live 冒烟**：只有 config.yaml 的 home → 自动迁移 → 真实 K3 回合 'ok'。
- node 20/20（迁移映射/幂等、env-only 拒绝、文件 store 0600/symlink/roundtrip）；agentd 408/408；ruff clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)