### PR TITLE
fix(agentd): match DecisionV1 stream marker whitespace-insensitively

### DIFF
--- a/src/rosclaw/agentd/stream_filter.py
+++ b/src/rosclaw/agentd/stream_filter.py
@@ -11,9 +11,20 @@ from __future__ import annotations
 from collections.abc import Callable
 
 _MARKER = '"schema_version": "rosclaw.decision.v1"'
+#: whitespace-insensitive marker form (models may emit compact JSON)
+_MARKER_COMPACT = "".join(_MARKER.split())
 _FENCE = "```"
 #: max chars after a fence that may still turn into a decision block
 _LOOKAHEAD = len(_MARKER) + 16
+
+
+def _is_decision_tail(tail: str) -> bool:
+    """True when the fence tail contains the DecisionV1 marker.
+
+    Whitespace-insensitive: ``"schema_version":"..."`` (compact JSON) and
+    ``"schema_version": "..."`` are the same protocol block.
+    """
+    return _MARKER_COMPACT in "".join(tail.split())
 
 
 class DecisionBlockFilter:
@@ -38,7 +49,7 @@ class DecisionBlockFilter:
         text = self._pending
         self._pending = ""
         fence = text.find(_FENCE)
-        if fence != -1 and _MARKER in text[fence:]:
+        if fence != -1 and _is_decision_tail(text[fence:]):
             text = text[:fence]
         if text:
             self._sink(text)
@@ -59,7 +70,7 @@ class DecisionBlockFilter:
                 self._sink(before)
             self._pending = self._pending[fence:]
             tail = self._pending
-            if _MARKER in tail:
+            if _is_decision_tail(tail):
                 self._suppressing = True
                 self._pending = ""
                 return

--- a/tests/agentd/test_stream_filter.py
+++ b/tests/agentd/test_stream_filter.py
@@ -45,3 +45,14 @@ class TestFilter:
         # remainder is correct. But if no marker follows, prose survives.
         text = '前文```json\n{"other": 1}\n```后文'
         assert _run([text]) == text
+
+    def test_compact_json_decision_block_hidden(self) -> None:
+        # Models may emit compact JSON (no space after colons); the marker
+        # match must be whitespace-tolerant or the protocol block leaks.
+        compact = DECISION.replace('": ', '":')
+        assert _run(["回答。", compact]) == "回答。"
+
+    def test_compact_json_split_across_deltas(self) -> None:
+        compact = "正文" + DECISION.replace('": ', '":')
+        pieces = [compact[i : i + 5] for i in range(0, len(compact), 5)]
+        assert _run(pieces) == "正文"


### PR DESCRIPTION
## Problem

`DecisionBlockFilter` detects streamed decision blocks via the literal marker

```
"schema_version": "rosclaw.decision.v1"   # note the space
```

When the model emits **compact JSON** (`"schema_version":"rosclaw.decision.v1"`, no space), the marker never matches and the machine-protocol block leaks into the user-visible reply:

```
ROSClaw> 你好，我是 Kimi...
```json
{"schema_version":"rosclaw.decision.v1","decision_id":...}
```
```

(observed live on the K3 endpoint in `--basic` chat)

## Fix

Compare a whitespace-stripped marker (`"schema_version":"rosclaw.decision.v1"`) against the whitespace-stripped fence tail — spaced and compact forms are the same protocol block. Substring semantics and lookahead window unchanged.

## Tests

Two new regression tests: compact block hidden; compact block split across 5-char deltas hidden. 31/31 pass (filter + loop + tools), ruff + mypy clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>