### PR TITLE
PR-PNA-9: resource security profiles + input guard

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -18,6 +18,7 @@ import {
 import { defaultOperatorSocket, operatorCall } from "../bridge/operatord-client.js";
 import { ApprovalCardComponent } from "../ui/approval-card.js";
 import { EventMirror } from "./event-mirror.js";
+import { guardInput } from "./input-guard.js";
 import { fetchEmbodiedContext, renderTrustedContext } from "./context-injection.js";
 
 export interface RosclawExtensionOptions {
@@ -220,6 +221,20 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			} catch (err) {
 				ctx.ui.notify(`授权卡交互失败：${(err as Error).message}`, "error");
 			}
+		});
+
+		// -- 输入防护（PNA-9，规格 §11）：未知命令不发模型；ROBOT 拦 trust/share --
+		pi.on("input", async (event, ctx) => {
+			if (event.source !== "interactive") return undefined;
+			const verdict = guardInput(event.text, options.profile);
+			if (verdict.action === "handled") {
+				ctx.ui.notify(verdict.notice ?? "blocked", "warning");
+				return { action: "handled" };
+			}
+			if (verdict.action === "transform") {
+				return { action: "transform", text: verdict.text ?? event.text };
+			}
+			return { action: "continue" };
 		});
 
 		// -- 认知事件镜像（PNA-8，规格 §24.2）：hash-only，不双写全文 ----------

--- a/packages/rosclaw-agent/src/extension/input-guard.ts
+++ b/packages/rosclaw-agent/src/extension/input-guard.ts
@@ -1,0 +1,83 @@
+/** 输入防护（PNA-9，规格 §11）。
+ *
+ * - 未知 slash 命令：不发模型，提示不存在（//text 显式转义发送普通文本）；
+ * - ROBOT profile：/trust /share /import 一律拦截（内建 dispatch 先于
+ *   input 事件，所以这里兜底的是非内建变形与直接文本注入）；
+ * - 已知内建命令与 ROSClaw 命令放行。
+ */
+
+export interface InputGuardResult {
+	action: "continue" | "handled" | "transform";
+	text?: string;
+	notice?: string;
+}
+
+const ROSCLAW_COMMANDS = new Set([
+	"/workers",
+	"/delegate",
+	"/worker-jobs",
+	"/mission",
+	"/body",
+	"/mode",
+	"/status",
+	"/tools",
+	"/approvals",
+	"/grants",
+	"/revoke",
+	"/evidence",
+	"/memory",
+	"/doctor",
+	"/estop",
+]);
+
+// Pi 内建（审计 §4 全表）——放行进内建 dispatch。
+const PI_BUILTINS = new Set([
+	"/settings",
+	"/model",
+	"/scoped-models",
+	"/export",
+	"/import",
+	"/share",
+	"/copy",
+	"/name",
+	"/session",
+	"/changelog",
+	"/hotkeys",
+	"/fork",
+	"/clone",
+	"/tree",
+	"/trust",
+	"/login",
+	"/logout",
+	"/new",
+	"/compact",
+	"/resume",
+	"/reload",
+	"/quit",
+]);
+
+// ROBOT profile 下禁止的内建（语义与 ROSClaw 信任模型冲突）。
+const ROBOT_BLOCKED = new Set(["/trust", "/share", "/import", "/reload"]);
+
+export function guardInput(raw: string, profile: "robot" | "developer"): InputGuardResult {
+	const text = raw.trim();
+	if (!text.startsWith("/")) return { action: "continue" };
+	if (text.startsWith("//")) {
+		// 显式转义：作为普通文本发送。
+		return { action: "transform", text: text.slice(1) };
+	}
+	const name = text.split(/\s/, 1)[0].toLowerCase();
+	if (profile === "robot" && ROBOT_BLOCKED.has(name)) {
+		return {
+			action: "handled",
+			notice: `${name} 在 ROBOT profile 下禁用（授权与信任由 ROSClaw operatord/门禁管理）`,
+		};
+	}
+	if (ROSCLAW_COMMANDS.has(name) || PI_BUILTINS.has(name)) {
+		return { action: "continue" };
+	}
+	return {
+		action: "handled",
+		notice: `未知命令 ${name}（不会发送给模型）。发送普通文本请用 // 前缀或去掉开头的 /`,
+	};
+}

--- a/packages/rosclaw-agent/src/extension/resource-policy.ts
+++ b/packages/rosclaw-agent/src/extension/resource-policy.ts
@@ -1,0 +1,60 @@
+/** 资源安全策略（PNA-9，规格 §10）。
+ *
+ * - robot：机器人/SHADOW/REAL——全部项目资源禁止，凭据 env-only；
+ * - developer：桌面开发/SIM——允许用户级主题，项目资源仍需显式批准
+ *   （默认不加载 .pi/extensions、AGENTS.md、~/.agents/skills）；
+ * - worker：headless 原生 Worker——无 ROS 网络/控制 socket/机器人设备，
+ *   仅 WorkOrder 指定目录的只读文件工具（本包内不启用任何文件工具，
+ *   worker sandbox 的文件能力由 WorkerPack 侧实现并验证）。
+ */
+
+export type ResourceProfile = "robot" | "developer" | "worker";
+
+export interface ResourcePolicy {
+	noExtensions: boolean;
+	noSkills: boolean;
+	noPromptTemplates: boolean;
+	noThemes: boolean;
+	noContextFiles: boolean;
+	credentialPolicy: "env-only" | "file-0600";
+	allowBash: boolean;
+	allowFileTools: boolean;
+}
+
+export function resourcePolicy(profile: ResourceProfile): ResourcePolicy {
+	switch (profile) {
+		case "robot":
+			return {
+				noExtensions: true,
+				noSkills: true,
+				noPromptTemplates: true,
+				noThemes: true,
+				noContextFiles: true,
+				credentialPolicy: "env-only",
+				allowBash: false,
+				allowFileTools: false,
+			};
+		case "developer":
+			return {
+				noExtensions: true, // 项目扩展默认不加载（显式批准机制后续批次）
+				noSkills: true,
+				noPromptTemplates: true,
+				noThemes: false, // 用户主题允许
+				noContextFiles: true, // AGENTS.md 不注入（具身注入走 envelope）
+				credentialPolicy: "file-0600",
+				allowBash: false,
+				allowFileTools: false,
+			};
+		case "worker":
+			return {
+				noExtensions: true,
+				noSkills: true,
+				noPromptTemplates: true,
+				noThemes: true,
+				noContextFiles: true,
+				credentialPolicy: "env-only",
+				allowBash: false,
+				allowFileTools: false, // WorkerPack 侧按 WorkOrder 授权
+			};
+	}
+}

--- a/packages/rosclaw-agent/src/runtime/create-runtime.ts
+++ b/packages/rosclaw-agent/src/runtime/create-runtime.ts
@@ -16,6 +16,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { migrateProviders } from "../credentials/migration.js";
 import { credentialStoreFor } from "../credentials/store.js";
+import { resourcePolicy } from "../extension/resource-policy.js";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -75,12 +76,18 @@ export async function createRosclawRuntime(
 				settingsManager,
 				modelRuntime,
 				resourceLoaderOptions: {
-					// 项目资源全关（审计 §5）；ROSClaw 扩展走内联工厂。
-					noExtensions: true,
-					noSkills: true,
-					noPromptTemplates: true,
-					noThemes: true,
-					noContextFiles: true,
+					// PNA-9：profile 化资源策略（robot 全禁；developer 仅用户
+					// 主题；项目 .pi/AGENTS.md/skills 一律不加载）。
+					...(function () {
+						const policy = resourcePolicy(options.profile);
+						return {
+							noExtensions: policy.noExtensions,
+							noSkills: policy.noSkills,
+							noPromptTemplates: policy.noPromptTemplates,
+							noThemes: policy.noThemes,
+							noContextFiles: policy.noContextFiles,
+						};
+					})(),
 					extensionFactories: [
 						{
 							name: "rosclaw",

--- a/packages/rosclaw-agent/test/security.test.ts
+++ b/packages/rosclaw-agent/test/security.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { guardInput } from "../src/extension/input-guard.js";
+import { resourcePolicy } from "../src/extension/resource-policy.js";
+
+test("unknown slash command is handled, never sent to the model", () => {
+	const verdict = guardInput("/evilcommand do something", "developer");
+	assert.equal(verdict.action, "handled");
+	assert.match(verdict.notice ?? "", /未知命令/);
+});
+
+test("//text escape transforms to plain text", () => {
+	const verdict = guardInput("//model 其实是文本", "developer");
+	assert.equal(verdict.action, "transform");
+	assert.equal(verdict.text, "/model 其实是文本");
+});
+
+test("robot profile blocks /trust /share /import /reload", () => {
+	for (const cmd of ["/trust", "/share", "/import", "/reload"]) {
+		const verdict = guardInput(`${cmd} something`, "robot");
+		assert.equal(verdict.action, "handled", cmd);
+		assert.match(verdict.notice ?? "", /禁用/);
+	}
+	// developer profile 放行给内建语义。
+	assert.equal(guardInput("/trust", "developer").action, "continue");
+});
+
+test("known commands pass through", () => {
+	for (const cmd of ["/model", "/resume", "/workers", "/delegate", "/estop"]) {
+		assert.equal(guardInput(cmd, "robot").action, "continue", cmd);
+	}
+});
+
+test("resource policy per profile", () => {
+	const robot = resourcePolicy("robot");
+	assert.ok(robot.noExtensions && robot.noSkills && robot.noContextFiles && robot.noThemes);
+	assert.equal(robot.credentialPolicy, "env-only");
+	assert.equal(robot.allowBash, false);
+	const developer = resourcePolicy("developer");
+	assert.equal(developer.noThemes, false, "developer 允许用户主题");
+	assert.equal(developer.credentialPolicy, "file-0600");
+	const worker = resourcePolicy("worker");
+	assert.equal(worker.allowFileTools, false);
+	assert.equal(worker.credentialPolicy, "env-only");
+});


### PR DESCRIPTION
重构规格 §10/§11 批次。

## Scope
- profile 资源策略表：robot（项目资源全禁 + env-only 凭据 + 无 bash/文件工具）、developer（用户主题放行；项目扩展/skills/AGENTS.md 仍禁）、worker（锁定，文件能力归 WorkerPack 侧）。
- InputGuard：未知 slash 命令本地处理**绝不进模型**（//text 转义发普通文本）；robot profile 拦 /trust /share /import /reload。
- `!` 维持 PNA-0 的 user_bash 全替换；loader 选项改由 profile 策略驱动。

## 验证
- 防护矩阵 + 策略表 node 测试（28/28）；ruff clean；不触碰 legacy。

🤖 Generated with [Claude Code](https://claude.com/claude-code)