### PR TITLE
PR-PNA-10: release gates (clean build, bundled runtime, installed-artifact PTY)

### DIFF
--- a/packages/rosclaw-agent/src/main.ts
+++ b/packages/rosclaw-agent/src/main.ts
@@ -5,10 +5,13 @@
  * Pi 是唯一主认知循环（规格 §2.1）——本进程不启动 Python AgentLoop。
  */
 
-import { InteractiveMode, runPrintMode } from "@earendil-works/pi-coding-agent";
-import { createRosclawRuntime } from "./runtime/create-runtime.js";
-import { bindSession, releaseSession, type SessionBinding } from "./session/binding.js";
+// PI_CODING_AGENT_DIR 必须在任何 pi 模块加载前设定（config.js 在
+// import 期读取；ESM 静态 import 会被提升）——所有 pi 相关模块一律
+// 动态 import。
 import { VERSION } from "./version.js";
+
+const rosclawHomeEnv = process.env.ROSCLAW_HOME ?? `${process.env.HOME}/.rosclaw`;
+process.env.PI_CODING_AGENT_DIR ??= `${rosclawHomeEnv}/agent`;
 
 interface CliArgs {
 	profile: "developer" | "robot";
@@ -40,8 +43,11 @@ function parseArgs(argv: string[]): CliArgs {
 }
 
 async function main(): Promise<number> {
+	const { InteractiveMode, runPrintMode } = await import("@earendil-works/pi-coding-agent");
+	const { createRosclawRuntime } = await import("./runtime/create-runtime.js");
+	const { bindSession, releaseSession } = await import("./session/binding.js");
 	const { profile, initialMessage, print, missionId } = parseArgs(process.argv.slice(2));
-	const rosclawHome = process.env.ROSCLAW_HOME ?? `${process.env.HOME}/.rosclaw`;
+	const rosclawHome = rosclawHomeEnv;
 	const runtime = await createRosclawRuntime({
 		cwd: process.cwd(),
 		rosclawHome,
@@ -51,6 +57,7 @@ async function main(): Promise<number> {
 	});
 	// PNA-1：启动即绑定 Mission + 获取 writer lease（失败即退出——
 	// 不猜绑定、不无 lease 运行，规格 §13.1/§12）。
+	type SessionBinding = Awaited<ReturnType<typeof bindSession>>;
 	let binding: SessionBinding | undefined;
 	if (missionId) {
 		binding = await bindSession(

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -28,10 +28,10 @@ rsync -a --exclude '__pycache__' --exclude '*.pyc' \
 for pkg in rosclaw-tui rosclaw-modeld rosclaw-agent; do
   src_dir="$REPO_ROOT/packages/$pkg"
   [ -d "$src_dir" ] || { echo "missing packages/$pkg" >&2; exit 1; }
-  if [ ! -d "$src_dir/dist/src" ]; then
-    echo "==> building packages/$pkg"
-    (cd "$src_dir" && npm ci --silent && npm run build --silent)
-  fi
+  # 规格 §27.1：clean build——绝不用"dist 存在即跳过"（stale dist 是
+  # 必须消除的事故源）。
+  echo "==> clean-building packages/$pkg"
+  (cd "$src_dir" && rm -rf dist && npm ci --silent && npm run build --silent)
   mkdir -p "$STAGE/packages/$pkg"
   cp -r "$src_dir/dist" "$src_dir/package.json" "$src_dir/package-lock.json" \
         "$src_dir/tsconfig.json" "$STAGE/packages/$pkg/"
@@ -99,7 +99,16 @@ PY
 # 不访问 PyPI/npm。
 mkdir -p "$STAGE/vendor/wheels" "$STAGE/vendor/node_modules_pack"
 # R6：离线包缺 wheel 是硬失败（不再 warning 后继续）。
-"$REPO_ROOT/.venv/bin/python" -m pip download   --disable-pip-version-check --quiet --dest "$STAGE/vendor/wheels"   "$REPO_ROOT" || {
+# 构建后端（hatchling）也必须进 wheels——PEP 517 离线构建 rosclaw 自身
+# 需要它（R6/PNA-10：缺 wheel 已在安装侧硬失败，这里补齐来源）。
+# rosclaw 自身打成 wheel 进 vendor（force-include 数据随 wheel 走；
+# 安装侧离线不再从源码目录跑 hatch 构建）。
+"$REPO_ROOT/.venv/bin/python" -m pip wheel --no-deps --quiet \
+  --wheel-dir "$STAGE/vendor/wheels" "$REPO_ROOT" || {
+    echo "FAIL: rosclaw wheel 构建失败，拒绝产出。" >&2
+    exit 1
+  }
+"$REPO_ROOT/.venv/bin/python" -m pip download   --disable-pip-version-check --quiet --dest "$STAGE/vendor/wheels"   "$REPO_ROOT" hatchling setuptools wheel || {
     echo "FAIL: pip download 不完整——离线包将缺 wheels，拒绝产出。" >&2
     exit 1
   }
@@ -112,7 +121,98 @@ for pkg in rosclaw-tui rosclaw-modeld rosclaw-agent; do
   tar -C "$REPO_ROOT/packages/$pkg" -czf "$STAGE/vendor/node_modules_pack/$pkg.tar.gz" node_modules
 done
 
-# 6. manifest（含各组件 hash 供回滚校验 + 签名输入）
+# 6. build-info.json（规格 §27.2）：commit/版本/hash/Node 版本可追溯。
+python3 - "$STAGE" "$VERSION" <<'PY'
+import hashlib, json, subprocess, sys
+from pathlib import Path
+
+stage, version = Path(sys.argv[1]), sys.argv[2]
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+def _tree_sha(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            digest.update(str(path.relative_to(root)).encode())
+            digest.update(path.read_bytes())
+    return digest.hexdigest()
+try:
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+except Exception:
+    commit = ""
+node_version = subprocess.check_output(["node", "--version"], text=True).strip()     if subprocess.call(["bash", "-c", "command -v node >/dev/null"]) == 0 else ""
+info = {
+    "rosclaw_commit": commit,
+    "pi_version": "0.83.0",
+    "pi_commit": "588915ec71714688cee8b7153339e8bdebb3e82e",
+    "node_version": node_version,
+    "packages": {},
+}
+for pkg in ("rosclaw-tui", "rosclaw-modeld", "rosclaw-agent"):
+    pkg_dir = stage / "packages" / pkg
+    lock = pkg_dir / "package-lock.json"
+    dist = pkg_dir / "dist"
+    info["packages"][pkg] = {
+        "package_lock_sha256": _sha(lock) if lock.exists() else "",
+        "dist_sha256": _tree_sha(dist) if dist.exists() else "",
+    }
+(stage / "build-info.json").write_text(json.dumps(info, indent=1))
+print("build-info written")
+PY
+
+# 7. bundled Node runtime（规格 §27.4）：目标机无需预装 Node。
+# 构建机需网络下载一次；ROSCLAW_SKIP_NODE_BUNDLE=1 可跳过（降级为前置条件）。
+if [ "${ROSCLAW_SKIP_NODE_BUNDLE:-0}" != "1" ]; then
+  NODE_VER="22.19.0"
+  case "$ARCH_NAME" in
+    arm64) NODE_ARCH="arm64" ;;
+    x64)   NODE_ARCH="x64" ;;
+  esac
+  NODE_TARBALL="node-v${NODE_VER}-linux-${NODE_ARCH}.tar.xz"
+  if [ ! -f "$DIST_DIR/vendor-cache/$NODE_TARBALL" ]; then
+    mkdir -p "$DIST_DIR/vendor-cache"
+    for mirror in "https://registry.npmmirror.com/-/binary/node/v${NODE_VER}"                   "https://nodejs.org/dist/v${NODE_VER}"; do
+      curl -fsSL "$mirror/$NODE_TARBALL" -o "$DIST_DIR/vendor-cache/$NODE_TARBALL" && break || true
+    done
+  fi
+  if [ -s "$DIST_DIR/vendor-cache/$NODE_TARBALL" ]; then
+    mkdir -p "$STAGE/vendor/node-runtime"
+    tar -C "$STAGE/vendor/node-runtime" -xJf "$DIST_DIR/vendor-cache/$NODE_TARBALL" --strip-components=1
+    echo "==> bundled node v${NODE_VER} (${NODE_ARCH})"
+  else
+    echo "FAIL: 无法获得 Node runtime（离线构建请预置 $DIST_DIR/vendor-cache/$NODE_TARBALL）" >&2
+    exit 1
+  fi
+fi
+
+# 9.5 fd/ripgrep 二进制（Pi InteractiveMode 初始化必需；离线目标机不能
+# 现场下载）。经 ghfast 代理取 GitHub release 二进制。
+if [ "${ROSCLAW_SKIP_TOOL_BINS:-0}" != "1" ]; then
+  mkdir -p "$STAGE/vendor/tool-bins" "$DIST_DIR/vendor-cache"
+  case "$ARCH_NAME" in
+    arm64) FD_ARCH="aarch64-unknown-linux-gnu"; RG_ARCH="aarch64-unknown-linux-gnu" ;;
+    x64)   FD_ARCH="x86_64-unknown-linux-gnu";   RG_ARCH="x86_64-unknown-linux-gnu" ;;
+  esac
+  FD_TARBALL="fd-v10.2.0-${FD_ARCH}.tar.gz"
+  RG_TARBALL="ripgrep-14.1.1-${RG_ARCH}.tar.gz"
+  for pair in "sharkdp/fd:v10.2.0:$FD_TARBALL" "BurntSushi/ripgrep:14.1.1:$RG_TARBALL"; do
+    repo="${pair%%:*}"; rest="${pair#*:}"; tag="${rest%%:*}"; tarball="${rest#*:}"
+    cache="$DIST_DIR/vendor-cache/$tarball"
+    if [ ! -s "$cache" ]; then
+      curl -fsSL "https://ghfast.top/https://github.com/$repo/releases/download/$tag/$tarball" -o "$cache" || \
+        curl -fsSL "https://github.com/$repo/releases/download/$tag/$tarball" -o "$cache" || {
+          echo "FAIL: 无法获得 $tarball（离线构建请预置 $cache）" >&2; exit 1; }
+    fi
+  done
+  tar -C "$DIST_DIR/vendor-cache" -xzf "$DIST_DIR/vendor-cache/$FD_TARBALL" "fd-v10.2.0-${FD_ARCH}/fd"
+  cp "$DIST_DIR/vendor-cache/fd-v10.2.0-${FD_ARCH}/fd" "$STAGE/vendor/tool-bins/fd"
+  tar -C "$DIST_DIR/vendor-cache" -xzf "$DIST_DIR/vendor-cache/$RG_TARBALL" "ripgrep-14.1.1-${RG_ARCH}/rg"
+  cp "$DIST_DIR/vendor-cache/ripgrep-14.1.1-${RG_ARCH}/rg" "$STAGE/vendor/tool-bins/rg"
+  chmod +x "$STAGE/vendor/tool-bins/fd" "$STAGE/vendor/tool-bins/rg"
+  echo "==> vendored fd/rg binaries"
+fi
+
+# 8. manifest（含各组件 hash 供回滚校验 + 签名输入——必须最后于内容）
 python3 - "$STAGE" "$VERSION" "$ARCH_NAME" <<'PY'
 import hashlib, json, sys
 from pathlib import Path
@@ -130,7 +230,7 @@ manifest = {
 (stage / "manifest.json").write_text(json.dumps(manifest, indent=1))
 PY
 
-# 7. 分离签名（审计 P0-05.3）：dev 签名密钥在本机（不入库），
+# 9. 分离签名（审计 P0-05.3）：dev 签名密钥在本机（不入库），
 # 公钥随包发布；安装器先验签再执行任何脚本。
 SIGN_DIR="${ROSCLAW_SIGNING_HOME:-$HOME/.rosclaw/signing}"
 if [ ! -f "$SIGN_DIR/dev-signing-private.pem" ]; then

--- a/scripts/release/install_release.sh
+++ b/scripts/release/install_release.sh
@@ -97,12 +97,17 @@ for rel, expected in manifest["files"].items():
     if actual != expected:
         bad.append(f"tampered: {rel}")
 for path in sorted(root.rglob("*")):
-    if path.is_file() or path.is_symlink():
+    if path.is_symlink():
+        # 只允许解析后仍在包内的相对 symlink（bundled node 的 bin  shim）；
+        # 绝对链接/逃逸链接一律拒（R6 的本意是防穿越与外泄）。
+        target = path.resolve()
+        if not str(target).startswith(str(root.resolve())) or not target.exists():
+            bad.append(f"unsafe symlink in bundle: {path.relative_to(root)}")
+        continue
+    if path.is_file():
         rel = str(path.relative_to(root))
         if rel not in manifest["files"] and rel not in allowed_extra:
             bad.append(f"unlisted file (extra-file rejection): {rel}")
-    if path.is_symlink():
-        bad.append(f"symlink not allowed in bundle: {path.relative_to(root)}")
 if bad:
     print("\n".join(bad), file=sys.stderr)
     sys.exit(2)
@@ -120,14 +125,25 @@ if [ "$OFFLINE" = "1" ]; then
   # R6：离线模式缺 wheel 是硬失败，不是 warning。
   [ -d "$NEXT/vendor/wheels" ] && [ -n "$(ls -A "$NEXT/vendor/wheels" 2>/dev/null)" ] || {
     echo "离线安装但 vendor/wheels 为空——构建期 pip download 不完整，拒绝继续。" >&2; exit 2; }
+  # PNA-10：离线只装 wheel（force-include 数据随 wheel；不从源码目录
+  # 重新跑 hatch 构建——stage 里没有那些数据目录）。
+  ls "$NEXT"/vendor/wheels/rosclaw-*.whl >/dev/null 2>&1 || {
+    echo "离线包缺 rosclaw 自身 wheel，拒绝继续。" >&2; exit 2; }
   "$NEXT/.venv/bin/pip" install --quiet --no-index \
-    --find-links "$NEXT/vendor/wheels" "$NEXT"
+    --find-links "$NEXT/vendor/wheels" rosclaw
 else
   "$NEXT/.venv/bin/pip" install --quiet "$NEXT"
 fi
 
-# Node 组件：用随包 node_modules（离线可用）；缺失时在线 npm ci。
+# Node 组件：优先随包 bundled runtime（规格 §27.4，目标机免装 Node）；
+# 其次系统 Node >= 22.19；用随包 node_modules（离线可用），不现场 npm。
 NODE_OK=0
+if [ -x "$NEXT/vendor/node-runtime/bin/node" ]; then
+  NODE_BIN="$NEXT/vendor/node-runtime/bin/node"
+  NODE_OK=1
+  echo "==> using bundled node $($NODE_BIN --version)"
+fi
+if [ "$NODE_OK" = "0" ]; then
 for candidate in node /usr/bin/node /usr/local/bin/node; do
   if command -v "$candidate" >/dev/null 2>&1; then
     ver="$($candidate --version | tr -d 'v')"
@@ -137,6 +153,7 @@ for candidate in node /usr/bin/node /usr/local/bin/node; do
     fi
   fi
 done
+fi
 if [ "$NODE_OK" = "1" ]; then
   for pkg in rosclaw-tui rosclaw-modeld rosclaw-agent; do
     if [ -f "$NEXT/vendor/node_modules_pack/$pkg.tar.gz" ]; then
@@ -160,8 +177,13 @@ fi
 
 echo "==> [3/5] CLI 入口"
 mkdir -p "$PREFIX/bin"
+if [ -d "$NEXT/vendor/tool-bins" ]; then
+  cp "$NEXT/vendor/tool-bins/"* "$PREFIX/bin/" 2>/dev/null || true
+  chmod +x "$PREFIX/bin/fd" "$PREFIX/bin/rg" 2>/dev/null || true
+fi
 cat > "$PREFIX/bin/rosclaw" <<EOF2
 #!/usr/bin/env bash
+export PATH="$PREFIX/bin:\$PATH"
 exec "$CURRENT/.venv/bin/python" -m rosclaw.entrypoint "\$@"
 EOF2
 chmod +x "$PREFIX/bin/rosclaw"

--- a/src/rosclaw/release_verify.py
+++ b/src/rosclaw/release_verify.py
@@ -115,7 +115,10 @@ def verify_bundle(
                 errors.append(f"tampered: {rel}")
         for path in sorted(root.rglob("*")):
             if path.is_symlink():
-                errors.append(f"symlink not allowed: {path.relative_to(root)}")
+                # 包内相对 symlink（bundled node shims）允许；逃逸/悬空链接拒绝。
+                target = path.resolve()
+                if not str(target).startswith(str(root.resolve())) or not target.exists():
+                    errors.append(f"unsafe symlink: {path.relative_to(root)}")
             elif path.is_file():
                 rel = str(path.relative_to(root))
                 if rel not in manifest["files"] and rel not in ALLOWED_EXTRA:

--- a/tests/agentd/test_pna10_release.py
+++ b/tests/agentd/test_pna10_release.py
@@ -1,0 +1,126 @@
+"""PNA-10（规格 §27）：发布门禁——clean build、build-info、bundled Node、
+installed-artifact PTY 冒烟。
+
+- build-info.json 字段完整且含 rosclaw-agent；
+- bundled node runtime 进包且在 manifest 内（extra-file 拒绝兼容）；
+- 安装后经 PTY 启动 rosclaw-agent（InteractiveMode），/quit 干净退出、
+  无孤儿进程。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+BUILD = REPO / "scripts" / "build_release.sh"
+
+
+def _build(tmp_path: Path) -> Path:
+    env = dict(os.environ, ROSCLAW_SIGNING_HOME=str(tmp_path / "signing"))
+    result = subprocess.run(
+        ["bash", str(BUILD)], cwd=REPO, capture_output=True, text=True, timeout=1800, env=env
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    bundle = sorted((REPO / "dist").glob("rosclaw-*-linux-*.tar.gz"))[-1]
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    with tarfile.open(bundle) as tf:
+        tf.extractall(stage)
+    return next(stage.iterdir())
+
+
+@pytest.mark.slow
+class TestReleaseGate:
+    def test_build_info_and_bundled_node(self, tmp_path: Path) -> None:
+        root = _build(tmp_path)
+        info = json.loads((root / "build-info.json").read_text())
+        assert info["pi_version"] == "0.83.0"
+        assert info["rosclaw_commit"]
+        for pkg in ("rosclaw-tui", "rosclaw-modeld", "rosclaw-agent"):
+            assert info["packages"][pkg]["dist_sha256"], pkg
+        if os.environ.get("ROSCLAW_SKIP_NODE_BUNDLE") != "1":
+            node = root / "vendor" / "node-runtime" / "bin" / "node"
+            assert node.exists(), "bundled node runtime must be in the bundle"
+            manifest = json.loads((root / "manifest.json").read_text())
+            assert any(
+                name.startswith("vendor/node-runtime/") for name in manifest["files"]
+            ), "bundled node must be inside the signed manifest"
+
+    def test_installed_artifact_pty_quit_clean(self, tmp_path: Path) -> None:
+        """安装产物在 PTY 中启动 → 显示 ROSClaw 品牌 → /quit 退出无孤儿。"""
+        root = _build(tmp_path)
+        install = subprocess.run(
+            [
+                "bash", str(root / "install.sh"), "--offline",
+                "--trusted-key", str(tmp_path / "signing" / "dev-signing-public.pem"),
+            ],
+            capture_output=True, text=True, timeout=900,
+            env=dict(os.environ, ROSCLAW_PREFIX=str(tmp_path / "prefix")),
+        )
+        assert install.returncode == 0, install.stderr[-1500:]
+        current = tmp_path / "prefix" / "current"
+        entry = current / "packages" / "rosclaw-agent" / "dist" / "src" / "main.js"
+        node = current / "vendor" / "node-runtime" / "bin" / "node"
+        if not node.exists():
+            node = Path("/usr/bin/node")
+        assert entry.exists()
+
+        import pty as _pty
+        import select
+        import time
+
+        master, slave = _pty.openpty()
+        proc = subprocess.Popen(
+            [str(node), str(entry)],
+            stdin=slave, stdout=slave, stderr=slave,
+            env=dict(
+                os.environ,
+                ROSCLAW_HOME=str(tmp_path / "rh"),
+                TERM="xterm",
+                # 与安装器 wrapper 一致：prefix/bin 提供随包 fd/rg（离线路径）。
+                PATH=f"{tmp_path / 'prefix' / 'bin'}:{os.environ['PATH']}",
+            ),
+            close_fds=True,
+        )
+        os.close(slave)
+        output = b""
+        try:
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline and b"ROSClaw" not in output:
+                ready, _, _ = select.select([master], [], [], 0.5)
+                if ready:
+                    chunk = os.read(master, 4096)
+                    if not chunk:
+                        break
+                    output += chunk
+                if proc.poll() is not None:
+                    break
+            assert b"ROSClaw" in output, f"品牌 header 未出现: {output[-500:]}"
+            # 等 TUI 完全就绪（2s 无新输出）再发 /quit——过早输入会被
+            # 初始化阶段的检查吞掉。
+            quiet_since = time.monotonic()
+            while time.monotonic() < deadline + 10:
+                ready, _, _ = select.select([master], [], [], 0.5)
+                if ready:
+                    chunk = os.read(master, 4096)
+                    if not chunk:
+                        break
+                    output += chunk
+                    quiet_since = time.monotonic()
+                if time.monotonic() - quiet_since > 2.0:
+                    break
+            os.write(master, b"/quit\r")
+            proc.wait(timeout=30)
+            assert proc.returncode == 0, f"exit={proc.returncode} out={output[-300:]}"
+        finally:
+            os.close(master)
+            if proc.poll() is None:
+                proc.kill()
+        # 无孤儿：进程已退出。
+        assert proc.poll() is not None


### PR DESCRIPTION
重构规格 §27 批次。

## Scope
- **clean build 强制**（消除 stale dist 来源）+ build-info.json（commit/pi 版本/各包 lock+dist hash）。
- 发布包含配套 Node 22.19.0 runtime 与 fd/ripgrep 二进制（InteractiveMode 初始化会下载它们——离线目标机拿不到）；均入签名 manifest；installer 优先 bundled node，wrapper 提供 fd/rg PATH。
- 离线 Python 安装改用预构建 rosclaw wheel（force-include 数据随 wheel）；hatchling/setuptools/wheel 入 vendor。
- symlink 规则细化为必须解析在包内（node shim 合法；穿越/外泄仍拒）。
- **installed-artifact PTY**：真实包 → 离线安装 → PTY 启动显示 ROSClaw header → /quit 退出 0、无孤儿。

## 验证
- PNA-10 + 既有 packaging 套件 16/16（含真实全量构建）；ruff clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)