### PR TITLE
PR-PNA-11: engine config + migration guide (default stays legacy)

### DIFF
--- a/docs/PI_ENGINE_MIGRATION.md
+++ b/docs/PI_ENGINE_MIGRATION.md
@@ -1,0 +1,64 @@
+# Pi Engine 迁移与切换指南（PNA-11）
+
+日期：2026-08-05
+
+## 当前阶段：Developer Preview（阶段 2）
+
+`engine=pi` 已可用但**不是默认**。默认保持 `legacy`——完整 Product Gate
+（PTY/IME 矩阵、产品旅程全自动 PTY、性能门槛实测）尚未全部通过，
+REAL 门禁不变（关闭）。
+
+## 切换方式
+
+```bash
+# 单次
+rosclaw chat --engine pi
+
+# 配置（Developer Preview）
+# ~/.rosclaw/config.yaml
+agent:
+  engine: pi
+```
+
+回退：
+
+```bash
+rosclaw chat --legacy
+```
+
+优先级：`--legacy` > `--engine` > `config.agent.engine` > `legacy`。
+
+## engine=pi 包含什么
+
+- Pi InteractiveMode（成熟 TUI：流式、working 动画、/model /login
+  /compact /resume /fork /tree 等内建命令）；
+- ROSClaw 品牌 header + 内联扩展（`!` bash 关闭、项目资源锁定）；
+- 每轮具身上下文注入（stale 禁止动作）；
+- rosclaw_* 工具：status / observe / verify / memory_query /
+  fail_safe / delegate / request_action；
+- ApprovalCard（Y/N/Esc，operatord 签名链）；
+- SessionBinding + writer lease；认知事件 hash 镜像；
+- Provider：Pi ModelRuntime（developer 文件凭据 / robot env-only；
+  config.yaml 自动迁移）。
+
+## 数据兼容（规格 §31 数据回滚）
+
+- Mission DB 不迁移为 Pi 格式；Pi Session 是附加认知存储；
+- 删除 pi engine 不影响 Mission/Receipt；legacy 仍能读取 Mission；
+- 新表（013–016）独立 migration，downgrade 不删 binding 数据。
+
+## legacy 冻结说明
+
+旧 `rosclaw-tui`（packages/rosclaw-tui）自 2026-08-05 起冻结：
+只修安全或阻断 bug，不新增功能。`--engine legacy` 路径在 PNA-11
+完成前保持完全可用。
+
+## 切换默认 engine 的前置条件（规格 §31 阶段 3/4）
+
+- [ ] 完整 Product Journey 全自动 PTY（clean install → chat → login →
+  model → ask → observe → delegate → SIM action → approve → receipt →
+  compact → exit → resume）；
+- [ ] PTY/IME 矩阵（中文输入法、退格、粘贴、resize、tmux/SSH）；
+- [ ] 性能门槛实测（§30 表格）；
+- [ ] 100 次启动退出零孤儿；
+- [ ] SIM E3 不回退；REAL 门禁不受影响。

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -370,7 +370,17 @@ def cmd_chat(args: argparse.Namespace) -> int:
         return 2
     # 重构路线（rosclaw_native_agent重构.md）：engine=pi 走 Pi-backed
     # harness（packages/rosclaw-agent），legacy 保持默认直到 Product Gate 通过。
-    engine = "legacy" if getattr(args, "legacy", False) else (getattr(args, "engine", None) or "legacy")
+    # 优先级：--legacy > --engine > config.agent.engine > legacy（规格 §5/
+    # §31——Product Gate 未全过前默认必须保持 legacy）。
+    if getattr(args, "legacy", False):
+        engine = "legacy"
+    elif getattr(args, "engine", None):
+        engine = args.engine
+    else:
+        try:
+            engine = load_agent_config(home / "config.yaml").engine
+        except Exception:  # noqa: BLE001 - 配置问题由后续步骤诚实报出
+            engine = "legacy"
     if engine == "pi":
         return _chat_pi(home, args)
     config = load_agent_config(home / "config.yaml")

--- a/src/rosclaw/agentd/config.py
+++ b/src/rosclaw/agentd/config.py
@@ -20,6 +20,9 @@ DEFAULT_CONFIG_PATH = Path.home() / ".rosclaw" / "config.yaml"
 @dataclass
 class AgentConfig:
     enabled: bool = True
+    # 重构规格 §5：pi（Pi-backed harness）| legacy（Python AgentLoop +
+    # rosclaw-tui）。默认 legacy——Product Gate 未全过前不得切 pi。
+    engine: str = "legacy"
     default_profile: str = "embodied_default"
     default_mode: str = "SIMULATION"
     max_tool_rounds: int = 12
@@ -81,8 +84,12 @@ def load_agent_config(path: Path | None = None) -> AgentConfig:
     ]
     context = agent.get("context", {}) or {}
     budgets = agent.get("budgets", {}) or {}
+    engine = str(agent.get("engine", "legacy")).lower()
+    if engine not in ("pi", "legacy"):
+        raise ValueError(f"agent.engine 只能是 pi|legacy（got {engine!r}）")
     return AgentConfig(
         enabled=bool(agent.get("enabled", True)),
+        engine=engine,
         default_profile=str(agent.get("default_profile", "embodied_default")),
         default_mode=str(agent.get("default_mode", "SIMULATION")),
         max_tool_rounds=int(agent.get("max_tool_rounds", 12)),

--- a/tests/agentd/test_engine_config.py
+++ b/tests/agentd/test_engine_config.py
@@ -1,0 +1,29 @@
+"""PNA-11（规格 §5/§31）：engine 配置与优先级。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.config import load_agent_config
+
+
+def test_default_engine_is_legacy(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("agent:\n  enabled: true\n", encoding="utf-8")
+    assert load_agent_config(tmp_path / "config.yaml").engine == "legacy"
+
+
+def test_engine_pi_explicit(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  enabled: true\n  engine: pi\n", encoding="utf-8"
+    )
+    assert load_agent_config(tmp_path / "config.yaml").engine == "pi"
+
+
+def test_engine_invalid_rejected(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  enabled: true\n  engine: turbo\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="pi|legacy"):
+        load_agent_config(tmp_path / "config.yaml")


### PR DESCRIPTION
重构规格 §5/§31 收尾批次。**默认 engine 不变（legacy）**——Product Journey 全自动 PTY、PTY/IME 矩阵、性能实测未齐，不满足切换条件（§33.24）。

## Scope
- `agent.engine: pi|legacy` 配置（非法值拒绝）+ 优先级 --legacy > --engine > config > legacy。
- docs/PI_ENGINE_MIGRATION.md：切换/回退/数据兼容/legacy 冻结说明/默认切换前置清单。

## 验证
- engine 配置测试 3/3；ruff clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)