### PR TITLE
Fix chat operator lifecycle and proposal leases

### DIFF
--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -501,7 +501,12 @@ def _find_tui_runtime() -> tuple[str, str] | None:
         return None
     entry_env = os.environ.get("ROSCLAW_TUI_ENTRY")
     repo_entry = (
-        Path(__file__).resolve().parents[3] / "packages" / "rosclaw-tui" / "dist" / "src" / "main.js"
+        Path(__file__).resolve().parents[3]
+        / "packages"
+        / "rosclaw-tui"
+        / "dist"
+        / "src"
+        / "main.js"
     )
     entry = entry_env or (str(repo_entry) if repo_entry.exists() else None)
     if not entry or not Path(entry).exists():
@@ -649,8 +654,7 @@ def cmd_backend(args: argparse.Namespace) -> int:
     models["backend"] = args.set
     config_path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
     print(
-        f"backend: {current} → {args.set}。"
-        "现有 profile 与 env 凭据引用保持不变；下一 turn 生效。"
+        f"backend: {current} → {args.set}。现有 profile 与 env 凭据引用保持不变；下一 turn 生效。"
     )
     return 0
 
@@ -669,6 +673,10 @@ async def _chat_repl(service: AgentService, args: argparse.Namespace) -> int:
         except Exception as exc:  # noqa: BLE001 - surface honest refusal
             print(f"无法创建 mission：{exc}", file=sys.stderr)
             return 2
+    # The basic REPL is an operator surface.  Expose its approval projection
+    # before accepting commands so the independently enrolled operatord can
+    # verify and decide the exact cards created by this service instance.
+    await service.start_operator_socket()
     print(f"ROSClaw chat — mission {mission.mission_id} [{mission.mode.value}]")
     print(
         "输入消息开始对话；/state 查看状态；/approvals 待授权；"

--- a/src/rosclaw/agentd/consent_channel.py
+++ b/src/rosclaw/agentd/consent_channel.py
@@ -25,6 +25,9 @@ from rosclaw.kernel.contracts import (
     VerificationPolicy,
 )
 
+_MIN_OPERATOR_ACTION_LEASE_MS = 30_000
+_MAX_OPERATOR_ACTION_LEASE_MS = 3_600_000
+
 
 class ConsentChannelError(ValidationError):
     """Proposal creation/decision/receipt failed (fail closed)."""
@@ -61,6 +64,17 @@ class DaemonConsentChannel:
         client_reference（R1/P0-6）：{agent_request_id, mission_id} 绑定，
         daemon 原样带入 challenge/receipt，agentd 精确比对。
         """
+        # Operator proposals are submitted by rosclawd after the interactive
+        # caller has returned, so there is no client-side lease-renewal loop.
+        # Bind the action lease to the same bounded lifetime as the proposal.
+        # The default 10 s ActionEnvelope lease is shorter than several real
+        # LIMO workers (camera/audio/localization preflight included) and can
+        # otherwise let the watchdog rewrite a successfully verified receipt
+        # to TIMED_OUT milliseconds after completion.
+        lease_ttl_ms = min(
+            _MAX_OPERATOR_ACTION_LEASE_MS,
+            max(_MIN_OPERATOR_ACTION_LEASE_MS, int(float(ttl_sec) * 1000)),
+        )
         envelope = ActionEnvelope(
             action_id=new_id("act"),
             actor_id=self._actor_id,
@@ -76,6 +90,8 @@ class DaemonConsentChannel:
             execution_mode=ExecutionMode(execution_mode),
             risk_class=risk_class,
             deadline_at=datetime.now(UTC) + timedelta(seconds=ttl_sec),
+            lease_ttl_ms=lease_ttl_ms,
+            renew_interval_ms=min(3_000, max(1_000, lease_ttl_ms // 3)),
             verification_policy=VerificationPolicy(
                 required_evidence=EvidenceLevel.DRIVER_CONFIRMED,
                 timeout_sec=ttl_sec,
@@ -109,7 +125,6 @@ class DaemonConsentChannel:
             "agentd no longer decides daemon proposals (P0-01) — "
             "decisions belong to rosclaw-operatord"
         )
-
 
     async def proposal(self, request_id: str) -> dict[str, Any]:
         try:

--- a/src/rosclaw/operatord/cli.py
+++ b/src/rosclaw/operatord/cli.py
@@ -13,7 +13,10 @@ def dispatch_operatord_argv(argv: list[str]) -> int | None:
     if argv[:1] != ["operatord"]:
         return None
     if len(argv) < 2:
-        print("用法: rosclaw operatord <enroll|register-daemon|list-daemon|revoke-daemon|start|status> [--home DIR]", file=sys.stderr)
+        print(
+            "用法: rosclaw operatord <enroll|register-daemon|list-daemon|revoke-daemon|start|status> [--home DIR]",
+            file=sys.stderr,
+        )
         return 2
     command = argv[1]
     home = Path(
@@ -47,14 +50,18 @@ def dispatch_operatord_argv(argv: list[str]) -> int | None:
         return 0
 
     if command == "register-daemon":
-        from rosclaw.daemon.client import DaemonClient, DaemonClientError
+        from rosclaw.daemon.client import (
+            DaemonClient,
+            DaemonClientError,
+            get_daemon_socket_path,
+        )
         from rosclaw.operatord.enrollment import (
             EnrollmentError,
             load_identity,
             read_public_key_pem,
         )
 
-        daemon_socket = home / "run" / "rosclawd.sock"
+        daemon_socket = get_daemon_socket_path()
         if not daemon_socket.exists():
             print(f"rosclawd socket 不存在：{daemon_socket}", file=sys.stderr)
             return 2
@@ -82,9 +89,13 @@ def dispatch_operatord_argv(argv: list[str]) -> int | None:
         return 0
 
     if command == "list-daemon":
-        from rosclaw.daemon.client import DaemonClient, DaemonClientError
+        from rosclaw.daemon.client import (
+            DaemonClient,
+            DaemonClientError,
+            get_daemon_socket_path,
+        )
 
-        daemon_socket = home / "run" / "rosclawd.sock"
+        daemon_socket = get_daemon_socket_path()
         if not daemon_socket.exists():
             print(f"rosclawd socket 不存在：{daemon_socket}", file=sys.stderr)
             return 2
@@ -100,9 +111,13 @@ def dispatch_operatord_argv(argv: list[str]) -> int | None:
         if len(argv) < 3:
             print("用法: rosclaw operatord revoke-daemon <enrollment_id>", file=sys.stderr)
             return 2
-        from rosclaw.daemon.client import DaemonClient, DaemonClientError
+        from rosclaw.daemon.client import (
+            DaemonClient,
+            DaemonClientError,
+            get_daemon_socket_path,
+        )
 
-        daemon_socket = home / "run" / "rosclawd.sock"
+        daemon_socket = get_daemon_socket_path()
         if not daemon_socket.exists():
             print(f"rosclawd socket 不存在：{daemon_socket}", file=sys.stderr)
             return 2
@@ -117,13 +132,14 @@ def dispatch_operatord_argv(argv: list[str]) -> int | None:
     if command == "start":
         import contextlib
 
+        from rosclaw.daemon.client import get_daemon_socket_path
         from rosclaw.operatord.enrollment import EnrollmentError
         from rosclaw.operatord.server import run_operatord
 
         async def _serve() -> None:
             daemon = await run_operatord(
                 home=home,
-                daemon_socket=home / "run" / "rosclawd.sock",
+                daemon_socket=get_daemon_socket_path(),
                 require_human_presence="--no-human-presence-check" not in argv,
             )
             print(f"rosclaw-operatord listening on {daemon._path}")

--- a/tests/agentd/test_cli_chat.py
+++ b/tests/agentd/test_cli_chat.py
@@ -1,0 +1,37 @@
+"""Basic chat operator-surface lifecycle tests."""
+
+from argparse import Namespace
+from types import SimpleNamespace
+
+import pytest
+
+from rosclaw.agentd.cli import _chat_repl
+
+
+@pytest.mark.asyncio
+async def test_basic_chat_starts_operator_projection_before_input(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class Service:
+        def create_mission(self, goal: str, *, mode: str):
+            assert goal == "operator socket smoke test"
+            assert mode == "REAL"
+            return SimpleNamespace(mission_id="mis_chat_socket", mode=SimpleNamespace(value="REAL"))
+
+        async def start_operator_socket(self) -> None:
+            calls.append("start")
+
+        async def close(self) -> None:
+            calls.append("close")
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: "/quit")
+    args = Namespace(
+        mission=None,
+        goal="operator socket smoke test",
+        mode="REAL",
+    )
+
+    result = await _chat_repl(Service(), args)
+
+    assert result == 0
+    assert calls == ["start", "close"]

--- a/tests/agentd/test_consent_channel.py
+++ b/tests/agentd/test_consent_channel.py
@@ -87,8 +87,9 @@ def daemon(tmp_path: Path):
         ledger_ctx.__exit__(None, None, None)
 
 
-
-async def _daemon_decide(client, request_id: str, *, principal_id: str, accept: bool, supervise_timeout_sec: float = 60.0) -> dict:
+async def _daemon_decide(
+    client, request_id: str, *, principal_id: str, accept: bool, supervise_timeout_sec: float = 60.0
+) -> dict:
     """operatord 语义：challenge.get → Ed25519 sign → decide（R1 协议路径）。"""
     from rosclaw.agentd.consent_channel import ConsentChannelError
     from rosclaw.daemon.client import DaemonRequestError as _DaemonRequestError
@@ -117,7 +118,11 @@ async def _daemon_decide(client, request_id: str, *, principal_id: str, accept: 
             reason="reviewed bounded action" if accept else "declined by operator",
         )
     except _DaemonRequestError as exc:
-        if exc.code in {"PROPOSAL_NOT_PENDING", "PROPOSAL_NOT_FOUND", "OPERATOR_PROPOSAL_NOT_FOUND"}:
+        if exc.code in {
+            "PROPOSAL_NOT_PENDING",
+            "PROPOSAL_NOT_FOUND",
+            "OPERATOR_PROPOSAL_NOT_FOUND",
+        }:
             raise ConsentChannelError(f"no pending proposal {request_id!r}") from exc
         raise
     if accept:
@@ -132,6 +137,36 @@ async def _daemon_decide(client, request_id: str, *, principal_id: str, accept: 
 
 def _channel(client: DaemonClient) -> DaemonConsentChannel:
     return DaemonConsentChannel(client, actor_id="agent:test", body_id="rh56-test", body_hash="h")
+
+
+@pytest.mark.parametrize(
+    ("ttl_sec", "expected_lease_ms"),
+    [(5.0, 30_000), (300.0, 300_000), (3_600.0, 3_600_000)],
+)
+async def test_operator_proposal_lease_covers_bounded_execution_window(
+    ttl_sec: float, expected_lease_ms: int
+) -> None:
+    class CapturingClient:
+        def __init__(self) -> None:
+            self.action = None
+
+        def create_operator_proposal(self, action, **_kwargs):
+            self.action = action
+            return {"proposal": {"request_id": "proposal-test"}}
+
+    client = CapturingClient()
+    channel = _channel(client)  # type: ignore[arg-type]
+    await channel.create_proposal(
+        capability_id=REAL_CAPABILITY,
+        arguments={"finger": "index", "delta_raw": 20},
+        display={"title": "bounded action", "risk_tier": "LOW"},
+        execution_mode="REAL",
+        ttl_sec=ttl_sec,
+    )
+
+    assert client.action is not None
+    assert client.action.lease_ttl_ms == expected_lease_ms
+    assert client.action.renew_interval_ms < client.action.lease_ttl_ms
 
 
 class TestRealConsentFlow:
@@ -178,7 +213,9 @@ class TestRealConsentFlow:
             risk_class="high",
             ttl_sec=60.0,
         )
-        await _daemon_decide(client, proposal["request_id"], principal_id=LOCAL_PRINCIPAL, accept=False)
+        await _daemon_decide(
+            client, proposal["request_id"], principal_id=LOCAL_PRINCIPAL, accept=False
+        )
         terminal = await channel.proposal(proposal["request_id"])
         assert terminal.get("state") == "DECLINED"
 
@@ -221,7 +258,9 @@ class TestRealConsentFlow:
             risk_class="high",
             ttl_sec=60.0,
         )
-        await _daemon_decide(client, proposal["request_id"], principal_id=LOCAL_PRINCIPAL, accept=True)
+        await _daemon_decide(
+            client, proposal["request_id"], principal_id=LOCAL_PRINCIPAL, accept=True
+        )
         with pytest.raises(ConsentChannelError, match="no pending proposal"):
             await _daemon_decide(
                 client, proposal["request_id"], principal_id=LOCAL_PRINCIPAL, accept=True

--- a/tests/operatord/test_cli.py
+++ b/tests/operatord/test_cli.py
@@ -1,0 +1,32 @@
+"""operatord CLI socket-selection regressions."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from rosclaw.operatord import cli
+
+
+def test_start_uses_configured_daemon_socket(monkeypatch, tmp_path: Path) -> None:
+    configured = tmp_path / "system-run" / "rosclawd.sock"
+    captured: dict[str, object] = {}
+
+    class Server:
+        _path = tmp_path / "operatord.sock"
+
+    async def fake_run_operatord(**kwargs):
+        captured.update(kwargs)
+        return Server()
+
+    async def stop_after_start() -> None:
+        while "daemon_socket" not in captured:
+            await asyncio.sleep(0)
+        raise KeyboardInterrupt
+
+    monkeypatch.setenv("ROSCLAW_DAEMON_SOCKET", str(configured))
+    monkeypatch.setattr("rosclaw.operatord.server.run_operatord", fake_run_operatord)
+    monkeypatch.setattr("asyncio.Event.wait", lambda _self: stop_after_start())
+
+    assert cli.dispatch_operatord_argv(["operatord", "start", "--home", str(tmp_path)]) == 0
+    assert captured["daemon_socket"] == configured


### PR DESCRIPTION
## What changed

- start the operator socket in basic `rosclaw chat`
- bind operator-created action leases to the bounded proposal lifetime
- honor the configured daemon socket in every operatord command

## Why

Basic chat could present approvals without a running operator endpoint, operatord could silently use the wrong socket, and the default 10-second lease could let the watchdog time out a successfully verified LIMO action immediately after completion.

## Validation

- 10 focused chat, consent-channel, and operatord tests passed after rebasing onto current `main`
- targeted Ruff checks passed
- installed ROSClaw daemon reports a healthy watchdog, verified ledger, no recovery requirement, and all eight LIMO SHADOW/REAL executors registered
