### PR TITLE
NA-FIX-7/8: credential broker + product root CLI + session switch soak

### DIFF
--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -15,7 +15,11 @@ import sys
 from pathlib import Path
 
 from rosclaw.agentd.config import load_agent_config
-from rosclaw.agentd.credentials import AgentCredentialStore, CredentialStoreError
+from rosclaw.agentd.credentials import (
+    AgentCredentialStore,
+    CredentialStoreError,
+    ModelCredentialBroker,
+)
 from rosclaw.agentd.onboarding import PROVIDER_CHOICES, configure_model, doctor
 from rosclaw.agentd.service import AgentService, create_app
 
@@ -33,8 +37,10 @@ def _home(args: argparse.Namespace) -> Path:
 
 
 def _load_stored_credentials(home: Path) -> bool:
+    """NA-FIX-7：统一经 ModelCredentialBroker——legacy 一次性 read-and-migrate，
+    不再双写。"""
     try:
-        AgentCredentialStore(home).inject()
+        ModelCredentialBroker(home).migrate_legacy_once()
     except CredentialStoreError as exc:
         print(str(exc), file=sys.stderr)
         return False

--- a/src/rosclaw/agentd/credentials.py
+++ b/src/rosclaw/agentd/credentials.py
@@ -171,3 +171,72 @@ class AgentCredentialStore:
             "fingerprint": hashlib.sha256(value.encode()).hexdigest()[:8] if value else None,
             "path": str(self.path),
         }
+
+
+#: 统一的模型凭据 broker（NA-FIX-7，规格 §22.4/P1-4）。
+#: provider → (Pi env key, legacy env key)
+BROKER_ENV_BY_PROVIDER = {
+    "kimi-code": ("KIMI_API_KEY", "ROSCLAW_KIMI_API_KEY"),
+    "kimi-api": ("MOONSHOT_API_KEY", "MOONSHOT_API_KEY"),
+    "openai": ("OPENAI_API_KEY", "OPENAI_API_KEY"),
+    "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
+    "openrouter": ("OPENROUTER_API_KEY", "OPENROUTER_API_KEY"),
+}
+
+
+class ModelCredentialBroker:
+    """统一模型凭据入口（NA-FIX-7）。
+
+    读取顺序：进程 env（Pi 键或 legacy 键）→ legacy AgentCredentialStore
+    **一次性** read-and-migrate（把值补进进程 env，不再二次写盘）。
+    doctor 用 ``source_report`` 展示每个 provider 的凭据来源——
+    永不打印 secret（只指纹前 8 位）。
+    """
+
+    def __init__(self, home: Path) -> None:
+        self._home = home
+        self._migrated: bool = False
+        self._migrated_from_legacy: list[str] = []
+
+    def migrate_legacy_once(self) -> tuple[str, ...]:
+        """legacy store → 进程 env（setdefault，绝不覆盖显式 env）。"""
+        if self._migrated:
+            return ()
+        store = AgentCredentialStore(self._home)
+        injected = store.inject()
+        self._migrated = True
+        self._migrated_from_legacy = list(injected)
+        # legacy env 键 → Pi env 键（进程内桥接，不落地）。
+        for pi_key, legacy_key in BROKER_ENV_BY_PROVIDER.values():
+            value = os.environ.get(legacy_key)
+            if value and pi_key != legacy_key and not os.environ.get(pi_key):
+                os.environ[pi_key] = value
+        return injected
+
+    def source_for(self, provider: str) -> dict[str, object]:
+        """凭据来源报告（无 secret 内容，只有来源与指纹）。"""
+        pi_key, legacy_key = BROKER_ENV_BY_PROVIDER.get(provider, ("", ""))
+        import hashlib as _hl
+
+        for key, source in ((pi_key, "env"), (legacy_key, "env-legacy")):
+            value = os.environ.get(key, "") if key else ""
+            if value:
+                return {
+                    "provider": provider,
+                    "source": source,
+                    "env_name": key,
+                    "fingerprint": _hl.sha256(value.encode()).hexdigest()[:8],
+                }
+        return {"provider": provider, "source": "none", "env_name": pi_key}
+
+    def source_report(self) -> list[dict[str, object]]:
+        report = [self.source_for(provider) for provider in BROKER_ENV_BY_PROVIDER]
+        if self._migrated_from_legacy:
+            report.append(
+                {
+                    "provider": "(legacy-migration)",
+                    "source": "agentd/credentials.json (read-once)",
+                    "env_names": self._migrated_from_legacy,
+                }
+            )
+        return report

--- a/src/rosclaw/agentd/onboarding.py
+++ b/src/rosclaw/agentd/onboarding.py
@@ -257,4 +257,11 @@ def doctor(home: Path) -> dict:
     elif probe.error:
         report["reason"] = probe.error
     report["pi_engine"] = _pi_engine_report(home)
+    # NA-FIX-7：凭据来源可见（无 secret 内容，仅来源与指纹）。
+    try:
+        from rosclaw.agentd.credentials import ModelCredentialBroker
+
+        report["credential_sources"] = ModelCredentialBroker(home).source_report()
+    except Exception as exc:  # noqa: BLE001
+        report["credential_sources"] = [{"error": str(exc)}]
     return report

--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -8,6 +8,15 @@ import sys
 def main() -> int:
     """Dispatch product workflows without importing the full legacy CLI."""
 
+    # NA-FIX-8：root CLI 产品化——精简 help / commands --json / topic 指引
+    # （命中即返回；未命中走既有 dispatcher，行为不变）。
+    from rosclaw.root_cli import dispatch_root_cli
+
+    _help_all = sys.argv[1:] == ["help", "--all"]
+    root = dispatch_root_cli(sys.argv[1:] if not _help_all else ["commands", "--help-all"])
+    if root is not None:
+        return root
+
     from rosclaw.operator.cli import dispatch_operator_argv
 
     result = dispatch_operator_argv(sys.argv[1:])
@@ -110,6 +119,8 @@ def main() -> int:
     if result is not None:
         return result
 
+    if _help_all:
+        sys.argv = [sys.argv[0], "--help"]
     from rosclaw.cli import main as legacy_main
 
     return legacy_main()

--- a/src/rosclaw/root_cli.py
+++ b/src/rosclaw/root_cli.py
@@ -1,0 +1,127 @@
+"""Root CLI 产品化（NA-FIX-8，规格 §8）：精简 root help + 机器可读注册表。
+
+原则（审计 §12）：不做大规模搬家——dispatch 顺序与旧别名行为不变；
+本模块只负责：精简 help、help --all 透传、commands --json、topic 指引。
+"""
+
+from __future__ import annotations
+
+import json
+
+#: 产品级入口（root help 默认只显示这些）。
+SLIM_HELP = """ROSClaw — Embodied Agent Runtime
+
+Get started
+  chat        Start the Native Agent
+  setup       Configure model, body and integrations
+  status      Show runtime and embodiment status
+  doctor      Diagnose installation and safety readiness
+
+Runtime
+  start       Start ROSClaw services
+  stop        Stop ROSClaw services
+  restart     Restart services
+  dashboard   Open the dashboard
+
+Domains
+  robot       Body, sensing, ROS, MCP and capabilities
+  worker      External Agent Workers and WorkOrders
+  safety      Operator, daemon, permits, firewall and evidence
+  evolve      Practice, memory, Darwin, Dream and SimForge
+  hub         Skills, apps, assets and deployable providers
+  dev         Logs, traces, sandbox, tests and benchmarks
+
+  help <topic>       Topic help
+  help --all         All compatibility commands
+  commands --json    Machine-readable command registry
+"""
+
+#: 领域分组 → 兼容命令映射（指引用；旧命令全部继续可执行）。
+DOMAIN_GROUPS: dict[str, list[str]] = {
+    "robot": ["body", "eurdf", "robot", "ros", "sense", "capability", "mcp", "fleet"],
+    "worker": ["worker", "collective"],
+    "safety": [
+        "daemon", "operatord", "firewall", "regime", "acceptance", "evidence",
+        "release",
+    ],
+    "evolve": [
+        "memory", "practice", "learning", "darwin", "dream", "simforge", "auto",
+        "eval", "bench", "forge",
+    ],
+    "hub": ["skill", "app", "hub", "provider", "lerobot"],
+    "dev": [
+        "logs", "events", "trace", "db", "sandbox", "runtime", "test", "demo",
+        "feedback",
+    ],
+    "setup": ["init", "firstboot", "setup", "config", "profile"],
+}
+
+#: 机器可读注册表（name → (group, summary)）。dispatch 实现见 entrypoint.py。
+COMMAND_REGISTRY: dict[str, tuple[str, str]] = {
+    "chat": ("core", "Start the Native Agent (Pi-backed harness or --legacy)"),
+    "setup": ("setup", "Configure model, body and integrations"),
+    "status": ("core", "Show runtime and embodiment status"),
+    "doctor": ("core", "Diagnose installation and safety readiness"),
+    "start": ("runtime", "Start ROSClaw services"),
+    "stop": ("runtime", "Stop ROSClaw services"),
+    "restart": ("runtime", "Restart services"),
+    "dashboard": ("runtime", "Open the dashboard"),
+    "agent": ("core", "Native Agent management (agentd)"),
+    "chat --engine": ("advanced", "Engine selection (developer preview; hidden later)"),
+    "operatord": ("safety", "Independent operator authorization process"),
+    "daemon": ("safety", "rosclawd control plane inspection"),
+    "release verify": ("safety", "Verify a release bundle offline"),
+    "evidence verify": ("safety", "Verify an acceptance evidence pack"),
+    "commands --json": ("core", "Machine-readable command registry"),
+}
+
+
+def _topics_help(topic: str) -> str:
+    lines = [f"# {topic}\n"]
+    members = DOMAIN_GROUPS.get(topic, [])
+    if members:
+        lines.append("Commands in this domain (all fully executable):")
+        lines.extend(f"  {name}" for name in members)
+    else:
+        lines.append(f"unknown topic {topic!r}; topics: {', '.join(DOMAIN_GROUPS)}")
+    lines.append("\n`rosclaw help --all` for the full compatibility command list.")
+    return "\n".join(lines)
+
+
+def dispatch_root_cli(argv: list[str]) -> int | None:
+    """精简 root help / commands --json / topic help。未命中返回 None。"""
+    if not argv or argv == ["help"] or argv == ["-h"] or argv == ["--help"]:
+        print(SLIM_HELP)
+        return 0
+    if argv[:2] == ["help", "--all"]:
+        return None  # 透传 legacy 全量 help
+    if argv[:2] == ["commands", "--json"]:
+        print(
+            json.dumps(
+                {
+                    "schema_version": "rosclaw.commands.v1",
+                    "product_entries": [
+                        line.strip().split()[0]
+                        for line in SLIM_HELP.splitlines()
+                        if line.startswith(("  chat", "  setup", "  status", "  doctor"))
+                    ],
+                    "registry": {
+                        name: {"group": group, "summary": summary}
+                        for name, (group, summary) in COMMAND_REGISTRY.items()
+                    },
+                    "domain_groups": DOMAIN_GROUPS,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return 0
+    if argv[:1] == ["help"] and len(argv) == 2:
+        print(_topics_help(argv[1]))
+        return 0
+    if argv[:1] == ["commands"]:
+        if len(argv) == 2 and argv[1] == "--help-all":
+            return None
+        print("用法: rosclaw commands --json")
+        return 2
+    return None

--- a/tests/agentd/test_credential_broker.py
+++ b/tests/agentd/test_credential_broker.py
@@ -1,0 +1,51 @@
+"""NA-FIX-7（规格 §22.4/P1-4）：ModelCredentialBroker。"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from rosclaw.agentd.credentials import ModelCredentialBroker
+
+
+def _seed_legacy(home: Path, values: dict[str, str]) -> None:
+    path = home / "agentd"
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "credentials.json").write_text(json.dumps({"environment": values}), encoding="utf-8")
+
+
+class TestBroker:
+    def test_legacy_read_once_and_pi_key_bridge(self, tmp_path: Path, monkeypatch) -> None:
+        _seed_legacy(tmp_path, {"ROSCLAW_KIMI_API_KEY": "sk-legacy-dummy"})
+        monkeypatch.delenv("KIMI_API_KEY", raising=False)
+        monkeypatch.delenv("ROSCLAW_KIMI_API_KEY", raising=False)
+        broker = ModelCredentialBroker(tmp_path)
+        injected = broker.migrate_legacy_once()
+        assert "ROSCLAW_KIMI_API_KEY" in injected
+        # legacy → Pi env 键桥接（进程内，不落地）。
+        assert os.environ["KIMI_API_KEY"] == "sk-legacy-dummy"
+        # 让 monkeypatch 负责清理 broker 写进 environ 的键（防跨测试泄漏）。
+        monkeypatch.setenv("KIMI_API_KEY", "sk-legacy-dummy")
+        monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "sk-legacy-dummy")
+        # 一次性：第二次不再注入。
+        assert broker.migrate_legacy_once() == ()
+
+    def test_env_precedence_and_source_report(self, tmp_path: Path, monkeypatch) -> None:
+        _seed_legacy(tmp_path, {"ROSCLAW_KIMI_API_KEY": "sk-legacy-dummy"})
+        monkeypatch.setenv("KIMI_API_KEY", "sk-explicit")
+        monkeypatch.delenv("ROSCLAW_KIMI_API_KEY", raising=False)
+        broker = ModelCredentialBroker(tmp_path)
+        broker.migrate_legacy_once()
+        # 显式 env 优先——不被 legacy 覆盖。
+        assert os.environ["KIMI_API_KEY"] == "sk-explicit"
+        report = {r["provider"]: r for r in broker.source_report() if "provider" in r}
+        assert report["kimi-code"]["source"] == "env"
+        assert report["kimi-code"]["fingerprint"]
+        assert "sk-explicit" not in json.dumps(report)
+
+    def test_no_credential_reports_none(self, tmp_path: Path, monkeypatch) -> None:
+        for key in ("KIMI_API_KEY", "ROSCLAW_KIMI_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+        broker = ModelCredentialBroker(tmp_path)
+        assert broker.source_for("kimi-code")["source"] == "none"

--- a/tests/agentd/test_modeld_gateway.py
+++ b/tests/agentd/test_modeld_gateway.py
@@ -43,6 +43,7 @@ def _request() -> ModelTurnRequest:
 class TestModeldGateway:
     async def test_probe_without_credential_is_honest(self, tmp_path: Path) -> None:
         os.environ.pop("ROSCLAW_KIMI_API_KEY", None)
+        os.environ.pop("KIMI_API_KEY", None)  # NA-FIX-7 broker 桥接键
         gateway = ModeldGateway(kimi_code_k3_profile(), home=tmp_path)
         try:
             probe = await gateway.probe()
@@ -53,6 +54,7 @@ class TestModeldGateway:
 
     async def test_stream_without_credential_fails_closed(self, tmp_path: Path) -> None:
         os.environ.pop("ROSCLAW_KIMI_API_KEY", None)
+        os.environ.pop("KIMI_API_KEY", None)  # NA-FIX-7 broker 桥接键
         gateway = ModeldGateway(kimi_code_k3_profile(), home=tmp_path)
         try:
             with pytest.raises(ModelGatewayError, match="no_credential|missing"):

--- a/tests/agentd/test_session_switch_soak.py
+++ b/tests/agentd/test_session_switch_soak.py
@@ -1,0 +1,52 @@
+"""T-SESSION（二次审计 NA-FIX-2 收尾）：100 次绑定/lease 切换无 split-brain。
+
+每一时刻只有一个 writer；旧 lease 正确释放；无孤儿 ACTIVE binding。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rosclaw.agentd.mission import MissionStore
+from rosclaw.agentd.pi_bridge.session_binding import BindingError, SessionBindingStore
+
+
+def test_hundred_switches_single_writer(tmp_path: Path) -> None:
+    store = MissionStore(tmp_path / "m.db")
+    bindings = SessionBindingStore(store.connection)
+    active_tokens: dict[str, str] = {}
+    for i in range(100):
+        session_id = f"pi_sess_{i % 4}"  # 4 个 session 轮转绑定两个 mission
+        mission_id = f"mis_{i % 2}"
+        binding = bindings.bind(
+            pi_session_id=session_id, pi_session_path="", mission_id=mission_id,
+            body_id="b", execution_mode="SIMULATION", created_by="user:local:1000",
+        )
+        assert binding.status == "ACTIVE"
+        # 同 session 重绑：幂等返回或降旧；ACTIVE binding 全局最多 4 个（每 session 1 个）。
+        lease, token = bindings.acquire_lease(
+            mission_id=mission_id, pi_session_id=session_id, owner_pid=100 + i, owner_uid=1000
+        )
+        writer = bindings.writer_of(mission_id)
+        assert writer is not None and writer.pi_session_id == session_id
+        active_tokens[mission_id] = token
+        # 换 session 抢同一 mission：WRITER_HELD。
+        try:
+            bindings.acquire_lease(
+                mission_id=mission_id, pi_session_id=f"pi_rival_{i}", owner_pid=900 + i,
+                owner_uid=1000,
+            )
+        except BindingError as exc:
+            assert exc.code == "WRITER_HELD"
+        else:
+            raise AssertionError(f"iteration {i}: rival session took the writer lease")
+        # 释放后新 session 可获得。
+        assert bindings.release_lease(mission_id, session_id, token)
+    # 终态：每个 session 至多一个 ACTIVE binding。
+    rows = store.connection.execute(
+        "SELECT pi_session_id, COUNT(*) c FROM pi_session_bindings "
+        "WHERE status = 'ACTIVE' GROUP BY pi_session_id"
+    ).fetchall()
+    for row in rows:
+        assert row["c"] == 1, f"split-brain: session {row['pi_session_id']} has {row['c']} ACTIVE bindings"
+    store.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,10 +24,18 @@ class TestVersion:
     def test_top_level_help_discovers_daemon_control_plane(self, capsys):
         from rosclaw.entrypoint import main
 
-        with pytest.raises(SystemExit) as exc:
-            sys.argv = ["rosclaw", "--help"]
+        # NA-FIX-8：--help 是产品级精简帮助（Get started/Domains，直接返回 0）。
+        sys.argv = ["rosclaw", "--help"]
+        assert main() == 0
+        captured = capsys.readouterr()
+        assert "Get started" in captured.out
+        assert "Native Agent" in captured.out
+
+        # 完整兼容清单在 help --all。
+        with pytest.raises(SystemExit) as exc_all:
+            sys.argv = ["rosclaw", "help", "--all"]
             main()
-        assert exc.value.code == 0
+        assert exc_all.value.code == 0
         captured = capsys.readouterr()
         assert "daemon" in captured.out
         assert "Inspect or call the local rosclawd control plane" in captured.out

--- a/tests/test_root_cli.py
+++ b/tests/test_root_cli.py
@@ -1,0 +1,55 @@
+"""NA-FIX-8（规格 §8/T-CLI）：root CLI 产品化。"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+ENTRY = [sys.executable, "-m", "rosclaw.entrypoint"]
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run([*ENTRY, *args], capture_output=True, text=True, timeout=120)
+
+
+def test_bare_help_is_slim_and_product_level() -> None:
+    result = _run()
+    assert result.returncode == 0
+    assert "Get started" in result.stdout
+    assert "Native Agent" in result.stdout
+    # 平铺的内部/科研命令不得出现在精简 help。
+    for hidden in ("simforge", "darwin", "lerobot", "muscle", "hat-trick"):
+        assert hidden not in result.stdout
+
+
+def test_help_all_shows_full_legacy_list() -> None:
+    result = _run("help", "--all")
+    assert result.returncode == 0
+    assert "simforge" in result.stdout
+    assert "darwin" in result.stdout
+
+
+def test_commands_json_schema_stable() -> None:
+    result = _run("commands", "--json")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["schema_version"] == "rosclaw.commands.v1"
+    assert "chat" in data["registry"]
+    assert "robot" in data["domain_groups"]
+    assert "body" in data["domain_groups"]["robot"]
+
+
+def test_topic_help_lists_domain_members() -> None:
+    result = _run("help", "robot")
+    assert result.returncode == 0
+    assert "eurdf" in result.stdout
+    result = _run("help", "nonsense-topic")
+    assert result.returncode == 0
+    assert "unknown topic" in result.stdout
+
+
+def test_legacy_commands_still_execute() -> None:
+    result = _run("--version")
+    assert result.returncode == 0
+    assert "rosclaw" in result.stdout


### PR DESCRIPTION
二次审计 NA-FIX-7/8 批次 + NA-FIX-2 收尾验证。

## NA-FIX-7（§22.4/P1-4）
- **ModelCredentialBroker** 单一读取权威：legacy store 变一次性 read-and-migrate（env setdefault、不重写、无双路径）；legacy env 键进程内桥接 Pi 键（值不落地）；doctor 按 provider 展示凭据来源（只指纹）。
- 测试：read-once、显式 env 优先、报告无 secret、无凭据=none。

## NA-FIX-8（§8）
- 精简 root help（Get started/Runtime/Domains）；`help --all` 透传 legacy 全量；`commands --json`（rosclaw.commands.v1）；topic 指引；**旧命令行为零变化**（审计 §12 不搬家的原则）。
- help snapshot/schema/topic/兼容执行 5 项测试。

## NA-FIX-2 收尾
- **100 次绑定/lease 切换 soak**：每一时刻单 writer、对手 WRITER_HELD、释放可得、终态无 split-brain ACTIVE binding。

## 其它
- modeld 无凭据测试隔离 broker 桥接的 KIMI_API_KEY（进程 env 注入是设计行为，测试必须自清）。

## 验证
- agentd **430/430**；root CLI 5/5；broker 3/3；soak 1/1；ruff clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)