### PR TITLE
Integrate Know and How v2

### DIFF
--- a/docs/architecture/KNOW_HOW_V2_INTEGRATION.md
+++ b/docs/architecture/KNOW_HOW_V2_INTEGRATION.md
@@ -1,0 +1,60 @@
+# Know / How v2 core integration
+
+Status: implemented in the 1.2.0 working tree.
+
+## Ownership boundary
+
+| Domain | Owns | Must not own |
+| --- | --- | --- |
+| `rosclaw-know` | external sources, immutable snapshots, source-linked wiki, knowledge units, retrieval indexes, Reference Packs, knowledge-governance feedback | robot experience, action authorization, physical success claims |
+| `rosclaw-how` | current-context interpretation and cited advisory output | a retrieval index, Memory records, ROS actions, safety authority |
+| Core `rosclaw` | optional transports, context projection, tool exposure, bounded orchestration, events and health | Know indexing algorithms or How recommendation algorithms |
+| Memory | robot experience and receipts from prior operation | external-world knowledge corpus |
+| Practice | sandbox evaluation and knowledge-use feedback | rewriting source provenance or bypassing normal execution policy |
+
+The data flow is deliberately one-way at the cognition boundary:
+
+```text
+external source -> Know snapshot/wiki/unit -> ReferencePackV2
+                                               |
+Body + Software + Runtime + labelled Memory ---+-> HowAdviceBundleV2
+                                                        |
+                                                        +-> Native Agent (advisory)
+                                                        +-> KnowledgeUsageFeedbackV1
+
+physical commands -> normal ROSClaw policy/safety/daemon path only
+```
+
+No raw trajectory, video, sensor stream, secret, Memory store handle or action
+authorization is accepted by the v2 context and event adapters.
+
+## Runtime modes
+
+- `disabled` is the rollback-safe default. Core loads neither optional package and makes no network connection.
+- `service` uses the versioned HTTP APIs. Core never starts or supervises the external processes implicitly.
+- `inprocess` imports `rosclaw-know` and `rosclaw-how` lazily. Only Know receives the explicitly configured Know store; How receives a Reference Pack client.
+
+`KnowledgeServiceManager` degrades missing packages, URLs and unavailable services into explicit health state. It does not fall back to Memory as a knowledge source. The older in-core Know/How modules remain available only when v2 is disabled.
+
+Environment controls:
+
+- `ROSCLAW_KNOWLEDGE_MODE` for both `RuntimeConfig` and the standalone v2 CLI adapter (`disabled`, `service`, `inprocess`).
+- `ROSCLAW_KNOW_URL`, `ROSCLAW_HOW_V2_URL`, API-key variables and `ROSCLAW_KNOWLEDGE_TIMEOUT` for service mode.
+- `ROSCLAW_KNOW_STORE_MODE` and `ROSCLAW_KNOW_SEEKDB_PATH` for in-process Know.
+
+## Agent and MCP surface
+
+The registered tools are intentionally small:
+
+- `rosclaw_know_research`: bounded read-only research.
+- `rosclaw_know_build_reference_pack`: evidence-cited retrieval.
+- `rosclaw_know_open_reference_pack`: progressive disclosure by opaque ID.
+- `rosclaw_how_advice`: DISCOVER, CONSULT, DIAGNOSE or CATALYZE advice.
+
+Every tool is S0/read-only. `rosclaw_how_advice` is additionally marked advisory. None can create an `ActionEnvelope`, call a robot driver or grant approval.
+
+## Feedback and observability
+
+Only allowlisted lifecycle events containing identifiers, counts, versions and statuses cross the EventBus adapter. Feedback records whether a unit was presented, opened or useful; a receipt or Practice reference is only a reference. Feedback cannot claim that a physical action succeeded and cannot carry raw Memory content.
+
+Dashboard status includes v2 mode and component health. A How or Know failure therefore remains observable without changing estop, safety policy, daemon or driver behavior.

--- a/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
+++ b/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
@@ -1,0 +1,243 @@
+# Know / How v2 implementation report
+
+Date: 2026-08-06
+Target release: 1.2.0
+Source plan: `know_how_优化v1.md`
+
+## Result
+
+The three repositories now implement the v2 ownership split and a tested
+external-source-to-advice loop:
+
+```text
+pinned external material
+  -> SourceRecord / immutable SourceSnapshot / EvidenceRef
+  -> Project Wiki / KnowledgeUnit
+  -> SeekDB-backed hybrid retrieval
+  -> ReferencePackV2
+  -> context-aware HowAdviceBundleV2
+  -> read-only Native Agent / MCP presentation
+  -> KnowledgeUsageFeedbackV1
+```
+
+Physical execution was deliberately not added to this path. Advice cannot
+create an `ActionEnvelope` or bypass Core policy, safety, daemon or driver
+boundaries. Memory remains a separately labelled robot-experience input and
+is not used as Know's corpus or store.
+
+The implementation is present as uncommitted working-tree changes based on:
+
+| Repository | Base commit | Package version |
+| --- | --- | --- |
+| `rosclaw-know` | `55ce4981f46ca469ff1cc6ca9582f82d6e2d8c92` | 1.2.0 |
+| `rosclaw-how` | `4639cd68bbe294ce61eb01d63c9a96999e3f969f` | 1.2.0 |
+| `rosclaw` | `fbf9a692bbf759fdc8f8e304d205c3d592ca4dc9` | 1.2.0 |
+
+## Architecture and contracts
+
+The authoritative contracts live in `rosclaw-know`; strict wire-compatible
+copies in How and Core prevent either consumer from importing Know internals.
+Schema-drift tests compare those copies to the authoritative JSON Schema.
+Unknown fields are rejected, timestamps must be timezone-aware, enumerations
+are bounded and wire versions are exact.
+
+Implemented public contracts:
+
+- `ResearchRequestV2`
+- `SourceRecordV2`
+- `SourceSnapshotV2`
+- `EvidenceRefV2`
+- `ProjectCardV2`
+- `KnowledgeUnitV2`
+- `ReferencePackV2`
+- `HowAdviceBundleV2`
+- `KnowledgeUsageFeedbackV1`
+- explicit Body, Software, Runtime and labelled Memory context contracts
+
+The generated `know_how_v2.json` is shipped inside the Know wheel. The full
+Core ownership and runtime-mode description is in
+`docs/architecture/KNOW_HOW_V2_INTEGRATION.md`.
+
+## rosclaw-know
+
+### Canonical store
+
+`KnowStore` is a light Protocol with explicit capabilities. The production
+implementation uses SeekDB; the in-memory implementation is test-only and
+requires explicit opt-in. Store creation has no silent production fallback.
+
+Six repeatable up/down migration groups cover sources, snapshots, documents,
+wiki pages, units, relations, packs, feedback, research jobs, index versions
+and retrieval indexes. They are packaged in the wheel. Snapshot writes are
+immutable and content-derived writes are idempotent. Startup isolation guards
+reject equal Know, Memory and Practice database names or embedded paths.
+
+Retrieval implements exact error/symbol match, metadata filtering,
+full-text/NGRAM branches, coordinated problem/mechanism/content/code vectors,
+RRF fusion, relation expansion, deterministic fallback, compatibility
+warnings, score breakdown, token budgets and continuation cursors. Index
+version records retain vector dimensions and capability state.
+
+The environment had `pyseekdb 1.4.0.post1` and `pylibseekdb 1.3.0.post4` in
+the integration environment. The isolated capability probe confirmed embedded
+client creation, collections, namespaces, full-text, sparse vector, hybrid
+search and RRF. The wheel-installed embedded store also opened successfully
+and returned statistics. Native single-collection multi-vector and server
+`AI_RERANK` were not advertised; coordinated collections and deterministic
+rerank fallback are used instead.
+
+### Sources, wiki and safety
+
+Read-only, bounded adapters exist for GitHub, an allowlisted official-docs
+catalog and arXiv. DeepWiki, GitMCP, Context7 and general web adapters report
+explicit unavailable state until their services are configured. Default tests
+use fixed transports and do not depend on the public internet.
+
+GitHub ingestion pins a commit, inventories repository metadata and relevant
+source/config/docs/test/deployment files, caps counts and sizes, rejects unsafe
+paths and binaries, and never executes repository content. Prompt-injection
+signals are retained as evidence metadata; source text never becomes a system
+instruction or tool call.
+
+The wiki compiler creates inventories, language-aware symbols, dependency
+relations, project/component/page records, evidence-linked knowledge units and
+content-hash incremental updates. Optional `.rosclaw/know.yaml` steering is
+data-only and cannot grant execution authority.
+
+### Service and compatibility
+
+The v2 service exposes health, capabilities, schema, research planning/run,
+source/snapshot/project/wiki/evidence reads, retrieval/Reference Pack building
+and governance feedback. Content endpoints enforce the optional
+`ROSCLAW_KNOW_API_KEYS` allowlist. Existing `/know/v1` behavior remains. JSON
+bridge and pattern assets can be imported without invented provenance and
+exported deterministically.
+
+Offline cognitive-wiki bundles have deterministic ZIP metadata, a manifest,
+per-file SHA-256/size verification, path and expansion limits, index/freshness/
+license fields and a signer Protocol. The included HMAC signer is for local
+offline integrity; deployment can provide a stronger signer. Offline imports
+remain explicitly marked as offline and freshness-limited.
+
+## rosclaw-how
+
+How accesses Know only through the versioned Reference Pack/feedback client;
+it owns no SeekDB index. HTTP, in-process and disabled clients have the same
+boundary.
+
+DISCOVER, CONSULT, DIAGNOSE and CATALYZE produce advisory recommendations with
+knowledge-unit and evidence citations. A citation guard drops invented or
+out-of-pack references. Empty, unavailable or invalid Know results cause an
+honest abstention rather than a blank pseudo-answer. Compatibility warnings
+and unknown context are surfaced explicitly. Know evidence and Memory evidence
+are separately labelled in diagnosis output.
+
+The v2 API now includes the four explicit mode endpoints, generic advice,
+bounded process-local advice lookup, feedback, health and capabilities.
+Capabilities explicitly state that How owns neither a retrieval index nor
+action authority. Advice and feedback endpoints enforce the existing optional
+How API-key allowlist. The legacy `/wiki/v1` path can be rolled through the v2
+engine behind a feature flag.
+
+## Core rosclaw
+
+Core contains contracts, Protocols and adapters only. It does not copy the
+source, wiki, retrieval or advice algorithms. `disabled`, `service` and
+`inprocess` modes are available; disabled is the rollback-safe default.
+Optional packages are imported lazily, service clients do not start processes,
+and missing packages/services become truthful degraded health rather than a
+Core startup failure.
+
+In-process mode gives the Know package its own explicitly configured store and
+passes How only a Reference Pack client. It never passes Memory's store.
+Body/Software/Runtime context projection rejects raw sensor streams,
+trajectories, video and secrets. The feedback adapter carries only knowledge
+governance fields. EventBus output is allowlisted to IDs, versions, counts and
+statuses.
+
+Native Agent and minimal MCP expose four S0 tools:
+
+- bounded Know research;
+- Reference Pack build;
+- Reference Pack open;
+- How advice.
+
+The research worker has only the bounded research capability. Runtime and
+dashboard status include v2 health. The four-mode CLI is available through the
+normal `rosclaw` entrypoint while unknown/older subcommands remain on the
+legacy path.
+
+## Reference study
+
+Read-only reference clones were locked before implementation. No reference
+code was copied or executed. The adopted ideas were bounded repository
+inventory and leaf-first wiki generation (CodeWiki), perspective-led research
+and citations (STORM), progressive read-only access (GitMCP/GitHub MCP/
+DeepWiki), version-aware documents (Context7), typed relations (GraphRAG),
+incremental updates (LightRAG) and the actual pyseekdb client capabilities.
+
+Exact revisions and non-adoptions are recorded in
+`rosclaw-know/docs/references/KNOW_HOW_REFERENCE_LOCK.yaml` and
+`KNOW_HOW_REFERENCE_STUDY.md`. The supplied RepoMaster repository URL was not
+available and no substitute was silently selected.
+
+## Verification performed
+
+All tests used fixtures, mocks, temporary directories or embedded stores. No
+real ROS graph, robot, actuator or hardware service was contacted.
+
+| Check | Result |
+| --- | --- |
+| `rosclaw-know` full pytest | 682 passed, 7 skipped |
+| `rosclaw-how` full pytest | 357 passed |
+| Core knowledge + E2E + MCP + CLI focused regression | 100 passed |
+| Real installed-package in-process Know→Pack→How→feedback loop | passed |
+| v2 Ruff scopes and all three `git diff --check` checks | passed |
+| Three 1.2.0 wheel builds | passed |
+| Wheel schema/migration/module inspection | passed |
+| Python 3.13 clean full-dependency wheel install | passed |
+| Clean uninstall and `--no-index --no-deps` local-wheel reinstall | passed |
+| `rosclaw[knowledge]==1.2.0` dependency resolution | passed |
+| `rosclaw[all]==1.2.0` dependency resolution | passed |
+| Installed entrypoint disabled/degradation check | passed |
+| Core full pytest | 6375 passed, 74 skipped, 39 deselected, 6 environment failures |
+
+The clean wheel environment reported all three installed versions as 1.2.0,
+found the packaged JSON Schema, found all 12 migration files and opened an
+isolated SeekDB embedded database.
+
+The six Core full-suite failures are outside the changed Know/How areas. Two
+external-worker tests assume the `codex` binary is absent, while this host has
+an incompatible/untrusted-directory Codex CLI. Four LeRobot integration tests
+are selected by their availability probe but the configured worker interpreter
+cannot import LeRobot. Focused reruns of all changed Core surfaces pass.
+
+## Known limits and release follow-ups
+
+- SeekDB server-mode construction, SQL migrations and feature negotiation are
+  implemented, and Core server-parameter wiring is unit tested, but no live
+  server endpoint was supplied; server integration, transaction rollback and
+  `AI_RERANK` remain unverified on this host.
+- Live GitHub, arXiv, official documentation and external MCP service tests
+  were intentionally not run. Default CI remains deterministic and offline.
+- Native multi-vector is not available in the probed collection API; the
+  implementation uses coordinated vector collections/fields and RRF.
+- Advice lookup is a bounded process-local cache, not a durable How database.
+  Reference Packs themselves remain durable in Know.
+- The HTTP clients do not yet serve a previously cached Reference Pack after
+  Know becomes unavailable; callers receive explicit degraded/unavailable
+  state instead of a stale pseudo-fresh answer.
+- HMAC is the included local bundle signer. A managed deployment should inject
+  an asymmetric signer and key-management policy through `BundleSigner`.
+- Knowledge feedback is stored and available to refresh/ranking governance,
+  but automatic source refresh scheduling is not enabled by feedback alone.
+- The Know v2 API implements the operational closed loop, but the plan's
+  separate discover/ingest, project-compare and admin endpoints are not all
+  split into independent public routes yet.
+- No physical execution was attempted. Real-hardware validation must remain a
+  separately approved ROSClaw workflow through the normal safety chain.
+
+These limits should prevent declaring every checkbox in the source plan's
+Definition of Done complete. The implemented default path and the tested
+closed loop are usable; server/live-source and deployment-signing validation
+remain release gates for environments that require them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rosclaw"
-version = "1.0.1"
+version = "1.2.0"
 description = "Trustworthy Physical Execution Runtime and Control Plane for Embodied Agents"
 readme = "README.md"
 license = {text = "MIT"}
@@ -54,14 +54,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-ros2 = [
-    "rclpy>=3.0.0",
-    "geometry-msgs",
-    "sensor-msgs",
-    "std-msgs",
-    "trajectory-msgs",
-    "control-msgs",
-]
+# ROS 2 Python/message packages are supplied by the selected ROS distribution
+# (apt/rosdep), not PyPI. Keeping the marker extra allows install scripts to
+# express intent without making ``pip install rosclaw[all]`` unsatisfiable.
+ros2 = []
 practice = [
     "rosclaw-practice @ git+https://github.com/ros-claw/rosclaw-practice.git@bfb4ac7",
 ]
@@ -81,8 +77,8 @@ embedding = [
     "transformers>=4.51,<6",
 ]
 knowledge = [
-    "rosclaw-know>=1.0.2",
-    "rosclaw-how>=1.0.2",
+    "rosclaw-know>=1.2.0,<2",
+    "rosclaw-how>=1.2.0,<2",
 ]
 lerobot = [
     "lerobot>=0.6,<0.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ embedding = [
     "transformers>=4.51,<6",
 ]
 knowledge = [
-    "rosclaw-know>=1.2.0,<2",
+    "rosclaw-know>=1.2.1,<2",
     "rosclaw-how>=1.2.0,<2",
 ]
 lerobot = [
@@ -102,8 +102,8 @@ dev = [
     # rosclaw-how permits newer pyseekdb releases, but the native-memory
     # integration and Jetson validation currently target the 1.3 API.
     "pyseekdb==1.3.0",
-    "rosclaw-know>=1.0.2",
-    "rosclaw-how>=1.0.2",
+    "rosclaw-know>=1.2.0,<2",
+    "rosclaw-how>=1.2.0,<2",
 ]
 dashboard = [
     "rosclaw-dashboard>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ Homepage = "https://rosclaw.io"
 Repository = "https://github.com/ros-claw/rosclaw"
 Documentation = "https://docs.rosclaw.io"
 "Bug Tracker" = "https://github.com/ros-claw/rosclaw/issues"
-"Contact" = "mailto:ai@rosclaw.io"
+"Contact" = "https://github.com/ros-claw/rosclaw"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rosclaw"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,10 @@ dependencies = [
 # (apt/rosdep), not PyPI. Keeping the marker extra allows install scripts to
 # express intent without making ``pip install rosclaw[all]`` unsatisfiable.
 ros2 = []
-practice = [
-    "rosclaw-practice @ git+https://github.com/ros-claw/rosclaw-practice.git@bfb4ac7",
-]
+# PyPI rejects direct Git dependencies in published Core Metadata. Practice is
+# not published on PyPI yet, so keep this marker extra resolvable and install
+# the separately versioned rosclaw-practice checkout through deployment tooling.
+practice = []
 practice-export = [
     "pandas>=2.0.0",
     "pyarrow>=15.0.0",

--- a/scripts/acceptance/website_contract.sh
+++ b/scripts/acceptance/website_contract.sh
@@ -52,7 +52,7 @@ demos = json.loads((root / "demos.json").read_text(encoding="utf-8"))
 status = json.loads((root / "status.json").read_text(encoding="utf-8"))
 
 assert demos["demos"][0]["id"] == "ur5e-reach"
-assert status["release"]["version"] == "1.0.1"
+assert status["release"]["version"] == "1.2.0"
 assert status["golden_paths"]["ur5e_reach"]["dimensions"]["simulation"] == "verified"
 assert status["golden_paths"]["rh56_single_step"]["agent_ready"] is False
 print("PASS website contract")

--- a/src/rosclaw/__init__.py
+++ b/src/rosclaw/__init__.py
@@ -11,7 +11,7 @@ import importlib
 from pkgutil import extend_path as _extend_path
 from typing import Any
 
-__version__ = "1.0.1"
+__version__ = "1.2.0"
 __author__ = "ROSClaw Team"
 
 # Allow sibling distributions such as rosclaw-sandbox to extend rosclaw.*.

--- a/src/rosclaw/agent/tool_catalog.py
+++ b/src/rosclaw/agent/tool_catalog.py
@@ -77,6 +77,10 @@ MCP_TOOL_SAFETY_LEVELS: dict[str, str] = {
     "list_body_history": "S0_READ_ONLY",
     "check_skill_compatibility": "S0_READ_ONLY",
     "fleet_skill_compatibility": "S0_READ_ONLY",
+    "rosclaw_know_research": "S0_READ_ONLY",
+    "rosclaw_know_build_reference_pack": "S0_READ_ONLY",
+    "rosclaw_know_open_reference_pack": "S0_READ_ONLY",
+    "rosclaw_how_advice": "S0_ADVISORY",
 }
 
 

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -87,6 +87,22 @@ class RuntimeConfig:
     enable_skill_manager: bool = True
     enable_knowledge: bool = True  # KnowledgeInterface (KNOW module)
     enable_how: bool = True  # HeuristicEngine (HOW module)
+    # Versioned Know/How integration. ``disabled`` preserves the legacy
+    # adapters as a rollback path; v2 never receives Memory's store.
+    knowledge_v2_mode: str = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_KNOWLEDGE_MODE", "disabled")
+    )
+    know_url: str | None = field(default_factory=lambda: os.environ.get("ROSCLAW_KNOW_URL"))
+    know_api_key: str | None = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_KNOW_API_KEY")
+    )
+    knowledge_timeout: float = 15.0
+    know_store_mode: str = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_KNOW_STORE_MODE", "embedded")
+    )
+    know_store_path: str | None = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_KNOW_SEEKDB_PATH")
+    )
     enable_auto: bool = True  # Self-Evolution Control Plane (AUTO module)
     enable_provider: bool = True
     joint_dof: int = 6
@@ -193,6 +209,8 @@ class Runtime(LifecycleMixin):
         self._swarm: Any | None = None
         self._skill_manager: Any | None = None
         self._knowledge: Any | None = None
+        self._knowledge_v2: Any | None = None
+        self._knowledge_v2_manager: Any | None = None
         self._knowledge_batch: Any | None = None
         self._knowledge_assets: Any | None = None
         self._how: Any | None = None
@@ -246,7 +264,8 @@ class Runtime(LifecycleMixin):
             else Path(self.config.timeline_output_dir).expanduser().resolve()
         )
 
-        # Shared SeekDB client reused by Memory, Knowledge, HOW, Auto, and SkillManager.
+        # Legacy store shared by Memory, Auto, SkillManager, and rollback-only
+        # Know/How adapters. Know/How v2 never receives this object.
         seekdb: Any | None = None
 
         # Initialize EventBus subscriptions for internal coordination
@@ -535,8 +554,44 @@ class Runtime(LifecycleMixin):
             except ImportError as e:
                 logger.info(f"SkillManager module not available: {e}")
 
-        # Initialize Knowledge Grounding (KnowledgeInterface) - MUST come before HOW
-        if self.config.enable_knowledge:
+        v2_mode = self.config.knowledge_v2_mode.casefold().strip()
+        if v2_mode not in {"disabled", "service", "inprocess"}:
+            logger.warning("Invalid knowledge_v2_mode=%r; disabling v2", v2_mode)
+            v2_mode = "disabled"
+        if v2_mode != "disabled" and (self.config.enable_knowledge or self.config.enable_how):
+            try:
+                from rosclaw.knowledge import KnowledgeFacade
+                from rosclaw.knowledge.service_manager import (
+                    KnowledgeServiceConfig,
+                    KnowledgeServiceManager,
+                )
+
+                know_path = self.config.know_store_path or str(
+                    workspace_home / "data" / "know" / "seekdb"
+                )
+                service_config = KnowledgeServiceConfig(
+                    mode=v2_mode,
+                    know_url=self.config.know_url,
+                    how_url=self.config.how_url,
+                    know_api_key=self.config.know_api_key or "",
+                    how_api_key=self.config.how_api_key or "",
+                    timeout=self.config.knowledge_timeout,
+                    know_store_mode=self.config.know_store_mode,
+                    know_store_path=know_path,
+                )
+                self._knowledge_v2_manager = KnowledgeServiceManager(service_config)
+                self._knowledge_v2 = KnowledgeFacade(
+                    self._knowledge_v2_manager, event_bus=self.event_bus
+                )
+                logger.info(
+                    "Knowledge v2 orchestration initialized (mode=%s, memory_store_shared=false)",
+                    v2_mode,
+                )
+            except Exception as exc:  # noqa: BLE001 - optional integration
+                logger.warning("Knowledge v2 initialization degraded: %s", exc)
+
+        # Rollback-only local KnowledgeInterface. v2 never receives Memory's store.
+        if self.config.enable_knowledge and v2_mode == "disabled":
             try:
                 from rosclaw.know.interface import KnowledgeInterface
                 from rosclaw.know.storage import seed_knowledge_graph
@@ -590,8 +645,8 @@ class Runtime(LifecycleMixin):
             except ImportError as e:
                 logger.info(f"Knowledge module not available: {e}")
 
-        # Initialize Heuristic Grounding (HeuristicEngine / HowClient) - depends on KNOW
-        if self.config.enable_how:
+        # Rollback-only local How path. How v2 is advisory through KnowledgeFacade.
+        if self.config.enable_how and v2_mode == "disabled":
             try:
                 # Reuse Memory's SeekDB client if available
                 if self._memory is not None:
@@ -675,7 +730,7 @@ class Runtime(LifecycleMixin):
         logger.info("Initialization complete")
 
     def _create_seekdb_client(self) -> Any:
-        """Create and return the shared knowledge-store client for Memory/Knowledge/HOW/Auto.
+        """Create the legacy Memory/Auto/Skill store (not the Know v2 store).
 
         Delegates to :class:`rosclaw.storage.factory.StorageFactory` so backend
         selection, URL validation, and future pooling/vector extensions live in
@@ -769,6 +824,12 @@ class Runtime(LifecycleMixin):
             except Exception as exc:
                 logger.warning("SeekDBBridge close failed (non-fatal): %s", exc)
             self._seekdb_bridge = None
+        if self._knowledge_v2_manager is not None:
+            try:
+                self._knowledge_v2_manager.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Knowledge v2 close failed (non-fatal): %s", exc)
+            self._knowledge_v2_manager = None
         self.event_bus.publish(
             Event(
                 topic="runtime.status",
@@ -1351,7 +1412,13 @@ class Runtime(LifecycleMixin):
 
     @property
     def knowledge(self) -> Any | None:
-        return self._knowledge
+        return self._knowledge_v2 or self._knowledge
+
+    @property
+    def knowledge_v2(self) -> Any | None:
+        """Return the v2 orchestration facade, never a knowledge algorithm."""
+
+        return self._knowledge_v2
 
     @property
     def how(self) -> Any | None:
@@ -3296,7 +3363,19 @@ class Runtime(LifecycleMixin):
                 "provider_layer": self._provider_registry is not None,
                 "auto": self._auto is not None,
                 "sense": self._sense is not None,
+                "knowledge_v2": self._knowledge_v2 is not None,
             },
+            "knowledge": (
+                self._knowledge_v2.health()
+                if self._knowledge_v2 is not None
+                else {
+                    "status": "legacy" if self._knowledge is not None else "disabled",
+                    "mode": "legacy" if self._knowledge is not None else "disabled",
+                    "memory_boundary": (
+                        "legacy_shared_store" if self._knowledge is not None else "isolated"
+                    ),
+                }
+            ),
             "body_sense": sense_status,
             "embodied_memory": {
                 "attached": self.config.embodied_memory is not None,

--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -47,6 +47,12 @@ def main() -> int:
     if result is not None:
         return result
 
+    from rosclaw.knowledge.cli import dispatch_knowledge_argv
+
+    result = dispatch_knowledge_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
     from rosclaw.evidence_verify import dispatch_evidence_argv
 
     result = dispatch_evidence_argv(sys.argv[1:])

--- a/src/rosclaw/how/__init__.py
+++ b/src/rosclaw/how/__init__.py
@@ -1,4 +1,8 @@
-"""rosclaw.how — Heuristic Rules & Recovery Strategies.
+"""Compatibility facade for legacy ROSClaw HOW integrations.
+
+Authoritative v2 implementation lives in ``rosclaw-how``. This package is a
+rollback-compatible runtime adapter; new evidence-backed cognition is exposed
+through :mod:`rosclaw.knowledge` and remains advisory-only.
 
 Two coexisting layers:
 

--- a/src/rosclaw/know/__init__.py
+++ b/src/rosclaw/know/__init__.py
@@ -1,4 +1,7 @@
-"""ROSClaw Knowledge Module — query + batch sides.
+"""Compatibility facade for legacy ROSClaw Knowledge integrations.
+
+Authoritative v2 implementation lives in ``rosclaw-know``. This package is a
+rollback-compatible runtime adapter and must not grow new retrieval algorithms.
 
 Provides structured knowledge for Agent Runtime:
 - Robot capabilities from e-URDF semantic tags

--- a/src/rosclaw/knowledge/__init__.py
+++ b/src/rosclaw/knowledge/__init__.py
@@ -1,0 +1,22 @@
+"""ROSClaw orchestration adapters for optional rosclaw-know/how v2 services."""
+
+from .contracts import (
+    HowAdviceBundleV2,
+    HowAdviceRequestV2,
+    KnowledgeUsageFeedbackV1,
+    ReferencePackV2,
+    ResearchRequestV2,
+)
+from .facade import KnowledgeFacade
+from .service_manager import KnowledgeServiceConfig, KnowledgeServiceManager
+
+__all__ = [
+    "HowAdviceBundleV2",
+    "HowAdviceRequestV2",
+    "KnowledgeFacade",
+    "KnowledgeServiceConfig",
+    "KnowledgeServiceManager",
+    "KnowledgeUsageFeedbackV1",
+    "ReferencePackV2",
+    "ResearchRequestV2",
+]

--- a/src/rosclaw/knowledge/agent_tools.py
+++ b/src/rosclaw/knowledge/agent_tools.py
@@ -1,0 +1,83 @@
+"""Native Agent-facing read-only/advisory tool definitions and dispatcher."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contracts import HowAdviceRequestV2, ReferenceContextV2, ResearchRequestV2
+
+TOOL_DEFINITIONS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "rosclaw_know_research",
+        "description": "Run bounded external-world research; never executes repository code.",
+        "inputSchema": ResearchRequestV2.model_json_schema(),
+        "read_only": True,
+        "advisory": False,
+    },
+    {
+        "name": "rosclaw_know_build_reference_pack",
+        "description": "Retrieve a pinned, evidence-cited reference pack.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "minLength": 1},
+                "context": ReferenceContextV2.model_json_schema(),
+                "top_k": {"type": "integer", "minimum": 1, "maximum": 100},
+                "token_budget": {"type": "integer", "minimum": 1},
+            },
+            "required": ["query", "context"],
+            "additionalProperties": False,
+        },
+        "read_only": True,
+        "advisory": False,
+    },
+    {
+        "name": "rosclaw_know_open_reference_pack",
+        "description": "Open a previously built Reference Pack by opaque id.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"reference_pack_id": {"type": "string", "minLength": 1}},
+            "required": ["reference_pack_id"],
+            "additionalProperties": False,
+        },
+        "read_only": True,
+        "advisory": False,
+    },
+    {
+        "name": "rosclaw_how_advice",
+        "description": "Get evidence-cited DISCOVER/CONSULT/DIAGNOSE/CATALYZE advice.",
+        "inputSchema": HowAdviceRequestV2.model_json_schema(),
+        "read_only": True,
+        "advisory": True,
+    },
+)
+
+
+class KnowledgeAgentTools:
+    def __init__(self, facade: Any) -> None:
+        self.facade = facade
+
+    def definitions(self) -> list[dict[str, Any]]:
+        return [dict(item) for item in TOOL_DEFINITIONS]
+
+    def call(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if name == "rosclaw_know_research":
+            return self.facade.research(arguments)
+        if name == "rosclaw_know_build_reference_pack":
+            pack = self.facade.reference_pack(
+                query=arguments["query"],
+                context=arguments["context"],
+                top_k=arguments.get("top_k", 10),
+                token_budget=arguments.get("token_budget", 8_000),
+            )
+            return pack.model_dump(mode="json")
+        if name == "rosclaw_know_open_reference_pack":
+            pack = self.facade.get_reference_pack(arguments["reference_pack_id"])
+            return (
+                pack.model_dump(mode="json")
+                if pack
+                else {"status": "not_found", "reference_pack_id": arguments["reference_pack_id"]}
+            )
+        if name == "rosclaw_how_advice":
+            return self.facade.advise(arguments).model_dump(mode="json")
+        raise KeyError(f"unknown knowledge tool: {name}")

--- a/src/rosclaw/knowledge/cli.py
+++ b/src/rosclaw/knowledge/cli.py
@@ -1,0 +1,161 @@
+"""Thin CLI adapter for versioned Know/How services."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import uuid
+from typing import Any
+
+from .context_adapter import build_how_context
+from .contracts import HowAdviceRequestV2, ReferenceContextV2, ResearchRequestV2
+from .facade import KnowledgeFacade
+from .feedback_adapter import build_usage_feedback
+from .service_manager import KnowledgeServiceConfig, KnowledgeServiceManager
+
+
+def _print(value: Any) -> None:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
+    print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _facade() -> tuple[KnowledgeServiceManager, KnowledgeFacade]:
+    manager = KnowledgeServiceManager(KnowledgeServiceConfig.from_env())
+    return manager, KnowledgeFacade(manager)
+
+
+def _know_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="rosclaw know")
+    subs = parser.add_subparsers(dest="action", required=True)
+    subs.add_parser("status")
+    research = subs.add_parser("research")
+    research.add_argument("topic")
+    research.add_argument("--goal", default="find reusable projects and implementation references")
+    research.add_argument("--depth", choices=["shallow", "standard", "deep"], default="standard")
+    research.add_argument("--max-sources", type=int, default=20)
+    discover = subs.add_parser("discover")
+    discover.add_argument("query")
+    discover.add_argument("--robot")
+    discover.add_argument("--simulator")
+    discover.add_argument("--ros-distro")
+    discover.add_argument("--top-k", type=int, default=10)
+    discover.add_argument("--token-budget", type=int, default=8000)
+    pack = subs.add_parser("reference-pack")
+    pack_subs = pack.add_subparsers(dest="pack_action", required=True)
+    build = pack_subs.add_parser("build")
+    build.add_argument("--task", required=True)
+    build.add_argument("--robot")
+    build.add_argument("--simulator")
+    build.add_argument("--ros-distro")
+    return parser
+
+
+def _how_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="rosclaw how")
+    subs = parser.add_subparsers(dest="action", required=True)
+    for mode in ("discover", "consult", "diagnose", "catalyze"):
+        command = subs.add_parser(mode)
+        command.add_argument("query")
+        command.add_argument("--task")
+        command.add_argument("--robot")
+        command.add_argument("--simulator")
+        command.add_argument("--ros-distro")
+        command.add_argument("--stage")
+        command.add_argument("--failure")
+        command.add_argument("--top-k", type=int, default=8)
+        command.add_argument("--token-budget", type=int, default=8000)
+    feedback = subs.add_parser("feedback")
+    feedback.add_argument("advice_id")
+    feedback.add_argument("--reference-pack-id", required=True)
+    feedback.add_argument("--knowledge-unit-id", required=True)
+    feedback.add_argument("--context-hash", required=True)
+    feedback.add_argument(
+        "--verdict",
+        choices=["useful", "irrelevant", "stale", "incompatible", "misleading", "unknown"],
+        required=True,
+    )
+    feedback.add_argument("--reason")
+    return parser
+
+
+def dispatch_knowledge_argv(argv: list[str]) -> int | None:
+    """Handle v2-only subcommands and leave legacy know/how commands untouched."""
+
+    if len(argv) < 2 or argv[0] not in {"know", "how"}:
+        return None
+    v2_actions = {
+        "know": {"status", "research", "discover", "reference-pack"},
+        "how": {"discover", "consult", "diagnose", "catalyze", "feedback"},
+    }
+    if argv[1] not in v2_actions[argv[0]]:
+        return None
+    args = (_know_parser() if argv[0] == "know" else _how_parser()).parse_args(argv[1:])
+    manager, facade = _facade()
+    try:
+        if argv[0] == "know":
+            if args.action == "status":
+                _print(facade.health())
+                return 0
+            if args.action == "research":
+                request = ResearchRequestV2(
+                    request_id=f"research_{uuid.uuid4().hex[:24]}",
+                    topic=args.topic,
+                    goal=args.goal,
+                    depth=args.depth,
+                    max_sources=args.max_sources,
+                )
+                _print(facade.research(request))
+                return 0
+            query = args.query if args.action == "discover" else args.task
+            context = ReferenceContextV2(
+                task=query,
+                robot=args.robot,
+                simulator=args.simulator,
+                ros_distro=args.ros_distro,
+            )
+            _print(
+                facade.reference_pack(
+                    query=query,
+                    context=context,
+                    top_k=getattr(args, "top_k", 10),
+                    token_budget=getattr(args, "token_budget", 8000),
+                )
+            )
+            return 0
+        if args.action == "feedback":
+            feedback = build_usage_feedback(
+                reference_pack_id=args.reference_pack_id,
+                advice_id=args.advice_id,
+                knowledge_unit_id=args.knowledge_unit_id,
+                context_hash=args.context_hash,
+                verdict=args.verdict,
+                reason=args.reason,
+                origin="user",
+            )
+            _print({"created": facade.feedback(feedback), "feedback_id": feedback.feedback_id})
+            return 0
+        context = build_how_context(
+            task=args.task or args.query,
+            robot_model=args.robot,
+            simulator=args.simulator,
+            ros_distro=args.ros_distro,
+            current_stage=args.stage,
+            current_failure=args.failure,
+            error_log=args.query if args.action == "diagnose" else None,
+        )
+        request = HowAdviceRequestV2(
+            request_id=f"advice_request_{uuid.uuid4().hex[:24]}",
+            mode=args.action,
+            query=args.query,
+            context=context,
+            top_k=args.top_k,
+            token_budget=args.token_budget,
+        )
+        _print(facade.advise(request))
+        return 0
+    except Exception as exc:  # noqa: BLE001 - CLI boundary
+        _print({"status": "unavailable", "error": f"{type(exc).__name__}: {exc}"})
+        return 2
+    finally:
+        manager.close()

--- a/src/rosclaw/knowledge/context_adapter.py
+++ b/src/rosclaw/knowledge/context_adapter.py
@@ -1,0 +1,106 @@
+"""Build minimum, explicitly separated context for How advice."""
+
+from __future__ import annotations
+
+import platform
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from .contracts import (
+    BodyContextV2,
+    HowContextV2,
+    MemoryEvidenceV2,
+    RuntimeContextV2,
+    SoftwareContextV2,
+)
+
+_FORBIDDEN_MEMORY_KEYS = {
+    "trajectory",
+    "frames",
+    "video",
+    "sensor_data",
+    "time_series",
+    "raw_content",
+    "embedding",
+}
+
+
+def _strings(values: Iterable[Any], *, limit: int = 100) -> list[str]:
+    return [str(value) for value in list(values)[:limit] if str(value)]
+
+
+def build_body_context(
+    *,
+    robot_model: str | None,
+    body: Any | None = None,
+    safety_limits: Iterable[Any] = (),
+) -> BodyContextV2:
+    """Read descriptive metadata only; no handles, permits, or commands cross."""
+
+    sensors = getattr(body, "sensors", ()) if body is not None else ()
+    actuators = getattr(body, "actuators", ()) if body is not None else ()
+    robot_type = getattr(body, "robot_type", None) if body is not None else None
+    return BodyContextV2(
+        robot_model=robot_model,
+        robot_type=str(robot_type) if robot_type else None,
+        sensors=_strings(sensors),
+        actuators=_strings(actuators),
+        safety_limits=_strings(safety_limits),
+    )
+
+
+def build_memory_evidence(items: Iterable[Mapping[str, Any]]) -> list[MemoryEvidenceV2]:
+    """Accept summaries and opaque refs only; reject raw Practice/Memory payloads."""
+
+    evidence = []
+    for item in list(items)[:20]:
+        forbidden = _FORBIDDEN_MEMORY_KEYS.intersection(item)
+        if forbidden:
+            raise ValueError(f"raw Memory/Practice fields are forbidden: {sorted(forbidden)}")
+        created_at = item.get("created_at") or datetime.now(UTC)
+        evidence.append(
+            MemoryEvidenceV2(
+                memory_id=str(item["memory_id"]),
+                summary=str(item["summary"]),
+                confidence=float(item.get("confidence", 0.0)),
+                receipt_ref=str(item["receipt_ref"]) if item.get("receipt_ref") else None,
+                practice_ref=str(item["practice_ref"]) if item.get("practice_ref") else None,
+                created_at=created_at,
+            )
+        )
+    return evidence
+
+
+def build_how_context(
+    *,
+    task: str,
+    robot_model: str | None = None,
+    body: Any | None = None,
+    safety_limits: Iterable[Any] = (),
+    ros_distro: str | None = None,
+    simulator: str | None = None,
+    software_versions: Mapping[str, str] | None = None,
+    current_stage: str | None = None,
+    current_failure: str | None = None,
+    error_log: str | None = None,
+    verifier_signals: Iterable[Any] = (),
+    memory_evidence: Iterable[Mapping[str, Any]] = (),
+) -> HowContextV2:
+    return HowContextV2(
+        body=build_body_context(robot_model=robot_model, body=body, safety_limits=safety_limits),
+        software=SoftwareContextV2(
+            ros_distro=ros_distro,
+            simulator=simulator,
+            versions=dict(software_versions or {}),
+            hardware_architecture=platform.machine() or None,
+        ),
+        runtime=RuntimeContextV2(
+            task=task,
+            current_stage=current_stage,
+            current_failure=current_failure,
+            error_log=error_log,
+            verifier_signals=_strings(verifier_signals),
+        ),
+        memory_evidence=build_memory_evidence(memory_evidence),
+    )

--- a/src/rosclaw/knowledge/contracts.py
+++ b/src/rosclaw/knowledge/contracts.py
@@ -1,0 +1,295 @@
+"""Dependency-light wire contracts shared with rosclaw-know/how v2.
+
+The authoritative schemas live in ``rosclaw-know``.  These deliberately small
+copies let Core validate service traffic without importing either optional
+package or their retrieval dependencies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class StrictWireModel(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid", strict=True, validate_assignment=True, str_strip_whitespace=True
+    )
+    SCHEMA_VERSION: ClassVar[str | None] = None
+
+    @classmethod
+    def validate_wire_json(cls, payload: str | bytes):
+        return cls.model_validate_json(payload)
+
+    def to_wire_json(self) -> str:
+        return self.model_dump_json(exclude_none=True)
+
+
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise ValueError("timestamp must include a timezone")
+    return value
+
+
+class ResearchConstraintsV2(StrictWireModel):
+    robot_model: str | None = None
+    simulator: str | None = None
+    ros_distro: str | None = None
+    language: list[str] = Field(default_factory=list)
+    date_after: str | None = None
+    software_versions: dict[str, str] = Field(default_factory=dict)
+
+
+class ResearchRequestV2(StrictWireModel):
+    SCHEMA_VERSION: ClassVar[str] = "rosclaw.know.research_request.v2"
+
+    schema_version: Literal["rosclaw.know.research_request.v2"] = SCHEMA_VERSION
+    request_id: str = Field(min_length=1, max_length=200)
+    topic: str = Field(min_length=1, max_length=2000)
+    goal: str = Field(min_length=1, max_length=4000)
+    perspectives: list[str] = Field(default_factory=list, max_length=20)
+    source_types: list[
+        Literal[
+            "repository",
+            "paper",
+            "official_documentation",
+            "issue",
+            "pull_request",
+            "release",
+            "web",
+        ]
+    ] = Field(default_factory=list, max_length=20)
+    constraints: ResearchConstraintsV2 = Field(default_factory=ResearchConstraintsV2)
+    depth: Literal["shallow", "standard", "deep"] = "standard"
+    max_sources: int = Field(default=20, ge=1, le=200)
+    token_budget: int = Field(default=50_000, ge=1_000, le=2_000_000)
+
+
+class EvidenceRefV2(StrictWireModel):
+    SCHEMA_VERSION: ClassVar[str] = "rosclaw.know.evidence_ref.v2"
+
+    schema_version: Literal["rosclaw.know.evidence_ref.v2"] = SCHEMA_VERSION
+    evidence_id: str = Field(min_length=1, max_length=240)
+    source_id: str = Field(min_length=1, max_length=200)
+    snapshot_id: str = Field(min_length=1, max_length=240)
+    document_id: str = Field(min_length=1, max_length=240)
+    path: str = Field(min_length=1, max_length=4000)
+    start_line: int | None = Field(default=None, ge=1)
+    end_line: int | None = Field(default=None, ge=1)
+    section: str | None = None
+    url: str = Field(min_length=1, max_length=4000)
+    content_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    excerpt: str = Field(min_length=1, max_length=2000)
+
+    @model_validator(mode="after")
+    def _line_range(self):
+        if self.end_line is not None and self.start_line is None:
+            raise ValueError("end_line requires start_line")
+        if self.start_line and self.end_line and self.end_line < self.start_line:
+            raise ValueError("end_line must be >= start_line")
+        return self
+
+
+class ReferenceContextV2(StrictWireModel):
+    task: str | None = None
+    robot: str | None = None
+    simulator: str | None = None
+    ros_distro: str | None = None
+    software_versions: dict[str, str] = Field(default_factory=dict)
+    current_stage: str | None = None
+    current_failure: str | None = None
+
+
+class ReferencePackItemV2(StrictWireModel):
+    rank: int = Field(ge=1)
+    project_id: str | None = None
+    knowledge_unit_ids: list[str] = Field(min_length=1)
+    title: str = Field(min_length=1)
+    why_relevant: str = Field(min_length=1)
+    relevance_dimensions: list[str] = Field(default_factory=list)
+    mechanism: str = Field(min_length=1)
+    what_to_borrow: list[str] = Field(default_factory=list)
+    exact_files: list[str] = Field(default_factory=list)
+    exact_sections: list[str] = Field(default_factory=list)
+    incompatibilities: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+    adaptation_needed: list[str] = Field(default_factory=list)
+    source_version: str = Field(min_length=1)
+    evidence_refs: list[EvidenceRefV2] = Field(min_length=1)
+    score: float | None = None
+    score_breakdown: dict[str, float] = Field(default_factory=dict)
+
+
+class ReferenceComparisonV2(StrictWireModel):
+    shared_principles: list[str] = Field(default_factory=list)
+    conflicting_assumptions: list[str] = Field(default_factory=list)
+    route_tradeoffs: list[str] = Field(default_factory=list)
+    preferred_references: list[str] = Field(default_factory=list)
+
+
+class ReferencePackV2(StrictWireModel):
+    SCHEMA_VERSION: ClassVar[str] = "rosclaw.know.reference_pack.v2"
+
+    schema_version: Literal["rosclaw.know.reference_pack.v2"] = SCHEMA_VERSION
+    reference_pack_id: str = Field(min_length=1)
+    query: str = Field(min_length=1)
+    context: ReferenceContextV2
+    generated_at: datetime
+    index_version: str = Field(min_length=1)
+    items: list[ReferencePackItemV2] = Field(default_factory=list)
+    comparison: ReferenceComparisonV2 = Field(default_factory=ReferenceComparisonV2)
+    recommended_reading_order: list[str] = Field(default_factory=list)
+    suggested_next_checks: list[str] = Field(default_factory=list)
+    open_questions: list[str] = Field(default_factory=list)
+    token_budget: int = Field(ge=1)
+    truncated: bool = False
+    continuation_cursor: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+    _generated_aware = field_validator("generated_at")(_aware)
+
+    @model_validator(mode="after")
+    def _cursor_when_truncated(self):
+        if self.truncated and not self.continuation_cursor:
+            raise ValueError("truncated packs require a continuation_cursor")
+        return self
+
+
+class AdviceRecommendationV2(StrictWireModel):
+    action_type: Literal["inspect", "compare", "configure", "implement", "verify", "abstain"]
+    description: str = Field(min_length=1)
+    rationale: str = Field(min_length=1)
+    knowledge_unit_ids: list[str] = Field(default_factory=list)
+    evidence_refs: list[EvidenceRefV2] = Field(default_factory=list)
+    safety_class: Literal["advisory"] = "advisory"
+
+
+class HowAdviceBundleV2(StrictWireModel):
+    SCHEMA_VERSION: ClassVar[str] = "rosclaw.how.advice.v2"
+
+    schema_version: Literal["rosclaw.how.advice.v2"] = SCHEMA_VERSION
+    advice_id: str = Field(min_length=1)
+    mode: Literal["discover", "consult", "diagnose", "catalyze"]
+    context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    reference_pack_id: str | None = None
+    summary: str = Field(min_length=1)
+    diagnosis: str | None = None
+    recommendations: list[AdviceRecommendationV2] = Field(default_factory=list)
+    compatibility_warnings: list[str] = Field(default_factory=list)
+    unknowns: list[str] = Field(default_factory=list)
+    abstained: bool = False
+    abstention_reason: str | None = None
+    created_at: datetime
+
+    _created_aware = field_validator("created_at")(_aware)
+
+    @model_validator(mode="after")
+    def _abstention_explained(self):
+        if self.abstained and not self.abstention_reason:
+            raise ValueError("abstained advice requires abstention_reason")
+        return self
+
+
+class KnowledgeUsageFeedbackV1(StrictWireModel):
+    SCHEMA_VERSION: ClassVar[str] = "rosclaw.knowledge_usage_feedback.v1"
+
+    schema_version: Literal["rosclaw.knowledge_usage_feedback.v1"] = SCHEMA_VERSION
+    feedback_id: str = Field(min_length=1)
+    reference_pack_id: str = Field(min_length=1)
+    advice_id: str | None = None
+    knowledge_unit_id: str = Field(min_length=1)
+    presented: bool = True
+    opened: bool = False
+    used_by_agent: bool = False
+    verdict: Literal["useful", "irrelevant", "stale", "incompatible", "misleading", "unknown"]
+    reason: str | None = None
+    context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    receipt_ref: str | None = None
+    practice_ref: str | None = None
+    origin: Literal["user", "agent", "verifier"]
+    created_at: datetime
+
+    _created_aware = field_validator("created_at")(_aware)
+
+
+_SECRET_RE = re.compile(r"(?i)(api[_-]?key|token|password|authorization)\s*[:=]\s*[^\s,;]+")
+
+
+class BodyContextV2(StrictWireModel):
+    robot_model: str | None = None
+    robot_type: str | None = None
+    sensors: list[str] = Field(default_factory=list)
+    actuators: list[str] = Field(default_factory=list)
+    safety_limits: list[str] = Field(default_factory=list)
+
+
+class SoftwareContextV2(StrictWireModel):
+    ros_distro: str | None = None
+    simulator: str | None = None
+    versions: dict[str, str] = Field(default_factory=dict)
+    hardware_architecture: str | None = None
+
+
+class RuntimeContextV2(StrictWireModel):
+    task: str
+    current_stage: str | None = None
+    current_failure: str | None = None
+    error_log: str | None = Field(default=None, max_length=20_000)
+    verifier_signals: list[str] = Field(default_factory=list, max_length=100)
+
+    @field_validator("error_log")
+    @classmethod
+    def _redact_secrets(cls, value: str | None) -> str | None:
+        return _SECRET_RE.sub(r"\1=[REDACTED]", value) if value else value
+
+
+class MemoryEvidenceV2(StrictWireModel):
+    evidence_domain: Literal["memory"] = "memory"
+    memory_id: str
+    summary: str = Field(min_length=1, max_length=2000)
+    confidence: float = Field(ge=0.0, le=1.0)
+    receipt_ref: str | None = None
+    practice_ref: str | None = None
+    created_at: datetime
+
+    _memory_created_aware = field_validator("created_at")(_aware)
+
+
+class HowContextV2(StrictWireModel):
+    body: BodyContextV2 = Field(default_factory=BodyContextV2)
+    software: SoftwareContextV2 = Field(default_factory=SoftwareContextV2)
+    runtime: RuntimeContextV2
+    memory_evidence: list[MemoryEvidenceV2] = Field(default_factory=list, max_length=20)
+
+    def context_hash(self) -> str:
+        payload = json.dumps(
+            self.model_dump(mode="json"), ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+
+class HowAdviceRequestV2(StrictWireModel):
+    SCHEMA_VERSION: ClassVar[str] = "rosclaw.how.advice_request.v2"
+
+    schema_version: Literal["rosclaw.how.advice_request.v2"] = SCHEMA_VERSION
+    request_id: str
+    mode: Literal["discover", "consult", "diagnose", "catalyze"]
+    query: str = Field(min_length=1, max_length=20_000)
+    context: HowContextV2
+    top_k: int = Field(default=8, ge=1, le=100)
+    token_budget: int = Field(default=8_000, ge=1, le=500_000)
+
+
+PUBLIC_CONTRACTS = (
+    ResearchRequestV2,
+    EvidenceRefV2,
+    ReferencePackV2,
+    HowAdviceBundleV2,
+    KnowledgeUsageFeedbackV1,
+    HowAdviceRequestV2,
+)

--- a/src/rosclaw/knowledge/event_adapter.py
+++ b/src/rosclaw/knowledge/event_adapter.py
@@ -1,0 +1,92 @@
+"""Redacted EventBus projection for knowledge lifecycle observability."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from rosclaw.core.event_bus import Event, EventBus, EventPriority
+
+KNOWLEDGE_EVENT_TOPICS = frozenset(
+    {
+        "know.research.requested",
+        "know.research.started",
+        "know.research.completed",
+        "know.research.failed",
+        "know.source.discovered",
+        "know.source.snapshotted",
+        "know.source.updated",
+        "know.source.superseded",
+        "know.project.indexed",
+        "know.wiki.updated",
+        "know.reference_pack.created",
+        "know.reference_pack.stale",
+        "how.advice.created",
+        "how.advice.abstained",
+        "how.feedback.recorded",
+    }
+)
+
+_FORBIDDEN_KEYS = {
+    "api_key",
+    "authorization",
+    "password",
+    "token",
+    "document_content",
+    "memory_content",
+    "trajectory",
+    "sensor_data",
+    "permit",
+    "action_authorization",
+}
+_ALLOWED_KEYS = {
+    "request_id",
+    "job_id",
+    "source_id",
+    "snapshot_id",
+    "project_id",
+    "reference_pack_id",
+    "advice_id",
+    "feedback_id",
+    "knowledge_unit_id",
+    "index_version",
+    "status",
+    "mode",
+    "verdict",
+    "count",
+    "stale",
+    "error_type",
+}
+
+
+def safe_event_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if _FORBIDDEN_KEYS.intersection(key.casefold() for key in payload):
+        raise ValueError("knowledge event payload contains a forbidden field")
+    result: dict[str, Any] = {}
+    for key, value in payload.items():
+        if key not in _ALLOWED_KEYS:
+            continue
+        if isinstance(value, str):
+            result[key] = value[:240]
+        elif isinstance(value, (bool, int, float)) or value is None:
+            result[key] = value
+    return result
+
+
+class KnowledgeEventAdapter:
+    def __init__(self, event_bus: EventBus | None) -> None:
+        self.event_bus = event_bus
+
+    def publish(self, topic: str, payload: Mapping[str, Any]) -> None:
+        if self.event_bus is None:
+            return
+        if topic not in KNOWLEDGE_EVENT_TOPICS:
+            raise ValueError(f"unsupported knowledge event topic: {topic}")
+        self.event_bus.publish(
+            Event(
+                topic=topic,
+                payload=safe_event_payload(payload),
+                source="knowledge_adapter",
+                priority=EventPriority.LOW,
+            )
+        )

--- a/src/rosclaw/knowledge/facade.py
+++ b/src/rosclaw/knowledge/facade.py
@@ -1,0 +1,122 @@
+"""Core orchestration facade over versioned Know and How protocols."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contracts import (
+    HowAdviceBundleV2,
+    HowAdviceRequestV2,
+    KnowledgeUsageFeedbackV1,
+    ReferenceContextV2,
+    ReferencePackV2,
+    ResearchRequestV2,
+)
+from .event_adapter import KnowledgeEventAdapter
+
+
+class KnowledgeFacade:
+    def __init__(self, manager: Any, *, event_bus: Any | None = None) -> None:
+        self.manager = manager
+        self.events = KnowledgeEventAdapter(event_bus)
+
+    def health(self) -> dict[str, Any]:
+        return self.manager.health()
+
+    def research(self, request: ResearchRequestV2 | dict[str, Any]) -> dict[str, Any]:
+        request = (
+            request
+            if isinstance(request, ResearchRequestV2)
+            else ResearchRequestV2.model_validate(request)
+        )
+        self.events.publish("know.research.requested", {"request_id": request.request_id})
+        try:
+            result = self.manager.know.research(request)
+        except Exception as exc:
+            self.events.publish(
+                "know.research.failed",
+                {"request_id": request.request_id, "error_type": type(exc).__name__},
+            )
+            raise
+        self.events.publish(
+            "know.research.completed",
+            {
+                "request_id": request.request_id,
+                "status": str(result.get("status", "completed")),
+            },
+        )
+        return result
+
+    def reference_pack(
+        self,
+        *,
+        query: str,
+        context: ReferenceContextV2 | dict[str, Any],
+        top_k: int = 10,
+        token_budget: int = 8_000,
+    ) -> ReferencePackV2:
+        context = (
+            context
+            if isinstance(context, ReferenceContextV2)
+            else ReferenceContextV2.model_validate(context)
+        )
+        pack = self.manager.know.reference_pack(
+            query=query, context=context, top_k=top_k, token_budget=token_budget
+        )
+        self.events.publish(
+            "know.reference_pack.created",
+            {
+                "reference_pack_id": pack.reference_pack_id,
+                "index_version": pack.index_version,
+                "count": len(pack.items),
+            },
+        )
+        return pack
+
+    def get_reference_pack(self, reference_pack_id: str) -> ReferencePackV2 | None:
+        return self.manager.know.get_reference_pack(reference_pack_id)
+
+    def advise(self, request: HowAdviceRequestV2 | dict[str, Any]) -> HowAdviceBundleV2:
+        request = (
+            request
+            if isinstance(request, HowAdviceRequestV2)
+            else HowAdviceRequestV2.model_validate(request)
+        )
+        advice = self.manager.how.advise(request)
+        topic = "how.advice.abstained" if advice.abstained else "how.advice.created"
+        self.events.publish(
+            topic,
+            {
+                "request_id": request.request_id,
+                "advice_id": advice.advice_id,
+                "reference_pack_id": advice.reference_pack_id,
+                "mode": advice.mode,
+                "status": "abstained" if advice.abstained else "created",
+            },
+        )
+        return advice
+
+    def feedback(
+        self, feedback: KnowledgeUsageFeedbackV1 | dict[str, Any], *, via_how: bool = True
+    ) -> bool:
+        feedback = (
+            feedback
+            if isinstance(feedback, KnowledgeUsageFeedbackV1)
+            else KnowledgeUsageFeedbackV1.model_validate(feedback)
+        )
+        created = (
+            self.manager.how.submit_feedback(feedback)
+            if via_how
+            else self.manager.know.submit_feedback(feedback)
+        )
+        self.events.publish(
+            "how.feedback.recorded",
+            {
+                "feedback_id": feedback.feedback_id,
+                "reference_pack_id": feedback.reference_pack_id,
+                "knowledge_unit_id": feedback.knowledge_unit_id,
+                "verdict": feedback.verdict,
+                "status": "created" if created else "duplicate",
+            },
+        )
+        return created

--- a/src/rosclaw/knowledge/feedback_adapter.py
+++ b/src/rosclaw/knowledge/feedback_adapter.py
@@ -1,0 +1,52 @@
+"""Convert receipts into governance feedback without copying execution data."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from typing import Literal
+
+from .contracts import KnowledgeUsageFeedbackV1
+
+
+def build_usage_feedback(
+    *,
+    reference_pack_id: str,
+    knowledge_unit_id: str,
+    context_hash: str,
+    verdict: Literal["useful", "irrelevant", "stale", "incompatible", "misleading", "unknown"],
+    advice_id: str | None = None,
+    presented: bool = True,
+    opened: bool = False,
+    used_by_agent: bool = False,
+    reason: str | None = None,
+    receipt_ref: str | None = None,
+    practice_ref: str | None = None,
+    origin: Literal["user", "agent", "verifier"] = "agent",
+) -> KnowledgeUsageFeedbackV1:
+    stable = ":".join(
+        [
+            reference_pack_id,
+            knowledge_unit_id,
+            advice_id or "",
+            verdict,
+            receipt_ref or "",
+            practice_ref or "",
+        ]
+    )
+    return KnowledgeUsageFeedbackV1(
+        feedback_id=f"feedback_{hashlib.sha256(stable.encode()).hexdigest()[:24]}",
+        reference_pack_id=reference_pack_id,
+        advice_id=advice_id,
+        knowledge_unit_id=knowledge_unit_id,
+        presented=presented,
+        opened=opened,
+        used_by_agent=used_by_agent,
+        verdict=verdict,
+        reason=reason[:1000] if reason else None,
+        context_hash=context_hash,
+        receipt_ref=receipt_ref,
+        practice_ref=practice_ref,
+        origin=origin,
+        created_at=datetime.now(UTC),
+    )

--- a/src/rosclaw/knowledge/health.py
+++ b/src/rosclaw/knowledge/health.py
@@ -1,0 +1,50 @@
+"""Health snapshots safe for Runtime and Dashboard display."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ComponentHealth:
+    name: str
+    mode: str
+    status: str
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class KnowledgeHealth:
+    status: str
+    mode: str
+    know: ComponentHealth
+    how: ComponentHealth
+    memory_boundary: str = "isolated"
+    advisory_only: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def probe_component(name: str, mode: str, client: Any) -> ComponentHealth:
+    try:
+        detail = client.health()
+        status = str(detail.get("status", "unknown"))
+    except Exception as exc:  # noqa: BLE001 - health must never break Core
+        status = "unavailable"
+        detail = {"error": type(exc).__name__}
+    return ComponentHealth(name=name, mode=mode, status=status, detail=detail)
+
+
+def combine_health(mode: str, know_client: Any, how_client: Any) -> KnowledgeHealth:
+    know = probe_component("know", mode, know_client)
+    how = probe_component("how", mode, how_client)
+    statuses = {know.status, how.status}
+    if statuses <= {"ok"}:
+        status = "ok"
+    elif statuses <= {"disabled"}:
+        status = "disabled"
+    else:
+        status = "degraded"
+    return KnowledgeHealth(status=status, mode=mode, know=know, how=how)

--- a/src/rosclaw/knowledge/how_client.py
+++ b/src/rosclaw/knowledge/how_client.py
@@ -1,0 +1,124 @@
+"""Advisory-only adapters for rosclaw-how v2."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .contracts import HowAdviceBundleV2, HowAdviceRequestV2, KnowledgeUsageFeedbackV1
+
+
+class HowUnavailableError(RuntimeError):
+    pass
+
+
+class HttpHowClient:
+    def __init__(self, base_url: str, *, api_key: str = "", timeout: float = 15.0) -> None:
+        if not base_url.startswith(("http://", "https://")):
+            raise ValueError("How URL must use http:// or https://")
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def _request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> bytes:
+        headers = {"Accept": "application/json"}
+        body = None
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+            body = json.dumps(payload, ensure_ascii=False).encode()
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        request = urllib.request.Request(
+            f"{self.base_url}{path}", data=body, headers=headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return response.read(10_000_000)
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as exc:
+            raise HowUnavailableError(
+                f"How request failed: {method} {path}: {type(exc).__name__}"
+            ) from exc
+
+    def health(self) -> dict[str, Any]:
+        return json.loads(self._request("GET", "/how/v2/health"))
+
+    def advise(self, request: HowAdviceRequestV2) -> HowAdviceBundleV2:
+        raw = self._request("POST", "/how/v2/advice", request.model_dump(mode="json"))
+        return HowAdviceBundleV2.validate_wire_json(raw)
+
+    def submit_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool:
+        raw = self._request(
+            "POST", "/how/v2/feedback", feedback.model_dump(mode="json", exclude_none=True)
+        )
+        return bool(json.loads(raw).get("created"))
+
+
+class InProcessHowClient:
+    def __init__(self, know_client: Any) -> None:
+        from rosclaw_how.v2 import AdviceEngine
+        from rosclaw_how.v2.know_client import InProcessKnowClient
+
+        external_know = InProcessKnowClient(
+            lambda **kwargs: _external_reference_pack(know_client, **kwargs),
+            feedback_sink=lambda feedback: know_client.submit_feedback(
+                KnowledgeUsageFeedbackV1.validate_wire_json(feedback.model_dump_json())
+            ),
+            health_provider=know_client.health,
+        )
+        self.engine = AdviceEngine(external_know)
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "transport": "inprocess",
+            "advisory_only": True,
+            "modes": ["discover", "consult", "diagnose", "catalyze"],
+            "know": self.engine.know_client.health(),
+        }
+
+    def advise(self, request: HowAdviceRequestV2) -> HowAdviceBundleV2:
+        from rosclaw_how.v2 import HowAdviceRequestV2 as ExternalAdviceRequestV2
+
+        external = ExternalAdviceRequestV2.validate_wire_json(request.to_wire_json())
+        advice = self.engine.advise(external)
+        return HowAdviceBundleV2.validate_wire_json(advice.model_dump_json())
+
+    def submit_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool:
+        from rosclaw_how.v2 import KnowledgeUsageFeedbackV1 as ExternalFeedbackV1
+
+        return bool(
+            self.engine.submit_feedback(
+                ExternalFeedbackV1.validate_wire_json(feedback.to_wire_json())
+            )
+        )
+
+
+def _external_reference_pack(know_client: Any, **kwargs: Any):
+    from rosclaw_how.v2 import ReferenceContextV2, ReferencePackV2
+
+    context = kwargs["context"]
+    core_context = __import__(
+        "rosclaw.knowledge.contracts", fromlist=["ReferenceContextV2"]
+    ).ReferenceContextV2.validate_wire_json(context.model_dump_json())
+    pack = know_client.reference_pack(
+        query=kwargs["query"],
+        context=core_context,
+        top_k=kwargs["top_k"],
+        token_budget=kwargs["token_budget"],
+    )
+    # Import above also asserts the How-side contract exists.
+    assert ReferenceContextV2 is not None
+    return ReferencePackV2.validate_wire_json(pack.model_dump_json())
+
+
+class DisabledHowClient:
+    def health(self) -> dict[str, Any]:
+        return {"status": "disabled", "transport": "disabled", "advisory_only": True}
+
+    def advise(self, request: HowAdviceRequestV2) -> HowAdviceBundleV2:
+        raise HowUnavailableError("How is disabled")
+
+    def submit_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool:
+        raise HowUnavailableError("How is disabled")

--- a/src/rosclaw/knowledge/know_client.py
+++ b/src/rosclaw/knowledge/know_client.py
@@ -1,0 +1,150 @@
+"""HTTP, in-process and disabled adapters for the optional Know package."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .contracts import (
+    KnowledgeUsageFeedbackV1,
+    ReferenceContextV2,
+    ReferencePackV2,
+    ResearchRequestV2,
+)
+
+
+class KnowUnavailableError(RuntimeError):
+    """Raised at the optional service boundary; Core remains operational."""
+
+
+class HttpKnowClient:
+    def __init__(self, base_url: str, *, api_key: str = "", timeout: float = 15.0) -> None:
+        if not base_url.startswith(("http://", "https://")):
+            raise ValueError("Know URL must use http:// or https://")
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def _request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> bytes:
+        headers = {"Accept": "application/json"}
+        body = None
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+            body = json.dumps(payload, ensure_ascii=False).encode()
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        request = urllib.request.Request(
+            f"{self.base_url}{path}", data=body, headers=headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                return response.read(10_000_000)
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as exc:
+            raise KnowUnavailableError(
+                f"Know request failed: {method} {path}: {type(exc).__name__}"
+            ) from exc
+
+    def health(self) -> dict[str, Any]:
+        payload = json.loads(self._request("GET", "/know/v2/health"))
+        return {"transport": "service", **payload}
+
+    def research(self, request: ResearchRequestV2) -> dict[str, Any]:
+        return json.loads(
+            self._request("POST", "/know/v2/research", request.model_dump(mode="json"))
+        )
+
+    def reference_pack(
+        self, *, query: str, context: ReferenceContextV2, top_k: int, token_budget: int
+    ) -> ReferencePackV2:
+        raw = self._request(
+            "POST",
+            "/know/v2/reference-packs",
+            {
+                "query": query,
+                "context": context.model_dump(mode="json", exclude_none=True),
+                "top_k": top_k,
+                "token_budget": token_budget,
+            },
+        )
+        return ReferencePackV2.validate_wire_json(raw)
+
+    def get_reference_pack(self, reference_pack_id: str) -> ReferencePackV2 | None:
+        try:
+            raw = self._request("GET", f"/know/v2/reference-packs/{reference_pack_id}")
+        except KnowUnavailableError:
+            return None
+        return ReferencePackV2.validate_wire_json(raw)
+
+    def submit_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool:
+        raw = self._request(
+            "POST", "/know/v2/feedback", feedback.model_dump(mode="json", exclude_none=True)
+        )
+        return bool(json.loads(raw).get("created"))
+
+
+class InProcessKnowClient:
+    """Explicit adapter over public rosclaw-know APIs, never its internals in Core."""
+
+    def __init__(self, store: Any) -> None:
+        from rosclaw_know.retrieval import ReferencePackBuilder
+
+        self.store = store
+        self.builder = ReferencePackBuilder(store)
+
+    def health(self) -> dict[str, Any]:
+        capabilities = self.store.capabilities.model_dump(mode="json")
+        return {"status": "ok", "transport": "inprocess", "store": capabilities}
+
+    def research(self, request: ResearchRequestV2) -> dict[str, Any]:
+        from rosclaw_know.contracts import ResearchRequestV2 as KnowResearchRequestV2
+        from rosclaw_know.sources import (
+            ResearchOrchestrator,
+            default_source_registry,
+        )
+
+        external = KnowResearchRequestV2.model_validate_json(request.to_wire_json())
+        result = asyncio.run(
+            ResearchOrchestrator(self.store, default_source_registry()).run(external)
+        )
+        return result.model_dump(mode="json")
+
+    def reference_pack(
+        self, *, query: str, context: ReferenceContextV2, top_k: int, token_budget: int
+    ) -> ReferencePackV2:
+        from rosclaw_know.contracts import ReferenceContextV2 as KnowReferenceContextV2
+
+        external_context = KnowReferenceContextV2.model_validate_json(context.to_wire_json())
+        pack = self.builder.retrieve(
+            query=query, context=external_context, top_k=top_k, token_budget=token_budget
+        )
+        return ReferencePackV2.validate_wire_json(pack.model_dump_json())
+
+    def get_reference_pack(self, reference_pack_id: str) -> ReferencePackV2 | None:
+        pack = self.store.get_reference_pack(reference_pack_id)
+        return ReferencePackV2.validate_wire_json(pack.model_dump_json()) if pack else None
+
+    def submit_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool:
+        from rosclaw_know.contracts import KnowledgeUsageFeedbackV1 as KnowFeedbackV1
+
+        external = KnowFeedbackV1.model_validate_json(feedback.to_wire_json())
+        return bool(self.store.put_feedback(external))
+
+
+class DisabledKnowClient:
+    def health(self) -> dict[str, Any]:
+        return {"status": "disabled", "transport": "disabled"}
+
+    def research(self, request: ResearchRequestV2) -> dict[str, Any]:
+        raise KnowUnavailableError("Know is disabled")
+
+    def reference_pack(self, **kwargs: Any) -> ReferencePackV2:
+        raise KnowUnavailableError("Know is disabled")
+
+    def get_reference_pack(self, reference_pack_id: str) -> ReferencePackV2 | None:
+        return None
+
+    def submit_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool:
+        raise KnowUnavailableError("Know is disabled")

--- a/src/rosclaw/knowledge/mcp_tools.py
+++ b/src/rosclaw/knowledge/mcp_tools.py
@@ -1,0 +1,20 @@
+"""MCP projection of knowledge tools. All tools are read-only or advisory."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .agent_tools import KnowledgeAgentTools
+
+
+class KnowledgeMCPTools:
+    def __init__(self, agent_tools: KnowledgeAgentTools) -> None:
+        self.agent_tools = agent_tools
+
+    def specs(self) -> list[dict[str, Any]]:
+        return self.agent_tools.definitions()
+
+    async def call(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        import asyncio
+
+        return await asyncio.to_thread(self.agent_tools.call, name, arguments)

--- a/src/rosclaw/knowledge/protocols.py
+++ b/src/rosclaw/knowledge/protocols.py
@@ -1,0 +1,36 @@
+"""Narrow Core-facing protocols; knowledge algorithms remain out of Core."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .contracts import (
+    HowAdviceBundleV2,
+    HowAdviceRequestV2,
+    KnowledgeUsageFeedbackV1,
+    ReferenceContextV2,
+    ReferencePackV2,
+    ResearchRequestV2,
+)
+
+
+class KnowProtocol(Protocol):
+    def health(self) -> dict[str, Any]: ...
+
+    def research(self, request: ResearchRequestV2) -> dict[str, Any]: ...
+
+    def reference_pack(
+        self, *, query: str, context: ReferenceContextV2, top_k: int, token_budget: int
+    ) -> ReferencePackV2: ...
+
+    def get_reference_pack(self, reference_pack_id: str) -> ReferencePackV2 | None: ...
+
+    def submit_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool: ...
+
+
+class HowProtocol(Protocol):
+    def health(self) -> dict[str, Any]: ...
+
+    def advise(self, request: HowAdviceRequestV2) -> HowAdviceBundleV2: ...
+
+    def submit_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool: ...

--- a/src/rosclaw/knowledge/service_manager.py
+++ b/src/rosclaw/knowledge/service_manager.py
@@ -1,0 +1,186 @@
+"""Construct optional Know/How transports without owning their algorithms."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from .health import combine_health
+from .how_client import DisabledHowClient, HttpHowClient, InProcessHowClient
+from .know_client import DisabledKnowClient, HttpKnowClient, InProcessKnowClient
+
+KnowledgeMode = Literal["disabled", "service", "inprocess"]
+
+
+@dataclass(frozen=True)
+class KnowledgeServiceConfig:
+    mode: KnowledgeMode = "disabled"
+    know_url: str | None = None
+    how_url: str | None = None
+    know_api_key: str = ""
+    how_api_key: str = ""
+    timeout: float = 15.0
+    know_store_mode: Literal["embedded", "server", "memory"] = "embedded"
+    know_store_path: str | None = None
+    allow_test_memory: bool = False
+    seekdb_host: str | None = field(default_factory=lambda: os.environ.get("SEEKDB_HOST"))
+    seekdb_port: int = field(default_factory=lambda: int(os.environ.get("SEEKDB_PORT", "2881")))
+    seekdb_tenant: str = field(default_factory=lambda: os.environ.get("SEEKDB_TENANT", "sys"))
+    seekdb_user: str = field(default_factory=lambda: os.environ.get("SEEKDB_USER", "root"))
+    seekdb_password: str = field(default_factory=lambda: os.environ.get("SEEKDB_PASSWORD", ""))
+    know_database: str = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_KNOW_DATABASE", "rosclaw_know")
+    )
+    memory_database: str | None = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_MEMORY_DATABASE")
+    )
+    practice_database: str | None = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_PRACTICE_DATABASE")
+    )
+    memory_path: str | None = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_MEMORY_SEEKDB_PATH")
+    )
+    practice_path: str | None = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_PRACTICE_SEEKDB_PATH")
+    )
+
+    @classmethod
+    def from_env(cls, *, workspace_home: str | Path | None = None) -> KnowledgeServiceConfig:
+        mode = os.environ.get("ROSCLAW_KNOWLEDGE_MODE", "disabled").casefold()
+        if mode not in {"disabled", "service", "inprocess"}:
+            raise ValueError(f"unsupported ROSCLAW_KNOWLEDGE_MODE: {mode!r}")
+        root = Path(workspace_home).expanduser() if workspace_home else Path.cwd()
+        return cls(
+            mode=mode,  # type: ignore[arg-type]
+            know_url=os.environ.get("ROSCLAW_KNOW_URL"),
+            how_url=os.environ.get("ROSCLAW_HOW_V2_URL") or os.environ.get("ROSCLAW_HOW_URL"),
+            know_api_key=os.environ.get("ROSCLAW_KNOW_API_KEY", ""),
+            how_api_key=os.environ.get("ROSCLAW_HOW_API_KEY", ""),
+            timeout=float(os.environ.get("ROSCLAW_KNOWLEDGE_TIMEOUT", "15")),
+            know_store_mode=os.environ.get(  # type: ignore[arg-type]
+                "ROSCLAW_KNOW_STORE_MODE", "embedded"
+            ).casefold(),
+            know_store_path=os.environ.get(
+                "ROSCLAW_KNOW_SEEKDB_PATH", str(root / "data" / "know" / "seekdb")
+            ),
+            allow_test_memory=os.environ.get("ROSCLAW_KNOW_ALLOW_TEST_MEMORY") == "1",
+            seekdb_host=os.environ.get("SEEKDB_HOST"),
+            seekdb_port=int(os.environ.get("SEEKDB_PORT", "2881")),
+            seekdb_tenant=os.environ.get("SEEKDB_TENANT", "sys"),
+            seekdb_user=os.environ.get("SEEKDB_USER", "root"),
+            seekdb_password=os.environ.get("SEEKDB_PASSWORD", ""),
+            know_database=os.environ.get("ROSCLAW_KNOW_DATABASE", "rosclaw_know"),
+            memory_database=os.environ.get("ROSCLAW_MEMORY_DATABASE"),
+            practice_database=os.environ.get("ROSCLAW_PRACTICE_DATABASE"),
+            memory_path=os.environ.get("ROSCLAW_MEMORY_SEEKDB_PATH"),
+            practice_path=os.environ.get("ROSCLAW_PRACTICE_SEEKDB_PATH"),
+        )
+
+
+class KnowledgeServiceManager:
+    """Lifecycle owner for adapters only; never starts services implicitly."""
+
+    def __init__(
+        self,
+        config: KnowledgeServiceConfig,
+        *,
+        know_client: Any | None = None,
+        how_client: Any | None = None,
+        inprocess_store: Any | None = None,
+    ) -> None:
+        self.config = config
+        self._store = inprocess_store
+        self._owns_store = False
+        self.startup_error: str | None = None
+        if know_client is not None:
+            self.know = know_client
+        else:
+            self.know = self._build_know()
+        if how_client is not None:
+            self.how = how_client
+        else:
+            self.how = self._build_how()
+
+    def _build_know(self) -> Any:
+        if self.config.mode == "disabled":
+            return DisabledKnowClient()
+        if self.config.mode == "service":
+            if not self.config.know_url:
+                self.startup_error = "service mode requires ROSCLAW_KNOW_URL"
+                return DisabledKnowClient()
+            return HttpKnowClient(
+                self.config.know_url,
+                api_key=self.config.know_api_key,
+                timeout=self.config.timeout,
+            )
+        try:
+            if self._store is None:
+                from rosclaw_know.store import create_know_store
+
+                store_kwargs: dict[str, Any] = {
+                    "mode": self.config.know_store_mode,
+                    "allow_test_memory": self.config.allow_test_memory,
+                }
+                if self.config.know_store_mode == "embedded":
+                    store_kwargs.update(
+                        path=self.config.know_store_path,
+                        database=self.config.know_database,
+                        memory_database=self.config.memory_database,
+                        practice_database=self.config.practice_database,
+                        memory_path=self.config.memory_path,
+                        practice_path=self.config.practice_path,
+                    )
+                elif self.config.know_store_mode == "server":
+                    store_kwargs.update(
+                        host=self.config.seekdb_host,
+                        port=self.config.seekdb_port,
+                        tenant=self.config.seekdb_tenant,
+                        user=self.config.seekdb_user,
+                        password=self.config.seekdb_password,
+                        database=self.config.know_database,
+                        memory_database=self.config.memory_database,
+                        practice_database=self.config.practice_database,
+                    )
+                self._store = create_know_store(**store_kwargs)
+                self._owns_store = True
+            return InProcessKnowClient(self._store)
+        except Exception as exc:  # noqa: BLE001 - optional dependency boundary
+            self.startup_error = f"Know in-process unavailable: {type(exc).__name__}: {exc}"
+            return DisabledKnowClient()
+
+    def _build_how(self) -> Any:
+        if self.config.mode == "disabled":
+            return DisabledHowClient()
+        if self.config.mode == "service":
+            if not self.config.how_url:
+                self.startup_error = self.startup_error or (
+                    "service mode requires ROSCLAW_HOW_V2_URL or ROSCLAW_HOW_URL"
+                )
+                return DisabledHowClient()
+            return HttpHowClient(
+                self.config.how_url,
+                api_key=self.config.how_api_key,
+                timeout=self.config.timeout,
+            )
+        try:
+            if isinstance(self.know, DisabledKnowClient):
+                return DisabledHowClient()
+            return InProcessHowClient(self.know)
+        except Exception as exc:  # noqa: BLE001 - optional dependency boundary
+            self.startup_error = f"How in-process unavailable: {type(exc).__name__}: {exc}"
+            return DisabledHowClient()
+
+    def health(self) -> dict[str, Any]:
+        result = combine_health(self.config.mode, self.know, self.how).as_dict()
+        if self.startup_error:
+            result["startup_error"] = self.startup_error
+            result["status"] = "degraded"
+        return result
+
+    def close(self) -> None:
+        if self._owns_store and self._store is not None and hasattr(self._store, "close"):
+            self._store.close()
+        self._store = None
+        self._owns_store = False

--- a/src/rosclaw/knowledge/worker.py
+++ b/src/rosclaw/knowledge/worker.py
@@ -1,0 +1,24 @@
+"""Bounded research delegation adapter; grants no shell or physical tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from .contracts import ResearchRequestV2, StrictWireModel
+
+
+class BoundedResearchWorkV1(StrictWireModel):
+    schema_version: str = "rosclaw.knowledge.research_work.v1"
+    research: ResearchRequestV2
+    deadline_seconds: int = Field(default=300, ge=1, le=3600)
+    allowed_tools: list[str] = Field(
+        default_factory=lambda: ["rosclaw_know_research"], max_length=1
+    )
+
+
+def execute_bounded_research(work: BoundedResearchWorkV1, facade: Any) -> dict[str, Any]:
+    if work.allowed_tools != ["rosclaw_know_research"]:
+        raise ValueError("research worker may only use rosclaw_know_research")
+    return facade.research(work.research)

--- a/src/rosclaw/mcp/minimal_server.py
+++ b/src/rosclaw/mcp/minimal_server.py
@@ -25,8 +25,13 @@ from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool, ToolAnnotations
 
+from rosclaw import __version__
 from rosclaw.agent_runtime.mcp_hub import MCPHub
 from rosclaw.core.event_bus import EventBus
+from rosclaw.knowledge.agent_tools import KnowledgeAgentTools
+from rosclaw.knowledge.facade import KnowledgeFacade
+from rosclaw.knowledge.mcp_tools import KnowledgeMCPTools
+from rosclaw.knowledge.service_manager import KnowledgeServiceConfig, KnowledgeServiceManager
 
 
 class ROSClawMinimalMCPServer:
@@ -43,6 +48,13 @@ class ROSClawMinimalMCPServer:
             self.hub.initialize()
         finally:
             sys.stdout = old_stdout
+
+        # Construction is non-blocking: service reachability is checked only
+        # by an explicit status/tool call, never while starting the safety MCP.
+        self._knowledge_manager = KnowledgeServiceManager(KnowledgeServiceConfig.from_env())
+        self._knowledge_tools = KnowledgeMCPTools(
+            KnowledgeAgentTools(KnowledgeFacade(self._knowledge_manager, event_bus=self.event_bus))
+        )
 
         self._register_handlers()
 
@@ -66,6 +78,15 @@ class ROSClawMinimalMCPServer:
                 )
             # Add system-level tools
             tools.extend(self._system_tools())
+            for spec in self._knowledge_tools.specs():
+                tools.append(
+                    Tool(
+                        name=spec["name"],
+                        description=spec["description"],
+                        inputSchema=spec["inputSchema"],
+                        annotations=ToolAnnotations(readOnlyHint=True),
+                    )
+                )
             return tools
 
         @self.server.call_tool()
@@ -73,6 +94,8 @@ class ROSClawMinimalMCPServer:
             try:
                 if name.startswith("system."):
                     result = await self._handle_system_tool(name, arguments)
+                elif name.startswith(("rosclaw_know_", "rosclaw_how_")):
+                    result = await self._knowledge_tools.call(name, arguments)
                 else:
                     result = await self.hub.handle_tool_call(name, arguments)
                 return [
@@ -224,7 +247,7 @@ class ROSClawMinimalMCPServer:
         elif name == "system.get_version":
             return {
                 "name": "rosclaw",
-                "version": "1.0.0",
+                "version": __version__,
                 "status": "ready",
                 "modules": {
                     "mcp_hub": self.hub._server is not None,
@@ -462,7 +485,7 @@ class ROSClawMinimalMCPServer:
         async with stdio_server() as (read, write):
             init_options = InitializationOptions(
                 server_name="rosclaw-minimal",
-                server_version="1.0.0",
+                server_version=__version__,
                 capabilities=self.server.get_capabilities(
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},
@@ -478,6 +501,7 @@ def main() -> None:
     except KeyboardInterrupt:
         print("\n[ROSClaw MCP] Shutdown complete", file=sys.stderr)
     finally:
+        server._knowledge_manager.close()
         with contextlib.suppress(ValueError):
             server.hub.stop()
 

--- a/src/rosclaw/product/status.yaml
+++ b/src/rosclaw/product/status.yaml
@@ -1,7 +1,7 @@
 schema_version: rosclaw.product_status.v1
 
 release:
-  version: 1.0.1
+  version: 1.2.0
   maturity: alpha
   supported_python:
     - "3.11"

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""System fixture tests."""

--- a/tests/e2e/test_knowledge_reference_loop.py
+++ b/tests/e2e/test_knowledge_reference_loop.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from rosclaw.knowledge.context_adapter import build_how_context
+from rosclaw.knowledge.contracts import HowAdviceRequestV2, ResearchRequestV2
+from rosclaw.knowledge.facade import KnowledgeFacade
+from rosclaw.knowledge.feedback_adapter import build_usage_feedback
+from rosclaw.knowledge.service_manager import KnowledgeServiceConfig, KnowledgeServiceManager
+from tests.knowledge.conftest import FakeHow, FakeKnow, make_reference_pack
+
+
+def test_fixture_research_reference_advice_feedback_loop():
+    reference_pack = make_reference_pack()
+    know = FakeKnow(reference_pack)
+    how = FakeHow(reference_pack, know)
+    facade = KnowledgeFacade(
+        KnowledgeServiceManager(
+            KnowledgeServiceConfig(mode="disabled"), know_client=know, how_client=how
+        )
+    )
+    research = facade.research(
+        ResearchRequestV2(
+            request_id="research_1", topic="camera error", goal="find pinned upstream evidence"
+        )
+    )
+    assert research["snapshot_count"] == 1
+    pack = facade.reference_pack(query="camera error", context={"task": "diagnose camera"})
+    context = build_how_context(task="diagnose camera", current_failure="camera error")
+    advice = facade.advise(
+        HowAdviceRequestV2(
+            request_id="advice_request_1",
+            mode="diagnose",
+            query="camera error",
+            context=context,
+        )
+    )
+    feedback = build_usage_feedback(
+        reference_pack_id=pack.reference_pack_id,
+        advice_id=advice.advice_id,
+        knowledge_unit_id=pack.items[0].knowledge_unit_ids[0],
+        context_hash=context.context_hash(),
+        verdict="useful",
+        receipt_ref="receipt_fixture_1",
+    )
+    assert facade.feedback(feedback)
+    assert know.feedback == [feedback]

--- a/tests/e2e/test_real_inprocess_knowledge_packages.py
+++ b/tests/e2e/test_real_inprocess_knowledge_packages.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("rosclaw_know.legacy")
+pytest.importorskip("rosclaw_how.v2")
+
+from rosclaw_how.v2 import AdviceEngine  # noqa: E402
+from rosclaw_know.legacy import import_legacy_assets  # noqa: E402
+from rosclaw_know.store import InMemoryKnowStore  # noqa: E402
+
+from rosclaw.knowledge.context_adapter import build_how_context  # noqa: E402
+from rosclaw.knowledge.contracts import HowAdviceRequestV2  # noqa: E402
+from rosclaw.knowledge.facade import KnowledgeFacade  # noqa: E402
+from rosclaw.knowledge.feedback_adapter import build_usage_feedback  # noqa: E402
+from rosclaw.knowledge.service_manager import (  # noqa: E402
+    KnowledgeServiceConfig,
+    KnowledgeServiceManager,
+)
+
+
+def test_real_inprocess_know_how_reference_loop(tmp_path):
+    bridge = tmp_path / "bridge_index.json"
+    bridge.write_text(
+        json.dumps(
+            {
+                "schema_version": "v2",
+                "symptom_clusters": {
+                    "uvc_error_5": {
+                        "standard_name": "uvcvideo Region of Interest returned -5",
+                        "domain": "Perception",
+                        "associated_patterns": [],
+                        "cross_domain_analogies": [
+                            {
+                                "insight": "Kernel and camera controls can be incompatible.",
+                                "action_suggestion": "Inspect the pinned compatibility evidence.",
+                            }
+                        ],
+                    }
+                },
+            },
+            sort_keys=True,
+        )
+    )
+    store = InMemoryKnowStore()
+    import_legacy_assets(store, bridge_path=bridge)
+    manager = KnowledgeServiceManager(
+        KnowledgeServiceConfig(mode="inprocess"), inprocess_store=store
+    )
+    assert manager.startup_error is None
+    # Assert the actual optional package engine is active, not a fixture facade.
+    assert isinstance(manager.how.engine, AdviceEngine)
+    facade = KnowledgeFacade(manager)
+    pack = facade.reference_pack(
+        query="uvcvideo Region of Interest returned -5",
+        context={
+            "task": "diagnose RealSense",
+            "robot": "limo",
+            "current_failure": "uvcvideo Region of Interest returned -5",
+        },
+    )
+    assert pack.items[0].evidence_refs[0].snapshot_id.startswith("snapshot_legacy_")
+    context = build_how_context(
+        task="diagnose RealSense",
+        robot_model="limo",
+        current_failure="uvcvideo Region of Interest returned -5",
+    )
+    advice = facade.advise(
+        HowAdviceRequestV2(
+            request_id="request_real_inprocess",
+            mode="diagnose",
+            query="uvcvideo Region of Interest returned -5",
+            context=context,
+        )
+    )
+    assert not advice.abstained
+    assert advice.reference_pack_id == pack.reference_pack_id
+    assert all(item.safety_class == "advisory" for item in advice.recommendations)
+    feedback = build_usage_feedback(
+        reference_pack_id=pack.reference_pack_id,
+        advice_id=advice.advice_id,
+        knowledge_unit_id=pack.items[0].knowledge_unit_ids[0],
+        context_hash=context.context_hash(),
+        verdict="useful",
+        receipt_ref="fixture_receipt",
+    )
+    assert facade.feedback(feedback)
+    assert len(store.feedback) == 1
+    assert not hasattr(store, "trajectories")
+    manager.close()

--- a/tests/knowledge/__init__.py
+++ b/tests/knowledge/__init__.py
@@ -1,0 +1,1 @@
+"""Knowledge v2 integration tests."""

--- a/tests/knowledge/conftest.py
+++ b/tests/knowledge/conftest.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from rosclaw.knowledge.contracts import (
+    EvidenceRefV2,
+    HowAdviceBundleV2,
+    ReferenceContextV2,
+    ReferencePackItemV2,
+    ReferencePackV2,
+)
+
+
+def make_reference_pack() -> ReferencePackV2:
+    evidence = EvidenceRefV2(
+        evidence_id="ev_1",
+        source_id="src_1",
+        snapshot_id="snap_commit_abc",
+        document_id="doc_1",
+        path="docs/guide.md",
+        start_line=10,
+        end_line=20,
+        url="https://example.test/repo/blob/abc/docs/guide.md#L10-L20",
+        content_hash="a" * 64,
+        excerpt="Pinned evidence about a documented control mechanism.",
+    )
+    return ReferencePackV2(
+        reference_pack_id="pack_1",
+        query="camera error",
+        context=ReferenceContextV2(task="diagnose camera", robot="limo"),
+        generated_at=datetime.now(UTC),
+        index_version="idx_1",
+        items=[
+            ReferencePackItemV2(
+                rank=1,
+                project_id="project_1",
+                knowledge_unit_ids=["unit_1"],
+                title="Pinned upstream issue",
+                why_relevant="Exact error token matched.",
+                relevance_dimensions=["exact"],
+                mechanism="Driver capability mismatch.",
+                what_to_borrow=["Check the documented version gate."],
+                exact_files=["docs/guide.md"],
+                source_version="commit:abc",
+                evidence_refs=[evidence],
+                score=1.0,
+                score_breakdown={"exact": 1.0},
+            )
+        ],
+        token_budget=8000,
+    )
+
+
+@pytest.fixture
+def reference_pack() -> ReferencePackV2:
+    return make_reference_pack()
+
+
+class FakeKnow:
+    def __init__(self, pack: ReferencePackV2):
+        self.pack = pack
+        self.feedback = []
+
+    def health(self):
+        return {"status": "ok", "transport": "fixture", "store": "know_only"}
+
+    def research(self, request):
+        return {
+            "status": "completed",
+            "request_id": request.request_id,
+            "source_count": 1,
+            "snapshot_count": 1,
+        }
+
+    def reference_pack(self, **kwargs):
+        return self.pack
+
+    def get_reference_pack(self, reference_pack_id):
+        return self.pack if reference_pack_id == self.pack.reference_pack_id else None
+
+    def submit_feedback(self, feedback):
+        self.feedback.append(feedback)
+        return True
+
+
+class FakeHow:
+    def __init__(self, pack: ReferencePackV2, know: FakeKnow):
+        self.pack = pack
+        self.know = know
+
+    def health(self):
+        return {"status": "ok", "transport": "fixture", "advisory_only": True}
+
+    def advise(self, request):
+        return HowAdviceBundleV2(
+            advice_id="advice_1",
+            mode=request.mode,
+            context_hash=request.context.context_hash(),
+            reference_pack_id=self.pack.reference_pack_id,
+            summary="Fixture evidence-backed advice.",
+            recommendations=[],
+            abstained=False,
+            created_at=datetime.now(UTC),
+        )
+
+    def submit_feedback(self, feedback):
+        return self.know.submit_feedback(feedback)

--- a/tests/knowledge/test_agent_tools.py
+++ b/tests/knowledge/test_agent_tools.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from rosclaw.knowledge.agent_tools import KnowledgeAgentTools
+from rosclaw.knowledge.facade import KnowledgeFacade
+from rosclaw.knowledge.service_manager import KnowledgeServiceConfig, KnowledgeServiceManager
+
+from .conftest import FakeHow, FakeKnow
+
+
+def test_agent_tools_are_read_only_or_advisory(reference_pack):
+    know = FakeKnow(reference_pack)
+    manager = KnowledgeServiceManager(
+        KnowledgeServiceConfig(mode="disabled"),
+        know_client=know,
+        how_client=FakeHow(reference_pack, know),
+    )
+    tools = KnowledgeAgentTools(KnowledgeFacade(manager))
+    definitions = tools.definitions()
+    assert definitions
+    assert all(item["read_only"] or item["advisory"] for item in definitions)
+    text = repr(definitions).casefold()
+    assert "permit" not in text
+    assert "shell" not in text
+    assert "execute robot" not in text
+
+
+def test_reference_pack_progressive_open(reference_pack):
+    know = FakeKnow(reference_pack)
+    manager = KnowledgeServiceManager(
+        KnowledgeServiceConfig(mode="disabled"),
+        know_client=know,
+        how_client=FakeHow(reference_pack, know),
+    )
+    tools = KnowledgeAgentTools(KnowledgeFacade(manager))
+    result = tools.call(
+        "rosclaw_know_build_reference_pack",
+        {"query": "camera error", "context": {"task": "diagnose"}, "top_k": 3},
+    )
+    assert result["reference_pack_id"] == "pack_1"
+    opened = tools.call("rosclaw_know_open_reference_pack", {"reference_pack_id": "pack_1"})
+    assert opened["items"][0]["evidence_refs"][0]["snapshot_id"] == "snap_commit_abc"

--- a/tests/knowledge/test_body_context.py
+++ b/tests/knowledge/test_body_context.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from rosclaw.knowledge.context_adapter import build_how_context, build_memory_evidence
+
+
+def test_body_software_runtime_and_memory_are_explicitly_separated():
+    context = build_how_context(
+        task="LIMO patrol",
+        robot_model="limo",
+        ros_distro="melodic",
+        simulator="gazebo",
+        safety_limits=["speed<=0.3"],
+        memory_evidence=[
+            {
+                "memory_id": "mem_1",
+                "summary": "Previous patrol required a wider turn.",
+                "confidence": 0.8,
+                "receipt_ref": "receipt_1",
+                "created_at": datetime.now(UTC),
+            }
+        ],
+    )
+    assert context.body.robot_model == "limo"
+    assert context.software.ros_distro == "melodic"
+    assert context.runtime.task == "LIMO patrol"
+    assert context.memory_evidence[0].evidence_domain == "memory"
+
+
+@pytest.mark.parametrize("field", ["trajectory", "video", "sensor_data", "raw_content"])
+def test_raw_memory_and_practice_content_is_rejected(field):
+    with pytest.raises(ValueError, match="forbidden"):
+        build_memory_evidence(
+            [
+                {
+                    "memory_id": "mem_1",
+                    "summary": "bounded summary",
+                    "confidence": 0.5,
+                    "created_at": datetime.now(UTC),
+                    field: "must not cross",
+                }
+            ]
+        )

--- a/tests/knowledge/test_contracts.py
+++ b/tests/knowledge/test_contracts.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from rosclaw.knowledge.context_adapter import build_how_context
+from rosclaw.knowledge.contracts import (
+    PUBLIC_CONTRACTS,
+    HowAdviceRequestV2,
+    KnowledgeUsageFeedbackV1,
+)
+
+
+def test_public_contracts_are_versioned_and_forbid_unknown_fields():
+    for contract in PUBLIC_CONTRACTS:
+        assert contract.SCHEMA_VERSION
+        assert contract.model_config["extra"] == "forbid"
+
+
+def test_advice_request_round_trip_and_strict_version():
+    request = HowAdviceRequestV2(
+        request_id="request_1",
+        mode="consult",
+        query="Which implementation should be inspected?",
+        context=build_how_context(task="inspection", robot_model="limo"),
+    )
+    assert HowAdviceRequestV2.validate_wire_json(request.to_wire_json()) == request
+    with pytest.raises(ValidationError):
+        HowAdviceRequestV2.model_validate(
+            {**request.model_dump(mode="json"), "schema_version": "rosclaw.how.advice_request.v3"}
+        )
+
+
+def test_feedback_requires_aware_timestamp():
+    with pytest.raises(ValidationError):
+        KnowledgeUsageFeedbackV1(
+            feedback_id="feedback_1",
+            reference_pack_id="pack_1",
+            knowledge_unit_id="unit_1",
+            verdict="useful",
+            context_hash="a" * 64,
+            origin="user",
+            created_at=datetime.now(),
+        )
+    feedback = KnowledgeUsageFeedbackV1(
+        feedback_id="feedback_1",
+        reference_pack_id="pack_1",
+        knowledge_unit_id="unit_1",
+        verdict="useful",
+        context_hash="a" * 64,
+        origin="user",
+        created_at=datetime.now(UTC),
+    )
+    assert feedback.schema_version == "rosclaw.knowledge_usage_feedback.v1"
+
+
+def test_core_wire_schema_matches_authoritative_know_checkout():
+    schema_path = Path(__file__).parents[3] / "rosclaw-know" / "schemas" / "know_how_v2.json"
+    authoritative = json.loads(schema_path.read_text())
+    for contract in PUBLIC_CONTRACTS:
+        version = contract.SCHEMA_VERSION
+        if version in authoritative:
+            assert contract.model_json_schema(mode="serialization") == authoritative[version]

--- a/tests/knowledge/test_contracts.py
+++ b/tests/knowledge/test_contracts.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import json
 from datetime import UTC, datetime
-from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
+from rosclaw_know.contracts import PUBLIC_CONTRACTS as KNOW_PUBLIC_CONTRACTS
 
 from rosclaw.knowledge.context_adapter import build_how_context
 from rosclaw.knowledge.contracts import (
@@ -58,9 +57,11 @@ def test_feedback_requires_aware_timestamp():
     assert feedback.schema_version == "rosclaw.knowledge_usage_feedback.v1"
 
 
-def test_core_wire_schema_matches_authoritative_know_checkout():
-    schema_path = Path(__file__).parents[3] / "rosclaw-know" / "schemas" / "know_how_v2.json"
-    authoritative = json.loads(schema_path.read_text())
+def test_core_wire_schema_matches_authoritative_know_package():
+    authoritative = {
+        contract.SCHEMA_VERSION: contract.model_json_schema(mode="serialization")
+        for contract in KNOW_PUBLIC_CONTRACTS
+    }
     for contract in PUBLIC_CONTRACTS:
         version = contract.SCHEMA_VERSION
         if version in authoritative:

--- a/tests/knowledge/test_event_bus.py
+++ b/tests/knowledge/test_event_bus.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.core.event_bus import EventBus
+from rosclaw.knowledge.event_adapter import KnowledgeEventAdapter, safe_event_payload
+
+
+def test_events_publish_only_redacted_ids():
+    bus = EventBus()
+    adapter = KnowledgeEventAdapter(bus)
+    adapter.publish(
+        "know.reference_pack.created",
+        {"reference_pack_id": "pack_1", "index_version": "idx_1", "document": "drop me"},
+    )
+    event = bus.get_history("know.reference_pack.created")[0]
+    assert dict(event.payload) == {"reference_pack_id": "pack_1", "index_version": "idx_1"}
+
+
+def test_sensitive_event_fields_fail_closed():
+    with pytest.raises(ValueError, match="forbidden"):
+        safe_event_payload({"reference_pack_id": "pack", "api_key": "secret"})

--- a/tests/knowledge/test_mcp_tools.py
+++ b/tests/knowledge/test_mcp_tools.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from rosclaw.knowledge.agent_tools import KnowledgeAgentTools
+from rosclaw.knowledge.facade import KnowledgeFacade
+from rosclaw.knowledge.mcp_tools import KnowledgeMCPTools
+from rosclaw.knowledge.service_manager import KnowledgeServiceConfig, KnowledgeServiceManager
+
+from .conftest import FakeHow, FakeKnow
+
+
+async def test_mcp_tools_delegate_without_action_channel(reference_pack):
+    know = FakeKnow(reference_pack)
+    manager = KnowledgeServiceManager(
+        KnowledgeServiceConfig(mode="disabled"),
+        know_client=know,
+        how_client=FakeHow(reference_pack, know),
+    )
+    tools = KnowledgeMCPTools(KnowledgeAgentTools(KnowledgeFacade(manager)))
+    result = await tools.call("rosclaw_know_open_reference_pack", {"reference_pack_id": "pack_1"})
+    assert result["reference_pack_id"] == "pack_1"
+    assert all(spec["read_only"] or spec["advisory"] for spec in tools.specs())

--- a/tests/knowledge/test_memory_separation.py
+++ b/tests/knowledge/test_memory_separation.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from rosclaw.knowledge.service_manager import KnowledgeServiceConfig, KnowledgeServiceManager
+
+from .conftest import FakeHow, FakeKnow
+
+
+def test_manager_never_accepts_or_exposes_memory_store(reference_pack):
+    memory_store = object()
+    know = FakeKnow(reference_pack)
+    manager = KnowledgeServiceManager(
+        KnowledgeServiceConfig(mode="disabled"),
+        know_client=know,
+        how_client=FakeHow(reference_pack, know),
+    )
+    assert manager.know is know
+    assert manager.know is not memory_store
+    assert manager.health()["memory_boundary"] == "isolated"
+    assert "memory" not in vars(manager)

--- a/tests/knowledge/test_practice_feedback.py
+++ b/tests/knowledge/test_practice_feedback.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from rosclaw.knowledge.feedback_adapter import build_usage_feedback
+
+
+def test_feedback_contains_governance_refs_not_practice_payload():
+    feedback = build_usage_feedback(
+        reference_pack_id="pack_1",
+        advice_id="advice_1",
+        knowledge_unit_id="unit_1",
+        context_hash="a" * 64,
+        verdict="useful",
+        used_by_agent=True,
+        receipt_ref="receipt_1",
+        practice_ref="episode_1",
+    )
+    payload = feedback.model_dump(mode="json")
+    assert payload["receipt_ref"] == "receipt_1"
+    assert payload["practice_ref"] == "episode_1"
+    assert not {"trajectory", "video", "sensor_data", "memory_content"}.intersection(payload)

--- a/tests/knowledge/test_runtime_integration.py
+++ b/tests/knowledge/test_runtime_integration.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from rosclaw.core.runtime import Runtime, RuntimeConfig
+from rosclaw.knowledge.how_client import HttpHowClient
+from rosclaw.knowledge.know_client import HttpKnowClient
+
+
+def test_runtime_v2_service_does_not_reuse_memory_store():
+    runtime = Runtime(
+        RuntimeConfig(
+            robot_id="fixture",
+            enable_firewall=False,
+            enable_memory=True,
+            enable_practice=False,
+            enable_swarm=False,
+            enable_skill_manager=False,
+            enable_knowledge=True,
+            enable_how=True,
+            enable_auto=False,
+            enable_provider=False,
+            enable_sense=False,
+            enable_event_persistence=False,
+            enable_tracing=False,
+            seekdb_backend="memory",
+            knowledge_v2_mode="service",
+            know_url="http://know.test:8087",
+            how_url="http://how.test:8088",
+        )
+    )
+    runtime.initialize()
+    assert runtime.memory is not None
+    assert runtime.knowledge_v2 is not None
+    assert runtime._knowledge is None
+    assert runtime._how is None
+    assert isinstance(runtime._knowledge_v2_manager.know, HttpKnowClient)
+    assert isinstance(runtime._knowledge_v2_manager.how, HttpHowClient)
+    assert runtime._knowledge_v2_manager.know is not runtime._memory.seekdb_client
+    runtime.stop()

--- a/tests/knowledge/test_service_degradation.py
+++ b/tests/knowledge/test_service_degradation.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.knowledge.contracts import ReferenceContextV2
+from rosclaw.knowledge.facade import KnowledgeFacade
+from rosclaw.knowledge.know_client import KnowUnavailableError
+from rosclaw.knowledge.service_manager import KnowledgeServiceConfig, KnowledgeServiceManager
+
+
+def test_disabled_reference_pack_fails_explicitly():
+    facade = KnowledgeFacade(KnowledgeServiceManager(KnowledgeServiceConfig(mode="disabled")))
+    with pytest.raises(KnowUnavailableError, match="disabled"):
+        facade.reference_pack(query="anything", context=ReferenceContextV2(task="test"))
+
+
+def test_missing_optional_packages_do_not_crash_core(monkeypatch, tmp_path):
+    real_import = __import__
+
+    def blocked(name, *args, **kwargs):
+        if name.startswith(("rosclaw_know", "rosclaw_how")):
+            raise ImportError("fixture missing optional package")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", blocked)
+    manager = KnowledgeServiceManager(
+        KnowledgeServiceConfig(
+            mode="inprocess", know_store_mode="embedded", know_store_path=str(tmp_path / "know")
+        )
+    )
+    assert manager.health()["status"] == "degraded"

--- a/tests/knowledge/test_service_discovery.py
+++ b/tests/knowledge/test_service_discovery.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from rosclaw.knowledge.how_client import DisabledHowClient, HttpHowClient
+from rosclaw.knowledge.know_client import DisabledKnowClient, HttpKnowClient
+from rosclaw.knowledge.service_manager import KnowledgeServiceConfig, KnowledgeServiceManager
+
+
+def test_disabled_mode_has_truthful_health():
+    manager = KnowledgeServiceManager(KnowledgeServiceConfig(mode="disabled"))
+    health = manager.health()
+    assert health["status"] == "disabled"
+    assert health["memory_boundary"] == "isolated"
+    assert isinstance(manager.know, DisabledKnowClient)
+    assert isinstance(manager.how, DisabledHowClient)
+
+
+def test_service_mode_builds_clients_without_network_call():
+    manager = KnowledgeServiceManager(
+        KnowledgeServiceConfig(
+            mode="service",
+            know_url="http://know.test:8087",
+            how_url="http://how.test:8088",
+        )
+    )
+    assert isinstance(manager.know, HttpKnowClient)
+    assert isinstance(manager.how, HttpHowClient)
+
+
+def test_missing_service_url_degrades_without_legacy_fallback():
+    manager = KnowledgeServiceManager(KnowledgeServiceConfig(mode="service"))
+    health = manager.health()
+    assert health["status"] == "degraded"
+    assert isinstance(manager.know, DisabledKnowClient)
+    assert isinstance(manager.how, DisabledHowClient)
+    assert "requires" in health["startup_error"]
+
+
+def test_inprocess_server_uses_server_coordinates_not_embedded_path(monkeypatch):
+    captured = {}
+    sentinel = object()
+
+    def fake_create_know_store(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr("rosclaw_know.store.create_know_store", fake_create_know_store)
+    manager = KnowledgeServiceManager(
+        KnowledgeServiceConfig(
+            mode="inprocess",
+            know_store_mode="server",
+            know_store_path="/must/not/reach/server",
+            seekdb_host="seekdb.internal",
+            seekdb_port=2881,
+            seekdb_tenant="tenant-a",
+            seekdb_user="know-reader",
+            seekdb_password="fixture-secret",
+            know_database="rosclaw_know",
+            memory_database="rosclaw_memory",
+            practice_database="rosclaw_practice",
+        ),
+        how_client=DisabledHowClient(),
+    )
+    assert manager.startup_error is None
+    assert captured["mode"] == "server"
+    assert captured["host"] == "seekdb.internal"
+    assert captured["database"] == "rosclaw_know"
+    assert captured["memory_database"] == "rosclaw_memory"
+    assert "path" not in captured

--- a/tests/knowledge/test_worker_research.py
+++ b/tests/knowledge/test_worker_research.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.knowledge.contracts import ResearchRequestV2
+from rosclaw.knowledge.worker import BoundedResearchWorkV1, execute_bounded_research
+
+
+class _Facade:
+    def research(self, request):
+        return {"request_id": request.request_id, "status": "completed"}
+
+
+def test_bounded_worker_grants_only_research_tool():
+    work = BoundedResearchWorkV1(
+        research=ResearchRequestV2(
+            request_id="research_1", topic="G1 football", goal="find prior work"
+        )
+    )
+    assert execute_bounded_research(work, _Facade())["status"] == "completed"
+    with pytest.raises(ValueError):
+        execute_bounded_research(work.model_copy(update={"allowed_tools": ["shell"]}), _Facade())

--- a/tests/mcp/tools/test_product_workflow.py
+++ b/tests/mcp/tools/test_product_workflow.py
@@ -25,7 +25,7 @@ def _payload(raw: str) -> dict:
 async def test_product_status_and_demo_catalog_are_discoverable() -> None:
     status = _payload(await get_product_status())
     assert status["ok"] is True
-    assert status["data"]["product_status"]["release"]["version"] == "1.0.1"
+    assert status["data"]["product_status"]["release"]["version"] == "1.2.0"
     assert status["usable_for_real_execution"] is False
 
     demos = _payload(await list_product_demos())

--- a/tests/product/test_demo_cli.py
+++ b/tests/product/test_demo_cli.py
@@ -31,7 +31,7 @@ def test_demo_catalog_and_capability_status_are_machine_readable(capsys) -> None
 
     assert dispatch_product_argv(["status", "capabilities", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)
-    assert status["release"]["version"] == "1.0.1"
+    assert status["release"]["version"] == "1.2.0"
     assert status["golden_paths"]["ur5e_reach"]["dimensions"]["simulation"] == "verified"
     assert status["golden_paths"]["rh56_single_step"]["modes"]["real"] == "developer_observed"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ class TestVersion:
             main()
         assert exc.value.code == 0
         captured = capsys.readouterr()
-        assert "rosclaw 1.0.1" in captured.out
+        assert "rosclaw 1.2.0" in captured.out
 
     def test_top_level_help_discovers_daemon_control_plane(self, capsys):
         from rosclaw.entrypoint import main

--- a/tests/test_mcp_minimal_server.py
+++ b/tests/test_mcp_minimal_server.py
@@ -118,7 +118,7 @@ class TestSystemToolHandlers:
         server = ROSClawMinimalMCPServer()
         result = await server._handle_system_tool("system.get_version", {})
         assert result["name"] == "rosclaw"
-        assert result["version"] == "1.0.0"
+        assert result["version"] == "1.2.0"
         assert result["status"] == "ready"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- adds lightweight contracts, Protocols, service/in-process/disabled clients, facade, context and feedback adapters
- exposes bounded Know research, Reference Pack build/open, and advisory How tools to Native Agent and minimal MCP
- integrates truthful health, EventBus observability, CLI commands, and runtime lifecycle
- preserves legacy rollback while preventing v2 from receiving Memory's store or bypassing physical safety paths
- updates package/release metadata to 1.2.0 and adds the implementation report

## Why

Core should orchestrate optional Know/How packages without copying their algorithms or conflating external knowledge, robot Memory, Practice feedback, and physical execution.

## Impact

Base installs retain a disabled-by-default lightweight boundary. `service` and `inprocess` modes are explicit; missing packages or services degrade without affecting the safety chain.

## Validation

- 100 focused knowledge/E2E/MCP/CLI tests passed
- full suite: 6375 passed, 74 skipped, 39 deselected; 6 known host-environment failures in Codex/LeRobot probes
- Ruff and diff checks passed
- wheel build, clean install, offline reinstall, and extras resolution passed
