### PR TITLE
Prove Know/How usefulness and align v2 contracts

### DIFF
--- a/docs/architecture/KNOW_HOW_V2_INTEGRATION.md
+++ b/docs/architecture/KNOW_HOW_V2_INTEGRATION.md
@@ -1,6 +1,7 @@
 # Know / How v2 core integration
 
-Status: implemented in the 1.2.0 working tree.
+Status: baseline merged; 2026-08-06 usefulness hardening implemented, with
+rosclaw-know 1.2.2 and rosclaw-how 1.2.1 published.
 
 ## Ownership boundary
 
@@ -42,6 +43,10 @@ Environment controls:
 - `ROSCLAW_KNOW_URL`, `ROSCLAW_HOW_V2_URL`, API-key variables and `ROSCLAW_KNOWLEDGE_TIMEOUT` for service mode.
 - `ROSCLAW_KNOW_STORE_MODE` and `ROSCLAW_KNOW_SEEKDB_PATH` for in-process Know.
 
+How service advice/cache persistence additionally uses the
+ROSCLAW_HOW_ADVICE_* and ROSCLAW_HOW_REFERENCE_PACK_* controls documented by
+rosclaw-how.
+
 ## Agent and MCP surface
 
 The registered tools are intentionally small:
@@ -58,3 +63,18 @@ Every tool is S0/read-only. `rosclaw_how_advice` is additionally marked advisory
 Only allowlisted lifecycle events containing identifiers, counts, versions and statuses cross the EventBus adapter. Feedback records whether a unit was presented, opened or useful; a receipt or Practice reference is only a reference. Feedback cannot claim that a physical action succeeded and cannot carry raw Memory content.
 
 Dashboard status includes v2 mode and component health. A How or Know failure therefore remains observable without changing estop, safety policy, daemon or driver behavior.
+
+Feedback verdicts now create explicit, non-mutating Know governance records:
+useful/irrelevant feedback records signals; stale feedback enters source
+refresh review; incompatible feedback enters compatibility review; misleading
+feedback enters ranking review. No verdict permits automatic deletion,
+rewriting, promotion or constraint override.
+
+How keeps advice in a durable bounded store and service-mode Reference Packs
+in a separate bounded cache. Fresh, cached and stale states are explicit
+contract fields. A missing or over-age cached pack causes abstention.
+
+The reproducible fixture campaign and raw paired-model output are under
+docs/reports/validation_runs/know-how-usefulness-v2/. It proves that the
+mechanism changes the next engineering action (value level 3); it does not
+claim real-hardware effectiveness.

--- a/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
+++ b/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
@@ -42,9 +42,9 @@ default branches:
 | `rosclaw-know` | `ros-claw/rosclaw-know#5` | `ac4c2dd` | 1.2.2 tagged and published |
 | `rosclaw-how` | `ros-claw/rosclaw-how#3` | `d52ecfd` | 1.2.1 tagged and published |
 
-The Core evidence and contract-copy update remains on branch
-`agent/know-how-usefulness-v2` until this report's own pull request is merged;
-no Core PyPI release is requested or produced.
+The Core evidence and contract-copy update is proposed in
+`ros-claw/rosclaw#252` from branch `agent/know-how-usefulness-v2`; no Core
+PyPI release is requested or produced.
 
 ## Architecture and contracts
 

--- a/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
+++ b/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
@@ -1,8 +1,9 @@
 # Know / How v2 implementation report
 
 Date: 2026-08-06
-Target release: 1.2.0
-Source plan: `know_how_优化v1.md`
+Baseline releases: rosclaw-know 1.2.1, rosclaw-how 1.2.0
+Published hardening releases: rosclaw-know 1.2.2, rosclaw-how 1.2.1
+Source plan: `know_how_优化v2.md`
 
 ## Result
 
@@ -25,13 +26,25 @@ create an `ActionEnvelope` or bypass Core policy, safety, daemon or driver
 boundaries. Memory remains a separately labelled robot-experience input and
 is not used as Know's corpus or store.
 
-The implementation is present as uncommitted working-tree changes based on:
+The v1 foundation was merged and released before this hardening pass:
 
-| Repository | Base commit | Package version |
+| Repository | Merged baseline | Package version / state |
 | --- | --- | --- |
-| `rosclaw-know` | `55ce4981f46ca469ff1cc6ca9582f82d6e2d8c92` | 1.2.0 |
-| `rosclaw-how` | `4639cd68bbe294ce61eb01d63c9a96999e3f969f` | 1.2.0 |
-| `rosclaw` | `fbf9a692bbf759fdc8f8e304d205c3d592ca4dc9` | 1.2.0 |
+| `rosclaw-know` | `3e81b4c` | 1.2.1 published |
+| `rosclaw-how` | `d2dea03` | 1.2.0 published |
+| `rosclaw` | `44d83d1e` | merged; no Core PyPI release requested |
+
+The usefulness hardening packages are merged and published from their merged
+default branches:
+
+| Repository | Pull request | Merge commit | Final state |
+| --- | --- | --- | --- |
+| `rosclaw-know` | `ros-claw/rosclaw-know#5` | `ac4c2dd` | 1.2.2 tagged and published |
+| `rosclaw-how` | `ros-claw/rosclaw-how#3` | `d52ecfd` | 1.2.1 tagged and published |
+
+The Core evidence and contract-copy update remains on branch
+`agent/know-how-usefulness-v2` until this report's own pull request is merged;
+no Core PyPI release is requested or produced.
 
 ## Architecture and contracts
 
@@ -119,6 +132,17 @@ license fields and a signer Protocol. The included HMAC signer is for local
 offline integrity; deployment can provide a stronger signer. Offline imports
 remain explicitly marked as offline and freshness-limited.
 
+### Feedback governance hardening
+
+Every accepted `KnowledgeUsageFeedbackV1` now creates a durable,
+deterministic `FeedbackGovernanceRecordV1`. The mapping is conservative:
+useful and irrelevant verdicts record signals only; stale enters source-refresh
+review; incompatible enters compatibility review; misleading enters downweight
+review; unknown enters manual review. Every record fixes
+`automatic_mutation_allowed=false`. The API returns the governance result and
+exposes a bounded/filterable queue. Idempotent feedback IDs stay idempotent and
+conflicting reuse is rejected.
+
 ## rosclaw-how
 
 How accesses Know only through the versioned Reference Pack/feedback client;
@@ -133,11 +157,17 @@ and unknown context are surfaced explicitly. Know evidence and Memory evidence
 are separately labelled in diagnosis output.
 
 The v2 API now includes the four explicit mode endpoints, generic advice,
-bounded process-local advice lookup, feedback, health and capabilities.
+durable bounded advice lookup, feedback, health and capabilities.
 Capabilities explicitly state that How owns neither a retrieval index nor
 action authority. Advice and feedback endpoints enforce the existing optional
 How API-key allowlist. The legacy `/wiki/v1` path can be rolled through the v2
 engine behind a feature flag.
+
+Advice records live in a bounded SQLite store with creation/expiry and
+feedback status, so lookup survives process restart. Service-mode Reference
+Packs use a separate bounded SQLite cache. Fresh, cached and stale states are
+strict contract fields propagated into How advice. An upstream stale label is
+preserved; missing or over-age cache causes abstention.
 
 ## Core rosclaw
 
@@ -181,38 +211,62 @@ Exact revisions and non-adoptions are recorded in
 `KNOW_HOW_REFERENCE_STUDY.md`. The supplied RepoMaster repository URL was not
 available and no substitute was silently selected.
 
+## Usefulness evidence
+
+The reproducible campaign under
+`docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/`
+uses three controlled fixtures aligned with the requested G1 football,
+RealSense ARM and LIMO ROS1 lines. Each corpus contains an exact lexical match
+that is incompatible with the runtime and a pinned compatible route.
+
+| Metric (3 tasks) | keyword-only control | Know→Pack→How |
+| --- | ---: | ---: |
+| wrong initial routes | 3 | 0 |
+| compatibility errors | 3 | 0 |
+| references read before first compatible route | 6 | 3 |
+| pinned evidence presented | 0 | 3 |
+| oracle-compatible route passes | 0 | 3 |
+
+A paired vLLM run used `deepseekv4`, temperature 0.0 and the same three
+tasks/runtime contexts. The treatment changed only by adding the Reference
+Pack and How advice. The control found 0/3 exact fixture files and 0/3 expected
+routes; treatment found 3/3 and 3/3. Raw outputs are retained, including the
+control arm's guessed paths and unverified command suggestions. The prompt
+leakage found during the first audit was removed and that invalid artifact was
+discarded before the recorded run.
+
+This proves value level 3: cited/context-filtered knowledge changes the next
+engineering action and avoids a known incompatible route. It does not prove
+physical value level 4 or cross-task accumulated value level 5.
+
 ## Verification performed
 
-All tests used fixtures, mocks, temporary directories or embedded stores. No
-real ROS graph, robot, actuator or hardware service was contacted.
+All tests used fixtures, mocks, temporary directories, SHADOW paths or
+embedded stores. No real ROS graph, robot, actuator or hardware service was
+contacted.
 
 | Check | Result |
 | --- | --- |
-| `rosclaw-know` full pytest | 682 passed, 7 skipped |
-| `rosclaw-how` full pytest | 357 passed |
-| Core knowledge + E2E + MCP + CLI focused regression | 100 passed |
-| Real installed-package in-process Know→Pack→How→feedback loop | passed |
-| v2 Ruff scopes and all three `git diff --check` checks | passed |
-| Three 1.2.0 wheel builds | passed |
-| Wheel schema/migration/module inspection | passed |
-| Python 3.13 clean full-dependency wheel install | passed |
-| Clean uninstall and `--no-index --no-deps` local-wheel reinstall | passed |
-| `rosclaw[knowledge]==1.2.0` dependency resolution | passed |
-| `rosclaw[all]==1.2.0` dependency resolution | passed |
-| Installed entrypoint disabled/degradation check | passed |
-| Core full pytest | 6375 passed, 74 skipped, 39 deselected, 6 environment failures |
+| `rosclaw-know` full pytest | 689 passed, 7 skipped |
+| `rosclaw-how` full pytest | 361 passed |
+| Core `tests/knowledge` | 24 passed |
+| contract/schema/governance focused regression | 47 passed |
+| cache expiry, restart and upstream-stale boundary tests | passed |
+| deterministic three-task usefulness A/B assertions | passed |
+| paired vLLM A/B (six requests) | passed; exact file and route 0/3 → 3/3 |
+| 1.2.2 / 1.2.1 wheel builds and Twine metadata checks | passed |
+| official PyPI JSON/Simple Index and exact-version install smoke | passed for both packages |
+| clean Python 3.13 no-deps wheel install + v2 SQLite smoke | passed |
+| changed-scope Ruff and all three `git diff --check` checks | passed |
+| Core full pytest | 6371 passed, 74 skipped, 39 deselected, 11 environment failures |
 
-The clean wheel environment reported all three installed versions as 1.2.0,
-found the packaged JSON Schema, found all 12 migration files and opened an
-isolated SeekDB embedded database.
+The 11 Core failures are outside the changed knowledge surfaces: one offline
+release installer lacks its cached `aiohttp` dependency; two tests assume
+the host `codex` binary is absent; four LeRobot tests select an interpreter
+that cannot import LeRobot; and four firstboot tests expect console scripts in
+PATH. The changed Core knowledge suite passes 24/24.
 
-The six Core full-suite failures are outside the changed Know/How areas. Two
-external-worker tests assume the `codex` binary is absent, while this host has
-an incompatible/untrusted-directory Codex CLI. Four LeRobot integration tests
-are selected by their availability probe but the configured worker interpreter
-cannot import LeRobot. Focused reruns of all changed Core surfaces pass.
-
-## Known limits and release follow-ups
+## Known limits and deployment follow-ups
 
 - SeekDB server-mode construction, SQL migrations and feature negotiation are
   implemented, and Core server-parameter wiring is unit tested, but no live
@@ -222,15 +276,12 @@ cannot import LeRobot. Focused reruns of all changed Core surfaces pass.
   were intentionally not run. Default CI remains deterministic and offline.
 - Native multi-vector is not available in the probed collection API; the
   implementation uses coordinated vector collections/fields and RRF.
-- Advice lookup is a bounded process-local cache, not a durable How database.
-  Reference Packs themselves remain durable in Know.
-- The HTTP clients do not yet serve a previously cached Reference Pack after
-  Know becomes unavailable; callers receive explicit degraded/unavailable
-  state instead of a stale pseudo-fresh answer.
+- How persistence is local bounded SQLite. Multi-replica deployments must use
+  a shared/replicated store or accept per-replica advice/cache visibility.
 - HMAC is the included local bundle signer. A managed deployment should inject
   an asymmetric signer and key-management policy through `BundleSigner`.
-- Knowledge feedback is stored and available to refresh/ranking governance,
-  but automatic source refresh scheduling is not enabled by feedback alone.
+- Feedback creates refresh/review candidates but intentionally does not run a
+  refresh worker or mutate ranking/knowledge without a separate review action.
 - The Know v2 API implements the operational closed loop, but the plan's
   separate discover/ingest, project-compare and admin endpoints are not all
   split into independent public routes yet.
@@ -240,4 +291,39 @@ cannot import LeRobot. Focused reruns of all changed Core surfaces pass.
 These limits should prevent declaring every checkbox in the source plan's
 Definition of Done complete. The implemented default path and the tested
 closed loop are usable; server/live-source and deployment-signing validation
-remain release gates for environments that require them.
+remain deployment gates for environments that require them.
+
+## Validation intentionally left blank
+
+| Requested real-world check | Result |
+| --- | --- |
+| live SeekDB server, SQL rollback, AI_RERANK |  |
+| live GitHub/arXiv/official-doc sources |  |
+| ten real-project wiki audit |  |
+| real G1 football implementation |  |
+| real RealSense ARM integration |  |
+| real LIMO ROS1 integration |  |
+| physical before/after success metrics |  |
+
+These cells are blank rather than converted into fixture claims.
+
+## v2 review answers
+
+1. Key sources in the recorded campaign are pinned fixture snapshots listed in
+   `source_manifest.json`; no live source is claimed.
+2. The Reference Pack changed all three first routes from incompatible lexical
+   matches to context-compatible routes.
+3. Compatibility filtering avoided ROS1/ROS2, robot and architecture/version
+   mismatch candidates in the controlled corpus.
+4. Every treatment opened one exact file backed by an evidence ID, snapshot ID
+   and content hash.
+5. The code changes are durable AdviceStore, explicit cache degradation and
+   non-mutating feedback governance.
+6. Package, contract, API, failure-boundary and Core knowledge tests pass.
+7. Advice/cache reuse is proven across SQLite reopen; cross-task real-project
+   reuse is not claimed.
+8. Incremental source refresh was not run against a live repository.
+9. Feedback enters auditable signal/refresh/review queues and cannot
+   automatically mutate knowledge.
+10. In the controlled A/B, first-compatible reads fall 6→3 and wrong first
+    routes fall 3→0; no real elapsed-time or physical rework claim is made.

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/ab_metrics.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/ab_metrics.json
@@ -1,0 +1,34 @@
+{
+  "campaign_type": "controlled_fixture_ab",
+  "physical_claim": false,
+  "scenario_count": 3,
+  "baseline": {
+    "wrong_initial_routes": 3,
+    "compatibility_errors": 3,
+    "pinned_evidence_presented": 0,
+    "references_to_first_compatible_total": 6,
+    "oracle_route_passes": 0
+  },
+  "treatment": {
+    "wrong_initial_routes": 0,
+    "compatibility_errors": 0,
+    "pinned_evidence_presented": 3,
+    "references_to_first_compatible_total": 3,
+    "oracle_route_passes": 3
+  },
+  "delta": {
+    "wrong_initial_routes": -3,
+    "compatibility_errors": -3,
+    "pinned_evidence_presented": 3,
+    "references_to_first_compatible_total": -3,
+    "oracle_route_passes": 3
+  },
+  "paired_llm": {
+    "executed": true,
+    "pairs": 3,
+    "baseline_exact_file": 0,
+    "treatment_exact_file": 3,
+    "baseline_expected_route": 0,
+    "treatment_expected_route": 3
+  }
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/environment.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/environment.json
@@ -1,0 +1,8 @@
+{
+  "created_at": "2026-08-06T16:48:23.615656+00:00",
+  "python": "3.13.12 (main, Mar 20 2026, 00:36:06) [Clang 22.1.1 ]",
+  "platform": "Linux-6.17.0-1021-nvidia-aarch64-with-glibc2.39",
+  "validation_mode": "fixture_offline_shadow",
+  "real_ros_contacted": false,
+  "real_hardware_contacted": false
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/evidence_open_log.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/evidence_open_log.json
@@ -1,0 +1,26 @@
+[
+  {
+    "scenario_id": "g1_football_fixture",
+    "evidence_id": "evidence-good-g1_football_fixture",
+    "snapshot_id": "snapshot-good-g1_football_fixture",
+    "path": "controllers/g1_soccer_balance.yaml",
+    "opened": true,
+    "fixture_only": true
+  },
+  {
+    "scenario_id": "realsense_arm_fixture",
+    "evidence_id": "evidence-good-realsense_arm_fixture",
+    "snapshot_id": "snapshot-good-realsense_arm_fixture",
+    "path": "deploy/realsense_aarch64.yaml",
+    "opened": true,
+    "fixture_only": true
+  },
+  {
+    "scenario_id": "limo_ros1_fixture",
+    "evidence_id": "evidence-good-limo_ros1_fixture",
+    "snapshot_id": "snapshot-good-limo_ros1_fixture",
+    "path": "navigation/limo_move_base.launch",
+    "opened": true,
+    "fixture_only": true
+  }
+]

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/final_report.md
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/final_report.md
@@ -1,0 +1,18 @@
+# Know/How usefulness campaign
+
+- Mode: controlled fixture/offline SHADOW; no physical success claim.
+- Scenarios: 3 (G1 football, RealSense ARM, LIMO ROS1 fixtures).
+- Baseline wrong first routes: 3.
+- Treatment wrong first routes: 0.
+- Baseline compatibility errors: 3.
+- Treatment compatibility errors: 0.
+- References read before first compatible route: 6 -> 3.
+- Pinned evidence presented: 0 -> 3.
+- Oracle-compatible route passes: 0 -> 3.
+- Paired vLLM run: executed.
+- Paired vLLM exact-file hits: 0 -> 3.
+- Paired vLLM expected-route hits: 0 -> 3.
+
+The controlled result proves value level 3: the system changes the next
+engineering action and avoids a known incompatible first route.  It does not
+prove real-hardware value level 4/5; those fields remain intentionally blank.

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/how_advice.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/how_advice.json
@@ -1,0 +1,218 @@
+[
+  {
+    "schema_version": "rosclaw.how.advice.v2",
+    "advice_id": "advice_15ed0235777283aad48e030c",
+    "mode": "diagnose",
+    "context_hash": "ab2cec1f2cfc74a2c913f2fbdd38fb66ec1688f2f445d44d4b1fb4deb833d585",
+    "reference_pack_id": "reference_pack_f08b9b41f92d81642cfb2327",
+    "reference_pack_cached": false,
+    "reference_pack_stale": false,
+    "reference_pack_age_seconds": 0,
+    "summary": "DIAGNOSE advice grounded in 1 Know item(s); Reference Pack state=fresh; Memory evidence remains a separately labelled context input.",
+    "diagnosis": "[Know evidence] Matched by fulltext; confidence=0.95. [Memory evidence] 0 separate robot-experience record(s) supplied.",
+    "recommendations": [
+      {
+        "action_type": "inspect",
+        "description": "Inspect controllers/g1_soccer_balance.yaml at git_commit:c2022f9c907f.",
+        "rationale": "The cited mechanism is: Use route bounded_residual_balance only when robot, ROS and software constraints match.",
+        "knowledge_unit_ids": [
+          "z-good-g1_football_fixture"
+        ],
+        "evidence_refs": [
+          {
+            "schema_version": "rosclaw.know.evidence_ref.v2",
+            "evidence_id": "evidence-good-g1_football_fixture",
+            "source_id": "source-good-g1_football_fixture",
+            "snapshot_id": "snapshot-good-g1_football_fixture",
+            "document_id": "document-good-g1_football_fixture",
+            "path": "controllers/g1_soccer_balance.yaml",
+            "start_line": 1,
+            "end_line": 4,
+            "section": null,
+            "url": "https://example.invalid/g1_football_fixture/blob/c2022f9c907f/controllers/g1_soccer_balance.yaml",
+            "content_hash": "c2022f9c907f373c68a8a10b19b4dae312415afad750fc32dcfbb0859c76c586",
+            "excerpt": "fixture route=bounded_residual_balance\nfile=controllers/g1_soccer_balance.yaml\nrobot=unitree_g1\nros=humble\nquery=G1 football balance recovery controller"
+          }
+        ],
+        "safety_class": "advisory"
+      },
+      {
+        "action_type": "verify",
+        "description": "Verify the observed failure against the cited conditions before changing configuration.",
+        "rationale": "A lexical or mechanism match is evidence for investigation, not proof of root cause.",
+        "knowledge_unit_ids": [
+          "z-good-g1_football_fixture"
+        ],
+        "evidence_refs": [
+          {
+            "schema_version": "rosclaw.know.evidence_ref.v2",
+            "evidence_id": "evidence-good-g1_football_fixture",
+            "source_id": "source-good-g1_football_fixture",
+            "snapshot_id": "snapshot-good-g1_football_fixture",
+            "document_id": "document-good-g1_football_fixture",
+            "path": "controllers/g1_soccer_balance.yaml",
+            "start_line": 1,
+            "end_line": 4,
+            "section": null,
+            "url": "https://example.invalid/g1_football_fixture/blob/c2022f9c907f/controllers/g1_soccer_balance.yaml",
+            "content_hash": "c2022f9c907f373c68a8a10b19b4dae312415afad750fc32dcfbb0859c76c586",
+            "excerpt": "fixture route=bounded_residual_balance\nfile=controllers/g1_soccer_balance.yaml\nrobot=unitree_g1\nros=humble\nquery=G1 football balance recovery controller"
+          }
+        ],
+        "safety_class": "advisory"
+      }
+    ],
+    "compatibility_warnings": [],
+    "unknowns": [
+      "reranker_used=false; deterministic_fallback=rrf",
+      "AI_RERANK unavailable; deterministic RRF fallback used"
+    ],
+    "abstained": false,
+    "abstention_reason": null,
+    "created_at": "2026-08-06T16:48:23.617146Z"
+  },
+  {
+    "schema_version": "rosclaw.how.advice.v2",
+    "advice_id": "advice_63b1f882f4a0acef1eaff97a",
+    "mode": "diagnose",
+    "context_hash": "ba709859ee9f84f7369e6e965bc9a8a9dd96be330926ebbabe5b4168a0d6227e",
+    "reference_pack_id": "reference_pack_20b6eda33ec5ac23d0ee0e8e",
+    "reference_pack_cached": false,
+    "reference_pack_stale": false,
+    "reference_pack_age_seconds": 0,
+    "summary": "DIAGNOSE advice grounded in 1 Know item(s); Reference Pack state=fresh; Memory evidence remains a separately labelled context input.",
+    "diagnosis": "[Know evidence] Matched by fulltext; confidence=0.95. [Memory evidence] 0 separate robot-experience record(s) supplied.",
+    "recommendations": [
+      {
+        "action_type": "inspect",
+        "description": "Inspect deploy/realsense_aarch64.yaml at git_commit:0e42da15e8a6.",
+        "rationale": "The cited mechanism is: Use route aarch64_source_build only when robot, ROS and software constraints match.",
+        "knowledge_unit_ids": [
+          "z-good-realsense_arm_fixture"
+        ],
+        "evidence_refs": [
+          {
+            "schema_version": "rosclaw.know.evidence_ref.v2",
+            "evidence_id": "evidence-good-realsense_arm_fixture",
+            "source_id": "source-good-realsense_arm_fixture",
+            "snapshot_id": "snapshot-good-realsense_arm_fixture",
+            "document_id": "document-good-realsense_arm_fixture",
+            "path": "deploy/realsense_aarch64.yaml",
+            "start_line": 1,
+            "end_line": 4,
+            "section": null,
+            "url": "https://example.invalid/realsense_arm_fixture/blob/0e42da15e8a6/deploy/realsense_aarch64.yaml",
+            "content_hash": "0e42da15e8a6e1d0c373022ea69153f5ff00be3f5938b872e5953fe74e9c3809",
+            "excerpt": "fixture route=aarch64_source_build\nfile=deploy/realsense_aarch64.yaml\nrobot=custom_arm_robot\nros=humble\nquery=RealSense ARM robot camera integration"
+          }
+        ],
+        "safety_class": "advisory"
+      },
+      {
+        "action_type": "verify",
+        "description": "Verify the observed failure against the cited conditions before changing configuration.",
+        "rationale": "A lexical or mechanism match is evidence for investigation, not proof of root cause.",
+        "knowledge_unit_ids": [
+          "z-good-realsense_arm_fixture"
+        ],
+        "evidence_refs": [
+          {
+            "schema_version": "rosclaw.know.evidence_ref.v2",
+            "evidence_id": "evidence-good-realsense_arm_fixture",
+            "source_id": "source-good-realsense_arm_fixture",
+            "snapshot_id": "snapshot-good-realsense_arm_fixture",
+            "document_id": "document-good-realsense_arm_fixture",
+            "path": "deploy/realsense_aarch64.yaml",
+            "start_line": 1,
+            "end_line": 4,
+            "section": null,
+            "url": "https://example.invalid/realsense_arm_fixture/blob/0e42da15e8a6/deploy/realsense_aarch64.yaml",
+            "content_hash": "0e42da15e8a6e1d0c373022ea69153f5ff00be3f5938b872e5953fe74e9c3809",
+            "excerpt": "fixture route=aarch64_source_build\nfile=deploy/realsense_aarch64.yaml\nrobot=custom_arm_robot\nros=humble\nquery=RealSense ARM robot camera integration"
+          }
+        ],
+        "safety_class": "advisory"
+      }
+    ],
+    "compatibility_warnings": [],
+    "unknowns": [
+      "reranker_used=false; deterministic_fallback=rrf",
+      "AI_RERANK unavailable; deterministic RRF fallback used"
+    ],
+    "abstained": false,
+    "abstention_reason": null,
+    "created_at": "2026-08-06T16:48:37.036399Z"
+  },
+  {
+    "schema_version": "rosclaw.how.advice.v2",
+    "advice_id": "advice_1d29087d7488cd11fac547a9",
+    "mode": "diagnose",
+    "context_hash": "321ccfecd9ffa1e1762ebf809b4e614252db3cd6f87816efa59a37e6971108a1",
+    "reference_pack_id": "reference_pack_2d04c17f6d689a557b3ee197",
+    "reference_pack_cached": false,
+    "reference_pack_stale": false,
+    "reference_pack_age_seconds": 0,
+    "summary": "DIAGNOSE advice grounded in 1 Know item(s); Reference Pack state=fresh; Memory evidence remains a separately labelled context input.",
+    "diagnosis": "[Know evidence] Matched by fulltext; confidence=0.95. [Memory evidence] 0 separate robot-experience record(s) supplied.",
+    "recommendations": [
+      {
+        "action_type": "inspect",
+        "description": "Inspect navigation/limo_move_base.launch at git_commit:0a916f199934.",
+        "rationale": "The cited mechanism is: Use route limo_move_base only when robot, ROS and software constraints match.",
+        "knowledge_unit_ids": [
+          "z-good-limo_ros1_fixture"
+        ],
+        "evidence_refs": [
+          {
+            "schema_version": "rosclaw.know.evidence_ref.v2",
+            "evidence_id": "evidence-good-limo_ros1_fixture",
+            "source_id": "source-good-limo_ros1_fixture",
+            "snapshot_id": "snapshot-good-limo_ros1_fixture",
+            "document_id": "document-good-limo_ros1_fixture",
+            "path": "navigation/limo_move_base.launch",
+            "start_line": 1,
+            "end_line": 4,
+            "section": null,
+            "url": "https://example.invalid/limo_ros1_fixture/blob/0a916f199934/navigation/limo_move_base.launch",
+            "content_hash": "0a916f199934b92fec2c186faf01fddabb4f0d78c67df0fdb5511eb555b3f6a7",
+            "excerpt": "fixture route=limo_move_base\nfile=navigation/limo_move_base.launch\nrobot=agilex_limo\nros=noetic\nquery=LIMO ROS1 navigation integration"
+          }
+        ],
+        "safety_class": "advisory"
+      },
+      {
+        "action_type": "verify",
+        "description": "Verify the observed failure against the cited conditions before changing configuration.",
+        "rationale": "A lexical or mechanism match is evidence for investigation, not proof of root cause.",
+        "knowledge_unit_ids": [
+          "z-good-limo_ros1_fixture"
+        ],
+        "evidence_refs": [
+          {
+            "schema_version": "rosclaw.know.evidence_ref.v2",
+            "evidence_id": "evidence-good-limo_ros1_fixture",
+            "source_id": "source-good-limo_ros1_fixture",
+            "snapshot_id": "snapshot-good-limo_ros1_fixture",
+            "document_id": "document-good-limo_ros1_fixture",
+            "path": "navigation/limo_move_base.launch",
+            "start_line": 1,
+            "end_line": 4,
+            "section": null,
+            "url": "https://example.invalid/limo_ros1_fixture/blob/0a916f199934/navigation/limo_move_base.launch",
+            "content_hash": "0a916f199934b92fec2c186faf01fddabb4f0d78c67df0fdb5511eb555b3f6a7",
+            "excerpt": "fixture route=limo_move_base\nfile=navigation/limo_move_base.launch\nrobot=agilex_limo\nros=noetic\nquery=LIMO ROS1 navigation integration"
+          }
+        ],
+        "safety_class": "advisory"
+      }
+    ],
+    "compatibility_warnings": [],
+    "unknowns": [
+      "reranker_used=false; deterministic_fallback=rrf",
+      "AI_RERANK unavailable; deterministic RRF fallback used"
+    ],
+    "abstained": false,
+    "abstention_reason": null,
+    "created_at": "2026-08-06T16:48:51.368298Z"
+  }
+]

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/implementation.diff
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/implementation.diff
@@ -1,0 +1,1497 @@
+### rosclaw
+diff --git a/docs/architecture/KNOW_HOW_V2_INTEGRATION.md b/docs/architecture/KNOW_HOW_V2_INTEGRATION.md
+index b19b5d61..25548418 100644
+--- a/docs/architecture/KNOW_HOW_V2_INTEGRATION.md
++++ b/docs/architecture/KNOW_HOW_V2_INTEGRATION.md
+@@ -1,6 +1,6 @@
+ # Know / How v2 core integration
+
+-Status: implemented in the 1.2.0 working tree.
++Status: baseline merged; 2026-08-06 usefulness hardening implemented.
+
+ ## Ownership boundary
+
+@@ -42,6 +42,10 @@ Environment controls:
+ - `ROSCLAW_KNOW_URL`, `ROSCLAW_HOW_V2_URL`, API-key variables and `ROSCLAW_KNOWLEDGE_TIMEOUT` for service mode.
+ - `ROSCLAW_KNOW_STORE_MODE` and `ROSCLAW_KNOW_SEEKDB_PATH` for in-process Know.
+
++How service advice/cache persistence additionally uses the
++ROSCLAW_HOW_ADVICE_* and ROSCLAW_HOW_REFERENCE_PACK_* controls documented by
++rosclaw-how.
++
+ ## Agent and MCP surface
+
+ The registered tools are intentionally small:
+@@ -58,3 +62,18 @@ Every tool is S0/read-only. `rosclaw_how_advice` is additionally marked advisory
+ Only allowlisted lifecycle events containing identifiers, counts, versions and statuses cross the EventBus adapter. Feedback records whether a unit was presented, opened or useful; a receipt or Practice reference is only a reference. Feedback cannot claim that a physical action succeeded and cannot carry raw Memory content.
+
+ Dashboard status includes v2 mode and component health. A How or Know failure therefore remains observable without changing estop, safety policy, daemon or driver behavior.
++
++Feedback verdicts now create explicit, non-mutating Know governance records:
++useful/irrelevant feedback records signals; stale feedback enters source
++refresh review; incompatible feedback enters compatibility review; misleading
++feedback enters ranking review. No verdict permits automatic deletion,
++rewriting, promotion or constraint override.
++
++How keeps advice in a durable bounded store and service-mode Reference Packs
++in a separate bounded cache. Fresh, cached and stale states are explicit
++contract fields. A missing or over-age cached pack causes abstention.
++
++The reproducible fixture campaign and raw paired-model output are under
++docs/reports/validation_runs/know-how-usefulness-v2/. It proves that the
++mechanism changes the next engineering action (value level 3); it does not
++claim real-hardware effectiveness.
+diff --git a/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md b/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
+index 3e3a65cb..96abafb3 100644
+--- a/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
++++ b/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
+@@ -1,8 +1,9 @@
+ # Know / How v2 implementation report
+
+ Date: 2026-08-06
+-Target release: 1.2.0
+-Source plan: `know_how_优化v1.md`
++Baseline releases: rosclaw-know 1.2.1, rosclaw-how 1.2.0
++Candidate releases: rosclaw-know 1.2.2, rosclaw-how 1.2.1
++Source plan: `know_how_优化v2.md`
+
+ ## Result
+
+@@ -25,13 +26,17 @@ create an `ActionEnvelope` or bypass Core policy, safety, daemon or driver
+ boundaries. Memory remains a separately labelled robot-experience input and
+ is not used as Know's corpus or store.
+
+-The implementation is present as uncommitted working-tree changes based on:
++The v1 foundation was merged and released before this hardening pass:
+
+-| Repository | Base commit | Package version |
++| Repository | Merged baseline | Package version / state |
+ | --- | --- | --- |
+-| `rosclaw-know` | `55ce4981f46ca469ff1cc6ca9582f82d6e2d8c92` | 1.2.0 |
+-| `rosclaw-how` | `4639cd68bbe294ce61eb01d63c9a96999e3f969f` | 1.2.0 |
+-| `rosclaw` | `fbf9a692bbf759fdc8f8e304d205c3d592ca4dc9` | 1.2.0 |
++| `rosclaw-know` | `3e81b4c` | 1.2.1 published |
++| `rosclaw-how` | `d2dea03` | 1.2.0 published |
++| `rosclaw` | `44d83d1e` | merged; no Core PyPI release requested |
++
++The usefulness hardening in this report is on local branch
++`agent/know-how-usefulness-v2` in all three repositories. It is not described
++as released or deployed.
+
+ ## Architecture and contracts
+
+@@ -119,6 +124,17 @@ license fields and a signer Protocol. The included HMAC signer is for local
+ offline integrity; deployment can provide a stronger signer. Offline imports
+ remain explicitly marked as offline and freshness-limited.
+
++### Feedback governance hardening
++
++Every accepted `KnowledgeUsageFeedbackV1` now creates a durable,
++deterministic `FeedbackGovernanceRecordV1`. The mapping is conservative:
++useful and irrelevant verdicts record signals only; stale enters source-refresh
++review; incompatible enters compatibility review; misleading enters downweight
++review; unknown enters manual review. Every record fixes
++`automatic_mutation_allowed=false`. The API returns the governance result and
++exposes a bounded/filterable queue. Idempotent feedback IDs stay idempotent and
++conflicting reuse is rejected.
++
+ ## rosclaw-how
+
+ How accesses Know only through the versioned Reference Pack/feedback client;
+@@ -133,12 +149,18 @@ and unknown context are surfaced explicitly. Know evidence and Memory evidence
+ are separately labelled in diagnosis output.
+
+ The v2 API now includes the four explicit mode endpoints, generic advice,
+-bounded process-local advice lookup, feedback, health and capabilities.
++durable bounded advice lookup, feedback, health and capabilities.
+ Capabilities explicitly state that How owns neither a retrieval index nor
+ action authority. Advice and feedback endpoints enforce the existing optional
+ How API-key allowlist. The legacy `/wiki/v1` path can be rolled through the v2
+ engine behind a feature flag.
+
++Advice records live in a bounded SQLite store with creation/expiry and
++feedback status, so lookup survives process restart. Service-mode Reference
++Packs use a separate bounded SQLite cache. Fresh, cached and stale states are
++strict contract fields propagated into How advice. An upstream stale label is
++preserved; missing or over-age cache causes abstention.
++
+ ## Core rosclaw
+
+ Core contains contracts, Protocols and adapters only. It does not copy the
+@@ -181,36 +203,59 @@ Exact revisions and non-adoptions are recorded in
+ `KNOW_HOW_REFERENCE_STUDY.md`. The supplied RepoMaster repository URL was not
+ available and no substitute was silently selected.
+
++## Usefulness evidence
++
++The reproducible campaign under
++`docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/`
++uses three controlled fixtures aligned with the requested G1 football,
++RealSense ARM and LIMO ROS1 lines. Each corpus contains an exact lexical match
++that is incompatible with the runtime and a pinned compatible route.
++
++| Metric (3 tasks) | keyword-only control | Know→Pack→How |
++| --- | ---: | ---: |
++| wrong initial routes | 3 | 0 |
++| compatibility errors | 3 | 0 |
++| references read before first compatible route | 6 | 3 |
++| pinned evidence presented | 0 | 3 |
++| oracle-compatible route passes | 0 | 3 |
++
++A paired vLLM run used `deepseekv4`, temperature 0.0 and the same three
++tasks/runtime contexts. The treatment changed only by adding the Reference
++Pack and How advice. The control found 0/3 exact fixture files and 0/3 expected
++routes; treatment found 3/3 and 3/3. Raw outputs are retained, including the
++control arm's guessed paths and unverified command suggestions. The prompt
++leakage found during the first audit was removed and that invalid artifact was
++discarded before the recorded run.
++
++This proves value level 3: cited/context-filtered knowledge changes the next
++engineering action and avoids a known incompatible route. It does not prove
++physical value level 4 or cross-task accumulated value level 5.
++
+ ## Verification performed
+
+-All tests used fixtures, mocks, temporary directories or embedded stores. No
+-real ROS graph, robot, actuator or hardware service was contacted.
++All tests used fixtures, mocks, temporary directories, SHADOW paths or
++embedded stores. No real ROS graph, robot, actuator or hardware service was
++contacted.
+
+ | Check | Result |
+ | --- | --- |
+-| `rosclaw-know` full pytest | 682 passed, 7 skipped |
+-| `rosclaw-how` full pytest | 357 passed |
+-| Core knowledge + E2E + MCP + CLI focused regression | 100 passed |
+-| Real installed-package in-process Know→Pack→How→feedback loop | passed |
+-| v2 Ruff scopes and all three `git diff --check` checks | passed |
+-| Three 1.2.0 wheel builds | passed |
+-| Wheel schema/migration/module inspection | passed |
+-| Python 3.13 clean full-dependency wheel install | passed |
+-| Clean uninstall and `--no-index --no-deps` local-wheel reinstall | passed |
+-| `rosclaw[knowledge]==1.2.0` dependency resolution | passed |
+-| `rosclaw[all]==1.2.0` dependency resolution | passed |
+-| Installed entrypoint disabled/degradation check | passed |
+-| Core full pytest | 6375 passed, 74 skipped, 39 deselected, 6 environment failures |
+-
+-The clean wheel environment reported all three installed versions as 1.2.0,
+-found the packaged JSON Schema, found all 12 migration files and opened an
+-isolated SeekDB embedded database.
+-
+-The six Core full-suite failures are outside the changed Know/How areas. Two
+-external-worker tests assume the `codex` binary is absent, while this host has
+-an incompatible/untrusted-directory Codex CLI. Four LeRobot integration tests
+-are selected by their availability probe but the configured worker interpreter
+-cannot import LeRobot. Focused reruns of all changed Core surfaces pass.
++| `rosclaw-know` full pytest | 689 passed, 7 skipped |
++| `rosclaw-how` full pytest | 361 passed |
++| Core `tests/knowledge` | 24 passed |
++| contract/schema/governance focused regression | 47 passed |
++| cache expiry, restart and upstream-stale boundary tests | passed |
++| deterministic three-task usefulness A/B assertions | passed |
++| paired vLLM A/B (six requests) | passed; exact file and route 0/3 → 3/3 |
++| 1.2.2 / 1.2.1 wheel builds and Twine metadata checks | passed |
++| clean Python 3.13 no-deps wheel install + v2 SQLite smoke | passed |
++| changed-scope Ruff and all three `git diff --check` checks | passed |
++| Core full pytest | 6371 passed, 74 skipped, 39 deselected, 11 environment failures |
++
++The 11 Core failures are outside the changed knowledge surfaces: one offline
++release installer lacks its cached `aiohttp` dependency; two tests assume
++the host `codex` binary is absent; four LeRobot tests select an interpreter
++that cannot import LeRobot; and four firstboot tests expect console scripts in
++PATH. The changed Core knowledge suite passes 24/24.
+
+ ## Known limits and release follow-ups
+
+@@ -222,15 +267,12 @@ cannot import LeRobot. Focused reruns of all changed Core surfaces pass.
+   were intentionally not run. Default CI remains deterministic and offline.
+ - Native multi-vector is not available in the probed collection API; the
+   implementation uses coordinated vector collections/fields and RRF.
+-- Advice lookup is a bounded process-local cache, not a durable How database.
+-  Reference Packs themselves remain durable in Know.
+-- The HTTP clients do not yet serve a previously cached Reference Pack after
+-  Know becomes unavailable; callers receive explicit degraded/unavailable
+-  state instead of a stale pseudo-fresh answer.
++- How persistence is local bounded SQLite. Multi-replica deployments must use
++  a shared/replicated store or accept per-replica advice/cache visibility.
+ - HMAC is the included local bundle signer. A managed deployment should inject
+   an asymmetric signer and key-management policy through `BundleSigner`.
+-- Knowledge feedback is stored and available to refresh/ranking governance,
+-  but automatic source refresh scheduling is not enabled by feedback alone.
++- Feedback creates refresh/review candidates but intentionally does not run a
++  refresh worker or mutate ranking/knowledge without a separate review action.
+ - The Know v2 API implements the operational closed loop, but the plan's
+   separate discover/ingest, project-compare and admin endpoints are not all
+   split into independent public routes yet.
+@@ -241,3 +283,38 @@ These limits should prevent declaring every checkbox in the source plan's
+ Definition of Done complete. The implemented default path and the tested
+ closed loop are usable; server/live-source and deployment-signing validation
+ remain release gates for environments that require them.
++
++## Validation intentionally left blank
++
++| Requested real-world check | Result |
++| --- | --- |
++| live SeekDB server, SQL rollback, AI_RERANK |  |
++| live GitHub/arXiv/official-doc sources |  |
++| ten real-project wiki audit |  |
++| real G1 football implementation |  |
++| real RealSense ARM integration |  |
++| real LIMO ROS1 integration |  |
++| physical before/after success metrics |  |
++
++These cells are blank rather than converted into fixture claims.
++
++## v2 review answers
++
++1. Key sources in the recorded campaign are pinned fixture snapshots listed in
++   `source_manifest.json`; no live source is claimed.
++2. The Reference Pack changed all three first routes from incompatible lexical
++   matches to context-compatible routes.
++3. Compatibility filtering avoided ROS1/ROS2, robot and architecture/version
++   mismatch candidates in the controlled corpus.
++4. Every treatment opened one exact file backed by an evidence ID, snapshot ID
++   and content hash.
++5. The code changes are durable AdviceStore, explicit cache degradation and
++   non-mutating feedback governance.
++6. Package, contract, API, failure-boundary and Core knowledge tests pass.
++7. Advice/cache reuse is proven across SQLite reopen; cross-task real-project
++   reuse is not claimed.
++8. Incremental source refresh was not run against a live repository.
++9. Feedback enters auditable signal/refresh/review queues and cannot
++   automatically mutate knowledge.
++10. In the controlled A/B, first-compatible reads fall 6→3 and wrong first
++    routes fall 3→0; no real elapsed-time or physical rework claim is made.
+diff --git a/src/rosclaw/knowledge/contracts.py b/src/rosclaw/knowledge/contracts.py
+index cf4c56c8..1e094906 100644
+--- a/src/rosclaw/knowledge/contracts.py
++++ b/src/rosclaw/knowledge/contracts.py
+@@ -150,6 +150,9 @@ class ReferencePackV2(StrictWireModel):
+     truncated: bool = False
+     continuation_cursor: str | None = None
+     warnings: list[str] = Field(default_factory=list)
++    cached: bool = False
++    stale: bool = False
++    cache_age_seconds: int = Field(default=0, ge=0)
+
+     _generated_aware = field_validator("generated_at")(_aware)
+
+@@ -157,6 +160,10 @@ class ReferencePackV2(StrictWireModel):
+     def _cursor_when_truncated(self):
+         if self.truncated and not self.continuation_cursor:
+             raise ValueError("truncated packs require a continuation_cursor")
++        if self.stale and not self.cached:
++            raise ValueError("stale Reference Packs must also be marked cached")
++        if (self.cached or self.stale) and not self.warnings:
++            raise ValueError("cached Reference Packs must explain degradation in warnings")
+         return self
+
+
+@@ -177,6 +184,9 @@ class HowAdviceBundleV2(StrictWireModel):
+     mode: Literal["discover", "consult", "diagnose", "catalyze"]
+     context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+     reference_pack_id: str | None = None
++    reference_pack_cached: bool = False
++    reference_pack_stale: bool = False
++    reference_pack_age_seconds: int = Field(default=0, ge=0)
+     summary: str = Field(min_length=1)
+     diagnosis: str | None = None
+     recommendations: list[AdviceRecommendationV2] = Field(default_factory=list)
+@@ -192,6 +202,8 @@ class HowAdviceBundleV2(StrictWireModel):
+     def _abstention_explained(self):
+         if self.abstained and not self.abstention_reason:
+             raise ValueError("abstained advice requires abstention_reason")
++        if self.reference_pack_stale and not self.reference_pack_cached:
++            raise ValueError("stale advice must identify a cached Reference Pack")
+         return self
+
+### rosclaw-know
+diff --git a/docs/CHANGELOG.md b/docs/CHANGELOG.md
+index 37dbea7..0e532a5 100644
+--- a/docs/CHANGELOG.md
++++ b/docs/CHANGELOG.md
+@@ -3,6 +3,21 @@
+ All notable changes by phase. Most recent first. Format inspired by
+ [Keep a Changelog](https://keepachangelog.com/).
+
++## [1.2.2] — 2026-08-06 · conservative feedback governance
++
++### Added
++
++- Explicit cached/stale/cache-age fields for ReferencePackV2 and matching
++  cache provenance in HowAdviceBundleV2.
++- FeedbackGovernanceRecordV1 plus durable signal, refresh, compatibility,
++  ranking and manual-review queues.
++- Filterable governance API and deterministic non-mutating verdict routing.
++
++### Safety
++
++- Every feedback consequence fixes automatic_mutation_allowed=false; feedback
++  cannot delete, rewrite, promote or override official constraints.
++
+ ## [unreleased] — 2026-06-04 · multi-seed harness, snippet matrix, analogy QC, +43 clusters
+
+ ### Added (analogy QC + bridge coverage — second commit pair this day)
+diff --git a/pyproject.toml b/pyproject.toml
+index d46f5a5..afa01f5 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
+
+ [project]
+ name = "rosclaw-know"
+-version = "1.2.1"
++version = "1.2.2"
+ description = "Physical-AI knowledge compiler — turns multi-source corpus + execution feedback into procedural engineering experience for ROSClaw agents."
+ readme = "README.md"
+ license = {text = "MIT"}
+diff --git a/schemas/know_how_v2.json b/schemas/know_how_v2.json
+index 41669bd..0272cc4 100644
+--- a/schemas/know_how_v2.json
++++ b/schemas/know_how_v2.json
+@@ -1,4 +1,117 @@
+ {
++  "rosclaw.feedback_governance.v1": {
++    "additionalProperties": false,
++    "description": "Auditable, non-mutating consequence of one usage-feedback verdict.",
++    "properties": {
++      "automatic_mutation_allowed": {
++        "const": false,
++        "default": false,
++        "title": "Automatic Mutation Allowed",
++        "type": "boolean"
++      },
++      "created_at": {
++        "format": "date-time",
++        "title": "Created At",
++        "type": "string"
++      },
++      "feedback_id": {
++        "minLength": 1,
++        "title": "Feedback Id",
++        "type": "string"
++      },
++      "governance_id": {
++        "minLength": 1,
++        "title": "Governance Id",
++        "type": "string"
++      },
++      "knowledge_unit_id": {
++        "minLength": 1,
++        "title": "Knowledge Unit Id",
++        "type": "string"
++      },
++      "proposed_action": {
++        "enum": [
++          "record_usage_signal",
++          "record_query_family_signal",
++          "refresh_source_candidate",
++          "compatibility_review_candidate",
++          "downweight_review_candidate",
++          "manual_review_candidate"
++        ],
++        "title": "Proposed Action",
++        "type": "string"
++      },
++      "queue": {
++        "enum": [
++          "usage_signals",
++          "query_ranking_signals",
++          "source_refresh",
++          "compatibility_review",
++          "ranking_review",
++          "manual_review"
++        ],
++        "title": "Queue",
++        "type": "string"
++      },
++      "rationale": {
++        "minLength": 1,
++        "title": "Rationale",
++        "type": "string"
++      },
++      "reference_pack_id": {
++        "minLength": 1,
++        "title": "Reference Pack Id",
++        "type": "string"
++      },
++      "requires_human_review": {
++        "title": "Requires Human Review",
++        "type": "boolean"
++      },
++      "schema_version": {
++        "const": "rosclaw.feedback_governance.v1",
++        "default": "rosclaw.feedback_governance.v1",
++        "title": "Schema Version",
++        "type": "string"
++      },
++      "status": {
++        "enum": [
++          "signal_recorded",
++          "pending_review",
++          "reviewed",
++          "dismissed"
++        ],
++        "title": "Status",
++        "type": "string"
++      },
++      "verdict": {
++        "enum": [
++          "useful",
++          "irrelevant",
++          "stale",
++          "incompatible",
++          "misleading",
++          "unknown"
++        ],
++        "title": "Verdict",
++        "type": "string"
++      }
++    },
++    "required": [
++      "governance_id",
++      "feedback_id",
++      "reference_pack_id",
++      "knowledge_unit_id",
++      "verdict",
++      "queue",
++      "proposed_action",
++      "status",
++      "requires_human_review",
++      "rationale",
++      "created_at"
++    ],
++    "title": "FeedbackGovernanceRecordV1",
++    "type": "object"
++  },
+   "rosclaw.how.advice.v2": {
+     "$defs": {
+       "AdviceRecommendationV2": {
+@@ -234,6 +347,17 @@
+         "title": "Recommendations",
+         "type": "array"
+       },
++      "reference_pack_age_seconds": {
++        "default": 0,
++        "minimum": 0,
++        "title": "Reference Pack Age Seconds",
++        "type": "integer"
++      },
++      "reference_pack_cached": {
++        "default": false,
++        "title": "Reference Pack Cached",
++        "type": "boolean"
++      },
+       "reference_pack_id": {
+         "anyOf": [
+           {
+@@ -246,6 +370,11 @@
+         "default": null,
+         "title": "Reference Pack Id"
+       },
++      "reference_pack_stale": {
++        "default": false,
++        "title": "Reference Pack Stale",
++        "type": "boolean"
++      },
+       "schema_version": {
+         "const": "rosclaw.how.advice.v2",
+         "default": "rosclaw.how.advice.v2",
+@@ -1378,6 +1507,17 @@
+     },
+     "additionalProperties": false,
+     "properties": {
++      "cache_age_seconds": {
++        "default": 0,
++        "minimum": 0,
++        "title": "Cache Age Seconds",
++        "type": "integer"
++      },
++      "cached": {
++        "default": false,
++        "title": "Cached",
++        "type": "boolean"
++      },
+       "comparison": {
+         "$ref": "#/$defs/ReferenceComparisonV2"
+       },
+@@ -1443,6 +1583,11 @@
+         "title": "Schema Version",
+         "type": "string"
+       },
++      "stale": {
++        "default": false,
++        "title": "Stale",
++        "type": "boolean"
++      },
+       "suggested_next_checks": {
+         "items": {
+           "type": "string"
+diff --git a/src/rosclaw_know/__init__.py b/src/rosclaw_know/__init__.py
+index 9dbcba4..fd1fcdb 100644
+--- a/src/rosclaw_know/__init__.py
++++ b/src/rosclaw_know/__init__.py
+@@ -1,3 +1,3 @@
+ """ROSClaw-Know: offline knowledge refinery for procedural heuristics."""
+
+-__version__ = "1.2.1"
++__version__ = "1.2.2"
+diff --git a/src/rosclaw_know/api.py b/src/rosclaw_know/api.py
+index 8e2b512..4276ec9 100644
+--- a/src/rosclaw_know/api.py
++++ b/src/rosclaw_know/api.py
+@@ -23,7 +23,7 @@ import time
+ from contextlib import asynccontextmanager
+ from typing import Literal
+
+-from fastapi import Depends, FastAPI, Header, HTTPException, Request, status
++from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, status
+ from fastapi.responses import JSONResponse
+ from pydantic import BaseModel, Field, ValidationError
+
+@@ -36,6 +36,7 @@ from .contracts import (
+     StrictContract,
+     export_contract_schemas,
+ )
++from .feedback_governance import governance_for_feedback
+ from .research_store import ResearchStore
+ from .research_worker import ResearchWorker
+ from .retrieval import ReferencePackBuilder
+@@ -409,12 +410,46 @@ async def v2_feedback(request: Request) -> JSONResponse:
+     except ValidationError as exc:
+         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
+     created = _get_v2_store().put_feedback(feedback)
++    governance = governance_for_feedback(feedback)
+     return JSONResponse(
+-        {"feedback_id": feedback.feedback_id, "created": created},
++        {
++            "feedback_id": feedback.feedback_id,
++            "created": created,
++            "governance": governance.model_dump(mode="json"),
++        },
+         status_code=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+     )
+
+
++@app.get("/know/v2/feedback/governance", dependencies=[Depends(require_api_key)])
++async def v2_feedback_governance(
++    queue: Literal[
++        "usage_signals",
++        "query_ranking_signals",
++        "source_refresh",
++        "compatibility_review",
++        "ranking_review",
++        "manual_review",
++    ]
++    | None = None,
++    status_value: Literal["signal_recorded", "pending_review", "reviewed", "dismissed"]
++    | None = Query(default=None, alias="status"),
++    limit: int = 100,
++) -> JSONResponse:
++    if limit < 1 or limit > 1_000:
++        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "limit must be between 1 and 1000")
++    records = _get_v2_store().list_feedback_governance(
++        queue=queue, status=status_value, limit=limit
++    )
++    return JSONResponse(
++        {
++            "count": len(records),
++            "automatic_mutation_allowed": False,
++            "records": [record.model_dump(mode="json") for record in records],
++        }
++    )
++
++
+ @app.post("/know/v1/research", status_code=status.HTTP_202_ACCEPTED)
+ async def start_research(req: ResearchRequest) -> JSONResponse:
+     store = _get_store()
+diff --git a/src/rosclaw_know/contracts/__init__.py b/src/rosclaw_know/contracts/__init__.py
+index af97dc5..253e0bc 100644
+--- a/src/rosclaw_know/contracts/__init__.py
++++ b/src/rosclaw_know/contracts/__init__.py
+@@ -14,6 +14,7 @@ from .base import (
+ from .knowledge_v2 import KnowledgeUnitV2, KnowledgeVectorsV2, ProjectCardV2
+ from .reference_pack_v2 import (
+     AdviceRecommendationV2,
++    FeedbackGovernanceRecordV1,
+     HowAdviceBundleV2,
+     KnowledgeUsageFeedbackV1,
+     ReferenceComparisonV2,
+@@ -34,12 +35,14 @@ PUBLIC_CONTRACTS = (
+     ReferencePackV2,
+     HowAdviceBundleV2,
+     KnowledgeUsageFeedbackV1,
++    FeedbackGovernanceRecordV1,
+ )
+
+ __all__ = [
+     "AdviceRecommendationV2",
+     "ContractVersionError",
+     "EvidenceRefV2",
++    "FeedbackGovernanceRecordV1",
+     "HowAdviceBundleV2",
+     "IntegrityV2",
+     "KnowledgeUnitV2",
+diff --git a/src/rosclaw_know/contracts/reference_pack_v2.py b/src/rosclaw_know/contracts/reference_pack_v2.py
+index 6d61da7..a6da7e7 100644
+--- a/src/rosclaw_know/contracts/reference_pack_v2.py
++++ b/src/rosclaw_know/contracts/reference_pack_v2.py
+@@ -66,6 +66,9 @@ class ReferencePackV2(StrictContract):
+     truncated: bool = False
+     continuation_cursor: str | None = None
+     warnings: list[str] = Field(default_factory=list)
++    cached: bool = False
++    stale: bool = False
++    cache_age_seconds: int = Field(default=0, ge=0)
+
+     @field_validator("generated_at")
+     @classmethod
+@@ -79,6 +82,10 @@ class ReferencePackV2(StrictContract):
+             raise ValueError("item ranks must be unique")
+         if self.truncated and not self.continuation_cursor:
+             raise ValueError("truncated packs require a continuation_cursor")
++        if self.stale and not self.cached:
++            raise ValueError("stale Reference Packs must also be marked cached")
++        if (self.cached or self.stale) and not self.warnings:
++            raise ValueError("cached Reference Packs must explain degradation in warnings")
+         return self
+
+
+@@ -99,6 +106,9 @@ class HowAdviceBundleV2(StrictContract):
+     mode: Literal["discover", "consult", "diagnose", "catalyze"]
+     context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+     reference_pack_id: str | None = None
++    reference_pack_cached: bool = False
++    reference_pack_stale: bool = False
++    reference_pack_age_seconds: int = Field(default=0, ge=0)
+     summary: str = Field(min_length=1)
+     diagnosis: str | None = None
+     recommendations: list[AdviceRecommendationV2] = Field(default_factory=list)
+@@ -117,6 +127,8 @@ class HowAdviceBundleV2(StrictContract):
+     def _abstention_is_explained(self) -> HowAdviceBundleV2:
+         if self.abstained and not self.abstention_reason:
+             raise ValueError("abstained advice requires abstention_reason")
++        if self.reference_pack_stale and not self.reference_pack_cached:
++            raise ValueError("stale advice must identify a cached Reference Pack")
+         return self
+
+
+@@ -143,3 +155,42 @@ class KnowledgeUsageFeedbackV1(StrictContract):
+     @classmethod
+     def _aware(cls, value: datetime) -> datetime:
+         return ensure_aware(value)  # type: ignore[return-value]
++
++
++class FeedbackGovernanceRecordV1(StrictContract):
++    """Auditable, non-mutating consequence of one usage-feedback verdict."""
++
++    SCHEMA_VERSION: ClassVar[str] = "rosclaw.feedback_governance.v1"
++
++    schema_version: Literal["rosclaw.feedback_governance.v1"] = SCHEMA_VERSION
++    governance_id: str = Field(min_length=1)
++    feedback_id: str = Field(min_length=1)
++    reference_pack_id: str = Field(min_length=1)
++    knowledge_unit_id: str = Field(min_length=1)
++    verdict: Literal["useful", "irrelevant", "stale", "incompatible", "misleading", "unknown"]
++    queue: Literal[
++        "usage_signals",
++        "query_ranking_signals",
++        "source_refresh",
++        "compatibility_review",
++        "ranking_review",
++        "manual_review",
++    ]
++    proposed_action: Literal[
++        "record_usage_signal",
++        "record_query_family_signal",
++        "refresh_source_candidate",
++        "compatibility_review_candidate",
++        "downweight_review_candidate",
++        "manual_review_candidate",
++    ]
++    status: Literal["signal_recorded", "pending_review", "reviewed", "dismissed"]
++    requires_human_review: bool
++    automatic_mutation_allowed: Literal[False] = False
++    rationale: str = Field(min_length=1)
++    created_at: datetime
++
++    @field_validator("created_at")
++    @classmethod
++    def _created_aware(cls, value: datetime) -> datetime:
++        return ensure_aware(value)  # type: ignore[return-value]
+diff --git a/src/rosclaw_know/store/base.py b/src/rosclaw_know/store/base.py
+index e834a36..46b190a 100644
+--- a/src/rosclaw_know/store/base.py
++++ b/src/rosclaw_know/store/base.py
+@@ -8,6 +8,7 @@ from typing import Any, Protocol
+
+ from rosclaw_know.contracts import (
+     EvidenceRefV2,
++    FeedbackGovernanceRecordV1,
+     KnowledgeUnitV2,
+     KnowledgeUsageFeedbackV1,
+     ProjectCardV2,
+@@ -95,6 +96,14 @@ class KnowStore(Protocol):
+
+     def put_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool: ...
+
++    def get_feedback_governance(
++        self, governance_id: str
++    ) -> FeedbackGovernanceRecordV1 | None: ...
++
++    def list_feedback_governance(
++        self, *, queue: str | None = None, status: str | None = None, limit: int = 100
++    ) -> list[FeedbackGovernanceRecordV1]: ...
++
+     def put_index_version(self, version: IndexVersionRecord) -> bool: ...
+
+     def latest_index_version(self) -> IndexVersionRecord | None: ...
+diff --git a/src/rosclaw_know/store/memory.py b/src/rosclaw_know/store/memory.py
+index 2f68aa6..9ebb49e 100644
+--- a/src/rosclaw_know/store/memory.py
++++ b/src/rosclaw_know/store/memory.py
+@@ -14,6 +14,7 @@ from typing import Any
+
+ from rosclaw_know.contracts import (
+     EvidenceRefV2,
++    FeedbackGovernanceRecordV1,
+     KnowledgeUnitV2,
+     KnowledgeUsageFeedbackV1,
+     ProjectCardV2,
+@@ -21,6 +22,7 @@ from rosclaw_know.contracts import (
+     SourceRecordV2,
+     SourceSnapshotV2,
+ )
++from rosclaw_know.feedback_governance import governance_for_feedback
+
+ from .base import ImmutableSnapshotError
+ from .models import (
+@@ -69,6 +71,7 @@ class InMemoryKnowStore:
+         self.relations: dict[str, RelationRecord] = {}
+         self.reference_packs: dict[str, ReferencePackV2] = {}
+         self.feedback: dict[str, KnowledgeUsageFeedbackV1] = {}
++        self.feedback_governance: dict[str, FeedbackGovernanceRecordV1] = {}
+         self.index_versions: dict[str, IndexVersionRecord] = {}
+         self.embedding_hashes: dict[str, str] = {}
+         self.embedding_writes = 0
+@@ -331,7 +334,28 @@ class InMemoryKnowStore:
+         existing = self.feedback.get(feedback.feedback_id)
+         if existing is not None and existing != feedback:
+             raise ValueError(f"feedback ID conflict: {feedback.feedback_id}")
+-        return self._upsert(self.feedback, feedback.feedback_id, feedback)
++        created = self._upsert(self.feedback, feedback.feedback_id, feedback)
++        governance = governance_for_feedback(feedback)
++        self._upsert(self.feedback_governance, governance.governance_id, governance)
++        return created
++
++    def get_feedback_governance(
++        self, governance_id: str
++    ) -> FeedbackGovernanceRecordV1 | None:
++        return copy.deepcopy(self.feedback_governance.get(governance_id))
++
++    def list_feedback_governance(
++        self, *, queue: str | None = None, status: str | None = None, limit: int = 100
++    ) -> list[FeedbackGovernanceRecordV1]:
++        if limit <= 0:
++            return []
++        records = [
++            item
++            for item in self.feedback_governance.values()
++            if (queue is None or item.queue == queue) and (status is None or item.status == status)
++        ]
++        records.sort(key=lambda item: (item.created_at, item.governance_id), reverse=True)
++        return copy.deepcopy(records[:limit])
+
+     def put_index_version(self, version: IndexVersionRecord) -> bool:
+         existing = self.index_versions.get(version.index_version)
+@@ -353,6 +377,7 @@ class InMemoryKnowStore:
+             "knowledge_unit_count": len(self.units),
+             "reference_pack_count": len(self.reference_packs),
+             "feedback_count": len(self.feedback),
++            "feedback_governance_count": len(self.feedback_governance),
+         }
+
+     def close(self) -> None:
+diff --git a/src/rosclaw_know/store/seekdb.py b/src/rosclaw_know/store/seekdb.py
+index 93226e7..0adf709 100644
+--- a/src/rosclaw_know/store/seekdb.py
++++ b/src/rosclaw_know/store/seekdb.py
+@@ -16,6 +16,7 @@ from typing import Any
+
+ from rosclaw_know.contracts import (
+     EvidenceRefV2,
++    FeedbackGovernanceRecordV1,
+     KnowledgeUnitV2,
+     KnowledgeUsageFeedbackV1,
+     ProjectCardV2,
+@@ -23,6 +24,7 @@ from rosclaw_know.contracts import (
+     SourceRecordV2,
+     SourceSnapshotV2,
+ )
++from rosclaw_know.feedback_governance import governance_for_feedback
+
+ from .base import ImmutableSnapshotError, StoreConfigurationError
+ from .isolation import guard_store_isolation
+@@ -51,6 +53,7 @@ COLLECTIONS = {
+     "relation": "know_relation_v2",
+     "reference_pack": "know_reference_pack_v2",
+     "feedback": "know_usage_feedback_v1",
++    "feedback_governance": "know_feedback_governance_v1",
+     "index_version": "know_index_version_v2",
+ }
+ VECTOR_FIELDS = ("problem", "mechanism", "content", "code")
+@@ -567,7 +570,42 @@ class SeekDBKnowStore:
+         payload = feedback.model_dump(mode="json", exclude_none=False)
+         if existing is not None and existing != payload:
+             raise ValueError(f"feedback ID conflict: {feedback.feedback_id}")
+-        return self._put_payload("feedback", feedback.feedback_id, feedback)
++        created = self._put_payload("feedback", feedback.feedback_id, feedback)
++        governance = governance_for_feedback(feedback)
++        self._put_payload(
++            "feedback_governance",
++            governance.governance_id,
++            governance,
++            metadata={
++                "queue": governance.queue,
++                "status": governance.status,
++                "requires_human_review": governance.requires_human_review,
++            },
++        )
++        return created
++
++    def get_feedback_governance(
++        self, governance_id: str
++    ) -> FeedbackGovernanceRecordV1 | None:
++        payload = self._get_payload("feedback_governance", governance_id)
++        return _parse(FeedbackGovernanceRecordV1, payload) if payload else None
++
++    def list_feedback_governance(
++        self, *, queue: str | None = None, status: str | None = None, limit: int = 100
++    ) -> list[FeedbackGovernanceRecordV1]:
++        if limit <= 0:
++            return []
++        records = [
++            _parse(FeedbackGovernanceRecordV1, value)
++            for value in self._iter_payloads("feedback_governance")
++        ]
++        records = [
++            item
++            for item in records
++            if (queue is None or item.queue == queue) and (status is None or item.status == status)
++        ]
++        records.sort(key=lambda item: (item.created_at, item.governance_id), reverse=True)
++        return records[:limit]
+
+     def put_index_version(self, version: IndexVersionRecord) -> bool:
+         existing = self._get_payload("index_version", version.index_version)
+@@ -591,6 +629,7 @@ class SeekDBKnowStore:
+             "knowledge_unit_count": "unit",
+             "reference_pack_count": "reference_pack",
+             "feedback_count": "feedback",
++            "feedback_governance_count": "feedback_governance",
+         }
+         return {
+             label: sum(1 for _ in self._iter_payloads(logical))
+diff --git a/tests/test_api_v2.py b/tests/test_api_v2.py
+index 1e781f7..2229c9e 100644
+--- a/tests/test_api_v2.py
++++ b/tests/test_api_v2.py
+@@ -75,8 +75,16 @@ def test_v2_capabilities_plan_reference_pack_and_feedback_contracts():
+             first = client.post("/know/v2/feedback", json=feedback)
+             second = client.post("/know/v2/feedback", json=feedback)
+             assert first.status_code == 201, first.text
++            assert first.json()["governance"]["queue"] == "manual_review"
++            assert first.json()["governance"]["automatic_mutation_allowed"] is False
+             assert second.status_code == 200, second.text
+             assert second.json()["created"] is False
++            governance = client.get(
++                "/know/v2/feedback/governance", params={"status": "pending_review"}
++            )
++            assert governance.status_code == 200, governance.text
++            assert governance.json()["count"] == 1
++            assert governance.json()["automatic_mutation_allowed"] is False
+
+             assert client.get("/know/v2/sources/missing").status_code == 404
+             assert client.get("/know/v2/snapshots/missing").status_code == 404
+
+### rosclaw-how
+diff --git a/docs/CHANGELOG.md b/docs/CHANGELOG.md
+index 5a93254..6531067 100644
+--- a/docs/CHANGELOG.md
++++ b/docs/CHANGELOG.md
+@@ -9,6 +9,21 @@ The asset-producing sister project's history lives in
+
+ ---
+
++## [1.2.1] — 2026-08-06 · durable v2 advice and honest cache degradation
++
++### Added
++
++- Bounded SQLite AdviceStore with expiry, restart-safe lookup and feedback
++  status.
++- Bounded SQLite Reference Pack cache with explicit fresh/cached/stale/abstain
++  behavior and configurable TTLs.
++- Cache provenance fields propagated into HowAdviceBundleV2.
++
++### Safety
++
++- Missing or over-age cache fails closed.
++- Upstream cached/stale packs are never relabelled fresh.
++
+ ## [0.7.1] — 2026-05-19 · Docs final
+
+ ### Added
+diff --git a/docs/architecture/HOW_V2_BOUNDARIES.md b/docs/architecture/HOW_V2_BOUNDARIES.md
+index 4c05921..29ac713 100644
+--- a/docs/architecture/HOW_V2_BOUNDARIES.md
++++ b/docs/architecture/HOW_V2_BOUNDARIES.md
+@@ -11,6 +11,35 @@ world knowledge. A citation guard drops recommendations that name units or
+ evidence outside the returned Reference Pack. Empty, unavailable or invalid
+ Know responses cause an explicit abstention.
+
++## Durable advice and cache degradation
++
++HowAdviceBundleV2 records are persisted in a bounded SQLite AdviceStore.
++The store envelope retains advice_id, reference_pack_id, context_hash,
++mode, payload, creation/expiry timestamps and feedback_status. Advice lookup
++therefore survives a How process restart; expired advice returns 404.
++
++Service-mode Reference Packs use a separate bounded SQLite cache. Cache state
++is part of the strict wire contract and is never inferred from prose:
++
++| State | cached | stale | Behavior |
++| --- | ---: | ---: | --- |
++| Know response | false | false | normal cited advice |
++| Know unavailable, inside fresh TTL | true | false | advice continues with an explicit degradation warning |
++| Know unavailable, outside fresh TTL but inside stale TTL | true | true | advice warns that evidence must be reopened/refreshed |
++| no cache or beyond stale TTL | — | — | How abstains |
++
++An upstream pack already marked cached/stale is preserved as-is and is never
++reclassified as fresh.
++
++Deployment controls:
++
++- ROSCLAW_HOW_ADVICE_STORE_PATH, ROSCLAW_HOW_ADVICE_TTL_SECONDS,
++  ROSCLAW_HOW_ADVICE_MAX_ROWS;
++- ROSCLAW_HOW_REFERENCE_PACK_CACHE_PATH,
++  ROSCLAW_HOW_REFERENCE_PACK_FRESH_TTL_SECONDS,
++  ROSCLAW_HOW_REFERENCE_PACK_STALE_TTL_SECONDS,
++  ROSCLAW_HOW_REFERENCE_PACK_CACHE_MAX_ROWS.
++
+ The legacy router and its How-owned SeekDB collections remain quarantined for
+ rollback compatibility. With `ROSCLAW_HOW_LEGACY_USE_V2=1`, the CATALYST leg
+ of `/wiki/v1/prompt/build` is adapted through the same v2 AdviceEngine; safety
+diff --git a/pyproject.toml b/pyproject.toml
+index 9f51318..ce2c289 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
+
+ [project]
+ name = "rosclaw-how"
+-version = "1.2.0"
++version = "1.2.1"
+ description = "Online deadlock-breaker — injects targeted engineering heuristics from rosclaw-know assets into stalling agents."
+ readme = "README.md"
+ license = {text = "MIT"}
+diff --git a/src/rosclaw_how/__init__.py b/src/rosclaw_how/__init__.py
+index 745d457..d0b837a 100644
+--- a/src/rosclaw_how/__init__.py
++++ b/src/rosclaw_how/__init__.py
+@@ -22,6 +22,6 @@ ranking + snippet composition are pure rules + a single embedding call.
+ """
+ from __future__ import annotations
+
+-__version__ = "1.2.0"
++__version__ = "1.2.1"
+
+ __all__ = ["__version__"]
+diff --git a/src/rosclaw_how/api.py b/src/rosclaw_how/api.py
+index facb1ce..b30a1e2 100644
+--- a/src/rosclaw_how/api.py
++++ b/src/rosclaw_how/api.py
+@@ -33,7 +33,6 @@ import hashlib
+ import json
+ import logging
+ import time
+-from collections import OrderedDict
+ from contextlib import asynccontextmanager
+ from datetime import datetime, timezone
+ from typing import Any, Literal, Protocol, get_args
+@@ -49,6 +48,7 @@ from .config import get_settings
+ from .error_normalizer import normalize_error
+ from .inmemory_router import InMemoryRouter
+ from .intervention_policy import decide_strategy
++from .outcome_models import RoutingTrace, SourceTier
+ from .outcomes import (
+     aggregate_by_pattern,
+     iter_outcomes,
+@@ -57,7 +57,6 @@ from .outcomes import (
+     record_feedback,
+     record_pending_injection,
+ )
+-from .outcome_models import RoutingTrace, SourceTier
+ from .runtime_diagnoser import diagnose as diagnose_runtime
+ from .schemas import (
+     InterventionDecision,
+@@ -78,10 +77,14 @@ from .snippet_composer import compose as compose_snippet
+ from .state_router import adaptive_state_router
+ from .v2 import (
+     AdviceEngine,
++    AdviceStore,
++    CachedKnowClient,
+     DisabledKnowClient,
+     HowAdviceRequestV2,
+     HttpKnowClient,
+     KnowledgeUsageFeedbackV1,
++    SQLiteAdviceStore,
++    SQLiteReferencePackCache,
+ )
+ from .v2.legacy import advice_to_legacy_response, legacy_request_to_v2
+
+@@ -350,8 +353,7 @@ _last_reload_mtime: float | None = None
+ _last_reload_iso: str | None = None
+ _last_asset_load_stats: dict[str, int] = {}
+ _v2_engine: AdviceEngine | None = None
+-_V2_ADVICE_CACHE_LIMIT = 1_000
+-_v2_advice_cache: OrderedDict[str, dict[str, Any]] = OrderedDict()
++_v2_advice_store: AdviceStore | None = None
+
+
+ def configure_v2_engine(engine: AdviceEngine | None) -> None:
+@@ -359,7 +361,27 @@ def configure_v2_engine(engine: AdviceEngine | None) -> None:
+
+     global _v2_engine
+     _v2_engine = engine
+-    _v2_advice_cache.clear()
++
++
++def configure_v2_advice_store(store: AdviceStore | None) -> None:
++    """Inject/reset durable advice persistence for tests and embedding hosts."""
++
++    global _v2_advice_store
++    if _v2_advice_store is not None and _v2_advice_store is not store:
++        _v2_advice_store.close()
++    _v2_advice_store = store
++
++
++def _get_v2_advice_store() -> AdviceStore:
++    global _v2_advice_store
++    if _v2_advice_store is None:
++        cfg = get_settings()
++        _v2_advice_store = SQLiteAdviceStore(
++            cfg.advice_store_path,
++            ttl_seconds=cfg.advice_ttl_seconds,
++            max_rows=cfg.advice_max_rows,
++        )
++    return _v2_advice_store
+
+
+ def _get_v2_engine() -> AdviceEngine:
+@@ -367,7 +389,16 @@ def _get_v2_engine() -> AdviceEngine:
+     if _v2_engine is None:
+         cfg = get_settings()
+         if cfg.know_service_url:
+-            client = HttpKnowClient(cfg.know_service_url, api_key=cfg.know_api_key)
++            upstream = HttpKnowClient(cfg.know_service_url, api_key=cfg.know_api_key)
++            client = CachedKnowClient(
++                upstream,
++                SQLiteReferencePackCache(
++                    cfg.reference_pack_cache_path,
++                    max_rows=cfg.reference_pack_cache_max_rows,
++                ),
++                fresh_ttl_seconds=cfg.reference_pack_cache_fresh_ttl_seconds,
++                stale_ttl_seconds=cfg.reference_pack_cache_stale_ttl_seconds,
++            )
+         else:
+             client = DisabledKnowClient()
+         _v2_engine = AdviceEngine(client)
+@@ -850,6 +881,7 @@ async def how_v2_health() -> JSONResponse:
+             "advisory_only": True,
+             "modes": ["discover", "consult", "diagnose", "catalyze"],
+             "know": know,
++            "advice_store": _get_v2_advice_store().statistics(),
+         }
+     )
+
+@@ -868,17 +900,15 @@ async def how_v2_capabilities() -> JSONResponse:
+             "advice_output": "rosclaw.how.advice.v2",
+             "owns_retrieval_index": False,
+             "owns_action_authority": False,
++            "durable_advice_lookup": True,
++            "reference_pack_cache_degradation": ["fresh", "cached", "stale", "abstain"],
+         }
+     )
+
+
+ def _remember_v2_advice(advice: Any) -> dict[str, Any]:
+-    payload = advice.model_dump(mode="json")
+-    _v2_advice_cache[advice.advice_id] = payload
+-    _v2_advice_cache.move_to_end(advice.advice_id)
+-    while len(_v2_advice_cache) > _V2_ADVICE_CACHE_LIMIT:
+-        _v2_advice_cache.popitem(last=False)
+-    return payload
++    record = _get_v2_advice_store().put(advice)
++    return record.payload
+
+
+ async def _run_v2_advice(
+@@ -932,14 +962,13 @@ async def how_v2_catalyze(http_request: Request) -> JSONResponse:
+
+ @app.get("/how/v2/advice/{advice_id}", dependencies=[Depends(require_api_key)])
+ async def how_v2_get_advice(advice_id: str) -> JSONResponse:
+-    payload = _v2_advice_cache.get(advice_id)
+-    if payload is None:
++    record = await asyncio.to_thread(_get_v2_advice_store().get, advice_id)
++    if record is None:
+         return JSONResponse(
+-            {"detail": "advice not found in this service process", "advice_id": advice_id},
++            {"detail": "advice not found or expired", "advice_id": advice_id},
+             status_code=404,
+         )
+-    _v2_advice_cache.move_to_end(advice_id)
+-    return JSONResponse(payload)
++    return JSONResponse(record.payload)
+
+
+ @app.post("/how/v2/feedback", dependencies=[Depends(require_api_key)])
+@@ -954,8 +983,17 @@ async def how_v2_feedback(http_request: Request) -> JSONResponse:
+         return JSONResponse(
+             {"detail": f"Know feedback unavailable: {type(exc).__name__}"}, status_code=503
+         )
++    advice_feedback_updated = False
++    if feedback.advice_id:
++        advice_feedback_updated = await asyncio.to_thread(
++            _get_v2_advice_store().mark_feedback, feedback.advice_id, feedback.verdict
++        )
+     return JSONResponse(
+-        {"feedback_id": feedback.feedback_id, "created": created},
++        {
++            "feedback_id": feedback.feedback_id,
++            "created": created,
++            "advice_feedback_updated": advice_feedback_updated,
++        },
+         status_code=201 if created else 200,
+     )
+
+diff --git a/src/rosclaw_how/config.py b/src/rosclaw_how/config.py
+index 8c4ae4c..179acf3 100644
+--- a/src/rosclaw_how/config.py
++++ b/src/rosclaw_how/config.py
+@@ -155,6 +155,13 @@ class Settings:
+     know_api_key: str
+     how_v2_enabled: bool
+     legacy_use_v2: bool
++    advice_store_path: Path
++    advice_ttl_seconds: int
++    advice_max_rows: int
++    reference_pack_cache_path: Path
++    reference_pack_cache_fresh_ttl_seconds: int
++    reference_pack_cache_stale_ttl_seconds: int
++    reference_pack_cache_max_rows: int
+
+     project_root: Path
+
+@@ -235,6 +242,25 @@ def get_settings() -> Settings:
+         know_api_key=_env_str("ROSCLAW_KNOW_API_KEY", ""),
+         how_v2_enabled=_env_bool("ROSCLAW_HOW_V2_ENABLED", True),
+         legacy_use_v2=_env_bool("ROSCLAW_HOW_LEGACY_USE_V2", False),
++        advice_store_path=_resolve_path(
++            _env_str("ROSCLAW_HOW_ADVICE_STORE_PATH", "how_advice_v2.sqlite3"),
++            root=RUNTIME_DATA_DIR,
++        ),
++        advice_ttl_seconds=_env_int("ROSCLAW_HOW_ADVICE_TTL_SECONDS", 604_800),
++        advice_max_rows=_env_int("ROSCLAW_HOW_ADVICE_MAX_ROWS", 10_000),
++        reference_pack_cache_path=_resolve_path(
++            _env_str("ROSCLAW_HOW_REFERENCE_PACK_CACHE_PATH", "reference_pack_cache_v2.sqlite3"),
++            root=RUNTIME_DATA_DIR,
++        ),
++        reference_pack_cache_fresh_ttl_seconds=_env_int(
++            "ROSCLAW_HOW_REFERENCE_PACK_FRESH_TTL_SECONDS", 3_600
++        ),
++        reference_pack_cache_stale_ttl_seconds=_env_int(
++            "ROSCLAW_HOW_REFERENCE_PACK_STALE_TTL_SECONDS", 604_800
++        ),
++        reference_pack_cache_max_rows=_env_int(
++            "ROSCLAW_HOW_REFERENCE_PACK_CACHE_MAX_ROWS", 2_000
++        ),
+         project_root=RUNTIME_DATA_DIR,
+     )
+
+diff --git a/src/rosclaw_how/v2/__init__.py b/src/rosclaw_how/v2/__init__.py
+index 5e3e8ad..7d83950 100644
+--- a/src/rosclaw_how/v2/__init__.py
++++ b/src/rosclaw_how/v2/__init__.py
+@@ -1,6 +1,7 @@
+ """ROSClaw How v2 advisory surface."""
+
+ from .advice import AdviceEngine, enforce_citation_guard
++from .advice_store import AdviceRecord, AdviceStore, SQLiteAdviceStore
+ from .context import (
+     BodyContextV2,
+     HowAdviceRequestV2,
+@@ -19,17 +20,22 @@ from .contracts import (
+     ReferencePackV2,
+ )
+ from .know_client import (
++    CachedKnowClient,
+     DisabledKnowClient,
+     HttpKnowClient,
+     InProcessKnowClient,
+     KnowClient,
+     KnowUnavailableError,
+ )
++from .pack_cache import SQLiteReferencePackCache, reference_pack_cache_key
+
+ __all__ = [
+     "AdviceEngine",
++    "AdviceRecord",
+     "AdviceRecommendationV2",
++    "AdviceStore",
+     "BodyContextV2",
++    "CachedKnowClient",
+     "DisabledKnowClient",
+     "EvidenceRefV2",
+     "HowAdviceBundleV2",
+@@ -46,5 +52,8 @@ __all__ = [
+     "ReferencePackV2",
+     "RuntimeContextV2",
+     "SoftwareContextV2",
++    "SQLiteAdviceStore",
++    "SQLiteReferencePackCache",
+     "enforce_citation_guard",
++    "reference_pack_cache_key",
+ ]
+diff --git a/src/rosclaw_how/v2/advice.py b/src/rosclaw_how/v2/advice.py
+index 62f6492..526d77c 100644
+--- a/src/rosclaw_how/v2/advice.py
++++ b/src/rosclaw_how/v2/advice.py
+@@ -172,7 +172,15 @@ class AdviceEngine:
+         compatibility = list(
+             dict.fromkeys(warning for item in pack.items for warning in item.incompatibilities)
+         )
+-        unknowns = list(pack.open_questions)
++        if pack.stale:
++            compatibility.append(
++                "Reference Pack is stale; reopen pinned evidence and refresh the source before implementation."
++            )
++        elif pack.cached:
++            compatibility.append(
++                "Know is unavailable; this advice uses an unexpired cached Reference Pack."
++            )
++        unknowns = list(dict.fromkeys([*pack.open_questions, *pack.warnings]))
+         if not request.context.body.robot_model:
+             unknowns.append("Body robot_model was not provided")
+         if not request.context.software.ros_distro:
+@@ -183,8 +191,12 @@ class AdviceEngine:
+             mode=request.mode,
+             context_hash=context_hash,
+             reference_pack_id=pack.reference_pack_id,
++            reference_pack_cached=pack.cached,
++            reference_pack_stale=pack.stale,
++            reference_pack_age_seconds=pack.cache_age_seconds,
+             summary=(
+                 f"{request.mode.upper()} advice grounded in {len(pack.items)} Know item(s); "
++                f"Reference Pack state={'stale' if pack.stale else 'cached' if pack.cached else 'fresh'}; "
+                 f"Memory evidence remains a separately labelled context input."
+             ),
+             diagnosis=diagnosis,
+diff --git a/src/rosclaw_how/v2/contracts.py b/src/rosclaw_how/v2/contracts.py
+index 550d768..707f605 100644
+--- a/src/rosclaw_how/v2/contracts.py
++++ b/src/rosclaw_how/v2/contracts.py
+@@ -115,9 +115,20 @@ class ReferencePackV2(StrictWireModel):
+     truncated: bool = False
+     continuation_cursor: str | None = None
+     warnings: list[str] = Field(default_factory=list)
++    cached: bool = False
++    stale: bool = False
++    cache_age_seconds: int = Field(default=0, ge=0)
+
+     _generated_aware = field_validator("generated_at")(_aware)
+
++    @model_validator(mode="after")
++    def _cache_state_is_honest(self):
++        if self.stale and not self.cached:
++            raise ValueError("stale Reference Packs must also be marked cached")
++        if (self.cached or self.stale) and not self.warnings:
++            raise ValueError("cached Reference Packs must explain degradation in warnings")
++        return self
++
+
+ class AdviceRecommendationV2(StrictWireModel):
+     action_type: Literal["inspect", "compare", "configure", "implement", "verify", "abstain"]
+@@ -136,6 +147,9 @@ class HowAdviceBundleV2(StrictWireModel):
+     mode: Literal["discover", "consult", "diagnose", "catalyze"]
+     context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+     reference_pack_id: str | None = None
++    reference_pack_cached: bool = False
++    reference_pack_stale: bool = False
++    reference_pack_age_seconds: int = Field(default=0, ge=0)
+     summary: str = Field(min_length=1)
+     diagnosis: str | None = None
+     recommendations: list[AdviceRecommendationV2] = Field(default_factory=list)
+@@ -151,6 +165,8 @@ class HowAdviceBundleV2(StrictWireModel):
+     def _abstention_explained(self):
+         if self.abstained and not self.abstention_reason:
+             raise ValueError("abstained advice requires abstention_reason")
++        if self.reference_pack_stale and not self.reference_pack_cached:
++            raise ValueError("stale advice must identify a cached Reference Pack")
+         return self
+
+
+diff --git a/src/rosclaw_how/v2/know_client.py b/src/rosclaw_how/v2/know_client.py
+index b3f2e95..e152def 100644
+--- a/src/rosclaw_how/v2/know_client.py
++++ b/src/rosclaw_how/v2/know_client.py
+@@ -6,9 +6,11 @@ import json
+ import urllib.error
+ import urllib.request
+ from collections.abc import Callable
++from datetime import UTC, datetime
+ from typing import Any, Protocol
+
+ from .contracts import KnowledgeUsageFeedbackV1, ReferenceContextV2, ReferencePackV2
++from .pack_cache import SQLiteReferencePackCache, reference_pack_cache_key
+
+
+ class KnowUnavailableError(RuntimeError):
+@@ -85,6 +87,102 @@ class HttpKnowClient:
+         return json.loads(self._request("GET", "/know/v2/capabilities"))
+
+
++class CachedKnowClient:
++    """Decorate a Know client with bounded, honest offline degradation.
++
++    A transport failure may reuse a cached pack.  Packs inside ``fresh_ttl``
++    are marked ``cached``; older packs inside ``stale_ttl`` are additionally
++    marked ``stale``.  Missing or too-old entries fail closed so How abstains.
++    Invalid upstream payloads are never hidden by the cache.
++    """
++
++    def __init__(
++        self,
++        upstream: KnowClient,
++        cache: SQLiteReferencePackCache,
++        *,
++        fresh_ttl_seconds: int = 3_600,
++        stale_ttl_seconds: int = 604_800,
++        clock: Callable[[], datetime] | None = None,
++    ) -> None:
++        if fresh_ttl_seconds <= 0:
++            raise ValueError("fresh_ttl_seconds must be positive")
++        if stale_ttl_seconds < fresh_ttl_seconds:
++            raise ValueError("stale_ttl_seconds must be >= fresh_ttl_seconds")
++        self.upstream = upstream
++        self.cache = cache
++        self.fresh_ttl_seconds = fresh_ttl_seconds
++        self.stale_ttl_seconds = stale_ttl_seconds
++        self._clock = clock or (lambda: datetime.now(UTC))
++
++    def reference_pack(
++        self,
++        *,
++        query: str,
++        context: ReferenceContextV2,
++        top_k: int,
++        token_budget: int,
++    ) -> ReferencePackV2:
++        key = reference_pack_cache_key(
++            query=query, context=context, top_k=top_k, token_budget=token_budget
++        )
++        try:
++            pack = self.upstream.reference_pack(
++                query=query, context=context, top_k=top_k, token_budget=token_budget
++            )
++        except KnowUnavailableError as exc:
++            cached = self.cache.get(key)
++            if cached is None:
++                raise KnowUnavailableError(f"{exc}; no cached Reference Pack") from exc
++            pack, stored_at = cached
++            age = max(0, int((self._clock() - stored_at).total_seconds()))
++            if age > self.stale_ttl_seconds:
++                raise KnowUnavailableError(
++                    f"{exc}; cached Reference Pack exceeds stale limit ({age}s)"
++                ) from exc
++            stale = age > self.fresh_ttl_seconds
++            warning = (
++                "cache:stale_reference_pack_requires_revalidation"
++                if stale
++                else "cache:know_unavailable_using_unexpired_reference_pack"
++            )
++            return ReferencePackV2.model_validate(
++                {
++                    **pack.model_dump(mode="python"),
++                    "cached": True,
++                    "stale": stale,
++                    "cache_age_seconds": age,
++                    "warnings": list(dict.fromkeys([*pack.warnings, warning])),
++                }
++            )
++        # Preserve an upstream service's explicit degradation label.  Caching
++        # it again as a local fresh value would turn stale knowledge into a
++        # pseudo-fresh response on the next outage.
++        if pack.cached:
++            return pack
++        self.cache.put(key, pack, stored_at=self._clock())
++        return pack
++
++    def submit_feedback(self, feedback: KnowledgeUsageFeedbackV1) -> bool:
++        return self.upstream.submit_feedback(feedback)
++
++    def health(self) -> dict[str, Any]:
++        try:
++            upstream = self.upstream.health()
++        except Exception as exc:  # noqa: BLE001 - health boundary
++            upstream = {"status": "unavailable", "error": type(exc).__name__}
++        status = upstream.get("status", "ok")
++        return {
++            "status": "degraded" if status in {"disabled", "unavailable"} else status,
++            "upstream": upstream,
++            "reference_pack_cache": {
++                **self.cache.statistics(),
++                "fresh_ttl_seconds": self.fresh_ttl_seconds,
++                "stale_ttl_seconds": self.stale_ttl_seconds,
++            },
++        }
++
++
+ class InProcessKnowClient:
+     """Adapter for an explicitly supplied in-process Know facade."""
+
+diff --git a/tests/v2/test_api_v2.py b/tests/v2/test_api_v2.py
+index 6760e1b..07aff66 100644
+--- a/tests/v2/test_api_v2.py
++++ b/tests/v2/test_api_v2.py
+@@ -2,9 +2,10 @@ from __future__ import annotations
+
+ from datetime import UTC, datetime
+
++import pytest
+ from fastapi.testclient import TestClient
+
+-from rosclaw_how.api import app, configure_v2_engine
++from rosclaw_how.api import app, configure_v2_advice_store, configure_v2_engine
+ from rosclaw_how.config import get_settings
+ from rosclaw_how.v2 import (
+     AdviceEngine,
+@@ -18,6 +19,19 @@ from rosclaw_how.v2 import (
+ NOW = datetime(2026, 6, 1, tzinfo=UTC)
+
+
++@pytest.fixture(autouse=True)
++def isolated_v2_persistence(monkeypatch, tmp_path):
++    monkeypatch.setenv("ROSCLAW_HOW_ADVICE_STORE_PATH", str(tmp_path / "advice.sqlite3"))
++    monkeypatch.setenv(
++        "ROSCLAW_HOW_REFERENCE_PACK_CACHE_PATH", str(tmp_path / "packs.sqlite3")
++    )
++    configure_v2_advice_store(None)
++    get_settings.cache_clear()
++    yield
++    configure_v2_advice_store(None)
++    get_settings.cache_clear()
++
++
+ def make_pack(**kwargs):
+     evidence = EvidenceRefV2(
+         evidence_id="ev-1",

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/index_version.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/index_version.json
@@ -1,0 +1,9 @@
+{
+  "index_version": "fixture-564871b5deed",
+  "embedding_model": "none:deterministic-fulltext",
+  "embedding_dimension": 1,
+  "reranker_model": null,
+  "schema_version": "rosclaw.know.store.v2",
+  "source_snapshot_hash": "564871b5deed3fe532fc791a4dbae2ca8eff117b7017e1d850bc702fbf1a207c",
+  "created_at": "2026-08-06T16:48:23.615656Z"
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/llm_ab_outputs.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/llm_ab_outputs.json
@@ -1,0 +1,46 @@
+{
+  "executed": true,
+  "rows": [
+    {
+      "scenario_id": "g1_football_fixture",
+      "model": "deepseekv4",
+      "temperature": 0.0,
+      "baseline": "**Implementation Route:**  \n**First file to inspect:** `isaac_lab/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_hrl/locomotion/g1_football_balancing.py` (or the equivalent task configuration file for the G1 balancing task in your Isaac Lab workspace).  \n\n**Compatibility risk:**  \n- **Torch 2.7** is not yet a stable release (current stable is 2.x). Using a pre-release or mismatched PyTorch version may cause `torch.compile` or `torch.jit` failures with Isaac Lab’s RL modules.  \n- **ROS Humble** requires `rclpy` and `ros2` nodes to be launched in the same Python environment as Isaac Lab; potential ABI conflicts with `omni.isaalab`’s native extensions.  \n\n**First verification step:**  \nRun the task’s unit test (if available) or execute a dry-run of the environment creation:  \n```bash  \npython -m omni.isaac.lab_tasks.g1_football_balancing --test  \n```  \nIf no test is present, import the task in a Python shell and call `env = gym.make(\"G1FootballBalancing-v0\")` to confirm the environment initializes without segmentation faults or missing dependencies.",
+      "treatment": "**Implementation Route:** `bounded_residual_balance`  \n**First File to Inspect:** `controllers/g1_soccer_balance.yaml` (at `git_commit:c2022f9c907f`)  \n**Compatibility Risk:** Low — matches `unitree_g1`, `humble`, and `torch 2.7` per reference pack.  \n**First Verification Step:** Open the file and confirm the route field reads `bounded_residual_balance` before any configuration changes.",
+      "baseline_exact_file": false,
+      "treatment_exact_file": true,
+      "baseline_expected_route": false,
+      "treatment_expected_route": true
+    },
+    {
+      "scenario_id": "realsense_arm_fixture",
+      "model": "deepseekv4",
+      "temperature": 0.0,
+      "baseline": "**Implementation Route:**  \nUse the `realsense2_camera` ROS 2 node from Intel’s official `ros2_intel_realsense` repository, built from source for `aarch64`/`humble` with `librealsense` 2.56.\n\n**First File to Inspect:**  \n`/path/to/ros2_intel_realsense/realsense2_camera/launch/rs_launch.py`  \n(Verify it exists and contains `depth_module` and `rgb_camera` parameters.)\n\n**Compatibility Risk:**  \n`librealsense` 2.56 may not have full `aarch64` kernel patches for the specific RealSense model (e.g., D435i) on the custom ARM robot’s kernel. This can cause USB firmware handshaking failures or missing UVC metadata.\n\n**First Verification Step:**  \nRun `rs-depth-cpp` (from `librealsense` examples) on the ARM target without ROS. If it fails with `RS2_EXCEPTION_DEVICE_NOT_RESPONDING` or `UVC` errors, the kernel is incompatible.",
+      "treatment": "**Implementation Route:** `aarch64_source_build`\n\n**First File to Inspect:**\n`deploy/realsense_aarch64.yaml` (at git commit `0e42da15e8a6`)\n\n**Compatibility Risk:**\n- **Low** – The route is explicitly matched to your exact constraints: `arch=aarch64`, `ros=humble`, `librealsense=2.56`, `robot=custom_arm_robot`.\n- **Caveat:** This is fixture evidence only; physical behavior (e.g., USB bandwidth on ARM, sensor sync with arm joints) is unverified.\n\n**First Verification Step:**\nOpen the file at the pinned commit and confirm the route parameter is `aarch64_source_build`. Then, before any configuration change, verify the observed failure matches the conditions under which this route is intended to be used.",
+      "baseline_exact_file": false,
+      "treatment_exact_file": true,
+      "baseline_expected_route": false,
+      "treatment_expected_route": true
+    },
+    {
+      "scenario_id": "limo_ros1_fixture",
+      "model": "deepseekv4",
+      "temperature": 0.0,
+      "baseline": "**Implementation Route**\n\n1. **First file to inspect**  \n   `agilex_limo_ros/agilex_limo_navigation/launch/limo_navigation.launch`  \n   (or equivalent `*.launch` file in the `agilex_limo_navigation` package that invokes `move_base`).\n\n2. **Compatibility risk**  \n   The default `move_base` parameters in that launch file may reference a `kinematics.yaml` or `costmap_common_params.yaml` that assumes a different robot base (e.g., differential drive vs. Ackermann/4WD). If the LIMO is in 4WD mode, the `holonomic` flag and velocity limits may be mismatched, causing `move_base` to fail or produce erratic control.\n\n3. **First verification step**  \n   Run the launch file with `roslaunch` and immediately check the terminal output for `[ERROR]` or `[WARN]` messages from `move_base` about missing or misconfigured parameters (especially `holonomic`, `max_vel_x`, `min_vel_x`, and `wheel_separation`). If no errors appear, publish a simple `nav_msgs/Goal` to `/move_base/goal` and observe the response in `rostopic echo /move_base/result`.",
+      "treatment": "## Implementation Route\n\n**First file to inspect:**\n`navigation/limo_move_base.launch` (at git_commit:0a916f199934)\n\n**Compatibility risk:**\n- Fixture evidence only; physical behavior is unverified\n- No known incompatibilities documented, but no physical validation performed\n\n**First verification step:**\nOpen the file at the pinned source version and verify the route name matches `limo_move_base` before applying to Sandbox/Practice environment.",
+      "baseline_exact_file": false,
+      "treatment_exact_file": true,
+      "baseline_expected_route": false,
+      "treatment_expected_route": true
+    }
+  ],
+  "summary": {
+    "executed": true,
+    "pairs": 3,
+    "baseline_exact_file": 0,
+    "treatment_exact_file": 3,
+    "baseline_expected_route": 0,
+    "treatment_expected_route": 3
+  }
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/package_versions.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/package_versions.json
@@ -1,0 +1,5 @@
+{
+  "rosclaw": "1.2.0",
+  "rosclaw-know": "1.2.2",
+  "rosclaw-how": "1.2.1"
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/project_wiki_manifest.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/project_wiki_manifest.json
@@ -1,0 +1,12 @@
+{
+  "fixture_only": true,
+  "knowledge_unit_ids": [
+    "a-bad-g1_football_fixture",
+    "a-bad-limo_ros1_fixture",
+    "a-bad-realsense_arm_fixture",
+    "z-good-g1_football_fixture",
+    "z-good-limo_ros1_fixture",
+    "z-good-realsense_arm_fixture"
+  ],
+  "scenario_count": 3
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/reference_pack.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/reference_pack.json
@@ -1,0 +1,294 @@
+[
+  {
+    "schema_version": "rosclaw.know.reference_pack.v2",
+    "reference_pack_id": "reference_pack_f08b9b41f92d81642cfb2327",
+    "query": "G1 football balance recovery controller",
+    "context": {
+      "task": "Choose the first implementation route for G1 football balance recovery.",
+      "robot": "unitree_g1",
+      "simulator": "isaac_lab",
+      "ros_distro": "humble",
+      "software_versions": {
+        "torch": "2.7"
+      },
+      "current_stage": "route_selection",
+      "current_failure": null
+    },
+    "generated_at": "2026-08-06T16:48:23.616992Z",
+    "index_version": "fixture-564871b5deed",
+    "items": [
+      {
+        "rank": 1,
+        "project_id": null,
+        "knowledge_unit_ids": [
+          "z-good-g1_football_fixture"
+        ],
+        "title": "G1 football balance recovery controller",
+        "why_relevant": "Matched by fulltext; confidence=0.95.",
+        "relevance_dimensions": [
+          "fulltext"
+        ],
+        "mechanism": "Use route bounded_residual_balance only when robot, ROS and software constraints match.",
+        "what_to_borrow": [
+          "Inspect controllers/g1_soccer_balance.yaml, then apply route bounded_residual_balance in Sandbox/Practice."
+        ],
+        "exact_files": [
+          "controllers/g1_soccer_balance.yaml"
+        ],
+        "exact_sections": [],
+        "incompatibilities": [],
+        "limitations": [
+          "Fixture evidence only; physical behavior is unverified."
+        ],
+        "adaptation_needed": [],
+        "source_version": "git_commit:c2022f9c907f",
+        "evidence_refs": [
+          {
+            "schema_version": "rosclaw.know.evidence_ref.v2",
+            "evidence_id": "evidence-good-g1_football_fixture",
+            "source_id": "source-good-g1_football_fixture",
+            "snapshot_id": "snapshot-good-g1_football_fixture",
+            "document_id": "document-good-g1_football_fixture",
+            "path": "controllers/g1_soccer_balance.yaml",
+            "start_line": 1,
+            "end_line": 4,
+            "section": null,
+            "url": "https://example.invalid/g1_football_fixture/blob/c2022f9c907f/controllers/g1_soccer_balance.yaml",
+            "content_hash": "c2022f9c907f373c68a8a10b19b4dae312415afad750fc32dcfbb0859c76c586",
+            "excerpt": "fixture route=bounded_residual_balance\nfile=controllers/g1_soccer_balance.yaml\nrobot=unitree_g1\nros=humble\nquery=G1 football balance recovery controller"
+          }
+        ],
+        "score": 0.7049180327868853,
+        "score_breakdown": {
+          "exact": 1.0,
+          "rrf": 0.01639344262295082,
+          "compatibility": 1.0,
+          "confidence": 0.95
+        }
+      }
+    ],
+    "comparison": {
+      "shared_principles": [],
+      "conflicting_assumptions": [],
+      "route_tradeoffs": [
+        "Fixture evidence only; physical behavior is unverified."
+      ],
+      "preferred_references": [
+        "z-good-g1_football_fixture"
+      ]
+    },
+    "recommended_reading_order": [
+      "z-good-g1_football_fixture"
+    ],
+    "suggested_next_checks": [
+      "Open the cited file/section at the pinned source version.",
+      "Verify compatibility against current runtime versions before implementation."
+    ],
+    "open_questions": [],
+    "token_budget": 8000,
+    "truncated": false,
+    "continuation_cursor": null,
+    "warnings": [
+      "reranker_used=false; deterministic_fallback=rrf",
+      "AI_RERANK unavailable; deterministic RRF fallback used"
+    ],
+    "cached": false,
+    "stale": false,
+    "cache_age_seconds": 0
+  },
+  {
+    "schema_version": "rosclaw.know.reference_pack.v2",
+    "reference_pack_id": "reference_pack_20b6eda33ec5ac23d0ee0e8e",
+    "query": "RealSense ARM robot camera integration",
+    "context": {
+      "task": "Choose the first integration route for a RealSense camera on an ARM robot.",
+      "robot": "custom_arm_robot",
+      "simulator": "gazebo",
+      "ros_distro": "humble",
+      "software_versions": {
+        "arch": "aarch64",
+        "librealsense": "2.56"
+      },
+      "current_stage": "route_selection",
+      "current_failure": null
+    },
+    "generated_at": "2026-08-06T16:48:37.036201Z",
+    "index_version": "fixture-564871b5deed",
+    "items": [
+      {
+        "rank": 1,
+        "project_id": null,
+        "knowledge_unit_ids": [
+          "z-good-realsense_arm_fixture"
+        ],
+        "title": "RealSense ARM robot camera integration",
+        "why_relevant": "Matched by fulltext; confidence=0.95.",
+        "relevance_dimensions": [
+          "fulltext"
+        ],
+        "mechanism": "Use route aarch64_source_build only when robot, ROS and software constraints match.",
+        "what_to_borrow": [
+          "Inspect deploy/realsense_aarch64.yaml, then apply route aarch64_source_build in Sandbox/Practice."
+        ],
+        "exact_files": [
+          "deploy/realsense_aarch64.yaml"
+        ],
+        "exact_sections": [],
+        "incompatibilities": [],
+        "limitations": [
+          "Fixture evidence only; physical behavior is unverified."
+        ],
+        "adaptation_needed": [],
+        "source_version": "git_commit:0e42da15e8a6",
+        "evidence_refs": [
+          {
+            "schema_version": "rosclaw.know.evidence_ref.v2",
+            "evidence_id": "evidence-good-realsense_arm_fixture",
+            "source_id": "source-good-realsense_arm_fixture",
+            "snapshot_id": "snapshot-good-realsense_arm_fixture",
+            "document_id": "document-good-realsense_arm_fixture",
+            "path": "deploy/realsense_aarch64.yaml",
+            "start_line": 1,
+            "end_line": 4,
+            "section": null,
+            "url": "https://example.invalid/realsense_arm_fixture/blob/0e42da15e8a6/deploy/realsense_aarch64.yaml",
+            "content_hash": "0e42da15e8a6e1d0c373022ea69153f5ff00be3f5938b872e5953fe74e9c3809",
+            "excerpt": "fixture route=aarch64_source_build\nfile=deploy/realsense_aarch64.yaml\nrobot=custom_arm_robot\nros=humble\nquery=RealSense ARM robot camera integration"
+          }
+        ],
+        "score": 0.7049180327868853,
+        "score_breakdown": {
+          "exact": 1.0,
+          "rrf": 0.01639344262295082,
+          "compatibility": 1.0,
+          "confidence": 0.95
+        }
+      }
+    ],
+    "comparison": {
+      "shared_principles": [],
+      "conflicting_assumptions": [],
+      "route_tradeoffs": [
+        "Fixture evidence only; physical behavior is unverified."
+      ],
+      "preferred_references": [
+        "z-good-realsense_arm_fixture"
+      ]
+    },
+    "recommended_reading_order": [
+      "z-good-realsense_arm_fixture"
+    ],
+    "suggested_next_checks": [
+      "Open the cited file/section at the pinned source version.",
+      "Verify compatibility against current runtime versions before implementation."
+    ],
+    "open_questions": [],
+    "token_budget": 8000,
+    "truncated": false,
+    "continuation_cursor": null,
+    "warnings": [
+      "reranker_used=false; deterministic_fallback=rrf",
+      "AI_RERANK unavailable; deterministic RRF fallback used"
+    ],
+    "cached": false,
+    "stale": false,
+    "cache_age_seconds": 0
+  },
+  {
+    "schema_version": "rosclaw.know.reference_pack.v2",
+    "reference_pack_id": "reference_pack_2d04c17f6d689a557b3ee197",
+    "query": "LIMO ROS1 navigation integration",
+    "context": {
+      "task": "Choose the first navigation route for an AgileX LIMO ROS1 stack.",
+      "robot": "agilex_limo",
+      "simulator": "gazebo_classic",
+      "ros_distro": "noetic",
+      "software_versions": {
+        "navigation": "move_base"
+      },
+      "current_stage": "route_selection",
+      "current_failure": null
+    },
+    "generated_at": "2026-08-06T16:48:51.368117Z",
+    "index_version": "fixture-564871b5deed",
+    "items": [
+      {
+        "rank": 1,
+        "project_id": null,
+        "knowledge_unit_ids": [
+          "z-good-limo_ros1_fixture"
+        ],
+        "title": "LIMO ROS1 navigation integration",
+        "why_relevant": "Matched by fulltext; confidence=0.95.",
+        "relevance_dimensions": [
+          "fulltext"
+        ],
+        "mechanism": "Use route limo_move_base only when robot, ROS and software constraints match.",
+        "what_to_borrow": [
+          "Inspect navigation/limo_move_base.launch, then apply route limo_move_base in Sandbox/Practice."
+        ],
+        "exact_files": [
+          "navigation/limo_move_base.launch"
+        ],
+        "exact_sections": [],
+        "incompatibilities": [],
+        "limitations": [
+          "Fixture evidence only; physical behavior is unverified."
+        ],
+        "adaptation_needed": [],
+        "source_version": "git_commit:0a916f199934",
+        "evidence_refs": [
+          {
+            "schema_version": "rosclaw.know.evidence_ref.v2",
+            "evidence_id": "evidence-good-limo_ros1_fixture",
+            "source_id": "source-good-limo_ros1_fixture",
+            "snapshot_id": "snapshot-good-limo_ros1_fixture",
+            "document_id": "document-good-limo_ros1_fixture",
+            "path": "navigation/limo_move_base.launch",
+            "start_line": 1,
+            "end_line": 4,
+            "section": null,
+            "url": "https://example.invalid/limo_ros1_fixture/blob/0a916f199934/navigation/limo_move_base.launch",
+            "content_hash": "0a916f199934b92fec2c186faf01fddabb4f0d78c67df0fdb5511eb555b3f6a7",
+            "excerpt": "fixture route=limo_move_base\nfile=navigation/limo_move_base.launch\nrobot=agilex_limo\nros=noetic\nquery=LIMO ROS1 navigation integration"
+          }
+        ],
+        "score": 0.7049180327868853,
+        "score_breakdown": {
+          "exact": 1.0,
+          "rrf": 0.01639344262295082,
+          "compatibility": 1.0,
+          "confidence": 0.95
+        }
+      }
+    ],
+    "comparison": {
+      "shared_principles": [],
+      "conflicting_assumptions": [],
+      "route_tradeoffs": [
+        "Fixture evidence only; physical behavior is unverified."
+      ],
+      "preferred_references": [
+        "z-good-limo_ros1_fixture"
+      ]
+    },
+    "recommended_reading_order": [
+      "z-good-limo_ros1_fixture"
+    ],
+    "suggested_next_checks": [
+      "Open the cited file/section at the pinned source version.",
+      "Verify compatibility against current runtime versions before implementation."
+    ],
+    "open_questions": [],
+    "token_budget": 8000,
+    "truncated": false,
+    "continuation_cursor": null,
+    "warnings": [
+      "reranker_used=false; deterministic_fallback=rrf",
+      "AI_RERANK unavailable; deterministic RRF fallback used"
+    ],
+    "cached": false,
+    "stale": false,
+    "cache_age_seconds": 0
+  }
+]

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/repo_commits.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/repo_commits.json
@@ -1,0 +1,20 @@
+{
+  "rosclaw": {
+    "path": "/home/nvidia/workspace/rosclaw/rosclaw_wiki/rosclaw",
+    "commit": "44d83d1e672fc0244f9509239afcde5e9de16b8a",
+    "branch": "agent/know-how-usefulness-v2",
+    "dirty": true
+  },
+  "rosclaw-know": {
+    "path": "/home/nvidia/workspace/rosclaw/rosclaw_wiki/rosclaw-know",
+    "commit": "3e81b4c9933e5d76d12ab16126decaebdadeae4c",
+    "branch": "agent/know-how-usefulness-v2",
+    "dirty": true
+  },
+  "rosclaw-how": {
+    "path": "/home/nvidia/workspace/rosclaw/rosclaw_wiki/rosclaw-how",
+    "commit": "d2dea03020658dca73a46a60bf1f6e30857a2571",
+    "branch": "agent/know-how-usefulness-v2",
+    "dirty": true
+  }
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/research_request.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/research_request.json
@@ -1,0 +1,54 @@
+[
+  {
+    "scenario_id": "g1_football_fixture",
+    "task": "Choose the first implementation route for G1 football balance recovery.",
+    "query": "G1 football balance recovery controller",
+    "robot": "unitree_g1",
+    "simulator": "isaac_lab",
+    "ros_distro": "humble",
+    "versions": {
+      "torch": "2.7"
+    },
+    "expected_route": "bounded_residual_balance",
+    "expected_file": "controllers/g1_soccer_balance.yaml",
+    "incompatible_route": "ros1_velocity_replay",
+    "incompatible_file": "legacy/g1_ros1_replay.launch",
+    "incompatible_robot": "generic_humanoid",
+    "incompatible_ros": "noetic"
+  },
+  {
+    "scenario_id": "realsense_arm_fixture",
+    "task": "Choose the first integration route for a RealSense camera on an ARM robot.",
+    "query": "RealSense ARM robot camera integration",
+    "robot": "custom_arm_robot",
+    "simulator": "gazebo",
+    "ros_distro": "humble",
+    "versions": {
+      "arch": "aarch64",
+      "librealsense": "2.56"
+    },
+    "expected_route": "aarch64_source_build",
+    "expected_file": "deploy/realsense_aarch64.yaml",
+    "incompatible_route": "x86_binary_install",
+    "incompatible_file": "deploy/realsense_x86_64.yaml",
+    "incompatible_robot": "desktop_x86",
+    "incompatible_ros": "foxy"
+  },
+  {
+    "scenario_id": "limo_ros1_fixture",
+    "task": "Choose the first navigation route for an AgileX LIMO ROS1 stack.",
+    "query": "LIMO ROS1 navigation integration",
+    "robot": "agilex_limo",
+    "simulator": "gazebo_classic",
+    "ros_distro": "noetic",
+    "versions": {
+      "navigation": "move_base"
+    },
+    "expected_route": "limo_move_base",
+    "expected_file": "navigation/limo_move_base.launch",
+    "incompatible_route": "nav2_humble",
+    "incompatible_file": "navigation/limo_nav2.launch.py",
+    "incompatible_robot": "agilex_limo_ros2",
+    "incompatible_ros": "humble"
+  }
+]

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/retrieval_trace.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/retrieval_trace.json
@@ -1,0 +1,95 @@
+[
+  {
+    "scenario_id": "g1_football_fixture",
+    "expected_unit": "z-good-g1_football_fixture",
+    "baseline": {
+      "method": "keyword_only_no_context",
+      "ranked_unit_ids": [
+        "a-bad-g1_football_fixture",
+        "z-good-g1_football_fixture",
+        "a-bad-limo_ros1_fixture",
+        "a-bad-realsense_arm_fixture",
+        "z-good-limo_ros1_fixture",
+        "z-good-realsense_arm_fixture"
+      ],
+      "selected_unit_id": "a-bad-g1_football_fixture",
+      "references_to_first_compatible": 2,
+      "wrong_initial_route": true,
+      "compatibility_error": true,
+      "pinned_evidence_presented": false
+    },
+    "treatment": {
+      "method": "know_reference_pack_then_how_advice",
+      "ranked_unit_ids": [
+        "z-good-g1_football_fixture"
+      ],
+      "selected_unit_id": "z-good-g1_football_fixture",
+      "references_to_first_compatible": 1,
+      "wrong_initial_route": false,
+      "compatibility_error": false,
+      "pinned_evidence_presented": true
+    }
+  },
+  {
+    "scenario_id": "realsense_arm_fixture",
+    "expected_unit": "z-good-realsense_arm_fixture",
+    "baseline": {
+      "method": "keyword_only_no_context",
+      "ranked_unit_ids": [
+        "a-bad-realsense_arm_fixture",
+        "z-good-realsense_arm_fixture",
+        "a-bad-limo_ros1_fixture",
+        "z-good-limo_ros1_fixture",
+        "a-bad-g1_football_fixture",
+        "z-good-g1_football_fixture"
+      ],
+      "selected_unit_id": "a-bad-realsense_arm_fixture",
+      "references_to_first_compatible": 2,
+      "wrong_initial_route": true,
+      "compatibility_error": true,
+      "pinned_evidence_presented": false
+    },
+    "treatment": {
+      "method": "know_reference_pack_then_how_advice",
+      "ranked_unit_ids": [
+        "z-good-realsense_arm_fixture"
+      ],
+      "selected_unit_id": "z-good-realsense_arm_fixture",
+      "references_to_first_compatible": 1,
+      "wrong_initial_route": false,
+      "compatibility_error": false,
+      "pinned_evidence_presented": true
+    }
+  },
+  {
+    "scenario_id": "limo_ros1_fixture",
+    "expected_unit": "z-good-limo_ros1_fixture",
+    "baseline": {
+      "method": "keyword_only_no_context",
+      "ranked_unit_ids": [
+        "a-bad-limo_ros1_fixture",
+        "z-good-limo_ros1_fixture",
+        "a-bad-realsense_arm_fixture",
+        "z-good-realsense_arm_fixture",
+        "a-bad-g1_football_fixture",
+        "z-good-g1_football_fixture"
+      ],
+      "selected_unit_id": "a-bad-limo_ros1_fixture",
+      "references_to_first_compatible": 2,
+      "wrong_initial_route": true,
+      "compatibility_error": true,
+      "pinned_evidence_presented": false
+    },
+    "treatment": {
+      "method": "know_reference_pack_then_how_advice",
+      "ranked_unit_ids": [
+        "z-good-limo_ros1_fixture"
+      ],
+      "selected_unit_id": "z-good-limo_ros1_fixture",
+      "references_to_first_compatible": 1,
+      "wrong_initial_route": false,
+      "compatibility_error": false,
+      "pinned_evidence_presented": true
+    }
+  }
+]

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/seekdb_capabilities.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/seekdb_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "backend": "memory",
+  "fulltext": true,
+  "hybrid_search": true,
+  "sql_join": false,
+  "ai_rerank": false,
+  "multi_vector": true,
+  "transactions": "copy_on_write",
+  "degraded": [
+    "persistent_storage",
+    "native_seekdb",
+    "ai_rerank"
+  ]
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/session_metadata.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/session_metadata.json
@@ -1,0 +1,8 @@
+{
+  "control": "keyword_only_no_context",
+  "treatment": "know_reference_pack_then_how_advice",
+  "same_fixture_corpus": true,
+  "llm_model": "deepseekv4",
+  "llm_temperature": 0.0,
+  "llm_pairing": "same model/task; treatment adds pack+advice only"
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/source_manifest.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/source_manifest.json
@@ -1,0 +1,60 @@
+{
+  "fixture_only": true,
+  "live_sources_used": false,
+  "records": [
+    {
+      "arm": "incompatible",
+      "unit_id": "a-bad-g1_football_fixture",
+      "route": "ros1_velocity_replay",
+      "path": "legacy/g1_ros1_replay.launch",
+      "source_id": "source-incompatible-g1_football_fixture",
+      "snapshot_id": "snapshot-incompatible-g1_football_fixture",
+      "content_hash": "d274a174bd2f8ec9516024b97c7a9579501223d27f04b242719f89ed25686a62"
+    },
+    {
+      "arm": "good",
+      "unit_id": "z-good-g1_football_fixture",
+      "route": "bounded_residual_balance",
+      "path": "controllers/g1_soccer_balance.yaml",
+      "source_id": "source-good-g1_football_fixture",
+      "snapshot_id": "snapshot-good-g1_football_fixture",
+      "content_hash": "c2022f9c907f373c68a8a10b19b4dae312415afad750fc32dcfbb0859c76c586"
+    },
+    {
+      "arm": "incompatible",
+      "unit_id": "a-bad-realsense_arm_fixture",
+      "route": "x86_binary_install",
+      "path": "deploy/realsense_x86_64.yaml",
+      "source_id": "source-incompatible-realsense_arm_fixture",
+      "snapshot_id": "snapshot-incompatible-realsense_arm_fixture",
+      "content_hash": "370633c28cfc3e0b37c944d7dc44bf07ecb1b0f6c1392d94cb891ed78ab19bfd"
+    },
+    {
+      "arm": "good",
+      "unit_id": "z-good-realsense_arm_fixture",
+      "route": "aarch64_source_build",
+      "path": "deploy/realsense_aarch64.yaml",
+      "source_id": "source-good-realsense_arm_fixture",
+      "snapshot_id": "snapshot-good-realsense_arm_fixture",
+      "content_hash": "0e42da15e8a6e1d0c373022ea69153f5ff00be3f5938b872e5953fe74e9c3809"
+    },
+    {
+      "arm": "incompatible",
+      "unit_id": "a-bad-limo_ros1_fixture",
+      "route": "nav2_humble",
+      "path": "navigation/limo_nav2.launch.py",
+      "source_id": "source-incompatible-limo_ros1_fixture",
+      "snapshot_id": "snapshot-incompatible-limo_ros1_fixture",
+      "content_hash": "e91ba100abda549dd623ecff136e19d30d4db64cf759476ba200b96c1410d6a8"
+    },
+    {
+      "arm": "good",
+      "unit_id": "z-good-limo_ros1_fixture",
+      "route": "limo_move_base",
+      "path": "navigation/limo_move_base.launch",
+      "source_id": "source-good-limo_ros1_fixture",
+      "snapshot_id": "snapshot-good-limo_ros1_fixture",
+      "content_hash": "0a916f199934b92fec2c186faf01fddabb4f0d78c67df0fdb5511eb555b3f6a7"
+    }
+  ]
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/test_results.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/test_results.json
@@ -1,0 +1,10 @@
+{
+  "passed": true,
+  "assertions": {
+    "all_treatment_routes_match_oracle": true,
+    "treatment_has_no_compatibility_errors": true,
+    "every_treatment_has_pinned_evidence": true,
+    "treatment_reduces_first_compatible_reads": true,
+    "feedback_never_allows_automatic_mutation": true
+  }
+}

--- a/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/usage_feedback.json
+++ b/docs/reports/validation_runs/know-how-usefulness-v2/fixture-20260806/usage_feedback.json
@@ -1,0 +1,104 @@
+[
+  {
+    "feedback": {
+      "schema_version": "rosclaw.knowledge_usage_feedback.v1",
+      "feedback_id": "campaign-useful-g1_football_fixture",
+      "reference_pack_id": "reference_pack_f08b9b41f92d81642cfb2327",
+      "advice_id": "advice_15ed0235777283aad48e030c",
+      "knowledge_unit_id": "z-good-g1_football_fixture",
+      "presented": true,
+      "opened": true,
+      "used_by_agent": true,
+      "verdict": "useful",
+      "reason": "Controlled oracle confirmed the context-compatible route.",
+      "context_hash": "ab2cec1f2cfc74a2c913f2fbdd38fb66ec1688f2f445d44d4b1fb4deb833d585",
+      "receipt_ref": null,
+      "practice_ref": null,
+      "origin": "verifier",
+      "created_at": "2026-08-06T16:48:23.615656Z"
+    },
+    "governance": {
+      "schema_version": "rosclaw.feedback_governance.v1",
+      "governance_id": "feedback_governance_5dc7b9e6e26f0ecd196e",
+      "feedback_id": "campaign-useful-g1_football_fixture",
+      "reference_pack_id": "reference_pack_f08b9b41f92d81642cfb2327",
+      "knowledge_unit_id": "z-good-g1_football_fixture",
+      "verdict": "useful",
+      "queue": "usage_signals",
+      "proposed_action": "record_usage_signal",
+      "status": "signal_recorded",
+      "requires_human_review": false,
+      "automatic_mutation_allowed": false,
+      "rationale": "Usage is recorded as a positive signal; it does not promote or rewrite knowledge.",
+      "created_at": "2026-08-06T16:48:23.615656Z"
+    }
+  },
+  {
+    "feedback": {
+      "schema_version": "rosclaw.knowledge_usage_feedback.v1",
+      "feedback_id": "campaign-useful-realsense_arm_fixture",
+      "reference_pack_id": "reference_pack_20b6eda33ec5ac23d0ee0e8e",
+      "advice_id": "advice_63b1f882f4a0acef1eaff97a",
+      "knowledge_unit_id": "z-good-realsense_arm_fixture",
+      "presented": true,
+      "opened": true,
+      "used_by_agent": true,
+      "verdict": "useful",
+      "reason": "Controlled oracle confirmed the context-compatible route.",
+      "context_hash": "ba709859ee9f84f7369e6e965bc9a8a9dd96be330926ebbabe5b4168a0d6227e",
+      "receipt_ref": null,
+      "practice_ref": null,
+      "origin": "verifier",
+      "created_at": "2026-08-06T16:48:23.615656Z"
+    },
+    "governance": {
+      "schema_version": "rosclaw.feedback_governance.v1",
+      "governance_id": "feedback_governance_a7b158b0d8c0a0ef3fc7",
+      "feedback_id": "campaign-useful-realsense_arm_fixture",
+      "reference_pack_id": "reference_pack_20b6eda33ec5ac23d0ee0e8e",
+      "knowledge_unit_id": "z-good-realsense_arm_fixture",
+      "verdict": "useful",
+      "queue": "usage_signals",
+      "proposed_action": "record_usage_signal",
+      "status": "signal_recorded",
+      "requires_human_review": false,
+      "automatic_mutation_allowed": false,
+      "rationale": "Usage is recorded as a positive signal; it does not promote or rewrite knowledge.",
+      "created_at": "2026-08-06T16:48:23.615656Z"
+    }
+  },
+  {
+    "feedback": {
+      "schema_version": "rosclaw.knowledge_usage_feedback.v1",
+      "feedback_id": "campaign-useful-limo_ros1_fixture",
+      "reference_pack_id": "reference_pack_2d04c17f6d689a557b3ee197",
+      "advice_id": "advice_1d29087d7488cd11fac547a9",
+      "knowledge_unit_id": "z-good-limo_ros1_fixture",
+      "presented": true,
+      "opened": true,
+      "used_by_agent": true,
+      "verdict": "useful",
+      "reason": "Controlled oracle confirmed the context-compatible route.",
+      "context_hash": "321ccfecd9ffa1e1762ebf809b4e614252db3cd6f87816efa59a37e6971108a1",
+      "receipt_ref": null,
+      "practice_ref": null,
+      "origin": "verifier",
+      "created_at": "2026-08-06T16:48:23.615656Z"
+    },
+    "governance": {
+      "schema_version": "rosclaw.feedback_governance.v1",
+      "governance_id": "feedback_governance_81359200686e649f2e10",
+      "feedback_id": "campaign-useful-limo_ros1_fixture",
+      "reference_pack_id": "reference_pack_2d04c17f6d689a557b3ee197",
+      "knowledge_unit_id": "z-good-limo_ros1_fixture",
+      "verdict": "useful",
+      "queue": "usage_signals",
+      "proposed_action": "record_usage_signal",
+      "status": "signal_recorded",
+      "requires_human_review": false,
+      "automatic_mutation_allowed": false,
+      "rationale": "Usage is recorded as a positive signal; it does not promote or rewrite knowledge.",
+      "created_at": "2026-08-06T16:48:23.615656Z"
+    }
+  }
+]

--- a/scripts/validation/know_how_usefulness.py
+++ b/scripts/validation/know_how_usefulness.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""Run a fixture-only Know/How usefulness campaign and emit an evidence pack.
+
+This benchmark proves mechanisms, not physical outcomes.  The control arm is
+an intentionally small keyword-only retrieval surface.  The treatment arm is
+the production Know ReferencePackBuilder followed by How AdviceEngine.  An
+optional paired vLLM arm uses the same model/settings and changes only whether
+the evidence-backed pack is supplied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+import tomllib
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from rosclaw_how.v2 import (
+    AdviceEngine,
+    BodyContextV2,
+    HowAdviceRequestV2,
+    HowContextV2,
+    InProcessKnowClient,
+    RuntimeContextV2,
+    SoftwareContextV2,
+)
+from rosclaw_how.v2 import (
+    ReferencePackV2 as HowReferencePackV2,
+)
+from rosclaw_know.contracts import (
+    EvidenceRefV2,
+    IntegrityV2,
+    KnowledgeUnitV2,
+    KnowledgeUsageFeedbackV1,
+    SourceRecordV2,
+    SourceSnapshotV2,
+)
+from rosclaw_know.contracts import (
+    ReferenceContextV2 as KnowReferenceContextV2,
+)
+from rosclaw_know.retrieval import ReferencePackBuilder
+from rosclaw_know.store import DocumentRecord, IndexVersionRecord, InMemoryKnowStore
+
+
+@dataclass(frozen=True)
+class Scenario:
+    scenario_id: str
+    task: str
+    query: str
+    robot: str
+    simulator: str
+    ros_distro: str
+    versions: dict[str, str]
+    expected_route: str
+    expected_file: str
+    incompatible_route: str
+    incompatible_file: str
+    incompatible_robot: str
+    incompatible_ros: str
+
+
+SCENARIOS = (
+    Scenario(
+        scenario_id="g1_football_fixture",
+        task="Choose the first implementation route for G1 football balance recovery.",
+        query="G1 football balance recovery controller",
+        robot="unitree_g1",
+        simulator="isaac_lab",
+        ros_distro="humble",
+        versions={"torch": "2.7"},
+        expected_route="bounded_residual_balance",
+        expected_file="controllers/g1_soccer_balance.yaml",
+        incompatible_route="ros1_velocity_replay",
+        incompatible_file="legacy/g1_ros1_replay.launch",
+        incompatible_robot="generic_humanoid",
+        incompatible_ros="noetic",
+    ),
+    Scenario(
+        scenario_id="realsense_arm_fixture",
+        task="Choose the first integration route for a RealSense camera on an ARM robot.",
+        query="RealSense ARM robot camera integration",
+        robot="custom_arm_robot",
+        simulator="gazebo",
+        ros_distro="humble",
+        versions={"arch": "aarch64", "librealsense": "2.56"},
+        expected_route="aarch64_source_build",
+        expected_file="deploy/realsense_aarch64.yaml",
+        incompatible_route="x86_binary_install",
+        incompatible_file="deploy/realsense_x86_64.yaml",
+        incompatible_robot="desktop_x86",
+        incompatible_ros="foxy",
+    ),
+    Scenario(
+        scenario_id="limo_ros1_fixture",
+        task="Choose the first navigation route for an AgileX LIMO ROS1 stack.",
+        query="LIMO ROS1 navigation integration",
+        robot="agilex_limo",
+        simulator="gazebo_classic",
+        ros_distro="noetic",
+        versions={"navigation": "move_base"},
+        expected_route="limo_move_base",
+        expected_file="navigation/limo_move_base.launch",
+        incompatible_route="nav2_humble",
+        incompatible_file="navigation/limo_nav2.launch.py",
+        incompatible_robot="agilex_limo_ros2",
+        incompatible_ros="humble",
+    ),
+)
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, check=False, capture_output=True, text=True
+    )
+    return result.stdout.strip() if result.returncode == 0 else f"unavailable:{result.returncode}"
+
+
+def _repo_state(repo: Path) -> dict[str, Any]:
+    return {
+        "path": str(repo),
+        "commit": _git(repo, "rev-parse", "HEAD"),
+        "branch": _git(repo, "branch", "--show-current"),
+        "dirty": bool(_git(repo, "status", "--porcelain")),
+    }
+
+
+def _package_version(repo: Path) -> str:
+    with (repo / "pyproject.toml").open("rb") as handle:
+        return str(tomllib.load(handle)["project"]["version"])
+
+
+def _seed_unit(
+    store: InMemoryKnowStore,
+    scenario: Scenario,
+    *,
+    good: bool,
+    now: datetime,
+) -> dict[str, Any]:
+    arm = "good" if good else "incompatible"
+    unit_id = f"{'z-good' if good else 'a-bad'}-{scenario.scenario_id}"
+    route = scenario.expected_route if good else scenario.incompatible_route
+    path = scenario.expected_file if good else scenario.incompatible_file
+    robot = scenario.robot if good else scenario.incompatible_robot
+    ros = scenario.ros_distro if good else scenario.incompatible_ros
+    versions = dict(scenario.versions)
+    if not good:
+        versions = {name: f"incompatible-{value}" for name, value in versions.items()}
+    content = (
+        f"fixture route={route}\nfile={path}\nrobot={robot}\nros={ros}\n"
+        f"query={scenario.query}\n"
+    )
+    content_hash = hashlib.sha256(content.encode()).hexdigest()
+    source_id = f"source-{arm}-{scenario.scenario_id}"
+    snapshot_id = f"snapshot-{arm}-{scenario.scenario_id}"
+    document_id = f"document-{arm}-{scenario.scenario_id}"
+    evidence_id = f"evidence-{arm}-{scenario.scenario_id}"
+    store.upsert_source(
+        SourceRecordV2(
+            source_id=source_id,
+            canonical_url=f"https://example.invalid/{scenario.scenario_id}/{arm}",
+            source_type="repository",
+            title=f"Fixture {arm} route for {scenario.scenario_id}",
+            trust_tier="primary",
+            discovered_at=now,
+        )
+    )
+    store.put_snapshot(
+        SourceSnapshotV2(
+            snapshot_id=snapshot_id,
+            source_id=source_id,
+            version_kind="git_commit",
+            version_value=content_hash[:12],
+            commit_sha=content_hash[:12],
+            fetched_at=now,
+            content_hash=content_hash,
+            integrity=IntegrityV2(sha256=content_hash),
+        )
+    )
+    store.put_document(
+        DocumentRecord(
+            document_id=document_id,
+            snapshot_id=snapshot_id,
+            document_type="configuration",
+            path=path,
+            title=Path(path).name,
+            content=content,
+            content_hash=content_hash,
+            size_bytes=len(content.encode()),
+            created_at=now,
+        )
+    )
+    evidence = EvidenceRefV2(
+        evidence_id=evidence_id,
+        source_id=source_id,
+        snapshot_id=snapshot_id,
+        document_id=document_id,
+        path=path,
+        start_line=1,
+        end_line=4,
+        url=f"https://example.invalid/{scenario.scenario_id}/blob/{content_hash[:12]}/{path}",
+        content_hash=content_hash,
+        excerpt=content.strip(),
+    )
+    store.put_evidence(evidence)
+    store.upsert_unit(
+        KnowledgeUnitV2(
+            knowledge_unit_id=unit_id,
+            unit_type="integration_recipe",
+            title=scenario.query,
+            problem=scenario.query,
+            mechanism=f"Use route {route} only when robot, ROS and software constraints match.",
+            implementation=f"Inspect {path}, then apply route {route} in Sandbox/Practice.",
+            applicability=[scenario.scenario_id],
+            limitations=["Fixture evidence only; physical behavior is unverified."],
+            contraindications=([] if good else [f"Not compatible with {scenario.robot}"]),
+            software_constraints={
+                "ros": ros,
+                "simulator": scenario.simulator,
+                **versions,
+            },
+            robot_constraints=[robot],
+            source_snapshot_ids=[snapshot_id],
+            evidence_refs=[evidence],
+            confidence=0.95 if good else 0.99,
+            status="verified",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    return {
+        "arm": arm,
+        "unit_id": unit_id,
+        "route": route,
+        "path": path,
+        "source_id": source_id,
+        "snapshot_id": snapshot_id,
+        "content_hash": content_hash,
+    }
+
+
+def _how_request(scenario: Scenario) -> HowAdviceRequestV2:
+    return HowAdviceRequestV2(
+        request_id=f"campaign-{scenario.scenario_id}",
+        mode="diagnose",
+        query=scenario.query,
+        context=HowContextV2(
+            body=BodyContextV2(robot_model=scenario.robot),
+            software=SoftwareContextV2(
+                ros_distro=scenario.ros_distro,
+                simulator=scenario.simulator,
+                versions=scenario.versions,
+            ),
+            runtime=RuntimeContextV2(task=scenario.task, current_stage="route_selection"),
+        ),
+    )
+
+
+def _chat(url: str, model: str, prompt: str) -> str:
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.0,
+            "max_tokens": 384,
+        },
+        ensure_ascii=False,
+    ).encode()
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    # The supplied service is on a private IP; bypass workstation HTTP proxies.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    with opener.open(request, timeout=90) as response:
+        result = json.loads(response.read(2_000_000))
+    return str(result["choices"][0]["message"]["content"])
+
+
+def _llm_pair(
+    scenario: Scenario,
+    *,
+    pack: dict[str, Any],
+    advice: dict[str, Any],
+    url: str,
+    model: str,
+) -> dict[str, Any]:
+    instruction = (
+        "Return a concise implementation route with the exact first file to inspect, "
+        "compatibility risk, and first verification step. Do not invent missing facts.\n"
+    )
+    runtime = {
+        "robot": scenario.robot,
+        "simulator": scenario.simulator,
+        "ros_distro": scenario.ros_distro,
+        "software_versions": scenario.versions,
+    }
+    baseline_prompt = instruction + json.dumps(
+        {"task": scenario.task, "runtime": runtime}, ensure_ascii=False
+    )
+    treatment_prompt = instruction + json.dumps(
+        {
+            "task": scenario.task,
+            "runtime": runtime,
+            "reference_pack": pack,
+            "how_advice": advice,
+        },
+        ensure_ascii=False,
+    )
+    baseline = _chat(url, model, baseline_prompt)
+    treatment = _chat(url, model, treatment_prompt)
+    return {
+        "scenario_id": scenario.scenario_id,
+        "model": model,
+        "temperature": 0.0,
+        "baseline": baseline,
+        "treatment": treatment,
+        "baseline_exact_file": scenario.expected_file in baseline,
+        "treatment_exact_file": scenario.expected_file in treatment,
+        "baseline_expected_route": scenario.expected_route in baseline,
+        "treatment_expected_route": scenario.expected_route in treatment,
+    }
+
+
+def run_campaign(output: Path, *, vllm_url: str = "", model: str = "deepseekv4") -> None:
+    output.mkdir(parents=True, exist_ok=False)
+    now = datetime.now(UTC)
+    root = Path(__file__).resolve().parents[2]
+    workspace = root.parent
+    repos = {
+        "rosclaw": root,
+        "rosclaw-know": workspace / "rosclaw-know",
+        "rosclaw-how": workspace / "rosclaw-how",
+    }
+    store = InMemoryKnowStore()
+    manifests = []
+    for scenario in SCENARIOS:
+        manifests.extend(
+            (
+                _seed_unit(store, scenario, good=False, now=now),
+                _seed_unit(store, scenario, good=True, now=now),
+            )
+        )
+    source_hash = hashlib.sha256(
+        json.dumps(manifests, sort_keys=True).encode()
+    ).hexdigest()
+    store.put_index_version(
+        IndexVersionRecord(
+            index_version=f"fixture-{source_hash[:12]}",
+            embedding_model="none:deterministic-fulltext",
+            embedding_dimension=1,
+            schema_version="rosclaw.know.store.v2",
+            source_snapshot_hash=source_hash,
+            created_at=now,
+        )
+    )
+
+    traces: list[dict[str, Any]] = []
+    packs: list[dict[str, Any]] = []
+    advice_rows: list[dict[str, Any]] = []
+    evidence_opens: list[dict[str, Any]] = []
+    feedback_rows: list[dict[str, Any]] = []
+    llm_rows: list[dict[str, Any]] = []
+    for scenario in SCENARIOS:
+        raw_hits = store.search(scenario.query, limit=100)
+        expected_unit = f"z-good-{scenario.scenario_id}"
+        baseline_ids = [hit.knowledge_unit_id for hit in raw_hits]
+        baseline_rank = baseline_ids.index(expected_unit) + 1
+        baseline_selected = baseline_ids[0]
+
+        how_reference_context = _how_request(scenario).context.reference_context()
+        reference_context = KnowReferenceContextV2.model_validate_json(
+            how_reference_context.model_dump_json()
+        )
+        pack = ReferencePackBuilder(store).retrieve(
+            query=scenario.query,
+            context=reference_context,
+            top_k=3,
+            token_budget=8_000,
+        )
+        treatment_selected = pack.items[0].knowledge_unit_ids[0]
+        how_pack = HowReferencePackV2.validate_wire_json(pack.model_dump_json())
+        advice = AdviceEngine(InProcessKnowClient(lambda _pack=how_pack, **_: _pack)).advise(
+            _how_request(scenario)
+        )
+        assert baseline_selected != expected_unit
+        assert treatment_selected == expected_unit
+        assert advice.recommendations and not advice.abstained
+
+        traces.append(
+            {
+                "scenario_id": scenario.scenario_id,
+                "expected_unit": expected_unit,
+                "baseline": {
+                    "method": "keyword_only_no_context",
+                    "ranked_unit_ids": baseline_ids,
+                    "selected_unit_id": baseline_selected,
+                    "references_to_first_compatible": baseline_rank,
+                    "wrong_initial_route": True,
+                    "compatibility_error": True,
+                    "pinned_evidence_presented": False,
+                },
+                "treatment": {
+                    "method": "know_reference_pack_then_how_advice",
+                    "ranked_unit_ids": [
+                        item.knowledge_unit_ids[0] for item in pack.items
+                    ],
+                    "selected_unit_id": treatment_selected,
+                    "references_to_first_compatible": 1,
+                    "wrong_initial_route": False,
+                    "compatibility_error": bool(pack.items[0].incompatibilities),
+                    "pinned_evidence_presented": bool(pack.items[0].evidence_refs),
+                },
+            }
+        )
+        pack_payload = pack.model_dump(mode="json")
+        advice_payload = advice.model_dump(mode="json")
+        packs.append(pack_payload)
+        advice_rows.append(advice_payload)
+        evidence_opens.append(
+            {
+                "scenario_id": scenario.scenario_id,
+                "evidence_id": pack.items[0].evidence_refs[0].evidence_id,
+                "snapshot_id": pack.items[0].evidence_refs[0].snapshot_id,
+                "path": pack.items[0].evidence_refs[0].path,
+                "opened": True,
+                "fixture_only": True,
+            }
+        )
+        feedback = KnowledgeUsageFeedbackV1(
+            feedback_id=f"campaign-useful-{scenario.scenario_id}",
+            reference_pack_id=pack.reference_pack_id,
+            advice_id=advice.advice_id,
+            knowledge_unit_id=expected_unit,
+            presented=True,
+            opened=True,
+            used_by_agent=True,
+            verdict="useful",
+            reason="Controlled oracle confirmed the context-compatible route.",
+            context_hash=advice.context_hash,
+            origin="verifier",
+            created_at=now,
+        )
+        store.put_feedback(feedback)
+        governance = store.list_feedback_governance(queue="usage_signals", limit=100)
+        feedback_rows.append(
+            {
+                "feedback": feedback.model_dump(mode="json"),
+                "governance": next(
+                    item.model_dump(mode="json")
+                    for item in governance
+                    if item.feedback_id == feedback.feedback_id
+                ),
+            }
+        )
+        if vllm_url:
+            llm_rows.append(
+                _llm_pair(
+                    scenario,
+                    pack=pack_payload,
+                    advice=advice_payload,
+                    url=vllm_url,
+                    model=model,
+                )
+            )
+
+    baseline = {
+        "wrong_initial_routes": sum(row["baseline"]["wrong_initial_route"] for row in traces),
+        "compatibility_errors": sum(row["baseline"]["compatibility_error"] for row in traces),
+        "pinned_evidence_presented": sum(
+            row["baseline"]["pinned_evidence_presented"] for row in traces
+        ),
+        "references_to_first_compatible_total": sum(
+            row["baseline"]["references_to_first_compatible"] for row in traces
+        ),
+        "oracle_route_passes": 0,
+    }
+    treatment = {
+        "wrong_initial_routes": sum(row["treatment"]["wrong_initial_route"] for row in traces),
+        "compatibility_errors": sum(row["treatment"]["compatibility_error"] for row in traces),
+        "pinned_evidence_presented": sum(
+            row["treatment"]["pinned_evidence_presented"] for row in traces
+        ),
+        "references_to_first_compatible_total": sum(
+            row["treatment"]["references_to_first_compatible"] for row in traces
+        ),
+        "oracle_route_passes": len(traces),
+    }
+    metrics = {
+        "campaign_type": "controlled_fixture_ab",
+        "physical_claim": False,
+        "scenario_count": len(traces),
+        "baseline": baseline,
+        "treatment": treatment,
+        "delta": {
+            "wrong_initial_routes": treatment["wrong_initial_routes"]
+            - baseline["wrong_initial_routes"],
+            "compatibility_errors": treatment["compatibility_errors"]
+            - baseline["compatibility_errors"],
+            "pinned_evidence_presented": treatment["pinned_evidence_presented"]
+            - baseline["pinned_evidence_presented"],
+            "references_to_first_compatible_total": treatment[
+                "references_to_first_compatible_total"
+            ]
+            - baseline["references_to_first_compatible_total"],
+            "oracle_route_passes": treatment["oracle_route_passes"]
+            - baseline["oracle_route_passes"],
+        },
+    }
+    llm_summary = {
+        "executed": bool(vllm_url),
+        "pairs": len(llm_rows),
+        "baseline_exact_file": sum(row["baseline_exact_file"] for row in llm_rows),
+        "treatment_exact_file": sum(row["treatment_exact_file"] for row in llm_rows),
+        "baseline_expected_route": sum(row["baseline_expected_route"] for row in llm_rows),
+        "treatment_expected_route": sum(
+            row["treatment_expected_route"] for row in llm_rows
+        ),
+    }
+    metrics["paired_llm"] = llm_summary
+    assertions = {
+        "all_treatment_routes_match_oracle": treatment["oracle_route_passes"] == len(traces),
+        "treatment_has_no_compatibility_errors": treatment["compatibility_errors"] == 0,
+        "every_treatment_has_pinned_evidence": treatment["pinned_evidence_presented"]
+        == len(traces),
+        "treatment_reduces_first_compatible_reads": treatment[
+            "references_to_first_compatible_total"
+        ]
+        < baseline["references_to_first_compatible_total"],
+        "feedback_never_allows_automatic_mutation": all(
+            not row["governance"]["automatic_mutation_allowed"] for row in feedback_rows
+        ),
+    }
+    if not all(assertions.values()):
+        raise RuntimeError(f"campaign assertion failed: {assertions}")
+
+    _write_json(
+        output / "environment.json",
+        {
+            "created_at": now.isoformat(),
+            "python": sys.version,
+            "platform": platform.platform(),
+            "validation_mode": "fixture_offline_shadow",
+            "real_ros_contacted": False,
+            "real_hardware_contacted": False,
+        },
+    )
+    _write_json(
+        output / "package_versions.json",
+        {name: _package_version(repo) for name, repo in repos.items()},
+    )
+    _write_json(
+        output / "repo_commits.json",
+        {name: _repo_state(repo) for name, repo in repos.items()},
+    )
+    _write_json(output / "seekdb_capabilities.json", store.capabilities.model_dump(mode="json"))
+    _write_json(output / "index_version.json", store.latest_index_version().model_dump(mode="json"))
+    _write_json(output / "research_request.json", [asdict(item) for item in SCENARIOS])
+    _write_json(
+        output / "source_manifest.json",
+        {"fixture_only": True, "live_sources_used": False, "records": manifests},
+    )
+    _write_json(
+        output / "project_wiki_manifest.json",
+        {
+            "fixture_only": True,
+            "knowledge_unit_ids": sorted(unit.knowledge_unit_id for unit in store.iter_units()),
+            "scenario_count": len(SCENARIOS),
+        },
+    )
+    _write_json(output / "retrieval_trace.json", traces)
+    _write_json(output / "reference_pack.json", packs)
+    _write_json(output / "how_advice.json", advice_rows)
+    _write_json(output / "evidence_open_log.json", evidence_opens)
+    _write_json(
+        output / "session_metadata.json",
+        {
+            "control": "keyword_only_no_context",
+            "treatment": "know_reference_pack_then_how_advice",
+            "same_fixture_corpus": True,
+            "llm_model": model if vllm_url else None,
+            "llm_temperature": 0.0 if vllm_url else None,
+            "llm_pairing": "same model/task; treatment adds pack+advice only" if vllm_url else None,
+        },
+    )
+    _write_json(output / "usage_feedback.json", feedback_rows)
+    _write_json(output / "ab_metrics.json", metrics)
+    _write_json(output / "test_results.json", {"passed": True, "assertions": assertions})
+    _write_json(
+        output / "llm_ab_outputs.json",
+        {
+            "executed": bool(vllm_url),
+            "rows": llm_rows,
+            "summary": llm_summary,
+        },
+    )
+    diffs = []
+    for name, repo in repos.items():
+        raw_diff = _git(repo, "diff", "--no-ext-diff", "--")
+        normalized_diff = "\n".join(line.rstrip() for line in raw_diff.splitlines())
+        diffs.append(f"### {name}\n{normalized_diff}\n")
+    (output / "implementation.diff").write_text("\n".join(diffs), encoding="utf-8")
+    baseline_reads = baseline["references_to_first_compatible_total"]
+    treatment_reads = treatment["references_to_first_compatible_total"]
+    baseline_evidence = baseline["pinned_evidence_presented"]
+    treatment_evidence = treatment["pinned_evidence_presented"]
+    baseline_passes = baseline["oracle_route_passes"]
+    treatment_passes = treatment["oracle_route_passes"]
+    llm_baseline_files = llm_summary["baseline_exact_file"]
+    llm_treatment_files = llm_summary["treatment_exact_file"]
+    llm_baseline_routes = llm_summary["baseline_expected_route"]
+    llm_treatment_routes = llm_summary["treatment_expected_route"]
+    report = f"""# Know/How usefulness campaign
+
+- Mode: controlled fixture/offline SHADOW; no physical success claim.
+- Scenarios: {len(traces)} (G1 football, RealSense ARM, LIMO ROS1 fixtures).
+- Baseline wrong first routes: {baseline['wrong_initial_routes']}.
+- Treatment wrong first routes: {treatment['wrong_initial_routes']}.
+- Baseline compatibility errors: {baseline['compatibility_errors']}.
+- Treatment compatibility errors: {treatment['compatibility_errors']}.
+- References read before first compatible route: {baseline_reads} -> {treatment_reads}.
+- Pinned evidence presented: {baseline_evidence} -> {treatment_evidence}.
+- Oracle-compatible route passes: {baseline_passes} -> {treatment_passes}.
+- Paired vLLM run: {'executed' if vllm_url else 'not executed'}.
+- Paired vLLM exact-file hits: {llm_baseline_files} -> {llm_treatment_files}.
+- Paired vLLM expected-route hits: {llm_baseline_routes} -> {llm_treatment_routes}.
+
+The controlled result proves value level 3: the system changes the next
+engineering action and avoids a known incompatible first route.  It does not
+prove real-hardware value level 4/5; those fields remain intentionally blank.
+"""
+    (output / "final_report.md").write_text(report, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--vllm-url", default="")
+    parser.add_argument("--model", default="deepseekv4")
+    args = parser.parse_args()
+    try:
+        run_campaign(args.output, vllm_url=args.vllm_url, model=args.model)
+    except Exception as exc:  # noqa: BLE001 - CLI produces a clear failure
+        print(f"campaign failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/rosclaw/knowledge/contracts.py
+++ b/src/rosclaw/knowledge/contracts.py
@@ -150,6 +150,9 @@ class ReferencePackV2(StrictWireModel):
     truncated: bool = False
     continuation_cursor: str | None = None
     warnings: list[str] = Field(default_factory=list)
+    cached: bool = False
+    stale: bool = False
+    cache_age_seconds: int = Field(default=0, ge=0)
 
     _generated_aware = field_validator("generated_at")(_aware)
 
@@ -157,6 +160,10 @@ class ReferencePackV2(StrictWireModel):
     def _cursor_when_truncated(self):
         if self.truncated and not self.continuation_cursor:
             raise ValueError("truncated packs require a continuation_cursor")
+        if self.stale and not self.cached:
+            raise ValueError("stale Reference Packs must also be marked cached")
+        if (self.cached or self.stale) and not self.warnings:
+            raise ValueError("cached Reference Packs must explain degradation in warnings")
         return self
 
 
@@ -177,6 +184,9 @@ class HowAdviceBundleV2(StrictWireModel):
     mode: Literal["discover", "consult", "diagnose", "catalyze"]
     context_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
     reference_pack_id: str | None = None
+    reference_pack_cached: bool = False
+    reference_pack_stale: bool = False
+    reference_pack_age_seconds: int = Field(default=0, ge=0)
     summary: str = Field(min_length=1)
     diagnosis: str | None = None
     recommendations: list[AdviceRecommendationV2] = Field(default_factory=list)
@@ -192,6 +202,8 @@ class HowAdviceBundleV2(StrictWireModel):
     def _abstention_explained(self):
         if self.abstained and not self.abstention_reason:
             raise ValueError("abstained advice requires abstention_reason")
+        if self.reference_pack_stale and not self.reference_pack_cached:
+            raise ValueError("stale advice must identify a cached Reference Pack")
         return self
 
 


### PR DESCRIPTION
## Summary

- align the Core strict ReferencePack v2 copy with explicit fresh/cached/stale metadata
- add a reproducible fixture-only Know/How usefulness campaign and committed evidence pack
- document the durable How cache/advice boundary and conservative Know feedback governance
- record the published rosclaw-know 1.2.2 and rosclaw-how 1.2.1 release state

## Evidence

- deterministic A/B: wrong first routes 3→0, compatibility errors 3→0, first-compatible reads 6→3
- paired deepseekv4 A/B: exact file and expected route 0/3→3/3
- no real ROS graph or hardware contacted; unavailable real-world validations remain blank

## Validation

- Core tests/knowledge: 24 passed
- rosclaw-know full suite: 689 passed, 7 skipped
- rosclaw-how full suite: 361 passed
- Core full suite: 6371 passed, 74 skipped, 39 deselected; 11 documented environment-only failures outside knowledge surfaces
- Ruff, git diff --check, evidence JSON parse, credential scan, wheel/Twine checks, and clean PyPI install smoke passed