### PR TITLE
Record final Know/How release state

### DIFF
--- a/docs/architecture/KNOW_HOW_V2_INTEGRATION.md
+++ b/docs/architecture/KNOW_HOW_V2_INTEGRATION.md
@@ -1,7 +1,8 @@
 # Know / How v2 core integration
 
 Status: baseline merged; 2026-08-06 usefulness hardening implemented, with
-rosclaw-know 1.2.2 and rosclaw-how 1.2.1 published.
+Core pull request #252 merged, and rosclaw-know 1.2.2 plus rosclaw-how 1.2.1
+published.
 
 ## Ownership boundary
 

--- a/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
+++ b/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
@@ -34,17 +34,17 @@ The v1 foundation was merged and released before this hardening pass:
 | `rosclaw-how` | `d2dea03` | 1.2.0 published |
 | `rosclaw` | `44d83d1e` | merged; no Core PyPI release requested |
 
-The usefulness hardening packages are merged and published from their merged
-default branches:
+The usefulness hardening is merged across all three repositories. Packages
+were published only for Know and How, as requested:
 
 | Repository | Pull request | Merge commit | Final state |
 | --- | --- | --- | --- |
 | `rosclaw-know` | `ros-claw/rosclaw-know#5` | `ac4c2dd` | 1.2.2 tagged and published |
 | `rosclaw-how` | `ros-claw/rosclaw-how#3` | `d52ecfd` | 1.2.1 tagged and published |
+| `rosclaw` | `ros-claw/rosclaw#252` | `b8cec725` | merged; no Core PyPI release |
 
-The Core evidence and contract-copy update is proposed in
-`ros-claw/rosclaw#252` from branch `agent/know-how-usefulness-v2`; no Core
-PyPI release is requested or produced.
+Core pull-request CI completed all 18 checks successfully. Its conditional
+`Release to PyPI` job was skipped; no Core package was produced or published.
 
 ## Architecture and contracts
 

--- a/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
+++ b/docs/reports/KNOW_HOW_V2_IMPLEMENTATION_REPORT.md
@@ -39,9 +39,9 @@ were published only for Know and How, as requested:
 
 | Repository | Pull request | Merge commit | Final state |
 | --- | --- | --- | --- |
-| `rosclaw-know` | `ros-claw/rosclaw-know#5` | `ac4c2dd` | 1.2.2 tagged and published |
-| `rosclaw-how` | `ros-claw/rosclaw-how#3` | `d52ecfd` | 1.2.1 tagged and published |
-| `rosclaw` | `ros-claw/rosclaw#252` | `b8cec725` | merged; no Core PyPI release |
+| `rosclaw-know` | [#5](https://github.com/ros-claw/rosclaw-know/pull/5) | `ac4c2dd` | [1.2.2 tagged and published](https://pypi.org/project/rosclaw-know/1.2.2/) |
+| `rosclaw-how` | [#3](https://github.com/ros-claw/rosclaw-how/pull/3) | `d52ecfd` | [1.2.1 tagged and published](https://pypi.org/project/rosclaw-how/1.2.1/) |
+| `rosclaw` | [#252](https://github.com/ros-claw/rosclaw/pull/252) | `b8cec725` | merged; no Core PyPI release |
 
 Core pull-request CI completed all 18 checks successfully. Its conditional
 `Release to PyPI` job was skipped; no Core package was produced or published.


### PR DESCRIPTION
## Summary

- mark Core usefulness PR #252 as merged at b8cec725
- record that all 18 Core PR checks passed
- make the package boundary explicit: only rosclaw-know 1.2.2 and rosclaw-how 1.2.1 were published
- record that the conditional Core PyPI release job was skipped

Documentation-only follow-up; no runtime code or package version changes.