### PR TITLE
feat(na-fix-9): Native Agent 成为 rosclaw chat 默认引擎

### DIFF
--- a/docs/PI_ENGINE_MIGRATION.md
+++ b/docs/PI_ENGINE_MIGRATION.md
@@ -1,34 +1,30 @@
-# Pi Engine 迁移与切换指南（PNA-11）
+# Native Agent 迁移说明（原 Pi Engine 迁移指南，NA-FIX-9 后）
 
-日期：2026-08-05
+日期：2026-08-06（取代 2026-08-05 Developer Preview 版）
 
-## 当前阶段：Developer Preview（阶段 2）
+## 当前阶段：Native Agent 为默认（阶段 3/4 已完成）
 
-`engine=pi` 已可用但**不是默认**。默认保持 `legacy`——完整 Product Gate
-（PTY/IME 矩阵、产品旅程全自动 PTY、性能门槛实测）尚未全部通过，
-REAL 门禁不变（关闭）。
+`rosclaw chat` 默认就是 Native Agent（Pi-backed harness）。公开界面
+不再暴露 "engine" 概念——`--engine` / `--legacy` 均不在 help 中显示。
+REAL 门禁不变（关闭；SHADOW/REAL 继续走独立安全 Gate）。
 
-## 切换方式
+## 使用
 
 ```bash
-# 单次
-rosclaw chat --engine pi
-
-# 配置（Developer Preview）
-# ~/.rosclaw/config.yaml
-agent:
-  engine: pi
+rosclaw chat            # Native Agent（默认）
+rosclaw chat --continue # 恢复最近一次会话
+rosclaw chat --resume <session-id>
 ```
 
-回退：
+临时回退（隐藏、保留一个稳定版本后随 legacy 一起退役）：
 
 ```bash
 rosclaw chat --legacy
 ```
 
-优先级：`--legacy` > `--engine` > `config.agent.engine` > `legacy`。
+优先级：`--legacy` > `--engine`（隐藏）> `config.agent.engine` > `pi`。
 
-## engine=pi 包含什么
+## Native Agent 包含什么
 
 - Pi InteractiveMode（成熟 TUI：流式、working 动画、/model /login
   /compact /resume /fork /tree 等内建命令）；
@@ -44,21 +40,24 @@ rosclaw chat --legacy
 ## 数据兼容（规格 §31 数据回滚）
 
 - Mission DB 不迁移为 Pi 格式；Pi Session 是附加认知存储；
-- 删除 pi engine 不影响 Mission/Receipt；legacy 仍能读取 Mission；
+- legacy 回退仍能读取 Mission/Receipt；
 - 新表（013–016）独立 migration，downgrade 不删 binding 数据。
 
-## legacy 冻结说明
+## legacy 冻结与退役路线
 
 旧 `rosclaw-tui`（packages/rosclaw-tui）自 2026-08-05 起冻结：
-只修安全或阻断 bug，不新增功能。`--engine legacy` 路径在 PNA-11
-完成前保持完全可用。
+只修安全或阻断 bug，不新增功能。`--legacy` 隐藏回退保留一个稳定
+版本；其后删除旧 TUI/model loop，保留数据迁移读取器（规格 §31）。
 
-## 切换默认 engine 的前置条件（规格 §31 阶段 3/4）
+## 默认切换的前置条件（全部已于 2026-08-06 完成，证据见
+## tests/agentd/test_product_journey.py 等 Gate E 测试）
 
-- [ ] 完整 Product Journey 全自动 PTY（clean install → chat → login →
-  model → ask → observe → delegate → SIM action → approve → receipt →
-  compact → exit → resume）；
-- [ ] PTY/IME 矩阵（中文输入法、退格、粘贴、resize、tmux/SSH）；
-- [ ] 性能门槛实测（§30 表格）；
-- [ ] 100 次启动退出零孤儿；
-- [ ] SIM E3 不回退；REAL 门禁不受影响。
+- [x] 完整 Product Journey 全自动 PTY（clean install → chat →
+  delegate → SIM action → approve → receipt → compact → exit →
+  resume）——`tests/agentd/test_product_journey.py`；
+- [x] PTY/IME 矩阵（中文输入、CJK 退格、bracketed paste、resize、
+  tmux）——`tests/agentd/test_tui_ime.py`、`test_tmux_env.py`；
+- [x] 性能门槛实测（§30：回显 p95=15.8ms、working 可见 p95=25.3ms、
+  redraw p95=16.8ms、idle CPU≈0）——`test_interaction_perf.py`；
+- [x] 100 次启动退出零孤儿、RSS/fd 趋势平坦——`test_start_exit_soak.py`；
+- [x] SIM E3 不回退；REAL 门禁不受影响（仍为关闭状态）。

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -374,10 +374,9 @@ def cmd_chat(args: argparse.Namespace) -> int:
     home = _home(args)
     if not _load_stored_credentials(home):
         return 2
-    # 重构路线（rosclaw_native_agent重构.md）：engine=pi 走 Pi-backed
-    # harness（packages/rosclaw-agent），legacy 保持默认直到 Product Gate 通过。
-    # 优先级：--legacy > --engine > config.agent.engine > legacy（规格 §5/
-    # §31——Product Gate 未全过前默认必须保持 legacy）。
+    # NA-FIX-9（规格 §5/§31，Gate A–E 已通过）：Native Agent（pi）是默认
+    # 引擎；legacy 仅作隐藏回退保留一个稳定版本。
+    # 优先级：--legacy > --engine > config.agent.engine > pi。
     if getattr(args, "legacy", False):
         engine = "legacy"
     elif getattr(args, "engine", None):
@@ -386,13 +385,19 @@ def cmd_chat(args: argparse.Namespace) -> int:
         try:
             engine = load_agent_config(home / "config.yaml").engine
         except Exception:  # noqa: BLE001 - 配置问题由后续步骤诚实报出
-            engine = "legacy"
+            engine = "pi"
+    # 两种引擎都需要模型配置——缺失时给出同一指引（pi 侧由
+    # ModelRuntime/auth 接续处理具体 provider 细节）。
+    try:
+        if not load_agent_config(home / "config.yaml").profiles:
+            print("未配置模型。先运行 `rosclaw agent init`。", file=sys.stderr)
+            return 2
+    except ValueError:
+        print("未配置模型。先运行 `rosclaw agent init`。", file=sys.stderr)
+        return 2
     if engine == "pi":
         return _chat_pi(home, args)
     config = load_agent_config(home / "config.yaml")
-    if not config.profiles:
-        print("未配置模型。先运行 `rosclaw agent init`。", file=sys.stderr)
-        return 2
     service = AgentService(config, home)
     if getattr(args, "basic", False):
         return asyncio.run(_chat_repl(service, args))
@@ -423,9 +428,9 @@ def _chat_pi(home: Path, args: argparse.Namespace) -> int:
     runtime = _find_pi_agent_entry()
     if runtime is None:
         print(
-            "engine=pi 需要 Node ≥22.19 且已构建 packages/rosclaw-agent"
+            "Native Agent 需要 Node ≥22.19 且已构建 packages/rosclaw-agent"
             "（发布包自带；源码环境先 npm ci && npm run build）。"
-            "回退：rosclaw chat --legacy",
+            "临时回退：rosclaw chat --legacy",
             file=sys.stderr,
         )
         return 2
@@ -463,7 +468,7 @@ def _chat_pi(home: Path, args: argparse.Namespace) -> int:
     while time.time() < deadline and not (home / "run" / "pi-bridge.sock").exists():
         time.sleep(0.05)
     if not (home / "run" / "pi-bridge.sock").exists():
-        print("pi-bridge 未能启动——engine=pi 不可用（agentd 内核未就绪）。", file=sys.stderr)
+        print("内核桥未能启动——Native Agent 不可用（agentd 内核未就绪）。", file=sys.stderr)
         server.should_exit = True
         asyncio.run(service.close())
         return 2
@@ -989,13 +994,14 @@ def add_agent_subparsers(subparsers) -> None:
         "--engine",
         default=None,
         choices=["pi", "legacy"],
-        help="Agent engine：pi（Pi-backed harness，重构路线）或 legacy"
-        "（当前 Python AgentLoop + rosclaw-tui）。默认 legacy（Product Gate 未过前）。",
+        # NA-FIX-9：公开面不再暴露引擎概念；仅兼容旧脚本/诊断。
+        help=argparse.SUPPRESS,
     )
     p_chat.add_argument(
         "--legacy",
         action="store_true",
-        help="等价于 --engine legacy",
+        # 隐藏回退（保留一个稳定版本后随 legacy 一起退役）。
+        help=argparse.SUPPRESS,
     )
     p_chat.add_argument(
         "--continue",

--- a/src/rosclaw/agentd/config.py
+++ b/src/rosclaw/agentd/config.py
@@ -20,9 +20,10 @@ DEFAULT_CONFIG_PATH = Path.home() / ".rosclaw" / "config.yaml"
 @dataclass
 class AgentConfig:
     enabled: bool = True
-    # 重构规格 §5：pi（Pi-backed harness）| legacy（Python AgentLoop +
-    # rosclaw-tui）。默认 legacy——Product Gate 未全过前不得切 pi。
-    engine: str = "legacy"
+    # 重构规格 §5/§31 + NA-FIX-9：pi（Pi-backed harness，Native Agent）
+    # 是默认；legacy（Python AgentLoop + rosclaw-tui）仅作隐藏回退保留
+    # 一个稳定版本（Gate A–E 已全部通过——见 docs 验证矩阵）。
+    engine: str = "pi"
     default_profile: str = "embodied_default"
     default_mode: str = "SIMULATION"
     max_tool_rounds: int = 12
@@ -84,7 +85,7 @@ def load_agent_config(path: Path | None = None) -> AgentConfig:
     ]
     context = agent.get("context", {}) or {}
     budgets = agent.get("budgets", {}) or {}
-    engine = str(agent.get("engine", "legacy")).lower()
+    engine = str(agent.get("engine", "pi")).lower()
     if engine not in ("pi", "legacy"):
         raise ValueError(f"agent.engine 只能是 pi|legacy（got {engine!r}）")
     return AgentConfig(

--- a/src/rosclaw/root_cli.py
+++ b/src/rosclaw/root_cli.py
@@ -58,7 +58,7 @@ DOMAIN_GROUPS: dict[str, list[str]] = {
 
 #: 机器可读注册表（name → (group, summary)）。dispatch 实现见 entrypoint.py。
 COMMAND_REGISTRY: dict[str, tuple[str, str]] = {
-    "chat": ("core", "Start the Native Agent (Pi-backed harness or --legacy)"),
+    "chat": ("core", "Start the Native Agent"),
     "setup": ("setup", "Configure model, body and integrations"),
     "status": ("core", "Show runtime and embodiment status"),
     "doctor": ("core", "Diagnose installation and safety readiness"),
@@ -67,7 +67,6 @@ COMMAND_REGISTRY: dict[str, tuple[str, str]] = {
     "restart": ("runtime", "Restart services"),
     "dashboard": ("runtime", "Open the dashboard"),
     "agent": ("core", "Native Agent management (agentd)"),
-    "chat --engine": ("advanced", "Engine selection (developer preview; hidden later)"),
     "operatord": ("safety", "Independent operator authorization process"),
     "daemon": ("safety", "rosclawd control plane inspection"),
     "release verify": ("safety", "Verify a release bundle offline"),

--- a/tests/agentd/test_engine_config.py
+++ b/tests/agentd/test_engine_config.py
@@ -9,8 +9,17 @@ import pytest
 from rosclaw.agentd.config import load_agent_config
 
 
-def test_default_engine_is_legacy(tmp_path: Path) -> None:
+def test_default_engine_is_pi(tmp_path: Path) -> None:
+    """NA-FIX-9（Gate A–E 已过后）：Native Agent 是默认引擎。"""
     (tmp_path / "config.yaml").write_text("agent:\n  enabled: true\n", encoding="utf-8")
+    assert load_agent_config(tmp_path / "config.yaml").engine == "pi"
+
+
+def test_engine_legacy_explicit(tmp_path: Path) -> None:
+    """legacy 仍可显式选择（隐藏回退，保留一个稳定版本）。"""
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  enabled: true\n  engine: legacy\n", encoding="utf-8"
+    )
     assert load_agent_config(tmp_path / "config.yaml").engine == "legacy"
 
 

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -470,7 +470,8 @@ class TestProductJourney:
         )
 
     def _run_journey(self, rosclaw: Path, env: dict[str, str], home: Path) -> None:
-        session = PtySession([str(rosclaw), "chat", "--engine", "pi"], env)
+        # NA-FIX-9 后默认引擎即 Native Agent——旅程显式验证无 --engine 的默认路径。
+        session = PtySession([str(rosclaw), "chat"], env)
         try:
             # 1. 品牌 header（T-IDENTITY：无 engine/pi 字样）。
             session.expect(b"ROSClaw Native Agent", timeout=60)
@@ -515,7 +516,7 @@ class TestProductJourney:
         finally:
             session.stop()
         # 9. --continue 恢复（同 session/binding）。
-        resumed = PtySession([str(rosclaw), "chat", "--engine", "pi", "--continue"], env)
+        resumed = PtySession([str(rosclaw), "chat", "--continue"], env)
         try:
             resumed.expect(b"ROSClaw Native Agent", timeout=60)
             resumed.send("/quit\r")


### PR DESCRIPTION
## NA-FIX-9（规格 §5/§31 阶段 3/4）——Gate A–E 证据已在 #254 合入

- `config.agent.engine` 默认 `pi`；`--legacy`/`--engine` 从 help 隐藏（`argparse.SUPPRESS`）——公开界面不再暴露 engine 概念；
- 优先级 `--legacy` > `--engine` > config > `pi`；
- root CLI registry 移除 `chat --engine` 条目；
- 错误信息去引擎黑话（"Native Agent 需要 Node…"）；
- 未配置模型时两种引擎统一指引 `rosclaw agent init`（此前仅 legacy 侧检查，pi 侧深层 ValueError——`test_chat_requires_config` 暴露并修复）；
- `docs/PI_ENGINE_MIGRATION.md` 重写为 Native Agent 迁移说明，前置条件五项全部勾选并指向 Gate E 测试证据；
- 旅程测试改为验证**无 --engine 的默认路径**（Gate A）——1 passed（139s）。

## 验证

- agentd 全量 428 passed（非 slow/live）；root_cli/engine_config/TestCli 12 passed；ruff clean；
- test_tui_ime / journey（默认路径）复验 passed。

## 不变的红线

- legacy 隐藏回退保留一个稳定版本，其后删除旧 TUI/model loop、保留数据迁移读取器；
- REAL 门禁保持关闭；SHADOW/REAL 继续走独立安全 Gate。