### PR TITLE
feat(pr-na-12): Approval/Receipt 精确证据链 + 卡片 fail-closed

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -197,31 +197,60 @@ ${line2}`);
 			// 覆盖；spinner 行持续重绘，是执行中唯一稳定可见的通道。
 			ctx.ui.setWorkingMessage(`等待 Operator 决定（approval ${approvalId}）…默认拒绝`);
 			ctx.ui.notify(`等待 Operator 决定（approval ${approvalId}）…默认拒绝`, "info");
-			// 从 operatord 拉这张精确卡片的内容（不猜、不取第一个）。
+			// P0-NA-14：经 approvals.get 精确拉卡（不扫 list）；拉取失败、
+			// 字段缺失或 display_hash 不一致 → fail-closed，不显示可批准卡。
 			let cardData: Record<string, unknown> | undefined;
+			let cardError = "";
 			try {
-				const listed = (await operatorCall(
+				const got = (await operatorCall(
 					defaultOperatorSocket(options.rosclawHome),
-					"approvals.list",
-					{ mission_id: options.active.current.missionId },
-				)) as { ok: boolean; approvals?: Array<Record<string, unknown>> };
-				cardData = (listed.approvals ?? []).find((a) => a.request_id === approvalId);
-			} catch {
-				cardData = undefined;
+					"approvals.get",
+					{ request_id: approvalId },
+				)) as { ok: boolean; approval?: Record<string, unknown>; error?: string };
+				if (got.ok && got.approval) {
+					cardData = got.approval;
+				} else {
+					cardError = String(got.error ?? "card not found");
+				}
+			} catch (err) {
+				cardError = (err as Error).message;
 			}
+			// 完整性与 hash 绑定校验：卡片必须带齐 mode/risk/capability/
+			// parameters/expires_at，且服务端 display_hash 与 tool 报告的一致。
+			// （early-return 收窄——TS 不跨复合布尔收窄。）
+			if (
+				cardData === undefined
+				|| typeof cardData.title !== "string"
+				|| typeof cardData.mode !== "string" || cardData.mode === ""
+				|| typeof cardData.risk_tier !== "string"
+				|| typeof cardData.expires_at !== "string" || cardData.expires_at === ""
+				|| typeof cardData.parameters !== "object" || cardData.parameters === null
+				|| (displayHash !== "" && String(cardData.display_hash ?? "") !== displayHash)
+			) {
+				ctx.ui.notify(
+					`授权卡不可用（${cardError || "字段缺失或 hash 不一致"}）——` +
+					"动作未执行。为安全起见本卡不可在此批准；请重新发起请求。",
+					"error",
+				);
+				return;
+			}
+			const card: Record<string, unknown> = cardData;
 			try {
 				await ctx.ui.custom<boolean>((_tui, _theme, _kb, done) => {
 					return new ApprovalCardComponent(
 						{
 							requestId: approvalId,
-							title: String(cardData?.title ?? approvalId),
-							summary: String(cardData?.summary ?? ""),
-							riskTier: String(cardData?.risk_tier ?? ""),
-							mode: String(cardData?.mode ?? "ACTION"),
-							capability: String(cardData?.capability_id ?? ""),
-							parameters: (cardData?.parameters ?? {}) as Record<string, unknown>,
-							expiresAt: String(cardData?.expires_at ?? ""),
+							title: String(card.title ?? approvalId),
+							summary: String(card.summary ?? ""),
+							riskTier: String(card.risk_tier ?? ""),
+							mode: String(card.mode ?? "ACTION"),
+							capability: String(card.capability_id ?? ""),
+							parameters: (card.parameters ?? {}) as Record<string, unknown>,
+							expiresAt: String(card.expires_at ?? ""),
 							displayHash,
+							expectedEffect: String(card.expected_effect ?? ""),
+							failureHandling: String(card.failure_handling ?? ""),
+							bodyId: String(card.body_id ?? ""),
 						},
 						(approve) => done(approve),
 					);

--- a/packages/rosclaw-agent/src/tools/request-action.ts
+++ b/packages/rosclaw-agent/src/tools/request-action.ts
@@ -159,6 +159,9 @@ export function buildRequestActionTool(ctx: BridgeToolContext) {
 					approval_id: card.approval_id,
 					grant_id: result.grant_id ?? null,
 					terminal_receipt: result.terminal_receipt ?? false,
+					// P0-NA-13：结构化证据引用（receipt://action_id）随结果
+					// 返回——/evidence 按本回合 action 精确展示，不是摘要。
+					evidence_ref: result.evidence_ref ?? null,
 					error_code: result.error_code ?? null,
 				},
 				isError: result.executed !== true && result.status !== "DECLINED",

--- a/packages/rosclaw-agent/src/ui/approval-card.ts
+++ b/packages/rosclaw-agent/src/ui/approval-card.ts
@@ -18,6 +18,10 @@ export interface ApprovalCardData {
 	parameters: Record<string, unknown>;
 	expiresAt: string;
 	displayHash: string;
+	/** P0-NA-14：完整知情确认——预期效果/失败处理/body 必须可见。 */
+	expectedEffect?: string;
+	failureHandling?: string;
+	bodyId?: string;
 }
 
 export class ApprovalCardComponent implements Component {
@@ -51,6 +55,15 @@ export class ApprovalCardComponent implements Component {
 		];
 		for (const [key, value] of Object.entries(this.card.parameters)) {
 			lines.push(`│   ${key} = ${JSON.stringify(value)}`);
+		}
+		if (this.card.expectedEffect) {
+			lines.push(`│ 预期效果: ${this.card.expectedEffect}`);
+		}
+		if (this.card.failureHandling) {
+			lines.push(`│ 失败处理: ${this.card.failureHandling}`);
+		}
+		if (this.card.bodyId) {
+			lines.push(`│ Body: ${this.card.bodyId}`);
 		}
 		lines.push(`│ display_hash: ${this.card.displayHash}`);
 		lines.push(`│ 过期: ${this.card.expiresAt}`);

--- a/src/rosclaw/agentd/operator_socket.py
+++ b/src/rosclaw/agentd/operator_socket.py
@@ -121,6 +121,37 @@ class OperatorSocketServer:
         method = request.get("method")
         params = request.get("params") or {}
         service = self._service
+        if method == "approvals.get":
+            # P0-NA-14：按精确 request_id 取单张卡——不扫 list（并发下
+            # list 的内容可能已变）。
+            request_id = str(params.get("request_id", ""))
+            if not request_id:
+                return {"ok": False, "error": "request_id required"}
+            pending = {r.request_id: r for r in service.pending_approvals(None)}
+            card = pending.get(request_id)
+            if card is None:
+                return {"ok": False, "error": "no pending approval card", "code": "CARD_NOT_FOUND"}
+            if service.principal_for_request(card.request_id) != principal:
+                return {"ok": False, "error": "not your card", "code": "FORBIDDEN"}
+            return {
+                "ok": True,
+                "approval": {
+                    "request_id": card.request_id,
+                    "mission_id": card.mission_id,
+                    "title": card.action_display.title,
+                    "summary": card.action_display.summary,
+                    "risk_tier": card.action_display.risk_tier,
+                    "parameters": card.action_display.parameters,
+                    "expected_effect": card.action_display.expected_effect,
+                    "failure_handling": card.action_display.failure_handling,
+                    "capability_id": getattr(card, "daemon_capability_id", "") or "",
+                    "body_id": card.body_id,
+                    "expires_at": card.expires_at,
+                    "display_hash": display_hash_for(card),
+                    "mode": card.mode,
+                    "daemon_proposal_id": getattr(card, "daemon_proposal_id", "") or "",
+                },
+            }
         if method == "approvals.list":
             mission_id = params.get("mission_id")
             pending = service.pending_approvals(mission_id)
@@ -144,6 +175,10 @@ class OperatorSocketServer:
                         "summary": r.action_display.summary,
                         "risk_tier": r.action_display.risk_tier,
                         "parameters": r.action_display.parameters,
+                        "expected_effect": r.action_display.expected_effect,
+                        "failure_handling": r.action_display.failure_handling,
+                        "capability_id": getattr(r, "daemon_capability_id", "") or "",
+                        "body_id": r.body_id,
                         "expires_at": r.expires_at,
                         "display_hash": display_hash_for(r),
                         "mode": r.mode,

--- a/src/rosclaw/operatord/server.py
+++ b/src/rosclaw/operatord/server.py
@@ -90,6 +90,11 @@ class OperatorDaemon:
             if self._agent_socket is None or not self._agent_socket.exists():
                 return {"ok": False, "error": "agentd projection socket unavailable"}
             return await operator_call(self._agent_socket, "approvals.list", params)
+        if method == "approvals.get":
+            # P0-NA-14：精确单卡查询（不扫 list）。
+            if self._agent_socket is None or not self._agent_socket.exists():
+                return {"ok": False, "error": "agentd projection socket unavailable"}
+            return await operator_call(self._agent_socket, "approvals.get", params)
         if method == "approvals.decide":
             return await self._decide(principal, params, peer_pid=peer_pid)
         if method == "grants.revoke":

--- a/tests/agentd/test_pi_approval.py
+++ b/tests/agentd/test_pi_approval.py
@@ -295,3 +295,47 @@ class TestAdmissionNegativeChain:
         await operatord.stop()
         await agent_server.stop()
         await service.close()
+
+
+class TestApprovalsGet:
+    """P0-NA-14：approvals.get 精确单卡查询 + fail-closed 语义。"""
+
+    async def test_get_exact_card(self, tmp_path: Path) -> None:
+        service, mission, operatord, agent_server, sock = await _setup_with_operatord(
+            tmp_path
+        )
+        from rosclaw.agentd.pi_bridge.action_admission import (
+            ActionAdmissionService,
+            ActionRequestContext,
+        )
+
+        snapshot = service.snapshot(mission.mission_id)
+        admission = ActionAdmissionService(service)
+        card = await admission.propose(
+            request=ActionRequestContext(
+                pi_session_id="pi_1",
+                mission_id=mission.mission_id,
+                context_revision=snapshot.context_revision,
+                body_hash=mission.body_binding.effective_body_hash,
+                mode=mission.mode.value,
+                idempotency_key="idem_get_1",
+            ),
+            capability_id="sim_ground_truth",
+            arguments={"beep": True},
+            expected_effect="蜂鸣",
+            risk_tier="LOW",
+        )
+        got = await operator_call(sock, "approvals.get", {"request_id": card["approval_id"]})
+        assert got.get("ok"), got
+        approval = got["approval"]
+        assert approval["request_id"] == card["approval_id"]
+        assert approval["parameters"] == {"beep": True}
+        assert approval["expected_effect"] == "蜂鸣"
+        assert approval["display_hash"] == card["display_hash"]
+        assert approval["mode"] == "SIMULATION"
+        # 不存在的卡 → CARD_NOT_FOUND（不是空卡）。
+        missing = await operator_call(sock, "approvals.get", {"request_id": "appr_nope"})
+        assert not missing.get("ok") and missing.get("code") == "CARD_NOT_FOUND"
+        await operatord.stop()
+        await agent_server.stop()
+        await service.close()

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -454,20 +454,55 @@ class TestProductJourney:
             fake.close()
 
     def _assert_grant_consumed(self, home: Path) -> None:
-        """授权→执行闭环：grant 必须被精确消费（单次），不许悬置。"""
+        """授权→执行闭环（P0-NA-13）：直接解析 DB/事件里的结构化证据，
+        断言 approval → grant → consume 的精确 ID 链——不是模型自述。"""
         import sqlite3
 
         db = sqlite3.connect(home / "agentd" / "missions.db")
         try:
-            rows = db.execute(
-                "SELECT grant_id, consumed, revoked FROM mission_grants"
+            # 1. approval 已批准且有精确 decided_by。
+            approvals = db.execute(
+                "SELECT request_id, status, decided_by FROM operator_requests"
             ).fetchall()
+            assert approvals, "应有 approval 记录"
+            for request_id, status, decided_by in approvals:
+                assert status == "APPROVED" and decided_by, (
+                    f"approval {request_id} 未正确落库: status={status}"
+                )
+            # 2. grant 与 approval 精确绑定且被消费（单次、未撤销）。
+            grants = db.execute(
+                "SELECT grant_id, request_id, consumed, revoked FROM mission_grants"
+            ).fetchall()
+            assert grants, "批准应产生 grant"
+            approval_ids = {a[0] for a in approvals}
+            for grant_id, request_id, consumed, revoked in grants:
+                assert request_id in approval_ids, (
+                    f"grant {grant_id} 绑定的 request_id {request_id} 不在 approval 链中"
+                )
+                assert consumed == 1 and revoked == 0, (
+                    f"grant {grant_id} 未被精确消费或被撤销"
+                )
+            # 3. 事件链：approval.requested → approval.decided → grant.consumed
+            #    的 ID 必须一致（结构化事件，不是文本）。
+            events = db.execute(
+                "SELECT type, payload_json FROM agent_events ORDER BY rowid"
+            ).fetchall()
+            requested = [json.loads(p) for t, p in events if t == "approval.requested"]
+            decided = [json.loads(p) for t, p in events if t == "approval.decided"]
+            consumed_evs = [json.loads(p) for t, p in events if t == "grant.consumed"]
+            assert requested and decided, f"事件链缺环: {[t for t, _ in events]}"
+            for req, dec in zip(requested, decided):
+                assert req["request_id"] == dec["request_id"], (
+                    f"requested/decided 不同卡: {req} vs {dec}"
+                )
+            if consumed_evs:
+                grant_ids = {g[0] for g in grants}
+                for ev in consumed_evs:
+                    assert ev.get("grant_id") in grant_ids, (
+                        f"grant.consumed 事件的 grant_id 不在链中: {ev}"
+                    )
         finally:
             db.close()
-        assert rows, "批准应产生 grant"
-        assert all(consumed == 1 and revoked == 0 for _, consumed, revoked in rows), (
-            f"grant 未被消费或被撤销: {rows}"
-        )
 
     def _run_journey(self, rosclaw: Path, env: dict[str, str], home: Path) -> None:
         # NA-FIX-9 后默认引擎即 Native Agent——旅程显式验证无 --engine 的默认路径。

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -491,7 +491,7 @@ class TestProductJourney:
             decided = [json.loads(p) for t, p in events if t == "approval.decided"]
             consumed_evs = [json.loads(p) for t, p in events if t == "grant.consumed"]
             assert requested and decided, f"事件链缺环: {[t for t, _ in events]}"
-            for req, dec in zip(requested, decided):
+            for req, dec in zip(requested, decided, strict=True):
                 assert req["request_id"] == dec["request_id"], (
                     f"requested/decided 不同卡: {req} vs {dec}"
                 )


### PR DESCRIPTION
三审 P0-NA-13/14。

- **`approvals.get(request_id)`**：agentd 精确单卡查询（owner 过滤、CARD_NOT_FOUND），operatord 透传；扩展不再扫 list 找卡；
- **卡片 fail-closed**：拉取失败/字段缺失/display_hash 不一致 → 不显示可批准卡，明确告知未执行；
- **完整披露**：卡片新增 expected_effect/failure_handling/body_id/capability_id（socket 投影同步补齐）；
- **结构化证据链**：execute 返回 evidence_ref（receipt://action_id）；journey 断言改为直接解析 DB/事件的 approval→grant→consume 精确 ID 链，不再依赖模型自述文本。

注：基于 #258（PR-NA-10）分支——execute 的 any-receipt 判定与 pending[-1] 取卡已在那里删除。

验证：approval 9 passed（含 approvals.get 用例）；agentd 全量 437 passed；node 32/32；ruff clean；安装产物 PTY 旅程（ID 链断言版）1 passed。