### PR TITLE
feat(hotfix-1): ValidatedContextLease——action 准入的权威 freshness 凭证

### DIFF
--- a/packages/rosclaw-agent/src/extension/context-injection.ts
+++ b/packages/rosclaw-agent/src/extension/context-injection.ts
@@ -27,6 +27,9 @@ export interface ContextFetchResult {
 	envelope?: EmbodiedContextEnvelope;
 	stale: boolean;
 	note: string;
+	/** HOTFIX-1：agentd 签发的 ValidatedContextLease（action 准入凭证）。 */
+	contextLeaseId?: string;
+	contextLeaseExpiresAt?: string;
 }
 
 /** 与 Python json.dumps(sort_keys=True, separators=(",", ":")) 逐字节一致。 */
@@ -51,10 +54,16 @@ export function envelopeHash(envelope: EmbodiedContextEnvelope): string {
 export async function fetchEmbodiedContext(
 	rosclawHome: string,
 	missionId: string,
+	piSessionId?: string,
 ): Promise<ContextFetchResult> {
 	let response: Record<string, unknown>;
 	try {
-		response = await bridgeCall(rosclawHome, "pi.context", { mission_id: missionId });
+		// HOTFIX-1：带 session 拉 context——agentd 会同时签发
+		// ValidatedContextLease（action 准入凭证）并随响应返回。
+		response = await bridgeCall(rosclawHome, "pi.context", {
+			mission_id: missionId,
+			...(piSessionId ? { pi_session_id: piSessionId } : {}),
+		});
 	} catch (err) {
 		return {
 			stale: true,
@@ -77,7 +86,21 @@ export async function fetchEmbodiedContext(
 	if (new Date(envelope.expires_at).getTime() < Date.now()) {
 		return { stale: true, note: "context expired (TTL) — physical actions forbidden" };
 	}
-	return { envelope, stale: false, note: "fresh" };
+	// HOTFIX-1：lease 是 action 准入凭证——无 session 拉取（如 doctor）
+	// 不带 lease，那样的 context 只用于展示，不能授权动作。
+	const leaseId = typeof response.context_lease_id === "string"
+		? response.context_lease_id
+		: undefined;
+	const leaseExpiresAt = typeof response.context_lease_expires_at === "string"
+		? response.context_lease_expires_at
+		: undefined;
+	return {
+		envelope,
+		stale: false,
+		note: "fresh",
+		...(leaseId ? { contextLeaseId: leaseId } : {}),
+		...(leaseExpiresAt ? { contextLeaseExpiresAt: leaseExpiresAt } : {}),
+	};
 }
 
 export function renderTrustedContext(result: ContextFetchResult): string {

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -107,10 +107,14 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			if (!missionId) {
 				return { systemPrompt: options.systemPrompt };
 			}
-			const fetched = await fetchEmbodiedContext(options.rosclawHome, missionId);
+			const fetched = await fetchEmbodiedContext(
+				options.rosclawHome,
+				missionId,
+				options.active.current.sessionId,
+			);
 			if (!fetched.stale && fetched.envelope) {
 				// P0-7：验证通过后写入精确 revision/body/mode。
-				options.active.applyEnvelope(fetched.envelope);
+				options.active.applyEnvelope(fetched.envelope, fetched.contextLeaseId);
 				// P0-NA-16：fresh envelope 到达 → header 从 LOADING 转 FRESH。
 				uiState.noteContextChanged();
 			}

--- a/packages/rosclaw-agent/src/session/active-context.ts
+++ b/packages/rosclaw-agent/src/session/active-context.ts
@@ -18,6 +18,8 @@ export interface ActiveSessionState {
 	bodyHash?: string;
 	mode: string;
 	profile: "developer" | "robot" | "worker";
+	/** HOTFIX-1：agentd 签发的 ValidatedContextLease（action 准入凭证）。 */
+	contextLeaseId?: string;
 }
 
 export class ActiveSessionContext {
@@ -40,8 +42,10 @@ export class ActiveSessionContext {
 		this.state = { ...this.state, ...partial };
 	}
 
-	/** 每轮注入验证通过后写入 revision/body/mode（P0-7 的精确数据来源）。 */
-	applyEnvelope(envelope: EmbodiedContextEnvelope): void {
+	/** 每轮注入验证通过后写入 revision/body/mode（P0-7 的精确数据来源）。
+	 *  HOTFIX-1：agentd 签发的 context lease 一并记录——action 工具必须
+	 *  出示它（lease 只存 id；它本身不是执行权）。 */
+	applyEnvelope(envelope: EmbodiedContextEnvelope, contextLeaseId?: string): void {
 		const body = envelope.body as { body_id?: string; effective_body_hash?: string };
 		const safety = envelope.safety as { mode?: string };
 		this.patch({
@@ -49,6 +53,7 @@ export class ActiveSessionContext {
 			bodyId: body.body_id,
 			bodyHash: body.effective_body_hash,
 			...(safety.mode ? { mode: safety.mode } : {}),
+			...(contextLeaseId ? { contextLeaseId } : {}),
 		});
 	}
 }

--- a/packages/rosclaw-agent/src/tools/request-action.ts
+++ b/packages/rosclaw-agent/src/tools/request-action.ts
@@ -48,6 +48,9 @@ export function buildRequestActionTool(ctx: BridgeToolContext) {
 				body_hash: state.bodyHash ?? "",
 				mode: state.mode,
 				idempotency_key: `idem_reqact_${state.sessionId}_${Date.now()}`,
+				// HOTFIX-1：agentd 签发的 ValidatedContextLease——无 lease
+				// 即 CONTEXT_LEASE_REQUIRED（fail closed）。
+				context_lease_id: state.contextLeaseId ?? "",
 			};
 			const proposed = await bridgeCall(ctx.rosclawHome, "pi.action.propose", {
 				...requestContext,
@@ -104,6 +107,8 @@ export function buildRequestActionTool(ctx: BridgeToolContext) {
 					};
 				}
 				const current = await bridgeCall(ctx.rosclawHome, "pi.action.status", {
+					// HOTFIX-1：status 也做卡主校验——必须带 session。
+					pi_session_id: state.sessionId,
 					approval_id: card.approval_id,
 				});
 				status = String(current.status ?? "PENDING");

--- a/src/rosclaw/agentd/pi_bridge/action_admission.py
+++ b/src/rosclaw/agentd/pi_bridge/action_admission.py
@@ -39,7 +39,12 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class ActionRequestContext:
-    """propose/execute 的完整请求上下文（P0-NA-10 结构化 contract）。"""
+    """propose/execute 的完整请求上下文（P0-NA-10 + HOTFIX-1 contract）。
+
+    HOTFIX-1（P0-4A）：context_lease_id 是 agentd 签发的
+    ValidatedContextLease——freshness 的权威凭证；无 lease 即
+    CONTEXT_NOT_FRESH（不再有"revision 碰巧相同就放行"的 stale 捷径）。
+    """
 
     pi_session_id: str
     mission_id: str
@@ -47,6 +52,7 @@ class ActionRequestContext:
     body_hash: str
     mode: str
     idempotency_key: str
+    context_lease_id: str
 
 
 class ActionAdmissionService:
@@ -59,11 +65,26 @@ class ActionAdmissionService:
     # -- 验证链 -----------------------------------------------------------------
 
     def _validate_request_context(self, ctx: ActionRequestContext) -> None:
-        """session → mission → lease → revision → body → mode 全链硬校验。"""
-        if not ctx.pi_session_id:
+        """session → mission → writer lease → context lease → revision →
+        body → mode 全链硬校验（HOTFIX-1：freshness 以 agentd 签发的
+        ValidatedContextLease 为准，不信 TUI 自报的 revision）。"""
+        # 1. 全字段非空（HOTFIX-1：空 body_hash/idempotency 不再放行）。
+        if not ctx.pi_session_id or not ctx.mission_id:
             raise ToolBridgeError(
-                "REQUEST_CONTEXT_REQUIRED", "pi_session_id is required (fail closed)"
+                "REQUEST_CONTEXT_REQUIRED", "session/mission required (fail closed)"
             )
+        if not ctx.body_hash:
+            raise ToolBridgeError(
+                "BODY_HASH_REQUIRED",
+                "body_hash is required for actions (fail closed; empty ≠ match)",
+            )
+        if not ctx.idempotency_key:
+            raise ToolBridgeError(
+                "IDEMPOTENCY_KEY_REQUIRED", "idempotency_key is required (fail closed)"
+            )
+        if not ctx.mode:
+            raise ToolBridgeError("REQUEST_CONTEXT_REQUIRED", "mode required")
+        # 2. session binding + mission。
         binding = self._bindings.binding_for_session(ctx.pi_session_id)
         if binding is None:
             raise ToolBridgeError(
@@ -77,27 +98,63 @@ class ActionAdmissionService:
         mission = self._service.get_mission(ctx.mission_id)
         if mission is None:
             raise ToolBridgeError("MISSION_NOT_FOUND", "unknown mission")
+        # 3. writer lease。
         writer = self._bindings.writer_of(ctx.mission_id)
         if writer is None or writer.pi_session_id != ctx.pi_session_id:
             raise ToolBridgeError(
                 "WRITER_LEASE_REQUIRED",
                 "this session does not hold the writer lease (fail closed)",
             )
+        # 4. ValidatedContextLease（HOTFIX-1 核心）：agentd 签发、未过期、
+        #    未撤销、session/mission 绑定、revision/body/mode 全匹配。
+        from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+
+        if not ctx.context_lease_id:
+            raise ToolBridgeError(
+                "CONTEXT_LEASE_REQUIRED",
+                "no validated context lease — fetch fresh embodied context "
+                "before acting (fail closed)",
+            )
+        leases = ContextLeaseStore(self._service._store.connection)
+        lease = leases.get(ctx.context_lease_id)
+        if lease is None or not leases.is_valid(lease):
+            raise ToolBridgeError(
+                "CONTEXT_NOT_FRESH",
+                "context lease expired, revoked, or unknown — refresh embodied "
+                "context (fail closed)",
+            )
+        if (
+            lease.pi_session_id != ctx.pi_session_id
+            or lease.mission_id != ctx.mission_id
+        ):
+            raise ToolBridgeError(
+                "CONTEXT_LEASE_MISMATCH",
+                "context lease belongs to another session/mission (fail closed)",
+            )
         snapshot = self._service.snapshot(ctx.mission_id)
-        if ctx.context_revision != snapshot.context_revision:
+        if lease.context_revision != snapshot.context_revision:
+            raise ToolBridgeError(
+                "CONTEXT_NOT_FRESH",
+                f"lease revision {lease.context_revision} != current "
+                f"{snapshot.context_revision} — refresh embodied context",
+            )
+        if ctx.context_revision != lease.context_revision:
             raise ToolBridgeError(
                 "CONTEXT_REVISION_MISMATCH",
-                f"request revision {ctx.context_revision} != current "
-                f"{snapshot.context_revision} — refresh embodied context and "
-                "re-propose (actions require exact context)",
+                "request revision != lease revision — use the context the "
+                "lease was issued for",
             )
         current_body_hash = mission.body_binding.effective_body_hash
-        if current_body_hash and ctx.body_hash and ctx.body_hash != current_body_hash:
+        if current_body_hash and lease.body_hash != current_body_hash:
             raise ToolBridgeError(
                 "BODY_HASH_MISMATCH",
                 "body hash changed since context was issued — re-observe and re-propose",
             )
-        if mission.mode.value != ctx.mode:
+        if ctx.body_hash != lease.body_hash:
+            raise ToolBridgeError(
+                "BODY_HASH_MISMATCH", "request body hash != lease body hash"
+            )
+        if mission.mode.value != ctx.mode or lease.mode != ctx.mode:
             raise ToolBridgeError(
                 "MODE_MISMATCH",
                 f"mission mode is {mission.mode.value}, not {ctx.mode}",
@@ -192,7 +249,7 @@ class ActionAdmissionService:
     # -- phase 2b: execute（TOCTOU 复验 + 精确 grant + 结构化回执） -----------------
 
     async def execute(
-        self, approval_id: str, *, request: ActionRequestContext | None = None
+        self, approval_id: str, *, request: ActionRequestContext
     ) -> dict[str, Any]:
         from rosclaw.contracts.agent.decision import (
             DecisionV1,
@@ -213,17 +270,17 @@ class ActionAdmissionService:
                 "executed": False,
                 "error_code": "OPERATOR_DECLINED",
             }
-        # TOCTOU 复验（P0-NA-10）：approve 之后、execute 之前 lease/
-        # revision/body/mode 任一变化都必须拒绝。
-        if request is not None:
-            if stored.context_revision != request.context_revision:
-                raise ToolBridgeError(
-                    "CONTEXT_REVISION_MISMATCH",
-                    f"card revision {stored.context_revision} != current request "
-                    f"revision {request.context_revision} — context changed after "
-                    "approval; re-propose with fresh context",
-                )
-            self._validate_request_context(request)
+        # TOCTOU 复验（P0-NA-10 + HOTFIX-1/P0-4B）：approve 之后、execute
+        # 之前 lease/revision/body/mode 任一变化都必须拒绝；请求上下文
+        # 强制必填——没有"只给 approval_id 就能执行"的绕过路径。
+        if stored.context_revision != request.context_revision:
+            raise ToolBridgeError(
+                "CONTEXT_REVISION_MISMATCH",
+                f"card revision {stored.context_revision} != current request "
+                f"revision {request.context_revision} — context changed after "
+                "approval; re-propose with fresh context",
+            )
+        self._validate_request_context(request)
         # 卡自身的 revision 与当前权威 snapshot 也必须一致（即使调用方
         # 没带 request context，也不能用过期卡执行）。
         snapshot = service.snapshot(stored.mission_id)

--- a/src/rosclaw/agentd/pi_bridge/context_lease.py
+++ b/src/rosclaw/agentd/pi_bridge/context_lease.py
@@ -1,0 +1,138 @@
+"""ValidatedContextLeaseV1（四审 HOTFIX-1，P0-4A）：agentd 签发的
+具身上下文准入证。
+
+语义：
+- `pi.context` 校验成功后由 agentd 签发（同一权威源，不是 TUI 自报）；
+- action propose/execute 必须出示 `context_lease_id`——admission 按
+  ID 重新读取并检查未过期、未撤销、session/mission/body/mode/
+  revision 全匹配；
+- context fetch 失败、TTL 到期、session 切换、body 变化 → 立即失效；
+- lease 只对 admission 有效，不是执行权；模型永远看不到它。
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from rosclaw.contracts.common import new_id
+
+LEASE_TTL_SEC = 120.0
+
+
+@dataclass(frozen=True)
+class ValidatedContextLeaseV1:
+    context_lease_id: str
+    pi_session_id: str
+    mission_id: str
+    context_revision: int
+    context_hash: str
+    body_hash: str
+    mode: str
+    issued_at: str
+    expires_at: str
+    revoked: bool = False
+
+
+class ContextLeaseStore:
+    def __init__(self, connection) -> None:
+        self._conn = connection
+
+    def issue(
+        self,
+        *,
+        pi_session_id: str,
+        mission_id: str,
+        context_revision: int,
+        context_hash: str,
+        body_hash: str,
+        mode: str,
+        ttl_sec: float = LEASE_TTL_SEC,
+    ) -> ValidatedContextLeaseV1:
+        """签发新 lease——同 (session, mission) 的旧 lease 立即撤销。"""
+        now = datetime.now(UTC)
+        self._conn.execute(
+            "UPDATE pi_context_leases SET revoked = 1 "
+            "WHERE pi_session_id = ? AND mission_id = ? AND revoked = 0",
+            (pi_session_id, mission_id),
+        )
+        lease = ValidatedContextLeaseV1(
+            context_lease_id=new_id("ctxl"),
+            pi_session_id=pi_session_id,
+            mission_id=mission_id,
+            context_revision=context_revision,
+            context_hash=context_hash,
+            body_hash=body_hash,
+            mode=mode,
+            issued_at=now.isoformat(),
+            expires_at=(now + timedelta(seconds=ttl_sec)).isoformat(),
+        )
+        self._conn.execute(
+            "INSERT INTO pi_context_leases (context_lease_id, pi_session_id, "
+            "mission_id, context_revision, context_hash, body_hash, mode, "
+            "issued_at, expires_at, revoked) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
+            (
+                lease.context_lease_id,
+                lease.pi_session_id,
+                lease.mission_id,
+                lease.context_revision,
+                lease.context_hash,
+                lease.body_hash,
+                lease.mode,
+                lease.issued_at,
+                lease.expires_at,
+            ),
+        )
+        self._conn.commit()
+        return lease
+
+    def get(self, context_lease_id: str) -> ValidatedContextLeaseV1 | None:
+        row = self._conn.execute(
+            "SELECT * FROM pi_context_leases WHERE context_lease_id = ?",
+            (context_lease_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return ValidatedContextLeaseV1(
+            context_lease_id=row["context_lease_id"],
+            pi_session_id=row["pi_session_id"],
+            mission_id=row["mission_id"],
+            context_revision=row["context_revision"],
+            context_hash=row["context_hash"],
+            body_hash=row["body_hash"],
+            mode=row["mode"],
+            issued_at=row["issued_at"],
+            expires_at=row["expires_at"],
+            revoked=bool(row["revoked"]),
+        )
+
+    def is_valid(self, lease: ValidatedContextLeaseV1) -> bool:
+        return not lease.revoked and lease.expires_at > datetime.now(UTC).isoformat()
+
+    def revoke(self, context_lease_id: str) -> None:
+        self._conn.execute(
+            "UPDATE pi_context_leases SET revoked = 1 WHERE context_lease_id = ?",
+            (context_lease_id,),
+        )
+        self._conn.commit()
+
+    def revoke_for_session(self, pi_session_id: str) -> int:
+        """session 切换/关闭——该 session 全部 lease 立即失效。"""
+        cursor = self._conn.execute(
+            "UPDATE pi_context_leases SET revoked = 1 "
+            "WHERE pi_session_id = ? AND revoked = 0",
+            (pi_session_id,),
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
+
+def context_hash_of(envelope: Any) -> str:
+    """envelope 内容 hash（RFC 8785 canonical——与跨语言 hash 同源）。"""
+    from rosclaw.contracts.pi.canonical import canonical_dumps
+
+    return hashlib.sha256(
+        canonical_dumps(envelope.model_dump(mode="json")).encode()
+    ).hexdigest()[:32]

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -103,8 +103,16 @@ class PiBridgeServer:
             mission = service.get_mission(mission_id)
             if mission is None:
                 return {"ok": False, "error": "unknown mission", "code": "MISSION_NOT_FOUND"}
+            session_id = str(params.get("pi_session_id", ""))
+            # HOTFIX-1：换绑（或重绑）作废旧 session 的全部 context
+            # lease——切换后必须重新拉取 fresh context 才能动作。
+            previous = self._bindings.binding_for_session(session_id)
+            if previous is not None and previous.mission_id != mission_id:
+                from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+
+                ContextLeaseStore(service._store.connection).revoke_for_session(session_id)
             binding = self._bindings.bind(
-                pi_session_id=str(params.get("pi_session_id", "")),
+                pi_session_id=session_id,
                 pi_session_path=str(params.get("pi_session_path", "")),
                 mission_id=mission_id,
                 body_id=mission.body_binding.body_id,
@@ -166,7 +174,28 @@ class PiBridgeServer:
                 envelope = build_embodied_context(service, mission_id)
             except ValueError as exc:
                 return {"ok": False, "error": str(exc), "code": "CONTEXT_UNAVAILABLE"}
-            return {"ok": True, "context": envelope.model_dump(mode="json")}
+            # HOTFIX-1（P0-4A）：context 校验成功后由 agentd 签发短期
+            # ValidatedContextLease——action 准入的权威 freshness 凭证
+            # （同一权威源，不信 TUI 自报）。无 session 不签发。
+            response: dict[str, Any] = {"ok": True, "context": envelope.model_dump(mode="json")}
+            pi_session_id = str(params.get("pi_session_id", ""))
+            if pi_session_id:
+                from rosclaw.agentd.pi_bridge.context_lease import (
+                    ContextLeaseStore,
+                    context_hash_of,
+                )
+
+                lease = ContextLeaseStore(service._store.connection).issue(
+                    pi_session_id=pi_session_id,
+                    mission_id=mission_id,
+                    context_revision=envelope.context_revision,
+                    context_hash=context_hash_of(envelope),
+                    body_hash=envelope.body.get("effective_body_hash", ""),
+                    mode=service.get_mission(mission_id).mode.value,
+                )
+                response["context_lease_id"] = lease.context_lease_id
+                response["context_lease_expires_at"] = lease.expires_at
+            return response
         if method == "pi.mission.create":
             # PNA-6（规格 §13）：/new /fork 的新 Mission——fork 强制
             # SIMULATION，authority（grant/permit/approval）永不复制。
@@ -209,6 +238,7 @@ class PiBridgeServer:
                         body_hash=str(params.get("body_hash", "")),
                         mode=str(params.get("mode", "")),
                         idempotency_key=str(params.get("idempotency_key", "")),
+                        context_lease_id=str(params.get("context_lease_id", "")),
                     ),
                     capability_id=str(params.get("capability_id", "")),
                     arguments=dict(params.get("arguments") or {}),
@@ -221,12 +251,32 @@ class PiBridgeServer:
                         "code": getattr(exc, "code", "PROPOSE_FAILED")}
             return {"ok": True, "card": card}
         if method == "pi.action.status":
+            # HOTFIX-1（P0-4B）：status 也必须证明调用方是卡主——只凭
+            # approval_id 不得窥探卡状态。
             from rosclaw.agentd.pi_bridge.action_admission import (
                 ActionAdmissionService,
             )
 
+            caller_session = str(params.get("pi_session_id", ""))
+            if not caller_session:
+                return {
+                    "ok": False,
+                    "error": "pi_session_id required (card ownership check)",
+                    "code": "REQUEST_CONTEXT_REQUIRED",
+                }
+            binding = self._bindings.binding_for_session(caller_session)
+            approval_id = str(params.get("approval_id", ""))
+            stored = service._broker.get_request(approval_id)
+            if stored is not None and (
+                binding is None or binding.mission_id != stored.mission_id
+            ):
+                return {
+                    "ok": False,
+                    "error": "not your card",
+                    "code": "FORBIDDEN",
+                }
             return {"ok": True, **ActionAdmissionService(service).decision_status(
-                str(params.get("approval_id", ""))
+                approval_id
             )}
         if method == "pi.action.execute":
             # P0-NA-10：execute 也带请求上下文做 TOCTOU 复验。
@@ -236,16 +286,24 @@ class PiBridgeServer:
             )
 
             admission = ActionAdmissionService(service)
-            request_ctx = None
-            if params.get("pi_session_id"):
-                request_ctx = ActionRequestContext(
-                    pi_session_id=str(params.get("pi_session_id", "")),
-                    mission_id=str(params.get("mission_id", "")),
-                    context_revision=int(params.get("context_revision", -1)),
-                    body_hash=str(params.get("body_hash", "")),
-                    mode=str(params.get("mode", "")),
-                    idempotency_key=str(params.get("idempotency_key", "")),
-                )
+            # HOTFIX-1（P0-4B）：请求上下文强制必填——没有"只给
+            # approval_id 就执行"的绕过路径。
+            if not params.get("pi_session_id"):
+                return {
+                    "ok": False,
+                    "error": "full request context required (pi_session_id/mission_id/"
+                    "context_revision/body_hash/mode/idempotency_key/context_lease_id)",
+                    "code": "REQUEST_CONTEXT_REQUIRED",
+                }
+            request_ctx = ActionRequestContext(
+                pi_session_id=str(params.get("pi_session_id", "")),
+                mission_id=str(params.get("mission_id", "")),
+                context_revision=int(params.get("context_revision", -1)),
+                body_hash=str(params.get("body_hash", "")),
+                mode=str(params.get("mode", "")),
+                idempotency_key=str(params.get("idempotency_key", "")),
+                context_lease_id=str(params.get("context_lease_id", "")),
+            )
             try:
                 result = await admission.execute(
                     str(params.get("approval_id", "")), request=request_ctx

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -351,6 +351,7 @@ class PiToolDispatcher:
             body_hash=body_hash,
             mode=mission.mode.value if mission else "",
             idempotency_key=request.idempotency_key,
+            context_lease_id=request.context_lease_id,
         )
         admission = ActionAdmissionService(self._service)
         card = await admission.propose(

--- a/src/rosclaw/contracts/pi/tool_request.py
+++ b/src/rosclaw/contracts/pi/tool_request.py
@@ -22,6 +22,9 @@ class PiToolRequestV1(ContractModel):
     requested_at: str
     idempotency_key: str
     actor: dict[str, Any] = Field(default_factory=dict)
+    # HOTFIX-1（P0-4A）：agentd 签发的 ValidatedContextLease——action 类
+    # 工具必须出示（admission 硬校验；缺即 CONTEXT_LEASE_REQUIRED）。
+    context_lease_id: str = ""
 
 
 class PiToolResultV1(ContractModel):

--- a/src/rosclaw/storage/migrations/017_pi_context_leases_sqlite.sql
+++ b/src/rosclaw/storage/migrations/017_pi_context_leases_sqlite.sql
@@ -1,0 +1,21 @@
+-- 017：ValidatedContextLeaseV1（四审 HOTFIX-1，P0-4A）
+-- agentd 签发的短期具身上下文准入证——action propose/execute 必须
+-- 出示有效 lease；context fetch 失败/TTL 到期/session 切换立即失效。
+-- 模型永远看不到它（只对 admission 有效，不是执行权）。
+
+CREATE TABLE IF NOT EXISTS pi_context_leases (
+    context_lease_id TEXT PRIMARY KEY,
+    pi_session_id TEXT NOT NULL,
+    mission_id TEXT NOT NULL,
+    context_revision INTEGER NOT NULL,
+    context_hash TEXT NOT NULL,
+    body_hash TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    issued_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    revoked INTEGER NOT NULL DEFAULT 0
+);
+
+-- 一个 (session, mission) 同时只有一个有效 lease（新签发即撤旧）。
+CREATE INDEX IF NOT EXISTS idx_pi_context_leases_session
+    ON pi_context_leases (pi_session_id, mission_id, revoked);

--- a/tests/agentd/test_action_admission_red.py
+++ b/tests/agentd/test_action_admission_red.py
@@ -173,7 +173,11 @@ async def test_stale_context_forced_tool_call_cannot_create_card(tmp_path: Path)
         },
     )
     assert not result.get("ok"), "stale/伪造 revision 的 propose 竟然成功"
+    # HOTFIX-1 后这条路径先被 context lease 拦截（无 lease 即
+    # CONTEXT_LEASE_REQUIRED）；旧 revision/body 校验层仍保留。
     assert result.get("code") in (
+        "CONTEXT_LEASE_REQUIRED",
+        "CONTEXT_NOT_FRESH",
         "CONTEXT_STALE",
         "CONTEXT_REVISION_MISMATCH",
         "BODY_HASH_MISMATCH",

--- a/tests/agentd/test_hotfix1_context_lease.py
+++ b/tests/agentd/test_hotfix1_context_lease.py
@@ -1,0 +1,238 @@
+"""HOTFIX-1 红测试（四审 P0-4A/4B）：ValidatedContextLeaseV1。
+
+红测试先行——以下缺陷必须稳定复现，修复后转绿：
+
+1. context 拉取失败但 revision 未变（同 revision stale）→ 仍能建卡；
+2. body_hash 为空被放行（TS 在无 Body 时发空字符串）；
+3. idempotency_key 为空被放行；
+4. pi.action.execute 不带请求上下文（request=None）→ 仍执行已批准卡；
+5. pi.action.propose/execute 不带 context_lease_id → 拒绝；
+6. context lease 过期/被撤销 → propose/execute 拒绝；
+7. pi.action.status 不校验调用方 session → 可窥探他人卡状态。
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "rosclaw"
+
+
+async def _setup_bound(tmp_path: Path):
+    from rosclaw.agentd.config import load_agent_config
+    from rosclaw.agentd.models.gateway import MockModelGateway
+    from rosclaw.agentd.models.profiles import mock_profile
+    from rosclaw.agentd.pi_bridge.session_binding import SessionBindingStore
+    from rosclaw.agentd.service import AgentService
+    from tests.agentd.test_pi_tool_bridge import _turn
+
+    config = load_agent_config(tmp_path / "config.yaml")
+    service = AgentService(
+        config, tmp_path, gateway=MockModelGateway(mock_profile(), [_turn()] * 4)
+    )
+    mission = service.create_mission("hotfix-1", mode="SIMULATION")
+    bindings = SessionBindingStore(service._store.connection)
+    bindings.bind(
+        pi_session_id="pi_1", pi_session_path="", mission_id=mission.mission_id,
+        body_id="sim/ur5e", execution_mode="SIMULATION", created_by="user:local:1000",
+    )
+    bindings.acquire_lease(
+        mission_id=mission.mission_id, pi_session_id="pi_1", owner_pid=1, owner_uid=1000
+    )
+    return service, mission
+
+
+def _ctx(service, mission, **overrides):
+    from rosclaw.agentd.pi_bridge.action_admission import ActionRequestContext
+
+    snapshot = service.snapshot(mission.mission_id)
+    return ActionRequestContext(
+        pi_session_id=overrides.get("session", "pi_1"),
+        mission_id=mission.mission_id,
+        context_revision=overrides.get("revision", snapshot.context_revision),
+        body_hash=overrides.get(
+            "body_hash", mission.body_binding.effective_body_hash
+        ),
+        mode=overrides.get("mode", mission.mode.value),
+        idempotency_key=overrides.get("idem", "idem_hf1"),
+        context_lease_id=overrides.get("lease", ""),
+    )
+
+
+# ---------------------------------------------------------------- 结构红线
+
+
+def test_action_request_context_requires_lease_and_nonempty_fields() -> None:
+    """ActionRequestContext 必须含 context_lease_id，且 session/mission/
+    revision/body_hash/mode/idempotency/lease 全部非空才可构造。"""
+    source = (SRC / "agentd" / "pi_bridge" / "action_admission.py").read_text(
+        encoding="utf-8"
+    )
+    assert "context_lease_id" in source, "ActionRequestContext 缺 context_lease_id"
+    # 空 body_hash 捷径必须消失（四审 §3.1 指出的放行点）。
+    assert "current_body_hash and ctx.body_hash and" not in source, (
+        "空 body_hash 跳过校验的捷径仍在"
+    )
+
+
+def test_execute_requires_request_context_no_none_path() -> None:
+    """execute 不得存在 request=None 的绕过路径（四审 P0-4B）。"""
+    tree = ast.parse(
+        (SRC / "agentd" / "pi_bridge" / "action_admission.py").read_text(encoding="utf-8")
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "execute":
+            for arg in node.args.args + node.args.kwonlyargs:
+                if arg.arg == "request":
+                    # 注解不得是 Optional/Union with None。
+                    annotation = ast.unparse(arg.annotation) if arg.annotation else ""
+                    assert "None" not in annotation, (
+                        f"execute.request 仍允许 None: {annotation}"
+                    )
+            return
+    pytest.fail("execute method not found")
+
+
+def test_bridge_execute_always_requires_context() -> None:
+    """bridge 的 pi.action.execute 不得有'缺 pi_session_id 就传 None'分支。"""
+    source = (SRC / "agentd" / "pi_bridge" / "server.py").read_text(encoding="utf-8")
+    assert "request_ctx = None" not in source, "execute 的 None 上下文分支仍在"
+
+
+# ---------------------------------------------------------------- 运行时红线
+
+
+@pytest.mark.asyncio
+async def test_same_revision_stale_context_cannot_propose(tmp_path: Path) -> None:
+    """四审 §3.2 核心场景：context 从未成功获取（无 lease），revision
+    恰好与 snapshot 相同（比如都是 0）——也必须拒绝建卡。"""
+    import pytest as _pytest
+
+    from rosclaw.agentd.pi_bridge.action_admission import ActionAdmissionService
+    from rosclaw.agentd.pi_bridge.tool_dispatch import ToolBridgeError
+
+    service, mission = await _setup_bound(tmp_path)
+    admission = ActionAdmissionService(service)
+    with _pytest.raises(ToolBridgeError) as excinfo:
+        await admission.propose(
+            request=_ctx(service, mission, lease=""),  # 无 context lease
+            capability_id="sim_ground_truth",
+            arguments={},
+            expected_effect="x",
+            risk_tier="LOW",
+        )
+    assert excinfo.value.code in (
+        "CONTEXT_NOT_FRESH",
+        "CONTEXT_LEASE_REQUIRED",
+        "REQUEST_CONTEXT_REQUIRED",
+    ), f"同 revision 无 lease 建卡未被拒绝: {excinfo.value.code}"
+    assert service.pending_approvals(mission.mission_id) == []
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_missing_body_hash_rejected(tmp_path: Path) -> None:
+    """body_hash 为空必须拒绝（TS 无 Body 时发空字符串——不能放行）。"""
+    import pytest as _pytest
+
+    from rosclaw.agentd.pi_bridge.action_admission import ActionAdmissionService
+    from rosclaw.agentd.pi_bridge.tool_dispatch import ToolBridgeError
+
+    service, mission = await _setup_bound(tmp_path)
+    admission = ActionAdmissionService(service)
+    with _pytest.raises(ToolBridgeError) as excinfo:
+        await admission.propose(
+            request=_ctx(service, mission, body_hash=""),
+            capability_id="sim_ground_truth",
+            arguments={},
+            expected_effect="x",
+            risk_tier="LOW",
+        )
+    assert excinfo.value.code in (
+        "REQUEST_CONTEXT_REQUIRED",
+        "BODY_HASH_REQUIRED",
+        "CONTEXT_NOT_FRESH",
+        "CONTEXT_LEASE_REQUIRED",
+    )
+    assert service.pending_approvals(mission.mission_id) == []
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_missing_idempotency_key_rejected(tmp_path: Path) -> None:
+    import pytest as _pytest
+
+    from rosclaw.agentd.pi_bridge.action_admission import ActionAdmissionService
+    from rosclaw.agentd.pi_bridge.tool_dispatch import ToolBridgeError
+
+    service, mission = await _setup_bound(tmp_path)
+    admission = ActionAdmissionService(service)
+    with _pytest.raises(ToolBridgeError) as excinfo:
+        await admission.propose(
+            request=_ctx(service, mission, idem=""),
+            capability_id="sim_ground_truth",
+            arguments={},
+            expected_effect="x",
+            risk_tier="LOW",
+        )
+    assert excinfo.value.code in ("REQUEST_CONTEXT_REQUIRED", "IDEMPOTENCY_KEY_REQUIRED")
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_bridge_execute_without_context_rejected(tmp_path: Path) -> None:
+    """pi.action.execute 只给 approval_id（无请求上下文）必须拒绝——
+    不得执行已批准卡（四审 P0-4B 直接复现）。"""
+    from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+
+    service, mission = await _setup_bound(tmp_path)
+    bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+    result = await bridge._dispatch(
+        "user:local:1000",
+        1234,
+        "pi.action.execute",
+        {"token": service.control_token, "approval_id": "appr_whatever"},
+    )
+    assert not result.get("ok")
+    assert result.get("code") in (
+        "REQUEST_CONTEXT_REQUIRED",
+        "CONTEXT_LEASE_REQUIRED",
+        "APPROVAL_NOT_FOUND",  # 卡本就不存在——但必须因缺上下文先拒
+    )
+    # 关键是错误语义：缺上下文时绝不进入执行路径。
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_action_status_filters_by_session_owner(tmp_path: Path) -> None:
+    """pi.action.status 必须做 card principal/session owner 过滤——
+    只凭 approval_id 不得窥探他人卡（四审 P0-4B）。"""
+    from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+
+    service, mission = await _setup_bound(tmp_path)
+    bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+    result = await bridge._dispatch(
+        "user:local:1000",
+        1234,
+        "pi.action.status",
+        {
+            "token": service.control_token,
+            "approval_id": "appr_someone_elses",
+            # 无 pi_session_id——无法证明是卡主
+        },
+    )
+    # 必须拒绝或至少不给卡内信息（MISSING/无敏感字段）。
+    if result.get("ok"):
+        assert result.get("status") == "MISSING", (
+            f"非卡主竟看到卡状态: {result}"
+        )
+    else:
+        assert result.get("code") in (
+            "REQUEST_CONTEXT_REQUIRED",
+            "FORBIDDEN",
+            "APPROVAL_NOT_FOUND",
+        )
+    await service.close()

--- a/tests/agentd/test_pi_approval.py
+++ b/tests/agentd/test_pi_approval.py
@@ -15,7 +15,7 @@ from rosclaw.agentd.operator_socket import OperatorSocketServer, operator_call
 from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
 from rosclaw.operatord.enrollment import enroll
 from rosclaw.operatord.server import OperatorDaemon
-from tests.agentd.test_pi_tool_bridge import _request, _setup
+from tests.agentd.test_pi_tool_bridge import _issue_lease, _request, _setup
 
 
 async def _setup_with_operatord(tmp_path: Path):
@@ -65,6 +65,7 @@ class TestRequestActionChain:
                     "rosclaw_request_action",
                     mission=mission.mission_id,
                     idem="idem_ra_1",
+                    lease=_issue_lease(service, mission),
                     arguments={
                         "capability_id": "sim_ground_truth",
                         "arguments": {},
@@ -101,6 +102,7 @@ class TestRequestActionChain:
                     "rosclaw_request_action",
                     mission=mission.mission_id,
                     idem="idem_ra_2",
+                    lease=_issue_lease(service, mission),
                     arguments={"capability_id": "sim_ground_truth", "arguments": {}},
                 )
             )
@@ -127,8 +129,26 @@ class TestAdmissionNegativeChain:
         )
 
         snapshot = service.snapshot(mission.mission_id)
+        # HOTFIX-1：admission 现在要求 agentd 签发的 context lease——
+        # 测试也按真实路径签发（不是绕过）。
+        from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+
+        session = overrides.get("session", "pi_1")
+        lease_id = overrides.get("lease_id")
+        if lease_id is None:
+            lease = ContextLeaseStore(service._store.connection).issue(
+                pi_session_id=session,
+                mission_id=mission.mission_id,
+                context_revision=overrides.get("revision", snapshot.context_revision),
+                context_hash="test_hash",
+                body_hash=overrides.get(
+                    "body_hash", mission.body_binding.effective_body_hash
+                ),
+                mode=overrides.get("mode", mission.mode.value),
+            )
+            lease_id = lease.context_lease_id
         ctx = ActionRequestContext(
-            pi_session_id=overrides.get("session", "pi_1"),
+            pi_session_id=session,
             mission_id=mission.mission_id,
             context_revision=overrides.get("revision", snapshot.context_revision),
             body_hash=overrides.get(
@@ -136,6 +156,7 @@ class TestAdmissionNegativeChain:
             ),
             mode=overrides.get("mode", mission.mode.value),
             idempotency_key=overrides.get("idem", "idem_neg"),
+            context_lease_id=lease_id,
         )
         admission = ActionAdmissionService(service)
         card = await admission.propose(
@@ -185,7 +206,9 @@ class TestAdmissionNegativeChain:
         service._store.bump_context_revision(mission.mission_id)
         with pytest.raises(ToolBridgeError) as excinfo:
             await admission.execute(card["approval_id"], request=ctx)
-        assert excinfo.value.code == "CONTEXT_REVISION_MISMATCH"
+        # 两层都正确：卡 revision 直接比对给 CONTEXT_REVISION_MISMATCH；
+        # lease 层（HOTFIX-1）发现 revision 前进给 CONTEXT_NOT_FRESH。
+        assert excinfo.value.code in ("CONTEXT_REVISION_MISMATCH", "CONTEXT_NOT_FRESH")
         # grant 未被消费。
         row = service._store.connection.execute(
             "SELECT consumed FROM mission_grants WHERE request_id = ?",
@@ -310,6 +333,16 @@ class TestApprovalsGet:
         )
 
         snapshot = service.snapshot(mission.mission_id)
+        from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+
+        lease = ContextLeaseStore(service._store.connection).issue(
+            pi_session_id="pi_1",
+            mission_id=mission.mission_id,
+            context_revision=snapshot.context_revision,
+            context_hash="test_hash",
+            body_hash=mission.body_binding.effective_body_hash,
+            mode=mission.mode.value,
+        )
         admission = ActionAdmissionService(service)
         card = await admission.propose(
             request=ActionRequestContext(
@@ -319,6 +352,7 @@ class TestApprovalsGet:
                 body_hash=mission.body_binding.effective_body_hash,
                 mode=mission.mode.value,
                 idempotency_key="idem_get_1",
+                context_lease_id=lease.context_lease_id,
             ),
             capability_id="sim_ground_truth",
             arguments={"beep": True},

--- a/tests/agentd/test_pi_tool_bridge.py
+++ b/tests/agentd/test_pi_tool_bridge.py
@@ -42,7 +42,24 @@ def _request(tool: str, session: str = "pi_1", mission: str = "", **kwargs) -> P
         arguments=kwargs.get("arguments", {}),
         requested_at=datetime.now(UTC).isoformat(),
         idempotency_key=kwargs.get("idem", f"idem_{tool}_{session}"),
+        context_lease_id=kwargs.get("lease", ""),
     )
+
+
+def _issue_lease(service, mission, session: str = "pi_1") -> str:
+    """按真实路径签发 ValidatedContextLease（HOTFIX-1：不绕过 admission）。"""
+    from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+
+    snapshot = service.snapshot(mission.mission_id)
+    lease = ContextLeaseStore(service._store.connection).issue(
+        pi_session_id=session,
+        mission_id=mission.mission_id,
+        context_revision=snapshot.context_revision,
+        context_hash="test_hash",
+        body_hash=mission.body_binding.effective_body_hash,
+        mode=mission.mode.value,
+    )
+    return lease.context_lease_id
 
 
 async def _setup(tmp_path: Path):


### PR DESCRIPTION
四审 P0-4A/4B（红测试先行）。

## 问题

1. context 拉取失败但 revision 未变（比如都是 0）时仍能建卡——freshness 只靠提示词约束；
2. 空 `body_hash` 被放行（校验短路）；
3. `pi.action.execute` 有 `request=None` 绕过路径；
4. `pi.action.status` 无卡主校验。

## 修复

- **ValidatedContextLeaseV1**（migration 017）：`pi.context` 校验成功后 agentd 签发（session+mission 绑定、TTL 120s、新签发撤旧、换绑作废）；
- admission 校验 lease 有效+全字段匹配；空 body_hash/idempotency/mode 一律拒绝；
- execute 请求上下文强制必填（删 None 路径）；status 要求 session+卡主校验；
- TS 全链：fetch context 带 session → 捕获 lease → applyEnvelope → action 工具出示。

## 验证

红测试 8 全绿；approval/admission/tool_bridge 29 passed；agentd 全量 452 passed；ruff clean；安装产物 PTY 旅程（lease 全生命周期验证）1 passed。