### PR TITLE
feat(hotfix-3): Session/Context 真事务——显式安全状态，无跨 Mission 继承

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -51,18 +51,22 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			options.version,
 		);
 		let modelDisplay = "";
+		let refreshHeader: () => void = () => undefined;
+		let probeTimer: ReturnType<typeof setInterval> | null = null;
 		pi.on("session_start", async (_event, ctx) => {
 			if (!ctx.hasUI) return;
 			ctx.ui.setTitle(`ROSClaw Native Agent`);
-			const refreshHeader = () => {
+			refreshHeader = () => {
 				ctx.ui.setHeader((_tui, _theme) => new Text(renderHeader(uiState.snapshot(), modelDisplay)));
 			};
 			refreshHeader();
 			// 真实探测 operatord——结果回来后再刷一次（OFFLINE/READY/
 			// UNKNOWN 都是真实返回值，绝不硬编码 ready）。
 			void uiState.probeOperator().then(() => refreshHeader());
-			// 30s 周期复探——operatord 中途上线/掉线都要反映。
-			const probeTimer = setInterval(() => {
+			// 30s 周期复探（HOTFIX-3：timer 有明确生命周期——session
+			// shutdown 时清理，不积累）。
+			if (probeTimer !== null) clearInterval(probeTimer);
+			probeTimer = setInterval(() => {
 				void uiState.probeOperator().then(() => refreshHeader());
 			}, 30_000);
 			probeTimer.unref();
@@ -102,6 +106,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			if (display && display !== modelDisplay) {
 				modelDisplay = display;
 				uiState.noteContextChanged();
+				refreshHeader();
 			}
 			const missionId = options.active.current.missionId;
 			if (!missionId) {
@@ -117,6 +122,13 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				options.active.applyEnvelope(fetched.envelope, fetched.contextLeaseId);
 				// P0-NA-16：fresh envelope 到达 → header 从 LOADING 转 FRESH。
 				uiState.noteContextChanged();
+				refreshHeader();
+			} else {
+				// HOTFIX-3（P0-4E）：context 拉取失败/过期 → 立即标记
+				// STALE + 禁动作（不再有"revision 碰巧没变就能动作"）。
+				options.active.markContextStale(fetched.note);
+				uiState.noteContextChanged();
+				refreshHeader();
 			}
 			return {
 				systemPrompt: options.systemPrompt,
@@ -353,6 +365,12 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				return undefined;
 			});
 			pi.on("session_shutdown", async () => {
+				// HOTFIX-3：timer 生命周期——shutdown 清理 operator probe
+				// timer（不积累）+ mirror 落盘。
+				if (probeTimer !== null) {
+					clearInterval(probeTimer);
+					probeTimer = null;
+				}
 				await activeMirror.flush();
 				return undefined;
 			});

--- a/packages/rosclaw-agent/src/runtime/create-runtime.ts
+++ b/packages/rosclaw-agent/src/runtime/create-runtime.ts
@@ -75,10 +75,18 @@ export async function createRosclawRuntime(
 		contextRevision: 0,
 		mode: "SIMULATION",
 		profile: options.profile,
+		contextState: "LOADING",
+		leaseState: "NONE",
+		actionsAllowed: false,
 	});
 	// P0-NA-12：coordinator 拥有 leaseManager；扩展 hook 与 main 初始
 	// 绑定都经它，lease_token 绝不丢弃、heartbeat 唯一。
 	const leaseManager = new SessionLeaseManager(options.rosclawHome);
+	// HOTFIX-3：heartbeat 连续失败 → LEASE_LOST——ActiveSessionContext
+	// 立即禁行动作（admission 的内核校验仍是最终权威）。
+	leaseManager.onLeaseLost = () => {
+		active.markLeaseLost();
+	};
 	const coordinator = new AgentSessionCoordinator({
 		rosclawHome: options.rosclawHome,
 		active,

--- a/packages/rosclaw-agent/src/session/active-context.ts
+++ b/packages/rosclaw-agent/src/session/active-context.ts
@@ -6,6 +6,9 @@
 
 import type { EmbodiedContextEnvelope } from "../extension/context-injection.js";
 
+export type ContextState = "LOADING" | "FRESH" | "STALE" | "UNAVAILABLE";
+export type LeaseState = "ACTIVE" | "LOST" | "NONE";
+
 export interface ActiveSessionState {
 	sessionId: string;
 	sessionFile?: string;
@@ -20,6 +23,14 @@ export interface ActiveSessionState {
 	profile: "developer" | "robot" | "worker";
 	/** HOTFIX-1：agentd 签发的 ValidatedContextLease（action 准入凭证）。 */
 	contextLeaseId?: string;
+	/** HOTFIX-3（P0-4E）：显式安全状态——不再是"revision>0 就猜 FRESH"。
+	 *  context 未验证时 LOADING/UNAVAILABLE，验证过才 FRESH，过期即 STALE。 */
+	contextState: ContextState;
+	/** writer lease 状态——heartbeat 连续失败即 LOST（动作禁行）。 */
+	leaseState: LeaseState;
+	/** 动作准入的 UI/tool 层单一判据——只有 FRESH + ACTIVE 才 true。
+	 *  admission 的内核校验仍是最终权威；本字段让 UI/工具提前诚实拒绝。 */
+	actionsAllowed: boolean;
 }
 
 export class ActiveSessionContext {
@@ -33,18 +44,33 @@ export class ActiveSessionContext {
 		return this.state;
 	}
 
-	/** 原子替换（NA-FIX-2 切换事务的唯一写入点）。 */
+	/** 原子替换（NA-FIX-2 切换事务的唯一写入点）。
+	 *  HOTFIX-3：replace 也必须重算派生字段——否则 A 的 actionsAllowed=true
+	 *  会随切换存活（commitState 设了 UNAVAILABLE 但 actionsAllowed 没变）。 */
 	replace(next: ActiveSessionState): void {
 		this.state = { ...next };
+		this.state = { ...this.state, actionsAllowed: this.computeActionsAllowed() };
 	}
 
 	patch(partial: Partial<ActiveSessionState>): void {
 		this.state = { ...this.state, ...partial };
+		// actionsAllowed 是派生字段——任何 patch 后重算，不留陈旧 true。
+		this.state = { ...this.state, actionsAllowed: this.computeActionsAllowed() };
+	}
+
+	private computeActionsAllowed(): boolean {
+		return (
+			this.state.missionId !== undefined
+			&& this.state.contextState === "FRESH"
+			&& this.state.leaseState === "ACTIVE"
+			&& this.state.contextLeaseId !== undefined
+		);
 	}
 
 	/** 每轮注入验证通过后写入 revision/body/mode（P0-7 的精确数据来源）。
 	 *  HOTFIX-1：agentd 签发的 context lease 一并记录——action 工具必须
-	 *  出示它（lease 只存 id；它本身不是执行权）。 */
+	 *  出示它（lease 只存 id；它本身不是执行权）。
+	 *  HOTFIX-3：验证通过即 FRESH + 重算动作准入。 */
 	applyEnvelope(envelope: EmbodiedContextEnvelope, contextLeaseId?: string): void {
 		const body = envelope.body as { body_id?: string; effective_body_hash?: string };
 		const safety = envelope.safety as { mode?: string };
@@ -53,7 +79,22 @@ export class ActiveSessionContext {
 			bodyId: body.body_id,
 			bodyHash: body.effective_body_hash,
 			...(safety.mode ? { mode: safety.mode } : {}),
+			contextState: "FRESH",
 			...(contextLeaseId ? { contextLeaseId } : {}),
 		});
+	}
+
+	/** context 拉取失败/过期（P0-4E）：清空 freshness 与动作准入——
+	 *  绝不保留旧 revision/body 当作"还能动作"。 */
+	markContextStale(note?: string): void {
+		this.patch({
+			contextState: "STALE",
+			contextLeaseId: undefined,
+		});
+	}
+
+	/** heartbeat 失败/lease 过期（P0-4E）：动作禁行。 */
+	markLeaseLost(): void {
+		this.patch({ leaseState: "LOST", contextLeaseId: undefined });
 	}
 }

--- a/packages/rosclaw-agent/src/session/coordinator.ts
+++ b/packages/rosclaw-agent/src/session/coordinator.ts
@@ -83,37 +83,49 @@ export class AgentSessionCoordinator {
 		};
 	}
 
-	/** fresh context 拉取 + 验证（失败即 stale——不落盘 revision）。 */
+	/** fresh context 拉取 + 验证 + lease（失败即 stale——不落盘 revision）。 */
 	private async freshContext(
 		missionId: string,
-	): Promise<EmbodiedContextEnvelope | null> {
-		const fetched = await fetchEmbodiedContext(this.deps.rosclawHome, missionId);
+		sessionId: string,
+	): Promise<{ envelope: EmbodiedContextEnvelope; leaseId?: string } | null> {
+		const fetched = await fetchEmbodiedContext(
+			this.deps.rosclawHome,
+			missionId,
+			sessionId,
+		);
 		if (fetched.stale || !fetched.envelope) return null;
-		return fetched.envelope;
+		return { envelope: fetched.envelope, leaseId: fetched.contextLeaseId };
 	}
 
-	/** 原子落盘：lease 状态 + fresh context + 新 session 一次性替换。 */
+	/** 原子落盘（P0-4E）：构造完整候选状态后一次性替换。
+	 *  context 失败 = 绑定成功但 NOT_READY——清空 revision/body/lease/
+	 *  动作准入，绝不继承旧 Mission 的任何数据（此前 `?? current.x`
+	 *  会把 A 的 revision/body 带进 B）。 */
 	private commitState(
 		targetSessionId: string,
 		missionId: string,
-		envelope: EmbodiedContextEnvelope | null,
+		fresh: { envelope: EmbodiedContextEnvelope; leaseId?: string } | null,
 	): void {
 		const current = this.deps.active.current;
-		const body = (envelope?.body ?? {}) as {
+		const body = (fresh?.envelope.body ?? {}) as {
 			body_id?: string;
 			effective_body_hash?: string;
 		};
-		const safety = (envelope?.safety ?? {}) as { mode?: string };
+		const safety = (fresh?.envelope.safety ?? {}) as { mode?: string };
 		const next: ActiveSessionState = {
 			...current,
 			sessionId: targetSessionId,
 			missionId,
 			bindingId: this.deps.leaseManager.active?.bindingId,
 			leaseToken: undefined, // token 只存 leaseManager，不进共享状态
-			contextRevision: envelope?.context_revision ?? current.contextRevision,
-			bodyId: body.body_id ?? current.bodyId,
-			bodyHash: body.effective_body_hash ?? current.bodyHash,
-			mode: safety.mode ?? current.mode,
+			leaseState: "ACTIVE",
+			// context：fresh 才有值；失败一律清空（NOT_READY，不继承旧值）。
+			contextRevision: fresh?.envelope.context_revision ?? 0,
+			bodyId: fresh ? body.body_id : undefined,
+			bodyHash: fresh ? body.effective_body_hash : undefined,
+			mode: fresh ? (safety.mode ?? current.mode) : current.mode,
+			contextState: fresh ? "FRESH" : "UNAVAILABLE",
+			contextLeaseId: fresh?.leaseId,
 		};
 		this.deps.active.replace(next);
 	}
@@ -160,15 +172,20 @@ export class AgentSessionCoordinator {
 		} catch (err) {
 			return this.enterNeedsBinding(`绑定失败：${(err as Error).message}`);
 		}
-		// 4. fresh context（失败 = 绑定成功但 context LOADING——不算
-		//    切换失败；before_agent_start 每轮还会重试注入，动作类工具
-		//    由 admission 的 revision 硬校验兜底）。
-		const envelope = await this.freshContext(missionId);
-		// 5. 原子替换。
-		this.commitState(targetSessionId, missionId, envelope);
+		// 4. fresh context（P0-4E：失败 = 绑定成功但 NOT_READY——
+		//    清空 revision/body/动作准入，绝不继承旧 Mission 数据）。
+		const fresh = await this.freshContext(missionId, targetSessionId);
+		// 5. 原子替换（完整候选状态，一次性）。
+		this.commitState(targetSessionId, missionId, fresh);
+		if (!fresh) {
+			this.deps.notify(
+				"已绑定新 Mission，但具身上下文不可用——动作已禁止（context 恢复后自动解除）",
+				"warning",
+			);
+		}
 		if (existing?.archived) {
 			this.deps.notify(
-				"原 Mission 已归档——已新建 SIM Mission 绑定（旧记录只读保留）",
+				"RESUME_REBOUND_TO_NEW_SIM：原 Mission 已归档——已新建 SIM Mission 绑定（旧记录只读保留，这不是原 Mission 的恢复）",
 				"warning",
 			);
 		}
@@ -203,8 +220,14 @@ export class AgentSessionCoordinator {
 		} catch (err) {
 			return this.enterNeedsBinding(`绑定失败：${(err as Error).message}`);
 		}
-		const envelope = await this.freshContext(missionId);
-		this.commitState(sessionId, missionId, envelope);
+		const fresh = await this.freshContext(missionId, sessionId);
+		this.commitState(sessionId, missionId, fresh);
+		if (!fresh) {
+			this.deps.notify(
+				"已绑定新 Mission，但具身上下文不可用——动作已禁止（context 恢复后自动解除）",
+				"warning",
+			);
+		}
 		this.deps.notify(
 			reason === "fork"
 				? `已 fork：新 SIM Mission ${missionId}（authority 不复制，来源 ${sourceMissionId ?? "—"} 仅作只读历史）`

--- a/packages/rosclaw-agent/src/session/lease-manager.ts
+++ b/packages/rosclaw-agent/src/session/lease-manager.ts
@@ -65,16 +65,43 @@ export class SessionLeaseManager {
 		}
 	}
 
+	private heartbeatFailures = 0;
+	/** HOTFIX-3（P0-4E）：heartbeat 连续失败 → LEASE_LOST 回调。 */
+	onLeaseLost: (() => void) | null = null;
+
 	private startHeartbeat(): void {
+		this.heartbeatFailures = 0;
 		this.heartbeat = setInterval(() => {
 			if (!this.current) return;
-			void bridgeCall(this.rosclawHome, "pi.session.heartbeat", {
+			void this.call(this.rosclawHome, "pi.session.heartbeat", {
 				mission_id: this.current.missionId,
 				pi_session_id: this.current.piSessionId,
 				lease_token: this.current.leaseToken,
-			}).catch(() => undefined);
+			})
+				.then((response) => {
+					// 心跳被拒（lease 过期/被抢/token 错）即失败，不等超时。
+					if (response.ok === false) {
+						this.noteHeartbeatFailure();
+					} else {
+						this.heartbeatFailures = 0;
+					}
+				})
+				.catch(() => {
+					this.noteHeartbeatFailure();
+				});
 		}, 30_000);
 		this.heartbeat.unref();
+	}
+
+	private noteHeartbeatFailure(): void {
+		this.heartbeatFailures += 1;
+		// 连续 2 次失败即判 LEASE_LOST（一次可能是网络抖动；
+		// 两次 = lease 真的没了——动作必须立即禁行）。
+		if (this.heartbeatFailures >= 2) {
+			this.stopHeartbeat();
+			this.current = null;
+			this.onLeaseLost?.();
+		}
 	}
 
 	private stopHeartbeat(): void {

--- a/packages/rosclaw-agent/src/session/lifecycle.ts
+++ b/packages/rosclaw-agent/src/session/lifecycle.ts
@@ -86,7 +86,11 @@ export async function shouldCancelTree(deps: {
 		const ctxResponse = await call(deps.rosclawHome, "pi.context", {
 			mission_id: deps.missionId,
 		});
-		if (!ctxResponse.ok) return null; // context 拉不到由注入层标 stale；tree 不背锅
+		if (!ctxResponse.ok) {
+			// HOTFIX-3（P0-4E）：context 不可达时 tree 不得放行——
+			// 无法证明没有进行中动作，fail closed。
+			return "具身上下文不可达——无法验证 tree 安全性，已阻止（fail closed）";
+		}
 		const context = ctxResponse.context as {
 			pending_approvals?: unknown[];
 			active_actions?: unknown[];
@@ -98,7 +102,8 @@ export async function shouldCancelTree(deps: {
 			return "有进行中的真实动作——tree navigation fail closed（§13.5）";
 		}
 	} catch {
-		return null;
+		// 查询异常同样不能证明安全——fail closed。
+		return "具身上下文查询异常——无法验证 tree 安全性，已阻止（fail closed）";
 	}
 	return null;
 }

--- a/packages/rosclaw-agent/src/ui/product-state.ts
+++ b/packages/rosclaw-agent/src/ui/product-state.ts
@@ -38,20 +38,18 @@ export class ProductUiState {
 		private readonly productVersion: string,
 	) {}
 
-	/** 当前只读快照（字段全部来自权威源）。 */
+	/** 当前只读快照（字段全部来自权威源）。
+	 *  HOTFIX-3：contextState 用 ActiveSessionContext 的显式状态——
+	 *  合法 revision 0 的 FRESH 不再误显 LOADING，过期 revision 12
+	 *  不再误显 FRESH（此前是"revision>0 猜 FRESH"的伪 freshness）。 */
 	snapshot(): ProductUiStateV1 {
 		const state = this.active.current;
-		const contextState: ContextState = !state.missionId
-			? "UNAVAILABLE"
-			: state.contextRevision > 0
-				? "FRESH"
-				: "LOADING";
 		return {
 			productVersion: this.productVersion,
 			missionId: state.missionId,
 			mode: state.mode,
 			bodyId: state.bodyId,
-			contextState,
+			contextState: state.missionId ? state.contextState : "UNAVAILABLE",
 			contextRevision: state.contextRevision,
 			operatorState: this.operatorState,
 			snapshotSeq: this.seq,

--- a/packages/rosclaw-agent/test/extension.test.ts
+++ b/packages/rosclaw-agent/test/extension.test.ts
@@ -26,6 +26,9 @@ async function collectHandlers() {
 		contextRevision: 0,
 		mode: "SIMULATION",
 		profile: "developer",
+		contextState: "LOADING",
+		leaseState: "NONE",
+		actionsAllowed: false,
 	});
 	const call = async () => ({ ok: false, error: "no bridge in test" });
 	const coordinator = new AgentSessionCoordinator({

--- a/packages/rosclaw-agent/test/lifecycle.test.ts
+++ b/packages/rosclaw-agent/test/lifecycle.test.ts
@@ -25,6 +25,9 @@ function makeCoordinator(
 		contextRevision: 0,
 		mode: "SIMULATION",
 		profile: "developer",
+		contextState: "LOADING",
+		leaseState: "NONE",
+		actionsAllowed: false,
 	});
 	const notes: string[] = [];
 	const leaseManager = new SessionLeaseManager("/tmp/rh", call);
@@ -220,4 +223,148 @@ test("100 次 A↔B 切换 soak：任何时刻只有一个 writer，无半切换
 			assert.equal(s, target, `round ${i}: mission ${m} writer 是 ${s}，期望 ${target}`);
 		}
 	}
+});
+
+test("场景 B（P0-4E）：A 的 body/rev 不得被带进 context 失败的 B", async () => {
+	// A: body_A/rev_12/FRESH → 切 B → B context fetch 失败 →
+	// B 必须 UNAVAILABLE/ACTIONS FORBIDDEN，且不含 A 的任何字段。
+	const { calls, call } = fakeBridge({
+		"pi.session.binding.get": {
+			ok: true,
+			binding: { mission_id: "mis_B" },
+			mission_archived: false,
+		},
+		"pi.session.bind": { ok: true, binding: { binding_id: "psb_B" }, lease_token: "t" },
+		"pi.session.release": { ok: true },
+		"pi.context": { ok: false, error: "bridge down" },
+	});
+	const { coordinator, active } = makeCoordinator(call, "mis_A");
+	// A 是 FRESH（body_A/rev 12）。
+	active.applyEnvelope(
+		{
+			schema_version: "rosclaw.embodied_context.v1",
+			mission_id: "mis_A",
+			context_revision: 12,
+			generated_at: "",
+			expires_at: "",
+			hash: "",
+			body: { body_id: "body_A", effective_body_hash: "hash_A" },
+			safety: { mode: "SIMULATION" },
+			pending_approvals: [],
+		} as never,
+		"ctxl_A",
+	);
+	// A 已绑定（leaseState ACTIVE）——否则 actionsAllowed 正确为 false。
+	active.patch({ leaseState: "ACTIVE" });
+	assert.equal(active.current.contextState, "FRESH");
+	assert.equal(active.current.actionsAllowed, true);
+	const outcome = await coordinator.resumeInitial("pi_B");
+	assert.equal(outcome.ok, true, "绑定成功但 NOT_READY 不算切换失败");
+	const state = active.current;
+	// 场景 B 核心断言：不含 A 的任何数据。
+	assert.equal(state.missionId, "mis_B");
+	assert.equal(state.contextState, "UNAVAILABLE");
+	assert.equal(state.actionsAllowed, false, "context 失败必须禁动作");
+	assert.equal(state.bodyId, undefined, "body_A 被继承了！");
+	assert.equal(state.bodyHash, undefined, "hash_A 被继承了！");
+	assert.equal(state.contextRevision, 0, "rev_12 被继承了！");
+	assert.equal(state.contextLeaseId, undefined);
+});
+
+test("revision 0 的合法 FRESH envelope 正确显示 FRESH（不再误判 LOADING）", async () => {
+	const { call } = fakeBridge({
+		"pi.session.binding.get": {
+			ok: true,
+			binding: { mission_id: "mis_fresh0" },
+			mission_archived: false,
+		},
+		"pi.session.bind": { ok: true, binding: { binding_id: "psb_f0" }, lease_token: "t" },
+		"pi.session.release": { ok: true },
+		"pi.context": {
+			ok: true,
+			context: {
+				schema_version: "rosclaw.embodied_context.v1",
+				mission_id: "mis_fresh0",
+				context_revision: 0,
+				generated_at: new Date().toISOString(),
+				expires_at: new Date(Date.now() + 60_000).toISOString(),
+				hash: "",
+				body: { body_id: "body_fresh", effective_body_hash: "h" },
+				safety: { mode: "SIMULATION" },
+				pending_approvals: [],
+			},
+			context_lease_id: "ctxl_fresh0",
+		},
+	});
+	const { coordinator, active } = makeCoordinator(call, "mis_fresh0");
+	// envelopeHash 会校验——测试 stub 的 hash 为空会 stale；绕过：
+	// 直接验证 applyEnvelope 的语义（revision 0 + FRESH 不矛盾）。
+	active.applyEnvelope(
+		{
+			schema_version: "rosclaw.embodied_context.v1",
+			mission_id: "mis_fresh0",
+			context_revision: 0,
+			generated_at: "",
+			expires_at: "",
+			hash: "",
+			body: { body_id: "body_fresh", effective_body_hash: "h" },
+			safety: { mode: "SIMULATION" },
+			pending_approvals: [],
+		} as never,
+		"ctxl_fresh0",
+	);
+	active.patch({ leaseState: "ACTIVE" });
+	assert.equal(active.current.contextRevision, 0);
+	assert.equal(active.current.contextState, "FRESH", "revision 0 的合法 envelope 必须是 FRESH");
+	assert.equal(active.current.actionsAllowed, true);
+});
+
+test("heartbeat 连续失败 → LEASE_LOST + 动作禁行", async () => {
+	let heartbeatCalls = 0;
+	const { call: baseCall } = fakeBridge({
+		"pi.session.binding.get": {
+			ok: true,
+			binding: { mission_id: "mis_hb" },
+			mission_archived: false,
+		},
+		"pi.session.bind": { ok: true, binding: { binding_id: "psb_hb" }, lease_token: "t" },
+		"pi.session.release": { ok: true },
+		"pi.context": { ok: false },
+	});
+	const call = async (home: string, method: string, params: Record<string, unknown> = {}) => {
+		if (method === "pi.session.heartbeat") {
+			heartbeatCalls += 1;
+			return { ok: false, error: "lease expired" };
+		}
+		return baseCall(home, method, params);
+	};
+	const { coordinator, active } = makeCoordinator(call, "mis_hb");
+	const { SessionLeaseManager } = await import("../src/session/lease-manager.js");
+	// 用真实 leaseManager + onLeaseLost（create-runtime 的接线语义）。
+	const leaseManager = (coordinator as unknown as { deps: { leaseManager: InstanceType<typeof SessionLeaseManager> } })
+		.deps.leaseManager;
+	let lost = false;
+	leaseManager.onLeaseLost = () => {
+		lost = true;
+		active.markLeaseLost();
+	};
+	await coordinator.resumeInitial("pi_hb");
+	// 手动触发两次 heartbeat 失败（真实 timer 是 30s——测试直接调）。
+	(leaseManager as unknown as { noteHeartbeatFailure: () => void }).noteHeartbeatFailure();
+	(leaseManager as unknown as { noteHeartbeatFailure: () => void }).noteHeartbeatFailure();
+	assert.equal(lost, true, "连续失败未触发 onLeaseLost");
+	assert.equal(active.current.leaseState, "LOST");
+	assert.equal(active.current.actionsAllowed, false, "lease 丢失必须禁动作");
+});
+
+test("tree context 不可达必须 veto（fail closed，不再放行）", async () => {
+	const { call } = fakeBridge({
+		"pi.context": { ok: false, error: "bridge down" },
+	});
+	const veto = await shouldCancelTree({
+		rosclawHome: "/tmp/rh",
+		missionId: "mis_x",
+		call,
+	});
+	assert.ok(veto?.includes("fail closed"), `context 不可达竟放行 tree: ${veto}`);
 });


### PR DESCRIPTION
四审 P0-4E。

- **ActiveSessionState 显式化**：contextState/leaseState/actionsAllowed（派生——只有 mission+FRESH+ACTIVE lease+context lease 才 true）；`replace` 也重算派生字段（修复 A 的 actionsAllowed=true 随切换存活的真 bug）；
- **commitState 候选事务**：context 失败 = 绑定成功但 NOT_READY——清空 revision/body，绝不继承旧 Mission 数据（场景 B 测试锁定）；
- **heartbeat 连续失败 → LEASE_LOST 禁动作**（此前静默吞掉）；
- **tree context 不可达一律 veto**（此前静默放行）；
- **ProductUiState 用显式状态**：合法 revision 0 正确显示 FRESH；header 立即刷新；probe timer 生命周期管理；
- **RESUME_REBOUND_TO_NEW_SIM 显式提示**；
- context 拉取失败 → markContextStale（与 admission 双层）。

验证：node 39/39（含场景 B/rev-0-FRESH/heartbeat/tree 新用例）；agentd 全量 452 passed；安装产物 PTY 旅程 1 passed。