### PR TITLE
feat(hotfix-4): TranscriptPolicy——raw reasoning 不持久化、不回放

### DIFF
--- a/packages/rosclaw-agent/patches/apply-upstream-patches.mjs
+++ b/packages/rosclaw-agent/patches/apply-upstream-patches.mjs
@@ -1,21 +1,19 @@
-/** 上游薄补丁应用器（NA-FIX-3）：patch-package 风格。
+/** 上游薄补丁应用器（NA-FIX-3 + HOTFIX-4）：patch-package 风格。
  *
  * 每个补丁：anchor（必须精确存在）→ replacement。锚点缺失即硬失败——
  * 静默不生效比构建失败更危险。
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const target = join(
-	here, "..", "node_modules", "@earendil-works", "pi-coding-agent",
-	"dist", "modes", "interactive", "interactive-mode.js",
-);
+const T = (...parts) => join(here, "..", "node_modules", ...parts);
 
 const PATCHES = [
 	{
+		target: T("@earendil-works", "pi-coding-agent", "dist", "modes", "interactive", "interactive-mode.js"),
 		name: "patch-01: rosclaw resume command formatter",
 		anchor:
 			"    const args = [APP_NAME];\n" +
@@ -34,6 +32,7 @@ const PATCHES = [
 			"    args.push(\"--session\", sessionManager.getSessionId());",
 	},
 	{
+		target: T("@earendil-works", "pi-coding-agent", "dist", "modes", "interactive", "interactive-mode.js"),
 		name: "patch-02: builtin command policy guard",
 		anchor:
 			"            text = text.trim();\n" +
@@ -54,21 +53,114 @@ const PATCHES = [
 			"              } }\n" +
 			"            // Handle commands",
 	},
+	// -- HOTFIX-4：TranscriptPolicy（P0-4G）-------------------------------------
+	// raw reasoning（thinking blocks / reasoning_content / redacted_thinking）
+	// 只作内存瞬态进度——写 session 前剥离；resume/replay/export 不再回放。
+	{
+		target: T("@earendil-works", "pi-coding-agent", "dist", "core", "session-manager.js"),
+		name: "patch-03: transcript policy — strip raw reasoning on write",
+		anchor:
+			"    appendMessage(message) {\n" +
+			"        const entry = {\n" +
+			"            type: \"message\",\n" +
+			"            id: generateId(this.byId),\n" +
+			"            parentId: this.leafId,\n" +
+			"            timestamp: new Date().toISOString(),\n" +
+			"            message,\n" +
+			"        };",
+		replacement:
+			"    appendMessage(message) {\n" +
+			"        // ROSCLAW-PATCH-03: TranscriptPolicy——raw reasoning 不持久化。\n" +
+			"        // thinking/reasoning 只用于内存瞬态进度；写 session 前剥离\n" +
+			"        // （thinking blocks + provider reasoning 字段变体）。\n" +
+			"        if (message && message.role === \"assistant\") {\n" +
+			"            const clone = { ...message };\n" +
+			"            delete clone.reasoning_content;\n" +
+			"            delete clone.reasoning;\n" +
+			"            delete clone.reasoning_text;\n" +
+			"            delete clone.redacted_thinking;\n" +
+			"            delete clone.thinking;\n" +
+			"            if (Array.isArray(clone.content)) {\n" +
+			"                clone.content = clone.content.filter((block) => {\n" +
+			"                    const t = block && block.type;\n" +
+			"                    return t !== \"thinking\" && t !== \"redacted_thinking\";\n" +
+			"                });\n" +
+			"            }\n" +
+			"            message = clone;\n" +
+			"        }\n" +
+			"        const entry = {\n" +
+			"            type: \"message\",\n" +
+			"            id: generateId(this.byId),\n" +
+			"            parentId: this.leafId,\n" +
+			"            timestamp: new Date().toISOString(),\n" +
+			"            message,\n" +
+			"        };",
+	},
+	{
+		// 注意：pi-ai 有顶层与嵌套（pi-coding-agent/node_modules）两份——
+		// 运行时实际加载嵌套副本，两份都必须打（见 patches/README.md）。
+		target: [
+			T("@earendil-works", "pi-ai", "dist", "api", "openai-completions.js"),
+			{ path: T("@earendil-works", "pi-coding-agent", "node_modules",
+				"@earendil-works", "pi-ai", "dist", "api", "openai-completions.js"),
+				optional: true },
+		],
+		name: "patch-04: transcript policy — never replay raw reasoning to provider",
+		anchor:
+			"                    // Use the signature from the first thinking block if available (for llama.cpp server + gpt-oss)\n" +
+			"                    let signature = nonEmptyThinkingBlocks[0].thinkingSignature;\n" +
+			"                    if (model.provider === \"opencode-go\" && signature === \"reasoning\") {\n" +
+			"                        signature = \"reasoning_content\";\n" +
+			"                    }\n" +
+			"                    if (signature && signature.length > 0) {\n" +
+			"                        assistantMsg[signature] = nonEmptyThinkingBlocks.map((block) => block.thinking).join(\"\\n\");\n" +
+			"                    }",
+		replacement:
+			"                    // ROSCLAW-PATCH-04: TranscriptPolicy——raw reasoning\n" +
+			"                    // 绝不回放进 provider 请求（resume/历史消息同策）。\n" +
+			"                    // thinking blocks 只作内存瞬态进度，不再外发。\n" +
+			"                    if (false) {\n" +
+			"                        let signature = nonEmptyThinkingBlocks[0].thinkingSignature;\n" +
+			"                        if (model.provider === \"opencode-go\" && signature === \"reasoning\") {\n" +
+			"                            signature = \"reasoning_content\";\n" +
+			"                        }\n" +
+			"                        if (signature && signature.length > 0) {\n" +
+			"                            assistantMsg[signature] = nonEmptyThinkingBlocks.map((block) => block.thinking).join(\"\\n\");\n" +
+			"                        }\n" +
+			"                    }",
+	},
 ];
 
-let source = readFileSync(target, "utf8");
+const grouped = new Map();
 for (const patch of PATCHES) {
-	if (source.includes(patch.replacement)) {
-		console.log(`[already applied] ${patch.name}`);
-		continue;
+	const targets = Array.isArray(patch.target) ? patch.target : [patch.target];
+	for (const raw of targets) {
+		const target = typeof raw === "string" ? raw : raw.path;
+		const optional = typeof raw === "string" ? false : Boolean(raw.optional);
+		if (optional && !existsSync(target)) {
+			console.log(`[skip optional] ${target}（npm dedupe 后不存在，正常）`);
+			continue;
+		}
+		if (!grouped.has(target)) grouped.set(target, []);
+		grouped.get(target).push(patch);
 	}
-	if (!source.includes(patch.anchor)) {
-		console.error(`PATCH ANCHOR MISSING: ${patch.name}`);
-		console.error("上游已漂移——升级 Pi 后必须人工复核补丁锚点（见 patches/README.md）。");
-		process.exit(1);
-	}
-	source = source.replace(patch.anchor, patch.replacement);
-	console.log(`[applied] ${patch.name}`);
 }
-writeFileSync(target, source);
+
+for (const [target, patches] of grouped) {
+	let source = readFileSync(target, "utf8");
+	for (const patch of patches) {
+		if (source.includes(patch.replacement)) {
+			console.log(`[already applied] ${patch.name}`);
+			continue;
+		}
+		if (!source.includes(patch.anchor)) {
+			console.error(`PATCH ANCHOR MISSING: ${patch.name}`);
+			console.error("上游已漂移——升级 Pi 后必须人工复核补丁锚点（见 patches/README.md）。");
+			process.exit(1);
+		}
+		source = source.replace(patch.anchor, patch.replacement);
+		console.log(`[applied] ${patch.name}`);
+	}
+	writeFileSync(target, source);
+}
 console.log("upstream patches applied");

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -444,7 +444,7 @@ class TestProductJourney:
                 assert operatord.poll() is None, "operatord 启动失败"
                 time.sleep(0.2)
             assert (home / "run" / "operatord.sock").exists(), "operatord.sock 未出现"
-            self._run_journey(rosclaw, env, home)
+            self._run_journey(rosclaw, env, home, fake)
         finally:
             operatord.terminate()
             try:
@@ -452,6 +452,36 @@ class TestProductJourney:
             except subprocess.TimeoutExpired:
                 operatord.kill()
             fake.close()
+
+    def _assert_no_reasoning_replay(
+        self, fake: FakeModelServer, home: Path, *, from_index: int
+    ) -> None:
+        """P0-4G TranscriptPolicy 验收：SECRET_PROBE 回合后，任何 provider
+        请求（live replay）、session 持久化文件、后续 resume 回放都不得
+        再出现 raw reasoning marker。
+
+        from_index=2：req0=你好、req1=SECRET_PROBE 自身（marker 由 fake
+        注入在响应里，请求里没有）——从 req2 起的历史消息必须零命中。
+        """
+        # 1. live replay：req[from_index:] 的任何字段不得含 marker。
+        for i, body in enumerate(fake.fake.requests[from_index:], start=from_index):
+            blob = json.dumps(body, ensure_ascii=False)
+            assert REASONING_MARKER not in blob, (
+                f"req{i} 的 provider 请求仍携带 raw reasoning marker"
+            )
+        # 2. session 持久化：Pi session JSONL 不得含 marker。
+        sessions_dir = home / "agent" / "sessions"
+        assert sessions_dir.exists(), "session 目录不存在"
+        for session_file in sessions_dir.glob("*.jsonl"):
+            content = session_file.read_text(encoding="utf-8", errors="replace")
+            assert REASONING_MARKER not in content, (
+                f"session 文件 {session_file.name} 持久化了 raw reasoning"
+            )
+            # 结构性断言：不得有 thinking/reasoning 字段变体。
+            for forbidden in ("reasoning_content", "redacted_thinking"):
+                assert forbidden not in content, (
+                    f"session 文件 {session_file.name} 含 {forbidden} 字段"
+                )
 
     def _assert_grant_consumed(self, home: Path) -> None:
         """授权→执行闭环（P0-NA-13）：直接解析 DB/事件里的结构化证据，
@@ -504,7 +534,9 @@ class TestProductJourney:
         finally:
             db.close()
 
-    def _run_journey(self, rosclaw: Path, env: dict[str, str], home: Path) -> None:
+    def _run_journey(
+        self, rosclaw: Path, env: dict[str, str], home: Path, fake: FakeModelServer
+    ) -> None:
         # NA-FIX-9 后默认引擎即 Native Agent——旅程显式验证无 --engine 的默认路径。
         session = PtySession([str(rosclaw), "chat"], env)
         try:
@@ -517,9 +549,8 @@ class TestProductJourney:
             # P0-NA-16：产品版本（launcher 传入），不是内部 npm 子包版本。
             from rosclaw import __version__ as _product_version
 
-            assert f"ROSClaw {_product_version}".encode() in session.output, (
-                f"header 未显示产品版本 {_product_version}；尾部: {session.output[-300:]!r}"
-            )
+            # header 在 operator probe 后重绘——等版本出现（不是瞬时断言）。
+            session.expect(f"ROSClaw {_product_version}".encode(), timeout=60)
             assert b"v0.1.0" not in session.output, "内部子包版本冒充产品版本"
             # Operator 状态必须是真实探测值（READY/OFFLINE/UNKNOWN），
             # 不是硬编码字符串。
@@ -540,6 +571,10 @@ class TestProductJourney:
             # 5. delegate worker。
             session.send("请委派 worker 总结这段日志\r")
             session.expect("Worker 结果已收到并验证".encode(), timeout=180)
+            # P0-4G（TranscriptPolicy）：SECRET_PROBE 回合后，任何后续
+            # provider 请求都不得携带 raw reasoning marker——live replay、
+            # session 持久化、resume 回放全链路零命中（四审核心反证点）。
+            self._assert_no_reasoning_replay(fake, home, from_index=2)
             # 6. request SIM action → 卡片 → Y。
             session.send("请播放提示音\r")
             session.expect("等待 Operator 决定".encode(), timeout=120)


### PR DESCRIPTION
四审 P0-4G。此前只 `setHideThinkingBlock`（UI 隐藏），CI artifact 证明 reasoning marker 被带进后续 provider 请求。

**修复（上游薄补丁 patch-03/04）**：
- patch-03：session-manager `appendMessage` 写 session 前剥离 thinking blocks + reasoning_content/redacted_thinking 等全部 provider 变体；
- patch-04：pi-ai 出站装配不再回放 thinking blocks（live replay 也断）；
- **关键发现**：pi-ai 有顶层与嵌套（pi-coding-agent/node_modules）两份副本，运行时实际加载嵌套副本——补丁器扩为多目标 + optional；

**旅程断言强化**：SECRET_PROBE 后任何 provider 请求零 marker（live replay）+ session JSONL 零 marker/零 reasoning 字段变体（持久化）+ resume 回放结构性保证（patch-04）。

实测：fake-requests.jsonl 0 命中、session JSONL 0 命中（修复前 req2 明确携带完整 marker）。node 39/39；journey 1 passed。