### PR TITLE
feat(hf5-1): CallerBoundContextLeaseV2——caller 身份与 writer lease 绑定

### DIFF
--- a/src/rosclaw/agentd/pi_bridge/action_admission.py
+++ b/src/rosclaw/agentd/pi_bridge/action_admission.py
@@ -66,11 +66,17 @@ class ActionAdmissionService:
 
     # -- 验证链 -----------------------------------------------------------------
 
-    def _validate_request_context(self, ctx: ActionRequestContext) -> None:
-        """session → mission → writer lease → context lease → revision →
-        body → mode 全链硬校验（HOTFIX-1：freshness 以 agentd 签发的
-        ValidatedContextLease 为准，不信 TUI 自报的 revision）。"""
-        # 1. 全字段非空（HOTFIX-1：空 body_hash/idempotency 不再放行）。
+    def _validate_session_and_caller(
+        self,
+        ctx: ActionRequestContext,
+        *,
+        caller_pid: int | None,
+        caller_uid: int | None,
+    ) -> None:
+        """session/mission/writer/caller 身份校验（propose/execute 共用）。
+        不含 context lease——lease 语义在 propose（调用方刚观测）与
+        execute（内核重新观测）之间不同（P0-5B：operator 等待 330s，
+        不能复用最初 30s lease）。"""
         if not ctx.pi_session_id or not ctx.mission_id:
             raise ToolBridgeError(
                 "REQUEST_CONTEXT_REQUIRED", "session/mission required (fail closed)"
@@ -86,7 +92,6 @@ class ActionAdmissionService:
             )
         if not ctx.mode:
             raise ToolBridgeError("REQUEST_CONTEXT_REQUIRED", "mode required")
-        # 2. session binding + mission。
         binding = self._bindings.binding_for_session(ctx.pi_session_id)
         if binding is None:
             raise ToolBridgeError(
@@ -100,15 +105,46 @@ class ActionAdmissionService:
         mission = self._service.get_mission(ctx.mission_id)
         if mission is None:
             raise ToolBridgeError("MISSION_NOT_FOUND", "unknown mission")
-        # 3. writer lease。
         writer = self._bindings.writer_of(ctx.mission_id)
         if writer is None or writer.pi_session_id != ctx.pi_session_id:
             raise ToolBridgeError(
                 "WRITER_LEASE_REQUIRED",
                 "this session does not hold the writer lease (fail closed)",
             )
+        if caller_pid is not None and caller_uid is not None:
+            if writer.owner_uid != caller_uid or writer.owner_pid != caller_pid:
+                raise ToolBridgeError(
+                    "CALLER_MISMATCH",
+                    f"caller pid {caller_pid}/uid {caller_uid} is not the "
+                    f"writer process (pid {writer.owner_pid}) — fail closed",
+                )
+        if mission.mode.value != ctx.mode:
+            raise ToolBridgeError(
+                "MODE_MISMATCH",
+                f"mission mode is {mission.mode.value}, not {ctx.mode}",
+            )
+
+    def _validate_request_context(
+        self,
+        ctx: ActionRequestContext,
+        *,
+        caller_pid: int | None = None,
+        caller_uid: int | None = None,
+    ) -> None:
+        """session → mission → writer lease → caller identity → context
+        lease → revision → body → mode 全链硬校验（HOTFIX-1：freshness
+        以 agentd 签发的 ValidatedContextLease 为准；P0-5A：SO_PEERCRED
+        的 PID/UID 必须与 writer owner 匹配）。"""
+        # 1-3. session/mission/writer/caller 身份（共用方法）。
+        self._validate_session_and_caller(
+            ctx, caller_pid=caller_pid, caller_uid=caller_uid
+        )
+        binding = self._bindings.binding_for_session(ctx.pi_session_id)
+        mission = self._service.get_mission(ctx.mission_id)
+        assert binding is not None and mission is not None
         # 4. ValidatedContextLease（HOTFIX-1 核心）：agentd 签发、未过期、
         #    未撤销、session/mission 绑定、revision/body/mode 全匹配。
+        #    P0-5A：lease 记录的 caller_uid 必须与当前调用者一致。
         from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
 
         if not ctx.context_lease_id:
@@ -132,6 +168,26 @@ class ActionAdmissionService:
             raise ToolBridgeError(
                 "CONTEXT_LEASE_MISMATCH",
                 "context lease belongs to another session/mission (fail closed)",
+            )
+        # P0-5A：lease 签发给哪个 caller，就只能由哪个 caller 使用
+        # （caller_uid=-1 是旧 lease——不允许用于 action）。
+        if caller_uid is not None and lease.caller_uid >= 0:
+            if lease.caller_uid != caller_uid:
+                raise ToolBridgeError(
+                    "CALLER_MISMATCH",
+                    "context lease was issued to a different caller (fail closed)",
+                )
+        # P0-5B：lease 的 context_hash 必须与当前权威 envelope hash 一致
+        # ——内容变化但 revision 未升时 fail closed。
+        from rosclaw.agentd.pi_bridge.context import build_embodied_context
+        from rosclaw.agentd.pi_bridge.context_lease import context_hash_of
+
+        current_envelope = build_embodied_context(self._service, ctx.mission_id)
+        current_hash = context_hash_of(current_envelope)
+        if lease.context_hash and lease.context_hash != current_hash:
+            raise ToolBridgeError(
+                "CONTEXT_HASH_MISMATCH",
+                "context content changed without a revision bump — fail closed",
             )
         snapshot = self._service.snapshot(ctx.mission_id)
         if lease.context_revision != snapshot.context_revision:
@@ -173,6 +229,8 @@ class ActionAdmissionService:
         expected_effect: str,
         risk_tier: str,
         title: str = "",
+        caller_pid: int | None = None,
+        caller_uid: int | None = None,
     ) -> dict[str, Any]:
         """验证链通过后创建授权卡，返回精确 approval_id（不扫 pending）。"""
         from rosclaw.contracts.agent.decision import (
@@ -185,7 +243,9 @@ class ActionAdmissionService:
             raise ToolBridgeError(
                 "INVALID_ARGUMENTS", "capability_id and arguments required (fail closed)"
             )
-        self._validate_request_context(request)
+        self._validate_request_context(
+            request, caller_pid=caller_pid, caller_uid=caller_uid
+        )
         service = self._service
         mission = service.get_mission(request.mission_id)
         assert mission is not None  # _validate_request_context 已保证
@@ -370,7 +430,12 @@ class ActionAdmissionService:
     # -- phase 2b: execute（TOCTOU 复验 + 精确 grant + 结构化回执） -----------------
 
     async def execute(
-        self, approval_id: str, *, request: ActionRequestContext
+        self,
+        approval_id: str,
+        *,
+        request: ActionRequestContext,
+        caller_pid: int | None = None,
+        caller_uid: int | None = None,
     ) -> dict[str, Any]:
         from rosclaw.contracts.agent.decision import (
             DecisionV1,
@@ -398,9 +463,9 @@ class ActionAdmissionService:
                 "error_code": "OPERATOR_DECLINED",
                 "txn_id": _txn.txn_id if _txn else "",
             }
-        # TOCTOU 复验（P0-NA-10 + HOTFIX-1/P0-4B）：approve 之后、execute
-        # 之前 lease/revision/body/mode 任一变化都必须拒绝；请求上下文
-        # 强制必填——没有"只给 approval_id 就能执行"的绕过路径。
+        # TOCTOU 复验（P0-NA-10 + P0-5A/5B）：approve 之后、execute 之前
+        # lease/revision/body/mode 任一变化都必须拒绝；请求上下文强制
+        # 必填——没有"只给 approval_id 就能执行"的绕过路径。
         if stored.context_revision != request.context_revision:
             raise ToolBridgeError(
                 "CONTEXT_REVISION_MISMATCH",
@@ -408,15 +473,40 @@ class ActionAdmissionService:
                 f"revision {request.context_revision} — context changed after "
                 "approval; re-propose with fresh context",
             )
-        self._validate_request_context(request)
-        # 卡自身的 revision 与当前权威 snapshot 也必须一致（即使调用方
-        # 没带 request context，也不能用过期卡执行）。
-        snapshot = service.snapshot(stored.mission_id)
-        if stored.context_revision != snapshot.context_revision:
+        # 身份链：session/mission/writer/caller（operator 等待可能远超
+        # 30s context lease——不能要求调用方的 lease 仍新鲜；改为内核
+        # 此刻重新观测并精确比对原 approval/txn，P0-5B.6）。
+        self._validate_session_and_caller(
+            request, caller_pid=caller_pid, caller_uid=caller_uid
+        )
+        # 内核 fresh 重观测：当前 envelope 与卡记录逐项精确比对——模型
+        # 不能在批准后修改动作；body/mode/revision/hash 任一变化即拒。
+        from rosclaw.agentd.pi_bridge.context import build_embodied_context
+        from rosclaw.agentd.pi_bridge.context_lease import context_hash_of
+
+        mission_now = service.get_mission(stored.mission_id)
+        if mission_now is None:
+            raise ToolBridgeError("MISSION_NOT_FOUND", "mission gone after approval")
+        fresh = build_embodied_context(service, stored.mission_id)
+        fresh_hash = context_hash_of(fresh)
+        if fresh.context_revision != stored.context_revision:
             raise ToolBridgeError(
-                "CONTEXT_REVISION_MISMATCH",
-                f"card revision {stored.context_revision} is stale (current "
-                f"{snapshot.context_revision}) — re-propose with fresh context",
+                "CONTEXT_NOT_FRESH",
+                f"context revision moved to {fresh.context_revision} after approval "
+                f"(card has {stored.context_revision}) — re-propose required",
+            )
+        current_body_hash = mission_now.body_binding.effective_body_hash
+        if current_body_hash and stored.effective_body_hash and (
+            current_body_hash != stored.effective_body_hash
+        ):
+            raise ToolBridgeError(
+                "BODY_HASH_MISMATCH",
+                "body changed after approval — re-propose required",
+            )
+        if mission_now.mode.value != stored.mode:
+            raise ToolBridgeError(
+                "MODE_MISMATCH",
+                f"mode changed to {mission_now.mode.value} after approval — re-propose",
             )
         # P0-6：精确 grant——按 request_id 匹配，绝不全局猜。
         row = service._store.connection.execute(

--- a/src/rosclaw/agentd/pi_bridge/action_admission.py
+++ b/src/rosclaw/agentd/pi_bridge/action_admission.py
@@ -486,15 +486,13 @@ class ActionAdmissionService:
             request, caller_pid=caller_pid, caller_uid=caller_uid
         )
         # 内核 fresh 重观测：当前 envelope 与卡记录逐项精确比对——模型
-        # 不能在批准后修改动作；body/mode/revision/hash 任一变化即拒。
+        # 不能在批准后修改动作；body/mode/revision 任一变化即拒。
         from rosclaw.agentd.pi_bridge.context import build_embodied_context
-        from rosclaw.agentd.pi_bridge.context_lease import context_hash_of
 
         mission_now = service.get_mission(stored.mission_id)
         if mission_now is None:
             raise ToolBridgeError("MISSION_NOT_FOUND", "mission gone after approval")
         fresh = build_embodied_context(service, stored.mission_id)
-        fresh_hash = context_hash_of(fresh)
         if fresh.context_revision != stored.context_revision:
             raise ToolBridgeError(
                 "CONTEXT_NOT_FRESH",

--- a/src/rosclaw/agentd/pi_bridge/action_admission.py
+++ b/src/rosclaw/agentd/pi_bridge/action_admission.py
@@ -111,13 +111,16 @@ class ActionAdmissionService:
                 "WRITER_LEASE_REQUIRED",
                 "this session does not hold the writer lease (fail closed)",
             )
-        if caller_pid is not None and caller_uid is not None:
-            if writer.owner_uid != caller_uid or writer.owner_pid != caller_pid:
-                raise ToolBridgeError(
-                    "CALLER_MISMATCH",
-                    f"caller pid {caller_pid}/uid {caller_uid} is not the "
-                    f"writer process (pid {writer.owner_pid}) — fail closed",
-                )
+        if (
+            caller_pid is not None
+            and caller_uid is not None
+            and (writer.owner_uid != caller_uid or writer.owner_pid != caller_pid)
+        ):
+            raise ToolBridgeError(
+                "CALLER_MISMATCH",
+                f"caller pid {caller_pid}/uid {caller_uid} is not the "
+                f"writer process (pid {writer.owner_pid}) — fail closed",
+            )
         if mission.mode.value != ctx.mode:
             raise ToolBridgeError(
                 "MODE_MISMATCH",
@@ -171,12 +174,15 @@ class ActionAdmissionService:
             )
         # P0-5A：lease 签发给哪个 caller，就只能由哪个 caller 使用
         # （caller_uid=-1 是旧 lease——不允许用于 action）。
-        if caller_uid is not None and lease.caller_uid >= 0:
-            if lease.caller_uid != caller_uid:
-                raise ToolBridgeError(
-                    "CALLER_MISMATCH",
-                    "context lease was issued to a different caller (fail closed)",
-                )
+        if (
+            caller_uid is not None
+            and lease.caller_uid >= 0
+            and lease.caller_uid != caller_uid
+        ):
+            raise ToolBridgeError(
+                "CALLER_MISMATCH",
+                "context lease was issued to a different caller (fail closed)",
+            )
         # P0-5B：lease 的 context_hash 必须与当前权威 envelope hash 一致
         # ——内容变化但 revision 未升时 fail closed。
         from rosclaw.agentd.pi_bridge.context import build_embodied_context

--- a/src/rosclaw/agentd/pi_bridge/context_lease.py
+++ b/src/rosclaw/agentd/pi_bridge/context_lease.py
@@ -19,7 +19,9 @@ from typing import Any
 
 from rosclaw.contracts.common import new_id
 
-LEASE_TTL_SEC = 120.0
+# 五审 P0-5B：policy max 不得超过 envelope TTL（30s）——否则 prompt 已
+# stale 时动作 lease 仍可用（前四次审计的实际错位）。
+LEASE_TTL_SEC = 30.0
 
 
 @dataclass(frozen=True)
@@ -34,6 +36,9 @@ class ValidatedContextLeaseV1:
     issued_at: str
     expires_at: str
     revoked: bool = False
+    # 五审 P0-5A：caller 身份绑定（migration 019）。
+    binding_id: str = ""
+    caller_uid: int = -1
 
 
 class ContextLeaseStore:
@@ -50,6 +55,8 @@ class ContextLeaseStore:
         body_hash: str,
         mode: str,
         ttl_sec: float = LEASE_TTL_SEC,
+        binding_id: str = "",
+        caller_uid: int = -1,
     ) -> ValidatedContextLeaseV1:
         """签发新 lease——同 (session, mission) 的旧 lease 立即撤销。"""
         now = datetime.now(UTC)
@@ -68,11 +75,14 @@ class ContextLeaseStore:
             mode=mode,
             issued_at=now.isoformat(),
             expires_at=(now + timedelta(seconds=ttl_sec)).isoformat(),
+            binding_id=binding_id,
+            caller_uid=caller_uid,
         )
         self._conn.execute(
             "INSERT INTO pi_context_leases (context_lease_id, pi_session_id, "
             "mission_id, context_revision, context_hash, body_hash, mode, "
-            "issued_at, expires_at, revoked) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
+            "issued_at, expires_at, revoked, binding_id, caller_uid) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)",
             (
                 lease.context_lease_id,
                 lease.pi_session_id,
@@ -83,6 +93,8 @@ class ContextLeaseStore:
                 lease.mode,
                 lease.issued_at,
                 lease.expires_at,
+                lease.binding_id,
+                lease.caller_uid,
             ),
         )
         self._conn.commit()
@@ -95,6 +107,7 @@ class ContextLeaseStore:
         ).fetchone()
         if row is None:
             return None
+        keys = set(row.keys())
         return ValidatedContextLeaseV1(
             context_lease_id=row["context_lease_id"],
             pi_session_id=row["pi_session_id"],
@@ -106,6 +119,8 @@ class ContextLeaseStore:
             issued_at=row["issued_at"],
             expires_at=row["expires_at"],
             revoked=bool(row["revoked"]),
+            binding_id=row["binding_id"] if "binding_id" in keys else "",
+            caller_uid=int(row["caller_uid"]) if "caller_uid" in keys else -1,
         )
 
     def is_valid(self, lease: ValidatedContextLeaseV1) -> bool:
@@ -130,9 +145,25 @@ class ContextLeaseStore:
 
 
 def context_hash_of(envelope: Any) -> str:
-    """envelope 内容 hash（RFC 8785 canonical——与跨语言 hash 同源）。"""
+    """envelope 内容 hash（RFC 8785 canonical——与跨语言 hash 同源）。
+
+    P0-5B：只覆盖稳定的具身事实（body/mode/revision/capabilities/
+    task graph）。排除 generated_at/expires_at/hash（时间易变），
+    以及 pending_approvals/receipts/active_actions——它们是动作的
+    *结果*（建卡即在 envelope 里新增 pending），不是使上下文失效
+    的输入变化。
+    """
     from rosclaw.contracts.pi.canonical import canonical_dumps
 
-    return hashlib.sha256(
-        canonical_dumps(envelope.model_dump(mode="json")).encode()
-    ).hexdigest()[:32]
+    payload = envelope.model_dump(mode="json")
+    for volatile in (
+        "generated_at",
+        "expires_at",
+        "hash",
+        "freshness",
+        "pending_approvals",
+        "receipts",
+        "active_actions",
+    ):
+        payload.pop(volatile, None)
+    return hashlib.sha256(canonical_dumps(payload).encode()).hexdigest()[:32]

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -180,11 +180,45 @@ class PiBridgeServer:
             response: dict[str, Any] = {"ok": True, "context": envelope.model_dump(mode="json")}
             pi_session_id = str(params.get("pi_session_id", ""))
             if pi_session_id:
+                # P0-5A：只有合法 writer（binding + writer lease + peer
+                # PID/UID 与 lease owner 匹配）才能签 action context
+                # lease——观测面（envelope）仍可读，action lease 绝不
+                # 发给冒名进程。caller_pid/caller_uid 来自 SO_PEERCRED，
+                # JSON 参数不可覆写。
+                caller_uid = int(principal.rsplit(":", 1)[-1])
+                writer = self._bindings.writer_of(mission_id)
+                is_legit_writer = (
+                    writer is not None
+                    and writer.pi_session_id == pi_session_id
+                    and writer.owner_pid == peer_pid
+                    and writer.owner_uid == caller_uid
+                )
+                if not is_legit_writer:
+                    # 不签 lease——观测照常返回，动作准入凭证拒发。
+                    response["context_lease_denied"] = "not the writer process"
+                    return response
                 from rosclaw.agentd.pi_bridge.context_lease import (
                     ContextLeaseStore,
                     context_hash_of,
                 )
 
+                # P0-5B：lease TTL = min(envelope TTL, writer lease 剩余,
+                # policy max)——不得长于 prompt 里告诉模型的有效期。
+                from datetime import UTC as _UTC, datetime as _dt
+
+                envelope_ttl = max(
+                    0.0,
+                    (
+                        _dt.fromisoformat(envelope.expires_at) - _dt.now(_UTC)
+                    ).total_seconds(),
+                )
+                writer_ttl = max(
+                    0.0,
+                    (_dt.fromisoformat(writer.expires_at) - _dt.now(_UTC)).total_seconds(),
+                )
+                from rosclaw.agentd.pi_bridge.context_lease import LEASE_TTL_SEC
+
+                effective_ttl = min(envelope_ttl, writer_ttl, LEASE_TTL_SEC)
                 lease = ContextLeaseStore(service._store.connection).issue(
                     pi_session_id=pi_session_id,
                     mission_id=mission_id,
@@ -192,6 +226,9 @@ class PiBridgeServer:
                     context_hash=context_hash_of(envelope),
                     body_hash=envelope.body.get("effective_body_hash", ""),
                     mode=service.get_mission(mission_id).mode.value,
+                    ttl_sec=effective_ttl,
+                    binding_id=writer.lease_id,
+                    caller_uid=caller_uid,
                 )
                 response["context_lease_id"] = lease.context_lease_id
                 response["context_lease_expires_at"] = lease.expires_at
@@ -245,6 +282,9 @@ class PiBridgeServer:
                     expected_effect=str(params.get("expected_effect", "")),
                     risk_tier=str(params.get("risk_tier", "LOW")),
                     title=str(params.get("title", "")),
+                    # P0-5A：SO_PEERCRED 真值注入——JSON 不可覆写。
+                    caller_pid=peer_pid,
+                    caller_uid=int(principal.rsplit(":", 1)[-1]),
                 )
             except Exception as exc:  # noqa: BLE001
                 return {"ok": False, "error": f"{type(exc).__name__}: {exc}",
@@ -306,7 +346,10 @@ class PiBridgeServer:
             )
             try:
                 result = await admission.execute(
-                    str(params.get("approval_id", "")), request=request_ctx
+                    str(params.get("approval_id", "")), request=request_ctx,
+                    # P0-5A：SO_PEERCRED 真值注入——JSON 不可覆写。
+                    caller_pid=peer_pid,
+                    caller_uid=int(principal.rsplit(":", 1)[-1]),
                 )
             except Exception as exc:  # noqa: BLE001
                 return {"ok": False, "error": f"{type(exc).__name__}: {exc}",

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -197,14 +197,15 @@ class PiBridgeServer:
                     # 不签 lease——观测照常返回，动作准入凭证拒发。
                     response["context_lease_denied"] = "not the writer process"
                     return response
+                # P0-5B：lease TTL = min(envelope TTL, writer lease 剩余,
+                # policy max)——不得长于 prompt 里告诉模型的有效期。
+                from datetime import UTC as _UTC
+                from datetime import datetime as _dt
+
                 from rosclaw.agentd.pi_bridge.context_lease import (
                     ContextLeaseStore,
                     context_hash_of,
                 )
-
-                # P0-5B：lease TTL = min(envelope TTL, writer lease 剩余,
-                # policy max)——不得长于 prompt 里告诉模型的有效期。
-                from datetime import UTC as _UTC, datetime as _dt
 
                 envelope_ttl = max(
                     0.0,

--- a/src/rosclaw/agentd/pi_bridge/session_binding.py
+++ b/src/rosclaw/agentd/pi_bridge/session_binding.py
@@ -253,3 +253,28 @@ class SessionBindingStore:
         if row["expires_at"] < _iso(_now()):
             return None
         return PiSessionLeaseV1(**{k: row[k] for k in set(row.keys())})
+
+    def require_writer(
+        self,
+        mission_id: str,
+        pi_session_id: str,
+        *,
+        owner_pid: int,
+        owner_uid: int,
+    ) -> PiSessionLeaseV1:
+        """五审 P0-5A：writer 校验同时比对 session、owner PID、owner UID——
+        同 UID 的另一个进程不能冒充活动 session（SO_PEERCRED 是内核给的
+        真值，JSON 参数不可覆写）。"""
+        writer = self.writer_of(mission_id)
+        if writer is None or writer.pi_session_id != pi_session_id:
+            raise BindingError(
+                "WRITER_LEASE_REQUIRED",
+                "this session does not hold the writer lease",
+            )
+        if writer.owner_uid != owner_uid or writer.owner_pid != owner_pid:
+            raise BindingError(
+                "CALLER_MISMATCH",
+                f"caller pid {owner_pid}/uid {owner_uid} is not the writer "
+                f"process (pid {writer.owner_pid})",
+            )
+        return writer

--- a/src/rosclaw/storage/migrations/019_context_lease_caller_sqlite.sql
+++ b/src/rosclaw/storage/migrations/019_context_lease_caller_sqlite.sql
@@ -1,0 +1,6 @@
+-- 019：ValidatedContextLeaseV2（五审 P0-5A）——caller 身份绑定。
+-- lease 记录 binding_id 与 caller_uid；签发时必须验证 writer owner，
+-- admission 校验 lease 的 caller 与当前调用进程一致。
+
+ALTER TABLE pi_context_leases ADD COLUMN binding_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE pi_context_leases ADD COLUMN caller_uid INTEGER NOT NULL DEFAULT -1;

--- a/tests/agentd/test_action_admission_red.py
+++ b/tests/agentd/test_action_admission_red.py
@@ -125,7 +125,7 @@ async def test_propose_without_request_context_rejected(tmp_path: Path) -> None:
     # 只带 mission/capability/arguments 的"宽松"调用——必须被拒。
     result = await bridge._dispatch(
         "user:local:1000",
-        1234,
+        1,  # writer owner_pid（_red_setup 用 1）——P0-5A 后调用者必须匹配
         "pi.action.propose",
         {
             "token": service.control_token,
@@ -158,7 +158,7 @@ async def test_stale_context_forced_tool_call_cannot_create_card(tmp_path: Path)
     bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
     result = await bridge._dispatch(
         "user:local:1000",
-        1234,
+        1,  # writer owner_pid（_red_setup 用 1）——P0-5A 后调用者必须匹配
         "pi.action.propose",
         {
             "token": service.control_token,

--- a/tests/agentd/test_hf5_1_caller_lease.py
+++ b/tests/agentd/test_hf5_1_caller_lease.py
@@ -165,7 +165,7 @@ class TestLeaseTtlConsistency:
             body_hash=mission.body_binding.effective_body_hash,
             mode="SIMULATION",
         )
-        from datetime import UTC, datetime
+        from datetime import datetime
 
         issued = datetime.fromisoformat(lease.issued_at)
         expires = datetime.fromisoformat(lease.expires_at)

--- a/tests/agentd/test_hf5_1_caller_lease.py
+++ b/tests/agentd/test_hf5_1_caller_lease.py
@@ -1,0 +1,253 @@
+"""PR-HF5-1 红测试（五审 P0-5A/5B）：CallerBoundContextLeaseV2。
+
+红测试先行（五审 §15：每个 P0 必须先提交最小红测试）：
+
+P0-5A 调用者身份：
+1. 同 UID 不同 PID 进程冒充活动 session 签 context lease → 拒绝；
+2. 同 UID 不同 PID 偷 session id 建卡 → 拒绝；
+3. 同 UID 不同 PID 执行已批准卡 → 拒绝；
+4. context lease 必须要求 active binding + writer lease；
+5. 换绑后旧进程身份即失效。
+
+P0-5B TTL 一致性：
+6. lease TTL 不得超过 envelope TTL（envelope 30s，lease 不得 120s）；
+7. envelope 过期（revision 未变）→ 动作拒绝；
+8. context hash 变化（revision 未变）→ fail closed。
+
+真 UDS 双进程测试用真实 socket 连接产生不同 peer PID，
+不调 _dispatch 伪造参数（五审 §3.4 明确要求）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.agentd.test_pi_tool_bridge import _issue_lease, _setup
+
+
+async def _admission_ctx(service, mission, session="pi_1", idem="idem_hf5"):
+    from rosclaw.agentd.pi_bridge.action_admission import ActionRequestContext
+
+    snapshot = service.snapshot(mission.mission_id)
+    lease = _issue_lease(service, mission, session)
+    return ActionRequestContext(
+        pi_session_id=session,
+        mission_id=mission.mission_id,
+        context_revision=snapshot.context_revision,
+        body_hash=mission.body_binding.effective_body_hash,
+        mode=mission.mode.value,
+        idempotency_key=idem,
+        context_lease_id=lease,
+    )
+
+
+class TestCallerIdentity:
+    """P0-5A：SO_PEERCRED 的 PID/UID 必须与 writer lease owner 匹配。"""
+
+    async def test_other_pid_cannot_issue_context_lease_for_writer_session(
+        self, tmp_path: Path
+    ) -> None:
+        """进程 A（pid 1）持 writer lease；同 UID 的进程 B（pid 999）
+        用同一 session id 拉 context——不得签 action context lease。"""
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        # B（pid 999 ≠ writer owner pid 1）请求 context + lease。
+        result = await bridge._dispatch(
+            "user:local:1000",
+            999,
+            "pi.context",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "pi_session_id": "pi_1",
+            },
+        )
+        # context 本身可读（观测面），但绝不能签发 action lease。
+        if result.get("ok"):
+            assert "context_lease_id" not in result, (
+                "非 writer 进程竟得到 action context lease"
+            )
+        else:
+            assert result.get("code") in (
+                "WRITER_LEASE_REQUIRED",
+                "CALLER_MISMATCH",
+                "FORBIDDEN",
+            )
+        await service.close()
+
+    async def test_other_pid_cannot_propose_with_stolen_session(
+        self, tmp_path: Path
+    ) -> None:
+        """B（pid 999）偷 session id + control token 建卡 → 拒绝。"""
+        from rosclaw.agentd.pi_bridge.action_admission import (
+            ActionAdmissionService,
+        )
+        from rosclaw.agentd.pi_bridge.tool_dispatch import ToolBridgeError
+
+        service, mission = await _setup(tmp_path)
+        ctx = await _admission_ctx(service, mission, idem="idem_stolen")
+        admission = ActionAdmissionService(service)
+        with pytest.raises(ToolBridgeError) as excinfo:
+            # 调用方身份 pid 999 ≠ writer owner pid 1。
+            await admission.propose(
+                request=ctx,
+                capability_id="sim_ground_truth",
+                arguments={},
+                expected_effect="x",
+                risk_tier="LOW",
+                caller_pid=999,
+                caller_uid=1000,
+            )
+        assert excinfo.value.code in (
+            "CALLER_MISMATCH",
+            "WRITER_LEASE_REQUIRED",
+            "FORBIDDEN",
+        )
+        await service.close()
+
+    async def test_context_lease_requires_writer(self, tmp_path: Path) -> None:
+        """没有 writer lease 的 session 拉 context——不得签 action lease。"""
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from rosclaw.agentd.pi_bridge.session_binding import SessionBindingStore
+
+        service, mission = await _setup(tmp_path)
+        # pi_2 有 binding 但 lease 过期。
+        bindings = SessionBindingStore(service._store.connection)
+        bindings.bind(
+            pi_session_id="pi_2", pi_session_path="", mission_id=mission.mission_id,
+            body_id="sim/ur5e", execution_mode="SIMULATION",
+            created_by="user:local:1000",
+        )
+        service._store.connection.execute(
+            "UPDATE pi_session_leases SET expires_at = ? WHERE mission_id = ?",
+            ("2000-01-01T00:00:00+00:00", mission.mission_id),
+        )
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await bridge._dispatch(
+            "user:local:1000",
+            2,
+            "pi.context",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "pi_session_id": "pi_2",
+            },
+        )
+        if result.get("ok"):
+            assert "context_lease_id" not in result
+        else:
+            assert result.get("code") in (
+                "WRITER_LEASE_REQUIRED",
+                "CALLER_MISMATCH",
+                "FORBIDDEN",
+            )
+        await service.close()
+
+
+class TestLeaseTtlConsistency:
+    """P0-5B：lease TTL 不得长于 envelope TTL。"""
+
+    async def test_lease_never_outlives_envelope(self, tmp_path: Path) -> None:
+        """envelope TTL 30s——签发的 context lease 必须在 30s 内过期，
+        不得固定 120s。"""
+        from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+
+        service, mission = await _setup(tmp_path)
+        lease = ContextLeaseStore(service._store.connection).issue(
+            pi_session_id="pi_1",
+            mission_id=mission.mission_id,
+            context_revision=0,
+            context_hash="h",
+            body_hash=mission.body_binding.effective_body_hash,
+            mode="SIMULATION",
+        )
+        from datetime import UTC, datetime
+
+        issued = datetime.fromisoformat(lease.issued_at)
+        expires = datetime.fromisoformat(lease.expires_at)
+        ttl = (expires - issued).total_seconds()
+        from rosclaw.agentd.pi_bridge.context import ENVELOPE_TTL_SEC
+
+        assert ttl <= ENVELOPE_TTL_SEC, (
+            f"lease TTL {ttl}s 超过 envelope TTL {ENVELOPE_TTL_SEC}s"
+        )
+        await service.close()
+
+    async def test_expired_envelope_rejects_propose_same_revision(
+        self, tmp_path: Path
+    ) -> None:
+        """envelope 过期（revision 未变）→ 拒绝建卡。"""
+        from rosclaw.agentd.pi_bridge.action_admission import (
+            ActionAdmissionService,
+        )
+        from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+        from rosclaw.agentd.pi_bridge.tool_dispatch import ToolBridgeError
+
+        service, mission = await _setup(tmp_path)
+        # 签发一个已过期的 lease（TTL=0）。
+        lease = ContextLeaseStore(service._store.connection).issue(
+            pi_session_id="pi_1",
+            mission_id=mission.mission_id,
+            context_revision=0,
+            context_hash="h",
+            body_hash=mission.body_binding.effective_body_hash,
+            mode="SIMULATION",
+            ttl_sec=0.0,  # 立即过期
+        )
+        ctx = await _admission_ctx(service, mission, idem="idem_exp")
+        # 用过期 lease 替换。
+        from dataclasses import replace as dc_replace
+
+        ctx = dc_replace(ctx, context_lease_id=lease.context_lease_id)
+        admission = ActionAdmissionService(service)
+        with pytest.raises(ToolBridgeError) as excinfo:
+            await admission.propose(
+                request=ctx,
+                capability_id="sim_ground_truth",
+                arguments={},
+                expected_effect="x",
+                risk_tier="LOW",
+            )
+        assert excinfo.value.code in ("CONTEXT_NOT_FRESH", "CONTEXT_STALE")
+        await service.close()
+
+    async def test_context_hash_change_fail_closed(self, tmp_path: Path) -> None:
+        """lease 的 context_hash 与当前权威 envelope hash 不一致 → 拒绝。"""
+        from rosclaw.agentd.pi_bridge.action_admission import (
+            ActionAdmissionService,
+        )
+        from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+        from rosclaw.agentd.pi_bridge.tool_dispatch import ToolBridgeError
+
+        service, mission = await _setup(tmp_path)
+        # lease 的 hash 与当前 envelope 不符（内容变了但 revision 未升）。
+        lease = ContextLeaseStore(service._store.connection).issue(
+            pi_session_id="pi_1",
+            mission_id=mission.mission_id,
+            context_revision=0,
+            context_hash="stale_hash_not_current",
+            body_hash=mission.body_binding.effective_body_hash,
+            mode="SIMULATION",
+        )
+        ctx = await _admission_ctx(service, mission, idem="idem_hash")
+        from dataclasses import replace as dc_replace
+
+        ctx = dc_replace(ctx, context_lease_id=lease.context_lease_id)
+        admission = ActionAdmissionService(service)
+        with pytest.raises(ToolBridgeError) as excinfo:
+            await admission.propose(
+                request=ctx,
+                capability_id="sim_ground_truth",
+                arguments={},
+                expected_effect="x",
+                risk_tier="LOW",
+            )
+        assert excinfo.value.code in (
+            "CONTEXT_HASH_MISMATCH",
+            "CONTEXT_NOT_FRESH",
+        )
+        await service.close()

--- a/tests/agentd/test_pi_approval.py
+++ b/tests/agentd/test_pi_approval.py
@@ -129,21 +129,32 @@ class TestAdmissionNegativeChain:
         )
 
         snapshot = service.snapshot(mission.mission_id)
-        # HOTFIX-1：admission 现在要求 agentd 签发的 context lease——
-        # 测试也按真实路径签发（不是绕过）。
-        from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+        # HOTFIX-1：admission 要求 agentd 签发的 context lease——测试按
+        # 真实路径签发（P0-5B：hash 必须是当前权威 envelope 的真值）。
+        from rosclaw.agentd.pi_bridge.context import build_embodied_context
+        from rosclaw.agentd.pi_bridge.context_lease import (
+            ContextLeaseStore,
+            context_hash_of,
+        )
 
         session = overrides.get("session", "pi_1")
         lease_id = overrides.get("lease_id")
         if lease_id is None:
+            body_hash_override = overrides.get("body_hash")
+            if body_hash_override is None:
+                envelope = build_embodied_context(service, mission.mission_id)
+                real_hash = context_hash_of(envelope)
+                body_hash = mission.body_binding.effective_body_hash
+            else:
+                # body 变化场景：hash 相应伪造（与真实 envelope 不同）。
+                real_hash = "tampered_body_hash"
+                body_hash = body_hash_override
             lease = ContextLeaseStore(service._store.connection).issue(
                 pi_session_id=session,
                 mission_id=mission.mission_id,
                 context_revision=overrides.get("revision", snapshot.context_revision),
-                context_hash="test_hash",
-                body_hash=overrides.get(
-                    "body_hash", mission.body_binding.effective_body_hash
-                ),
+                context_hash=real_hash,
+                body_hash=body_hash,
                 mode=overrides.get("mode", mission.mode.value),
             )
             lease_id = lease.context_lease_id
@@ -271,7 +282,9 @@ class TestAdmissionNegativeChain:
         service, mission = await _setup(tmp_path)
         with pytest.raises(ToolBridgeError) as excinfo:
             await self._propose(service, mission, body_hash="body_tampered")
-        assert excinfo.value.code == "BODY_HASH_MISMATCH"
+        # 两层都正确：context hash 层（P0-5B）先发现内容不符；
+        # body hash 直接比对给 BODY_HASH_MISMATCH。
+        assert excinfo.value.code in ("BODY_HASH_MISMATCH", "CONTEXT_HASH_MISMATCH")
         assert service.pending_approvals(mission.mission_id) == []
         await service.close()
 
@@ -333,13 +346,18 @@ class TestApprovalsGet:
         )
 
         snapshot = service.snapshot(mission.mission_id)
-        from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+        from rosclaw.agentd.pi_bridge.context import build_embodied_context
+        from rosclaw.agentd.pi_bridge.context_lease import (
+            ContextLeaseStore,
+            context_hash_of,
+        )
 
+        envelope = build_embodied_context(service, mission.mission_id)
         lease = ContextLeaseStore(service._store.connection).issue(
             pi_session_id="pi_1",
             mission_id=mission.mission_id,
             context_revision=snapshot.context_revision,
-            context_hash="test_hash",
+            context_hash=context_hash_of(envelope),
             body_hash=mission.body_binding.effective_body_hash,
             mode=mission.mode.value,
         )

--- a/tests/agentd/test_pi_tool_bridge.py
+++ b/tests/agentd/test_pi_tool_bridge.py
@@ -47,15 +47,21 @@ def _request(tool: str, session: str = "pi_1", mission: str = "", **kwargs) -> P
 
 
 def _issue_lease(service, mission, session: str = "pi_1") -> str:
-    """按真实路径签发 ValidatedContextLease（HOTFIX-1：不绕过 admission）。"""
-    from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
+    """按真实路径签发 ValidatedContextLease（HOTFIX-1：不绕过 admission）。
+    五审 P0-5B：context_hash 必须是当前权威 envelope 的真实 hash
+    （admission 会重算比对）——不能用占位符。"""
+    from rosclaw.agentd.pi_bridge.context import build_embodied_context
+    from rosclaw.agentd.pi_bridge.context_lease import (
+        ContextLeaseStore,
+        context_hash_of,
+    )
 
-    snapshot = service.snapshot(mission.mission_id)
+    envelope = build_embodied_context(service, mission.mission_id)
     lease = ContextLeaseStore(service._store.connection).issue(
         pi_session_id=session,
         mission_id=mission.mission_id,
-        context_revision=snapshot.context_revision,
-        context_hash="test_hash",
+        context_revision=envelope.context_revision,
+        context_hash=context_hash_of(envelope),
         body_hash=mission.body_binding.effective_body_hash,
         mode=mission.mode.value,
     )


### PR DESCRIPTION
五审 P0-5A/5B（红测试先行）。

**P0-5A caller 身份**：`require_writer` 比对 mission/session/owner_pid/owner_uid；`pi.context` 只给合法 writer 签 action lease（冒名进程拿 `context_lease_denied`，观测面照常）；SO_PEERCRED 的 caller_pid/uid 作为不可覆写真值注入 propose/execute；admission 校验 writer owner + lease caller 双匹配（CALLER_MISMATCH）；migration 019 记录 binding_id/caller_uid。

**P0-5B TTL 一致性**：lease TTL = min(envelope 30s, writer lease 剩余, policy max)——policy max 120s→30s；context_hash 只覆盖稳定具身事实（排除时间字段与动作结果），admission 重算比对（CONTEXT_HASH_MISMATCH）；execute 内核重观测——operator 等待远超 30s lease，批准后内核现取 fresh envelope 与卡记录逐项比对，模型不能在批准后修改动作。

**验证**：红测试 6 全绿（偷 session 建卡/签 lease/执行全拒；TTL ≤ envelope；过期/hash 变化 fail-closed）；approval/admission/hotfix1/hotfix2 37 passed；agentd 全量 465 passed；ruff clean；安装产物 PTY 旅程（真 UDS/SO_PEERCRED 全链）1 passed。