### PR TITLE
feat: EIGHT-1 Behavior Gate + 用量计量（八审 §4 P0-1/P0-8）

### DIFF
--- a/.github/workflows/native-agent-gate.yml
+++ b/.github/workflows/native-agent-gate.yml
@@ -376,3 +376,71 @@ jobs:
           assert m.get("source_checkout_accessible") is False
           print("manifest fields OK:", {k: m[k] for k in required})
           PY
+
+  # 八审 §4 P0-1：真实模型 Behavior Gate——与 Protocol Journey 并存、
+  # 互不替代。nightly 或显式 dispatch 运行；无真实 provider key 时
+  # 诚实 skip（不假绿）。artifact 为脱敏指标/verdict，无密钥无正文。
+  behavior-gate:
+    name: Real-Model Behavior Gate (Kimi K3)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+      - name: Install Python deps (repo .venv — build_release.sh 依赖它)
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -e . pytest pytest-asyncio
+      - name: Install Node deps (rosclaw-agent)
+        run: |
+          cd packages/rosclaw-agent
+          npm ci
+      - name: Run real-model behavior journey
+        id: run
+        env:
+          ROSCLAW_KIMI_API_KEY: ${{ secrets.ROSCLAW_KIMI_API_KEY }}
+        run: |
+          .venv/bin/python -m pytest tests/behavior/test_real_model_sim_star.py -q --tb=short \
+            --junitxml=/tmp/junit-behavior.xml
+      - name: Curate behavior evidence (sanitized)
+        if: always()
+        run: |
+          PACK=/tmp/behavior-pack
+          mkdir -p "$PACK"
+          SRC=$(ls -dt /tmp/pytest-of-*/pytest-*/test_sim_star_real_model0 2>/dev/null | head -1)
+          for f in behavior-metrics.json behavior-verdict.json; do
+            if [ -f "$SRC/$f" ]; then cp "$SRC/$f" "$PACK/$f"; fi
+          done
+          [ -f /tmp/junit-behavior.xml ] && cp /tmp/junit-behavior.xml "$PACK/junit.xml" || true
+          ls -la "$PACK"
+      - name: Upload behavior evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: behavior-gate-${{ github.sha }}
+          path: /tmp/behavior-pack/**
+          if-no-files-found: warn
+          retention-days: 30
+      - name: Write evidence manifest
+        if: always()
+        env:
+          GITHUB_EVENT_HEAD_SHA: ${{ github.event.head_commit.id || github.sha }}
+          GITHUB_EVENT_BASE_SHA: ${{ github.event.before || github.sha }}
+          TEST_SELECTION: "pytest tests/behavior/test_real_model_sim_star.py"
+          TEST_CONCLUSION: ${{ steps.run.outcome }}
+        run: bash scripts/ci/write_evidence_manifest.sh "${{ github.job }}" /tmp/evidence/evidence-manifest.json
+      - name: Upload evidence manifest
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: evidence-manifest-${{ github.job }}-${{ github.sha }}
+          path: /tmp/evidence/evidence-manifest.json
+          if-no-files-found: error
+          retention-days: 90

--- a/packages/rosclaw-agent/src/extension/commands.ts
+++ b/packages/rosclaw-agent/src/extension/commands.ts
@@ -133,6 +133,49 @@ export function buildCommandHandlers(deps: CommandDeps): Record<string, { descri
 				);
 			},
 		},
+		tokens: {
+			description: "Token/延迟用量分解（/tokens）",
+			handler: async (_args, ctx) => {
+				const loc = deps.locale.effective;
+				const missionId = deps.active.current.missionId;
+				if (!missionId) {
+					notify(ctx, i18nT("tokens.no_mission", loc), "warning");
+					return;
+				}
+				try {
+					const result = await deps.center.call("pi.usage", { mission_id: missionId });
+					if (!result.ok) {
+						notify(ctx, `usage: ${String(result.error ?? "")}`, "error");
+						return;
+					}
+					const u = (result.usage ?? {}) as {
+						model_turns?: number; prompt_tokens?: number;
+						completion_tokens?: number; total_tokens?: number;
+						cost_microunits?: number; wall_span_ms?: number | null;
+						provider_latency_ms?: { p50?: number | null; p95?: number | null };
+						tool_calls?: { proposed?: number; completed?: number };
+					};
+					const lat = u.provider_latency_ms ?? {};
+					const tools = u.tool_calls ?? {};
+					notify(
+						ctx,
+						`${i18nT("tokens.title", loc)}:
+` +
+						`模型请求 ${u.model_turns ?? 0} · tokens in/out/total ` +
+						`${u.prompt_tokens ?? 0}/${u.completion_tokens ?? 0}/${u.total_tokens ?? 0} · ` +
+						`成本 ${(u.cost_microunits ?? 0) / 1e6} 元
+` +
+						`provider 延迟 p50/p95 ${lat.p50 ?? "-"}/${lat.p95 ?? "-"}ms · ` +
+						`端到端跨度 ${u.wall_span_ms ?? "-"}ms
+` +
+						`工具调用 proposed/completed ${tools.proposed ?? 0}/${tools.completed ?? 0}`,
+						"info",
+					);
+				} catch (err) {
+					notify(ctx, `agentd=UNREACHABLE（${(err as Error).message}）`, "error");
+				}
+			},
+		},
 		doctor: {
 			description: "诊断摘要 + 任务就绪检查：/doctor [task <目标>]",
 			handler: async (args, ctx) => {

--- a/packages/rosclaw-agent/src/extension/input-guard.ts
+++ b/packages/rosclaw-agent/src/extension/input-guard.ts
@@ -36,6 +36,8 @@ const ROSCLAW_COMMANDS = new Set([
 	"/robot",
 	"/robots",
 	"/capabilities",
+	// PR-EIGHT-1：token/延迟用量。
+	"/tokens",
 ]);
 
 // Pi 内建（审计 §4 全表）——放行进内建 dispatch。

--- a/packages/rosclaw-agent/src/i18n/catalog.en-US.ts
+++ b/packages/rosclaw-agent/src/i18n/catalog.en-US.ts
@@ -56,4 +56,6 @@ export const CATALOG_EN: Record<CatalogKey, string> = {
 	"doctor.task_ready": "Task ready",
 	"doctor.task_missing": "Task missing capabilities",
 	"doctor.remediation": "Remediation",
+	"tokens.title": "Usage (this mission)",
+	"tokens.no_mission": "No mission bound — no usage data",
 };

--- a/packages/rosclaw-agent/src/i18n/catalog.zh-CN.ts
+++ b/packages/rosclaw-agent/src/i18n/catalog.zh-CN.ts
@@ -54,6 +54,8 @@ export const CATALOG_ZH = {
 	"doctor.task_ready": "任务就绪",
 	"doctor.task_missing": "任务缺能力",
 	"doctor.remediation": "修复建议",
+	"tokens.title": "用量（本 Mission）",
+	"tokens.no_mission": "未绑定 Mission——无用量数据",
 } as const;
 
 export type CatalogKey = keyof typeof CATALOG_ZH;

--- a/packages/rosclaw-agent/test/robot-ux.test.ts
+++ b/packages/rosclaw-agent/test/robot-ux.test.ts
@@ -51,7 +51,7 @@ test("Robot-first 命令已注册并放行", async () => {
 		locale: { effective: "zh-CN", current: { ui_locale: "auto", reply_language: "follow-user" } },
 	} as never;
 	const handlers = buildCommandHandlers(deps);
-	for (const name of ["robot", "robots", "capabilities", "doctor"]) {
+	for (const name of ["robot", "robots", "capabilities", "doctor", "tokens"]) {
 		assert.ok(handlers[name], `缺 /${name} handler`);
 		const guard = guardInput(`/${name}`, "developer");
 		assert.equal(guard.action, "continue", `/${name} 被 InputGuard 拦截`);

--- a/src/rosclaw/agentd/behavior_judge.py
+++ b/src/rosclaw/agentd/behavior_judge.py
@@ -1,0 +1,74 @@
+"""Behavior Gate 判定器（八审 §4 P0-1）。
+
+把"任务效率"从人眼审计变成机器判定：一次会话的结构化指标
+（模型请求数、动作提案数、重试分类、verifier 结果、用户交互）
+对照 SLO 给出 PASS/FAIL + 逐项违规。
+
+判定器是唯一权威——真实模型 journey、失败回归 fixture、CI artifact
+分析全部走这里，不允许各测试自造口径。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: 五角星默认 SIM 任务的 SLO（八审 §4 P0-8 表 + §7.3 发布阻断条件）。
+STAR_TASK_SLO: dict[str, Any] = {
+    "user_messages": 1,  # 用户只发一句话（0 次"继续"）
+    "user_confirmations": 0,  # 默认 SIM 零确认
+    "model_requests_max": 3,  # ≤3，目标 2
+    "action_proposals_exact": 1,  # 恰好一次任务级提案
+    "retry_budget": 0,  # schema/hash/lease/CONTEXT_NOT_FRESH 重试全零
+    "verifier_pass_required": True,  # verifier PASS 才能声称完成
+}
+
+
+def judge_session(metrics: dict[str, Any]) -> dict[str, Any]:
+    """对照 SLO 判定一次会话。metrics 键见 STAR_TASK_SLO 与测试。
+
+    返回 {"verdict": "PASS"|"FAIL", "violations": [str, ...]}——
+    violations 逐条列出（不是一句笼统 fail），供 CI artifact 与报告
+    直接引用。
+    """
+    violations: list[str] = []
+
+    user_messages = int(metrics.get("user_messages", 1))
+    if user_messages > STAR_TASK_SLO["user_messages"]:
+        violations.append(
+            f"user_messages={user_messages} > {STAR_TASK_SLO['user_messages']}"
+            "（要求用户回复'继续'——发布阻断）"
+        )
+    confirmations = int(metrics.get("user_confirmations", 0))
+    if confirmations > STAR_TASK_SLO["user_confirmations"]:
+        violations.append(
+            f"user_confirmations={confirmations} > 0（默认 SIM 不应打断）"
+        )
+    model_requests = int(metrics.get("model_requests", 0))
+    if model_requests > STAR_TASK_SLO["model_requests_max"]:
+        violations.append(
+            f"model_requests={model_requests} > {STAR_TASK_SLO['model_requests_max']}"
+        )
+    proposals = int(metrics.get("action_proposals", 0))
+    if proposals != STAR_TASK_SLO["action_proposals_exact"]:
+        violations.append(
+            f"action_proposals={proposals} != {STAR_TASK_SLO['action_proposals_exact']}"
+            "（必须恰好一次任务级提案）"
+        )
+    retries = {
+        name: int(metrics.get(key, 0))
+        for name, key in (
+            ("context_not_fresh", "context_not_fresh_retries"),
+            ("schema", "schema_retries"),
+            ("hash", "hash_retries"),
+            ("lease", "lease_retries"),
+        )
+    }
+    for name, count in retries.items():
+        if count > STAR_TASK_SLO["retry_budget"]:
+            violations.append(f"{name}_retries={count} > 0（确定性协议工作交给了 LLM）")
+    # verifier 未 PASS 却声称完成——单独即 FAIL。
+    if metrics.get("task_completed") and not metrics.get("verifier_pass"):
+        violations.append("verifier 未 PASS 却声称完成（完成真实性违规）")
+    if metrics.get("conflict_with_kernel"):
+        violations.append("模型叙述与内核权威结果冲突")
+    return {"verdict": "FAIL" if violations else "PASS", "violations": violations}

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -323,6 +323,13 @@ class PiBridgeServer:
         if method == "pi.doctor.task":
             # 七审 PR-SEVEN-5：task readiness（/doctor task <goal>）。
             return await service.doctor_task(str(params.get("goal", "")))
+        if method == "pi.usage":
+            # 八审 §4 P0-8：/tokens 的用量面（provider 请求/token 分项/
+            # 工具计数/延迟分离）。
+            mission_id = str(params.get("mission_id", ""))
+            if mission_id and service.get_mission(mission_id) is None:
+                return {"ok": False, "error": "unknown mission", "code": "MISSION_NOT_FOUND"}
+            return {"ok": True, "usage": service.usage_report(mission_id)}
         if method == "pi.capabilities":
             # 六审 §6.2.1/§6.2.6：当前 body 的可信能力面——模型不再靠猜
             # capability ID。动作能力只列 body 兼容项；不兼容/被隔离项进

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -595,6 +595,47 @@ class AgentService:
     def mission_usage(self, mission_id: str) -> dict:
         return self._usage.mission_totals(mission_id)
 
+    def usage_report(self, mission_id: str) -> dict:
+        """八审 §4 P0-8：面向 /tokens 的用量报告——provider 请求数、
+        token 分项、工具调用计数、provider 延迟与端到端跨度分离。
+        聚合实时计算，不存可变计数器。"""
+        totals = self._usage.mission_totals(mission_id)
+        rows = self._usage.rows(mission_id)
+        latencies = sorted(int(r.get("latency_ms") or 0) for r in rows)
+        latency: dict[str, int | None] = {"p50": None, "p95": None}
+        if latencies:
+            import math
+
+            latency["p50"] = latencies[
+                max(0, min(len(latencies) - 1, math.ceil(0.50 * len(latencies)) - 1))
+            ]
+            latency["p95"] = latencies[
+                max(0, min(len(latencies) - 1, math.ceil(0.95 * len(latencies)) - 1))
+            ]
+        wall_span_ms: int | None = None
+        if len(rows) >= 2:
+            from datetime import datetime
+
+            first = datetime.fromisoformat(rows[0]["recorded_at"])
+            last = datetime.fromisoformat(rows[-1]["recorded_at"])
+            wall_span_ms = int((last - first).total_seconds() * 1000)
+        tool_events = self._store.connection.execute(
+            "SELECT type, COUNT(*) AS n FROM agent_events "
+            "WHERE mission_id = ? AND type IN ('tool.proposed', 'tool.completed') "
+            "GROUP BY type",
+            (mission_id,),
+        ).fetchall()
+        tool_counts = {t: int(n) for t, n in tool_events}
+        return {
+            **totals,
+            "provider_latency_ms": latency,
+            "wall_span_ms": wall_span_ms,
+            "tool_calls": {
+                "proposed": tool_counts.get("tool.proposed", 0),
+                "completed": tool_counts.get("tool.completed", 0),
+            },
+        }
+
     async def robot_kit_status(self) -> dict:
         """七审 PR-SEVEN-1.4：kit 完整性状态——identity/capabilities/
         executor/policy/probes 要么全 READY 要么 BROKEN（不再"有

--- a/tests/behavior/test_behavior_judge.py
+++ b/tests/behavior/test_behavior_judge.py
@@ -1,0 +1,92 @@
+"""PR-EIGHT-1 红测试（八审 §4 P0-1）：Behavior Gate 判定器。
+
+红测试先行——当前没有行为判定器：真实会话的 25 次模型阶段/16 次
+动作提案/12 次 CONTEXT_NOT_FRESH/3-边五角星只能靠人眼审计。
+
+判定器必须把八审 §0 的失败特征固化为回归：同签名会话必须 FAIL；
+满足 SLO 的会话 PASS。禁止用"模型偶尔发挥不好"豁免。
+"""
+
+from __future__ import annotations
+
+
+def _judge(metrics: dict):
+    from rosclaw.agentd.behavior_judge import judge_session
+
+    return judge_session(metrics)
+
+
+def _failed_user_session() -> dict:
+    """八审 §0 记录的真实失败会话签名（2026-08-10 用户实测）。"""
+    return {
+        "goal": "draw star",
+        "user_messages": 4,  # 多次"继续"
+        "model_requests": 25,
+        "action_proposals": 16,
+        "observation_calls": 5,
+        "capability_queries": 2,
+        "context_not_fresh_retries": 12,
+        "schema_retries": 3,  # trajectory/points/hash 猜测
+        "hash_retries": 2,
+        "lease_retries": 2,
+        "task_completed": True,  # 模型自称完成
+        "verifier_pass": False,  # 只画完 3/5 边；无 verifier PASS
+        "user_confirmations": 0,
+        "conflict_with_kernel": True,  # 模型叙述与内核结果冲突
+    }
+
+
+def _good_session() -> dict:
+    """目标体验：一句话 → 1 次 task → verifier PASS。"""
+    return {
+        "goal": "draw star",
+        "user_messages": 1,
+        "model_requests": 2,
+        "action_proposals": 1,
+        "observation_calls": 0,
+        "capability_queries": 1,
+        "context_not_fresh_retries": 0,
+        "schema_retries": 0,
+        "hash_retries": 0,
+        "lease_retries": 0,
+        "task_completed": True,
+        "verifier_pass": True,
+        "user_confirmations": 0,
+        "conflict_with_kernel": False,
+    }
+
+
+class TestBehaviorJudge:
+    def test_documented_failure_session_fails(self) -> None:
+        verdict = _judge(_failed_user_session())
+        assert verdict["verdict"] == "FAIL", (
+            f"八审记录的真实失败会话竟被判过: {verdict}"
+        )
+        reasons = verdict["violations"]
+        # 关键违规逐项命中（不是一句笼统 fail）。
+        assert any("model_requests" in r for r in reasons)
+        assert any("action_proposals" in r for r in reasons)
+        assert any("context_not_fresh" in r for r in reasons)
+        assert any("verifier" in r for r in reasons)  # 未 PASS 却称完成
+        assert any("user_messages" in r for r in reasons)  # 要求"继续"
+
+    def test_good_session_passes(self) -> None:
+        verdict = _judge(_good_session())
+        assert verdict["verdict"] == "PASS", f"达标会话被误判: {verdict}"
+
+    def test_unverified_completion_is_fail(self) -> None:
+        """verifier 未 PASS 而自称完成——单独即 FAIL（发布阻断条件）。"""
+        metrics = _good_session()
+        metrics["verifier_pass"] = False
+        verdict = _judge(metrics)
+        assert verdict["verdict"] == "FAIL"
+        assert any("verifier" in r for r in verdict["violations"])
+
+    def test_slo_thresholds_visible(self) -> None:
+        """判定器暴露 SLO 阈值（CI/报告引用同一定义）。"""
+        from rosclaw.agentd.behavior_judge import STAR_TASK_SLO
+
+        assert STAR_TASK_SLO["model_requests_max"] == 3
+        assert STAR_TASK_SLO["action_proposals_exact"] == 1
+        assert STAR_TASK_SLO["user_messages"] == 1
+        assert STAR_TASK_SLO["retry_budget"] == 0

--- a/tests/behavior/test_eight1_usage.py
+++ b/tests/behavior/test_eight1_usage.py
@@ -1,0 +1,84 @@
+"""PR-EIGHT-1 红测试（八审 §4 P0-8）：可量化 token/latency 预算。
+
+红测试先行——当前没有面向用户/CI 的用量面：
+pi.usage 必须返回 provider 请求数、token 分项、工具调用计数、
+provider 延迟与端到端耗时分离——否则"任务为何昂贵"无法回答。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.agentd.test_pi_tool_bridge import _turn
+
+
+async def _service(tmp_path: Path):
+    from rosclaw.agentd.config import load_agent_config
+    from rosclaw.agentd.models.gateway import MockModelGateway
+    from rosclaw.agentd.models.profiles import mock_profile
+    from rosclaw.agentd.service import AgentService
+
+    config = load_agent_config(tmp_path / "config.yaml")
+    return AgentService(
+        config, tmp_path, gateway=MockModelGateway(mock_profile(), [_turn()] * 4)
+    )
+
+
+class TestUsageReport:
+    async def test_usage_report_shape(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+
+        service = await _service(tmp_path)
+        mission = service.create_mission("usage probe")
+        # 记两笔用量（不同延迟，验证分位数）。
+        from rosclaw.agentd.usage import UsageRecorder
+        from rosclaw.contracts.agent.model_turn import (
+            ModelTurnResultV1,
+            ModelUsage,
+        )
+
+        recorder = UsageRecorder(service._store.connection)
+        for i, latency in enumerate((120, 480)):
+            recorder.record(
+                ModelTurnResultV1(
+                    turn_id=f"turn_{i}",
+                    mission_id=mission.mission_id,
+                    provider="fake",
+                    model="fake-k3",
+                    profile="p",
+                    usage=ModelUsage(
+                        prompt_tokens=100 * (i + 1),
+                        completion_tokens=50,
+                        reasoning_tokens=0,
+                        total_tokens=100 * (i + 1) + 50,
+                        cost_microunits=0,
+                    ),
+                    latency_ms=latency,
+                    provider_request_id="",
+                    context_id="",
+                    context_revision=0,
+                    finish_reason="stop",
+                )
+            )
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await bridge._dispatch(
+            "user:local:1000",
+            1,
+            "pi.usage",
+            {"token": service.control_token, "mission_id": mission.mission_id},
+        )
+        assert result.get("ok"), result
+        report = result.get("usage") or {}
+        # provider 请求数与 token 分项。
+        assert report.get("model_turns") == 2
+        assert report.get("prompt_tokens") == 300
+        assert report.get("completion_tokens") == 100
+        assert report.get("total_tokens") == 400
+        # provider 延迟分布（p50/p95）与端到端跨度分离。
+        latency = report.get("provider_latency_ms") or {}
+        assert latency.get("p50") is not None and latency.get("p95") == 480
+        assert report.get("wall_span_ms") is not None
+        # 工具调用计数面（本测试无工具调用——必须为 0 而不是缺字段）。
+        tools = report.get("tool_calls") or {}
+        assert tools.get("proposed") == 0 and tools.get("completed") == 0
+        await service.close()

--- a/tests/behavior/test_real_model_sim_star.py
+++ b/tests/behavior/test_real_model_sim_star.py
@@ -1,0 +1,200 @@
+"""PR-EIGHT-1（八审 §4 P0-1）：真实模型 Behavior Journey。
+
+与 Protocol Journey（假模型硬编码工具链）并存、互不替代：
+
+- 测试端只给一句自然语言目标——不写死 tool call ID/顺序/参数；
+- 默认 provider 用真实 Kimi K3（env: ROSCLAW_KIMI_API_KEY /
+  KIMI_API_KEY / MOONSHOT_API_KEY——无 key 时诚实 skip，绝不假绿）；
+- 行为判定走 behavior_judge 唯一权威（与失败回归同一口径）；
+- 会话指标（模型请求/工具调用/重试分类/token/延迟）落盘为
+  artifact——清洗后无密钥，仅有结构化计数。
+
+八审 §7.3 发布阻断：fake scripted journey 绿但真实 provider journey
+红 → Gate 必须红。本测试默认 **不** 加 pytest.mark.slow 以外的豁免；
+在 CI 中由 nightly/required 矩阵驱动。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.agentd.test_product_journey import (
+    PtySession,
+    _build_and_install,
+    _hidden_source_checkout,
+)
+
+KIMI_ENV_VARS = ("ROSCLAW_KIMI_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY")
+
+
+def _provider_key() -> tuple[str, str] | None:
+    for var in KIMI_ENV_VARS:
+        value = os.environ.get(var, "")
+        if value:
+            return var, value
+    return None
+
+
+def _write_real_home(home: Path, key_var: str) -> None:
+    """真实 Kimi K3 配置——api_key 只用 env 引用（红线：绝不落盘）。"""
+    (home / "run").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "agent:\n  enabled: true\n  default_profile: kimi_k3\n"
+        "models:\n  backend: legacy\n  profiles:\n    kimi_k3:\n"
+        "      provider: kimi_code\n      model: k3\n"
+        "      base_url: https://api.kimi.com/coding/v1\n"
+        f"      api_key_ref: env:{key_var}\n"
+        "      capabilities: [llm.chat, llm.structured_decision, llm.tool_use]\n",
+        encoding="utf-8",
+    )
+    (home / "agent").mkdir(parents=True, exist_ok=True)
+    (home / "agent" / "settings.json").write_text(
+        json.dumps({"defaultProvider": "kimi-coding", "defaultModel": "k3"}),
+        encoding="utf-8",
+    )
+    (home / "agent" / "models.json").write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "kimi-coding": {
+                        "name": "Kimi Coding",
+                        "baseUrl": "https://api.kimi.com/coding/v1",
+                        "api": "openai-completions",
+                        "apiKey": f"${key_var}",
+                        "models": [
+                            {
+                                "id": "k3",
+                                "name": "Kimi K3",
+                                "contextWindow": 262144,
+                                "maxTokens": 8192,
+                            }
+                        ],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _collect_metrics(home: Path, session: PtySession) -> dict:
+    """从 missions.db + PTY 文本收集行为指标（结构化计数，无正文）。"""
+    db = sqlite3.connect(home / "agentd" / "missions.db")
+    try:
+        model_requests = db.execute(
+            "SELECT COUNT(*) FROM model_usage"
+        ).fetchone()[0]
+        action_proposals = db.execute(
+            "SELECT COUNT(*) FROM operator_requests"
+        ).fetchone()[0]
+        events = [
+            r[0]
+            for r in db.execute(
+                "SELECT type FROM agent_events ORDER BY rowid"
+            ).fetchall()
+        ]
+        receipts = db.execute(
+            "SELECT payload_json FROM agent_events WHERE type='receipt.received'"
+        ).fetchall()
+    finally:
+        db.close()
+    with session._lock:
+        clean = session.clean.decode("utf-8", "replace")
+    verifier_pass = "几何验证" in clean and (
+        "PASS" in clean or "通过" in clean or "验证通过" in clean
+    )
+    return {
+        "goal": "draw star",
+        "user_messages": 1,
+        "user_confirmations": clean.count("授权请求"),
+        "model_requests": model_requests,
+        "action_proposals": action_proposals,
+        "observation_calls": events.count("tool.proposed"),  # 粗计数见 artifact
+        "capability_queries": 0,
+        "context_not_fresh_retries": clean.count("CONTEXT_NOT_FRESH"),
+        "schema_retries": clean.count("INVALID_ARGUMENTS")
+        + clean.count("trajectory required"),
+        "hash_retries": clean.count("hash"),
+        "lease_retries": clean.count("lease"),
+        "task_completed": "完成" in clean,
+        "verifier_pass": verifier_pass,
+        "conflict_with_kernel": "冲突" in clean,
+        "_event_counts": {e: events.count(e) for e in sorted(set(events))},
+        "_receipt_count": len(receipts),
+    }
+
+
+@pytest.mark.slow
+class TestRealModelBehavior:
+    def test_sim_star_real_model(self, tmp_path: Path) -> None:
+        key = _provider_key()
+        if key is None:
+            pytest.skip(
+                "无真实 provider key（ROSCLAW_KIMI_API_KEY/KIMI_API_KEY/"
+                "MOONSHOT_API_KEY）——Behavior Gate 诚实跳过，不假绿"
+            )
+        key_var, _ = key
+        prefix, _root = _build_and_install(tmp_path)
+        home = tmp_path / "rh"
+        _write_real_home(home, key_var)
+        rosclaw = prefix / "bin" / "rosclaw"
+        env = dict(
+            os.environ,
+            ROSCLAW_HOME=str(home),
+            TERM="xterm",
+            ROSCLAW_UI_LOCALE="zh-CN",
+            PATH=f"{prefix / 'bin'}:{os.environ['PATH']}",
+        )
+        session = PtySession(
+            [str(rosclaw), "chat"], env, log_path=tmp_path / "pty-behavior.log"
+        )
+        started = time.monotonic()
+        try:
+            with _hidden_source_checkout():
+                session.expect(b"ROSClaw Native Agent", timeout=120)
+                session.send("我想用机械臂画个五角星\r")
+                # 真实模型延迟不可控——等完成证据或失败信号，最长 10 分钟。
+                deadline = time.monotonic() + 600
+                done = False
+                while time.monotonic() < deadline and not done:
+                    with session._lock:
+                        clean = session.clean
+                    if (
+                        "几何验证".encode() in clean
+                        or "验证通过".encode() in clean
+                        or "无法完成".encode() in clean
+                        or "未能完成".encode() in clean
+                    ):
+                        done = True
+                        break
+                    if session.proc.poll() is not None:
+                        break
+                    time.sleep(2.0)
+                time.sleep(2.0)  # 让最终回合落盘
+                metrics = _collect_metrics(home, session)
+                metrics["wall_seconds"] = round(time.monotonic() - started, 1)
+                metrics["settled"] = done
+                session.send("/quit\r")
+        finally:
+            session.stop()
+        # artifact：脱敏指标（结构化计数，无密钥无正文）。
+        (tmp_path / "behavior-metrics.json").write_text(
+            json.dumps(metrics, indent=1, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
+        from rosclaw.agentd.behavior_judge import judge_session
+
+        verdict = judge_session(metrics)
+        (tmp_path / "behavior-verdict.json").write_text(
+            json.dumps(verdict, indent=1, ensure_ascii=False), encoding="utf-8"
+        )
+        assert verdict["verdict"] == "PASS", (
+            f"真实模型 Behavior Gate FAIL: {verdict['violations']} "
+            f"metrics={metrics}"
+        )


### PR DESCRIPTION
## 八审 PR-EIGHT-1（红测试先行）

### Behavior Gate
- `behavior_judge`：唯一行为判定权威——SLO（用户 1 句/0 继续/≤3 模型请求/恰好 1 次动作提案/0 schema/hash/lease 重试/verifier PASS 才能称完成）+ 逐项违规
- 八审记录的真实失败会话签名（25 模型阶段/16 提案/12 次 CONTEXT_NOT_FRESH/未验证称完成）固化为回归：必须 FAIL
- `tests/behavior/test_real_model_sim_star.py`：真实 Kimi K3 PTY 旅程——只给一句自然语言，不写死任何工具顺序/ID/参数；无 key 诚实 skip（不假绿）；指标/verdict 落脱敏 artifact。与 Protocol Journey 并存不互替
- CI behavior-gate job（nightly/dispatch，secret 缺失即 skip）

### 用量计量
- `pi.usage` + `/tokens`：provider 请求数、token in/out/total、成本、provider 延迟 p50/p95 与端到端跨度分离、工具调用计数

### Red→green
- 红：`test_behavior_judge.py` 4 failed（模块不存在）；`test_eight1_usage.py` 1 failed（pi.usage 不存在）
- 绿：tests/behavior 5 passed + 1 honest skip；tests/ci 全绿；node 55/55

🤖 Generated with [Claude Code](https://claude.com/claude-code)