### PR TITLE
feat: WP-P0-1 会话可发现性（总纲 §5.1）

### DIFF
--- a/packages/rosclaw-agent/patches/apply-upstream-patches.mjs
+++ b/packages/rosclaw-agent/patches/apply-upstream-patches.mjs
@@ -13,6 +13,18 @@ const T = (...parts) => join(here, "..", "node_modules", ...parts);
 
 const PATCHES = [
 	{
+		// WP-P0-1：清理旧版 hint（'rosclaw chat --resume <id>'）——旧
+		// patch 已应用的 node_modules 会残留旧 return（先 return 先生效）。
+		// optionalAnchor：全新 npm ci 的 pristine 上游没有这行，跳过。
+		target: T("@earendil-works", "pi-coding-agent", "dist", "modes", "interactive", "interactive-mode.js"),
+		name: "patch-01b: retire pre-WP-P0-1 resume hint",
+		optionalAnchor: true,
+		anchor:
+			"    return `rosclaw chat --resume ${sessionManager.getSessionId()}`;\n",
+		replacement:
+			"    // (retired by WP-P0-1: product resume hint below)\n",
+	},
+	{
 		target: T("@earendil-works", "pi-coding-agent", "dist", "modes", "interactive", "interactive-mode.js"),
 		name: "patch-01: rosclaw resume command formatter",
 		anchor:
@@ -24,7 +36,10 @@ const PATCHES = [
 		replacement:
 			"    // ROSCLAW-PATCH-01: AppIdentity resumeCommandFormatter——恢复必须\n" +
 			"    // 经 ROSClaw runtime（kernel/binding/lease/policy），绝不引导外部 CLI。\n" +
-			"    return `rosclaw chat --resume ${sessionManager.getSessionId()}`;\n" +
+			"    // WP-P0-1：退出提示只给产品命令——不暴露内部 session id。\n" +
+			"    const __name = sessionManager.getSessionName?.() || '';\n" +
+			"    return `会话已保存${__name ? '：' + __name : ''}\\n继续：rosclaw continue\\n查看全部：rosclaw sessions`;\n" +
+			"    // ROSCLAW-PATCH-01-APPLIED\n" +
 			"    const args = [APP_NAME];\n" +
 			"    if (!sessionManager.usesDefaultSessionDir()) {\n" +
 			"        args.push(\"--session-dir\", quoteIfNeeded(sessionManager.getSessionDir()));\n" +
@@ -154,6 +169,10 @@ for (const [target, patches] of grouped) {
 			continue;
 		}
 		if (!source.includes(patch.anchor)) {
+			if (patch.optionalAnchor) {
+				console.log(`[skip: anchor absent] ${patch.name}`);
+				continue;
+			}
 			console.error(`PATCH ANCHOR MISSING: ${patch.name}`);
 			console.error("上游已漂移——升级 Pi 后必须人工复核补丁锚点（见 patches/README.md）。");
 			process.exit(1);

--- a/packages/rosclaw-agent/src/main.ts
+++ b/packages/rosclaw-agent/src/main.ts
@@ -24,6 +24,8 @@ interface CliArgs {
 	print: boolean;
 	missionId?: string;
 	resumeSessionId?: string;
+	resumeSessionPath?: string;
+	browseSessions: boolean;
 	continueLast: boolean;
 }
 
@@ -33,6 +35,8 @@ function parseArgs(argv: string[]): CliArgs {
 	let print = false;
 	let missionId: string | undefined;
 	let resumeSessionId: string | undefined;
+	let resumeSessionPath: string | undefined;
+	let browseSessions = false;
 	let continueLast = false;
 	for (let i = 0; i < argv.length; i += 1) {
 		if (argv[i] === "--profile" && argv[i + 1]) {
@@ -49,11 +53,21 @@ function parseArgs(argv: string[]): CliArgs {
 		} else if (argv[i] === "--resume" && argv[i + 1]) {
 			resumeSessionId = argv[i + 1];
 			i += 1;
+		} else if (argv[i] === "--resume-path" && argv[i + 1]) {
+			// WP-P0-1：Python 侧已把 ID/前缀/标题解析成真实路径——
+			// 不由用户输入拼路径。
+			resumeSessionPath = argv[i + 1];
+			i += 1;
+		} else if (argv[i] === "--browse-sessions") {
+			browseSessions = true;
 		} else if (argv[i] === "--continue" || argv[i] === "-c") {
 			continueLast = true;
 		}
 	}
-	return { profile, initialMessage, print, missionId, resumeSessionId, continueLast };
+	return {
+		profile, initialMessage, print, missionId,
+		resumeSessionId, resumeSessionPath, browseSessions, continueLast,
+	};
 }
 
 async function main(): Promise<number> {
@@ -61,44 +75,43 @@ async function main(): Promise<number> {
 		"@earendil-works/pi-coding-agent"
 	);
 	const { createRosclawRuntime } = await import("./runtime/create-runtime.js");
-	const { profile, initialMessage, print, missionId, resumeSessionId, continueLast } = parseArgs(
-		process.argv.slice(2),
-	);
+	const {
+		profile, initialMessage, print, missionId,
+		resumeSessionId, resumeSessionPath, browseSessions, continueLast,
+	} = parseArgs(process.argv.slice(2));
 	const rosclawHome = rosclawHomeEnv;
-	// NA-FIX-2：--resume/--continue 走 SessionManager.open（不新建 session
-	// 文件、不预建 Mission——由 coordinator 的 resumeInitial 事务接管绑定）。
-	// P0-NA-12：session id 必须是纯标识符（拒绝 ../ 路径穿越与任意 JSONL）；
-	// --continue 按文件 mtime 选最近 session，不按文件名排序。
+	// WP-P0-1（总纲 §5.1）：恢复路径全部经 Pi SessionManager 公开
+	// API——不再有手写目录扫描/mtime 排序/文件名拼接（Pi 文件名可含
+	// 时间前缀，拼接 id 是格式漂移风险）。
 	let initialSession: import("@earendil-works/pi-coding-agent").SessionManager | undefined;
-	if (resumeSessionId || continueLast) {
-		const sessionDir = `${rosclawHome}/agent/sessions`;
-		const { readdirSync, statSync, existsSync } = await import("node:fs");
-		let sessionFile = "";
-		if (resumeSessionId) {
-			if (!/^[A-Za-z0-9_-]+$/.test(resumeSessionId)) {
-				console.error(`非法 session id：${resumeSessionId}（只允许字母数字-_）`);
-				return 2;
-			}
-			const { join } = await import("node:path");
-			sessionFile = join(sessionDir, `${resumeSessionId}.jsonl`);
-			if (!existsSync(sessionFile)) {
-				console.error(
-					`session ${resumeSessionId} 不存在（${sessionDir} 下无此记录）——` +
-					"未启动未绑定会话。用 `rosclaw chat` 开新会话或 `rosclaw chat --continue` 恢复最近会话。",
-				);
-				return 2;
-			}
-		} else {
-			// --continue：mtime 最新且头可解析的 session 文件。
-			const candidates = readdirSync(sessionDir)
-				.filter((f) => f.endsWith(".jsonl"))
-				.map((f) => ({ f, mtime: statSync(`${sessionDir}/${f}`).mtimeMs }))
-				.sort((a, b) => b.mtime - a.mtime);
-			sessionFile = candidates[0] ? `${sessionDir}/${candidates[0].f}` : "";
+	const sessionDir = `${rosclawHome}/agent/sessions`;
+	if (browseSessions) {
+		const { browseSessions: openPicker } = await import("./session/picker.js");
+		const picked = await openPicker(
+			(onProgress) => SessionManager.list(process.cwd(), sessionDir, onProgress),
+			(onProgress) => SessionManager.listAll(sessionDir, onProgress),
+		);
+		if (!picked) return 0;  // 用户取消——干净退出，不建会话
+		initialSession = SessionManager.open(picked, sessionDir);
+	} else if (resumeSessionPath) {
+		initialSession = SessionManager.open(resumeSessionPath, sessionDir);
+	} else if (resumeSessionId) {
+		// 兼容路径：`chat --resume <id>`——精确 ID/唯一前缀经
+		// SessionManager.listAll 解析（拒绝路径穿越由解析保证）。
+		const { resolveSessionQuery } = await import("./session/resolve.js");
+		const sessions = await SessionManager.listAll(sessionDir);
+		const hit = resolveSessionQuery(resumeSessionId, sessions);
+		if (!hit.ok) {
+			console.error(
+				hit.error === "AMBIGUOUS"
+					? `会话不唯一（${hit.candidates.length} 个候选）——请用 rosclaw resume 打开选择器`
+					: `会话 ${resumeSessionId} 不存在——rosclaw sessions 查看全部`,
+			);
+			return 2;
 		}
-		if (sessionFile) {
-			initialSession = SessionManager.open(sessionFile, sessionDir);
-		}
+		initialSession = SessionManager.open(hit.path, sessionDir);
+	} else if (continueLast) {
+		initialSession = SessionManager.continueRecent(process.cwd(), sessionDir);
 	}
 	const { runtime, coordinator, leaseManager } = await createRosclawRuntime({
 		cwd: process.cwd(),
@@ -120,7 +133,7 @@ async function main(): Promise<number> {
 			console.error(`初始 Mission 接入失败：${outcome.reason}`);
 			return 2;
 		}
-	} else if (resumeSessionId || continueLast) {
+	} else if (resumeSessionId || resumeSessionPath || browseSessions || continueLast) {
 		// 恢复路径：重接既有绑定（丢失/已归档 → coordinator 新建 SIM
 		// 绑定并明确告知）——不再"只看到 header 就算恢复"。
 		const outcome = await coordinator.resumeInitial(sessionId);

--- a/packages/rosclaw-agent/src/session/picker.ts
+++ b/packages/rosclaw-agent/src/session/picker.ts
@@ -1,0 +1,51 @@
+/** ROSClaw 会话选择器（总纲 WP-P0-1 §5.1/§13）。
+ *
+ * 组合 Pi 0.83.0 公开 API（SessionSelectorComponent + pi-tui），不复制
+ * picker/search/tree 内核。交互结构参考上游
+ * packages/coding-agent/src/cli/session-picker.ts（MIT，固定
+ * v0.83.0；上游 selectSession 不是公开 export，本文件是总纲允许的
+ * 极薄组装层——差异测试：test/session-discovery.test.ts）。
+ */
+
+import { ProcessTerminal, TUI } from "@earendil-works/pi-tui";
+import { SessionSelectorComponent } from "@earendil-works/pi-coding-agent";
+import type { SessionInfo } from "@earendil-works/pi-coding-agent";
+
+// SessionListProgress 未从包根导出——结构类型即可（loader 签名兼容）。
+type SessionsLoader = (
+	onProgress?: (loaded: number, total: number) => void,
+) => Promise<SessionInfo[]>;
+
+/** 打开会话选择器；返回选中的 session 文件路径，取消返回 null。 */
+export async function browseSessions(
+	currentSessionsLoader: SessionsLoader,
+	allSessionsLoader: SessionsLoader,
+): Promise<string | null> {
+	const terminal = new ProcessTerminal();
+	const ui = new TUI(terminal);
+	return new Promise((resolve) => {
+		let resolved = false;
+		const finish = (path: string | null) => {
+			if (resolved) return;
+			resolved = true;
+			ui.stop();
+			resolve(path);
+		};
+		const selector = new SessionSelectorComponent(
+			currentSessionsLoader,
+			allSessionsLoader,
+			(path) => finish(path),
+			() => finish(null),
+			() => {
+				ui.stop();
+				process.exit(0);
+			},
+			() => ui.requestRender(),
+			// keybindings 为可选——缺省时组件用内建默认键位。
+			{ showRenameHint: false },
+		);
+		ui.addChild(selector);
+		ui.setFocus(selector.getSessionList());
+		ui.start();
+	});
+}

--- a/packages/rosclaw-agent/src/session/resolve.ts
+++ b/packages/rosclaw-agent/src/session/resolve.ts
@@ -1,0 +1,27 @@
+/** 会话查询解析（总纲 WP-P0-1）：精确 ID → 唯一前缀 → 标题。
+ * 纯函数（测试直接驱动）；歧义报候选不猜。 */
+
+import type { SessionInfo } from "@earendil-works/pi-coding-agent";
+
+export type SessionResolution =
+	| { ok: true; path: string; info: SessionInfo }
+	| { ok: false; error: "NOT_FOUND" | "AMBIGUOUS"; candidates: SessionInfo[] };
+
+export function resolveSessionQuery(
+	query: string,
+	sessions: SessionInfo[],
+): SessionResolution {
+	const q = query.trim();
+	if (!q) return { ok: false, error: "NOT_FOUND", candidates: [] };
+	const exact = sessions.find((s) => s.id === q);
+	if (exact) return { ok: true, path: exact.path, info: exact };
+	const prefix = sessions.filter((s) => s.id.startsWith(q));
+	if (prefix.length === 1) return { ok: true, path: prefix[0].path, info: prefix[0] };
+	if (prefix.length > 1) return { ok: false, error: "AMBIGUOUS", candidates: prefix };
+	const titled = sessions.filter(
+		(s) => (s.name ?? "").includes(q) || s.firstMessage.includes(q),
+	);
+	if (titled.length === 1) return { ok: true, path: titled[0].path, info: titled[0] };
+	if (titled.length > 1) return { ok: false, error: "AMBIGUOUS", candidates: titled };
+	return { ok: false, error: "NOT_FOUND", candidates: [] };
+}

--- a/packages/rosclaw-agent/test/session-discovery.test.ts
+++ b/packages/rosclaw-agent/test/session-discovery.test.ts
@@ -1,0 +1,45 @@
+/** WP-P0-1（总纲 §5.1）：会话查询解析——精确 ID → 唯一前缀 →
+ * 标题/首条消息；歧义报候选不猜。 */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { SessionInfo } from "@earendil-works/pi-coding-agent";
+
+function info(id: string, name: string, firstMessage: string): SessionInfo {
+	return {
+		path: `/sessions/2026-08-10T10-00-00_${id}.jsonl`,
+		id,
+		cwd: "/x",
+		name,
+		created: new Date("2026-08-10T10:00:00Z"),
+		modified: new Date("2026-08-10T11:00:00Z"),
+		messageCount: 3,
+		firstMessage,
+		allMessagesText: "",
+	} as SessionInfo;
+}
+
+test("resolveSessionQuery：ID/前缀/标题/歧义", async () => {
+	const { resolveSessionQuery } = await import("../src/session/resolve.js");
+	const sessions = [
+		info("abc123", "五角星轨迹仿真", "画五角星"),
+		info("abd999", "五角星复测", "再画一次"),
+	];
+	const byId = resolveSessionQuery("abc123", sessions);
+	assert.ok(byId.ok && byId.path.includes("abc123"));
+	const byTitle = resolveSessionQuery("五角星轨迹仿真", sessions);
+	assert.ok(byTitle.ok && byTitle.info.id === "abc123");
+	const ambiguous = resolveSessionQuery("ab", sessions);
+	assert.ok(!ambiguous.ok && ambiguous.error === "AMBIGUOUS");
+	assert.equal(ambiguous.ok ? "" : ambiguous.candidates.length, 2);
+	const missing = resolveSessionQuery("zzz", sessions);
+	assert.ok(!missing.ok && missing.error === "NOT_FOUND");
+});
+
+test("picker 是公开 API 薄组装（不复制上游 picker 内核）", async () => {
+	const { readFileSync } = await import("node:fs");
+	const source = readFileSync("src/session/picker.ts", "utf-8");
+	assert.ok(source.includes("SessionSelectorComponent"), "必须用 Pi 公开组件");
+	assert.ok(!source.includes("class SessionList"), "不得复制上游列表内核");
+	assert.ok(source.split("\n").length < 80, "薄组装层应保持极小");
+});

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -445,7 +445,30 @@ def _chat_pi(home: Path, args: argparse.Namespace) -> int:
     if getattr(args, "continue_last", False):
         resume_argv = ["--continue"]
     elif getattr(args, "resume", None):
-        resume_argv = ["--resume", args.resume]
+        query = str(args.resume)
+        if query == "__picker__":
+            # WP-P0-1：裸 --resume → 会话选择器。
+            resume_argv = ["--browse-sessions"]
+        else:
+            # WP-P0-1：ID/前缀/标题 → 真实 session 路径（用户不再
+            # 需要知道内部 ID；歧义报候选不猜）。
+            from rosclaw.agentd.session_list import (
+                list_sessions,
+                resolve_session_query,
+            )
+
+            hit = resolve_session_query(list_sessions(home), query)
+            if hit.get("error"):
+                print(f"会话未解析：{query}", file=sys.stderr)
+                for cand in hit.get("candidates", []):
+                    print(
+                        "  候选："
+                        f"{cand.get('display_name') or cand.get('first_message') or cand['session_id']}"
+                        f"（{cand['session_id'][:12]}…）",
+                        file=sys.stderr,
+                    )
+                return 2
+            resume_argv = ["--resume-path", hit["path"]]
     if args.mission:
         mission = service.get_mission(args.mission)
         if mission is None:
@@ -1136,11 +1159,75 @@ def add_agent_subparsers(subparsers) -> None:
     )
     p_chat.add_argument(
         "--resume",
+        nargs="?",
+        const="__picker__",
         default=None,
-        metavar="SESSION_ID",
-        help="恢复指定会话（Native Agent session + Mission 绑定）",
+        metavar="ID或标题",
+        # WP-P0-1：裸 --resume 打开会话选择器；参数支持精确 ID/
+        # 唯一前缀/标题（由 session_list.resolve_session_query 解析）。
+        help="恢复会话：无参数打开选择器；或给 ID/唯一前缀/标题",
     )
     p_chat.set_defaults(func=cmd_chat)
+
+    # WP-P0-1（总纲 §4.2/§5.1）：会话可发现性——用户不再需要知道
+    # 内部 session id。
+    p_sessions = subparsers.add_parser(
+        "sessions", help="列出/搜索会话（TTY 下引导选择器）"
+    )
+    p_sessions.add_argument("query", nargs="?", default="", help="搜索标题/内容")
+    p_sessions.set_defaults(func=cmd_sessions)
+    p_resume = subparsers.add_parser(
+        "resume", help="恢复会话：无参数打开选择器；或给 ID/前缀/标题"
+    )
+    p_resume.add_argument("query", nargs="?", default="", metavar="ID或标题")
+    p_resume.set_defaults(func=cmd_resume)
+    p_continue = subparsers.add_parser("continue", help="继续最近会话")
+    p_continue.set_defaults(func=cmd_continue)
+
+
+def cmd_sessions(args: argparse.Namespace) -> int:
+    # rosclaw sessions——产品级会话列表（标题/消息数/最近活动）。
+    from rosclaw.agentd.session_list import list_sessions
+
+    home = _home(args)
+    sessions = list_sessions(home)
+    query = str(getattr(args, "query", "") or "")
+    if query:
+        sessions = [
+            s for s in sessions
+            if query in (s.get("display_name") or "")
+            or query in (s.get("first_message") or "")
+            or query in s["session_id"]
+        ]
+    if not sessions:
+        print("还没有会话。运行 `rosclaw chat` 开始第一个任务。")
+        return 0
+    for s in sessions:
+        title = s.get("display_name") or s.get("first_message") or "（未命名）"
+        print(f"  {title:<30}  {s['message_count']:>4} 条消息  {s['session_id'][:12]}…")
+    print("\n恢复：rosclaw resume <标题或ID> · 继续最近：rosclaw continue")
+    return 0
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    # rosclaw resume [ID|标题]——无参数打开选择器。
+    query = str(getattr(args, "query", "") or "")
+    args.resume = query if query else "__picker__"
+    args.continue_last = False
+    for attr, default in (("mission", None), ("mode", None), ("goal", None)):
+        if not hasattr(args, attr):
+            setattr(args, attr, default)
+    return cmd_chat(args)
+
+
+def cmd_continue(args: argparse.Namespace) -> int:
+    # rosclaw continue——继续最近会话。
+    args.continue_last = True
+    args.resume = None
+    for attr, default in (("mission", None), ("mode", None), ("goal", None)):
+        if not hasattr(args, attr):
+            setattr(args, attr, default)
+    return cmd_chat(args)
 
 
 def dispatch_agent_command(args: argparse.Namespace) -> int:

--- a/src/rosclaw/agentd/session_list.py
+++ b/src/rosclaw/agentd/session_list.py
@@ -1,0 +1,108 @@
+"""会话发现（总纲 WP-P0-1）：Pi JSONL 的产品级列表/解析。
+
+不做全量 transcript 扫描——只读 header/session_info/首条用户消息 +
+行数 + mtime；损坏文件跳过不拖垮列表。WP-P0-2 的 SessionCatalog
+落库后本模块退化为 backfill 来源。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _sessions_dir(home: Path) -> Path:
+    return home / "agent" / "sessions"
+
+
+def list_sessions(home: Path) -> list[dict[str, Any]]:
+    """列出全部 Pi 会话（最近活动降序）。损坏 JSONL 跳过。"""
+    sessions_dir = _sessions_dir(home)
+    if not sessions_dir.is_dir():
+        return []
+    sessions: list[dict[str, Any]] = []
+    for path in sessions_dir.glob("*.jsonl"):
+        try:
+            info = _parse_session_file(path)
+        except Exception:  # noqa: BLE001 — 损坏文件不拖垮列表
+            continue
+        if info is not None:
+            sessions.append(info)
+    sessions.sort(key=lambda s: s.get("modified", ""), reverse=True)
+    return sessions
+
+
+def _parse_session_file(path: Path) -> dict[str, Any] | None:
+    session_id = ""
+    name = ""
+    first_message = ""
+    message_count = 0
+    created = ""
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # 跳过坏行而不是整个文件
+            etype = entry.get("type")
+            if etype == "session":
+                session_id = str(entry.get("id", ""))
+                created = str(entry.get("timestamp", ""))
+            elif etype == "session_info" and entry.get("name"):
+                name = str(entry["name"])
+            elif etype == "message":
+                message_count += 1
+                if not first_message:
+                    message = entry.get("message") or {}
+                    if message.get("role") == "user":
+                        content = message.get("content", "")
+                        if isinstance(content, list):
+                            content = " ".join(
+                                str(b.get("text", ""))
+                                for b in content
+                                if isinstance(b, dict)
+                            )
+                        first_message = str(content)[:120]
+    if not session_id:
+        return None
+    stat = path.stat()
+    return {
+        "session_id": session_id,
+        "path": str(path),
+        "display_name": name,
+        "first_message": first_message,
+        "message_count": message_count,
+        "created": created,
+        "modified": str(stat.st_mtime),
+    }
+
+
+def resolve_session_query(
+    sessions: list[dict[str, Any]], query: str
+) -> dict[str, Any]:
+    """精确 ID → 唯一前缀 → 标题/首条消息匹配。歧义报候选，不猜。"""
+    query = query.strip()
+    if not query:
+        return {"error": "EMPTY_QUERY"}
+    for s in sessions:
+        if s["session_id"] == query:
+            return s
+    prefix = [s for s in sessions if s["session_id"].startswith(query)]
+    if len(prefix) == 1:
+        return prefix[0]
+    if len(prefix) > 1:
+        return {"error": "AMBIGUOUS", "candidates": prefix}
+    titled = [
+        s
+        for s in sessions
+        if query in (s.get("display_name") or "") or query in (s.get("first_message") or "")
+    ]
+    if len(titled) == 1:
+        return titled[0]
+    if len(titled) > 1:
+        return {"error": "AMBIGUOUS", "candidates": titled}
+    return {"error": "NOT_FOUND"}

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -8930,7 +8930,11 @@ def main() -> int:
                 return dispatch_app_command(args)
             app_parser.print_help()
             return 1
-        elif args.command in ("agentd", "chat", "worker", "eval", "learning"):
+        elif args.command in (
+            "agentd", "chat", "worker", "eval", "learning",
+            # WP-P0-1：会话可发现性顶层命令。
+            "sessions", "resume", "continue",
+        ):
             return dispatch_agent_command(args)
         elif args.command == "provider":
             if args.provider_command == "list":

--- a/src/rosclaw/root_cli.py
+++ b/src/rosclaw/root_cli.py
@@ -13,6 +13,9 @@ SLIM_HELP = """ROSClaw — Embodied Agent Runtime
 
 Get started
   chat        Start the Native Agent
+  continue    Continue the most recent session
+  resume      Resume a session (picker / id / title)
+  sessions    List and search sessions
   setup       Configure model, body and integrations
   status      Show runtime and embodiment status
   doctor      Diagnose installation and safety readiness
@@ -59,6 +62,9 @@ DOMAIN_GROUPS: dict[str, list[str]] = {
 #: 机器可读注册表（name → (group, summary)）。dispatch 实现见 entrypoint.py。
 COMMAND_REGISTRY: dict[str, tuple[str, str]] = {
     "chat": ("core", "Start the Native Agent"),
+    "sessions": ("core", "List and search sessions"),
+    "resume": ("core", "Resume a session (picker / id / title)"),
+    "continue": ("core", "Continue the most recent session"),
     "setup": ("setup", "Configure model, body and integrations"),
     "status": ("core", "Show runtime and embodiment status"),
     "doctor": ("core", "Diagnose installation and safety readiness"),

--- a/tests/agentd/test_hf5_4_action_result_ui.py
+++ b/tests/agentd/test_hf5_4_action_result_ui.py
@@ -223,7 +223,7 @@ class TestActionResultUi:
                     raise AssertionError("第二轮谎言未出现")
                 time.sleep(2.0)
                 session.send("/quit\r")
-                session.expect(b"rosclaw chat --resume", timeout=30)
+                session.expect(b"rosclaw continue", timeout=30)
                 session.proc.wait(timeout=30)
                 output = session.clean
             finally:

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -900,7 +900,7 @@ class TestProductJourney:
             assert grants == 1, f"被拒绝的动作竟产生 grant: {grants}"
             self._journey_verdicts["deny_fail_closed"] = True
             self._write_sanitized_evidence(home)
-            session.expect_with_resend(b"rosclaw chat --resume", "/quit\r", timeout=60)
+            session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
             session.proc.wait(timeout=30)
             assert session.proc.returncode == 0, session.clean[-400:]
         finally:
@@ -978,7 +978,7 @@ class TestProductJourney:
                     assert count == 0, f"边界探测不应产生 {table} 行: {count}"
             db.close()
             self._journey_verdicts["zero_real_artifacts"] = True
-            session.expect_with_resend(b"rosclaw chat --resume", "/quit\r", timeout=60)
+            session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
             session.proc.wait(timeout=30)
             assert session.proc.returncode == 0, session.clean[-400:]
         finally:
@@ -1555,9 +1555,11 @@ class TestProductJourney:
             self._write_sanitized_evidence(home)
             # 8. /quit → resume 提示必须是 ROSClaw 命令（T-IDENTITY）。
             session.send("/quit\r")
-            session.expect(b"rosclaw chat --resume", timeout=30)
+            session.expect(b"rosclaw continue", timeout=30)
             assert b"pi --session" not in session.clean
             assert b"--session-dir" not in session.clean
+            # WP-P0-1：退出提示不暴露内部 session id。
+            assert b"chat --resume" not in session.clean
             session.proc.wait(timeout=30)
             assert session.proc.returncode == 0, session.clean[-400:]
         finally:
@@ -1606,7 +1608,7 @@ class TestProductJourney:
                 f"resume 后 lease 未恢复: {leases}"
             )
             resumed.send("/quit\r")
-            resumed.expect(b"rosclaw chat --resume", timeout=30)
+            resumed.expect(b"rosclaw continue", timeout=30)
             resumed.proc.wait(timeout=30)
         finally:
             resumed.stop()

--- a/tests/agentd/test_tmux_env.py
+++ b/tests/agentd/test_tmux_env.py
@@ -118,12 +118,12 @@ class TestTmuxEnvironment:
                 if probe.returncode != 0 or "1" in probe.stdout:
                     exited = True
                     break
-                if "rosclaw chat --resume" in pane:
+                if "rosclaw continue" in pane:
                     exited = True
                     break
                 time.sleep(1.0)
             assert exited, f"/quit 后会话未结束: {last_pane[-400:]}"
-            assert "rosclaw chat --resume" in last_pane, (
+            assert "rosclaw continue" in last_pane, (
                 f"退出未见 ROSClaw resume 提示: {last_pane[-400:]}"
             )
             assert "pi --session" not in last_pane

--- a/tests/agentd/test_wp01_session_discovery.py
+++ b/tests/agentd/test_wp01_session_discovery.py
@@ -1,0 +1,116 @@
+"""WP-P0-1 红测试（总纲 §5.1）：会话可发现性紧急修复。
+
+红测试先行——当前断点（总纲 §2.2 表）：
+
+1. `chat --resume` 必须带 SESSION_ID，而系统从不展示 ID；
+2. main.ts 自己 readdirSync+mtime 扫描——绕过 Pi SessionManager；
+3. 没有 rosclaw sessions/resume/continue 顶层命令；
+4. 退出提示暴露内部 session id（应给 rosclaw continue/sessions）。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class TestCliSurface:
+    def test_resume_bare_is_picker(self) -> None:
+        """`rosclaw chat --resume` 无参数 → picker 标记（不再缺参报错）。"""
+        import argparse
+
+        from rosclaw.agentd.cli import add_agent_subparsers
+
+        parser = argparse.ArgumentParser(prog="rosclaw")
+        add_agent_subparsers(parser.add_subparsers(dest="command"))
+        args = parser.parse_args(["chat", "--resume"])
+        assert args.resume == "__picker__", (
+            f"裸 --resume 应为 picker 标记，实际 {args.resume!r}"
+        )
+        # 带参数仍按原样解析。
+        args2 = parser.parse_args(["chat", "--resume", "abc123"])
+        assert args2.resume == "abc123"
+
+    def test_top_level_commands_exist(self) -> None:
+        """rosclaw sessions / resume / continue 在 root registry。"""
+        from rosclaw.root_cli import COMMAND_REGISTRY
+
+        for name in ("sessions", "resume", "continue"):
+            assert name in COMMAND_REGISTRY, f"顶层命令 {name} 不存在"
+
+
+class TestSessionListing:
+    def _write_session(self, sessions_dir: Path, session_id: str, name: str,
+                       first_message: str, when: str) -> Path:
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        path = sessions_dir / f"2026-08-10T10-00-00_{session_id}.jsonl"
+        lines = [
+            json.dumps({"type": "session", "id": session_id, "timestamp": when}),
+            json.dumps({"type": "session_info", "name": name}),
+            json.dumps({"type": "message", "message": {"role": "user", "content": first_message}}),
+        ]
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
+
+    def test_list_sessions_reads_pi_jsonl(self, tmp_path: Path) -> None:
+        """sessions 列表读 Pi JSONL（时间前缀文件名/名称/首条消息/
+        损坏文件不拖垮列表）。"""
+        from rosclaw.agentd.session_list import list_sessions
+
+        sessions_dir = tmp_path / "agent" / "sessions"
+        self._write_session(sessions_dir, "abc123", "五角星轨迹仿真", "画五角星", "2026-08-10T10:00:00Z")
+        self._write_session(sessions_dir, "def456", "", "巡检", "2026-08-11T09:00:00Z")
+        (sessions_dir / "broken.jsonl").write_text("{not json", encoding="utf-8")
+        sessions = list_sessions(tmp_path)
+        assert len(sessions) == 2, sessions
+        by_id = {s["session_id"]: s for s in sessions}
+        assert by_id["abc123"]["display_name"] == "五角星轨迹仿真"
+        assert by_id["def456"]["first_message"] == "巡检"
+        # 最近活动排序：def456 更新。
+        assert sessions[0]["session_id"] == "def456"
+
+    def test_resolve_query_id_prefix_title(self, tmp_path: Path) -> None:
+        """精确 ID / 唯一前缀 / 标题解析；歧义报候选不猜。"""
+        from rosclaw.agentd.session_list import list_sessions, resolve_session_query
+
+        sessions_dir = tmp_path / "agent" / "sessions"
+        self._write_session(sessions_dir, "abc123", "五角星轨迹仿真", "画五角星", "2026-08-10T10:00:00Z")
+        self._write_session(sessions_dir, "abd999", "五角星复测", "再画", "2026-08-11T10:00:00Z")
+        # 精确 ID
+        hit = resolve_session_query(list_sessions(tmp_path), "abc123")
+        assert hit.get("path", "").endswith(".jsonl")
+        # 标题
+        hit = resolve_session_query(list_sessions(tmp_path), "五角星轨迹仿真")
+        assert "abc123" in hit.get("path", "")
+        # 歧义前缀
+        miss = resolve_session_query(list_sessions(tmp_path), "ab")
+        assert miss.get("error") == "AMBIGUOUS"
+        assert len(miss.get("candidates", [])) == 2
+        # 不存在
+        none = resolve_session_query(list_sessions(tmp_path), "zzz")
+        assert none.get("error") == "NOT_FOUND"
+
+
+class TestExitHintIsProductCommand:
+    def test_resume_hint_uses_rosclaw_continue(self) -> None:
+        """退出提示必须是 rosclaw continue/sessions——不暴露内部
+        session id（patch-01 替换文本断言）。"""
+        patch = Path(
+            "packages/rosclaw-agent/patches/apply-upstream-patches.mjs"
+        ).read_text(encoding="utf-8")
+        assert "rosclaw continue" in patch, "退出提示未给 rosclaw continue"
+        assert "rosclaw sessions" in patch
+        # 01b 清理补丁的 anchor 合法含旧串（它是删除目标）——剥离后
+        # 不得再出现（patch-01 的 replacement 不得含内部 id）。
+        stripped = patch.replace(
+            '"    return `rosclaw chat --resume ${sessionManager.getSessionId()}`;\\n",', ""
+        )
+        assert "chat --resume ${sessionManager.getSessionId()}" not in stripped, (
+            "退出提示仍暴露内部 session id"
+        )
+
+    def test_main_ts_has_no_handrolled_scan(self) -> None:
+        """main.ts 不得再自己 readdirSync+mtime 扫描会话目录。"""
+        source = Path("packages/rosclaw-agent/src/main.ts").read_text(encoding="utf-8")
+        assert "readdirSync" not in source, "手写目录扫描仍在"
+        assert "SessionManager" in source, "应复用 Pi SessionManager"


### PR DESCRIPTION
## 总纲 WP-P0-1（红测试先行）

断点：`chat --resume` 强制 SESSION_ID 但系统从不展示 ID；main.ts 手写目录扫描绕过 Pi SessionManager；退出提示暴露内部 session id。

- 顶层命令：`rosclaw sessions` / `resume [ID|前缀|标题]`（无参数打开选择器）/ `continue`
- `chat --resume` 裸用打开选择器；查询经 `resolve_session_query` 解析成真实路径，歧义报候选不猜
- main.ts 删除手写扫描：`SessionManager.continueRecent`/`listAll`/`open` + `SessionSelectorComponent` 薄组装（公开 API，MIT 归属，<80 行）
- 退出提示：`会话已保存：<标题> / 继续：rosclaw continue / 查看全部：rosclaw sessions`（patcher 新增 optionalAnchor + 旧 hint 清理）

### Red→green
- 红：`test_wp01_session_discovery.py` 6 failed
- 绿：6/6；journey A 绿；node 61/61

🤖 Generated with [Claude Code](https://claude.com/claude-code)