### PR TITLE
feat: WP-P0-6 证据诚实化（总纲 §8.3）

### DIFF
--- a/src/rosclaw/agentd/task_runner.py
+++ b/src/rosclaw/agentd/task_runner.py
@@ -377,7 +377,12 @@ class TaskRunner:
         # 八审 §4 P0-7 三通道：user_view 一行进度（model_view 是本
         # 结构；audit_view 全量在 task_records/receipt，/trace 展开）。
         if record["state"] == "VERIFIED":
-            user_view = "规划 ✓  安全校验 ✓  仿真执行 ✓  几何验证 PASS（运动学仿真）"
+            # WP-P0-6（总纲 §8.3）：诚实证据等级——当前 sandbox 是
+            # 命令回放（路径自洽），不宣称机械臂真的运动过。
+            user_view = (
+                "快速运动学预演完成（命令回放）：路径数据自洽、几何闭合 "
+                "验证 PASS——不能证明动力学或真实机械臂完成运动"
+            )
         elif record["state"] == "WAITING_APPROVAL":
             user_view = "规划 ✓  安全校验 ✓  等待人工确认…"
         else:
@@ -390,6 +395,7 @@ class TaskRunner:
             "goal": record["goal"],
             "policy": policy,
             "user_view": user_view,
+            "evidence_level": "COMMAND_REPLAY",
             "plan_id": record.get("plan_id") or "",
             "summary": (
                 "UR5e 运动学沙盒绘制闭合五角星"

--- a/src/rosclaw/contracts/operator/evidence.py
+++ b/src/rosclaw/contracts/operator/evidence.py
@@ -1,0 +1,41 @@
+"""证据等级合约（总纲 §8.3，WP-P0-6）。
+
+顺序即强度——任何 receipt/trace/task 结果必须声明其一；文案不得
+超出等级能力：
+
+- PLANNED：只有规划，未执行。
+- COMMAND_REPLAY：把命令/规划点写入 sandbox state——能证明路径数据
+  自洽，不能证明动力学或真实机械臂完成运动。
+- KINEMATIC_SIM：运动学求解与关节/末端状态演化。
+- PHYSICS_SIM：物理引擎（MuJoCo/Gazebo）返回的模拟状态。
+- INDEPENDENT_SIM_OBSERVATION：独立观测器从 simulator state/传感器
+  读取（不是 executor 自己复制）。
+- REAL_COMMAND_ACCEPTED：真机控制栈接受目标（不证明完成）。
+- REAL_OBSERVED：独立传感/状态反馈证明执行结果。
+"""
+
+from __future__ import annotations
+
+EVIDENCE_LEVELS: tuple[str, ...] = (
+    "PLANNED",
+    "COMMAND_REPLAY",
+    "KINEMATIC_SIM",
+    "PHYSICS_SIM",
+    "INDEPENDENT_SIM_OBSERVATION",
+    "REAL_COMMAND_ACCEPTED",
+    "REAL_OBSERVED",
+)
+
+#: 各等级的诚实局限文案（用户可见）。
+LIMITATION_TEXT: dict[str, str] = {
+    "PLANNED": "仅规划，未执行。",
+    "COMMAND_REPLAY": (
+        "trace 与计划来自同一 sandbox——能证明路径数据自洽，"
+        "不能证明 MuJoCo 动力学或真实机械臂完成运动"
+    ),
+    "KINEMATIC_SIM": "运动学仿真结果，不含动力学/接触/真实传感。",
+    "PHYSICS_SIM": "物理仿真结果，非真机证据。",
+    "INDEPENDENT_SIM_OBSERVATION": "独立仿真观测，非真机证据。",
+    "REAL_COMMAND_ACCEPTED": "真机已接受目标——完成需独立观测确认。",
+    "REAL_OBSERVED": "真机独立观测确认。",
+}

--- a/src/rosclaw/sim/ur5e_mcp.py
+++ b/src/rosclaw/sim/ur5e_mcp.py
@@ -294,6 +294,14 @@ def _execute_trajectory(trajectory: dict) -> str:
             "driver": "completed",
             "evidence_domain": "simulation",
             "sim_kind": SIM_KIND,
+            # WP-P0-6（总纲 §8.3）：本执行器把规划点写入 sandbox
+            # state——证据等级是 COMMAND_REPLAY（路径自洽），不是
+            # 运动学/动力学仿真，更不是真实机械臂观测。
+            "evidence_level": "COMMAND_REPLAY",
+            "limitation": (
+                "trace 与计划来自同一 sandbox——能证明路径数据自洽，"
+                "不能证明 MuJoCo 动力学或真实机械臂完成运动"
+            ),
             "trajectory_hash": actual,
             "points_executed": len(points),
             "executed_at": _ts(),
@@ -343,6 +351,8 @@ def get_cartesian_trace(include_points: bool = False) -> str:
         "first_point": trace[0] if trace else None,
         "last_point": trace[-1] if trace else None,
         "svg": _trace_svg(trace),
+        # WP-P0-6：trace 来源标注——command replay 不是独立观测。
+        "origin": "command_replay",
     }
     if include_points:
         trace_view["points"] = trace
@@ -350,6 +360,7 @@ def get_cartesian_trace(include_points: bool = False) -> str:
         {
             "ok": True,
             "evidence_domain": "simulation",
+            "evidence_level": "COMMAND_REPLAY",
             "sim_kind": SIM_KIND,
             "trace": trace_view,
             "observed_at": _ts(),

--- a/tests/agentd/test_wp06_evidence_honesty.py
+++ b/tests/agentd/test_wp06_evidence_honesty.py
@@ -1,0 +1,106 @@
+"""WP-P0-6 红测试（总纲 §8.3）：仿真证据诚实化。
+
+红测试先行——当前运动学 sandbox 把规划点复制成 trace 再与规划点
+比较，却让用户看到"仿真执行 ✓"这类表述。这只能证明路径数据
+自洽（COMMAND_REPLAY），不能证明动力学或真实机械臂完成运动。
+
+证据等级：PLANNED / COMMAND_REPLAY / KINEMATIC_SIM / PHYSICS_SIM /
+INDEPENDENT_SIM_OBSERVATION / REAL_COMMAND_ACCEPTED / REAL_OBSERVED。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _call(name: str, **kwargs):
+    from rosclaw.sim import ur5e_mcp
+
+    fn = getattr(ur5e_mcp, name.replace("ur5e.", "").replace(".", "_"), None)
+    return json.loads(fn(**kwargs))
+
+
+class TestEvidenceLevel:
+    def test_execute_result_declares_command_replay(self) -> None:
+        """执行结果必须声明 evidence_level=COMMAND_REPLAY + 局限性。"""
+        from rosclaw.sim import ur5e_mcp
+
+        ur5e_mcp.reset_simulation()
+        plan = _call(
+            "ur5e.plan_cartesian_path",
+            shape="star5", center_x=0.35, center_y=0.25, z=0.30, outer_radius=0.10,
+        )
+        result = _call("ur5e.execute_plan", plan_id=plan["plan_id"])
+        assert result.get("evidence_level") == "COMMAND_REPLAY", result
+        limitation = str(result.get("limitation", ""))
+        assert "自洽" in limitation and "不能证明" in limitation, limitation
+
+    def test_trace_labeled_replay_not_observation(self) -> None:
+        """trace 视图必须标 replay——不得自称独立观测。"""
+        from rosclaw.sim import ur5e_mcp
+
+        ur5e_mcp.reset_simulation()
+        plan = _call(
+            "ur5e.plan_cartesian_path",
+            shape="star5", center_x=0.35, center_y=0.25, z=0.30, outer_radius=0.10,
+        )
+        _call("ur5e.execute_plan", plan_id=plan["plan_id"])
+        trace = _call("ur5e.get_cartesian_trace")
+        assert trace["trace"].get("origin") == "command_replay", trace["trace"].keys()
+        assert trace.get("evidence_level") == "COMMAND_REPLAY"
+
+    def test_evidence_level_enum_contract(self) -> None:
+        """证据等级枚举是合约（顺序=强度，不得改名）。"""
+        from rosclaw.contracts.operator.evidence import EVIDENCE_LEVELS
+
+        assert list(EVIDENCE_LEVELS) == [
+            "PLANNED",
+            "COMMAND_REPLAY",
+            "KINEMATIC_SIM",
+            "PHYSICS_SIM",
+            "INDEPENDENT_SIM_OBSERVATION",
+            "REAL_COMMAND_ACCEPTED",
+            "REAL_OBSERVED",
+        ]
+
+
+class TestNoOverclaimCopy:
+    def test_product_copy_has_no_overclaim(self) -> None:
+        """产品文案不得超出证据能力（实际执行轨迹/真实走过/物理仿真
+        已完成 等）。"""
+        banned = ["实际执行轨迹", "真实走过", "实际走过的路径", "物理仿真已完成"]
+        for path in (
+            Path("src/rosclaw/sim/ur5e_mcp.py"),
+            Path("src/rosclaw/agentd/task_runner.py"),
+            Path("packages/rosclaw-agent/src/tools/task.ts"),
+        ):
+            text = path.read_text(encoding="utf-8")
+            for phrase in banned:
+                assert phrase not in text, f"{path.name} 含过度宣称: {phrase}"
+
+    async def test_task_user_view_is_honest(self, tmp_path: Path) -> None:
+        """TaskResult user_view 必须含证据等级与局限（不是单纯
+        '仿真执行 ✓'）。"""
+        from tests.agentd.test_pi_tool_bridge import _issue_lease, _request, _setup
+
+        service, mission = await _setup(tmp_path)
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+
+        result = await PiToolDispatcher(service).execute(
+            caller_pid=1, caller_uid=1000,
+            request=_request(
+                "rosclaw_task", mission=mission.mission_id, idem="idem_ev_1",
+                lease=await _issue_lease(service, mission),
+                arguments={
+                    "goal": "draw_shape",
+                    "parameters": {"shape": "star5", "center_m": [0.35, 0.25, 0.30], "radius_m": 0.10},
+                },
+            ),
+        )
+        payload = json.loads(result.summary)
+        view = payload.get("user_view", "")
+        assert "命令回放" in view or "预演" in view, view
+        assert "自洽" in view and "不能证明" in view, view
+        assert payload.get("evidence_level") == "COMMAND_REPLAY"
+        await service.close()


### PR DESCRIPTION
## 总纲 WP-P0-6（栈在 WP-P0-3 之上，红测试先行）

当前 sandbox 把规划点复制成 trace 再自比——只能证明路径数据自洽，不能宣称"机械臂实际走过"。

- `EvidenceLevel` 合约：PLANNED/COMMAND_REPLAY/KINEMATIC_SIM/PHYSICS_SIM/INDEPENDENT_SIM_OBSERVATION/REAL_COMMAND_ACCEPTED/REAL_OBSERVED + 各级诚实局限文案
- 执行/trace 结果声明 `evidence_level=COMMAND_REPLAY` + limitation；trace 标 `origin=command_replay`
- TaskResult user_view 诚实化；过度宣称源码扫描测试

### Red→green
- 红：`test_wp06_evidence_honesty.py` 4 failed
- 绿：5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)