### PR TITLE
feat(cli): discover downstream command extensions

### DIFF
--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -40,6 +40,7 @@ from rosclaw.app.cli import add_app_subparsers, dispatch_app_command
 from rosclaw.body.cli import add_body_subparser, dispatch_body_command
 from rosclaw.body.registry import BodyRegistryManager
 from rosclaw.body.resolver import BodyResolver
+from rosclaw.cli_extensions import dispatch_cli_extension, register_cli_extensions
 from rosclaw.connectors.ros.cli import add_ros_subparser, cmd_doctor_ros, dispatch_ros_command
 from rosclaw.core.event_bus import Event, EventPriority
 from rosclaw.darwin.cli import cmd_darwin
@@ -8863,8 +8864,15 @@ def main() -> int:
     # feedback and telemetry
     add_feedback_subparser(subparsers)
 
+    # Downstream applications may contribute namespaced command trees without
+    # importing their domain logic into ROSClaw core.
+    register_cli_extensions(subparsers)
+
     args = parser.parse_args()
     with telemetry_command_hook(args):
+        extension_result = dispatch_cli_extension(args)
+        if extension_result is not None:
+            return extension_result
         if args.command == "init":
             return cmd_init(args)
         elif args.command in ("run", "start"):

--- a/src/rosclaw/cli_extensions.py
+++ b/src/rosclaw/cli_extensions.py
@@ -1,0 +1,106 @@
+"""Discover downstream command trees without coupling them to ROSClaw core."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import logging
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger("rosclaw.cli_extensions")
+
+CLI_EXTENSION_GROUP = "rosclaw.cli_extensions"
+CLI_EXTENSION_HANDLER = "rosclaw_extension_handler"
+_DISABLE_ENV = "ROSCLAW_DISABLE_CLI_EXTENSIONS"
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+CLIExtensionRegister = Callable[[Any], None]
+CLIExtensionHandler = Callable[[argparse.Namespace], int]
+
+
+@dataclass(frozen=True)
+class CLIExtensionReport:
+    """Immutable discovery result for diagnostics and tests."""
+
+    loaded: tuple[str, ...]
+    errors: tuple[str, ...]
+    disabled: bool = False
+
+
+def register_cli_extensions(
+    subparsers: Any,
+    *,
+    entry_point_group: str = CLI_EXTENSION_GROUP,
+) -> CLIExtensionReport:
+    """Load installed downstream CLI adapters, failing open for core commands.
+
+    An adapter must expose ``register_cli(subparsers)`` through the
+    ``rosclaw.cli_extensions`` entry-point group. Adapters may add command
+    parsers, but they do not receive a runtime, driver, or hardware handle.
+    Set ``ROSCLAW_DISABLE_CLI_EXTENSIONS=1`` to recover from a broken optional
+    installation.
+    """
+
+    if os.environ.get(_DISABLE_ENV, "").strip().lower() in _TRUE_VALUES:
+        return CLIExtensionReport(loaded=(), errors=(), disabled=True)
+
+    try:
+        entry_points = importlib.metadata.entry_points()
+        selected: Iterable[Any]
+        if hasattr(entry_points, "select"):
+            selected = entry_points.select(group=entry_point_group)
+        else:  # pragma: no cover - compatibility with older metadata providers
+            selected = entry_points.get(entry_point_group, ())
+    except Exception as exc:
+        message = f"discovery failed: {exc}"
+        logger.warning("ROSClaw CLI extension %s", message)
+        return CLIExtensionReport(loaded=(), errors=(message,))
+
+    loaded: list[str] = []
+    errors: list[str] = []
+    ordered = sorted(
+        selected,
+        key=lambda item: (
+            str(getattr(item, "name", "")),
+            str(getattr(item, "value", "")),
+        ),
+    )
+    for entry_point in ordered:
+        name = str(getattr(entry_point, "name", getattr(entry_point, "value", "unknown")))
+        try:
+            register = entry_point.load()
+            if not callable(register):
+                raise TypeError("entry point must resolve to a callable")
+            register(subparsers)
+        except Exception as exc:
+            message = f"{name}: {exc}"
+            errors.append(message)
+            logger.warning("Failed to register ROSClaw CLI extension %s", message)
+            continue
+        loaded.append(name)
+        logger.debug("Registered ROSClaw CLI extension: %s", name)
+
+    return CLIExtensionReport(loaded=tuple(loaded), errors=tuple(errors))
+
+
+def dispatch_cli_extension(args: argparse.Namespace) -> int | None:
+    """Run an extension handler selected by argparse, if present."""
+
+    handler = getattr(args, CLI_EXTENSION_HANDLER, None)
+    if handler is None:
+        return None
+    if not callable(handler):
+        raise TypeError(f"{CLI_EXTENSION_HANDLER} must be callable")
+    return int(handler(args))
+
+
+__all__ = [
+    "CLI_EXTENSION_GROUP",
+    "CLI_EXTENSION_HANDLER",
+    "CLIExtensionReport",
+    "dispatch_cli_extension",
+    "register_cli_extensions",
+]

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from rosclaw import cli_extensions
+
+
+@dataclass
+class _EntryPoint:
+    name: str
+    value: Any
+    error: Exception | None = None
+
+    def load(self) -> Any:
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+
+class _EntryPoints(list[_EntryPoint]):
+    def select(self, *, group: str) -> _EntryPoints:
+        assert group == cli_extensions.CLI_EXTENSION_GROUP
+        return self
+
+
+def _parsers() -> tuple[argparse.ArgumentParser, Any]:
+    parser = argparse.ArgumentParser()
+    return parser, parser.add_subparsers(dest="command")
+
+
+def test_register_and_dispatch_downstream_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    parser, subparsers = _parsers()
+
+    def register(target: Any) -> None:
+        sample = target.add_parser("sample")
+        sample.set_defaults(rosclaw_extension_handler=lambda _args: 7)
+
+    monkeypatch.setattr(
+        cli_extensions.importlib.metadata,
+        "entry_points",
+        lambda: _EntryPoints([_EntryPoint("sample", register)]),
+    )
+
+    report = cli_extensions.register_cli_extensions(subparsers)
+    args = parser.parse_args(["sample"])
+
+    assert report.loaded == ("sample",)
+    assert report.errors == ()
+    assert cli_extensions.dispatch_cli_extension(args) == 7
+
+
+def test_broken_extension_does_not_hide_core_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    parser, subparsers = _parsers()
+    subparsers.add_parser("core")
+    monkeypatch.setattr(
+        cli_extensions.importlib.metadata,
+        "entry_points",
+        lambda: _EntryPoints([_EntryPoint("broken", None, RuntimeError("boom"))]),
+    )
+
+    report = cli_extensions.register_cli_extensions(subparsers)
+
+    assert parser.parse_args(["core"]).command == "core"
+    assert report.loaded == ()
+    assert report.errors == ("broken: boom",)
+    assert "broken: boom" in caplog.text
+
+
+def test_extensions_can_be_disabled_for_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    _parser, subparsers = _parsers()
+    monkeypatch.setenv("ROSCLAW_DISABLE_CLI_EXTENSIONS", "true")
+    monkeypatch.setattr(
+        cli_extensions.importlib.metadata,
+        "entry_points",
+        lambda: pytest.fail("disabled discovery must not inspect entry points"),
+    )
+
+    report = cli_extensions.register_cli_extensions(subparsers)
+
+    assert report.disabled is True
+    assert report.loaded == ()
+
+
+def test_non_callable_handler_is_rejected() -> None:
+    args = argparse.Namespace(rosclaw_extension_handler="unsafe")
+    with pytest.raises(TypeError, match="must be callable"):
+        cli_extensions.dispatch_cli_extension(args)
+
+
+def test_extension_registration_order_is_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _parser, subparsers = _parsers()
+    calls: list[str] = []
+
+    def register(name: str) -> Any:
+        return lambda _target: calls.append(name)
+
+    monkeypatch.setattr(
+        cli_extensions.importlib.metadata,
+        "entry_points",
+        lambda: _EntryPoints(
+            [
+                _EntryPoint("z-last", register("z-last")),
+                _EntryPoint("a-first", register("a-first")),
+            ]
+        ),
+    )
+
+    report = cli_extensions.register_cli_extensions(subparsers)
+
+    assert calls == ["a-first", "z-last"]
+    assert report.loaded == ("a-first", "z-last")


### PR DESCRIPTION
## What changed

- adds the `rosclaw.cli_extensions` entry-point boundary
- lets downstream packages contribute namespaced command trees without Core imports
- gives extensions only argparse subparsers, never a Runtime, driver, executor, or hardware handle
- isolates broken extensions and provides `ROSCLAW_DISABLE_CLI_EXTENSIONS` recovery
- makes discovery order deterministic

## Why

The Phase 8 football experiment proved that application-specific command trees do not belong in ROSClaw Core. This is C1 of the domain-decontamination split from draft PR #271.

## Validation

- `pytest tests/test_cli_extensions.py -q`: 5 passed
- Ruff: passed
- mypy for CLI extension surface: passed
- installed `rosclaw-soccer` smoke: `rosclaw soccer academy status` returned the Age-4 SIM_ONLY card
- disabled-extension Core help smoke: passed
