### PR TITLE
feat(growth): add task-neutral PARC contracts

### DIFF
--- a/src/rosclaw/growth/__init__.py
+++ b/src/rosclaw/growth/__init__.py
@@ -13,17 +13,45 @@ from rosclaw.growth.contracts import (
     SkillGrowthSpec,
     TrainingEligibility,
 )
+from rosclaw.growth.experience import (
+    ActionTraceCommitment,
+    DerivedExperienceLineage,
+    ExperienceSegment,
+    FailureSignature,
+    PhysicalAdvantageLabel,
+)
+from rosclaw.growth.generalization import (
+    CoreGeneralizationGate,
+    DomainValidationProof,
+    GeneralizationDecision,
+    GeneralizationEvidence,
+    GeneralizationStatus,
+)
+from rosclaw.growth.plan import CandidateManifest, LearningJob, LearningPlan
 
 __all__ = [
+    "ActionTraceCommitment",
+    "CandidateManifest",
     "ConsolidationDecision",
     "ConsolidationManifest",
+    "CoreGeneralizationGate",
+    "DerivedExperienceLineage",
+    "DomainValidationProof",
     "EvidenceLevel",
     "EvidenceUsePolicy",
+    "ExperienceSegment",
+    "FailureSignature",
     "GateName",
     "GateResult",
     "GateStatus",
+    "GeneralizationDecision",
+    "GeneralizationEvidence",
+    "GeneralizationStatus",
     "GrowthMetricSpec",
+    "LearningJob",
+    "LearningPlan",
     "MetricDirection",
+    "PhysicalAdvantageLabel",
     "SkillGrowthSpec",
     "TrainingEligibility",
 ]

--- a/src/rosclaw/growth/_validation.py
+++ b/src/rosclaw/growth/_validation.py
@@ -1,0 +1,73 @@
+"""Shared validation helpers for task-neutral Growth contracts."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from types import MappingProxyType
+
+_HASH = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
+
+
+def require_hash(label: str, value: str) -> None:
+    if not _HASH.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+def require_identifier(label: str, value: str) -> None:
+    if not _IDENTIFIER.fullmatch(value):
+        raise ValueError(f"{label} must be a normalized identifier")
+
+
+def unique_identifiers(
+    values: tuple[str, ...],
+    *,
+    label: str,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    normalized = tuple(values)
+    if not allow_empty and not normalized:
+        raise ValueError(f"{label} must not be empty")
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must be unique")
+    for value in normalized:
+        require_identifier(label, value)
+    return normalized
+
+
+def unique_hashes(
+    values: tuple[str, ...],
+    *,
+    label: str,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    normalized = tuple(values)
+    if not allow_empty and not normalized:
+        raise ValueError(f"{label} must not be empty")
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must be unique")
+    for value in normalized:
+        require_hash(label, value)
+    return normalized
+
+
+def finite_mapping(
+    values: Mapping[str, float],
+    *,
+    label: str,
+    non_negative: bool,
+) -> Mapping[str, float]:
+    normalized = {str(key): float(value) for key, value in values.items()}
+    if not normalized:
+        raise ValueError(f"{label} must not be empty")
+    for key, value in normalized.items():
+        require_identifier(f"{label} key", key)
+        if not math.isfinite(value) or (non_negative and value < 0.0):
+            qualifier = "finite and non-negative" if non_negative else "finite"
+            raise ValueError(f"{label} values must be {qualifier}")
+    return MappingProxyType(normalized)
+
+
+__all__: list[str] = []

--- a/src/rosclaw/growth/experience.py
+++ b/src/rosclaw/growth/experience.py
@@ -1,0 +1,315 @@
+"""Task-neutral PARC experience, provenance, and failure contracts."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.growth._validation import (
+    finite_mapping,
+    require_hash,
+    require_identifier,
+    unique_hashes,
+    unique_identifiers,
+)
+from rosclaw.growth.contracts import EvidenceLevel
+
+
+@dataclass(frozen=True)
+class DerivedExperienceLineage:
+    """Bind derived observations to their source events and time alignment.
+
+    A transform that combines multiple events must carry a synchronization
+    receipt and prove that observed skew stayed within its declared bound.
+    This prevents separately sampled state channels from being presented as
+    one physical observation without auditable alignment evidence.
+    """
+
+    source_artifact_hash: str
+    source_event_hashes: tuple[str, ...]
+    transform_hash: str
+    clock_id: str
+    maximum_skew_sec: float
+    observed_skew_sec: float
+    synchronization_receipt_hash: str | None = None
+    schema_version: str = "rosclaw.growth.derived_experience_lineage.v1"
+
+    def __post_init__(self) -> None:
+        require_hash("source_artifact_hash", self.source_artifact_hash)
+        require_hash("transform_hash", self.transform_hash)
+        object.__setattr__(
+            self,
+            "source_event_hashes",
+            unique_hashes(self.source_event_hashes, label="source_event_hashes"),
+        )
+        require_identifier("clock_id", self.clock_id)
+        if not math.isfinite(self.maximum_skew_sec) or self.maximum_skew_sec < 0.0:
+            raise ValueError("maximum_skew_sec must be finite and non-negative")
+        if not math.isfinite(self.observed_skew_sec) or self.observed_skew_sec < 0.0:
+            raise ValueError("observed_skew_sec must be finite and non-negative")
+        if self.observed_skew_sec > self.maximum_skew_sec:
+            raise ValueError("observed skew exceeds the declared synchronization bound")
+        if len(self.source_event_hashes) > 1:
+            if self.synchronization_receipt_hash is None:
+                raise ValueError("multi-event derivation requires a synchronization receipt")
+            require_hash("synchronization_receipt_hash", self.synchronization_receipt_hash)
+        elif self.synchronization_receipt_hash is not None:
+            require_hash("synchronization_receipt_hash", self.synchronization_receipt_hash)
+
+    @property
+    def lineage_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source_artifact_hash": self.source_artifact_hash,
+            "source_event_hashes": list(self.source_event_hashes),
+            "transform_hash": self.transform_hash,
+            "clock_id": self.clock_id,
+            "maximum_skew_sec": self.maximum_skew_sec,
+            "observed_skew_sec": self.observed_skew_sec,
+            "synchronization_receipt_hash": self.synchronization_receipt_hash,
+        }
+
+
+class PhysicalAdvantageLabel(StrEnum):
+    UNLABELED = "unlabeled"
+    ADVANTAGE_POSITIVE = "advantage_positive"
+    ADVANTAGE_NEGATIVE = "advantage_negative"
+    ADVANTAGE_NEUTRAL = "advantage_neutral"
+    UNSAFE_NEGATIVE = "unsafe_negative"
+
+
+@dataclass(frozen=True)
+class FailureSignature:
+    primary_type: str
+    contributors: tuple[str, ...]
+    confidence: float
+    affected_capability_ids: tuple[str, ...]
+    reusable_evidence_ids: tuple[str, ...]
+    recommended_learner_ids: tuple[str, ...]
+    schema_version: str = "rosclaw.growth.failure_signature.v1"
+
+    def __post_init__(self) -> None:
+        require_identifier("primary_type", self.primary_type)
+        for label in ("contributors", "affected_capability_ids", "recommended_learner_ids"):
+            object.__setattr__(
+                self,
+                label,
+                unique_identifiers(tuple(getattr(self, label)), label=label),
+            )
+        object.__setattr__(
+            self,
+            "reusable_evidence_ids",
+            unique_identifiers(
+                self.reusable_evidence_ids,
+                label="reusable_evidence_ids",
+                allow_empty=True,
+            ),
+        )
+        if not math.isfinite(self.confidence) or not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be finite and in [0, 1]")
+
+    @property
+    def signature_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "primary_type": self.primary_type,
+            "contributors": list(self.contributors),
+            "confidence": self.confidence,
+            "affected_capability_ids": list(self.affected_capability_ids),
+            "reusable_evidence_ids": list(self.reusable_evidence_ids),
+            "recommended_learner_ids": list(self.recommended_learner_ids),
+        }
+
+
+@dataclass(frozen=True)
+class ActionTraceCommitment:
+    commanded_action_hash: str
+    executed_action_hash: str
+    safety_projected_action_hash: str
+    policy_version: str
+    controller_hash: str
+    projection_applied: bool
+    schema_version: str = "rosclaw.growth.action_trace_commitment.v1"
+
+    def __post_init__(self) -> None:
+        for label in (
+            "commanded_action_hash",
+            "executed_action_hash",
+            "safety_projected_action_hash",
+            "controller_hash",
+        ):
+            require_hash(label, getattr(self, label))
+        require_identifier("policy_version", self.policy_version)
+        if not self.projection_applied and (
+            self.executed_action_hash != self.safety_projected_action_hash
+        ):
+            raise ValueError("an unprojected action must match the executed action")
+
+    @property
+    def commitment_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "commanded_action_hash": self.commanded_action_hash,
+            "executed_action_hash": self.executed_action_hash,
+            "safety_projected_action_hash": self.safety_projected_action_hash,
+            "policy_version": self.policy_version,
+            "controller_hash": self.controller_hash,
+            "projection_applied": self.projection_applied,
+        }
+
+
+@dataclass(frozen=True)
+class ExperienceSegment:
+    """One physically meaningful PARC segment, independent of task semantics."""
+
+    segment_id: str
+    episode_id: str
+    skill_id: str
+    phase: str
+    start_time_sec: float
+    end_time_sec: float
+    body_hash: str
+    regime_hash: str
+    source_evidence_level: EvidenceLevel
+    lineage: DerivedExperienceLineage
+    base_policy_version: str
+    residual_policy_version: str | None
+    state_start_hash: str
+    observation_sequence_hash: str
+    self_state_hash: str
+    world_state_hash: str
+    action: ActionTraceCommitment
+    reward_vector: Mapping[str, float]
+    cost_vector: Mapping[str, float]
+    terminal_state_hash: str
+    advantage_label: PhysicalAdvantageLabel = PhysicalAdvantageLabel.UNLABELED
+    label_confidence: float = 0.0
+    failure_signature: FailureSignature | None = None
+    schema_version: str = "rosclaw.growth.experience_segment.v1"
+
+    def __post_init__(self) -> None:
+        for label in ("segment_id", "episode_id", "skill_id", "phase", "base_policy_version"):
+            require_identifier(label, getattr(self, label))
+        if self.residual_policy_version is not None:
+            require_identifier("residual_policy_version", self.residual_policy_version)
+        if not math.isfinite(self.start_time_sec) or not math.isfinite(self.end_time_sec):
+            raise ValueError("segment times must be finite")
+        if self.start_time_sec < 0.0 or self.end_time_sec <= self.start_time_sec:
+            raise ValueError("segment times must satisfy 0 <= start < end")
+        for label in (
+            "body_hash",
+            "regime_hash",
+            "state_start_hash",
+            "observation_sequence_hash",
+            "self_state_hash",
+            "world_state_hash",
+            "terminal_state_hash",
+        ):
+            require_hash(label, getattr(self, label))
+        if not isinstance(self.source_evidence_level, EvidenceLevel):
+            raise ValueError("source_evidence_level must be an EvidenceLevel")
+        if not isinstance(self.lineage, DerivedExperienceLineage):
+            raise ValueError("lineage must be a DerivedExperienceLineage")
+        if not isinstance(self.action, ActionTraceCommitment):
+            raise ValueError("action must be an ActionTraceCommitment")
+        if not isinstance(self.advantage_label, PhysicalAdvantageLabel):
+            raise ValueError("advantage_label must be a PhysicalAdvantageLabel")
+        object.__setattr__(
+            self,
+            "reward_vector",
+            finite_mapping(self.reward_vector, label="reward_vector", non_negative=False),
+        )
+        object.__setattr__(
+            self,
+            "cost_vector",
+            finite_mapping(self.cost_vector, label="cost_vector", non_negative=True),
+        )
+        if not math.isfinite(self.label_confidence) or not 0.0 <= self.label_confidence <= 1.0:
+            raise ValueError("label_confidence must be finite and in [0, 1]")
+        negative = self.advantage_label in {
+            PhysicalAdvantageLabel.ADVANTAGE_NEGATIVE,
+            PhysicalAdvantageLabel.UNSAFE_NEGATIVE,
+        }
+        if negative and self.failure_signature is None:
+            raise ValueError("negative advantage segments require a failure signature")
+        if self.failure_signature is not None and not isinstance(
+            self.failure_signature, FailureSignature
+        ):
+            raise ValueError("failure_signature must be a FailureSignature")
+        if self.advantage_label is PhysicalAdvantageLabel.UNSAFE_NEGATIVE and not any(
+            value > 0.0 for value in self.cost_vector.values()
+        ):
+            raise ValueError("unsafe-negative segments require a non-zero safety cost")
+        if self.advantage_label is PhysicalAdvantageLabel.ADVANTAGE_POSITIVE and any(
+            value > 0.0 for value in self.cost_vector.values()
+        ):
+            raise ValueError("positive advantage cannot contain a safety cost")
+
+    @property
+    def segment_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "segment_id": self.segment_id,
+            "episode_id": self.episode_id,
+            "skill_id": self.skill_id,
+            "phase": self.phase,
+            "start_time_sec": self.start_time_sec,
+            "end_time_sec": self.end_time_sec,
+            "identity": {
+                "body_hash": self.body_hash,
+                "regime_hash": self.regime_hash,
+                "base_policy_version": self.base_policy_version,
+                "residual_policy_version": self.residual_policy_version,
+            },
+            "source": {
+                "evidence_level": self.source_evidence_level.value,
+                "lineage": self.lineage.to_dict(),
+            },
+            "state": {
+                "start_hash": self.state_start_hash,
+                "observation_sequence_hash": self.observation_sequence_hash,
+                "self_state_hash": self.self_state_hash,
+                "world_state_hash": self.world_state_hash,
+            },
+            "action": self.action.to_dict(),
+            "outcome": {
+                "reward_vector": dict(sorted(self.reward_vector.items())),
+                "cost_vector": dict(sorted(self.cost_vector.items())),
+                "terminal_state_hash": self.terminal_state_hash,
+            },
+            "labels": {
+                "advantage": self.advantage_label.value,
+                "confidence": self.label_confidence,
+                "failure_signature": (
+                    self.failure_signature.to_dict() if self.failure_signature else None
+                ),
+            },
+            "promotion_truth_allowed": self.source_evidence_level
+            in {EvidenceLevel.EXECUTION_RECEIPT, EvidenceLevel.PHYSICS_REPLAY},
+            "hardware_authorized": False,
+        }
+
+
+__all__ = [
+    "ActionTraceCommitment",
+    "DerivedExperienceLineage",
+    "ExperienceSegment",
+    "FailureSignature",
+    "PhysicalAdvantageLabel",
+]

--- a/src/rosclaw/growth/generalization.py
+++ b/src/rosclaw/growth/generalization.py
@@ -1,0 +1,208 @@
+"""Fail-closed admission gate for promoting domain discoveries into Core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.growth._validation import (
+    require_hash,
+    require_identifier,
+    unique_identifiers,
+)
+
+
+@dataclass(frozen=True)
+class DomainValidationProof:
+    domain_id: str
+    task_id: str
+    adapter_id: str
+    evidence_hash: str
+    schema_version: str = "rosclaw.growth.domain_validation_proof.v1"
+
+    def __post_init__(self) -> None:
+        for label in ("domain_id", "task_id", "adapter_id"):
+            require_identifier(label, getattr(self, label))
+        require_hash("evidence_hash", self.evidence_hash)
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "schema_version": self.schema_version,
+            "domain_id": self.domain_id,
+            "task_id": self.task_id,
+            "adapter_id": self.adapter_id,
+            "evidence_hash": self.evidence_hash,
+        }
+
+
+@dataclass(frozen=True)
+class GeneralizationEvidence:
+    component_id: str
+    source_paths: tuple[str, ...]
+    imported_modules: tuple[str, ...]
+    adapter_entry_point_group: str
+    synthetic_test_report_hash: str
+    plugin_removal_test_report_hash: str
+    domain_proofs: tuple[DomainValidationProof, ...]
+    schema_version: str = "rosclaw.growth.generalization_evidence.v1"
+
+    def __post_init__(self) -> None:
+        require_identifier("component_id", self.component_id)
+        object.__setattr__(
+            self,
+            "source_paths",
+            _unique_strings(self.source_paths, label="source_paths"),
+        )
+        object.__setattr__(
+            self,
+            "imported_modules",
+            _unique_strings(self.imported_modules, label="imported_modules", allow_empty=True),
+        )
+        require_identifier("adapter_entry_point_group", self.adapter_entry_point_group)
+        require_hash("synthetic_test_report_hash", self.synthetic_test_report_hash)
+        require_hash("plugin_removal_test_report_hash", self.plugin_removal_test_report_hash)
+        proofs = tuple(self.domain_proofs)
+        if not proofs or any(not isinstance(proof, DomainValidationProof) for proof in proofs):
+            raise ValueError("domain_proofs must contain DomainValidationProof records")
+        if len({(proof.domain_id, proof.task_id) for proof in proofs}) != len(proofs):
+            raise ValueError("domain proofs must be unique by domain and task")
+        object.__setattr__(self, "domain_proofs", proofs)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "component_id": self.component_id,
+            "source_paths": list(self.source_paths),
+            "imported_modules": list(self.imported_modules),
+            "adapter_entry_point_group": self.adapter_entry_point_group,
+            "synthetic_test_report_hash": self.synthetic_test_report_hash,
+            "plugin_removal_test_report_hash": self.plugin_removal_test_report_hash,
+            "domain_proofs": [proof.to_dict() for proof in self.domain_proofs],
+        }
+
+
+class GeneralizationStatus(StrEnum):
+    PASSED = "passed"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class GeneralizationDecision:
+    status: GeneralizationStatus
+    evidence_hash: str
+    reasons: tuple[str, ...]
+    schema_version: str = "rosclaw.growth.generalization_decision.v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, GeneralizationStatus):
+            raise ValueError("status must be a GeneralizationStatus")
+        require_hash("evidence_hash", self.evidence_hash)
+        object.__setattr__(
+            self,
+            "reasons",
+            unique_identifiers(self.reasons, label="reasons", allow_empty=True),
+        )
+        if (self.status is GeneralizationStatus.PASSED) != (not self.reasons):
+            raise ValueError("a passed decision has no rejection reasons")
+
+    @property
+    def hardware_authorized(self) -> bool:
+        return False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status.value,
+            "evidence_hash": self.evidence_hash,
+            "reasons": list(self.reasons),
+            "hardware_authorized": self.hardware_authorized,
+        }
+
+
+@dataclass(frozen=True)
+class CoreGeneralizationGate:
+    """Evaluate CI-collected facts; never execute a domain plugin or robot."""
+
+    downstream_import_prefixes: tuple[str, ...]
+    domain_tokens: tuple[str, ...]
+    minimum_distinct_domains: int = 2
+    schema_version: str = "rosclaw.growth.core_generalization_gate.v1"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "downstream_import_prefixes",
+            _unique_strings(
+                self.downstream_import_prefixes,
+                label="downstream_import_prefixes",
+                allow_empty=True,
+            ),
+        )
+        normalized_tokens = tuple(token.strip().lower() for token in self.domain_tokens)
+        if any(not token for token in normalized_tokens) or len(normalized_tokens) != len(
+            set(normalized_tokens)
+        ):
+            raise ValueError("domain_tokens must be unique non-empty strings")
+        object.__setattr__(self, "domain_tokens", normalized_tokens)
+        if not 2 <= self.minimum_distinct_domains <= 32:
+            raise ValueError("minimum_distinct_domains must be in [2, 32]")
+
+    def evaluate(self, evidence: GeneralizationEvidence) -> GeneralizationDecision:
+        if not isinstance(evidence, GeneralizationEvidence):
+            raise ValueError("evidence must be GeneralizationEvidence")
+        reasons: list[str] = []
+        searchable_names = (evidence.component_id, *evidence.source_paths)
+        if any(
+            token in name.lower().replace("-", "_")
+            for token in self.domain_tokens
+            for name in searchable_names
+        ):
+            reasons.append("domain_specific_name")
+        if any(
+            module == prefix or module.startswith(prefix + ".")
+            for module in evidence.imported_modules
+            for prefix in self.downstream_import_prefixes
+        ):
+            reasons.append("downstream_import")
+        if not evidence.adapter_entry_point_group:
+            reasons.append("missing_adapter_injection")
+        domain_count = len({proof.domain_id for proof in evidence.domain_proofs})
+        task_count = len({proof.task_id for proof in evidence.domain_proofs})
+        adapter_count = len({proof.adapter_id for proof in evidence.domain_proofs})
+        if domain_count < self.minimum_distinct_domains:
+            reasons.append("insufficient_domains")
+        if task_count < self.minimum_distinct_domains:
+            reasons.append("insufficient_tasks")
+        if adapter_count < self.minimum_distinct_domains:
+            reasons.append("insufficient_adapters")
+        status = GeneralizationStatus.REJECTED if reasons else GeneralizationStatus.PASSED
+        return GeneralizationDecision(
+            status=status,
+            evidence_hash=canonical_hash(evidence.to_dict()),
+            reasons=tuple(reasons),
+        )
+
+
+def _unique_strings(
+    values: tuple[str, ...],
+    *,
+    label: str,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    normalized = tuple(str(value).strip() for value in values)
+    if not allow_empty and not normalized:
+        raise ValueError(f"{label} must not be empty")
+    if any(not value for value in normalized) or len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must contain unique non-empty strings")
+    return normalized
+
+
+__all__ = [
+    "CoreGeneralizationGate",
+    "DomainValidationProof",
+    "GeneralizationDecision",
+    "GeneralizationEvidence",
+    "GeneralizationStatus",
+]

--- a/src/rosclaw/growth/plan.py
+++ b/src/rosclaw/growth/plan.py
@@ -1,0 +1,206 @@
+"""Content-addressed learning plans and candidate lineage contracts."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+from rosclaw.growth._validation import (
+    require_hash,
+    require_identifier,
+    unique_hashes,
+    unique_identifiers,
+)
+
+
+@dataclass(frozen=True)
+class LearningJob:
+    job_id: str
+    learner_id: str
+    data_query_hash: str
+    target_artifact_kind: str
+    required_field_ids: tuple[str, ...]
+    trainable_component_ids: tuple[str, ...]
+    schema_version: str = "rosclaw.growth.learning_job.v1"
+
+    def __post_init__(self) -> None:
+        for label in ("job_id", "learner_id", "target_artifact_kind"):
+            require_identifier(label, getattr(self, label))
+        require_hash("data_query_hash", self.data_query_hash)
+        for label in ("required_field_ids", "trainable_component_ids"):
+            object.__setattr__(
+                self,
+                label,
+                unique_identifiers(tuple(getattr(self, label)), label=label),
+            )
+
+    @property
+    def job_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "job_id": self.job_id,
+            "learner_id": self.learner_id,
+            "data_query_hash": self.data_query_hash,
+            "target_artifact_kind": self.target_artifact_kind,
+            "required_field_ids": list(self.required_field_ids),
+            "trainable_component_ids": list(self.trainable_component_ids),
+        }
+
+
+@dataclass(frozen=True)
+class LearningPlan:
+    campaign_id: str
+    skill_id: str
+    failure_cluster_hashes: tuple[str, ...]
+    jobs: tuple[LearningJob, ...]
+    frozen_component_ids: tuple[str, ...]
+    trainable_component_ids: tuple[str, ...]
+    historical_anchor_bank_hash: str
+    boundary_suite_hash: str
+    budget: Mapping[str, float]
+    promotion_profile_hash: str
+    schema_version: str = "rosclaw.growth.learning_plan.v1"
+
+    def __post_init__(self) -> None:
+        for label in ("campaign_id", "skill_id"):
+            require_identifier(label, getattr(self, label))
+        object.__setattr__(
+            self,
+            "failure_cluster_hashes",
+            unique_hashes(self.failure_cluster_hashes, label="failure_cluster_hashes"),
+        )
+        jobs = tuple(self.jobs)
+        if not jobs or any(not isinstance(value, LearningJob) for value in jobs):
+            raise ValueError("jobs must contain LearningJob records")
+        if len({value.job_id for value in jobs}) != len(jobs):
+            raise ValueError("job ids must be unique")
+        object.__setattr__(self, "jobs", jobs)
+        for label in ("frozen_component_ids", "trainable_component_ids"):
+            object.__setattr__(
+                self,
+                label,
+                unique_identifiers(tuple(getattr(self, label)), label=label),
+            )
+        overlap = set(self.frozen_component_ids).intersection(self.trainable_component_ids)
+        if overlap:
+            raise ValueError(f"components cannot be both frozen and trainable: {sorted(overlap)}")
+        undeclared = {
+            component
+            for job in jobs
+            for component in job.trainable_component_ids
+            if component not in self.trainable_component_ids
+        }
+        if undeclared:
+            raise ValueError(
+                f"jobs reference undeclared trainable components: {sorted(undeclared)}"
+            )
+        for label in (
+            "historical_anchor_bank_hash",
+            "boundary_suite_hash",
+            "promotion_profile_hash",
+        ):
+            require_hash(label, getattr(self, label))
+        budget = {str(key): float(value) for key, value in self.budget.items()}
+        if not budget:
+            raise ValueError("budget must not be empty")
+        for key, value in budget.items():
+            require_identifier("budget key", key)
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError("budget values must be finite and positive")
+        object.__setattr__(self, "budget", MappingProxyType(budget))
+
+    @property
+    def plan_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "campaign_id": self.campaign_id,
+            "skill_id": self.skill_id,
+            "failure_cluster_hashes": list(self.failure_cluster_hashes),
+            "jobs": [value.to_dict() for value in self.jobs],
+            "frozen_component_ids": list(self.frozen_component_ids),
+            "trainable_component_ids": list(self.trainable_component_ids),
+            "historical_anchor_bank_hash": self.historical_anchor_bank_hash,
+            "boundary_suite_hash": self.boundary_suite_hash,
+            "budget": dict(sorted(self.budget.items())),
+            "promotion_profile_hash": self.promotion_profile_hash,
+            "evidence_domain": "SIM_ONLY",
+            "hardware_authorized": False,
+        }
+
+
+@dataclass(frozen=True)
+class CandidateManifest:
+    candidate_id: str
+    skill_id: str
+    parent_artifact_hash: str
+    learning_plan_hash: str
+    code_hash: str
+    environment_hash: str
+    body_hash: str
+    training_data_hashes: tuple[str, ...]
+    learned_artifacts: Mapping[str, str]
+    learned_output_fraction: float
+    schema_version: str = "rosclaw.growth.candidate_manifest.v1"
+
+    def __post_init__(self) -> None:
+        for label in ("candidate_id", "skill_id"):
+            require_identifier(label, getattr(self, label))
+        for label in (
+            "parent_artifact_hash",
+            "learning_plan_hash",
+            "code_hash",
+            "environment_hash",
+            "body_hash",
+        ):
+            require_hash(label, getattr(self, label))
+        object.__setattr__(
+            self,
+            "training_data_hashes",
+            unique_hashes(self.training_data_hashes, label="training_data_hashes"),
+        )
+        learned = {str(key): str(value) for key, value in self.learned_artifacts.items()}
+        if not learned:
+            raise ValueError("learned_artifacts must not be empty")
+        for key, value in learned.items():
+            require_identifier("learned artifact key", key)
+            require_hash("learned artifact hash", value)
+        object.__setattr__(self, "learned_artifacts", MappingProxyType(learned))
+        if not math.isfinite(self.learned_output_fraction) or not (
+            0.0 <= self.learned_output_fraction <= 1.0
+        ):
+            raise ValueError("learned_output_fraction must be finite and in [0, 1]")
+
+    @property
+    def manifest_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "candidate_id": self.candidate_id,
+            "skill_id": self.skill_id,
+            "parent_artifact_hash": self.parent_artifact_hash,
+            "learning_plan_hash": self.learning_plan_hash,
+            "code_hash": self.code_hash,
+            "environment_hash": self.environment_hash,
+            "body_hash": self.body_hash,
+            "training_data_hashes": list(self.training_data_hashes),
+            "learned_artifacts": dict(sorted(self.learned_artifacts.items())),
+            "learned_output_fraction": self.learned_output_fraction,
+            "promotion_truth_allowed": False,
+            "evidence_domain": "SIM_ONLY",
+            "hardware_authorized": False,
+        }
+
+
+__all__ = ["CandidateManifest", "LearningJob", "LearningPlan"]

--- a/tests/architecture/test_growth_core_domain_purity.py
+++ b/tests/architecture/test_growth_core_domain_purity.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+GROWTH_ROOT = Path(__file__).resolve().parents[2] / "src/rosclaw/growth"
+DOWNSTREAM_PREFIXES = ("rosclaw_soccer",)
+DOMAIN_PATH_TOKENS = (
+    "ballistic_contact",
+    "football",
+    "free_kick",
+    "g1_",
+    "goalkeeper",
+    "stadium",
+)
+
+
+def _imports(path: Path) -> tuple[str, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    values: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            values.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            values.append(node.module)
+    return tuple(values)
+
+
+def test_growth_core_has_no_downstream_import_or_domain_path() -> None:
+    violations: list[str] = []
+    for path in sorted(GROWTH_ROOT.rglob("*.py")):
+        relative = path.relative_to(GROWTH_ROOT).as_posix().lower().replace("-", "_")
+        for token in DOMAIN_PATH_TOKENS:
+            if token in relative:
+                violations.append(f"domain path: {relative} ({token})")
+        for module in _imports(path):
+            if any(
+                module == prefix or module.startswith(prefix + ".")
+                for prefix in DOWNSTREAM_PREFIXES
+            ):
+                violations.append(f"downstream import: {relative} -> {module}")
+
+    assert violations == []

--- a/tests/growth/test_task_neutral_experience.py
+++ b/tests/growth/test_task_neutral_experience.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from rosclaw.growth import (
+    ActionTraceCommitment,
+    CandidateManifest,
+    CoreGeneralizationGate,
+    DerivedExperienceLineage,
+    DomainValidationProof,
+    EvidenceLevel,
+    ExperienceSegment,
+    FailureSignature,
+    GeneralizationEvidence,
+    GeneralizationStatus,
+    LearningJob,
+    LearningPlan,
+    PhysicalAdvantageLabel,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _hash(value: str | bytes) -> str:
+    payload = value.encode() if isinstance(value, str) else value
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _file_hash(path: Path) -> str:
+    return _hash(path.read_bytes())
+
+
+def _lineage(source_path: Path, event_values: list[dict[str, Any]]) -> DerivedExperienceLineage:
+    event_hashes = tuple(
+        _hash(json.dumps(event, sort_keys=True, separators=(",", ":"))) for event in event_values
+    )
+    return DerivedExperienceLineage(
+        source_artifact_hash=_file_hash(source_path),
+        source_event_hashes=event_hashes,
+        transform_hash=_hash("task-neutral-segmenter.v1"),
+        clock_id="monotonic.source",
+        maximum_skew_sec=0.02,
+        observed_skew_sec=0.01 if len(event_hashes) > 1 else 0.0,
+        synchronization_receipt_hash=(
+            _hash("alignment-receipt") if len(event_hashes) > 1 else None
+        ),
+    )
+
+
+def _action(label: str) -> ActionTraceCommitment:
+    executed = _hash(f"{label}.executed")
+    return ActionTraceCommitment(
+        commanded_action_hash=_hash(f"{label}.commanded"),
+        executed_action_hash=executed,
+        safety_projected_action_hash=executed,
+        policy_version="baseline.v1",
+        controller_hash=_hash(f"{label}.controller"),
+        projection_applied=False,
+    )
+
+
+def _segment(
+    *,
+    segment_id: str,
+    episode_id: str,
+    skill_id: str,
+    phase: str,
+    lineage: DerivedExperienceLineage,
+    failure_type: str,
+) -> ExperienceSegment:
+    failure = FailureSignature(
+        primary_type=failure_type,
+        contributors=("regime.shift",),
+        confidence=0.91,
+        affected_capability_ids=(skill_id,),
+        reusable_evidence_ids=(),
+        recommended_learner_ids=("system_identification",),
+    )
+    return ExperienceSegment(
+        segment_id=segment_id,
+        episode_id=episode_id,
+        skill_id=skill_id,
+        phase=phase,
+        start_time_sec=0.1,
+        end_time_sec=0.4,
+        body_hash=_hash(f"{skill_id}.body"),
+        regime_hash=_hash(f"{skill_id}.regime"),
+        source_evidence_level=EvidenceLevel.PHYSICS_REPLAY,
+        lineage=lineage,
+        base_policy_version="baseline.v1",
+        residual_policy_version=None,
+        state_start_hash=_hash(f"{skill_id}.state"),
+        observation_sequence_hash=_hash(f"{skill_id}.observations"),
+        self_state_hash=_hash(f"{skill_id}.self"),
+        world_state_hash=_hash(f"{skill_id}.world"),
+        action=_action(skill_id),
+        reward_vector={"task.progress": 0.4},
+        cost_vector={"safety.violation": 0.0},
+        terminal_state_hash=_hash(f"{skill_id}.terminal"),
+        advantage_label=PhysicalAdvantageLabel.ADVANTAGE_NEGATIVE,
+        label_confidence=0.82,
+        failure_signature=failure,
+    )
+
+
+def test_same_experience_contract_accepts_rh56_and_arm_reach_evidence() -> None:
+    fixture_path = REPOSITORY_ROOT / "tests/fixtures/practice/rh56_minimal_loop.json"
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    hand_segment = _segment(
+        segment_id="segment.hand.001",
+        episode_id="episode.hand.001",
+        skill_id="rh56.single_step",
+        phase="contact.recovery",
+        lineage=_lineage(fixture_path, fixture["events"][1:3]),
+        failure_type="contact.force_overshoot",
+    )
+
+    reach_path = REPOSITORY_ROOT / "src/rosclaw/simforge/tasks/shield_reach.py"
+    reach_segment = _segment(
+        segment_id="segment.reach.001",
+        episode_id="episode.reach.001",
+        skill_id="arm.shield_reach",
+        phase="boundary.approach",
+        lineage=_lineage(reach_path, [{"case_id": "boundary.001", "risk": 0.82}]),
+        failure_type="shield.boundary_error",
+    )
+
+    assert hand_segment.to_dict()["source"]["lineage"]["synchronization_receipt_hash"]
+    assert hand_segment.segment_hash != reach_segment.segment_hash
+    assert hand_segment.to_dict()["hardware_authorized"] is False
+    assert reach_segment.to_dict()["promotion_truth_allowed"] is True
+
+
+def test_multi_event_lineage_fails_closed_without_alignment_receipt() -> None:
+    with pytest.raises(ValueError, match="synchronization receipt"):
+        DerivedExperienceLineage(
+            source_artifact_hash=_hash("source"),
+            source_event_hashes=(_hash("event-a"), _hash("event-b")),
+            transform_hash=_hash("transform"),
+            clock_id="monotonic.source",
+            maximum_skew_sec=0.01,
+            observed_skew_sec=0.005,
+        )
+
+
+def test_physical_advantage_labels_preserve_safety_cost_semantics() -> None:
+    fixture_path = REPOSITORY_ROOT / "tests/fixtures/practice/rh56_minimal_loop.json"
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    segment = _segment(
+        segment_id="segment.hand.002",
+        episode_id="episode.hand.002",
+        skill_id="rh56.single_step",
+        phase="contact.recovery",
+        lineage=_lineage(fixture_path, fixture["events"][1:2]),
+        failure_type="contact.force_overshoot",
+    )
+
+    with pytest.raises(ValueError, match="positive advantage"):
+        replace(
+            segment,
+            advantage_label=PhysicalAdvantageLabel.ADVANTAGE_POSITIVE,
+            cost_vector={"safety.violation": 1.0},
+        )
+
+
+def _learning_plan() -> LearningPlan:
+    job = LearningJob(
+        job_id="job.regime.identification",
+        learner_id="system_identification",
+        data_query_hash=_hash("query"),
+        target_artifact_kind="regime.model",
+        required_field_ids=("state.self", "action.executed", "outcome.cost"),
+        trainable_component_ids=("regime.adapter",),
+    )
+    return LearningPlan(
+        campaign_id="campaign.cross_domain.001",
+        skill_id="adaptive.control",
+        failure_cluster_hashes=(_hash("failures"),),
+        jobs=(job,),
+        frozen_component_ids=("safety.projector",),
+        trainable_component_ids=("regime.adapter",),
+        historical_anchor_bank_hash=_hash("anchors"),
+        boundary_suite_hash=_hash("boundaries"),
+        budget={"rollout.steps": 1000.0},
+        promotion_profile_hash=_hash("promotion"),
+    )
+
+
+def test_learning_plan_and_candidate_never_self_authorize_activation() -> None:
+    plan = _learning_plan()
+    candidate = CandidateManifest(
+        candidate_id="candidate.cross_domain.001",
+        skill_id=plan.skill_id,
+        parent_artifact_hash=_hash("parent"),
+        learning_plan_hash=plan.plan_hash,
+        code_hash=_hash("code"),
+        environment_hash=_hash("environment"),
+        body_hash=_hash("body"),
+        training_data_hashes=(_hash("data"),),
+        learned_artifacts={"regime.adapter": _hash("weights")},
+        learned_output_fraction=0.2,
+    )
+
+    assert plan.to_dict()["hardware_authorized"] is False
+    assert candidate.to_dict()["promotion_truth_allowed"] is False
+    assert candidate.to_dict()["hardware_authorized"] is False
+
+
+def test_core_generalization_gate_requires_two_real_repository_domains() -> None:
+    hand_fixture = REPOSITORY_ROOT / "tests/fixtures/practice/rh56_minimal_loop.json"
+    reach_task = REPOSITORY_ROOT / "src/rosclaw/simforge/tasks/shield_reach.py"
+    evidence = GeneralizationEvidence(
+        component_id="growth.experience",
+        source_paths=("src/rosclaw/growth/experience.py",),
+        imported_modules=("rosclaw.feedback.contracts", "rosclaw.growth.contracts"),
+        adapter_entry_point_group="rosclaw.growth.adapters",
+        synthetic_test_report_hash=_hash("synthetic-tests"),
+        plugin_removal_test_report_hash=_hash("core-without-plugins"),
+        domain_proofs=(
+            DomainValidationProof(
+                domain_id="dexterous_manipulation",
+                task_id="rh56.single_step",
+                adapter_id="rh56.practice",
+                evidence_hash=_file_hash(hand_fixture),
+            ),
+            DomainValidationProof(
+                domain_id="arm_reach",
+                task_id="arm.shield_reach",
+                adapter_id="simforge.shield_reach",
+                evidence_hash=_file_hash(reach_task),
+            ),
+        ),
+    )
+    gate = CoreGeneralizationGate(
+        downstream_import_prefixes=("rosclaw_soccer",),
+        domain_tokens=("football", "free_kick", "ballistic_contact", "g1_"),
+    )
+
+    decision = gate.evaluate(evidence)
+
+    assert decision.status is GeneralizationStatus.PASSED
+    assert decision.reasons == ()
+    assert decision.hardware_authorized is False
+
+
+def test_core_generalization_gate_rejects_one_domain_and_reverse_dependency() -> None:
+    proof = DomainValidationProof(
+        domain_id="dexterous_manipulation",
+        task_id="rh56.single_step",
+        adapter_id="rh56.practice",
+        evidence_hash=_hash("evidence"),
+    )
+    evidence = GeneralizationEvidence(
+        component_id="growth.experience",
+        source_paths=("src/rosclaw/growth/experience.py",),
+        imported_modules=("rosclaw_soccer.skills",),
+        adapter_entry_point_group="rosclaw.growth.adapters",
+        synthetic_test_report_hash=_hash("synthetic-tests"),
+        plugin_removal_test_report_hash=_hash("core-without-plugins"),
+        domain_proofs=(proof,),
+    )
+    gate = CoreGeneralizationGate(
+        downstream_import_prefixes=("rosclaw_soccer",),
+        domain_tokens=("football",),
+    )
+
+    decision = gate.evaluate(evidence)
+
+    assert decision.status is GeneralizationStatus.REJECTED
+    assert decision.reasons == (
+        "downstream_import",
+        "insufficient_domains",
+        "insufficient_tasks",
+        "insufficient_adapters",
+    )


### PR DESCRIPTION
## What changed

- adds task-neutral `ExperienceSegment`, failure, action-trace, learning-plan, and candidate-lineage contracts
- adds `DerivedExperienceLineage` with fail-closed synchronization receipts for multi-event derived state
- adds a `CoreGeneralizationGate` enforcing two distinct domains/tasks/adapters, no downstream imports, synthetic evidence, and plugin-removal evidence
- adds Growth Core dependency/path purity CI

## Why

Football is a stress case, not the ROSClaw product boundary. These contracts retain the reusable PARC mechanisms while leaving joint, contact, scoring, and robot semantics in downstream adapters. This is C2 split from draft PR #271.

## Validation

- RH56 practice fixture and ShieldReach source evidence pass the same experience/lineage contract
- one-domain and reverse-dependency claims fail closed
- candidate contracts never self-authorize promotion or hardware
- stacked Growth/SimForge regression: 207 passed, 1 skipped, 3 deselected
- Ruff and mypy: passed
