### PR TITLE
feat(growth): add learner routing and extension registry

### DIFF
--- a/src/rosclaw/extension_discovery.py
+++ b/src/rosclaw/extension_discovery.py
@@ -1,0 +1,73 @@
+"""Minimal entry-point discovery with deterministic, recoverable failure isolation."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger("rosclaw.extension_discovery")
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+@dataclass(frozen=True)
+class EntryPointDiscoveryReport:
+    group: str
+    loaded: tuple[str, ...]
+    errors: tuple[str, ...]
+    disabled: bool = False
+
+
+def discover_entry_point_objects(
+    *,
+    group: str,
+    disable_env: str,
+    register: Callable[[Any], str],
+) -> EntryPointDiscoveryReport:
+    """Load isolated extension objects and register each validated object.
+
+    Only the loaded object is passed to ``register``. The discovery layer does
+    not provide a runtime, driver, executor, transport, or actuator handle.
+    One broken optional package is reported without hiding healthy packages.
+    """
+
+    if os.environ.get(disable_env, "").strip().lower() in _TRUE_VALUES:
+        return EntryPointDiscoveryReport(group=group, loaded=(), errors=(), disabled=True)
+    try:
+        entry_points = importlib.metadata.entry_points()
+        selected: Iterable[Any]
+        if hasattr(entry_points, "select"):
+            selected = entry_points.select(group=group)
+        else:  # pragma: no cover - compatibility with older metadata providers
+            selected = entry_points.get(group, ())
+    except Exception as exc:
+        message = f"discovery failed: {exc}"
+        logger.warning("ROSClaw extension group %s %s", group, message)
+        return EntryPointDiscoveryReport(group=group, loaded=(), errors=(message,))
+
+    loaded: list[str] = []
+    errors: list[str] = []
+    ordered = sorted(
+        selected,
+        key=lambda item: (
+            str(getattr(item, "name", "")),
+            str(getattr(item, "value", "")),
+        ),
+    )
+    for entry_point in ordered:
+        name = str(getattr(entry_point, "name", getattr(entry_point, "value", "unknown")))
+        try:
+            identifier = register(entry_point.load())
+        except Exception as exc:
+            message = f"{name}: {exc}"
+            errors.append(message)
+            logger.warning("Failed to register ROSClaw extension %s in %s", name, group)
+            continue
+        loaded.append(identifier)
+    return EntryPointDiscoveryReport(group=group, loaded=tuple(loaded), errors=tuple(errors))
+
+
+__all__ = ["EntryPointDiscoveryReport", "discover_entry_point_objects"]

--- a/src/rosclaw/growth/__init__.py
+++ b/src/rosclaw/growth/__init__.py
@@ -28,6 +28,21 @@ from rosclaw.growth.generalization import (
     GeneralizationStatus,
 )
 from rosclaw.growth.plan import CandidateManifest, LearningJob, LearningPlan
+from rosclaw.growth.registry import (
+    GROWTH_ADAPTER_GROUP,
+    GROWTH_LEARNER_GROUP,
+    GrowthAdapter,
+    GrowthDiscoveryReport,
+    GrowthExtensionRegistry,
+    LearnerDescriptor,
+)
+from rosclaw.growth.routing import (
+    DataProfile,
+    GrowthProblemSignals,
+    LearnerRoute,
+    RouteDisposition,
+    route_learners,
+)
 
 __all__ = [
     "ActionTraceCommitment",
@@ -41,6 +56,8 @@ __all__ = [
     "EvidenceUsePolicy",
     "ExperienceSegment",
     "FailureSignature",
+    "GROWTH_ADAPTER_GROUP",
+    "GROWTH_LEARNER_GROUP",
     "GateName",
     "GateResult",
     "GateStatus",
@@ -48,10 +65,19 @@ __all__ = [
     "GeneralizationEvidence",
     "GeneralizationStatus",
     "GrowthMetricSpec",
+    "GrowthAdapter",
+    "GrowthDiscoveryReport",
+    "GrowthExtensionRegistry",
+    "GrowthProblemSignals",
+    "DataProfile",
     "LearningJob",
     "LearningPlan",
+    "LearnerDescriptor",
+    "LearnerRoute",
     "MetricDirection",
     "PhysicalAdvantageLabel",
+    "RouteDisposition",
     "SkillGrowthSpec",
     "TrainingEligibility",
+    "route_learners",
 ]

--- a/src/rosclaw/growth/registry.py
+++ b/src/rosclaw/growth/registry.py
@@ -1,0 +1,126 @@
+"""Runtime-free registries for downstream Growth adapters and learners."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from rosclaw.extension_discovery import (
+    EntryPointDiscoveryReport,
+    discover_entry_point_objects,
+)
+from rosclaw.growth._validation import require_identifier, unique_identifiers
+from rosclaw.growth.experience import ExperienceSegment, FailureSignature
+
+GROWTH_ADAPTER_GROUP = "rosclaw.growth.adapters"
+GROWTH_LEARNER_GROUP = "rosclaw.growth.learners"
+_DISABLE_ENV = "ROSCLAW_DISABLE_GROWTH_EXTENSIONS"
+
+
+@runtime_checkable
+class GrowthAdapter(Protocol):
+    """Domain semantic boundary; deliberately carries no execution authority."""
+
+    adapter_id: str
+    skill_ids: tuple[str, ...]
+
+    def normalize_experience(self, payload: Mapping[str, Any]) -> ExperienceSegment: ...
+
+    def diagnose(self, segment: ExperienceSegment) -> FailureSignature | None: ...
+
+
+@dataclass(frozen=True)
+class LearnerDescriptor:
+    learner_id: str
+    required_field_ids: tuple[str, ...]
+    artifact_kinds: tuple[str, ...]
+    online_rollout_required: bool
+    consumes_cost_vector: bool
+    schema_version: str = "rosclaw.growth.learner_descriptor.v1"
+
+    def __post_init__(self) -> None:
+        require_identifier("learner_id", self.learner_id)
+        for label in ("required_field_ids", "artifact_kinds"):
+            object.__setattr__(
+                self,
+                label,
+                unique_identifiers(tuple(getattr(self, label)), label=label),
+            )
+
+
+@dataclass(frozen=True)
+class GrowthDiscoveryReport:
+    adapters: EntryPointDiscoveryReport
+    learners: EntryPointDiscoveryReport
+
+
+class GrowthExtensionRegistry:
+    """In-memory catalog populated only with validated extension contracts."""
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, GrowthAdapter] = {}
+        self._learners: dict[str, LearnerDescriptor] = {}
+
+    def register_adapter(self, adapter: Any) -> str:
+        if not isinstance(adapter, GrowthAdapter):
+            raise TypeError("growth adapter does not satisfy the GrowthAdapter protocol")
+        require_identifier("adapter_id", adapter.adapter_id)
+        skill_ids = unique_identifiers(tuple(adapter.skill_ids), label="skill_ids")
+        if tuple(adapter.skill_ids) != skill_ids:
+            raise ValueError("adapter skill_ids must be a stable tuple")
+        if adapter.adapter_id in self._adapters:
+            raise ValueError(f"duplicate growth adapter: {adapter.adapter_id}")
+        self._adapters[adapter.adapter_id] = adapter
+        return adapter.adapter_id
+
+    def register_learner(self, descriptor: Any) -> str:
+        if not isinstance(descriptor, LearnerDescriptor):
+            raise TypeError("learner entry point must expose LearnerDescriptor")
+        if descriptor.learner_id in self._learners:
+            raise ValueError(f"duplicate learner: {descriptor.learner_id}")
+        self._learners[descriptor.learner_id] = descriptor
+        return descriptor.learner_id
+
+    def adapter(self, adapter_id: str) -> GrowthAdapter:
+        try:
+            return self._adapters[adapter_id]
+        except KeyError as exc:
+            raise KeyError(f"unknown growth adapter: {adapter_id}") from exc
+
+    def learner(self, learner_id: str) -> LearnerDescriptor:
+        try:
+            return self._learners[learner_id]
+        except KeyError as exc:
+            raise KeyError(f"unknown growth learner: {learner_id}") from exc
+
+    @property
+    def adapter_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._adapters))
+
+    @property
+    def learner_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._learners))
+
+    def discover(self) -> GrowthDiscoveryReport:
+        adapters = discover_entry_point_objects(
+            group=GROWTH_ADAPTER_GROUP,
+            disable_env=_DISABLE_ENV,
+            register=self.register_adapter,
+        )
+        learners = discover_entry_point_objects(
+            group=GROWTH_LEARNER_GROUP,
+            disable_env=_DISABLE_ENV,
+            register=self.register_learner,
+        )
+        return GrowthDiscoveryReport(adapters=adapters, learners=learners)
+
+
+__all__ = [
+    "GROWTH_ADAPTER_GROUP",
+    "GROWTH_LEARNER_GROUP",
+    "GrowthAdapter",
+    "GrowthDiscoveryReport",
+    "GrowthExtensionRegistry",
+    "LearnerDescriptor",
+]

--- a/src/rosclaw/growth/routing/__init__.py
+++ b/src/rosclaw/growth/routing/__init__.py
@@ -1,0 +1,17 @@
+"""Deterministic, evidence-conditioned learner routing."""
+
+from rosclaw.growth.routing.rule_router import (
+    DataProfile,
+    GrowthProblemSignals,
+    LearnerRoute,
+    RouteDisposition,
+    route_learners,
+)
+
+__all__ = [
+    "DataProfile",
+    "GrowthProblemSignals",
+    "LearnerRoute",
+    "RouteDisposition",
+    "route_learners",
+]

--- a/src/rosclaw/growth/routing/rule_router.py
+++ b/src/rosclaw/growth/routing/rule_router.py
@@ -1,0 +1,197 @@
+"""Evidence-conditioned routing across complementary learning mechanisms."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+
+def _score(label: str, value: float) -> None:
+    if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+        raise ValueError(f"{label} must be finite and in [0, 1]")
+
+
+@dataclass(frozen=True)
+class GrowthProblemSignals:
+    repeated_error: float = 0.0
+    regime_shift: float = 0.0
+    local_physics_residual: float = 0.0
+    out_of_distribution: float = 0.0
+    gradient_conflict: float = 0.0
+    safety_model_complete: bool = True
+    schema_version: str = "rosclaw.growth.problem_signals.v1"
+
+    def __post_init__(self) -> None:
+        for label in (
+            "repeated_error",
+            "regime_shift",
+            "local_physics_residual",
+            "out_of_distribution",
+            "gradient_conflict",
+        ):
+            _score(label, getattr(self, label))
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DataProfile:
+    has_state: bool = False
+    has_executed_action: bool = False
+    has_next_state: bool = False
+    has_reward_vector: bool = False
+    has_cost_vector: bool = False
+    has_kinematic_reference: bool = False
+    has_chunk_feedback: bool = False
+    fixed_dataset: bool = False
+    online_rollout_allowed: bool = False
+    schema_version: str = "rosclaw.growth.data_profile.v1"
+
+    @property
+    def transition_ready(self) -> bool:
+        return all(
+            (
+                self.has_state,
+                self.has_executed_action,
+                self.has_next_state,
+                self.has_reward_vector,
+                self.has_cost_vector,
+            )
+        )
+
+    @property
+    def offline_rl_ready(self) -> bool:
+        return self.fixed_dataset and self.transition_ready
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["transition_ready"] = self.transition_ready
+        value["offline_rl_ready"] = self.offline_rl_ready
+        return value
+
+
+class RouteDisposition(StrEnum):
+    SELECTED = "selected"
+    NEED_MORE_EVIDENCE = "need_more_evidence"
+    BLOCKED_SAFETY_MODEL = "blocked_safety_model"
+
+
+@dataclass(frozen=True)
+class LearnerRoute:
+    disposition: RouteDisposition
+    learner_ids: tuple[str, ...]
+    reasons: tuple[str, ...]
+    missing_requirements: tuple[str, ...]
+    schema_version: str = "rosclaw.growth.learner_route.v1"
+
+    @property
+    def route_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "disposition": self.disposition.value,
+            "learner_ids": list(self.learner_ids),
+            "reasons": list(self.reasons),
+            "missing_requirements": list(self.missing_requirements),
+            "evidence_domain": "LEARNING_CONTROL_PLANE",
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+
+
+def route_learners(signals: GrowthProblemSignals, data: DataProfile) -> LearnerRoute:
+    """Choose mechanisms from evidence shape instead of task or robot name."""
+
+    if not isinstance(signals, GrowthProblemSignals) or not isinstance(data, DataProfile):
+        raise ValueError("route_learners requires GrowthProblemSignals and DataProfile")
+    if not signals.safety_model_complete:
+        return LearnerRoute(
+            disposition=RouteDisposition.BLOCKED_SAFETY_MODEL,
+            learner_ids=(),
+            reasons=("safety_model_incomplete",),
+            missing_requirements=("complete_cost_and_safety_projection_contract",),
+        )
+
+    learners: list[str] = []
+    reasons: list[str] = []
+    missing: list[str] = []
+    if signals.regime_shift >= 0.60:
+        learners.append("system_identification")
+        reasons.append("body_or_environment_regime_shift")
+    if signals.repeated_error >= 0.70 and signals.regime_shift < 0.60:
+        learners.append("ilc")
+        reasons.append("stable_repeatable_error")
+    if data.has_kinematic_reference and not data.transition_ready:
+        learners.append("motion_tracking")
+        reasons.append("kinematic_reference_without_physics_transition")
+    if data.offline_rl_ready:
+        learners.append("iql")
+        reasons.append("complete_fixed_transition_dataset")
+    elif data.fixed_dataset and any(
+        (data.has_state, data.has_executed_action, data.has_next_state, data.has_reward_vector)
+    ):
+        missing.extend(_missing_transition_fields(data))
+    if signals.local_physics_residual >= 0.60:
+        if data.transition_ready and data.online_rollout_allowed:
+            learners.append("residual_sac")
+            reasons.append("bounded_local_physics_residual")
+        else:
+            missing.extend(_missing_residual_requirements(data))
+    if data.has_chunk_feedback:
+        learners.append("advantage_sft")
+        reasons.append("chunk_level_feedback_available")
+    if signals.out_of_distribution >= 0.70:
+        learners.append("world_model_observer")
+        reasons.append("world_prediction_or_state_ood")
+    if signals.gradient_conflict >= 0.70:
+        learners.append("new_expert_adapter")
+        reasons.append("shared_parameter_gradient_conflict")
+
+    learner_ids = tuple(dict.fromkeys(learners))
+    missing_requirements = tuple(dict.fromkeys(missing))
+    if learner_ids:
+        disposition = RouteDisposition.SELECTED
+    else:
+        disposition = RouteDisposition.NEED_MORE_EVIDENCE
+        if not missing_requirements:
+            missing_requirements = ("diagnostic_signal_or_qualified_learning_data",)
+    return LearnerRoute(
+        disposition=disposition,
+        learner_ids=learner_ids,
+        reasons=tuple(reasons),
+        missing_requirements=missing_requirements,
+    )
+
+
+def _missing_transition_fields(data: DataProfile) -> list[str]:
+    fields = (
+        ("state", data.has_state),
+        ("executed_action", data.has_executed_action),
+        ("next_state", data.has_next_state),
+        ("reward_vector", data.has_reward_vector),
+        ("cost_vector", data.has_cost_vector),
+    )
+    return [f"transition.{name}" for name, present in fields if not present]
+
+
+def _missing_residual_requirements(data: DataProfile) -> list[str]:
+    missing = _missing_transition_fields(data)
+    if not data.online_rollout_allowed:
+        missing.append("simulation_online_rollout")
+    return missing
+
+
+__all__ = [
+    "DataProfile",
+    "GrowthProblemSignals",
+    "LearnerRoute",
+    "RouteDisposition",
+    "route_learners",
+]

--- a/tests/growth/test_extension_registry.py
+++ b/tests/growth/test_extension_registry.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from rosclaw import extension_discovery
+from rosclaw.growth import (
+    GROWTH_ADAPTER_GROUP,
+    GROWTH_LEARNER_GROUP,
+    GrowthExtensionRegistry,
+    LearnerDescriptor,
+)
+
+
+@dataclass
+class _EntryPoint:
+    name: str
+    group: str
+    value: Any
+    error: Exception | None = None
+
+    def load(self) -> Any:
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+
+class _EntryPoints(list[_EntryPoint]):
+    def select(self, *, group: str) -> _EntryPoints:
+        return _EntryPoints(item for item in self if item.group == group)
+
+
+@dataclass
+class _Adapter:
+    adapter_id: str
+    skill_ids: tuple[str, ...]
+
+    def normalize_experience(self, _payload: Any) -> Any:
+        raise NotImplementedError
+
+    def diagnose(self, _segment: Any) -> Any:
+        raise NotImplementedError
+
+
+def _learner(learner_id: str) -> LearnerDescriptor:
+    return LearnerDescriptor(
+        learner_id=learner_id,
+        required_field_ids=("state.self", "action.executed", "outcome.cost"),
+        artifact_kinds=("residual.policy",),
+        online_rollout_required=False,
+        consumes_cost_vector=True,
+    )
+
+
+def test_registry_discovers_two_domains_without_runtime_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entries = _EntryPoints(
+        [
+            _EntryPoint(
+                "navigation",
+                GROWTH_ADAPTER_GROUP,
+                _Adapter("navigation.path_follow", ("navigation.follow_path",)),
+            ),
+            _EntryPoint(
+                "manipulation",
+                GROWTH_ADAPTER_GROUP,
+                _Adapter("manipulation.force_control", ("manipulation.soft_grip",)),
+            ),
+            _EntryPoint("system-identification", GROWTH_LEARNER_GROUP, _learner("sysid")),
+        ]
+    )
+    monkeypatch.setattr(extension_discovery.importlib.metadata, "entry_points", lambda: entries)
+    registry = GrowthExtensionRegistry()
+
+    report = registry.discover()
+
+    assert registry.adapter_ids == (
+        "manipulation.force_control",
+        "navigation.path_follow",
+    )
+    assert registry.learner_ids == ("sysid",)
+    assert report.adapters.errors == ()
+    assert report.learners.errors == ()
+
+
+def test_broken_or_duplicate_extension_isolated_from_healthy_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entries = _EntryPoints(
+        [
+            _EntryPoint(
+                "broken",
+                GROWTH_ADAPTER_GROUP,
+                None,
+                RuntimeError("broken package"),
+            ),
+            _EntryPoint(
+                "first",
+                GROWTH_ADAPTER_GROUP,
+                _Adapter("navigation.path_follow", ("navigation.follow_path",)),
+            ),
+            _EntryPoint(
+                "second",
+                GROWTH_ADAPTER_GROUP,
+                _Adapter("navigation.path_follow", ("navigation.follow_path",)),
+            ),
+        ]
+    )
+    monkeypatch.setattr(extension_discovery.importlib.metadata, "entry_points", lambda: entries)
+    registry = GrowthExtensionRegistry()
+
+    report = registry.discover()
+
+    assert registry.adapter_ids == ("navigation.path_follow",)
+    assert report.adapters.loaded == ("navigation.path_follow",)
+    assert report.adapters.errors == (
+        "broken: broken package",
+        "second: duplicate growth adapter: navigation.path_follow",
+    )
+
+
+def test_growth_extension_discovery_has_operator_recovery_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ROSCLAW_DISABLE_GROWTH_EXTENSIONS", "true")
+    monkeypatch.setattr(
+        extension_discovery.importlib.metadata,
+        "entry_points",
+        lambda: pytest.fail("disabled discovery must not inspect packages"),
+    )
+
+    report = GrowthExtensionRegistry().discover()
+
+    assert report.adapters.disabled is True
+    assert report.learners.disabled is True
+
+
+def test_registry_rejects_objects_that_do_not_satisfy_contracts() -> None:
+    registry = GrowthExtensionRegistry()
+
+    with pytest.raises(TypeError, match="GrowthAdapter protocol"):
+        registry.register_adapter(object())
+    with pytest.raises(TypeError, match="LearnerDescriptor"):
+        registry.register_learner(object())

--- a/tests/growth/test_rule_router.py
+++ b/tests/growth/test_rule_router.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from rosclaw.growth import (
+    DataProfile,
+    GrowthProblemSignals,
+    RouteDisposition,
+    route_learners,
+)
+
+
+def _transition_data(**changes: bool) -> DataProfile:
+    values = {
+        "has_state": True,
+        "has_executed_action": True,
+        "has_next_state": True,
+        "has_reward_vector": True,
+        "has_cost_vector": True,
+        "fixed_dataset": True,
+        "online_rollout_allowed": True,
+    }
+    values.update(changes)
+    return DataProfile(**values)
+
+
+def test_router_blocks_learning_when_safety_model_is_incomplete() -> None:
+    route = route_learners(
+        GrowthProblemSignals(local_physics_residual=1.0, safety_model_complete=False),
+        _transition_data(),
+    )
+
+    assert route.disposition is RouteDisposition.BLOCKED_SAFETY_MODEL
+    assert route.learner_ids == ()
+    assert route.to_dict()["hardware_authorized"] is False
+
+
+def test_router_uses_sysid_before_policy_for_regime_shift() -> None:
+    route = route_learners(
+        GrowthProblemSignals(regime_shift=0.9, repeated_error=0.9),
+        DataProfile(),
+    )
+
+    assert route.disposition is RouteDisposition.SELECTED
+    assert route.learner_ids == ("system_identification",)
+
+
+def test_router_keeps_raw_kinematics_out_of_offline_rl() -> None:
+    route = route_learners(
+        GrowthProblemSignals(),
+        DataProfile(has_kinematic_reference=True, fixed_dataset=True),
+    )
+
+    assert route.learner_ids == ("motion_tracking",)
+    assert "iql" not in route.learner_ids
+
+
+def test_router_can_stage_offline_then_online_residual_learning() -> None:
+    route = route_learners(
+        GrowthProblemSignals(local_physics_residual=0.8),
+        _transition_data(),
+    )
+
+    assert route.learner_ids == ("iql", "residual_sac")
+    assert route.route_hash.startswith("sha256:")
+
+
+def test_incomplete_transition_data_reports_exact_missing_requirements() -> None:
+    route = route_learners(
+        GrowthProblemSignals(local_physics_residual=0.8),
+        _transition_data(has_executed_action=False, has_cost_vector=False),
+    )
+
+    assert route.disposition is RouteDisposition.NEED_MORE_EVIDENCE
+    assert route.learner_ids == ()
+    assert route.missing_requirements == (
+        "transition.executed_action",
+        "transition.cost_vector",
+    )
+
+
+def test_same_router_handles_manipulation_and_navigation_failure_shapes() -> None:
+    manipulation = route_learners(
+        GrowthProblemSignals(repeated_error=0.9, regime_shift=0.2),
+        DataProfile(has_chunk_feedback=True),
+    )
+    navigation = route_learners(
+        GrowthProblemSignals(regime_shift=0.8, out_of_distribution=0.9),
+        DataProfile(),
+    )
+
+    assert manipulation.learner_ids == ("ilc", "advantage_sft")
+    assert navigation.learner_ids == ("system_identification", "world_model_observer")


### PR DESCRIPTION
## What changed

- adds evidence-conditioned learner routing independent of robot/task names
- distinguishes regime identification, ILC, motion tracking, offline IQL, bounded residual learning, advantage SFT, OOD observation, and expert separation
- blocks learning when the safety/cost model is incomplete
- adds `rosclaw.growth.adapters` and `rosclaw.growth.learners` entry-point registries
- isolates broken/duplicate plugins and provides an operator recovery switch
- discovery passes no Runtime, driver, transport, executor, or hardware handle

## Why

The Phase 8 experiment routed almost every problem through football-specific code. This C3 PR turns the reusable diagnosis-to-learner decision into a Core control-plane mechanism while keeping learner implementations and domain semantics downstream.

## Validation

- identical router exercised with manipulation and navigation failure shapes
- two downstream adapter namespaces discovered through the same registry
- broken and duplicate extensions fail independently
- stacked Growth/SimForge regression: 207 passed, 1 skipped, 3 deselected
- Ruff and mypy: passed
