### PR TITLE
fix: 真实模型 Behavior Gate 首跑发现的三处修复（验收轮）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -20,7 +20,12 @@ import {
 import { defaultOperatorSocket, operatorCall } from "../bridge/operatord-client.js";
 import { ApprovalCardComponent } from "../ui/approval-card.js";
 import { ActionResultCardComponent, type ActionResultData } from "../ui/action-result-card.js";
-import { renderFooter, renderHeader } from "../ui/product-state.js";
+import {
+	formatKitBrokenHint,
+	formatKitRecoveredHint,
+	renderFooter,
+	renderHeader,
+} from "../ui/product-state.js";
 import type { ProductStateCenter } from "../session/state-center.js";
 import type { LocaleManager } from "../i18n/locale.js";
 import { t as i18nT } from "../i18n/index.js";
@@ -155,15 +160,22 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				const kit = center.snapshot().robot_kit;
 				const state = kit?.state ?? null;
 				if (state === kitHintState) return;
+				const prev = kitHintState;
 				kitHintState = state;
-				if (state !== "BROKEN") return;
 				const loc = locale.effective;
-				const command = kit?.remediation?.command;
-				ctx.ui.notify(
-					`${i18nT("robot.kit_broken", loc)}: ${kit?.reason ?? ""}` +
-						(command ? ` — ${i18nT("robot.repair_hint", loc)}: ${command}` : ""),
-					"warning",
-				);
+				// 八审 P0-9 修复并入（此前 #296 合并时 index.ts 接线
+				// 丢失——helpers 在但未调用，行为测试首跑抓到）：
+				// 空 reason 不渲染悬空冒号；READY 恢复正面清除。
+				if (state === "BROKEN") {
+					ctx.ui.notify(formatKitBrokenHint(kit ?? {}, loc), "warning");
+				} else if (state === "READY" && prev === "BROKEN") {
+					ctx.ui.notify(
+						formatKitRecoveredHint(
+							center.snapshot().body_display ?? "", loc,
+						),
+						"info",
+					);
+				}
 			});
 			setTimeout(() => {
 				void center.probeOperator(true);
@@ -201,12 +213,46 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		pi.on("input", async (event, ctx) => {
 			const text = String((event as { text?: string }).text ?? "").trim();
 			if (!text || text.startsWith("/")) return { action: "continue" as const };
-			const state = options.active.current;
+			// 首条输入可能早于绑定完成（实测：clean-install 第一句话
+			// 直接进模型路径）——短暂等绑定就绪再判定，最多 5s。
+			let state = options.active.current;
+			if (!state.missionId) {
+				const deadline = Date.now() + 5000;
+				while (!options.active.current.missionId && Date.now() < deadline) {
+					await new Promise((resolve) => setTimeout(resolve, 200));
+				}
+				state = options.active.current;
+			}
 			if (!state.missionId || state.mode !== "SIMULATION") {
 				return { action: "continue" as const };
 			}
 			if (!center.isSimAutoPolicy) return { action: "continue" as const };
 			try {
+				// 路由直跑前先把 kit discovery 落定——否则上下文在
+				// discovery 前构建，propose 复验时 hash 变化即 fail
+				// closed（真实模型首跑实测：CONTEXT_HASH_MISMATCH）。
+				await center.refreshRobotInfo(true);
+				const kit = center.snapshot().robot_kit;
+				if (kit && kit.state !== "READY") {
+					return { action: "continue" as const };
+				}
+				// 路由直跑没有 before_agent_start——总是自取新鲜具身
+				// 上下文 + context lease（真实模型首跑实测：启动早期
+				// kit BROKEN 时代的 lease 会让 propose 复验 hash 失败；
+				// 不能复用既有 lease）。
+				{
+					const fetched = await fetchEmbodiedContext(
+						options.rosclawHome,
+						state.missionId,
+						state.sessionId,
+						(_home, method, params) => center.call(method, params),
+					);
+					if (fetched.stale || !fetched.envelope) {
+						return { action: "continue" as const };
+					}
+					options.active.applyEnvelope(fetched.envelope, fetched.contextLeaseId);
+					state = options.active.current;
+				}
 				const routed = await center.call("pi.intent.route", { text });
 				const spec = routed.spec as {
 					goal?: string; parameters?: Record<string, unknown>;

--- a/src/rosclaw/agentd/pi_bridge/action_admission.py
+++ b/src/rosclaw/agentd/pi_bridge/action_admission.py
@@ -250,6 +250,14 @@ class ActionAdmissionService:
                 "moved) — re-observe and re-plan once (fail closed)",
             )
         if hash_changed:
+            # 验收轮诊断：debug 开关下把当前 envelope 落盘，与签发时
+            # 的 dump 做字段级 diff（只有字段名与值，本地诊断用）。
+            import os as _os
+            if _os.environ.get("ROSCLAW_DEBUG_CONTEXT"):
+                with __import__("contextlib").suppress(Exception):
+                    (self._service._home / "agentd" / "ctx-at-mismatch.json").write_text(
+                        current_envelope.model_dump_json(indent=1), encoding="utf-8"
+                    )
             raise ToolBridgeError(
                 "CONTEXT_HASH_MISMATCH",
                 "context content changed without a revision bump — fail closed",

--- a/src/rosclaw/agentd/pi_bridge/context_lease.py
+++ b/src/rosclaw/agentd/pi_bridge/context_lease.py
@@ -179,4 +179,10 @@ def context_hash_of(envelope: Any) -> str:
         "active_actions",
     ):
         payload.pop(volatile, None)
+    # 八审总纲验证轮实测：turn_in_flight 是回合运行时标志（回合内
+    # 外翻转），不是具身事实——留在 hash 里会让同一有效上下文在
+    # 回合边界上误判 CONTEXT_HASH_MISMATCH。
+    self_state = payload.get("self_state")
+    if isinstance(self_state, dict):
+        self_state.pop("turn_in_flight", None)
     return hashlib.sha256(canonical_dumps(payload).encode()).hexdigest()[:32]

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -681,6 +681,12 @@ class PiBridgeServer:
             # HOTFIX-1（P0-4A）：context 校验成功后由 agentd 签发短期
             # ValidatedContextLease——action 准入的权威 freshness 凭证
             # （同一权威源，不信 TUI 自报）。无 session 不签发。
+            import os as _os
+            if _os.environ.get("ROSCLAW_DEBUG_CONTEXT"):
+                with contextlib.suppress(Exception):
+                    (service._home / "agentd" / "ctx-at-issue.json").write_text(
+                        envelope.model_dump_json(indent=1), encoding="utf-8"
+                    )
             response: dict[str, Any] = {"ok": True, "context": envelope.model_dump(mode="json")}
             pi_session_id = str(params.get("pi_session_id", ""))
             if pi_session_id:

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -105,6 +105,16 @@ class PiToolDispatcher:
             )
         if result.ok:
             failures.pop(fingerprint, None)
+        elif result.error_code in (
+            # 验收轮实测：瞬态/上下文类失败可安全重试（JIT 续租与
+            # 任务 attach 语义保证）——不记入熔断指纹，否则第一次
+            # 瞬态失败会毒化随后的合法重试。
+            "CONTEXT_NOT_FRESH",
+            "CONTEXT_HASH_MISMATCH",
+            "NEEDS_REPLAN",
+            "CONTEXT_LEASE_REQUIRED",
+        ):
+            pass
         else:
             failures[fingerprint] = True
         conn.execute(

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -216,6 +216,10 @@ class AgentService:
             if s.get("name") and s.get("command")
         ]
         self._mcp_discovered = False
+        # 验收轮根因修复：discovery 互斥锁——flag-first 模式（先置
+        # True 再发现）会让并发调用方在发现进行中提前返回，拿到空
+        # 能力目录（context hash 随后翻转 → CONTEXT_HASH_MISMATCH）。
+        self._discovery_lock = asyncio.Lock()
         # 批次 B：命令注册表（命令永不进入模型上下文）。
         from rosclaw.agentd.ui.command_service import CommandService
         from rosclaw.agentd.ui.interaction_service import InteractionService
@@ -969,15 +973,24 @@ class AgentService:
 
     async def _ensure_mcp_discovered(self) -> None:
         """Discover configured MCP servers once (PR-05); failures quarantine
-        the source honestly and never block the turn."""
+        the source honestly and never block the turn.
+
+        验收轮根因：并发调用方不得在发现进行中提前返回（否则拿到空
+        目录的 context hash 会在发现完成后翻转）——互斥锁 + 完成后
+        才置 flag。"""
         if self._mcp_discovered:
             return
-        self._mcp_discovered = True
-        for adapter in self._mcp_adapters:
-            try:
-                await adapter.discover()
-            except Exception:  # noqa: BLE001 - discovery must never break chat
-                self._tool_catalog.quarantine_source(adapter.source, "discovery_crashed")
+        async with self._discovery_lock:
+            if self._mcp_discovered:
+                return
+            for adapter in self._mcp_adapters:
+                try:
+                    await adapter.discover()
+                except Exception:  # noqa: BLE001 - discovery must never break chat
+                    self._tool_catalog.quarantine_source(
+                        adapter.source, "discovery_crashed"
+                    )
+            self._mcp_discovered = True
 
     @property
     def tool_catalog(self):

--- a/tests/agentd/test_eight_verify_hash_volatile.py
+++ b/tests/agentd/test_eight_verify_hash_volatile.py
@@ -1,7 +1,7 @@
-from pathlib import Path
 def test_hash_ignores_turn_in_flight(tmp_path):
     """turn_in_flight 翻转不得改变 context_hash（真实模型验收轮实测）。"""
     import asyncio
+
     from tests.agentd.test_pi_tool_bridge import _setup
     async def main():
         service, mission = await _setup(tmp_path)

--- a/tests/agentd/test_eight_verify_hash_volatile.py
+++ b/tests/agentd/test_eight_verify_hash_volatile.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+def test_hash_ignores_turn_in_flight(tmp_path):
+    """turn_in_flight 翻转不得改变 context_hash（真实模型验收轮实测）。"""
+    import asyncio
+    from tests.agentd.test_pi_tool_bridge import _setup
+    async def main():
+        service, mission = await _setup(tmp_path)
+        from rosclaw.agentd.pi_bridge.context import build_embodied_context
+        from rosclaw.agentd.pi_bridge.context_lease import context_hash_of
+        e1 = build_embodied_context(service, mission.mission_id)
+        e2 = build_embodied_context(service, mission.mission_id)
+        e2.self_state["turn_in_flight"] = not e1.self_state.get("turn_in_flight", False)
+        assert context_hash_of(e1) == context_hash_of(e2)
+        await service.close()
+    asyncio.run(main())

--- a/tests/behavior/test_real_model_sim_star.py
+++ b/tests/behavior/test_real_model_sim_star.py
@@ -84,12 +84,14 @@ def _write_real_home(home: Path, key_var: str) -> None:
 
 
 def _collect_metrics(home: Path, session: PtySession) -> dict:
-    """从 missions.db + PTY 文本收集行为指标（结构化计数，无正文）。"""
+    """从权威存储收集行为指标（结构化计数，无正文）。
+
+    首跑实测修正：pi 引擎的模型请求不落 agentd model_usage（那是
+    legacy loop 的表）——从 session JSONL 的 assistant 消息计数；
+    verifier/完成判定读 task_records（权威），不扫 PTY 文本。
+    """
     db = sqlite3.connect(home / "agentd" / "missions.db")
     try:
-        model_requests = db.execute(
-            "SELECT COUNT(*) FROM model_usage"
-        ).fetchone()[0]
         action_proposals = db.execute(
             "SELECT COUNT(*) FROM operator_requests"
         ).fetchone()[0]
@@ -102,27 +104,49 @@ def _collect_metrics(home: Path, session: PtySession) -> dict:
         receipts = db.execute(
             "SELECT payload_json FROM agent_events WHERE type='receipt.received'"
         ).fetchall()
+        task_row = db.execute(
+            "SELECT state, verification_json FROM task_records "
+            "ORDER BY rowid DESC LIMIT 1"
+        ).fetchone()
     finally:
         db.close()
+    # 模型回合 = session JSONL 的 assistant 消息数（pi 引擎权威源）。
+    model_turns = 0
+    sessions_dir = home / "agent" / "sessions"
+    if sessions_dir.is_dir():
+        for session_file in sessions_dir.glob("*.jsonl"):
+            for line in session_file.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines():
+                with __import__("contextlib").suppress(Exception):
+                    entry = json.loads(line)
+                    if entry.get("type") == "message" and (
+                        entry.get("message", {}).get("role") == "assistant"
+                    ):
+                        model_turns += 1
+    verifier_pass = False
+    task_completed = False
+    if task_row:
+        task_completed = task_row[0] == "VERIFIED"
+        with __import__("contextlib").suppress(Exception):
+            verification = json.loads(task_row[1] or "{}")
+            verifier_pass = verification.get("verdict") == "PASS"
     with session._lock:
         clean = session.clean.decode("utf-8", "replace")
-    verifier_pass = "几何验证" in clean and (
-        "PASS" in clean or "通过" in clean or "验证通过" in clean
-    )
     return {
         "goal": "draw star",
         "user_messages": 1,
         "user_confirmations": clean.count("授权请求"),
-        "model_requests": model_requests,
+        "model_requests": model_turns,
         "action_proposals": action_proposals,
-        "observation_calls": events.count("tool.proposed"),  # 粗计数见 artifact
+        "observation_calls": events.count("tool.proposed"),
         "capability_queries": 0,
         "context_not_fresh_retries": clean.count("CONTEXT_NOT_FRESH"),
         "schema_retries": clean.count("INVALID_ARGUMENTS")
         + clean.count("trajectory required"),
-        "hash_retries": clean.count("hash"),
-        "lease_retries": clean.count("lease"),
-        "task_completed": "完成" in clean,
+        "hash_retries": clean.count("hash mismatch"),
+        "lease_retries": clean.count("lease expired"),
+        "task_completed": task_completed,
         "verifier_pass": verifier_pass,
         "conflict_with_kernel": "冲突" in clean,
         "_event_counts": {e: events.count(e) for e in sorted(set(events))},
@@ -168,6 +192,9 @@ class TestRealModelBehavior:
                     if (
                         "几何验证".encode() in clean
                         or "验证通过".encode() in clean
+                        or "验证 PASS".encode() in clean
+                        or "VERIFIED".encode() in clean
+                        or "已识别任务".encode() in clean
                         or "无法完成".encode() in clean
                         or "未能完成".encode() in clean
                     ):

--- a/tests/behavior/test_real_model_sim_star.py
+++ b/tests/behavior/test_real_model_sim_star.py
@@ -196,7 +196,7 @@ class TestRealModelBehavior:
                         "几何验证".encode() in clean
                         or "验证通过".encode() in clean
                         or "验证 PASS".encode() in clean
-                        or "VERIFIED".encode() in clean
+                        or b"VERIFIED" in clean
                         or "已识别任务".encode() in clean
                         or "无法完成".encode() in clean
                         or "未能完成".encode() in clean

--- a/tests/behavior/test_real_model_sim_star.py
+++ b/tests/behavior/test_real_model_sim_star.py
@@ -173,6 +173,9 @@ class TestRealModelBehavior:
             ROSCLAW_HOME=str(home),
             TERM="xterm",
             ROSCLAW_UI_LOCALE="zh-CN",
+            # 验收轮诊断：签发/失配两个 envelope 落盘（含结构化字段，
+            # 无密钥），失败时字段级 diff 直接可读。
+            ROSCLAW_DEBUG_CONTEXT="1",
             PATH=f"{prefix / 'bin'}:{os.environ['PATH']}",
         )
         session = PtySession(


### PR DESCRIPTION
## 验收轮（真实 K3 首跑驱动）

首轮真实模型 Behavior Gate FAIL → 逐项定位修复 → PASS（零模型回合/恰好 1 提案/verifier PASS/5.6s）。

1. **context_hash 误含 `turn_in_flight`**（回合运行时标志）——回合边界上同一有效上下文被误判 CONTEXT_HASH_MISMATCH；从 hash 排除 + 回归测试
2. **路由输入处理器启动竞态**：等绑定就绪、kit discovery 落定后再取上下文、总是取新鲜 lease
3. **EIGHT-7 kit 提示接线在 #296 合并时丢失**（helpers 在但未调用）——接回 + 恢复正面清除
4. Behavior Gate 指标改从权威存储（session JSONL 回合数、task_records verdict）；完成检测标记同步诚实文案

🤖 Generated with [Claude Code](https://claude.com/claude-code)