### PR TITLE
feat(dataset): add task-neutral source registry and doctor

### DIFF
--- a/src/rosclaw/dataset/__init__.py
+++ b/src/rosclaw/dataset/__init__.py
@@ -1,0 +1,41 @@
+"""Governed dataset provenance and quality inspection.
+
+Inspection is a learning-plane concern. It never authorizes a robot action,
+and a technically complete snapshot remains ineligible until license and
+target-applicability reviews occur elsewhere.
+"""
+
+from rosclaw.dataset.contracts import (
+    DatasetDoctorReport,
+    DatasetFileAnnotation,
+    DatasetFileRecord,
+    DatasetInventory,
+    DatasetSnapshotState,
+    DatasetSourceDescriptor,
+    FileHashMode,
+)
+from rosclaw.dataset.doctor import inspect_dataset_root, write_dataset_doctor_artifacts
+from rosclaw.dataset.registry import (
+    DATASET_SOURCE_GROUP,
+    DatasetAnnotationResolution,
+    DatasetSource,
+    DatasetSourceRegistry,
+    register_sources,
+)
+
+__all__ = [
+    "DATASET_SOURCE_GROUP",
+    "DatasetAnnotationResolution",
+    "DatasetDoctorReport",
+    "DatasetFileAnnotation",
+    "DatasetFileRecord",
+    "DatasetInventory",
+    "DatasetSnapshotState",
+    "DatasetSource",
+    "DatasetSourceDescriptor",
+    "DatasetSourceRegistry",
+    "FileHashMode",
+    "inspect_dataset_root",
+    "register_sources",
+    "write_dataset_doctor_artifacts",
+]

--- a/src/rosclaw/dataset/cli.py
+++ b/src/rosclaw/dataset/cli.py
@@ -1,0 +1,121 @@
+"""CLI surface for governed, task-neutral dataset inspection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+from rosclaw.dataset.contracts import FileHashMode
+from rosclaw.dataset.doctor import inspect_dataset_root, write_dataset_doctor_artifacts
+
+
+def dispatch_dataset_argv(argv: list[str]) -> int | None:
+    if not argv or argv[0] != "dataset":
+        return None
+    args = _parser().parse_args(argv[1:])
+    try:
+        return int(args.handler(args))
+    except (OSError, PermissionError, RuntimeError, ValueError) as exc:
+        _print(
+            {
+                "schema_version": "rosclaw.dataset.cli_error.v1",
+                "ok": False,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+                "training_eligible": False,
+                "activation_authorized": False,
+                "hardware_authorized": False,
+            },
+            stream=sys.stderr,
+        )
+        return 2
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="rosclaw dataset",
+        description="Inspect external datasets without making them training or promotion truth.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    doctor = commands.add_parser("doctor", help="build a transfer-aware dataset inventory")
+    doctor.add_argument("--root", type=Path, required=True)
+    doctor.add_argument("--output-dir", type=Path, required=True)
+    doctor.add_argument(
+        "--hash",
+        dest="hash_mode",
+        choices=[value.value for value in FileHashMode],
+        default=FileHashMode.METADATA.value,
+    )
+    doctor.add_argument(
+        "--transfer-active",
+        action="store_true",
+        help="mark this point-in-time scan as an in-progress transfer snapshot",
+    )
+    doctor.add_argument("--annotation-limit", type=int, default=100)
+    doctor.add_argument(
+        "--no-source-extensions",
+        action="store_true",
+        help="inspect files without loading installed dataset source classifiers",
+    )
+    doctor.add_argument("--source-checkout", type=Path, default=Path.cwd())
+    doctor.add_argument("--force", action="store_true")
+    doctor.set_defaults(handler=_doctor)
+    return parser
+
+
+def _doctor(args: argparse.Namespace) -> int:
+    output_dir = args.output_dir.expanduser().resolve()
+    checkout = args.source_checkout.expanduser().resolve()
+    dataset_root = args.root.expanduser().resolve()
+    if output_dir == checkout or checkout in output_dir.parents:
+        raise ValueError("dataset evidence output must be outside the source checkout")
+    if output_dir == dataset_root or dataset_root in output_dir.parents:
+        raise ValueError("dataset evidence output must be outside the inspected dataset root")
+    expected = (
+        "dataset_inventory.json",
+        "dataset_quality_report.html",
+        "license_manifest.json",
+        "dataset_source_manifest.json",
+        "dataset_label_matrix.csv",
+    )
+    existing = [name for name in expected if (output_dir / name).exists()]
+    if existing and not args.force:
+        raise ValueError(
+            f"dataset doctor outputs already exist: {existing}; pass --force to replace"
+        )
+    report = inspect_dataset_root(
+        dataset_root,
+        hash_mode=FileHashMode(args.hash_mode),
+        transfer_active=bool(args.transfer_active),
+        annotation_limit=args.annotation_limit,
+        discover_sources=not bool(args.no_source_extensions),
+    )
+    artifacts = write_dataset_doctor_artifacts(report, output_dir)
+    _print(
+        {
+            "schema_version": "rosclaw.dataset.doctor_receipt.v2",
+            "ok": True,
+            "report_hash": report.report_hash,
+            "snapshot_complete": report.snapshot_complete,
+            "transfer_active": report.transfer_active,
+            "dataset_states": {value.dataset_id: value.state.value for value in report.inventories},
+            "source_ids": [value.source_id for value in report.sources],
+            "extension_errors": list(report.extension_errors),
+            "artifacts": artifacts,
+            "training_eligible": False,
+            "promotion_truth_allowed": False,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+    )
+    return 0
+
+
+def _print(value: dict[str, Any], *, stream: TextIO | None = None) -> None:
+    print(json.dumps(value, ensure_ascii=False, sort_keys=True), file=stream or sys.stdout)
+
+
+__all__ = ["dispatch_dataset_argv"]

--- a/src/rosclaw/dataset/contracts.py
+++ b/src/rosclaw/dataset/contracts.py
@@ -1,0 +1,497 @@
+"""Immutable contracts emitted by the task-neutral dataset doctor."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_HASH = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
+
+
+def _require_hash(label: str, value: str) -> None:
+    if not _HASH.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+def _require_identifier(label: str, value: str) -> None:
+    if not _IDENTIFIER.fullmatch(value):
+        raise ValueError(f"{label} must be a normalized identifier")
+
+
+def _require_dataset_name(label: str, value: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value in {".", ".."}
+        or len(value) > 128
+        or "/" in value
+        or "\\" in value
+        or any(ord(character) < 32 for character in value)
+    ):
+        raise ValueError(f"{label} must be a bounded dataset name")
+
+
+def _unique_identifiers(
+    values: tuple[str, ...],
+    *,
+    label: str,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    normalized = tuple(values)
+    if not allow_empty and not normalized:
+        raise ValueError(f"{label} must not be empty")
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must be unique")
+    for value in normalized:
+        _require_identifier(label, value)
+    return normalized
+
+
+def _safe_relative_path(value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("relative_path must be a safe relative path")
+    normalized = value.replace("\\", "/")
+    if (
+        not normalized
+        or normalized.startswith("/")
+        or ".." in normalized.split("/")
+        or any(ord(character) < 32 for character in normalized)
+    ):
+        raise ValueError("relative_path must be a safe relative path")
+    return normalized
+
+
+def _bounded_strings(
+    values: tuple[str, ...],
+    *,
+    label: str,
+    maximum_length: int,
+    allow_empty: bool = True,
+) -> tuple[str, ...]:
+    normalized = tuple(values)
+    if not allow_empty and not normalized:
+        raise ValueError(f"{label} must not be empty")
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{label} must be unique")
+    if any(
+        not isinstance(value, str)
+        or not value
+        or len(value) > maximum_length
+        or any(ord(character) < 32 for character in value)
+        for value in normalized
+    ):
+        raise ValueError(f"{label} contains an invalid bounded string")
+    return normalized
+
+
+def _count_mapping(values: Mapping[str, int], *, label: str) -> Mapping[str, int]:
+    normalized: dict[str, int] = {}
+    for key, value in values.items():
+        if not isinstance(key, str) or not key or len(key) > 128:
+            raise ValueError(f"{label} keys must be bounded non-empty strings")
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{label} values must be non-negative integers")
+        normalized[key] = value
+    return MappingProxyType(dict(sorted(normalized.items())))
+
+
+class FileHashMode(StrEnum):
+    NONE = "none"
+    METADATA = "metadata"
+    SHA256 = "sha256"
+
+
+class DatasetSnapshotState(StrEnum):
+    READY = "ready"
+    EMPTY = "empty"
+    PARTIAL = "partial"
+    TRANSFERRING = "transferring"
+    UNREADABLE = "unreadable"
+
+
+@dataclass(frozen=True)
+class DatasetSourceDescriptor:
+    """Provenance and label vocabulary declared by a downstream source plugin."""
+
+    source_id: str
+    dataset_ids: tuple[str, ...]
+    label_ids: tuple[str, ...]
+    source_uri: str
+    revision: str
+    manifest_hash: str | None = None
+    schema_version: str = "rosclaw.dataset.source_descriptor.v1"
+
+    def __post_init__(self) -> None:
+        _require_identifier("source_id", self.source_id)
+        dataset_ids = tuple(self.dataset_ids)
+        if not dataset_ids or len(dataset_ids) != len(set(dataset_ids)):
+            raise ValueError("dataset_ids must contain unique bounded dataset names")
+        for value in dataset_ids:
+            _require_dataset_name("dataset_ids", value)
+        object.__setattr__(self, "dataset_ids", dataset_ids)
+        object.__setattr__(
+            self,
+            "label_ids",
+            _unique_identifiers(self.label_ids, label="label_ids"),
+        )
+        for label in ("source_uri", "revision"):
+            value = getattr(self, label)
+            if (
+                not isinstance(value, str)
+                or not value
+                or len(value) > 2048
+                or any(ord(character) < 32 for character in value)
+            ):
+                raise ValueError(f"{label} must be a bounded non-empty string")
+        if self.manifest_hash is not None:
+            _require_hash("manifest_hash", self.manifest_hash)
+
+    @property
+    def descriptor_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source_id": self.source_id,
+            "dataset_ids": list(self.dataset_ids),
+            "label_ids": list(self.label_ids),
+            "source_uri": self.source_uri,
+            "revision": self.revision,
+            "manifest_hash": self.manifest_hash,
+        }
+
+
+@dataclass(frozen=True)
+class DatasetFileRecord:
+    relative_path: str
+    size_bytes: int
+    mtime_ns: int
+    suffix: str
+    digest: str | None
+    hash_status: str
+    issue_codes: tuple[str, ...] = ()
+    schema_version: str = "rosclaw.dataset.file_record.v1"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "relative_path", _safe_relative_path(self.relative_path))
+        for label in ("size_bytes", "mtime_ns"):
+            value = getattr(self, label)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{label} must be a non-negative integer")
+        if self.digest is not None:
+            _require_hash("digest", self.digest)
+        if not isinstance(self.hash_status, str) or not self.hash_status:
+            raise ValueError("hash_status must not be empty")
+        object.__setattr__(
+            self,
+            "issue_codes",
+            _unique_identifiers(
+                self.issue_codes,
+                label="issue_codes",
+                allow_empty=True,
+            ),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "relative_path": self.relative_path,
+            "size_bytes": self.size_bytes,
+            "mtime_ns": self.mtime_ns,
+            "suffix": self.suffix,
+            "digest": self.digest,
+            "hash_status": self.hash_status,
+            "issue_codes": list(self.issue_codes),
+        }
+
+
+@dataclass(frozen=True)
+class DatasetFileAnnotation:
+    relative_path: str
+    source_id: str
+    label_ids: tuple[str, ...]
+    schema_version: str = "rosclaw.dataset.file_annotation.v1"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "relative_path", _safe_relative_path(self.relative_path))
+        _require_identifier("source_id", self.source_id)
+        object.__setattr__(
+            self,
+            "label_ids",
+            _unique_identifiers(self.label_ids, label="label_ids"),
+        )
+
+    @property
+    def annotation_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "relative_path": self.relative_path,
+            "source_id": self.source_id,
+            "label_ids": list(self.label_ids),
+        }
+
+
+@dataclass(frozen=True)
+class DatasetInventory:
+    dataset_id: str
+    state: DatasetSnapshotState
+    total_file_count: int
+    total_size_bytes: int
+    extension_counts: Mapping[str, int]
+    issue_counts: Mapping[str, int]
+    license_files: tuple[str, ...]
+    label_match_count: int
+    annotation_count: int
+    label_counts: Mapping[str, int]
+    annotations: tuple[DatasetFileAnnotation, ...]
+    duplicate_content_groups: tuple[tuple[str, ...], ...]
+    files: tuple[DatasetFileRecord, ...]
+    source_error_count: int = 0
+    source_errors: tuple[str, ...] = ()
+    scan_error_count: int = 0
+    scan_errors: tuple[str, ...] = ()
+    schema_version: str = "rosclaw.dataset.inventory.v3"
+
+    def __post_init__(self) -> None:
+        _require_dataset_name("dataset_id", self.dataset_id)
+        if not isinstance(self.state, DatasetSnapshotState):
+            raise ValueError("state must be a DatasetSnapshotState")
+        for label in (
+            "total_file_count",
+            "total_size_bytes",
+            "label_match_count",
+            "annotation_count",
+            "source_error_count",
+            "scan_error_count",
+        ):
+            value = getattr(self, label)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{label} must be a non-negative integer")
+        files = tuple(self.files)
+        if any(not isinstance(value, DatasetFileRecord) for value in files):
+            raise ValueError("files must contain DatasetFileRecord values")
+        if self.total_file_count != len(files):
+            raise ValueError("total_file_count must match files")
+        if self.total_size_bytes != sum(value.size_bytes for value in files):
+            raise ValueError("total_size_bytes must match files")
+        paths = [value.relative_path for value in files]
+        if len(paths) != len(set(paths)):
+            raise ValueError("file paths must be unique")
+        object.__setattr__(self, "files", files)
+        object.__setattr__(
+            self,
+            "extension_counts",
+            _count_mapping(self.extension_counts, label="extension_counts"),
+        )
+        object.__setattr__(
+            self,
+            "issue_counts",
+            _count_mapping(self.issue_counts, label="issue_counts"),
+        )
+        object.__setattr__(
+            self,
+            "label_counts",
+            _count_mapping(self.label_counts, label="label_counts"),
+        )
+        license_files = tuple(_safe_relative_path(value) for value in self.license_files)
+        if len(license_files) != len(set(license_files)) or any(
+            value not in paths for value in license_files
+        ):
+            raise ValueError("license_files must be unique inventory paths")
+        object.__setattr__(self, "license_files", license_files)
+        annotations = tuple(self.annotations)
+        if any(not isinstance(value, DatasetFileAnnotation) for value in annotations):
+            raise ValueError("annotations must contain DatasetFileAnnotation values")
+        if any(value.relative_path not in paths for value in annotations):
+            raise ValueError("annotations must reference inventory paths")
+        annotation_keys = [(value.relative_path, value.source_id) for value in annotations]
+        if len(annotation_keys) != len(set(annotation_keys)):
+            raise ValueError("annotations must be unique by path and source")
+        if self.label_match_count < len({value.relative_path for value in annotations}):
+            raise ValueError("label_match_count must cover retained annotations")
+        if self.annotation_count < len(annotations):
+            raise ValueError("annotation_count must cover retained annotations")
+        object.__setattr__(self, "annotations", annotations)
+        groups = tuple(
+            tuple(_safe_relative_path(path) for path in group)
+            for group in self.duplicate_content_groups
+        )
+        if len(groups) != len(set(groups)) or any(
+            len(group) < 2
+            or len(group) != len(set(group))
+            or any(path not in paths for path in group)
+            for group in groups
+        ):
+            raise ValueError("duplicate content groups must contain inventory paths")
+        object.__setattr__(self, "duplicate_content_groups", groups)
+        for count_label, values_label in (
+            ("source_error_count", "source_errors"),
+            ("scan_error_count", "scan_errors"),
+        ):
+            values = _bounded_strings(
+                tuple(getattr(self, values_label)),
+                label=values_label,
+                maximum_length=1024,
+            )
+            if getattr(self, count_label) < len(values):
+                raise ValueError(f"{count_label} must cover retained errors")
+            object.__setattr__(self, values_label, values)
+
+    @property
+    def snapshot_complete(self) -> bool:
+        return self.state is DatasetSnapshotState.READY
+
+    @property
+    def license_evidence_present(self) -> bool:
+        return bool(self.license_files)
+
+    @property
+    def annotations_truncated(self) -> bool:
+        return self.annotation_count > len(self.annotations)
+
+    @property
+    def source_errors_truncated(self) -> bool:
+        return self.source_error_count > len(self.source_errors)
+
+    @property
+    def scan_errors_truncated(self) -> bool:
+        return self.scan_error_count > len(self.scan_errors)
+
+    @property
+    def training_eligible(self) -> bool:
+        return False
+
+    @property
+    def inventory_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "dataset_id": self.dataset_id,
+            "state": self.state.value,
+            "total_file_count": self.total_file_count,
+            "total_size_bytes": self.total_size_bytes,
+            "extension_counts": dict(self.extension_counts),
+            "issue_counts": dict(self.issue_counts),
+            "license_files": list(self.license_files),
+            "license_evidence_present": self.license_evidence_present,
+            "label_match_count": self.label_match_count,
+            "annotation_count": self.annotation_count,
+            "label_counts": dict(self.label_counts),
+            "annotations": [value.to_dict() for value in self.annotations],
+            "annotations_truncated": self.annotations_truncated,
+            "duplicate_content_groups": [list(group) for group in self.duplicate_content_groups],
+            "files": [value.to_dict() for value in self.files],
+            "source_error_count": self.source_error_count,
+            "source_errors": list(self.source_errors),
+            "source_errors_truncated": self.source_errors_truncated,
+            "scan_error_count": self.scan_error_count,
+            "scan_errors": list(self.scan_errors),
+            "scan_errors_truncated": self.scan_errors_truncated,
+            "snapshot_complete": self.snapshot_complete,
+            "training_eligible": self.training_eligible,
+        }
+
+
+@dataclass(frozen=True)
+class DatasetDoctorReport:
+    root: str
+    started_at: str
+    finished_at: str
+    hash_mode: FileHashMode
+    transfer_active: bool
+    sources: tuple[DatasetSourceDescriptor, ...]
+    extension_errors: tuple[str, ...]
+    inventories: tuple[DatasetInventory, ...]
+    schema_version: str = "rosclaw.dataset.doctor_report.v2"
+
+    def __post_init__(self) -> None:
+        for label in ("root", "started_at", "finished_at"):
+            value = getattr(self, label)
+            if not isinstance(value, str) or not value or len(value) > 4096:
+                raise ValueError(f"{label} must be a bounded non-empty string")
+        if not isinstance(self.hash_mode, FileHashMode):
+            raise ValueError("hash_mode must be a FileHashMode")
+        if not isinstance(self.transfer_active, bool):
+            raise ValueError("transfer_active must be boolean")
+        sources = tuple(self.sources)
+        if any(not isinstance(value, DatasetSourceDescriptor) for value in sources):
+            raise ValueError("sources must contain DatasetSourceDescriptor values")
+        if len({value.source_id for value in sources}) != len(sources):
+            raise ValueError("source ids must be unique")
+        object.__setattr__(self, "sources", sources)
+        object.__setattr__(
+            self,
+            "extension_errors",
+            _bounded_strings(
+                self.extension_errors,
+                label="extension_errors",
+                maximum_length=1024,
+            ),
+        )
+        inventories = tuple(self.inventories)
+        identifiers = [value.dataset_id for value in inventories]
+        if (
+            not inventories
+            or any(not isinstance(value, DatasetInventory) for value in inventories)
+            or len(identifiers) != len(set(identifiers))
+        ):
+            raise ValueError("inventories must be non-empty with unique dataset ids")
+        object.__setattr__(self, "inventories", inventories)
+
+    @property
+    def snapshot_complete(self) -> bool:
+        return (
+            not self.transfer_active
+            and not self.extension_errors
+            and all(value.snapshot_complete for value in self.inventories)
+        )
+
+    @property
+    def training_eligible(self) -> bool:
+        return False
+
+    @property
+    def report_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "root": self.root,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "hash_mode": self.hash_mode.value,
+            "transfer_active": self.transfer_active,
+            "sources": [value.to_dict() for value in self.sources],
+            "extension_errors": list(self.extension_errors),
+            "inventories": [value.to_dict() for value in self.inventories],
+            "snapshot_complete": self.snapshot_complete,
+            "training_eligible": self.training_eligible,
+            "promotion_truth_allowed": False,
+            "activation_authorized": False,
+            "hardware_authorized": False,
+        }
+
+
+__all__ = [
+    "DatasetDoctorReport",
+    "DatasetFileAnnotation",
+    "DatasetFileRecord",
+    "DatasetInventory",
+    "DatasetSnapshotState",
+    "DatasetSourceDescriptor",
+    "FileHashMode",
+]

--- a/src/rosclaw/dataset/doctor.py
+++ b/src/rosclaw/dataset/doctor.py
@@ -1,0 +1,476 @@
+"""Point-in-time, transfer-aware inspection for operator-managed datasets."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import html
+import io
+import json
+import os
+import re
+import tempfile
+from collections import Counter, defaultdict
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+
+from rosclaw.dataset.contracts import (
+    DatasetDoctorReport,
+    DatasetFileAnnotation,
+    DatasetFileRecord,
+    DatasetInventory,
+    DatasetSnapshotState,
+    FileHashMode,
+)
+from rosclaw.dataset.registry import DatasetSourceRegistry
+from rosclaw.feedback.contracts import canonical_hash
+
+_PARTIAL_MARKERS = (
+    ".aria2",
+    ".download",
+    ".incomplete",
+    ".part",
+    ".partial",
+    ".tmp",
+)
+_LICENSE_NAMES = {
+    "copying",
+    "copying.md",
+    "license",
+    "license.md",
+    "license.txt",
+    "terms",
+    "terms.md",
+    "terms.txt",
+}
+_MAX_RETAINED_ERRORS = 100
+
+
+def inspect_dataset_root(
+    root: Path,
+    *,
+    hash_mode: FileHashMode = FileHashMode.METADATA,
+    transfer_active: bool = False,
+    annotation_limit: int = 100,
+    source_registry: DatasetSourceRegistry | None = None,
+    discover_sources: bool = True,
+) -> DatasetDoctorReport:
+    """Inspect top-level datasets without following symbolic links.
+
+    ``transfer_active`` is an operator assertion. It prevents an otherwise
+    clean prefix of a download from being mislabeled as a complete snapshot.
+    Source plugins receive names only and cannot read the inspected root.
+    """
+
+    root = root.expanduser().resolve(strict=True)
+    if not root.is_dir():
+        raise ValueError(f"dataset root is not a readable directory: {root}")
+    if (
+        isinstance(annotation_limit, bool)
+        or not isinstance(annotation_limit, int)
+        or not 1 <= annotation_limit <= 100_000
+    ):
+        raise ValueError("annotation_limit must be in [1, 100000]")
+    if not isinstance(hash_mode, FileHashMode):
+        raise ValueError("hash_mode must be a FileHashMode")
+    if not isinstance(transfer_active, bool) or not isinstance(discover_sources, bool):
+        raise ValueError("dataset doctor flags must be boolean")
+    registry = source_registry or DatasetSourceRegistry()
+    discovery_errors: tuple[str, ...] = ()
+    if discover_sources:
+        discovery_errors = tuple(
+            dict.fromkeys(_bounded_text(value) for value in registry.discover().errors)
+        )
+    started = _timestamp()
+    children = sorted(
+        (path for path in root.iterdir() if path.is_dir() and not path.is_symlink()),
+        key=lambda path: path.name,
+    )
+    if not children:
+        raise ValueError("dataset root contains no top-level dataset directories")
+    inventories = tuple(
+        _inspect_one(
+            path,
+            hash_mode=hash_mode,
+            transfer_active=transfer_active,
+            annotation_limit=annotation_limit,
+            source_registry=registry,
+        )
+        for path in children
+    )
+    return DatasetDoctorReport(
+        root=str(root),
+        started_at=started,
+        finished_at=_timestamp(),
+        hash_mode=hash_mode,
+        transfer_active=transfer_active,
+        sources=registry.descriptors,
+        extension_errors=discovery_errors,
+        inventories=inventories,
+    )
+
+
+def write_dataset_doctor_artifacts(
+    report: DatasetDoctorReport,
+    output_dir: Path,
+) -> dict[str, str]:
+    """Write review artifacts atomically; never mutate the dataset root."""
+
+    output_dir = output_dir.expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths = {
+        "inventory": output_dir / "dataset_inventory.json",
+        "quality_report": output_dir / "dataset_quality_report.html",
+        "license_manifest": output_dir / "license_manifest.json",
+        "source_manifest": output_dir / "dataset_source_manifest.json",
+        "label_matrix": output_dir / "dataset_label_matrix.csv",
+    }
+    inventory = report.to_dict()
+    inventory["report_hash"] = report.report_hash
+    _atomic_write_text(
+        paths["inventory"],
+        json.dumps(inventory, ensure_ascii=False, indent=2) + "\n",
+    )
+    license_manifest = {
+        "schema_version": "rosclaw.dataset.license_manifest.v1",
+        "report_hash": report.report_hash,
+        "datasets": [
+            {
+                "dataset_id": value.dataset_id,
+                "license_files": list(value.license_files),
+                "license_evidence": [
+                    {
+                        "path": record.relative_path,
+                        "sha256": record.digest,
+                        "size_bytes": record.size_bytes,
+                        "hash_status": record.hash_status,
+                    }
+                    for record in value.files
+                    if record.relative_path in value.license_files
+                ],
+                "decision": "pending_operator_review",
+                "training_eligible": False,
+                "public_demo_allowed": False,
+                "commercial_promotion_allowed": False,
+            }
+            for value in report.inventories
+        ],
+    }
+    _atomic_write_text(
+        paths["license_manifest"],
+        json.dumps(license_manifest, ensure_ascii=False, indent=2) + "\n",
+    )
+    source_manifest = {
+        "schema_version": "rosclaw.dataset.source_manifest.v1",
+        "report_hash": report.report_hash,
+        "sources": [value.to_dict() for value in report.sources],
+        "extension_errors": list(report.extension_errors),
+        "provenance_review_required": True,
+        "training_eligible": False,
+    }
+    _atomic_write_text(
+        paths["source_manifest"],
+        json.dumps(source_manifest, ensure_ascii=False, indent=2) + "\n",
+    )
+    _atomic_write_text(paths["label_matrix"], _label_matrix_csv(report))
+    _atomic_write_text(paths["quality_report"], _quality_html(report))
+    return {key: str(value) for key, value in paths.items()}
+
+
+def _inspect_one(
+    root: Path,
+    *,
+    hash_mode: FileHashMode,
+    transfer_active: bool,
+    annotation_limit: int,
+    source_registry: DatasetSourceRegistry,
+) -> DatasetInventory:
+    files: list[DatasetFileRecord] = []
+    scan_error_count = 0
+    scan_errors: list[str] = []
+    for directory, directory_names, file_names in os.walk(root, followlinks=False):
+        retained_directories: list[str] = []
+        for name in sorted(directory_names):
+            path = Path(directory) / name
+            if path.is_symlink():
+                scan_error_count += 1
+                _retain_unique(
+                    scan_errors,
+                    f"{path.relative_to(root).as_posix()}: symbolic_directory_not_followed",
+                )
+            else:
+                retained_directories.append(name)
+        directory_names[:] = retained_directories
+        for file_name in sorted(file_names):
+            path = Path(directory) / file_name
+            relative = path.relative_to(root).as_posix()
+            try:
+                files.append(_inspect_file(path, relative=relative, hash_mode=hash_mode))
+            except (OSError, PermissionError) as exc:
+                scan_error_count += 1
+                _retain_unique(
+                    scan_errors,
+                    _bounded_error(relative, exc),
+                )
+    files.sort(key=lambda value: value.relative_path)
+    extension_counts = Counter(value.suffix or "<none>" for value in files)
+    issue_counts = Counter(issue for value in files for issue in value.issue_codes)
+    license_files = tuple(
+        value.relative_path
+        for value in files
+        if Path(value.relative_path).name.lower() in _LICENSE_NAMES
+    )
+    digests: dict[str, list[str]] = defaultdict(list)
+    if hash_mode is FileHashMode.SHA256:
+        for value in files:
+            if value.digest is not None and value.hash_status == "computed":
+                digests[value.digest].append(value.relative_path)
+    duplicate_groups = tuple(tuple(paths) for _, paths in sorted(digests.items()) if len(paths) > 1)
+
+    annotations: list[DatasetFileAnnotation] = []
+    annotation_count = 0
+    matched_paths: set[str] = set()
+    label_counts: Counter[str] = Counter()
+    source_error_count = 0
+    source_errors: list[str] = []
+    for record in files:
+        resolution = source_registry.classify(
+            dataset_id=root.name,
+            relative_path=record.relative_path,
+        )
+        if resolution.annotations:
+            matched_paths.add(record.relative_path)
+        annotation_count += len(resolution.annotations)
+        for annotation in resolution.annotations:
+            label_counts.update(annotation.label_ids)
+            if len(annotations) < annotation_limit:
+                annotations.append(annotation)
+        source_error_count += len(resolution.errors)
+        for error in resolution.errors:
+            _retain_unique(source_errors, error)
+
+    state = _state(
+        files,
+        scan_error_count=scan_error_count,
+        source_error_count=source_error_count,
+        transfer_active=transfer_active,
+    )
+    return DatasetInventory(
+        dataset_id=root.name,
+        state=state,
+        total_file_count=len(files),
+        total_size_bytes=sum(value.size_bytes for value in files),
+        extension_counts=dict(extension_counts),
+        issue_counts=dict(issue_counts),
+        license_files=license_files,
+        label_match_count=len(matched_paths),
+        annotation_count=annotation_count,
+        label_counts=dict(label_counts),
+        annotations=tuple(annotations),
+        duplicate_content_groups=duplicate_groups,
+        files=tuple(files),
+        source_error_count=source_error_count,
+        source_errors=tuple(source_errors),
+        scan_error_count=scan_error_count,
+        scan_errors=tuple(scan_errors),
+    )
+
+
+def _inspect_file(path: Path, *, relative: str, hash_mode: FileHashMode) -> DatasetFileRecord:
+    before = path.lstat()
+    issues: list[str] = []
+    digest: str | None = None
+    hash_status = "skipped"
+    if path.is_symlink():
+        issues.append("symbolic_link_not_followed")
+    elif not path.is_file():
+        issues.append("not_regular_file")
+    else:
+        if before.st_size == 0:
+            issues.append("zero_byte_file")
+        if _is_partial_name(path.name):
+            issues.append("partial_transfer_file")
+        if before.st_size <= 1024 and _is_lfs_pointer(path):
+            issues.append("git_lfs_pointer")
+        if hash_mode is FileHashMode.METADATA and path.name.lower() not in _LICENSE_NAMES:
+            digest = canonical_hash(
+                {
+                    "relative_path": relative,
+                    "size_bytes": before.st_size,
+                    "mtime_ns": before.st_mtime_ns,
+                }
+            )
+            hash_status = "metadata_only"
+        elif hash_mode is FileHashMode.SHA256 or path.name.lower() in _LICENSE_NAMES:
+            digest = _sha256_file(path)
+            after = path.stat()
+            if (before.st_size, before.st_mtime_ns) != (
+                after.st_size,
+                after.st_mtime_ns,
+            ):
+                digest = None
+                hash_status = "changed_during_scan"
+                issues.append("changed_during_scan")
+            else:
+                hash_status = (
+                    "computed_license" if hash_mode is not FileHashMode.SHA256 else "computed"
+                )
+    return DatasetFileRecord(
+        relative_path=relative,
+        size_bytes=before.st_size,
+        mtime_ns=before.st_mtime_ns,
+        suffix=path.suffix.lower(),
+        digest=digest,
+        hash_status=hash_status,
+        issue_codes=tuple(dict.fromkeys(issues)),
+    )
+
+
+def _state(
+    files: list[DatasetFileRecord],
+    *,
+    scan_error_count: int,
+    source_error_count: int,
+    transfer_active: bool,
+) -> DatasetSnapshotState:
+    if scan_error_count and not files:
+        return DatasetSnapshotState.UNREADABLE
+    if transfer_active:
+        return DatasetSnapshotState.TRANSFERRING
+    if not files:
+        return DatasetSnapshotState.EMPTY
+    issues = {issue for value in files for issue in value.issue_codes}
+    if "partial_transfer_file" in issues or "changed_during_scan" in issues:
+        return DatasetSnapshotState.TRANSFERRING
+    if (
+        scan_error_count
+        or source_error_count
+        or "git_lfs_pointer" in issues
+        or "not_regular_file" in issues
+        or "zero_byte_file" in issues
+        or "symbolic_link_not_followed" in issues
+    ):
+        return DatasetSnapshotState.PARTIAL
+    return DatasetSnapshotState.READY
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def _is_lfs_pointer(path: Path) -> bool:
+    try:
+        return path.read_bytes().startswith(b"version https://git-lfs.github.com/spec/v1\n")
+    except OSError:
+        return False
+
+
+def _is_partial_name(name: str) -> bool:
+    lowered = name.lower()
+    if re.search(r"\.part_[a-z]{2,}(?:\.metadata)?$", lowered):
+        return False
+    return any(lowered.endswith(marker) for marker in _PARTIAL_MARKERS)
+
+
+def _label_matrix_csv(report: DatasetDoctorReport) -> str:
+    stream = io.StringIO()
+    writer = csv.writer(stream, lineterminator="\n")
+    writer.writerow(
+        [
+            "dataset_id",
+            "snapshot_state",
+            "file_count",
+            "size_bytes",
+            "label_match_count",
+            "label_counts_json",
+            "license_file_count",
+            "source_error_count",
+            "scan_error_count",
+            "snapshot_complete",
+            "training_eligible",
+        ]
+    )
+    for value in report.inventories:
+        writer.writerow(
+            [
+                value.dataset_id,
+                value.state.value,
+                value.total_file_count,
+                value.total_size_bytes,
+                value.label_match_count,
+                json.dumps(dict(value.label_counts), sort_keys=True),
+                len(value.license_files),
+                value.source_error_count,
+                value.scan_error_count,
+                str(value.snapshot_complete).lower(),
+                "false",
+            ]
+        )
+    return stream.getvalue()
+
+
+def _quality_html(report: DatasetDoctorReport) -> str:
+    rows = "\n".join(
+        "<tr>"
+        f"<td>{html.escape(value.dataset_id)}</td>"
+        f"<td><code>{value.state.value}</code></td>"
+        f"<td>{value.total_file_count:,}</td>"
+        f"<td>{value.total_size_bytes / (1024**3):.3f}</td>"
+        f"<td>{value.label_match_count}</td>"
+        f"<td>{html.escape(json.dumps(dict(value.label_counts), sort_keys=True))}</td>"
+        f"<td>{len(value.license_files)}</td>"
+        f"<td>{value.source_error_count + value.scan_error_count}</td>"
+        "</tr>"
+        for value in report.inventories
+    )
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ROSClaw Dataset Doctor</title>
+<style>body{{font:15px/1.55 system-ui,sans-serif;max-width:1180px;margin:40px auto;padding:0 24px;color:#171717}}code{{background:#f2f2f2;padding:2px 6px;border-radius:5px}}table{{border-collapse:collapse;width:100%}}th,td{{border-bottom:1px solid #ddd;text-align:left;padding:9px;vertical-align:top}}th{{background:#f7f7f7}}.warn{{padding:14px;border-left:4px solid #d97706;background:#fff7ed}}</style></head>
+<body><h1>ROSClaw Dataset Doctor</h1>
+<p class="warn"><strong>Evidence boundary:</strong> This is a point-in-time snapshot. transfer_active={str(report.transfer_active).lower()}. Technical completeness never establishes license approval, target applicability, promotion truth, or hardware authority.</p>
+<p>Root: <code>{html.escape(report.root)}</code><br>Hash mode: <code>{report.hash_mode.value}</code><br>Report hash: <code>{report.report_hash}</code></p>
+<table><thead><tr><th>Dataset</th><th>State</th><th>Files</th><th>GiB</th><th>Label matches</th><th>Labels</th><th>License files</th><th>Errors</th></tr></thead><tbody>{rows}</tbody></table>
+<h2>Conclusion</h2><p>snapshot_complete={str(report.snapshot_complete).lower()}; training_eligible=false; hardware_authorized=false.</p>
+</body></html>\n"""
+
+
+def _retain_unique(values: list[str], value: str) -> None:
+    if len(values) < _MAX_RETAINED_ERRORS and value not in values:
+        values.append(value)
+
+
+def _bounded_error(relative: str, exc: Exception) -> str:
+    detail = " ".join(str(exc).split())[:768]
+    return f"{relative}: {type(exc).__name__}: {detail}"
+
+
+def _bounded_text(value: str) -> str:
+    return " ".join(str(value).split())[:1024]
+
+
+def _atomic_write_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as stream:
+            stream.write(value)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_name, path)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            os.unlink(temporary_name)
+        raise
+
+
+def _timestamp() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+__all__ = ["inspect_dataset_root", "write_dataset_doctor_artifacts"]

--- a/src/rosclaw/dataset/registry.py
+++ b/src/rosclaw/dataset/registry.py
@@ -1,0 +1,133 @@
+"""Runtime-free registry for downstream dataset source classifiers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from rosclaw.dataset.contracts import DatasetFileAnnotation, DatasetSourceDescriptor
+from rosclaw.extension_discovery import (
+    EntryPointDiscoveryReport,
+    discover_entry_point_objects,
+)
+
+DATASET_SOURCE_GROUP = "rosclaw.dataset.sources"
+_DISABLE_ENV = "ROSCLAW_DISABLE_DATASET_EXTENSIONS"
+
+
+@runtime_checkable
+class DatasetSource(Protocol):
+    """Classify relative names only; no root, file handle, runtime, or driver."""
+
+    descriptor: DatasetSourceDescriptor
+
+    def classify_file(self, dataset_id: str, relative_path: str) -> tuple[str, ...]: ...
+
+
+@dataclass(frozen=True)
+class DatasetAnnotationResolution:
+    annotations: tuple[DatasetFileAnnotation, ...]
+    errors: tuple[str, ...]
+
+
+class DatasetSourceRegistry:
+    def __init__(self) -> None:
+        self._sources: dict[str, DatasetSource] = {}
+
+    def register_source(self, source: Any) -> str:
+        if not isinstance(source, DatasetSource):
+            raise TypeError("dataset source does not satisfy the DatasetSource protocol")
+        if not isinstance(source.descriptor, DatasetSourceDescriptor):
+            raise TypeError("dataset source descriptor has the wrong contract type")
+        source_id = source.descriptor.source_id
+        if source_id in self._sources:
+            raise ValueError(f"duplicate dataset source: {source_id}")
+        self._sources[source_id] = source
+        return source_id
+
+    def source(self, source_id: str) -> DatasetSource:
+        try:
+            return self._sources[source_id]
+        except KeyError as exc:
+            raise KeyError(f"unknown dataset source: {source_id}") from exc
+
+    @property
+    def source_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._sources))
+
+    @property
+    def descriptors(self) -> tuple[DatasetSourceDescriptor, ...]:
+        return tuple(self._sources[source_id].descriptor for source_id in self.source_ids)
+
+    def discover(self) -> EntryPointDiscoveryReport:
+        return discover_entry_point_objects(
+            group=DATASET_SOURCE_GROUP,
+            disable_env=_DISABLE_ENV,
+            register=self.register_source,
+        )
+
+    def classify(self, *, dataset_id: str, relative_path: str) -> DatasetAnnotationResolution:
+        annotations: list[DatasetFileAnnotation] = []
+        errors: list[str] = []
+        for source_id in self.source_ids:
+            source = self._sources[source_id]
+            descriptor = source.descriptor
+            if dataset_id not in descriptor.dataset_ids:
+                continue
+            try:
+                labels = source.classify_file(dataset_id, relative_path)
+                normalized = _validated_labels(labels, descriptor=descriptor)
+            except Exception as exc:
+                errors.append(_bounded_error(source_id, exc))
+                continue
+            if normalized:
+                annotations.append(
+                    DatasetFileAnnotation(
+                        relative_path=relative_path,
+                        source_id=source_id,
+                        label_ids=normalized,
+                    )
+                )
+        return DatasetAnnotationResolution(
+            annotations=tuple(annotations),
+            errors=tuple(errors),
+        )
+
+
+def _validated_labels(
+    labels: Any,
+    *,
+    descriptor: DatasetSourceDescriptor,
+) -> tuple[str, ...]:
+    if not isinstance(labels, tuple):
+        raise TypeError("classify_file must return a stable tuple")
+    if len(labels) != len(set(labels)):
+        raise ValueError("classify_file labels must be unique")
+    allowed = set(descriptor.label_ids)
+    if any(not isinstance(value, str) or value not in allowed for value in labels):
+        raise ValueError("classify_file returned a label outside its descriptor vocabulary")
+    return labels
+
+
+def _bounded_error(source_id: str, exc: Exception) -> str:
+    detail = " ".join(str(exc).split())[:768]
+    return f"{source_id}: {type(exc).__name__}: {detail}"
+
+
+def register_sources(
+    registry: DatasetSourceRegistry,
+    sources: Iterable[DatasetSource],
+) -> tuple[str, ...]:
+    """Small helper for deterministic in-process composition and tests."""
+
+    return tuple(registry.register_source(source) for source in sources)
+
+
+__all__ = [
+    "DATASET_SOURCE_GROUP",
+    "DatasetAnnotationResolution",
+    "DatasetSource",
+    "DatasetSourceRegistry",
+    "register_sources",
+]

--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -79,6 +79,12 @@ def main() -> int:
     if result is not None:
         return result
 
+    from rosclaw.dataset.cli import dispatch_dataset_argv
+
+    result = dispatch_dataset_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
     from rosclaw.collective.cli import dispatch_collective_argv
 
     result = dispatch_collective_argv(sys.argv[1:])

--- a/tests/architecture/test_dataset_core_domain_purity.py
+++ b/tests/architecture/test_dataset_core_domain_purity.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+DATASET_ROOT = Path(__file__).resolve().parents[2] / "src/rosclaw/dataset"
+DOWNSTREAM_PREFIXES = ("rosclaw_soccer",)
+DOMAIN_PATH_TOKENS = (
+    "ballistic_contact",
+    "football",
+    "free_kick",
+    "g1_",
+    "goalkeeper",
+    "stadium",
+)
+
+
+def _imports(path: Path) -> tuple[str, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    values: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            values.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            values.append(node.module)
+    return tuple(values)
+
+
+def test_dataset_core_has_no_downstream_import_or_domain_path() -> None:
+    violations: list[str] = []
+    for path in sorted(DATASET_ROOT.rglob("*.py")):
+        relative = path.relative_to(DATASET_ROOT).as_posix().lower().replace("-", "_")
+        source = path.read_text(encoding="utf-8").lower().replace("-", "_")
+        for token in DOMAIN_PATH_TOKENS:
+            if token in relative:
+                violations.append(f"domain path: {relative} ({token})")
+            if token in source:
+                violations.append(f"domain source token: {relative} ({token})")
+        for module in _imports(path):
+            if any(
+                module == prefix or module.startswith(prefix + ".")
+                for prefix in DOWNSTREAM_PREFIXES
+            ):
+                violations.append(f"downstream import: {relative} -> {module}")
+
+    assert violations == []

--- a/tests/dataset/test_source_registry.py
+++ b/tests/dataset/test_source_registry.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from rosclaw import extension_discovery
+from rosclaw.dataset import (
+    DATASET_SOURCE_GROUP,
+    DatasetSnapshotState,
+    DatasetSourceDescriptor,
+    DatasetSourceRegistry,
+    FileHashMode,
+    inspect_dataset_root,
+    write_dataset_doctor_artifacts,
+)
+from rosclaw.dataset.cli import dispatch_dataset_argv
+
+
+def _hash(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()
+
+
+@dataclass
+class _EntryPoint:
+    name: str
+    group: str
+    value: Any
+    error: Exception | None = None
+
+    def load(self) -> Any:
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+
+class _EntryPoints(list[_EntryPoint]):
+    def select(self, *, group: str) -> _EntryPoints:
+        return _EntryPoints(item for item in self if item.group == group)
+
+
+@dataclass
+class _NameSource:
+    descriptor: DatasetSourceDescriptor
+    rules: tuple[tuple[str, str], ...]
+    observed_inputs: list[tuple[str, str]] = field(default_factory=list)
+
+    def classify_file(self, dataset_id: str, relative_path: str) -> tuple[str, ...]:
+        self.observed_inputs.append((dataset_id, relative_path))
+        lowered = relative_path.lower()
+        return tuple(label for token, label in self.rules if token in lowered)
+
+
+def _source(
+    *,
+    source_id: str,
+    dataset_id: str,
+    labels: tuple[str, ...],
+    rules: tuple[tuple[str, str], ...],
+) -> _NameSource:
+    return _NameSource(
+        descriptor=DatasetSourceDescriptor(
+            source_id=source_id,
+            dataset_ids=(dataset_id,),
+            label_ids=labels,
+            source_uri=f"https://datasets.example/{source_id}",
+            revision="fixture-v1",
+            manifest_hash=_hash(source_id),
+        ),
+        rules=rules,
+    )
+
+
+def test_registry_discovers_two_task_domains_without_runtime_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entries = _EntryPoints(
+        [
+            _EntryPoint(
+                "navigation",
+                DATASET_SOURCE_GROUP,
+                _source(
+                    source_id="navigation.corridors",
+                    dataset_id="Nav Set",
+                    labels=("corridor", "turn"),
+                    rules=(("corridor", "corridor"), ("turn", "turn")),
+                ),
+            ),
+            _EntryPoint(
+                "manipulation",
+                DATASET_SOURCE_GROUP,
+                _source(
+                    source_id="manipulation.tabletop",
+                    dataset_id="ArmSet",
+                    labels=("grasp", "release"),
+                    rules=(("grasp", "grasp"), ("release", "release")),
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(extension_discovery.importlib.metadata, "entry_points", lambda: entries)
+    registry = DatasetSourceRegistry()
+
+    report = registry.discover()
+
+    assert registry.source_ids == (
+        "manipulation.tabletop",
+        "navigation.corridors",
+    )
+    assert report.loaded == registry.source_ids
+    assert report.errors == ()
+
+
+def test_registry_isolates_broken_plugins_and_out_of_vocabulary_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    healthy = _source(
+        source_id="navigation.corridors",
+        dataset_id="NavSet",
+        labels=("corridor",),
+        rules=(("corridor", "corridor"),),
+    )
+    invalid = _source(
+        source_id="navigation.invalid",
+        dataset_id="NavSet",
+        labels=("turn",),
+        rules=(("corridor", "undeclared"),),
+    )
+    entries = _EntryPoints(
+        [
+            _EntryPoint("broken", DATASET_SOURCE_GROUP, None, RuntimeError("bad package")),
+            _EntryPoint("healthy", DATASET_SOURCE_GROUP, healthy),
+            _EntryPoint("invalid", DATASET_SOURCE_GROUP, invalid),
+        ]
+    )
+    monkeypatch.setattr(extension_discovery.importlib.metadata, "entry_points", lambda: entries)
+    registry = DatasetSourceRegistry()
+
+    discovery = registry.discover()
+    resolution = registry.classify(dataset_id="NavSet", relative_path="corridor/001.json")
+
+    assert discovery.loaded == ("navigation.corridors", "navigation.invalid")
+    assert discovery.errors == ("broken: bad package",)
+    assert tuple(value.source_id for value in resolution.annotations) == ("navigation.corridors",)
+    assert resolution.errors == (
+        "navigation.invalid: ValueError: classify_file returned a label outside its descriptor vocabulary",
+    )
+
+
+def test_dataset_source_discovery_has_operator_recovery_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ROSCLAW_DISABLE_DATASET_EXTENSIONS", "true")
+    monkeypatch.setattr(
+        extension_discovery.importlib.metadata,
+        "entry_points",
+        lambda: pytest.fail("disabled discovery must not inspect packages"),
+    )
+
+    report = DatasetSourceRegistry().discover()
+
+    assert report.disabled is True
+
+
+def test_cross_domain_doctor_inventory_is_generic_and_provenance_bound(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "datasets"
+    nav = root / "Nav Set"
+    arm = root / "ArmSet"
+    nav.mkdir(parents=True)
+    arm.mkdir()
+    (nav / "LICENSE").write_text("fixture license", encoding="utf-8")
+    (nav / "corridor_turn_001.json").write_text("{}", encoding="utf-8")
+    (arm / "grasp_001.json").write_text("{}", encoding="utf-8")
+    (arm / "release_002.json").write_text("{}", encoding="utf-8")
+
+    nav_source = _source(
+        source_id="navigation.corridors",
+        dataset_id="Nav Set",
+        labels=("corridor", "turn"),
+        rules=(("corridor", "corridor"), ("turn", "turn")),
+    )
+    arm_source = _source(
+        source_id="manipulation.tabletop",
+        dataset_id="ArmSet",
+        labels=("grasp", "release"),
+        rules=(("grasp", "grasp"), ("release", "release")),
+    )
+    registry = DatasetSourceRegistry()
+    registry.register_source(nav_source)
+    registry.register_source(arm_source)
+
+    report = inspect_dataset_root(
+        root,
+        hash_mode=FileHashMode.SHA256,
+        source_registry=registry,
+        discover_sources=False,
+    )
+
+    inventories = {value.dataset_id: value for value in report.inventories}
+    assert report.snapshot_complete is True
+    assert tuple(value.source_id for value in report.sources) == (
+        "manipulation.tabletop",
+        "navigation.corridors",
+    )
+    assert inventories["Nav Set"].label_counts == {"corridor": 1, "turn": 1}
+    assert inventories["ArmSet"].label_counts == {"grasp": 1, "release": 1}
+    assert inventories["Nav Set"].license_evidence_present is True
+    assert inventories["Nav Set"].training_eligible is False
+    assert report.to_dict()["promotion_truth_allowed"] is False
+    assert nav_source.observed_inputs == [
+        ("Nav Set", "LICENSE"),
+        ("Nav Set", "corridor_turn_001.json"),
+    ]
+    assert all(not Path(relative).is_absolute() for _, relative in nav_source.observed_inputs)
+
+    artifacts = write_dataset_doctor_artifacts(report, tmp_path / "evidence")
+    assert set(artifacts) == {
+        "inventory",
+        "quality_report",
+        "license_manifest",
+        "source_manifest",
+        "label_matrix",
+    }
+    source_manifest = json.loads(Path(artifacts["source_manifest"]).read_text(encoding="utf-8"))
+    assert source_manifest["training_eligible"] is False
+    assert len(source_manifest["sources"]) == 2
+
+
+def test_transfer_and_plugin_errors_fail_snapshot_closed(tmp_path: Path) -> None:
+    root = tmp_path / "datasets"
+    dataset = root / "NavSet"
+    dataset.mkdir(parents=True)
+    (dataset / "sample.json.part").write_text("partial", encoding="utf-8")
+    invalid = _source(
+        source_id="navigation.invalid",
+        dataset_id="NavSet",
+        labels=("turn",),
+        rules=(("sample", "undeclared"),),
+    )
+    registry = DatasetSourceRegistry()
+    registry.register_source(invalid)
+
+    report = inspect_dataset_root(
+        root,
+        source_registry=registry,
+        discover_sources=False,
+    )
+    inventory = report.inventories[0]
+
+    assert inventory.state is DatasetSnapshotState.TRANSFERRING
+    assert inventory.source_error_count == 1
+    assert report.snapshot_complete is False
+
+
+def test_sha256_inventory_detects_duplicate_content(tmp_path: Path) -> None:
+    root = tmp_path / "datasets"
+    dataset = root / "GenericSet"
+    dataset.mkdir(parents=True)
+    (dataset / "a.bin").write_bytes(b"same")
+    (dataset / "b.bin").write_bytes(b"same")
+
+    report = inspect_dataset_root(
+        root,
+        hash_mode=FileHashMode.SHA256,
+        discover_sources=False,
+    )
+
+    assert report.inventories[0].duplicate_content_groups == (("a.bin", "b.bin"),)
+
+
+def test_cli_no_extension_smoke_writes_generic_artifacts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "datasets"
+    dataset = root / "GenericSet"
+    dataset.mkdir(parents=True)
+    (dataset / "sample.json").write_text("{}", encoding="utf-8")
+    output = tmp_path / "output"
+
+    status = dispatch_dataset_argv(
+        [
+            "dataset",
+            "doctor",
+            "--root",
+            str(root),
+            "--output-dir",
+            str(output),
+            "--source-checkout",
+            str(Path(__file__).resolve().parents[2]),
+            "--no-source-extensions",
+        ]
+    )
+    receipt = json.loads(capsys.readouterr().out)
+
+    assert status == 0
+    assert receipt["ok"] is True
+    assert receipt["source_ids"] == []
+    assert receipt["hardware_authorized"] is False
+    assert (output / "dataset_label_matrix.csv").is_file()
+
+
+def test_registry_rejects_objects_without_source_contract() -> None:
+    with pytest.raises(TypeError, match="DatasetSource protocol"):
+        DatasetSourceRegistry().register_source(object())


### PR DESCRIPTION
## What changed

- add task-neutral dataset source descriptors and `rosclaw.dataset.sources` discovery
- add a transfer-aware, symlink-safe Dataset Doctor with metadata or SHA-256 inventory modes
- emit atomic inventory, quality, license, source, and generic label-matrix artifacts
- add `rosclaw dataset doctor` with output-boundary and overwrite guards
- add Core domain-purity checks and navigation/manipulation source fixtures

## Why

The earlier Dataset Doctor embedded football-specific counters in Core. This PR keeps Core responsible only for bounded inspection, provenance, license/quality evidence, and generic source-provided labels. Domain interpretation belongs to installed adapters.

This is a stacked PR based on `agent/growth-router-registry` (PR #307).

## Safety and architecture

- plugins receive only a dataset ID and normalized relative path, never the dataset root, file handles, runtime, driver, or hardware authority
- transfer markers, LFS pointers, zero-byte files, scan changes, duplicates, bad plugins, and symlinks are represented explicitly and fail closed where required
- generated evidence is never training eligibility, promotion truth, activation authority, or hardware authority
- extension loading is deterministic, isolated, bounded, and disableable with `ROSCLAW_DISABLE_DATASET_EXTENSIONS`
- deleting all domain plugins leaves the Core doctor usable

## Validation

- `9 passed` — Dataset registry/doctor/CLI and Dataset Core purity tests
- Ruff passed on changed Dataset, entrypoint, and test paths
- mypy passed on `src/rosclaw/dataset` and `src/rosclaw/entrypoint.py`
- `rosclaw dataset --help` smoke passed
- combined integration branch: `198 passed, 6 skipped` across Growth, Dataset, architecture, and affected root CLI tests
