### PR TITLE
fix: NINE-1 P0-INPUT-LOSS 热修（九审 §0.1/§1.4）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -48,6 +48,10 @@ export interface RosclawExtensionOptions {
 	/** PR-SIX-5：UI/回答语言策略。 */
 	locale: LocaleManager;
 	rosclawHome: string;
+	/** WP-P0-3：恢复启动——session_start 展示 Resume Report。 */
+	resumed?: boolean;
+	/** 会话命名（WP-P0-2 标题产品化）：写入 Pi session_info。 */
+	sessionManager?: import("@earendil-works/pi-coding-agent").SessionManager;
 }
 
 const WORKING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -59,11 +63,34 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		//    Kimi K3/OFFLINE 与底部未选模型/UNKNOWN 长期共存） --
 		const center = options.center;
 		const locale = options.locale;
+		// WP-P0-3：恢复对账报告（恢复了什么/重新验证了什么/哪些权限
+		// 失效）——一次性展示，不重复。
+		let resumeReportShown = !options.resumed;
 		let refreshChrome: () => void = () => undefined;
 		let probeTimer: ReturnType<typeof setInterval> | null = null;
 		pi.on("session_start", async (_event, ctx) => {
 			if (!ctx.hasUI) return;
 			ctx.ui.setTitle(`ROSClaw Native Agent`);
+			if (!resumeReportShown) {
+				resumeReportShown = true;
+				try {
+					const sessionId = options.active.current.sessionId;
+					const result = await center.call("pi.session.resume_report", {
+						pi_session_id: sessionId,
+					});
+					const report = (result.report ?? {}) as {
+						verdict?: string; lines?: string[];
+					};
+					if (result.ok && report.lines?.length) {
+						ctx.ui.notify(
+							`已恢复（${report.verdict ?? "?"}）\n${report.lines.join("\n")}`,
+							report.verdict === "RESUMED" ? "info" : "warning",
+						);
+					}
+				} catch {
+					// 报告失败不阻塞会话——恢复本身已由 coordinator 完成。
+				}
+			}
 			refreshChrome = () => {
 				const snap = center.snapshot(); // 一次读取，Header/Footer 共享
 				const loc = locale.effective;
@@ -207,98 +234,25 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			ctx.ui.setHiddenThinkingLabel(i18nT("working.default", locale.effective));
 		});
 
-		// -- WP-P0-5（总纲 §7.1）：确定性 Intent Router——已知任务零模型
-		//    回合。仅 SIM + POLICY_AUTO 直跑（ask 走模型→任务卡通道）；
-		//    未命中/异常一律 continue 交模型，绝不吞输入。
-		pi.on("input", async (event, ctx) => {
+		// -- 九审 §1.4/§1.5（P0-INPUT-LOSS 热修）：自然语言绝不 handled。
+		//    先显示、先落账、先分配 Turn ID，然后才路由/执行——Pi 的
+		//    handled 语义是"扩展即时处理的小命令"，自然语言任务经
+		//    handled 会从模型/消息链/session JSONL 消失（幽灵执行）。
+		//    本 handler 只做两件无状态小事：自动命名 + 永远 continue。
+		pi.on("input", async (event, _ctx) => {
 			const text = String((event as { text?: string }).text ?? "").trim();
 			if (!text || text.startsWith("/")) return { action: "continue" as const };
-			// 首条输入可能早于绑定完成（实测：clean-install 第一句话
-			// 直接进模型路径）——短暂等绑定就绪再判定，最多 5s。
-			let state = options.active.current;
-			if (!state.missionId) {
-				const deadline = Date.now() + 5000;
-				while (!options.active.current.missionId && Date.now() < deadline) {
-					await new Promise((resolve) => setTimeout(resolve, 200));
-				}
-				state = options.active.current;
-			}
-			if (!state.missionId || state.mode !== "SIMULATION") {
-				return { action: "continue" as const };
-			}
-			if (!center.isSimAutoPolicy) return { action: "continue" as const };
+			// WP-P0-2：首个有效输入自动命名（确定性截断 ≤30 字，不调
+			// 模型）——退出提示/会话列表展示标题而非内部 ID。
 			try {
-				// 路由直跑前先把 kit discovery 落定——否则上下文在
-				// discovery 前构建，propose 复验时 hash 变化即 fail
-				// closed（真实模型首跑实测：CONTEXT_HASH_MISMATCH）。
-				await center.refreshRobotInfo(true);
-				const kit = center.snapshot().robot_kit;
-				if (kit && kit.state !== "READY") {
-					return { action: "continue" as const };
+				const sm = options.sessionManager;
+				if (sm && !sm.getSessionName()) {
+					sm.appendSessionInfo(text.slice(0, 30));
 				}
-				// 路由直跑没有 before_agent_start——总是自取新鲜具身
-				// 上下文 + context lease（真实模型首跑实测：启动早期
-				// kit BROKEN 时代的 lease 会让 propose 复验 hash 失败；
-				// 不能复用既有 lease）。
-				{
-					const fetched = await fetchEmbodiedContext(
-						options.rosclawHome,
-						state.missionId,
-						state.sessionId,
-						(_home, method, params) => center.call(method, params),
-					);
-					if (fetched.stale || !fetched.envelope) {
-						return { action: "continue" as const };
-					}
-					options.active.applyEnvelope(fetched.envelope, fetched.contextLeaseId);
-					state = options.active.current;
-				}
-				const routed = await center.call("pi.intent.route", { text });
-				const spec = routed.spec as {
-					goal?: string; parameters?: Record<string, unknown>;
-				} | null;
-				if (!routed.ok || !spec?.goal) return { action: "continue" as const };
-				const response = await center.call("pi.tools.execute", {
-					request: {
-						schema_version: "rosclaw.pi_tool_request.v1",
-						request_id: `ptr_router_${Date.now()}`,
-						pi_session_id: state.sessionId,
-						mission_id: state.missionId,
-						context_revision: state.contextRevision,
-						context_lease_id: state.contextLeaseId ?? "",
-						tool_name: "rosclaw_task",
-						arguments: {
-							goal: spec.goal,
-							parameters: spec.parameters ?? {},
-						},
-						requested_at: new Date().toISOString(),
-						idempotency_key: `idem_router_${state.sessionId}_${Date.now()}`,
-						actor: { engine: "pi" },
-					},
-				});
-				const result = (response.result ?? {}) as { summary?: string };
-				let payload: Record<string, unknown> = {};
-				try {
-					payload = JSON.parse(String(result.summary ?? "{}"));
-				} catch {
-					payload = { state: "FAILED", error: String(result.summary ?? "") };
-				}
-				if (String(payload.state ?? "") !== "VERIFIED") {
-					// 路由直跑未过——交回模型解释/处理（不掩盖失败）。
-					ctx.ui.notify(
-						`任务${String(payload.state ?? "FAILED")}：${String(payload.error ?? "")}`,
-						"warning",
-					);
-					return { action: "continue" as const };
-				}
-				ctx.ui.notify(
-					`已识别任务「${text.slice(0, 30)}」→ ${String(payload.user_view ?? "完成")}`,
-					"info",
-				);
-				return { action: "handled" as const };
 			} catch {
-				return { action: "continue" as const };
+				// 命名失败不阻塞输入。
 			}
+			return { action: "continue" as const };
 		});
 
 		// -- `!` bash 功能级关闭（PNA-0 即生效；PNA-9 再做 profile 化 UI 拦截） -----

--- a/packages/rosclaw-agent/src/runtime/create-runtime.ts
+++ b/packages/rosclaw-agent/src/runtime/create-runtime.ts
@@ -44,6 +44,8 @@ export interface RosclawRuntimeOptions {
 	missionId?: string;
 	/** NA-FIX-2：--resume/--continue 打开的既有 session（否则新建）。 */
 	sessionManager?: import("@earendil-works/pi-coding-agent").SessionManager;
+	/** WP-P0-3：本次启动是恢复——session_start 展示 Resume Report。 */
+	resumed?: boolean;
 }
 
 /** native_agent_v2.md：构建期从 Python 源树拷入 dist/prompts（单一事实源）。 */
@@ -172,6 +174,8 @@ export async function createRosclawRuntime(
 								center,
 								locale,
 								rosclawHome: options.rosclawHome,
+								resumed: options.resumed === true,
+								sessionManager,
 							}),
 						},
 					],

--- a/packages/rosclaw-agent/test/input-loss.test.ts
+++ b/packages/rosclaw-agent/test/input-loss.test.ts
@@ -1,0 +1,105 @@
+/** NINE-1 红测试（九审 §0.1/§1.4）：P0-INPUT-LOSS。
+ *
+ * 红测试先行——九审实测：自然语言"我想用机械臂画五角星"在 input
+ * hook 里被路由直跑并返回 handled，Pi prompt() 立即返回——输入
+ * 不进模型、不进消息链、不落 session JSONL（幽灵执行）。
+ *
+ * 原则：先显示、先落账、先分配 Turn ID，然后才能路由/执行。
+ * natural language 绝不许在 input hook 里 handled。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function callInputHandler(text: string) {
+	const { createRosclawExtension } = await import("../src/extension/index.js");
+	const { envelopeHash } = await import("../src/extension/context-injection.js");
+	const handlers: Record<string, (event: unknown, ctx: unknown) => Promise<unknown>> = {};
+	const fakePi = new Proxy(
+		{
+			on(name: string, handler: never) {
+				handlers[name] = handler;
+			},
+			events: { emit: async () => ({}) },
+		},
+		{
+			get(target, prop) {
+				if (prop in target) return (target as Record<string | symbol, unknown>)[prop];
+				return () => undefined; // 其余 pi API 一律吞掉（测试只要 input handler）
+			},
+		},
+	);
+	const center = {
+		call: async (method: string, _params: unknown) => {
+			// 路由命中 + 任务成功——当前代码会据此返回 handled（红）；
+			// 修复后即使全链可用也必须 continue。
+			if (method === "pi.intent.route") {
+				return { ok: true, spec: { goal: "draw_shape", parameters: {} } };
+			}
+			if (method === "pi.tools.execute") {
+				return {
+					ok: true,
+					result: { summary: JSON.stringify({ state: "VERIFIED", user_view: "ok" }) },
+				};
+			}
+			if (method === "pi.context") {
+				const envelope = {
+					schema_version: "rosclaw.embodied_context.v1",
+					expires_at: new Date(Date.now() + 60_000).toISOString(),
+				} as Record<string, unknown>;
+				(envelope as { hash?: string }).hash = envelopeHash(envelope as never);
+				return {
+					ok: true,
+					context: envelope,
+					context_lease_id: "ctxl_mock",
+					context_lease_expires_at: new Date(Date.now() + 60_000).toISOString(),
+				};
+			}
+			return { ok: true };
+		},
+		probeOperator: async () => "OFFLINE",
+		refreshCapabilities: async () => {},
+		refreshRobotInfo: async () => {},
+		snapshot: () => ({ robot_kit: { state: "READY" } }),
+		isSimAutoPolicy: true,
+		subscribe: () => () => {},
+	};
+	const options = {
+		profile: "developer",
+		version: "1.2.0",
+		systemPrompt: "",
+		active: {
+			current: {
+				missionId: "mis_1",
+				sessionId: "pi_1",
+				mode: "SIMULATION",
+				contextLeaseId: "ctxl_1",
+				contextRevision: 0,
+			},
+			subscribe: () => () => {},
+			applyEnvelope() {},
+		},
+		coordinator: {},
+		center,
+		locale: { effective: "zh-CN", subscribe: () => () => {} },
+		rosclawHome: "/tmp/rh-nine1",
+	} as never;
+	const factory = createRosclawExtension(options);
+	factory(fakePi as never);
+	const input = handlers["input"];
+	assert.ok(input, "input handler 未注册");
+	const ctx = { hasUI: true, ui: { notify() {}, setTitle() {}, setWidget() {}, setWorkingIndicator() {}, setWorkingMessage() {}, setHiddenThinkingLabel() {}, setHeader() {}, setFooter() {} } };
+	return await input({ text }, ctx);
+}
+
+test("自然语言任务输入绝不返回 handled", async () => {
+	for (const text of ["我想用机械臂画五角星", "画一个五角星", "帮我诊断 RealSense 断流"]) {
+		const result = (await callInputHandler(text)) as { action: string };
+		assert.notEqual(
+			result.action,
+			"handled",
+			`输入被 handled 吞掉（P0-INPUT-LOSS）: ${text}`,
+		);
+		assert.equal(result.action, "continue");
+	}
+});

--- a/tests/agentd/test_nine1_input_loss.py
+++ b/tests/agentd/test_nine1_input_loss.py
@@ -1,0 +1,81 @@
+"""NINE-1 红测试（九审 §0.1/§25.1）：输入吞噬的最小复现（PTY 级）。
+
+红测试先行——九审实测顺序：hello（正常）→ 自然语言五角星（输入
+消失，后台出现任务结果，模型不知情）。本测试固定：自然语言任务
+输入必须进入 Pi session JSONL 的 user message——TUI、模型消息、
+持久化账本三者一致。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.agentd.test_product_journey import (
+    FakeModelServer,
+    PtySession,
+    _build_and_install,
+    _hidden_source_checkout,
+    _prepare_installed_chat,
+)
+
+
+@pytest.mark.slow
+class TestInputNeverLost:
+    def test_nl_task_input_lands_in_session_jsonl(self, tmp_path: Path) -> None:
+        fake = FakeModelServer(log_path=tmp_path / "fake-requests.jsonl")
+        prefix, _root = _build_and_install(tmp_path)
+        home, env, rosclaw = _prepare_installed_chat(tmp_path, fake, prefix)
+        try:
+            with _hidden_source_checkout():
+                session = PtySession(
+                    [str(rosclaw), "chat"], env,
+                    log_path=tmp_path / "pty-input.log",
+                )
+                try:
+                    session.expect(b"ROSClaw Native Agent", timeout=60)
+                    session.send("你好\r")
+                    session.expect("你好，我是 ROSClaw".encode(), timeout=90)
+                    # 九审复现步骤：正常回合后输入自然语言任务。
+                    session.send("我想用机械臂画一个五角星\r")
+                    # 等任务结果或模型回应（任一路径）——关键是输入落账。
+                    import time
+
+                    time.sleep(15.0)
+                    session.send("/quit\r")
+                    session.expect(b"rosclaw continue", timeout=30)
+                    session.proc.wait(timeout=30)
+                finally:
+                    session.stop()
+        finally:
+            fake.close()
+        # 核心断言：用户输入作为 user message 存在于 session JSONL。
+        sessions_dir = home / "agent" / "sessions"
+        found = False
+        for session_file in sessions_dir.glob("*.jsonl"):
+            for line in session_file.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines():
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("type") != "message":
+                    continue
+                message = entry.get("message", {})
+                if message.get("role") != "user":
+                    continue
+                content = message.get("content", "")
+                if isinstance(content, list):
+                    content = " ".join(
+                        str(b.get("text", "")) for b in content if isinstance(b, dict)
+                    )
+                if "画一个五角星" in str(content):
+                    found = True
+                    break
+        assert found, (
+            "用户输入'我想用机械臂画一个五角星'未进入 session JSONL——"
+            "P0-INPUT-LOSS（幽灵执行）"
+        )

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1498,21 +1498,17 @@ class TestProductJourney:
             #    SIM 自动执行）：能力面 → 初始观测 → POLICY_AUTO（无人工
             #    卡、不按 Y）→ 执行 → 后置观测验证。
             action_start = len(session.clean)
-            fake_requests_before = len(fake.fake.requests)
             session.send("我想跑一个机械臂仿真，让机械臂画五角星\r")
-            # 总纲 §7.1/WP-P0-5：已知任务走确定性 Intent Router——零
-            # 模型回合、零审批卡、单行任务结果。
-            session.expect("已识别任务".encode(), timeout=120)
-            session.expect("验证 PASS".encode(), timeout=120)
+            # 九审 §1.5：Intent Router 直跑已移除（input 落账优先于
+            # 零模型快路）——模型经 rosclaw_task 完成任务；政策自动
+            # 授权可见（POLICY_AUTO），无人工卡。
+            session.expect(b"POLICY_AUTO", timeout=180)
+            # 最终回答必须基于 verifier（不是模型自称画完）。
+            session.expect("五角星已绘制完成，几何验证通过".encode(), timeout=120)
             action_segment = session.clean[action_start:]
             assert "ROSCLAW 授权请求".encode() not in action_segment, (
                 "默认安全 SIM 竟弹人工审批卡"
             )
-            # 零模型回合：该段不得产生新的 provider 请求。
-            assert len(fake.fake.requests) == fake_requests_before, (
-                f"已知任务竟消耗模型请求: +{len(fake.fake.requests) - fake_requests_before}"
-            )
-            self._journey_verdicts["known_task_zero_model_turn"] = True
             self._assert_grant_consumed(home)
             # POLICY_AUTO 的审计链：decided_by 记录政策权威。
             import sqlite3 as _sq


### PR DESCRIPTION
## 九审 P0 热修（红测试先行）

九审实测：自然语言任务输入在 input hook 被路由直跑并返回 `handled`——Pi `prompt()` 立即返回，输入不进模型/消息链/session JSONL（幽灵执行）。

- input hook 移除全部 NL 任务执行：NL 一律 `continue`（先显示先落账先分配 turn）；`handled` 仅限本地命令
- 找回两个合并丢失：WP-P0-3 Resume Report 接线 + 自动命名（此前从未在 main 生效）
- Journey A 回到模型+任务工具流；PTY 复现测试固定"输入落入 session JSONL"

### Red→green
- 红：`input-loss.test.ts`（handled 实测返回）
- 绿：TS + PTY + journey A；node 62/62

🤖 Generated with [Claude Code](https://claude.com/claude-code)