### PR TITLE
feat: 十审 Gate W0 止血——异步委派 + cancel 进程组闭环 + 能力诚实 + 启动静默

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -336,6 +336,8 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					"rosclaw_memory_query",
 					"rosclaw_fail_safe",
 					"rosclaw_delegate",
+					"rosclaw_check_work",
+					"rosclaw_cancel_work",
 					"rosclaw_request_action",
 				],
 			}),
@@ -403,9 +405,16 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 							actor: { engine: "pi-command" },
 						},
 					});
-					const result = (response.result ?? {}) as { summary?: string; error_code?: string };
+					const result = (response.result ?? {}) as {
+						summary?: string;
+						error_code?: string;
+						status?: string;
+					};
 					if (response.ok) {
-						ctx.ui.notify(`Worker 完成（已验证）：${(result.summary ?? "").slice(0, 200)}`, "info");
+						// 十审 W0：STARTED 不是"完成"——summary 自带精确 ID/
+						// worker/预算/deadline，原样展示，不伪造完成。
+						const headline = result.status === "STARTED" ? "Worker 已启动" : "Worker 完成（已验证）";
+						ctx.ui.notify(`${headline}：${(result.summary ?? "").slice(0, 400)}`, "info");
 					} else {
 						ctx.ui.notify(
 							`委派失败 [${result.error_code ?? response.code ?? "?"}]：${result.summary ?? response.error ?? ""}`,

--- a/packages/rosclaw-agent/src/runtime/create-runtime.ts
+++ b/packages/rosclaw-agent/src/runtime/create-runtime.ts
@@ -29,7 +29,7 @@ import { fileURLToPath } from "node:url";
 
 import { createRosclawExtension } from "../extension/index.js";
 import { buildBridgeTools } from "../tools/bridge-tools.js";
-import { buildDelegateTool } from "../tools/delegate.js";
+import { buildDelegateTool, buildCheckWorkTool, buildCancelWorkTool } from "../tools/delegate.js";
 import { buildRequestActionTool } from "../tools/request-action.js";
 import { buildCapabilitiesTool } from "../tools/capabilities.js";
 import { buildComputeTool } from "../tools/compute.js";
@@ -213,6 +213,17 @@ export async function createRosclawRuntime(
 					center,
 				}),
 				buildDelegateTool({
+					rosclawHome: options.rosclawHome,
+					active,
+					center,
+				}),
+				// 十审 W0：异步 WorkOrder 协议（按精确 ID 查询/取消）。
+				buildCheckWorkTool({
+					rosclawHome: options.rosclawHome,
+					active,
+					center,
+				}),
+				buildCancelWorkTool({
 					rosclawHome: options.rosclawHome,
 					active,
 					center,

--- a/packages/rosclaw-agent/src/tools/delegate.ts
+++ b/packages/rosclaw-agent/src/tools/delegate.ts
@@ -1,4 +1,20 @@
-/** rosclaw_delegate 工具（PNA-4，规格 §19）：后台委派 + 原位进度更新。 */
+/** rosclaw_delegate 工具（十审 W0 重写）：真正异步委派。
+ *
+ * 废止的旧行为（P0-WORKER-BLOCK / P0-ORDER-CORRELATION）：
+ * - await 整个 run_to_completion——父会话被"Working…"阻塞数小时；
+ * - 轮询 mission 全部 orders 取最后一条——并发/残留时等错任务；
+ * - finally 等 polling 结束——第二种无限等待。
+ *
+ * 新语义：
+ * - agentd 端 hire + 后台驱动，工具在 grace（≤3s）内返回；
+ * - 快任务 grace 内完成 → 直接返回已验证结果（旧体验保持）；
+ * - 慢任务返回 STARTED + 精确 WorkOrder ID/worker/预算/deadline
+ *   （第一屏信息是审计硬要求）；
+ * - work_order_id 由本工具预生成并随请求下发——signal abort 在响应
+ *   返回前也能按精确 ID cancel（闭环到进程组 kill）。
+ */
+
+import { randomBytes } from "node:crypto";
 
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool } from "@earendil-works/pi-coding-agent";
@@ -6,14 +22,54 @@ import type { BridgeToolContext } from "./bridge-tools.js";
 
 let counter = 0;
 
+function buildRequest(
+	ctx: BridgeToolContext,
+	toolName: string,
+	arguments_: Record<string, unknown>,
+) {
+	counter += 1;
+	const state = ctx.active.current;
+	return {
+		schema_version: "rosclaw.pi_tool_request.v1",
+		request_id: `ptr_${toolName}_${Date.now()}_${counter}`,
+		pi_session_id: state.sessionId,
+		mission_id: state.missionId,
+		context_revision: state.contextRevision,
+		body_hash: state.bodyHash ?? "",
+		mode: state.mode,
+		tool_name: toolName,
+		arguments: arguments_,
+		requested_at: new Date().toISOString(),
+		idempotency_key: `idem_${toolName}_${Date.now()}_${counter}`,
+		actor: { engine: "pi", process_id: process.pid, uid: process.getuid?.() ?? 0 },
+	};
+}
+
+/** abort → 精确 ID cancel（尽力而为，不阻塞 abort 路径）。 */
+function cancelOnAbort(ctx: BridgeToolContext, signal: AbortSignal | undefined, workOrderId: string) {
+	if (!signal) return;
+	signal.addEventListener(
+		"abort",
+		() => {
+			const request = buildRequest(ctx, "rosclaw_cancel_work", {
+				work_order_id: workOrderId,
+				reason: "tool_abort",
+			});
+			void ctx.center.call("pi.tools.execute", { request }).catch(() => undefined);
+		},
+		{ once: true },
+	);
+}
+
 export function buildDelegateTool(ctx: BridgeToolContext) {
 	return defineTool({
 		name: "rosclaw_delegate",
 		label: "ROSClaw Delegate",
 		description:
-			"Hire a bounded worker for a self-contained subtask (WorkOrder with " +
-			"budget + verification). Worker output enters the main context only " +
-			"after ROSClaw verification passes.",
+			"Start a bounded background worker for a self-contained subtask. Returns " +
+			"immediately with a precise WorkOrder ID (worker, budget, deadline). " +
+			"Poll with rosclaw_check_work; cancel with rosclaw_cancel_work. Worker " +
+			"output enters the main context only after ROSClaw verification passes.",
 		parameters: Type.Object({
 			goal: Type.String({ description: "self-contained subtask goal" }),
 			worker_id: Type.Optional(
@@ -28,77 +84,122 @@ export function buildDelegateTool(ctx: BridgeToolContext) {
 				}),
 			),
 		}),
-		async execute(_id, params, signal, onUpdate, _ctx) {
-			counter += 1;
-			const requestId = `ptr_delegate_${Date.now()}_${counter}`;
-			const state = ctx.active.current;
-			const request = {
-				schema_version: "rosclaw.pi_tool_request.v1",
-				request_id: requestId,
-				pi_session_id: state.sessionId,
-				mission_id: state.missionId,
-				context_revision: state.contextRevision,
-				body_hash: state.bodyHash ?? "",
-				mode: state.mode,
-				tool_name: "rosclaw_delegate",
-				arguments: params,
-				requested_at: new Date().toISOString(),
-				idempotency_key: `idem_${requestId}`,
-				actor: { engine: "pi", process_id: process.pid, uid: process.getuid?.() ?? 0 },
+		async execute(_id, params, signal, _onUpdate, _ctx) {
+			const workOrderId = `wo_${randomBytes(8).toString("hex")}`;
+			const request = buildRequest(ctx, "rosclaw_delegate", {
+				...(params as Record<string, unknown>),
+				work_order_id: workOrderId,
+			});
+			cancelOnAbort(ctx, signal, workOrderId);
+			const response = await ctx.center.call("pi.tools.execute", { request });
+			const result = (response.result ?? {}) as {
+				ok?: boolean;
+				status?: string;
+				summary?: string;
+				error_code?: string;
+				artifact_refs?: string[];
 			};
-			// 后台委派 + 轮询 worker 状态原位更新（规格 §19.3）。
-			const done = ctx.center.call("pi.tools.execute", { request });
-			const poll = async () => {
-				while (true) {
-					await new Promise((resolve) => setTimeout(resolve, 2000));
-					if (signal?.aborted) return;
-					try {
-						const status = await ctx.center.call("pi.worker.status", {
-							mission_id: state.missionId,
-						});
-						const orders = (status.orders ?? []) as Array<Record<string, unknown>>;
-						const latest = orders[orders.length - 1];
-						if (latest) {
-							onUpdate?.({
-								content: [
-									{
-										type: "text",
-										text: `Worker ${String(latest.assigned_to ?? "?")}: ${String(latest.status ?? "")}`,
-									},
-								],
-								details: { status: latest.status },
-							});
-							if (["ACCEPTED", "FAILED", "VERIFY_FAILED"].includes(String(latest.status))) return;
-						}
-					} catch {
-						return;
-					}
-				}
+			const ok = response.ok === true;
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: ok
+							? (result.summary ?? "worker completed")
+							: `Worker 未通过验证或被拒 [${result.error_code ?? "?"}]: ${result.summary ?? response.error ?? ""}`,
+					},
+				],
+				details: {
+					ok,
+					status: result.status ?? null,
+					error_code: result.error_code ?? null,
+					work_order_id: workOrderId,
+				},
+				isError: !ok,
 			};
-			const polling = poll();
-			try {
-				const response = await done;
-				const result = (response.result ?? {}) as {
-					ok?: boolean;
-					summary?: string;
-					error_code?: string;
-				};
-				const ok = response.ok === true;
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: ok
-								? (result.summary ?? "worker completed")
-								: `Worker 未通过验证或被拒 [${result.error_code ?? "?"}]: ${result.summary ?? response.error ?? ""}`,
-						},
-					],
-					details: { ok, error_code: result.error_code ?? null },
-					isError: !ok,
-				};
-			} finally {
-				await polling.catch(() => undefined);
-			}
+		},
+	});
+}
+
+export function buildCheckWorkTool(ctx: BridgeToolContext) {
+	return defineTool({
+		name: "rosclaw_check_work",
+		label: "ROSClaw Check Work",
+		description:
+			"Check a background WorkOrder by its exact ID: current phase, terminal " +
+			"verdict, verified summary and artifacts.",
+		parameters: Type.Object({
+			work_order_id: Type.String({ description: "exact wo_... id returned by rosclaw_delegate" }),
+		}),
+		async execute(_id, params, _signal, _onUpdate, _ctx) {
+			const request = buildRequest(ctx, "rosclaw_check_work", params as Record<string, unknown>);
+			const response = await ctx.center.call("pi.tools.execute", { request });
+			const result = (response.result ?? {}) as {
+				ok?: boolean;
+				status?: string;
+				summary?: string;
+				error_code?: string;
+			};
+			const ok = response.ok === true;
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: ok
+							? (result.summary ?? "")
+							: `查询被拒 [${result.error_code ?? response.code ?? "?"}]: ${result.summary ?? response.error ?? ""}`,
+					},
+				],
+				details: {
+					ok,
+					status: result.status ?? null,
+					error_code: result.error_code ?? null,
+					work_order_id: (params as { work_order_id?: string }).work_order_id ?? null,
+				},
+				isError: !ok,
+			};
+		},
+	});
+}
+
+export function buildCancelWorkTool(ctx: BridgeToolContext) {
+	return defineTool({
+		name: "rosclaw_cancel_work",
+		label: "ROSClaw Cancel Work",
+		description:
+			"Cancel a running background WorkOrder by exact ID. Kills the worker " +
+			"process tree; the order transitions to CANCELLED.",
+		parameters: Type.Object({
+			work_order_id: Type.String({ description: "exact wo_... id" }),
+			reason: Type.Optional(Type.String()),
+		}),
+		async execute(_id, params, _signal, _onUpdate, _ctx) {
+			const request = buildRequest(ctx, "rosclaw_cancel_work", params as Record<string, unknown>);
+			const response = await ctx.center.call("pi.tools.execute", { request });
+			const result = (response.result ?? {}) as {
+				ok?: boolean;
+				status?: string;
+				summary?: string;
+				error_code?: string;
+			};
+			const ok = response.ok === true;
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: ok
+							? (result.summary ?? "")
+							: `取消失败 [${result.error_code ?? response.code ?? "?"}]: ${result.summary ?? response.error ?? ""}`,
+					},
+				],
+				details: {
+					ok,
+					status: result.status ?? null,
+					error_code: result.error_code ?? null,
+					work_order_id: (params as { work_order_id?: string }).work_order_id ?? null,
+				},
+				isError: !ok,
+			};
 		},
 	});
 }

--- a/packages/rosclaw-agent/test/delegate-async.test.ts
+++ b/packages/rosclaw-agent/test/delegate-async.test.ts
@@ -1,0 +1,132 @@
+/** 十审 Gate W0 红测试（P0-WORKER-BLOCK / P0-ORDER-CORRELATION）：
+ *
+ * 1. delegate_returns_handle_without_awaiting_completion——工具不得
+ *    同步等待整个任务；STARTED 响应必须带精确 WorkOrder ID（第一屏
+ *    ID/worker/预算/deadline 由 agentd summary 承载，details 带结构化 ID）。
+ * 2. delegate 不再做 mission 级轮询（pi.worker.status 取最后一单是
+ *    错误的关联方式）。
+ * 3. abort_propagates_to_cancel——signal abort 必须按精确 ID 发
+ *    rosclaw_cancel_work（响应尚未返回也能 cancel）。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function makeCtx(
+	calls: Array<{ method: string; tool?: string; args?: Record<string, unknown> }>,
+	executeImpl: (toolName: string, args: Record<string, unknown>) => Promise<unknown>,
+) {
+	const { ActiveSessionContext } = await import("../src/session/active-context.js");
+	const active = new ActiveSessionContext({
+		sessionId: "pi_test",
+		missionId: "mis_1",
+		contextRevision: 3,
+		mode: "SIMULATION",
+		profile: "developer",
+		contextState: "FRESH",
+		leaseState: "ACTIVE",
+		actionsAllowed: true,
+	});
+	const center = {
+		call: async (method: string, params?: unknown) => {
+			const p = (params ?? {}) as { request?: { tool_name?: string; arguments?: Record<string, unknown> } };
+			const tool = p.request?.tool_name ?? "";
+			const args = p.request?.arguments ?? {};
+			calls.push({ method, tool, args });
+			if (method === "pi.tools.execute") return await executeImpl(tool, args);
+			return { ok: true };
+		},
+	};
+	return { active, center };
+}
+
+test("delegate 返回 STARTED + 精确 WorkOrder ID，不做 mission 级轮询", async () => {
+	const calls: Array<{ method: string; tool?: string; args?: Record<string, unknown> }> = [];
+	const ctx = await makeCtx(calls, async () => ({
+		ok: true,
+		result: {
+			ok: true,
+			status: "STARTED",
+			summary:
+				"已启动后台 Worker（不阻塞本会话）。\nWorkOrder: wo_placeholder\nWorker: worker:native:basic\n预算: wall_time 300s",
+		},
+	}));
+	const { buildDelegateTool } = await import("../src/tools/delegate.js");
+	const tool = buildDelegateTool({ rosclawHome: "/tmp/rh", ...ctx } as never);
+	const started = Date.now();
+	const result = await tool.execute("t1", { goal: "长任务" }, undefined, undefined, {} as never);
+	const elapsed = Date.now() - started;
+	assert.ok(elapsed < 1000, `delegate 阻塞了 ${elapsed}ms`);
+	const text = result.content.map((b) => ("text" in b ? b.text : "")).join("");
+	assert.match(text, /WorkOrder: wo_/);
+	const details = result.details as { status?: string; work_order_id?: string };
+	assert.equal(details.status, "STARTED");
+	assert.match(details.work_order_id ?? "", /^wo_[0-9a-f]{16}$/);
+	// 不再经 pi.worker.status 做 mission 级轮询（错误关联根因）。
+	assert.ok(
+		!calls.some((c) => c.method === "pi.worker.status"),
+		`仍做 mission 级轮询: ${JSON.stringify(calls)}`,
+	);
+	// 请求必须携带预生成的 work_order_id（abort 闭环的前提）。
+	const delegateCall = calls.find((c) => c.tool === "rosclaw_delegate");
+	assert.ok(delegateCall, "未调用 rosclaw_delegate");
+	assert.equal(delegateCall.args?.work_order_id, details.work_order_id);
+});
+
+test("abort 按精确 ID 发 rosclaw_cancel_work（响应未返回也生效）", async () => {
+	const calls: Array<{ method: string; tool?: string; args?: Record<string, unknown> }> = [];
+	let releaseExecute: (() => void) | undefined;
+	const gate = new Promise<void>((resolve) => {
+		releaseExecute = resolve;
+	});
+	const ctx = await makeCtx(calls, async (tool) => {
+		if (tool === "rosclaw_delegate") {
+			await gate; // agentd 还在跑——abort 必须在此之前就能 cancel
+			return { ok: true, result: { ok: true, status: "CANCELLED", summary: "已取消" } };
+		}
+		return { ok: true, result: { ok: true, status: "CANCELLED", summary: "已取消" } };
+	});
+	const { buildDelegateTool } = await import("../src/tools/delegate.js");
+	const tool = buildDelegateTool({ rosclawHome: "/tmp/rh", ...ctx } as never);
+	const controller = new AbortController();
+	const pending = tool.execute("t1", { goal: "长任务" }, controller.signal, undefined, {} as never);
+	// 等 delegate 请求发出。
+	for (let i = 0; i < 100 && !calls.some((c) => c.tool === "rosclaw_delegate"); i++) {
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	const delegateCall = calls.find((c) => c.tool === "rosclaw_delegate");
+	assert.ok(delegateCall, "delegate 请求未发出");
+	const workOrderId = String(delegateCall.args?.work_order_id ?? "");
+	assert.match(workOrderId, /^wo_[0-9a-f]{16}$/);
+	controller.abort();
+	// cancel 必须按同一个精确 ID 发出（不等 delegate 响应）。
+	for (let i = 0; i < 100 && !calls.some((c) => c.tool === "rosclaw_cancel_work"); i++) {
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	const cancelCall = calls.find((c) => c.tool === "rosclaw_cancel_work");
+	assert.ok(cancelCall, `abort 未触发 cancel: ${JSON.stringify(calls)}`);
+	assert.equal(cancelCall.args?.work_order_id, workOrderId);
+	releaseExecute?.();
+	await pending;
+});
+
+test("check/cancel 工具按精确 ID 直发对应 agentd 工具", async () => {
+	const calls: Array<{ method: string; tool?: string; args?: Record<string, unknown> }> = [];
+	const ctx = await makeCtx(calls, async (tool) => ({
+		ok: true,
+		result: { ok: true, status: tool === "rosclaw_check_work" ? "RUNNING" : "CANCELLED", summary: "x" },
+	}));
+	const { buildCheckWorkTool, buildCancelWorkTool } = await import("../src/tools/delegate.js");
+	const check = buildCheckWorkTool({ rosclawHome: "/tmp/rh", ...ctx } as never);
+	await check.execute("t1", { work_order_id: "wo_abc12345" }, undefined, undefined, {} as never);
+	const cancel = buildCancelWorkTool({ rosclawHome: "/tmp/rh", ...ctx } as never);
+	await cancel.execute(
+		"t2",
+		{ work_order_id: "wo_abc12345", reason: "user" },
+		undefined,
+		undefined,
+		{} as never,
+	);
+	assert.ok(calls.some((c) => c.tool === "rosclaw_check_work" && c.args?.work_order_id === "wo_abc12345"));
+	assert.ok(calls.some((c) => c.tool === "rosclaw_cancel_work" && c.args?.work_order_id === "wo_abc12345"));
+});

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -398,10 +398,36 @@ def cmd_chat(args: argparse.Namespace) -> int:
     if engine == "pi":
         return _chat_pi(home, args)
     config = load_agent_config(home / "config.yaml")
+    # 诊断路由必须先于 AgentService 构造（启动 warning 就在那里出现）。
+    _route_internal_diagnostics_to_log(home, debug=bool(getattr(args, "debug", False)))
     service = AgentService(config, home)
     if getattr(args, "basic", False):
         return asyncio.run(_chat_repl(service, args))
     return _chat_tui(service, args)
+
+
+def _route_internal_diagnostics_to_log(home: Path, *, debug: bool) -> None:
+    """十审 W0（P1-PRODUCT-NOISE）：Python warnings（pydantic forward-ref、
+    第三方 deprecation 等内部诊断）默认进 logs/python-warnings.log，
+    不糊 TUI 第一屏；--debug 或 ROSCLAW_DEBUG 时保持终端可见。
+    """
+    import logging as _logging
+
+    if debug or os.environ.get("ROSCLAW_DEBUG"):
+        return
+    try:
+        log_dir = home / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        handler = _logging.FileHandler(log_dir / "python-warnings.log")
+        handler.setFormatter(
+            _logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+        )
+        py_warnings = _logging.getLogger("py.warnings")
+        py_warnings.addHandler(handler)
+        py_warnings.propagate = False
+        _logging.captureWarnings(True)
+    except OSError:
+        pass
 
 
 def _find_pi_agent_entry() -> tuple[str, str] | None:
@@ -436,6 +462,8 @@ def _chat_pi(home: Path, args: argparse.Namespace) -> int:
         return 2
     node, entry = runtime
     config = load_agent_config(home / "config.yaml")
+    # 十审 W0：诊断路由必须先于 AgentService 构造（启动 warning 就在那里）。
+    _route_internal_diagnostics_to_log(home, debug=bool(getattr(args, "debug", False)))
     service = AgentService(config, home)
     # Mission：--mission 复用或新建（SIMULATION 默认）。
     # --continue/--resume 不预建 Mission（P0-2：由 session 切换事务
@@ -1137,6 +1165,11 @@ def add_agent_subparsers(subparsers) -> None:
         "--basic",
         action="store_true",
         help="兼容/诊断模式：Python input() 行式 REPL（无 TUI）",
+    )
+    p_chat.add_argument(
+        "--debug",
+        action="store_true",
+        help="诊断模式：内部 warning/MCP 子进程诊断回显终端（默认写入 logs/）",
     )
     p_chat.add_argument(
         "--engine",

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -13,8 +13,10 @@ PNA-3 工具集（read/observe/verify/memory/fail_safe/status）：
 
 from __future__ import annotations
 
+import asyncio
 import json
-from datetime import UTC, datetime
+import re
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from rosclaw.agentd.pi_bridge.session_binding import SessionBindingStore
@@ -32,6 +34,10 @@ _TOOL_TABLE: dict[str, str] = {
     "rosclaw_memory_query": "read",
     "rosclaw_fail_safe": "control",
     "rosclaw_delegate": "delegate",
+    # 十审 W0：异步 WorkOrder 协议——start 立即返回精确 ID；check/cancel
+    # 按 ID 精确关联（不再是"取 mission 最后一单"）。
+    "rosclaw_check_work": "read",
+    "rosclaw_cancel_work": "delegate",
     "rosclaw_request_action": "physical_action",
     # 八审 P0-5：任务级入口——确定性编译器编排，模型只交 TaskSpec。
     "rosclaw_task": "task",
@@ -300,6 +306,10 @@ class PiToolDispatcher:
             return await self._task(request)
         if name == "rosclaw_delegate":
             return await self._delegate(request)
+        if name == "rosclaw_check_work":
+            return await self._check_work(request)
+        if name == "rosclaw_cancel_work":
+            return await self._cancel_work(request)
         if name == "rosclaw_fail_safe":
             await service.cancel(request.mission_id)
             return PiToolResultV1(
@@ -346,8 +356,14 @@ class PiToolDispatcher:
             )
         order_depth = 0
         capability = str(args.get("capability") or "analysis.text")
+        # 十审 W0：调用方（TS 工具层，非模型字段）可预生成 work_order_id——
+        # abort 在响应返回前也能按精确 ID cancel（修 P0-ORDER-CORRELATION
+        # 的另一半：abort 不再"找不到要杀的单"）。
+        provided_wo = str(args.get("work_order_id", "") or "")
+        if provided_wo and not re.fullmatch(r"wo_[A-Za-z0-9]{8,32}", provided_wo):
+            raise ToolBridgeError("INVALID_ARGUMENTS", "malformed work_order_id")
         order = WorkOrderV1(
-            work_order_id=new_id("wo"),
+            work_order_id=provided_wo or new_id("wo"),
             mission_id=request.mission_id,
             issued_by="rosclaw-agent:pi",
             capability=capability,
@@ -393,25 +409,185 @@ class PiToolDispatcher:
             scheduled = service._worker_manager.hire(order, candidates)
         except Exception as exc:  # noqa: BLE001 - 诚实失败，不伪造委派
             raise ToolBridgeError("SCHEDULING_FAILED", str(exc), retryable=True) from exc
-        result, report = await service._worker_manager.run_to_completion(scheduled)
-        if not report.accepted:
+        # 十审 W0（P0-WORKER-BLOCK）：不在工具请求栈里同步等待整个任务。
+        # 后台驱动任务驱动到终态；这里只在短 grace 内等"快任务"——
+        # 超时返回 STARTED + 精确 WorkOrder ID/worker/预算/deadline。
+        service.spawn_worker_driver(scheduled)
+        grace = float(args.get("sync_grace_sec", 3.0) or 0)
+        grace = max(0.0, min(grace, 10.0))  # 硬上限：永不长阻塞父会话
+        terminal = await self._await_terminal(
+            scheduled.work_order_id, timeout_sec=grace
+        )
+        if terminal is not None:
+            return self._terminal_response(request, terminal)
+        deadline = datetime.now(UTC) + timedelta(seconds=scheduled.budgets.wall_time_sec)
+        return PiToolResultV1(
+            request_id=request.request_id,
+            ok=True,
+            status="STARTED",
+            summary=(
+                "已启动后台 Worker（不阻塞本会话——你可以继续与用户交互）。\n"
+                f"WorkOrder: {scheduled.work_order_id}\n"
+                f"Worker: {scheduled.assigned_to}\n"
+                f"预算: wall_time {scheduled.budgets.wall_time_sec}s · "
+                f"{scheduled.budgets.model_tokens} tokens\n"
+                f"Deadline: {deadline.isoformat()}\n"
+                f"查询进度：rosclaw_check_work(work_order_id=\"{scheduled.work_order_id}\")；"
+                f"取消：rosclaw_cancel_work(work_order_id=\"{scheduled.work_order_id}\")。"
+                "Worker 产出须经 ROSClaw 验证后才会被采纳。"
+            ),
+        )
+
+    async def _await_terminal(self, work_order_id: str, *, timeout_sec: float):
+        """短 grace 内等待终态（快任务保持同步体验）；超时返回 None。"""
+        if timeout_sec <= 0:
+            return None
+        loop = asyncio.get_running_loop()
+        end = loop.time() + timeout_sec
+        while loop.time() < end:
+            order = self._service._worker_manager.order(work_order_id)
+            if order is not None and order.status in (
+                "ACCEPTED",
+                "FAILED",
+                "EXPIRED",
+                "CANCELLED",
+            ):
+                return order
+            await asyncio.sleep(0.05)
+        return None
+
+    def _terminal_response(self, request: PiToolRequestV1, order) -> PiToolResultV1:
+        """终态 WorkOrder → 工具结果（从权威存储读结果与验证报告）。"""
+        conn = self._service._store.connection
+        row = conn.execute(
+            "SELECT result_json FROM work_results WHERE work_order_id = ?",
+            (order.work_order_id,),
+        ).fetchone()
+        summary = ""
+        artifact_refs: list[str] = []
+        result_status = ""
+        if row is not None:
+            payload = json.loads(row["result_json"])
+            summary = str(payload.get("summary", ""))
+            artifact_refs = [str(a.get("ref", "")) for a in payload.get("artifacts", [])]
+            result_status = str(payload.get("status", ""))
+        verify_row = conn.execute(
+            "SELECT verify_report_json FROM work_orders WHERE work_order_id = ?",
+            (order.work_order_id,),
+        ).fetchone()
+        accepted = False
+        reasons: list[str] = []
+        if verify_row and verify_row["verify_report_json"]:
+            report = json.loads(verify_row["verify_report_json"])
+            accepted = bool(report.get("accepted"))
+            reasons = [str(r) for r in report.get("reasons", [])]
+        if order.status == "ACCEPTED" and accepted:
+            return PiToolResultV1(
+                request_id=request.request_id,
+                ok=True,
+                status="COMPLETED",
+                summary=summary,
+                artifact_refs=artifact_refs,
+            )
+        if order.status == "CANCELLED":
             return PiToolResultV1(
                 request_id=request.request_id,
                 ok=False,
-                status="VERIFY_FAILED",
-                summary=(
-                    f"Worker {scheduled.assigned_to} 提交的结果未通过验证"
-                    f"（{'；'.join(report.reasons) or '未知'}）——未采纳进主上下文。"
-                ),
-                error_code="VERIFICATION_REJECTED",
+                status="CANCELLED",
+                summary=f"WorkOrder {order.work_order_id} 已取消。",
+                error_code="WORK_CANCELLED",
+            )
+        if result_status == "FAILED" or order.status == "FAILED":
+            if reasons:
+                return PiToolResultV1(
+                    request_id=request.request_id,
+                    ok=False,
+                    status="VERIFY_FAILED",
+                    summary=(
+                        f"Worker {order.assigned_to} 提交的结果未通过验证"
+                        f"（{'；'.join(reasons)}）——未采纳进主上下文。"
+                    ),
+                    error_code="VERIFICATION_REJECTED",
+                    retryable=True,
+                )
+            return PiToolResultV1(
+                request_id=request.request_id,
+                ok=False,
+                status="FAILED",
+                summary=summary or f"Worker {order.assigned_to} 失败。",
+                error_code="WORKER_FAILED",
                 retryable=True,
             )
         return PiToolResultV1(
             request_id=request.request_id,
+            ok=False,
+            status=order.status,
+            summary=f"WorkOrder {order.work_order_id} 终态 {order.status}。",
+            error_code="WORK_NOT_COMPLETED",
+            retryable=True,
+        )
+
+    async def _check_work(self, request: PiToolRequestV1) -> PiToolResultV1:
+        """十审 W0：按精确 work_order_id 查询（修 P0-ORDER-CORRELATION）。"""
+        work_order_id = str(request.arguments.get("work_order_id", "")).strip()
+        if not work_order_id:
+            raise ToolBridgeError("INVALID_ARGUMENTS", "work_order_id required")
+        order = self._service._worker_manager.order(work_order_id)
+        if order is None:
+            raise ToolBridgeError(
+                "WORK_ORDER_NOT_FOUND", f"unknown work order {work_order_id!r}"
+            )
+        if order.mission_id != request.mission_id:
+            raise ToolBridgeError(
+                "MISSION_MISMATCH", "work order belongs to a different mission"
+            )
+        if order.status in ("ACCEPTED", "FAILED", "EXPIRED", "CANCELLED"):
+            response = self._terminal_response(request, order)
+            # check 的语义是"查询"——终态本身不是调用失败。
+            response.ok = True
+            return response
+        conn = self._service._store.connection
+        hb = conn.execute(
+            "SELECT last_heartbeat_at, heartbeat_seq FROM work_orders WHERE work_order_id = ?",
+            (work_order_id,),
+        ).fetchone()
+        return PiToolResultV1(
+            request_id=request.request_id,
             ok=True,
-            status="COMPLETED",
-            summary=result.summary,
-            artifact_refs=[a.ref for a in result.artifacts],
+            status=order.status,
+            summary=(
+                f"WorkOrder {order.work_order_id} · Worker {order.assigned_to} · "
+                f"状态 {order.status}"
+                + (
+                    f" · 心跳 seq={hb['heartbeat_seq']} at {hb['last_heartbeat_at']}"
+                    if hb and hb["last_heartbeat_at"]
+                    else " · 暂无心跳"
+                )
+            ),
+        )
+
+    async def _cancel_work(self, request: PiToolRequestV1) -> PiToolResultV1:
+        """十审 W0：cancel 闭环——WorkOrder CANCELLED + adapter 杀进程树。"""
+        work_order_id = str(request.arguments.get("work_order_id", "")).strip()
+        if not work_order_id:
+            raise ToolBridgeError("INVALID_ARGUMENTS", "work_order_id required")
+        reason = str(request.arguments.get("reason", "") or "model_cancel")
+        order = self._service._worker_manager.order(work_order_id)
+        if order is None:
+            raise ToolBridgeError(
+                "WORK_ORDER_NOT_FOUND", f"unknown work order {work_order_id!r}"
+            )
+        if order.mission_id != request.mission_id:
+            raise ToolBridgeError(
+                "MISSION_MISMATCH", "work order belongs to a different mission"
+            )
+        final = await self._service._worker_manager.cancel_order(work_order_id, reason=reason)
+        return PiToolResultV1(
+            request_id=request.request_id,
+            ok=True,
+            status=final.status,
+            summary=f"WorkOrder {work_order_id} 当前状态 {final.status}。",
+            error_code=None if final.status == "CANCELLED" else "ALREADY_TERMINAL",
         )
 
     async def _task(self, request: PiToolRequestV1) -> PiToolResultV1:

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -292,6 +292,10 @@ class AgentService:
 
         self._events = AgentEventStore(self._store.connection)
         self._turn_tasks: dict[str, asyncio.Task] = {}
+        # 十审 W0：WorkOrder 后台驱动任务——delegate 立即返回后由它们
+        # 驱动 run_to_completion；close() 时统一取消（DB 终态权威不变：
+        # 未完成的单由 sweeper/重启对账处理，绝不永久假装 RUNNING 健康）。
+        self._worker_bg_tasks: dict[str, asyncio.Task] = {}
         from rosclaw.agentd.runner import MissionRunner
 
         self._runner = MissionRunner(self)
@@ -1700,7 +1704,39 @@ class AgentService:
         await self._pi_bridge.start()
         return path
 
+    def spawn_worker_driver(self, order) -> None:
+        """十审 W0：WorkOrder 后台驱动——pi 工具请求栈立即返回后由本
+        任务驱动 run_to_completion 到终态；请求断开不影响权威状态。"""
+        task = asyncio.create_task(self._worker_manager.run_to_completion(order))
+        self._worker_bg_tasks[order.work_order_id] = task
+
+        def _done(t: asyncio.Task, wo_id: str = order.work_order_id) -> None:
+            self._worker_bg_tasks.pop(wo_id, None)
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is not None:  # 防御：manager 已兜底——这里只记录。
+                import logging
+
+                logging.getLogger("rosclaw.agentd.workers").warning(
+                    "worker driver for %s raised: %s", wo_id, exc
+                )
+
+        task.add_done_callback(_done)
+
     async def close(self) -> None:
+        # 十审 W0：先杀活动 Worker 的底层进程树（adapter 级），再取消
+        # 后台驱动任务——顺序反过来会让驱动先死、进程泄漏。
+        import contextlib as _cl
+
+        with _cl.suppress(Exception):
+            await self._worker_manager.shutdown()
+        for task in list(getattr(self, "_worker_bg_tasks", {}).values()):
+            task.cancel()
+        if getattr(self, "_worker_bg_tasks", None):
+            with _cl.suppress(Exception):
+                await asyncio.gather(*self._worker_bg_tasks.values(), return_exceptions=True)
+            self._worker_bg_tasks.clear()
         # 六审 §7：产品 supervisor 管理的 operatord 随 service 终止。
         managed = getattr(self, "_managed_operator", None)
         if managed is not None:

--- a/src/rosclaw/agentd/tooling/persistent_client.py
+++ b/src/rosclaw/agentd/tooling/persistent_client.py
@@ -22,8 +22,21 @@ from rosclaw.contracts.common import ValidationError
 def _safe_errlog():
     # MCP stdio spawn 的 errlog 必须有 fileno（捕获环境下
     # sys.stderr 是替身对象）。
+    # 十审 W0：子进程 stderr 是内部诊断——默认写 ROSCLAW_HOME 日志文件，
+    # 不糊 TUI 终端（--debug/ROSCLAW_DEBUG 时才回到 stderr）。
     import sys
 
+    if not os.environ.get("ROSCLAW_DEBUG"):
+        home = os.environ.get("ROSCLAW_HOME")
+        if home:
+            try:
+                log_dir = os.path.join(home, "logs")
+                os.makedirs(log_dir, exist_ok=True)
+                return open(  # noqa: SIM115 - 进程级常量生命周期
+                    os.path.join(log_dir, "mcp-child.log"), "a", buffering=1
+                )
+            except OSError:
+                pass
     for stream in (sys.stderr, sys.__stderr__):
         try:
             stream.fileno()

--- a/src/rosclaw/agentd/workers/external.py
+++ b/src/rosclaw/agentd/workers/external.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import shutil
+import signal
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -40,6 +41,34 @@ _ANALYSIS_SYSTEM = (
     "outcomes; clearly mark inference vs fact; reply concisely in the "
     "requester's language."
 )
+
+#: 十审 W0：cancel grace——先 SIGTERM，超时 SIGKILL（指标：2s 级，硬上限 7s）。
+_CANCEL_GRACE_SEC = 5.0
+
+
+async def _kill_process_tree(proc) -> None:
+    """杀整个进程组（start_new_session=True 保证子进程是组长）。
+
+    SIGTERM → grace → SIGKILL；最后 reap。进程已退则静默返回。
+    """
+    if proc.returncode is not None:
+        return
+    import contextlib
+
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, PermissionError):
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGTERM)
+    with contextlib.suppress(TimeoutError):
+        await asyncio.wait_for(proc.wait(), timeout=_CANCEL_GRACE_SEC)
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGKILL)
+    # 防御：内核都杀不动——不阻塞 cancel 闭环。
+    with contextlib.suppress(TimeoutError):
+        await asyncio.wait_for(proc.wait(), timeout=2)
 
 
 class ExternalHarnessAdapter:
@@ -191,19 +220,39 @@ class ExternalHarnessAdapter:
                 stderr=asyncio.subprocess.PIPE,
                 cwd=str(self._cwd) if self._cwd else None,
                 env=self._env(pack, credential_refs),
+                # 十审 W0：独立进程组——cancel/timeout 才能整组 SIGTERM/
+                # SIGKILL（此前只 cancel asyncio task，子进程与孙进程
+                # 全部变孤儿继续跑/继续计费）。
+                start_new_session=True,
             )
         except FileNotFoundError as exc:
             raise AdapterError(
                 f"{pack.executable!r} not found at start time ({pack.install_hint})"
             ) from exc
+        stdout_task = asyncio.create_task(proc.stdout.read())  # type: ignore[union-attr]
+        stderr_task = asyncio.create_task(proc.stderr.read())  # type: ignore[union-attr]
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=order.budgets.wall_time_sec or pack.default_timeout_sec
+            await asyncio.wait_for(
+                proc.wait(),
+                timeout=order.budgets.wall_time_sec or pack.default_timeout_sec,
             )
         except TimeoutError:
-            proc.kill()
-            await proc.wait()
+            await _kill_process_tree(proc)
             raise AdapterError("external harness timed out") from None
+        except asyncio.CancelledError:
+            await _kill_process_tree(proc)
+            stdout_task.cancel()
+            stderr_task.cancel()
+            raise
+        # 进程死后管道 EOF——reader 自然结束（限时兜底防残留）。
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                asyncio.gather(stdout_task, stderr_task), timeout=5
+            )
+        except (TimeoutError, asyncio.CancelledError):
+            stdout_task.cancel()
+            stderr_task.cancel()
+            stdout, stderr = b"", b""
         finished = datetime.now(UTC)
         text, usage_raw = self._parse_output(pack, stdout, proc.returncode, stderr)
         digest = hashlib.sha256(text.encode()).hexdigest()

--- a/src/rosclaw/agentd/workers/manager.py
+++ b/src/rosclaw/agentd/workers/manager.py
@@ -20,7 +20,7 @@ import json
 import sqlite3
 from datetime import UTC, datetime, timedelta
 
-from rosclaw.agentd.workers.adapter import WorkerAdapter
+from rosclaw.agentd.workers.adapter import RunHandle, WorkerAdapter
 from rosclaw.agentd.workers.scheduler import CandidateView, Scheduler, SchedulingError
 from rosclaw.agentd.workers.verify import VerificationReport, verify_result
 from rosclaw.contracts.common import ValidationError, new_id
@@ -72,6 +72,46 @@ class WorkerManager:
         self._poll_interval = poll_interval_sec
         self._event_recorder = event_recorder
         self._scheduler = Scheduler()
+        # 十审 W0：活动 run 注册表——cancel_order 凭它找到 adapter+handle
+        # 杀进程（此前 handle 只是 run_to_completion 的局部变量，cancel
+        # 永远够不到进程）。
+        self._runs: dict[str, tuple[WorkerAdapter, RunHandle]] = {}
+
+    # ------------------------------------------------------------------
+    # cancel（十审 W0：abort → WorkOrder CANCELLED → adapter cancel →
+    # 进程组 kill 闭环）
+    # ------------------------------------------------------------------
+    async def cancel_order(self, work_order_id: str, *, reason: str = "user_cancel") -> WorkOrderV1:
+        """取消未终态的 WorkOrder：adapter.cancel（杀进程树）+ CANCELLED。
+
+        已终态返回当前状态（诚实 no-op）；未知 ID 抛 ValidationError。
+        run_to_completion 的驱动循环会发现 CANCELLED 并退出（不改写终态）。
+        """
+        order = self.order(work_order_id)
+        if order is None:
+            raise ValidationError(f"unknown work order {work_order_id!r}")
+        if order.status in ("ACCEPTED", "FAILED", "EXPIRED", "CANCELLED"):
+            return order
+        import contextlib
+
+        entry = self._runs.get(work_order_id)
+        if entry is not None:
+            adapter, handle = entry
+            # cancel 尽力而为，状态机照常收尾。
+            with contextlib.suppress(Exception):
+                await adapter.cancel(handle, reason)
+        if self.order(work_order_id).status not in (  # type: ignore[union-attr]
+            "ACCEPTED",
+            "FAILED",
+            "EXPIRED",
+            "CANCELLED",
+        ):
+            # 与驱动循环竞态（如已进 SUBMITTED）：保持诚实当前态。
+            with contextlib.suppress(ValidationError):
+                self._transition(work_order_id, "CANCELLED", reason)
+        current = self.order(work_order_id)
+        assert current is not None
+        return current
 
     # ------------------------------------------------------------------
     # lifecycle
@@ -118,7 +158,47 @@ class WorkerManager:
     async def run_to_completion(
         self, order: WorkOrderV1, *, timeout_sec: float | None = None
     ) -> tuple[WorkResultV1, VerificationReport]:
-        """Drive CLAIMED→RUNNING→SUBMITTED→VERIFYING→ACCEPTED/FAILED."""
+        """Drive CLAIMED→RUNNING→SUBMITTED→VERIFYING→ACCEPTED/FAILED.
+
+        十审 W0：
+        - handle 注册进 self._runs（cancel_order 由此杀进程树）；
+        - 驱动循环发现外部 CANCELLED 即退出（不改写终态、不做验证）；
+        - 驱动器自身异常不得让 WorkOrder 永久 RUNNING——标记 FAILED。
+        """
+        try:
+            return await self._run_to_completion_inner(order, timeout_sec=timeout_sec)
+        except Exception as exc:  # noqa: BLE001 - 后台驱动永不抛出；失败即数据
+            try:
+                current = self.order(order.work_order_id)
+                if current is not None and current.status not in (
+                    "ACCEPTED",
+                    "FAILED",
+                    "EXPIRED",
+                    "CANCELLED",
+                ):
+                    self._transition(
+                        order.work_order_id, "FAILED", f"driver_crash:{type(exc).__name__}"
+                    )
+            finally:
+                self._runs.pop(order.work_order_id, None)
+            result = WorkResultV1(
+                work_order_id=order.work_order_id,
+                worker_id=order.assigned_to or "",
+                lease_id=order.lease.lease_id if order.lease else "",
+                status="FAILED",
+                summary=f"worker driver crashed: {type(exc).__name__}: {exc}",
+                warnings=["driver_crash"],
+            )
+            report = VerificationReport(
+                accepted=False,
+                verifier_results={"driver_alive": False},
+                reasons=(f"driver crashed: {type(exc).__name__}",),
+            )
+            return result, report
+
+    async def _run_to_completion_inner(
+        self, order: WorkOrderV1, *, timeout_sec: float | None = None
+    ) -> tuple[WorkResultV1, VerificationReport]:
         card_row = self._conn.execute(
             "SELECT card_json FROM worker_cards WHERE worker_id = ?",
             (order.assigned_to,),
@@ -128,15 +208,39 @@ class WorkerManager:
         card = WorkerCardV1(**json.loads(card_row["card_json"]))
         adapter = self._adapters[card.adapter_type]
         handle = await adapter.start(order, {})
-        deadline = datetime.now(UTC) + timedelta(seconds=timeout_sec or order.budgets.wall_time_sec)
-        result: WorkResultV1 | None = None
-        while datetime.now(UTC) < deadline:
-            polled = await adapter.poll(handle)
-            if isinstance(polled, WorkResultV1):
-                result = polled
-                break
-            self._heartbeat(order.work_order_id, polled.progress_seq)
-            await asyncio.sleep(self._poll_interval)
+        self._runs[order.work_order_id] = (adapter, handle)
+        try:
+            deadline = datetime.now(UTC) + timedelta(
+                seconds=timeout_sec or order.budgets.wall_time_sec
+            )
+            result: WorkResultV1 | None = None
+            while datetime.now(UTC) < deadline:
+                # 外部 cancel（cancel_order）已翻转状态：退出，不验证不改写。
+                current = self.order(order.work_order_id)
+                if current is not None and current.status == "CANCELLED":
+                    return self._cancelled_result(order), VerificationReport(
+                        accepted=False,
+                        verifier_results={"cancelled": True},
+                        reasons=("cancelled before completion",),
+                    )
+                try:
+                    polled = await adapter.poll(handle)
+                except Exception:  # noqa: BLE001 - cancel 后 handle 已移除等
+                    current = self.order(order.work_order_id)
+                    if current is not None and current.status == "CANCELLED":
+                        return self._cancelled_result(order), VerificationReport(
+                            accepted=False,
+                            verifier_results={"cancelled": True},
+                            reasons=("cancelled before completion",),
+                        )
+                    raise
+                if isinstance(polled, WorkResultV1):
+                    result = polled
+                    break
+                self._heartbeat(order.work_order_id, polled.progress_seq)
+                await asyncio.sleep(self._poll_interval)
+        finally:
+            self._runs.pop(order.work_order_id, None)
         if result is None:
             await adapter.cancel(handle, "deadline_exceeded")
             self._transition(order.work_order_id, "FAILED", "deadline_exceeded")
@@ -197,6 +301,28 @@ class WorkerManager:
         )
         self._update_circuit(order.assigned_to or "", order.capability, report.accepted)
         return result, report
+
+    async def shutdown(self) -> None:
+        """服务关闭：取消所有活动 run 的底层进程/任务（十审 W0：不留孤儿）。
+
+        DB 状态不翻转——权威终态由 sweeper/重启对账决定；这里只保证
+        子进程树不泄漏。
+        """
+        import contextlib
+
+        for _wo_id, (adapter, handle) in list(self._runs.items()):
+            with contextlib.suppress(Exception):  # 尽力而为
+                await adapter.cancel(handle, "service_shutdown")
+
+    def _cancelled_result(self, order: WorkOrderV1) -> WorkResultV1:
+        return WorkResultV1(
+            work_order_id=order.work_order_id,
+            worker_id=order.assigned_to or "",
+            lease_id=order.lease.lease_id if order.lease else "",
+            status="CANCELLED",
+            summary="cancelled before completion",
+            warnings=["cancelled"],
+        )
 
     # ------------------------------------------------------------------
     # lease sweeper + reconciliation

--- a/src/rosclaw/agentd/workers/packs.py
+++ b/src/rosclaw/agentd/workers/packs.py
@@ -57,10 +57,12 @@ CLAUDE_CODE_PACK = WorkerPackManifest(
         "`rosclaw worker probe worker:claude-code:local` 与 `rosclaw worker enable`。"
     ),
     license="proprietary",
+    # 十审 W0（P0-CAPABILITY-LIE）：移除 docs.write——该 pack 运行时
+    # --disallowedTools "*" 禁止一切写；声明 write 是能力欺诈。等 W3
+    # Workbench（真沙箱写）落地后才允许重新声明写能力。
     capabilities=(
         ("code.repository_analysis", "rosclaw://schemas/text-task.v1"),
         ("code.test_analysis", "rosclaw://schemas/text-task.v1"),
-        ("docs.write", "rosclaw://schemas/text-task.v1"),
     ),
     env_passthrough=(
         "ANTHROPIC_BASE_URL",

--- a/src/rosclaw/agentd/workers/registry.py
+++ b/src/rosclaw/agentd/workers/registry.py
@@ -23,6 +23,12 @@ HARD_FORBIDDEN_SCOPES = frozenset(
     {"daemon_private_ledger", "physical_permits", "raw_secrets", "direct_hardware"}
 )
 
+#: 十审 W0（P0-CAPABILITY-LIE）：能力名尾段暗示副作用时，side_effect_class
+#: 不得是 "none"——声明即承诺，注册处硬拒绝（docs.write + none = 欺诈）。
+_SIDE_EFFECT_IMPLYING_TAILS = frozenset(
+    {"write", "edit", "delete", "execute", "install", "promote", "apply"}
+)
+
 _WORKER_STATUSES = ("ENABLED", "DISABLED", "QUARANTINED")
 
 
@@ -55,6 +61,13 @@ def validate_card(card: WorkerCardV1) -> None:
             errors.append(f"capability name {cap.name!r} must be namespaced")
         if cap.side_effect_class == "physical":
             errors.append(f"capability {cap.name!r}: physical side effects forbidden in P0/P1")
+        # 十审 W0：名字暗示写/执行副作用却声明 none——能力欺诈，拒绝注册。
+        tail = cap.name.rsplit(".", 1)[-1]
+        if tail in _SIDE_EFFECT_IMPLYING_TAILS and cap.side_effect_class == "none":
+            errors.append(
+                f"capability {cap.name!r} implies side effects but declares "
+                "side_effect_class='none' (capability lie)"
+            )
     requested = set(card.security.default_data_scopes)
     if requested & HARD_FORBIDDEN_SCOPES:
         errors.append(

--- a/src/rosclaw/limo/sim_mcp.py
+++ b/src/rosclaw/limo/sim_mcp.py
@@ -21,7 +21,8 @@ import time
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
-server = FastMCP("limo-sim")
+# 十审 W0：WARNING——见 ur5e_mcp（stderr INFO 日志泄漏进 TUI）。
+server = FastMCP("limo-sim", log_level="WARNING")
 
 _state = {
     "pose": {"x": 1.25, "y": -0.5, "theta": 0.03},

--- a/src/rosclaw/sim/ur5e_mcp.py
+++ b/src/rosclaw/sim/ur5e_mcp.py
@@ -24,7 +24,10 @@ import time
 
 from mcp.server.fastmcp import FastMCP
 
-server = FastMCP("ur5e-sim")
+# 十审 W0：WARNING——FastMCP 默认 INFO 会把 "Processing request of type
+# ListToolsRequest" 打到 stderr（经 errlog 泄漏进 TUI 第一屏）。内部诊断
+# 只在 --debug/doctor/log 出现。
+server = FastMCP("ur5e-sim", log_level="WARNING")
 
 # UR5e 近似关节限位（rad）——教学级 SIM 边界，不是真实 DH 模型。
 _JOINT_LIMITS = (-2 * math.pi, 2 * math.pi)

--- a/tests/agentd/test_ten_w0.py
+++ b/tests/agentd/test_ten_w0.py
@@ -1,0 +1,608 @@
+"""十审 Gate W0 红测试（P0-WORKER-BLOCK / P0-CAPABILITY-LIE / cancel 闭环 /
+P0-ORDER-CORRELATION / P1-PRODUCT-NOISE）。
+
+红测试先行——以下缺陷修复前必须红：
+
+1. rosclaw_delegate 不得同步阻塞父会话超过短阈值：慢 Worker 时必须在
+   grace 内返回 STARTED + 精确 WorkOrder ID + worker + 预算 + deadline。
+2. rosclaw_check_work 按精确 work_order_id 关联（不再取 mission 最后
+   一单）；终态返回真实结果。
+3. rosclaw_cancel_work → WorkOrder CANCELLED + adapter cancel + 外部
+   进程整组 SIGTERM/SIGKILL（无孤儿进程）。
+4. driver 崩溃不得让 WorkOrder 永久 RUNNING（标记 FAILED）。
+5. 能力诚实：side_effect_class=none 的卡不得声明 write/edit/delete/
+   execute 类能力名；官方 pack 不得含 docs.write。
+6. SIM MCP server 默认不在 stderr 泄漏 INFO 请求日志。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import time
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _request, _setup
+
+
+def _slow_adapter_module():
+    from rosclaw.agentd.workers.adapter import RunHandle
+
+    class SlowStubAdapter:
+        """poll 永不完成的 Worker（直到 release 事件置位）。"""
+
+        def __init__(self) -> None:
+            self.cancelled: list[tuple[str, str]] = []
+            self.release = asyncio.Event()
+
+        async def probe(self, worker_id=None):  # noqa: ARG002
+            from rosclaw.agentd.workers.adapter import WorkerProbeResult
+
+            return WorkerProbeResult(ready=True, detail="stub")
+
+        async def start(self, order, credential_refs):  # noqa: ARG002
+            handle = RunHandle(
+                work_order_id=order.work_order_id,
+                lease_id=order.lease.lease_id if order.lease else "",
+                worker_id=order.assigned_to or "worker:stub:slow",
+            )
+            task = asyncio.create_task(self._run(order, handle))
+            self._tasks = getattr(self, "_tasks", {})
+            self._tasks[order.work_order_id] = (handle, task)
+            return handle
+
+        async def _run(self, order, handle):
+            from rosclaw.contracts.worker.order import (
+                ResultArtifact,
+                ResultClaim,
+                WorkResultV1,
+            )
+
+            await self.release.wait()
+            ref = "artifact://text/sha256:stub"
+            return WorkResultV1(
+                work_order_id=order.work_order_id,
+                worker_id=handle.worker_id,
+                lease_id=handle.lease_id,
+                status="COMPLETED",
+                summary="slow stub finished",
+                artifacts=[
+                    ResultArtifact(ref=ref, media_type="text/plain", digest="sha256:stub")
+                ],
+                claims=[ResultClaim(claim="stub done", evidence_refs=[ref])],
+            )
+
+        async def poll(self, handle):
+            entry = getattr(self, "_tasks", {}).get(handle.work_order_id)
+            if entry is None:
+                from rosclaw.agentd.workers.adapter import AdapterError
+
+                raise AdapterError(f"unknown handle {handle.work_order_id}")
+            stored, task = entry
+            if not task.done():
+                return stored
+            return task.result()
+
+        async def cancel(self, handle, reason: str) -> None:
+            self.cancelled.append((handle.work_order_id, reason))
+            entry = getattr(self, "_tasks", {}).pop(handle.work_order_id, None)
+            if entry is not None:
+                entry[1].cancel()
+
+        async def reconcile(self, idempotency_key: str) -> str:  # noqa: ARG002
+            return "not_found"
+
+    return SlowStubAdapter
+
+
+def _crash_adapter_class():
+    from rosclaw.agentd.workers.adapter import AdapterError
+
+    class CrashStubAdapter:
+        async def probe(self, worker_id=None):  # noqa: ARG002
+            from rosclaw.agentd.workers.adapter import WorkerProbeResult
+
+            return WorkerProbeResult(ready=True, detail="stub")
+
+        async def start(self, order, credential_refs):  # noqa: ARG002
+            raise AdapterError("spawn blew up")
+
+        async def poll(self, handle):  # pragma: no cover - never reached
+            raise AdapterError("n/a")
+
+        async def cancel(self, handle, reason: str) -> None:  # noqa: ARG002
+            return None
+
+        async def reconcile(self, idempotency_key: str) -> str:  # noqa: ARG002
+            return "not_found"
+
+    return CrashStubAdapter
+
+
+def _register_stub(service, adapter, *, worker_id: str, adapter_type: str):
+    from rosclaw.contracts.worker.card import (
+        CapabilityDecl,
+        WorkerCardV1,
+        WorkerConstraints,
+        WorkerHealth,
+        WorkerImplementation,
+        WorkerKind,
+        WorkerProvenance,
+        WorkerSecurity,
+        WorkerTrust,
+    )
+
+    card = WorkerCardV1(
+        worker_id=worker_id,
+        display_name="Stub Worker",
+        kind=WorkerKind.HARNESS,
+        adapter_type=adapter_type,
+        adapter_version="1.0.0",
+        implementation=WorkerImplementation(
+            product="stub", version="1.0.0", executable_ref="inproc:"
+        ),
+        capabilities=[
+            CapabilityDecl(
+                name="analysis.text",
+                input_schema="rosclaw://schemas/text-task.v1",
+                output_schema="rosclaw://schemas/text-result.v1",
+                side_effect_class="none",
+            )
+        ],
+        constraints=WorkerConstraints(supported_platforms=["linux"], max_concurrency=4),
+        security=WorkerSecurity(isolation="process"),
+        health=WorkerHealth(probe="adapter:ping", heartbeat_interval_sec=15, lease_ttl_sec=3600),
+        provenance=WorkerProvenance(source="test", license="MIT"),
+        trust=WorkerTrust(initial_level="T3", evidence_count=0),
+    )
+    service._registry.register(card, actor_id="test")
+    service._worker_manager._adapters[adapter_type] = adapter
+    return card
+
+
+class TestNonBlockingDelegate:
+    async def test_delegate_slow_worker_returns_started_with_full_identity(
+        self, tmp_path: Path
+    ) -> None:
+        service, mission = await _setup(tmp_path)
+        stub = _slow_adapter_module()()
+        _register_stub(
+            service, stub, worker_id="worker:stub:slow", adapter_type="process_stdio"
+        )
+        dispatcher = PiToolDispatcher(service)
+        started = time.monotonic()
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w0_slow",
+                arguments={"goal": "跑一个长任务", "worker_id": "worker:stub:slow"},
+            )
+        )
+        elapsed = time.monotonic() - started
+        # 不得同步等到 Worker 完成（stub 永不完成）——短阈值内返回。
+        assert elapsed < 30, f"delegate 阻塞了 {elapsed:.1f}s"
+        assert result.ok, result.summary
+        assert result.status == "STARTED", f"慢 Worker 应返回 STARTED: {result.status}"
+        orders = service._worker_manager.orders_for_mission(mission.mission_id)
+        assert len(orders) == 1
+        order = orders[0]
+        # 第一屏：精确 WorkOrder ID + worker + 预算 + deadline。
+        assert order.work_order_id in result.summary
+        assert "worker:stub:slow" in result.summary
+        assert str(order.budgets.wall_time_sec) in result.summary
+        assert "deadline" in result.summary.lower() or "截止" in result.summary
+        await service.close()
+
+    async def test_fast_worker_still_completes_within_grace(self, tmp_path: Path) -> None:
+        """快任务保持同步返回 COMPLETED（不在本轮回归）。"""
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w0_fast",
+                arguments={"goal": "总结这段日志", "worker_id": "auto"},
+            )
+        )
+        assert result.ok and result.status == "COMPLETED"
+        await service.close()
+
+    async def test_background_driver_eventually_completes_order(self, tmp_path: Path) -> None:
+        """STARTED 后后台 driver 必须真正驱动到终态（结果可经 check_work 读到）。"""
+        service, mission = await _setup(tmp_path)
+        stub = _slow_adapter_module()()
+        _register_stub(service, stub, worker_id="worker:stub:slow", adapter_type="process_stdio")
+        dispatcher = PiToolDispatcher(service)
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w0_bg",
+                arguments={"goal": "长任务", "worker_id": "worker:stub:slow"},
+            )
+        )
+        assert result.status == "STARTED"
+        order = service._worker_manager.orders_for_mission(mission.mission_id)[0]
+        stub.release.set()
+        # 后台 driver 驱动到终态。
+        for _ in range(200):
+            current = service._worker_manager.order(order.work_order_id)
+            if current and current.status in ("ACCEPTED", "FAILED", "CANCELLED"):
+                break
+            await asyncio.sleep(0.05)
+        current = service._worker_manager.order(order.work_order_id)
+        assert current is not None and current.status == "ACCEPTED", current.status
+        await service.close()
+
+
+class TestCheckWork:
+    async def test_check_work_correlates_exact_order(self, tmp_path: Path) -> None:
+        """P0-ORDER-CORRELATION：查询绑定精确 ID，不取 mission 最后一单。"""
+        service, mission = await _setup(tmp_path)
+        stub1 = _slow_adapter_module()()
+        _register_stub(service, stub1, worker_id="worker:stub:slow", adapter_type="process_stdio")
+        dispatcher = PiToolDispatcher(service)
+        first = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w0_corr1",
+                arguments={"goal": "第一单", "worker_id": "worker:stub:slow"},
+            )
+        )
+        second = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w0_corr2",
+                arguments={"goal": "第二单", "worker_id": "worker:stub:slow"},
+            )
+        )
+        assert first.status == "STARTED" and second.status == "STARTED"
+        orders = service._worker_manager.orders_for_mission(mission.mission_id)
+        wo1, wo2 = orders[0].work_order_id, orders[1].work_order_id
+        check = await dispatcher.execute(
+            _request(
+                "rosclaw_check_work",
+                mission=mission.mission_id,
+                idem="idem_w0_chk1",
+                arguments={"work_order_id": wo1},
+            )
+        )
+        assert check.ok, check.summary
+        assert wo1 in check.summary
+        assert wo2 not in check.summary
+        await service.close()
+
+    async def test_check_work_unknown_id_honest(self, tmp_path: Path) -> None:
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_check_work",
+                mission=mission.mission_id,
+                idem="idem_w0_chk404",
+                arguments={"work_order_id": "wo_nonexistent"},
+            )
+        )
+        assert not result.ok
+        assert result.error_code == "WORK_ORDER_NOT_FOUND"
+        await service.close()
+
+    async def test_check_work_cross_mission_refused(self, tmp_path: Path) -> None:
+        service, mission = await _setup(tmp_path)
+        other = service.create_mission("别的 mission")
+        stub = _slow_adapter_module()()
+        _register_stub(service, stub, worker_id="worker:stub:slow", adapter_type="process_stdio")
+        dispatcher = PiToolDispatcher(service)
+        started = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w0_xm",
+                arguments={"goal": "x", "worker_id": "worker:stub:slow"},
+            )
+        )
+        assert started.status == "STARTED"
+        wo = service._worker_manager.orders_for_mission(mission.mission_id)[0].work_order_id
+        # 用 other mission 的绑定请求查本 mission 的单——拒绝。
+        # （_request 固定绑 pi_1→mission；直接换 mission_id 会先撞
+        # MISSION_MISMATCH——这也算拒绝。）
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_check_work",
+                mission=other.mission_id,
+                idem="idem_w0_xm2",
+                arguments={"work_order_id": wo},
+            )
+        )
+        assert not result.ok
+        await service.close()
+
+
+class TestCancelWork:
+    async def test_cancel_transitions_order_and_stops_driver(self, tmp_path: Path) -> None:
+        service, mission = await _setup(tmp_path)
+        stub = _slow_adapter_module()()
+        _register_stub(service, stub, worker_id="worker:stub:slow", adapter_type="process_stdio")
+        dispatcher = PiToolDispatcher(service)
+        started = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w0_cancel",
+                arguments={"goal": "长任务", "worker_id": "worker:stub:slow"},
+            )
+        )
+        assert started.status == "STARTED"
+        wo = service._worker_manager.orders_for_mission(mission.mission_id)[0].work_order_id
+        cancelled = await dispatcher.execute(
+            _request(
+                "rosclaw_cancel_work",
+                mission=mission.mission_id,
+                idem="idem_w0_cancel2",
+                arguments={"work_order_id": wo, "reason": "user_abort"},
+            )
+        )
+        assert cancelled.ok, cancelled.summary
+        assert "CANCELLED" in cancelled.summary or "取消" in cancelled.summary
+        # adapter cancel 被真实调用（handle 级）。
+        assert stub.cancelled and stub.cancelled[0][0] == wo
+        # DB 终态 CANCELLED；后台 driver 随之退出且不改写终态。
+        for _ in range(100):
+            current = service._worker_manager.order(wo)
+            if current and current.status == "CANCELLED":
+                break
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(0.3)
+        current = service._worker_manager.order(wo)
+        assert current is not None and current.status == "CANCELLED", current.status
+        await service.close()
+
+    async def test_cancel_terminal_order_is_honest_noop(self, tmp_path: Path) -> None:
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        done = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w0_ct",
+                arguments={"goal": "快任务", "worker_id": "auto"},
+            )
+        )
+        assert done.status == "COMPLETED"
+        wo = service._worker_manager.orders_for_mission(mission.mission_id)[0].work_order_id
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_cancel_work",
+                mission=mission.mission_id,
+                idem="idem_w0_ct2",
+                arguments={"work_order_id": wo},
+            )
+        )
+        # 已终态：诚实返回当前状态，不报错也不翻转。
+        assert result.ok
+        current = service._worker_manager.order(wo)
+        assert current is not None and current.status == "ACCEPTED"
+        await service.close()
+
+    async def test_cancel_kills_external_process_group(self, tmp_path: Path) -> None:
+        """外部 harness cancel 必须杀整个进程组（含孙进程），无孤儿。"""
+        from rosclaw.agentd.workers.external import ExternalHarnessAdapter
+        from rosclaw.agentd.workers.packs import WorkerPackManifest
+
+        script = tmp_path / "fake-harness"
+        pgid_file = tmp_path / "pgid.txt"
+        script.write_text(
+            "#!/bin/sh\n"
+            f"echo $$ > {pgid_file}\n"
+            "sleep 300 &\n"  # 孙进程——cancel 必须连带杀掉
+            "sleep 300\n"
+        )
+        script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        pack = WorkerPackManifest(
+            pack_id="fake",
+            worker_id="worker:fake:local",
+            product="codex-cli",  # 复用其命令构造（参数被脚本忽略）
+            display_name="Fake",
+            executable=str(script),
+            min_version="0.0.0",
+            install_hint="",
+            license="MIT",
+            capabilities=(("analysis.text", "rosclaw://schemas/text-task.v1"),),
+        )
+        adapter = ExternalHarnessAdapter(cwd=tmp_path)
+        adapter._packs = {pack.worker_id: pack}
+
+        service, mission = await _setup(tmp_path)
+        # 用测试 adapter 替换 service 的 external_cli 实现（指向 fake 脚本）。
+        service._worker_manager._adapters["external_cli"] = adapter
+        _register_stub_card = None  # 直接走 manager
+        from rosclaw.contracts.common import new_id
+
+        # 注册 fake 卡 + adapter。
+        from rosclaw.contracts.worker.card import (
+            CapabilityDecl,
+            WorkerCardV1,
+            WorkerConstraints,
+            WorkerHealth,
+            WorkerImplementation,
+            WorkerKind,
+            WorkerProvenance,
+            WorkerSecurity,
+            WorkerTrust,
+        )
+        from rosclaw.contracts.worker.order import (
+            BudgetEnvelope,
+            ExpectedOutput,
+            SideEffectPolicy,
+            WorkOrderV1,
+        )
+
+        card = WorkerCardV1(
+            worker_id=pack.worker_id,
+            display_name="Fake",
+            kind=WorkerKind.HARNESS,
+            adapter_type="external_cli",
+            adapter_version="1.0.0",
+            implementation=WorkerImplementation(
+                product="codex-cli", version="0", executable_ref=f"path:{script}"
+            ),
+            capabilities=[
+                CapabilityDecl(name="analysis.text", side_effect_class="none")
+            ],
+            constraints=WorkerConstraints(supported_platforms=["linux"], max_concurrency=1),
+            security=WorkerSecurity(isolation="process"),
+            health=WorkerHealth(
+                probe="adapter:ping", heartbeat_interval_sec=15, lease_ttl_sec=3600
+            ),
+            provenance=WorkerProvenance(source="test", license="MIT"),
+            trust=WorkerTrust(initial_level="T3", evidence_count=0),
+        )
+        service._registry.register(card, actor_id="test")
+        order = WorkOrderV1(
+            work_order_id=new_id("wo"),
+            mission_id=mission.mission_id,
+            issued_by="test",
+            capability="analysis.text",
+            goal="sleep forever",
+            inputs={"instructions": "x"},
+            budgets=BudgetEnvelope(wall_time_sec=300, model_tokens=1000),
+            expected_output=ExpectedOutput(artifacts=["text/plain"]),
+            side_effect_policy=SideEffectPolicy(**{"class": "none"}),
+        )
+        from rosclaw.agentd.workers.scheduler import CandidateView
+
+        scheduled = service._worker_manager.hire(
+            order,
+            [
+                CandidateView(
+                    card=card, registry_status="ENABLED", running_orders=0, circuit_open=False
+                )
+            ],
+        )
+        driver = asyncio.create_task(service._worker_manager.run_to_completion(scheduled))
+        # 等子进程起来。
+        for _ in range(200):
+            if pgid_file.exists():
+                break
+            await asyncio.sleep(0.05)
+        assert pgid_file.exists(), "fake harness 未启动"
+        pgid = int(pgid_file.read_text().strip())
+        # 进程组活着（shell + 两个 sleep）。
+        os.killpg(pgid, 0)
+        t0 = time.monotonic()
+        await service._worker_manager.cancel_order(
+            scheduled.work_order_id, reason="test_abort"
+        )
+        # cancel 后进程组必须整体消失（2s 级，硬上限 7s）。
+        deadline = time.monotonic() + 7
+        while time.monotonic() < deadline:
+            try:
+                os.killpg(pgid, 0)
+            except (ProcessLookupError, PermissionError):
+                break
+            await asyncio.sleep(0.1)
+        elapsed = time.monotonic() - t0
+        with pytest.raises((ProcessLookupError, PermissionError)):
+            os.killpg(pgid, 0)
+        assert elapsed < 7, f"进程组清理耗时 {elapsed:.1f}s"
+        current = service._worker_manager.order(scheduled.work_order_id)
+        assert current is not None and current.status == "CANCELLED", current.status
+        await asyncio.wait_for(driver, 10)
+        await service.close()
+
+
+class TestDriverCrashSafety:
+    async def test_driver_crash_marks_failed_not_running_forever(
+        self, tmp_path: Path
+    ) -> None:
+        service, mission = await _setup(tmp_path)
+        crash = _crash_adapter_class()()
+        _register_stub(service, crash, worker_id="worker:stub:crash", adapter_type="process_stdio")
+        dispatcher = PiToolDispatcher(service)
+        await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w0_crash",
+                arguments={"goal": "x", "worker_id": "worker:stub:crash"},
+            )
+        )
+        # 启动即崩：可能同步 FAILED，也可能 STARTED 后后台转 FAILED——
+        # 关键是不得永久 RUNNING。
+        wo = service._worker_manager.orders_for_mission(mission.mission_id)[0].work_order_id
+        for _ in range(200):
+            current = service._worker_manager.order(wo)
+            if current and current.status in ("FAILED", "ACCEPTED", "CANCELLED", "EXPIRED"):
+                break
+            await asyncio.sleep(0.05)
+        current = service._worker_manager.order(wo)
+        assert current is not None and current.status == "FAILED", current.status
+        await service.close()
+
+
+class TestCapabilityHonesty:
+    def test_registry_rejects_write_named_capability_with_none_side_effect(self) -> None:
+        """capability_registry_rejects_docs_write_without_write_profile。"""
+        from rosclaw.agentd.workers.registry import CardValidationError, validate_card
+        from rosclaw.contracts.worker.card import (
+            CapabilityDecl,
+            WorkerCardV1,
+            WorkerConstraints,
+            WorkerHealth,
+            WorkerImplementation,
+            WorkerKind,
+            WorkerProvenance,
+            WorkerSecurity,
+            WorkerTrust,
+        )
+
+        card = WorkerCardV1(
+            worker_id="worker:fake:writer",
+            display_name="Fake Writer",
+            kind=WorkerKind.HARNESS,
+            adapter_type="external_cli",
+            adapter_version="1.0.0",
+            implementation=WorkerImplementation(
+                product="fake", version="1", executable_ref="path:fake"
+            ),
+            capabilities=[
+                CapabilityDecl(name="docs.write", side_effect_class="none"),
+            ],
+            constraints=WorkerConstraints(supported_platforms=["linux"], max_concurrency=1),
+            security=WorkerSecurity(isolation="process"),
+            health=WorkerHealth(probe="adapter:ping", heartbeat_interval_sec=15, lease_ttl_sec=60),
+            provenance=WorkerProvenance(source="test", license="MIT"),
+            trust=WorkerTrust(initial_level="T1", evidence_count=0),
+        )
+        with pytest.raises(CardValidationError):
+            validate_card(card)
+
+    def test_official_packs_declare_no_fake_write_capability(self) -> None:
+        from rosclaw.agentd.workers.packs import ALL_PACKS
+
+        implying = {"write", "edit", "delete", "execute", "install", "promote"}
+        for pack in ALL_PACKS:
+            for name, _schema in pack.capabilities:
+                tail = name.rsplit(".", 1)[-1]
+                assert tail not in implying, (
+                    f"{pack.pack_id} 仍声明副作用能力 {name}（side_effect_class=none 下虚假）"
+                )
+
+
+class TestStartupNoise:
+    def test_sim_mcp_servers_default_quiet(self) -> None:
+        """SIM MCP server 默认 log_level WARNING——INFO 请求日志（如
+        Processing request of type ListToolsRequest）不得泄漏到终端。"""
+        from rosclaw.limo.sim_mcp import server as limo_server
+        from rosclaw.sim.ur5e_mcp import server as ur5e_server
+
+        assert ur5e_server.settings.log_level.upper() in ("WARNING", "ERROR")
+        assert limo_server.settings.log_level.upper() in ("WARNING", "ERROR")


### PR DESCRIPTION
## 十审 Gate W0（止血）

审计：`ROSClaw_十审_内置PiWorker与异步WorkerFabric重建总纲_2026-08-12.md` §12 Gate W0。停止条件：**任何委派仍可能无 ID 地阻塞父会话，Gate W0 不通过** —— 本 PR 后委派永不无 ID 阻塞。

### 五项

1. **P0-WORKER-BLOCK**：`rosclaw_delegate` 不再在工具请求栈里 `run_to_completion`。hire 后 agentd 后台驱动；grace（默认 3s，硬上限 10s）内完成则同步返回已验证结果，否则返回 `STARTED`。
2. **第一屏**：STARTED 响应含精确 WorkOrder ID / worker / 预算 / deadline；TS details 结构化携带。
3. **P0-ORDER-CORRELATION**：新工具 `rosclaw_check_work` / `rosclaw_cancel_work` 按精确 ID 关联；删除 mission 级"取最后一单"轮询与 `finally await polling` 第二无限等待；`work_order_id` 由工具层预生成，abort 在响应返回前即可按 ID cancel。
4. **cancel 闭环**：`manager.cancel_order`（活动 run 注册表）→ adapter cancel → 外部子进程 `start_new_session` 独立进程组 SIGTERM→(5s grace)→SIGKILL 整组杀（无孤儿）；driver 崩溃标 FAILED（不永久 RUNNING）；`service.close` 先杀进程树再取消驱动。
5. **能力诚实 + 启动静默**：移除 claude-code pack 的 `docs.write`（运行时禁一切工具——声明即欺诈）；registry 硬拒绝"名字暗示副作用但 side_effect_class=none"的卡；SIM MCP `log_level=WARNING` + MCP 子进程 stderr 落 `logs/mcp-child.log` + chat 入口 Python warnings 落 `logs/python-warnings.log`（`--debug`/`ROSCLAW_DEBUG` 恢复）。

### 红→绿证据

- 红：`tests/agentd/test_ten_w0.py` 首跑——慢 stub 下 delegate 阻塞至 deadline（300s 级）；cancel 测试拿不到进程；`docs.write` 可注册；SIM MCP stderr 泄漏 INFO 日志。
- 绿：13/13 通过；`test_pi_delegate.py`（grace 内快任务仍 COMPLETED）等 39 项回归通过；agentd 全套 637/637（22min）；TS 65/65（含新 `delegate-async.test.ts` 3 项）；ruff 全库绿。
- 本地仅有失败：`test_external_packs.py` 2 项（本机旧 codex CLI 干扰，CI 绿——与 main 一致）。

### 边界（诚实声明）

- 完成结果**尚不主动推送**主会话——模型/用户经 `rosclaw_check_work` 查询（W2 做 completion push + `/jobs`）。
- 父会话在 Worker 运行时可继续对话（delegate ≤10s 返回），但 Worker 自身仍是 text-in/text-out（W1 内置 Pi Worker 才有真工具）。
- `code.repository_analysis` 命名仍偏强（外部 CLI 当前 text-only）——W5 conformance 一并处理。
- REAL 门禁全程未触碰。