### PR TITLE
feat: 十审 Gate W5——外部 Worker streaming conformance（栈于 #320 之上）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -366,6 +366,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					"rosclaw_cancel_work",
 					"rosclaw_list_work",
 					"rosclaw_update_work",
+					"rosclaw_retry_work",
 					"rosclaw_request_action",
 				],
 			}),
@@ -444,9 +445,10 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				}
 				const trimmed = args.trim();
 				const cancelMatch = trimmed.match(/^cancel\s+(\S+)$/);
+				const retryMatch = trimmed.match(/^retry\s+(\S+)$/);
 				const idMatch = trimmed.match(/^(\S+)$/);
-				if (!idMatch && !cancelMatch) {
-					ctx.ui.notify("用法：/job <wo_id> | /job cancel <wo_id>", "warning");
+				if (!idMatch && !cancelMatch && !retryMatch) {
+					ctx.ui.notify("用法：/job <wo_id> | /job cancel <wo_id> | /job retry <wo_id>", "warning");
 					return;
 				}
 				const state = options.active.current;
@@ -463,6 +465,17 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					actor: { engine: "pi-command" },
 				});
 				try {
+					if (retryMatch) {
+						const response = await center.call("pi.tools.execute", {
+							request: mkRequest("rosclaw_retry_work", retryMatch[1]),
+						});
+						const result = (response.result ?? {}) as { summary?: string };
+						ctx.ui.notify(
+							response.ok ? (result.summary ?? "已 retry") : `retry 失败：${result.summary ?? response.error ?? ""}`,
+							response.ok ? "info" : "error",
+						);
+						return;
+					}
 					if (cancelMatch) {
 						const response = await center.call("pi.tools.execute", {
 							request: mkRequest("rosclaw_cancel_work", cancelMatch[1], { reason: "user_command" }),

--- a/packages/rosclaw-agent/src/runtime/create-runtime.ts
+++ b/packages/rosclaw-agent/src/runtime/create-runtime.ts
@@ -35,6 +35,7 @@ import {
 	buildCancelWorkTool,
 	buildListWorkTool,
 	buildUpdateWorkTool,
+	buildRetryWorkTool,
 } from "../tools/delegate.js";
 import { buildRequestActionTool } from "../tools/request-action.js";
 import { buildCapabilitiesTool } from "../tools/capabilities.js";
@@ -235,6 +236,12 @@ export async function createRosclawRuntime(
 					center,
 				}),
 				buildUpdateWorkTool({
+					rosclawHome: options.rosclawHome,
+					active,
+					center,
+				}),
+				// 十审 W4：终态单 retry（lineage 保留）。
+				buildRetryWorkTool({
 					rosclawHome: options.rosclawHome,
 					active,
 					center,

--- a/packages/rosclaw-agent/src/tools/delegate.ts
+++ b/packages/rosclaw-agent/src/tools/delegate.ts
@@ -76,7 +76,16 @@ export function buildDelegateTool(ctx: BridgeToolContext) {
 				Type.String({ description: "auto | worker:rosclaw:pi | worker:native:basic | ..." }),
 			),
 			worker_profile: Type.Optional(
-				Type.String({ description: "built-in worker profile: scout | analyst" }),
+				Type.String({ description: "built-in worker profile: scout | analyst | developer | sim-builder" }),
+			),
+			workspace: Type.Optional(
+				Type.String({
+					description:
+						"target workspace path (developer/sim-builder only; a git repo gets an isolated worktree)",
+				}),
+			),
+			base_ref: Type.Optional(
+				Type.String({ description: "git base ref for the worktree (default HEAD)" }),
 			),
 			capability: Type.Optional(Type.String()),
 			instructions: Type.Optional(Type.String()),

--- a/packages/rosclaw-agent/src/tools/delegate.ts
+++ b/packages/rosclaw-agent/src/tools/delegate.ts
@@ -140,6 +140,41 @@ export function buildDelegateTool(ctx: BridgeToolContext) {
 	});
 }
 
+export function buildRetryWorkTool(ctx: BridgeToolContext) {
+	return defineTool({
+		name: "rosclaw_retry_work",
+		label: "ROSClaw Retry Work",
+		description:
+			"Retry a terminal WorkOrder as a new attempt. Carries recorded steer " +
+			"notes into the new attempt and preserves parent/root lineage.",
+		parameters: Type.Object({
+			work_order_id: Type.String({ description: "exact wo_... id of the TERMINAL order" }),
+		}),
+		async execute(_id, params, _signal, _onUpdate, _toolCtx) {
+			const request = buildRequest(ctx, "rosclaw_retry_work", params as Record<string, unknown>);
+			const response = await ctx.center.call("pi.tools.execute", { request });
+			const result = (response.result ?? {}) as {
+				ok?: boolean;
+				summary?: string;
+				error_code?: string;
+			};
+			const ok = response.ok === true;
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: ok
+							? (result.summary ?? "")
+							: `retry 被拒 [${result.error_code ?? response.code ?? "?"}]: ${result.summary ?? response.error ?? ""}`,
+					},
+				],
+				details: { ok, error_code: result.error_code ?? null },
+				isError: !ok,
+			};
+		},
+	});
+}
+
 export function buildListWorkTool(ctx: BridgeToolContext) {
 	return defineTool({
 		name: "rosclaw_list_work",

--- a/packages/rosclaw-agent/src/workers/pi-worker-main.ts
+++ b/packages/rosclaw-agent/src/workers/pi-worker-main.ts
@@ -27,6 +27,8 @@ export interface WorkerEnvelope {
 	cwd: string;
 	budget: { wall_time_sec: number; model_tokens: number };
 	model?: { provider: string; model: string; thinking?: string };
+	/** W3：工件目录（bash log、patch、渲染产物）。 */
+	artifacts_dir?: string;
 }
 
 interface Usage {
@@ -122,12 +124,25 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 				noPromptTemplates: true,
 				noThemes: true,
 				noContextFiles: true,
+				// profile 系统提示（W1 起定义但此前未注入——W3 修复）。
+				systemPrompt: profile.systemPrompt,
 			},
 		});
+		// 十审 W3：全部 profile 使用 Workbench 约束工具（custom 同名覆盖
+		// Pi 内建）——scout/analyst 是只读子集，developer/sim-builder 增加
+		// write/edit/bash。路径必须在 workspace 内、bash argv 白名单、
+		// env 不含凭据（防 read auth.json / curl 外泄）。
+		const { buildWorkbenchTools } = await import("./workbench.js");
+		const workbenchTools = buildWorkbenchTools({
+			root: envelope.cwd,
+			bashLogPath: `${envelope.artifacts_dir ?? `${envelope.cwd}/.rosclaw-work`}/bash-log.txt`,
+			emitProgress: (message) => emit(wo, att, "tool_progress", { message }),
+		}).filter((tool) => profile.tools.includes(tool.name));
 		const { session } = await createAgentSessionFromServices({
 			services,
 			sessionManager: SessionManager.inMemory(envelope.cwd),
 			tools: profile.tools,
+			customTools: workbenchTools,
 			...(model ? { model } : {}),
 		});
 

--- a/packages/rosclaw-agent/src/workers/pi-worker-main.ts
+++ b/packages/rosclaw-agent/src/workers/pi-worker-main.ts
@@ -195,6 +195,41 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 		process.on("SIGTERM", abort);
 		process.on("SIGINT", abort);
 
+		// 十审 W4：stdin steer 通道——supervisor 写入单行 JSON
+		// {type:"steer", text} 即转向运行中的 Worker（custom 消息，
+		// 不冒充用户输入）。
+		process.stdin.setEncoding("utf-8");
+		let stdinBuf = "";
+		process.stdin.on("data", (chunk: string) => {
+			stdinBuf += chunk;
+			const lines = stdinBuf.split("\n");
+			stdinBuf = lines.pop() ?? "";
+			for (const line of lines) {
+				if (!line.trim()) continue;
+				try {
+					const msg = JSON.parse(line) as { type?: string; text?: string };
+					if (msg.type === "steer" && msg.text) {
+						void session
+							.sendCustomMessage(
+								{
+									role: "custom",
+									customType: "rosclaw.worker.steer",
+									content: `Supervisor steer（追加约束，权威来自 agentd WorkOrder）：${msg.text}`,
+									display: false,
+									details: { source: "rosclaw_update_work" },
+									timestamp: Date.now(),
+								} as never,
+								{ deliverAs: "steer" },
+							)
+							.then(() => emit(wo, att, "steer_ack", { text: msg.text?.slice(0, 200) }))
+							.catch(() => undefined);
+					}
+				} catch {
+					// malformed line 忽略
+				}
+			}
+		});
+
 		const task =
 			`WorkOrder goal: ${envelope.goal}\n\n` +
 			`Instructions: ${envelope.instructions || envelope.goal}\n\n` +

--- a/packages/rosclaw-agent/src/workers/profiles.ts
+++ b/packages/rosclaw-agent/src/workers/profiles.ts
@@ -15,8 +15,10 @@
 
 export interface WorkerProfileV1 {
 	name: string;
-	/** Pi 内建工具 allowlist（显式，不用 noTools 推断）。 */
+	/** Pi 工具 allowlist（custom 同名工具覆盖内建——见 workbench.ts）。 */
 	tools: string[];
+	/** true = Developer Workbench（约束 write/edit/bash + workspace 隔离）。 */
+	workbench: boolean;
 	systemPrompt: string;
 	defaults: { wallTimeSec: number; modelTokens: number };
 }
@@ -40,6 +42,7 @@ export const WORKER_PROFILES: Record<string, WorkerProfileV1> = {
 	scout: {
 		name: "scout",
 		tools: ["read", "grep", "find", "ls"],
+		workbench: false,
 		systemPrompt: `${_COMMON_RULES}
 ROLE: scout — repository/log investigation. Locate the relevant files and
 evidence with your read tools; cite concrete paths and line numbers in your
@@ -50,12 +53,45 @@ final report. Do not propose edits you cannot verify.
 	analyst: {
 		name: "analyst",
 		tools: ["read"],
+		workbench: false,
 		systemPrompt: `${_COMMON_RULES}
 ROLE: analyst — evidence synthesis over provided artifacts/files. Read what
 the WorkOrder lists, then produce a structured, honest assessment. If the
 inputs are insufficient, say what is missing instead of guessing.
 `,
 		defaults: { wallTimeSec: 300, modelTokens: 60_000 },
+	},
+	developer: {
+		name: "developer",
+		tools: ["read", "grep", "find", "ls", "write", "edit", "bash"],
+		workbench: true,
+		systemPrompt: `${_COMMON_RULES}
+ROLE: developer — implement and verify changes INSIDE the assigned
+workspace only.
+
+- All file tools and bash are confined to the workspace root; paths outside
+  it are hard-denied. Do not attempt to read credentials, devices, or the
+  host system.
+- bash is argv-allowlisted (no network, no privilege escalation). Tests and
+  builds must be run with the allowlisted commands.
+- Definition of done: your changes exist as real files in the workspace AND
+  you ran the relevant tests/checks with bash. Never claim "implemented" or
+  "tests pass" without actually running them.
+- Your final report must list: files changed (with paths), the exact test
+  commands you ran and their exit codes, and anything left unverified.
+`,
+		defaults: { wallTimeSec: 900, modelTokens: 200_000 },
+	},
+	"sim-builder": {
+		name: "sim-builder",
+		tools: ["read", "grep", "find", "ls", "write", "edit", "bash"],
+		workbench: true,
+		systemPrompt: `${_COMMON_RULES}
+ROLE: sim-builder — simulation assets, offline rendering, data artifacts.
+Same workspace confinement as developer. Generated images/GIFs/videos must
+be written inside the workspace; report their exact paths.
+`,
+		defaults: { wallTimeSec: 900, modelTokens: 200_000 },
 	},
 };
 

--- a/packages/rosclaw-agent/src/workers/workbench.ts
+++ b/packages/rosclaw-agent/src/workers/workbench.ts
@@ -1,0 +1,435 @@
+/** Developer Workbench 约束工具（十审 W3，审计 §9）。
+ *
+ * 本机 user namespace 被禁（unshare -rm / bwrap 不可用）——隔离在工具层
+ * 实现，不假装有 OS 沙箱：
+ *
+ * 1. 路径约束：所有文件工具（read/grep/find/ls/write/edit）的目标必须
+ *    realpath 在 workspace root 内——绝对路径、`..`、symlink 逃逸一律
+ *    拒绝（写新文件时对最近存在的祖先做 realpath）。
+ * 2. bash：argv/allow-policy（白名单二进制 + 危险参数模式拒绝 +
+ *    逐参数路径检查）；网络命令（curl/wget/ssh/nc）、特权命令
+ *    （sudo/su/chown/docker）、/dev 访问一律拒绝；
+ *    env 白名单（**不含任何 API key**，HOME=workspace）；
+ *    每条命令带超时/输出上限，全程日志写 artifacts/bash-log.txt。
+ * 3. secret 隔离：env 不含凭据 + 路径约束挡住 ~/.rosclaw/agent/auth.json
+ *    + 结果侧 verifier secret scan 兜底。
+ *
+ * 工具名与 Pi 内建同名（read/grep/find/ls/write/edit/bash）——custom
+ * 工具在 AgentSession 注册表中覆盖同名内建（dist/core/agent-session.js
+ * _refreshToolRegistry 后写覆盖先写，实证）。
+ */
+
+import { appendFileSync, existsSync, mkdirSync, realpathSync, statSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { dirname, isAbsolute, resolve, sep } from "node:path";
+
+import { Type } from "@earendil-works/pi-ai";
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+
+export interface WorkbenchOptions {
+	/** workspace 根（必须是已存在的目录）。 */
+	root: string;
+	/** bash 日志（artifacts/bash-log.txt）。 */
+	bashLogPath: string;
+	/** 长命令保活：bash 运行期间周期性回调（喂 idle watchdog）。 */
+	emitProgress?: (message: string) => void;
+	/** 单命令默认超时（ms）。 */
+	defaultTimeoutMs?: number;
+}
+
+/** argv 白名单（首参数必须精确命中；不含任何网络/特权工具）。 */
+const ALLOWED_BINARIES = new Set([
+	"ls", "cat", "head", "tail", "grep", "find", "wc", "echo", "printf", "pwd",
+	"mkdir", "touch", "cp", "mv", "rm", "diff", "sed", "awk", "sort", "uniq",
+	"tr", "cut", "xargs", "tee", "git", "python", "python3", "pytest",
+	"node", "npm", "npx", "tsc", "make", "jq", "sha256sum", "file", "stat",
+	"chmod", "basename", "dirname", "realpath", "true", "false", "test", "[",
+	"sleep",
+]);
+
+/** 任何参数命中这些模式即拒绝（网络/特权/设备/宿主机敏感面）。 */
+const DENIED_ARG_PATTERNS = [
+	/^\/dev\//,
+	/^\/proc\//,
+	/^\/sys\//,
+	/(^|\/)\.rosclaw\/agent\/auth\.json/,
+	/^~\/\.rosclaw/,
+	/DANGEROUSLY/,
+];
+
+const DENIED_BINARIES = new Set([
+	"sudo", "su", "doas", "curl", "wget", "ssh", "scp", "sftp", "nc", "ncat",
+	"netcat", "docker", "podman", "kubectl", "dd", "mount", "umount", "mkfs",
+	"chown", "kill", "killall", "pkill", "systemctl", "service", "crontab",
+	"pip", "pip3", "apt", "apt-get", "dpkg", "snap", "npm-publish",
+]);
+
+const MAX_OUTPUT_BYTES = 64 * 1024;
+
+/** 路径必须解析在 root 内（symlink 感知）。返回解析后的绝对路径。 */
+export function resolveInRoot(root: string, target: string): string {
+	const base = resolve(root);
+	const candidate = isAbsolute(target) ? resolve(target) : resolve(base, target);
+	if (candidate !== base && !candidate.startsWith(base + sep)) {
+		throw new Error(`path escapes workspace: ${target}`);
+	}
+	// symlink 检查：最近存在的祖先 realpath 必须在 root 内。
+	let probe = candidate;
+	while (!existsSync(probe)) {
+		const parent = dirname(probe);
+		if (parent === probe) break;
+		probe = parent;
+	}
+	if (existsSync(probe)) {
+		const real = realpathSync(probe);
+		const realBase = realpathSync(base);
+		if (real !== realBase && !real.startsWith(realBase + sep)) {
+			throw new Error(`symlink escapes workspace: ${target}`);
+		}
+	}
+	return candidate;
+}
+
+function argPathCheck(root: string, arg: string): void {
+	for (const pattern of DENIED_ARG_PATTERNS) {
+		if (pattern.test(arg)) throw new Error(`forbidden argument: ${arg}`);
+	}
+	// 以 / 开头的参数视作路径检查；相对路径含 .. 也检查。
+	if (arg.startsWith("/") || arg.includes("..")) {
+		// 允许以 - 开头的 flag。
+		if (arg.startsWith("-")) return;
+		resolveInRoot(root, arg);
+	}
+}
+
+export function buildWorkbenchTools(options: WorkbenchOptions): ToolDefinition[] {
+	const root = resolve(options.root);
+	const log = (line: string) => {
+		try {
+			mkdirSync(dirname(options.bashLogPath), { recursive: true });
+			appendFileSync(options.bashLogPath, `${line}\n`, "utf-8");
+		} catch {
+			// 日志失败不阻塞工具结果（verifier 会看到缺口）。
+		}
+	};
+
+	const denied = (err: unknown) => ({
+		content: [{ type: "text" as const, text: `DENIED: ${(err as Error).message}` }],
+		details: { error: "denied", reason: (err as Error).message } as Record<string, unknown>,
+		isError: true,
+	});
+
+	const readTool = defineTool({
+		name: "read",
+		label: "read (workspace)",
+		description: "Read a file inside the workspace (path-checked).",
+		parameters: Type.Object({
+			path: Type.String(),
+			offset: Type.Optional(Type.Number()),
+			limit: Type.Optional(Type.Number()),
+		}),
+		async execute(_id, params) {
+			let p: string;
+			try {
+				p = resolveInRoot(root, String(params.path));
+			} catch (err) {
+				return denied(err);
+			}
+			const text = readFileSync(p, "utf-8");
+			const lines = text.split("\n");
+			const start = Math.max(0, (params.offset ?? 1) - 1);
+			const slice = lines.slice(start, params.limit ? start + params.limit : undefined);
+			return {
+				content: [{ type: "text" as const, text: slice.join("\n") }],
+				details: { path: p, total_lines: lines.length },
+			};
+		},
+	});
+
+	const writeTool = defineTool({
+		name: "write",
+		label: "write (workspace)",
+		description: "Create/overwrite a file inside the workspace (path-checked).",
+		parameters: Type.Object({
+			path: Type.String(),
+			content: Type.String(),
+		}),
+		async execute(_id, params) {
+			let p: string;
+			try {
+				p = resolveInRoot(root, String(params.path));
+			} catch (err) {
+				return denied(err);
+			}
+			mkdirSync(dirname(p), { recursive: true });
+			writeFileSync(p, String(params.content), "utf-8");
+			log(`write ${p} (${(params.content as string).length} bytes)`);
+			return {
+				content: [{ type: "text" as const, text: `wrote ${p}` }],
+				details: { path: p },
+			};
+		},
+	});
+
+	const editTool = defineTool({
+		name: "edit",
+		label: "edit (workspace)",
+		description: "Replace exact text in a workspace file (path-checked; single occurrence required).",
+		parameters: Type.Object({
+			path: Type.String(),
+			old_text: Type.String(),
+			new_text: Type.String(),
+		}),
+		async execute(_id, params) {
+			let p: string;
+			try {
+				p = resolveInRoot(root, String(params.path));
+			} catch (err) {
+				return denied(err);
+			}
+			const oldText = String(params.old_text);
+			const text = readFileSync(p, "utf-8");
+			const occurrences = text.split(oldText).length - 1;
+			if (occurrences === 0) {
+				return {
+					content: [{ type: "text" as const, text: `ERROR: old_text not found in ${p}` }],
+					details: { path: p, error: "not_found" as string | null },
+					isError: true,
+				};
+			}
+			if (occurrences > 1) {
+				return {
+					content: [{ type: "text" as const, text: `ERROR: old_text occurs ${occurrences} times — be more specific` }],
+					details: { path: p, error: "ambiguous" as string | null },
+					isError: true,
+				};
+			}
+			writeFileSync(p, text.replace(oldText, String(params.new_text)), "utf-8");
+			log(`edit ${p}`);
+			return {
+				content: [{ type: "text" as const, text: `edited ${p}` }],
+				details: { path: p, error: null as string | null },
+			};
+		},
+	});
+
+	const lsTool = defineTool({
+		name: "ls",
+		label: "ls (workspace)",
+		description: "List a directory inside the workspace (path-checked).",
+		parameters: Type.Object({ path: Type.Optional(Type.String()) }),
+		async execute(_id, params) {
+			let p: string;
+			try {
+				p = resolveInRoot(root, String(params.path ?? "."));
+			} catch (err) {
+				return denied(err);
+			}
+			const entries = readdirSync(p, { withFileTypes: true }).map(
+				(e) => `${e.isDirectory() ? "d" : "-"} ${e.name}`,
+			);
+			return {
+				content: [{ type: "text" as const, text: entries.join("\n") || "(empty)" }],
+				details: { path: p, count: entries.length },
+			};
+		},
+	});
+
+	const findTool = defineTool({
+		name: "find",
+		label: "find (workspace)",
+		description: "Find files by name substring inside the workspace (path-checked).",
+		parameters: Type.Object({
+			pattern: Type.String(),
+			path: Type.Optional(Type.String()),
+		}),
+		async execute(_id, params) {
+			let base: string;
+			try {
+				base = resolveInRoot(root, String(params.path ?? "."));
+			} catch (err) {
+				return denied(err);
+			}
+			const needle = String(params.pattern).toLowerCase();
+			const hits: string[] = [];
+			const walk = (dir: string, depth: number) => {
+				if (depth > 8 || hits.length >= 200) return;
+				for (const entry of readdirSync(dir, { withFileTypes: true })) {
+					if (entry.name === "node_modules" || entry.name === ".git") continue;
+					const full = `${dir}/${entry.name}`;
+					if (entry.name.toLowerCase().includes(needle)) hits.push(full);
+					if (entry.isDirectory()) walk(full, depth + 1);
+				}
+			};
+			walk(base, 0);
+			return {
+				content: [{ type: "text" as const, text: hits.join("\n") || "(no matches)" }],
+				details: { count: hits.length },
+			};
+		},
+	});
+
+	const grepTool = defineTool({
+		name: "grep",
+		label: "grep (workspace)",
+		description: "Search file contents (literal substring) inside the workspace (path-checked).",
+		parameters: Type.Object({
+			pattern: Type.String(),
+			path: Type.Optional(Type.String()),
+			limit: Type.Optional(Type.Number()),
+		}),
+		async execute(_id, params) {
+			let base: string;
+			try {
+				base = resolveInRoot(root, String(params.path ?? "."));
+			} catch (err) {
+				return denied(err);
+			}
+			const needle = String(params.pattern);
+			const cap = params.limit ?? 100;
+			const hits: string[] = [];
+			const walk = (dir: string, depth: number) => {
+				if (depth > 8 || hits.length >= cap) return;
+				for (const entry of readdirSync(dir, { withFileTypes: true })) {
+					if (hits.length >= cap) return;
+					if (entry.name === "node_modules" || entry.name === ".git") continue;
+					const full = `${dir}/${entry.name}`;
+					if (entry.isDirectory()) {
+						walk(full, depth + 1);
+					} else {
+						try {
+							if (statSync(full).size > 2 * 1024 * 1024) continue;
+							const lines = readFileSync(full, "utf-8").split("\n");
+							lines.forEach((line, i) => {
+								if (hits.length < cap && line.includes(needle)) {
+									hits.push(`${full}:${i + 1}: ${line.slice(0, 200)}`);
+								}
+							});
+						} catch {
+							// 二进制/不可读跳过
+						}
+					}
+				}
+			};
+			const st = statSync(base);
+			if (st.isDirectory()) walk(base, 0);
+			else {
+				const lines = readFileSync(base, "utf-8").split("\n");
+				lines.forEach((line, i) => {
+					if (hits.length < cap && line.includes(needle)) hits.push(`${base}:${i + 1}: ${line.slice(0, 200)}`);
+				});
+			}
+			return {
+				content: [{ type: "text" as const, text: hits.join("\n") || "(no matches)" }],
+				details: { count: hits.length },
+			};
+		},
+	});
+
+	const bashTool = defineTool({
+		name: "bash",
+		label: "bash (workspace, allowlisted)",
+		description:
+			"Run an allowlisted command in the workspace. argv only (no shell " +
+			"metacharacters). No network, no privilege escalation, no paths " +
+			"outside the workspace, no credentials in the environment.",
+		parameters: Type.Object({
+			argv: Type.Array(Type.String(), { description: "command argv (first element must be allowlisted)" }),
+			timeout_sec: Type.Optional(Type.Number()),
+		}),
+		async execute(_id, params, signal) {
+			const argv = (params.argv as string[]).map(String);
+			const detailsOf = (fields: {
+				error?: string | null;
+				reason?: string | null;
+				exit_code?: number | null;
+			}) => ({
+				error: fields.error ?? null,
+				reason: fields.reason ?? null,
+				exit_code: fields.exit_code ?? null,
+				argv,
+			});
+			if (argv.length === 0) {
+				return {
+					content: [{ type: "text" as const, text: "ERROR: empty argv" }],
+					details: detailsOf({ error: "empty_argv" }),
+					isError: true,
+				};
+			}
+			const bin = argv[0];
+			try {
+				if (DENIED_BINARIES.has(bin)) throw new Error(`binary not allowed: ${bin}`);
+				if (!ALLOWED_BINARIES.has(bin)) throw new Error(`binary not in allowlist: ${bin}`);
+				for (const arg of argv.slice(1)) argPathCheck(root, arg);
+			} catch (err) {
+				log(`DENIED ${argv.join(" ")} (${(err as Error).message})`);
+				return {
+					content: [{ type: "text" as const, text: `DENIED: ${(err as Error).message}` }],
+					details: detailsOf({ error: "denied", reason: (err as Error).message }),
+					isError: true,
+				};
+			}
+			const timeoutMs = Math.min(
+				(params.timeout_sec ?? 0) > 0 ? Number(params.timeout_sec) * 1000 : (options.defaultTimeoutMs ?? 120_000),
+				600_000,
+			);
+			log(`$ ${argv.join(" ")}`);
+			const result = await new Promise<{ code: number; output: string }>((resolvePromise) => {
+				const proc = spawn(bin, argv.slice(1), {
+					cwd: root,
+					// 关键隔离：env 白名单——没有任何 API key；HOME=workspace
+					// （~ 不再指向用户家目录）；不带 ROSCLAW_HOME。
+					env: {
+						PATH: process.env.PATH ?? "/usr/bin:/bin",
+						HOME: root,
+						LANG: process.env.LANG ?? "C.UTF-8",
+						LC_ALL: process.env.LC_ALL ?? "",
+						TZ: process.env.TZ ?? "UTC",
+						ROSCLAW_WORKER_PROTOCOL: "workbench",
+					},
+					stdio: ["ignore", "pipe", "pipe"],
+				});
+				let output = "";
+				let truncated = false;
+				const collect = (chunk: Buffer) => {
+					if (output.length < MAX_OUTPUT_BYTES) output += chunk.toString();
+					else truncated = true;
+				};
+				proc.stdout.on("data", collect);
+				proc.stderr.on("data", collect);
+				const heartbeat = setInterval(() => {
+					options.emitProgress?.(`bash 仍在运行：${argv.join(" ").slice(0, 80)}`);
+				}, 5000);
+				const timer = setTimeout(() => {
+					proc.kill("SIGKILL");
+				}, timeoutMs);
+				signal?.addEventListener("abort", () => proc.kill("SIGKILL"), { once: true });
+				proc.on("close", (code) => {
+					clearTimeout(timer);
+					clearInterval(heartbeat);
+					if (truncated) output += "\n[output truncated]";
+					resolvePromise({ code: code ?? -1, output });
+				});
+				proc.on("error", (err) => {
+					clearTimeout(timer);
+					clearInterval(heartbeat);
+					resolvePromise({ code: -1, output: `spawn error: ${err.message}` });
+				});
+			});
+			const tail = result.output.length > 8000 ? `…${result.output.slice(-8000)}` : result.output;
+			log(`${tail}\n(exit ${result.code})\n`);
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: `exit ${result.code}\n${tail || "(no output)"}`,
+					},
+				],
+				details: detailsOf({ exit_code: result.code }),
+				isError: result.code !== 0,
+			};
+		},
+	});
+
+	return [readTool, grepTool, findTool, lsTool, writeTool, editTool, bashTool];
+}

--- a/packages/rosclaw-agent/test/workbench.test.ts
+++ b/packages/rosclaw-agent/test/workbench.test.ts
@@ -1,0 +1,130 @@
+/** 十审 Gate W3 红测试：Developer Workbench 约束工具。
+ *
+ * 1. 路径约束：../、绝对路径、symlink 逃逸一律拒绝；
+ * 2. bash argv 白名单：网络/特权/未列出二进制拒绝；逐参数路径检查；
+ * 3. env 隔离：KIMI_API_KEY 等凭据不进 bash 子进程；HOME=workspace；
+ * 4. write/edit 真实落盘；bash 日志写 artifacts；
+ * 5. 超时/abort 杀命令。
+ */
+
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+async function makeWorkbench(root?: string) {
+	const { buildWorkbenchTools, resolveInRoot } = await import("../src/workers/workbench.js");
+	const ws = root ?? mkdtempSync(join(tmpdir(), "wb-"));
+	const logPath = join(ws, "artifacts", "bash-log.txt");
+	const tools = buildWorkbenchTools({ root: ws, bashLogPath: logPath });
+	type ToolResult = { isError?: boolean; content: Array<{ type: string; text?: string }> };
+	type LooseTool = { execute: (...args: any[]) => Promise<ToolResult> };
+	const byName = Object.fromEntries(tools.map((t) => [t.name, t])) as Record<string, LooseTool>;
+	return { ws, logPath, byName, resolveInRoot };
+}
+
+test("路径约束：../ 与绝对路径与 symlink 逃逸拒绝", async () => {
+	const { ws, resolveInRoot } = await makeWorkbench();
+	assert.throws(() => resolveInRoot(ws, "../evil.txt"), /escapes/);
+	assert.throws(() => resolveInRoot(ws, "/etc/passwd"), /escapes/);
+	// symlink 逃逸：workspace 内的链接指向外部。
+	const outside = mkdtempSync(join(tmpdir(), "wb-out-"));
+	writeFileSync(join(outside, "secret.txt"), "top secret");
+	symlinkSync(outside, join(ws, "link-out"), "dir");
+	assert.throws(() => resolveInRoot(ws, "link-out/secret.txt"), /symlink/);
+	// 合法路径可用。
+	assert.equal(resolveInRoot(ws, "src/a.ts"), join(ws, "src/a.ts"));
+});
+
+test("write/edit 真实落盘且拒绝越界", async () => {
+	const { ws, byName } = await makeWorkbench();
+	await byName.write.execute("t1", { path: "src/hello.py", content: "print('hi')\n" }, undefined, undefined, {} as never);
+	assert.equal(readFileSync(join(ws, "src/hello.py"), "utf-8"), "print('hi')\n");
+	const denied = await byName.write.execute("t2", { path: "/tmp/wb-evil-x", content: "x" }, undefined, undefined, {} as never);
+	// resolveInRoot 在 execute 内抛错——必须被工具层拦住（不静默成功）。
+	assert.ok(denied.isError || !existsSync("/tmp/wb-evil-x"));
+	const edited = await byName.edit.execute(
+		"t3",
+		{ path: "src/hello.py", old_text: "print('hi')", new_text: "print('hello')" },
+		undefined,
+		undefined,
+		{} as never,
+	);
+	assert.ok(!edited.isError);
+	assert.match(readFileSync(join(ws, "src/hello.py"), "utf-8"), /hello/);
+	const missing = await byName.edit.execute(
+		"t4",
+		{ path: "src/hello.py", old_text: "not there", new_text: "x" },
+		undefined,
+		undefined,
+		{} as never,
+	);
+	assert.ok(missing.isError);
+});
+
+test("bash 白名单：允许 echo/python，拒绝 curl/sudo/pip/未列出", async () => {
+	const { byName } = await makeWorkbench();
+	const ok = await byName.bash.execute("t1", { argv: ["echo", "hi"] }, undefined, undefined, {} as never);
+	assert.match((ok.content[0] as { text: string }).text, /exit 0/);
+	for (const bin of ["curl", "sudo", "pip", "docker", "ssh", "rm-rf-notreal"]) {
+		const denied = await byName.bash.execute("t2", { argv: [bin, "x"] }, undefined, undefined, {} as never);
+		assert.ok(denied.isError, `${bin} 未被拒绝`);
+		assert.match((denied.content[0] as { text: string }).text, /DENIED/);
+	}
+});
+
+test("bash 参数路径检查：/etc/passwd、auth.json、/dev 拒绝", async () => {
+	const { byName } = await makeWorkbench();
+	for (const argv of [
+		["cat", "/etc/passwd"],
+		["cat", "/dev/zero"],
+		["cat", `${process.env.HOME}/.rosclaw/agent/auth.json`],
+		["cat", "../../etc/passwd"],
+	]) {
+		const denied = await byName.bash.execute("t1", { argv }, undefined, undefined, {} as never);
+		assert.ok(denied.isError, `${argv.join(" ")} 未被拒绝`);
+	}
+});
+
+test("bash env 隔离：API key 不进子进程，HOME=workspace", async () => {
+	process.env.KIMI_API_KEY = "sk-test-should-not-leak";
+	const { ws, byName } = await makeWorkbench();
+	const result = await byName.bash.execute(
+		"t1",
+		{ argv: ["python3", "-c", "import os; print('key=' + str(os.environ.get('KIMI_API_KEY'))); print('home=' + os.environ.get('HOME', ''))"] },
+		undefined,
+		undefined,
+		{} as never,
+	);
+	const text = (result.content[0] as { text: string }).text;
+	assert.match(text, /key=None/);
+	assert.match(text, new RegExp(`home=${ws.replace(/[/.]/g, (c) => `\\${c}`)}`));
+	assert.ok(!text.includes("sk-test-should-not-leak"));
+	delete process.env.KIMI_API_KEY;
+});
+
+test("bash 超时杀掉长命令 + 日志落 artifacts", async () => {
+	const { ws, logPath, byName } = await makeWorkbench();
+	const result = await byName.bash.execute(
+		"t1",
+		{ argv: ["sleep", "30"], timeout_sec: 1 },
+		undefined,
+		undefined,
+		{} as never,
+	);
+	assert.ok(result.isError, "超时命令未被杀掉");
+	assert.ok(existsSync(logPath), "bash log 未写");
+	const logText = readFileSync(logPath, "utf-8");
+	assert.match(logText, /\$ sleep 30/);
+});
+
+test("git diff 语义：workspace 内改动可见（供 patch 工件）", async () => {
+	const { ws, byName } = await makeWorkbench();
+	await byName.bash.execute("t1", { argv: ["git", "init", "-q"] }, undefined, undefined, {} as never);
+	await byName.bash.execute("t2", { argv: ["git", "add", "-A"] }, undefined, undefined, {} as never);
+	await byName.write.execute("t3", { path: "a.txt", content: "hello" }, undefined, undefined, {} as never);
+	const status = await byName.bash.execute("t4", { argv: ["git", "status", "--porcelain"] }, undefined, undefined, {} as never);
+	assert.match((status.content[0] as { text: string }).text, /a\.txt/);
+});

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -42,6 +42,8 @@ _TOOL_TABLE: dict[str, str] = {
     # 备注；运行中 Worker 的实时转向在 W4，update 诚实说明生效范围）。
     "rosclaw_list_work": "read",
     "rosclaw_update_work": "delegate",
+    # 十审 W4：终态单 retry（新 attempt 携带 steer 备注 + parent lineage）。
+    "rosclaw_retry_work": "delegate",
     "rosclaw_request_action": "physical_action",
     # 八审 P0-5：任务级入口——确定性编译器编排，模型只交 TaskSpec。
     "rosclaw_task": "task",
@@ -318,6 +320,8 @@ class PiToolDispatcher:
             return await self._list_work(request)
         if name == "rosclaw_update_work":
             return await self._update_work(request)
+        if name == "rosclaw_retry_work":
+            return await self._retry_work(request)
         if name == "rosclaw_fail_safe":
             await service.cancel(request.mission_id)
             return PiToolResultV1(
@@ -331,7 +335,6 @@ class PiToolDispatcher:
     async def _delegate(self, request: PiToolRequestV1) -> PiToolResultV1:
         """PNA-4（规格 §19）：招聘 Worker——受限 WorkOrder + 递归上限 +
         验证通过才进结果（未验证输出绝不进入主上下文）。"""
-        from rosclaw.agentd.workers.scheduler import CandidateView
         from rosclaw.contracts.common import new_id
         from rosclaw.contracts.worker.order import (
             BudgetEnvelope,
@@ -418,18 +421,8 @@ class PiToolDispatcher:
             root_work_order_id=str(args.get("root_work_order_id", "") or "") or parent_id,
         )
         service = self._service
-        candidates = [
-            CandidateView(
-                card=card,
-                registry_status=service._registry.status_of(card.worker_id) or "DISABLED",
-                running_orders=len(
-                    service._worker_manager.active_orders_for_worker(card.worker_id)
-                ),
-                circuit_open=service._worker_manager.circuit_open(card.worker_id, capability),
-            )
-            for card in service._registry.list()
-            if worker_hint in ("", "auto") or card.worker_id == worker_hint
-        ]
+        self._check_worker_token_budget(request.mission_id)
+        candidates = self._candidates_for(worker_hint, capability)
         if not candidates:
             raise ToolBridgeError(
                 "WORKER_UNAVAILABLE", f"no worker matches {worker_hint!r}", retryable=True
@@ -617,14 +610,154 @@ class PiToolDispatcher:
             (updated.model_dump_json(), datetime.now(UTC).isoformat(), work_order_id),
         )
         conn.commit()
+        # 十审 W4：运行中的内置 Worker 可实时 steer（stdin 通道）——
+        # 送达与否诚实报告（不假装运行外进程也能收到）。
+        delivered = False
+        if order.status == "RUNNING":
+            card_row = conn.execute(
+                "SELECT card_json FROM worker_cards WHERE worker_id = ?",
+                (order.assigned_to,),
+            ).fetchone()
+            if card_row is not None:
+                card = json.loads(card_row["card_json"])
+                adapter = self._service._worker_manager._adapters.get(
+                    card.get("adapter_type", "")
+                )
+                steer = getattr(adapter, "steer", None)
+                if steer is not None:
+                    import contextlib as _cl
+
+                    with _cl.suppress(Exception):
+                        delivered = await steer(work_order_id, note)
+        if delivered:
+            return PiToolResultV1(
+                request_id=request.request_id,
+                ok=True,
+                status="UPDATED",
+                summary=f"steer 已实时送达运行中的 Worker（{work_order_id}），并落账备查。",
+            )
         return PiToolResultV1(
             request_id=request.request_id,
             ok=True,
             status="UPDATED",
             summary=(
-                f"已记录 steer 备注（{work_order_id}）。注意：当前版本运行中的 "
-                "Worker 不能实时接收新约束——备注对 retry/后续 attempt 生效；"
+                f"已记录 steer 备注（{work_order_id}）。注意：该 Worker 当前不可实时接收"
+                "（非运行中或 adapter 无 steer 通道）——备注对 retry/后续 attempt 生效；"
                 "要立刻改变方向请 rosclaw_cancel_work 后重新委派。"
+            ),
+        )
+
+    def _candidates_for(self, worker_hint: str, capability: str):
+        from rosclaw.agentd.workers.scheduler import CandidateView
+
+        service = self._service
+        return [
+            CandidateView(
+                card=card,
+                registry_status=service._registry.status_of(card.worker_id) or "DISABLED",
+                running_orders=len(
+                    service._worker_manager.active_orders_for_worker(card.worker_id)
+                ),
+                circuit_open=service._worker_manager.circuit_open(card.worker_id, capability),
+            )
+            for card in service._registry.list()
+            if worker_hint in ("", "auto") or card.worker_id == worker_hint
+        ]
+
+    def _check_worker_token_budget(self, mission_id: str) -> None:
+        """十审 W4：mission 级 Worker token 预算——超过即诚实拒绝新委派
+        （防 runaway 计费；ROSCLAW_WORKER_TOKEN_BUDGET 可调，默认 1M）。"""
+        import os
+
+        cap = int(os.environ.get("ROSCLAW_WORKER_TOKEN_BUDGET", "1000000"))
+        if cap <= 0:
+            return
+        conn = self._service._store.connection
+        rows = conn.execute(
+            "SELECT wr.result_json FROM work_results wr "
+            "JOIN work_orders wo ON wo.work_order_id = wr.work_order_id "
+            "WHERE wo.mission_id = ?",
+            (mission_id,),
+        ).fetchall()
+        spent = 0
+        for row in rows:
+            usage = (json.loads(row["result_json"]).get("usage") or {})
+            spent += int(usage.get("prompt_tokens") or 0) + int(
+                usage.get("completion_tokens") or 0
+            )
+        if spent >= cap:
+            raise ToolBridgeError(
+                "WORKER_BUDGET_EXHAUSTED",
+                f"本 Mission 的 Worker token 预算已用尽（{spent}/{cap}）——"
+                "请开新 Mission 或调大 ROSCLAW_WORKER_TOKEN_BUDGET。",
+            )
+
+    async def _retry_work(self, request: PiToolRequestV1) -> PiToolResultV1:
+        """十审 W4：终态单 retry——新 attempt 携带 steer 备注（拼入
+        instructions）+ parent/root lineage（可审计重试链）。"""
+        from rosclaw.contracts.common import new_id
+        from rosclaw.contracts.worker.order import WorkOrderV1
+
+        work_order_id = str(request.arguments.get("work_order_id", "")).strip()
+        if not work_order_id:
+            raise ToolBridgeError("INVALID_ARGUMENTS", "work_order_id required")
+        manager = self._service._worker_manager
+        order = manager.order(work_order_id)
+        if order is None:
+            raise ToolBridgeError(
+                "WORK_ORDER_NOT_FOUND", f"unknown work order {work_order_id!r}"
+            )
+        if order.mission_id != request.mission_id:
+            raise ToolBridgeError(
+                "MISSION_MISMATCH", "work order belongs to a different mission"
+            )
+        if order.status not in ("ACCEPTED", "FAILED", "EXPIRED", "CANCELLED"):
+            raise ToolBridgeError(
+                "NOT_TERMINAL",
+                f"work order is {order.status}——只能 retry 终态单（运行中请先 cancel）",
+            )
+        notes = order.inputs.get("steer_notes") or []
+        instructions = str(order.inputs.get("instructions") or order.goal)
+        if notes:
+            instructions += "\n\n追加约束（来自 retry 前的 steer 备注）：" + "；".join(
+                str(n.get("note", "")) for n in notes
+            )
+        new_order = WorkOrderV1(
+            work_order_id=new_id("wo"),
+            mission_id=order.mission_id,
+            issued_by="rosclaw-agent:pi",
+            capability=order.capability,
+            goal=order.goal,
+            inputs={**dict(order.inputs), "instructions": instructions},
+            budgets=order.budgets,
+            expected_output=order.expected_output,
+            side_effect_policy=order.side_effect_policy,
+            delegation_depth=0,
+            max_delegation_depth=1,
+            parent_work_order_id=order.work_order_id,
+            root_work_order_id=order.root_work_order_id or order.work_order_id,
+        )
+        self._check_worker_token_budget(request.mission_id)
+        worker_hint = order.assigned_to or "auto"
+        candidates = self._candidates_for(worker_hint, order.capability)
+        if not candidates:
+            raise ToolBridgeError(
+                "WORKER_UNAVAILABLE", f"no worker matches {worker_hint!r}", retryable=True
+            )
+        try:
+            scheduled = manager.hire(new_order, candidates)
+        except Exception as exc:  # noqa: BLE001
+            raise ToolBridgeError("SCHEDULING_FAILED", str(exc), retryable=True) from exc
+        self._service.spawn_worker_driver(scheduled)
+        return PiToolResultV1(
+            request_id=request.request_id,
+            ok=True,
+            status="STARTED",
+            summary=(
+                f"已 retry（新 attempt）：{scheduled.work_order_id}\n"
+                f"parent: {order.work_order_id} · root: {new_order.root_work_order_id}\n"
+                f"Worker: {scheduled.assigned_to}"
+                + (f" · 携带 {len(notes)} 条 steer 备注" if notes else "")
             ),
         )
 

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -443,6 +443,15 @@ class PiToolDispatcher:
         if terminal is not None:
             return self._terminal_response(request, terminal)
         deadline = datetime.now(UTC) + timedelta(seconds=scheduled.budgets.wall_time_sec)
+        # 十审 §10.3：外部 harness 的模型/账号配置独立——UI 明示，不得
+        # 假装继承 Native Agent。
+        external_note = ""
+        card = service._registry.get(scheduled.assigned_to or "")
+        if card is not None and card.kind.value == "harness":
+            external_note = (
+                "\n注意：这是外部 Worker——使用其自身账号/模型/权限配置"
+                "（独立于 Native Agent 的 Kimi 配置）。"
+            )
         return PiToolResultV1(
             request_id=request.request_id,
             ok=True,
@@ -457,6 +466,7 @@ class PiToolDispatcher:
                 f"查询进度：rosclaw_check_work(work_order_id=\"{scheduled.work_order_id}\")；"
                 f"取消：rosclaw_cancel_work(work_order_id=\"{scheduled.work_order_id}\")。"
                 "Worker 产出须经 ROSClaw 验证后才会被采纳。"
+                f"{external_note}"
             ),
         )
 

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -363,13 +363,21 @@ class PiToolDispatcher:
                 f"(max_delegation_depth={max_depth})",
             )
         order_depth = 0
-        capability = str(args.get("capability") or "analysis.text")
+        worker_profile = str(args.get("worker_profile") or "")
+        capability = str(args.get("capability") or "")
+        if not capability:
+            # W3：写能力 profile 默认 code.develop（sandbox_process 语义）。
+            capability = (
+                "code.develop" if worker_profile in ("developer", "sim-builder")
+                else "analysis.text"
+            )
         # 十审 W0：调用方（TS 工具层，非模型字段）可预生成 work_order_id——
         # abort 在响应返回前也能按精确 ID cancel（修 P0-ORDER-CORRELATION
         # 的另一半：abort 不再"找不到要杀的单"）。
         provided_wo = str(args.get("work_order_id", "") or "")
         if provided_wo and not re.fullmatch(r"wo_[A-Za-z0-9]{8,32}", provided_wo):
             raise ToolBridgeError("INVALID_ARGUMENTS", "malformed work_order_id")
+        is_workbench = worker_profile in ("developer", "sim-builder")
         order = WorkOrderV1(
             work_order_id=provided_wo or new_id("wo"),
             mission_id=request.mission_id,
@@ -383,7 +391,11 @@ class PiToolDispatcher:
                 # provider/model/thinking）+ Worker profile。快照绝不携带
                 # 凭据（pi_managed 写 envelope 前有硬校验）。
                 "model_snapshot": args.get("model_snapshot") or {},
-                "worker_profile": str(args.get("worker_profile") or ""),
+                "worker_profile": worker_profile,
+                # W3：目标 workspace（git 仓库→worktree；默认当前 cwd）+
+                # 可选 base_ref。
+                "workspace": str(args.get("workspace") or ""),
+                "base_ref": str(args.get("base_ref") or ""),
             },
             budgets=BudgetEnvelope(
                 wall_time_sec=int(args.get("budget", {}).get("wall_time_sec", 300))
@@ -394,8 +406,12 @@ class PiToolDispatcher:
                 else 50_000,
                 # 叶子 worker 单：max_children=0（native adapter 不接受子委派）。
             ),
-            expected_output=ExpectedOutput(artifacts=["text/plain"]),
-            side_effect_policy=SideEffectPolicy(**{"class": "none"}),
+            expected_output=ExpectedOutput(
+                artifacts=["text/plain", "text/x-diff"] if is_workbench else ["text/plain"]
+            ),
+            side_effect_policy=SideEffectPolicy(
+                **{"class": "sandbox_process" if is_workbench else "none"}
+            ),
             delegation_depth=order_depth,
             max_delegation_depth=max_depth,
             parent_work_order_id=parent_id,

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -1717,6 +1717,47 @@ class AgentService:
         await self._pi_bridge.start()
         return path
 
+    async def reconcile_workers_on_start(self) -> list[str]:
+        """十审 W4：agentd 重启对账——所有非终态 WorkOrder 都是孤儿
+        （内存 run 注册表已随进程消失）：
+
+        - 有 child.pid 的 pi worker 子进程：整组杀掉（不留孤儿继续计费）；
+        - RUNNING → FAILED（agentd_restart）；OFFERED/CLAIMED → CANCELLED；
+        - 绝不假装它们仍在健康运行（resume 后 /jobs 显示真实状态）。
+        """
+        import signal as _signal
+
+        reconciled: list[str] = []
+        conn = self._store.connection
+        rows = conn.execute(
+            "SELECT work_order_id, status FROM work_orders "
+            "WHERE status NOT IN ('ACCEPTED', 'FAILED', 'EXPIRED', 'CANCELLED')"
+        ).fetchall()
+        for row in rows:
+            wo_id = row["work_order_id"]
+            pid_file = self._home / "work" / wo_id / "child.pid"
+            if pid_file.exists():
+                try:
+                    pid = int(pid_file.read_text().strip())
+                    import contextlib as _cl
+
+                    with _cl.suppress(ProcessLookupError, PermissionError):
+                        os.killpg(os.getpgid(pid), _signal.SIGTERM)
+                        await asyncio.sleep(0.5)
+                        os.killpg(os.getpgid(pid), _signal.SIGKILL)
+                except (ValueError, OSError):
+                    pass
+                pid_file.unlink(missing_ok=True)
+            try:
+                if row["status"] == "RUNNING":
+                    self._worker_manager._transition(wo_id, "FAILED", "agentd_restart")
+                else:
+                    self._worker_manager._transition(wo_id, "CANCELLED", "agentd_restart")
+                reconciled.append(wo_id)
+            except Exception:  # noqa: BLE001 - 对账继续
+                pass
+        return reconciled
+
     def spawn_worker_driver(self, order) -> None:
         """十审 W0：WorkOrder 后台驱动——pi 工具请求栈立即返回后由本
         任务驱动 run_to_completion 到终态；请求断开不影响权威状态。"""
@@ -1905,6 +1946,8 @@ def create_app(service: AgentService):
         # PR-11：operator.sock 随 HTTP 服务启动（同一事件循环）。
         # P1-3：HTTP 服务停止时必须关闭 service（子进程/socket/句柄）。
         # P1-4：ephemeral control token 落 0600 文件供同机 TUI/CLI。
+        # 十审 W4：先做 Worker 崩溃对账（孤儿进程清理 + 诚实终态）。
+        await service.reconcile_workers_on_start()
         await service.start_operator_socket()
         await service.start_pi_bridge()
         service.write_control_token_file()

--- a/src/rosclaw/agentd/workers/external.py
+++ b/src/rosclaw/agentd/workers/external.py
@@ -38,6 +38,55 @@ from rosclaw.contracts.worker.order import (
     WorkUsage,
 )
 
+#: 十审 §7.4/§10.3：startup/idle 超时（wall 由 order budget 兜底）。
+STARTUP_TIMEOUT_SEC = 15.0
+IDLE_TIMEOUT_SEC = 60.0
+
+
+def _parse_stream_line(pack: WorkerPackManifest, line: bytes) -> tuple[str, str, dict]:
+    """官方 streaming JSONL 逐行解析。返回 (kind, text, usage)：
+
+    kind: "event"（进度，无文本）| "result"（最终结果）| "error"。
+    """
+    try:
+        event = json.loads(line.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        return ("event", "", {})
+    if pack.product == "claude-code":
+        etype = event.get("type")
+        if etype is None and "result" in event:
+            # 兼容单发 JSON（旧 fake/旧版本 CLI 非 stream 输出）。
+            usage = dict(event.get("usage") or {})
+            usage.setdefault(
+                "cost_usd",
+                event.get("total_cost_usd") or event.get("cost_usd") or 0,
+            )
+            return ("result", str(event.get("result") or ""), usage)
+        if etype == "result":
+            usage = dict(event.get("usage") or {})
+            usage.setdefault(
+                "cost_usd",
+                event.get("total_cost_usd") or event.get("cost_usd") or 0,
+            )
+            if event.get("is_error"):
+                return ("error", str(event.get("result") or "claude error"), usage)
+            return ("result", str(event.get("result") or ""), usage)
+        return ("event", "", {})
+    # codex --json：item.completed / turn.completed 事件流。
+    if pack.product == "codex-cli":
+        etype = event.get("type", "")
+        if etype == "turn.completed":
+            return ("event", "", dict(event.get("usage") or {}))
+        if etype == "item.completed":
+            item = event.get("item") or {}
+            if item.get("type") in ("agent_message", "message", "assistant_message"):
+                text = str(item.get("text") or item.get("content") or "")
+                if text:
+                    return ("result", text, {})
+        if etype in ("error", "turn.failed"):
+            return ("error", str(event.get("message") or event.get("error") or "codex error"), {})
+        return ("event", "", {})
+    return ("event", "", {})
 _ANALYSIS_SYSTEM = (
     "You are a ROSClaw-managed analysis worker. Rules: answer ONLY the given "
     "task; do not modify, create, or delete files; do not access devices, "
@@ -100,17 +149,29 @@ class ExternalHarnessAdapter:
                 pack.executable,
                 "-p",
                 prompt,
+                # 十审 W5：官方 non-interactive streaming JSON（逐行事件，
+                # 不再 communicate() 到最后）。
                 "--output-format",
-                "json",
+                "stream-json",
+                "--verbose",
                 "--max-turns",
                 str(pack.max_turns),
-                # T1 分析任务：禁止一切工具（不写文件、不联网执行命令），
-                # 而非跳过权限检查。
+                # 十审 §10.3 read-only 权限档：禁写/禁命令执行/禁网络，
+                # 保留 Read/Grep/Glob——repository_analysis 从"text-only
+                # 伪能力"变成真实只读分析（cwd 是 WorkOrder workspace）。
                 "--disallowedTools",
-                "*",
+                "Write Edit NotebookEdit Bash WebFetch WebSearch",
             ]
         if pack.product == "codex-cli":
-            return [pack.executable, "exec", "--json", prompt]
+            # codex 官方 JSONL 事件流 + read-only 沙箱档。
+            return [
+                pack.executable,
+                "exec",
+                "--json",
+                "--sandbox",
+                "read-only",
+                prompt,
+            ]
         raise AdapterError(f"unsupported product {pack.product!r}")
 
     def _env(self, pack: WorkerPackManifest, credential_refs: dict) -> dict[str, str]:
@@ -189,12 +250,18 @@ class ExternalHarnessAdapter:
     ) -> WorkResultV1:
         started = datetime.now(UTC)
         command = self._command(pack, self._prompt_for(order))
+        # 十审 §10.3：cwd 来自已验证的 WorkOrder workspace（不再固定
+        # ~/.rosclaw）——repository_analysis 的目标目录必须真实可读。
+        workspace = str(order.inputs.get("workspace") or "")
+        cwd = workspace if workspace and Path(workspace).is_dir() else (
+            str(self._cwd) if self._cwd else None
+        )
         try:
             proc = await asyncio.create_subprocess_exec(
                 *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                cwd=str(self._cwd) if self._cwd else None,
+                cwd=cwd,
                 env=self._env(pack, credential_refs),
                 # 十审 W0：独立进程组——cancel/timeout 才能整组 SIGTERM/
                 # SIGKILL（此前只 cancel asyncio task，子进程与孙进程
@@ -205,32 +272,91 @@ class ExternalHarnessAdapter:
             raise AdapterError(
                 f"{pack.executable!r} not found at start time ({pack.install_hint})"
             ) from exc
-        stdout_task = asyncio.create_task(proc.stdout.read())  # type: ignore[union-attr]
-        stderr_task = asyncio.create_task(proc.stderr.read())  # type: ignore[union-attr]
+        # 十审 W5：stdout/stderr 并发逐行读取——streaming 事件驱动
+        # progress（真实心跳），startup/idle/wall 三种 timeout 分离。
+        text = ""
+        usage_raw: dict = {}
+        stderr_tail = ""
+        saw_event = False
+
+        async def _read_stdout() -> None:
+            nonlocal text, usage_raw, saw_event
+            assert proc.stdout is not None
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    return
+                saw_event = True
+                handle.progress_seq += 1  # 真实子进程事件才推进心跳
+                kind, t, u = _parse_stream_line(pack, line)
+                if u:
+                    usage_raw.update(u)
+                if kind == "result":
+                    text = t
+                elif kind == "error":
+                    raise AdapterError(t)
+
+        async def _read_stderr() -> None:
+            nonlocal stderr_tail
+            assert proc.stderr is not None
+            while True:
+                line = await proc.stderr.readline()
+                if not line:
+                    return
+                stderr_tail = (stderr_tail + line.decode(errors="replace"))[-2000:]
+
+        readers = asyncio.gather(_read_stdout(), _read_stderr())
+
+        async def _teardown() -> None:
+            if proc.returncode is None:
+                await _kill_process_tree(proc)
+            readers.cancel()
+            import contextlib as _cl
+
+            with _cl.suppress(Exception):
+                await readers
+
         try:
-            await asyncio.wait_for(
-                proc.wait(),
-                timeout=order.budgets.wall_time_sec or pack.default_timeout_sec,
+            # startup：第一条事件必须在限定时间内出现。
+            startup_end = asyncio.get_running_loop().time() + STARTUP_TIMEOUT_SEC
+            while not saw_event:
+                if proc.returncode is not None:
+                    raise AdapterError(
+                        f"{pack.product} exited {proc.returncode} before first event: "
+                        f"{stderr_tail[-300:]}"
+                    )
+                if asyncio.get_running_loop().time() > startup_end:
+                    raise AdapterError(f"{pack.product} startup timeout (no events)")
+                await asyncio.sleep(0.05)
+            # idle/wall：无事件超时 idle；总时长由 wall budget 兜底。
+            wall_end = asyncio.get_running_loop().time() + (
+                order.budgets.wall_time_sec or pack.default_timeout_sec
             )
-        except TimeoutError:
-            await _kill_process_tree(proc)
-            raise AdapterError("external harness timed out") from None
+            while proc.returncode is None:
+                last_seq = handle.progress_seq
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=IDLE_TIMEOUT_SEC)
+                except TimeoutError:
+                    if asyncio.get_running_loop().time() > wall_end:
+                        raise AdapterError("external harness timed out") from None
+                    if handle.progress_seq == last_seq:
+                        raise AdapterError(
+                            f"{pack.product} idle timeout ({IDLE_TIMEOUT_SEC:.0f}s 无事件)"
+                        ) from None
         except asyncio.CancelledError:
-            await _kill_process_tree(proc)
-            stdout_task.cancel()
-            stderr_task.cancel()
+            await _teardown()
             raise
-        # 进程死后管道 EOF——reader 自然结束（限时兜底防残留）。
-        try:
-            stdout, stderr = await asyncio.wait_for(
-                asyncio.gather(stdout_task, stderr_task), timeout=5
-            )
-        except (TimeoutError, asyncio.CancelledError):
-            stdout_task.cancel()
-            stderr_task.cancel()
-            stdout, stderr = b"", b""
+        except Exception:
+            await _teardown()
+            raise
+        await readers
         finished = datetime.now(UTC)
-        text, usage_raw = self._parse_output(pack, stdout, proc.returncode, stderr)
+        if proc.returncode not in (0, None) and not text:
+            raise AdapterError(
+                f"{pack.product} exited {proc.returncode}: {stderr_tail[-300:]}"
+            )
+        if not text:
+            text = "(empty result)"
         digest = hashlib.sha256(text.encode()).hexdigest()
         usage = WorkUsage(
             wall_time_ms=int((finished - started).total_seconds() * 1000),
@@ -262,38 +388,3 @@ class ExternalHarnessAdapter:
             usage=usage,
         )
 
-    def _parse_output(
-        self, pack: WorkerPackManifest, stdout: bytes, returncode: int | None, stderr: bytes
-    ) -> tuple[str, dict]:
-        raw = stdout.decode(errors="replace").strip()
-        if pack.product == "claude-code":
-            try:
-                payload = json.loads(raw)
-                text = payload.get("result") or raw
-                usage = dict(payload.get("usage") or {})
-                usage.setdefault(
-                    "cost_usd",
-                    payload.get("total_cost_usd") or payload.get("cost_usd") or 0,
-                )
-                return text, usage
-            except json.JSONDecodeError:
-                if returncode not in (0, None):
-                    raise AdapterError(
-                        f"claude exited {returncode}: {stderr.decode(errors='replace')[:300]}"
-                    ) from None
-                return raw or "(empty result)", {}
-        # codex --json 是 JSONL：取最后一行的完整结果。
-        lines = [line for line in raw.splitlines() if line.strip()]
-        for line in reversed(lines):
-            try:
-                payload = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            text = payload.get("result") or payload.get("message") or payload.get("output") or ""
-            if text:
-                return text, payload.get("usage") or {}
-        if returncode not in (0, None):
-            raise AdapterError(
-                f"codex exited {returncode}: {stderr.decode(errors='replace')[:300]}"
-            )
-        return raw or "(empty result)", {}

--- a/src/rosclaw/agentd/workers/pi_managed.py
+++ b/src/rosclaw/agentd/workers/pi_managed.py
@@ -44,6 +44,21 @@ WORKER_ID = "worker:rosclaw:pi"
 STARTUP_TIMEOUT_SEC = 10.0
 IDLE_TIMEOUT_SEC = 60.0
 
+#: W3：写能力 profile（Developer Workbench）——workspace 隔离 + diff 工件。
+WORKBENCH_PROFILES = ("developer", "sim-builder")
+
+
+async def _git(*args: str, cwd: str | None = None) -> tuple[int, str]:
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        cwd=cwd,
+    )
+    out, _ = await proc.communicate()
+    return proc.returncode or 0, out.decode(errors="replace")
+
 
 class PiManagedAdapter:
     """内置 Pi Worker（每个 WorkOrder 一个 headless 子进程）。"""
@@ -119,7 +134,111 @@ class PiManagedAdapter:
         return "not_found"
 
     # ------------------------------------------------------------------
-    def _write_envelope(self, order: WorkOrderV1) -> tuple[Path, str]:
+    async def _prepare_workspace(self, order: WorkOrderV1) -> tuple[str, Path | None]:
+        """W3 Developer Workbench：写能力 profile 在独立 workspace 运行。
+
+        git 仓库 → `git worktree add`（branch rosclaw/<wo>，基于 inputs
+        .base_ref 或 HEAD）——diff/promotion 可审查；非 git → 独立 scratch
+        目录（诚实降级：patch 以文件清单代替）。只读 profile 原地运行。
+        返回 (workspace_cwd, base_ref|None)。
+        """
+        profile = str(order.inputs.get("worker_profile") or "scout")
+        target = str(order.inputs.get("workspace") or Path.cwd())
+        if profile not in WORKBENCH_PROFILES:
+            if not Path(target).is_dir():
+                raise AdapterError(f"workspace {target} 不存在")
+            return target, None
+        work_root = self._home / "work" / order.work_order_id
+        ws = work_root / "workspace"
+        base_ref = str(order.inputs.get("base_ref") or "HEAD")
+        if (Path(target) / ".git").exists():
+            branch = f"rosclaw/{order.work_order_id}"
+            code, out = await _git(
+                "worktree", "add", str(ws), "-b", branch, base_ref, cwd=target
+            )
+            if code != 0:
+                raise AdapterError(f"git worktree add 失败: {out.strip()[:300]}")
+            _, resolved = await _git("rev-parse", base_ref, cwd=target)
+            return str(ws), resolved.strip()
+        # 非 git：scratch workspace（诚实——result 里注明无 VCS diff）。
+        ws.mkdir(parents=True, exist_ok=True)
+        return str(ws), None
+
+    async def _collect_workbench_artifacts(
+        self, order: WorkOrderV1, workspace: str, base_ref: str | None
+    ) -> tuple[list[ResultArtifact], list[ResultClaim], str]:
+        """W3：patch + bash log + 媒体工件；promotion 是独立动作——
+        这里只产出可审查证据，绝不自动合并回主仓库。"""
+        work_root = self._home / "work" / order.work_order_id
+        artifacts_dir = work_root / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        artifacts: list[ResultArtifact] = []
+        claims: list[ResultClaim] = []
+        notes: list[str] = []
+
+        def _file_artifact(path: Path, media_type: str) -> ResultArtifact:
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            return ResultArtifact(
+                ref=f"artifact://{media_type.split('/')[-1]}/sha256:{digest[:32]}",
+                media_type=media_type,
+                digest=f"sha256:{digest}",
+            )
+
+        if base_ref:
+            # 含新文件的完整 diff：先 add -A（只在 worktree 内，不碰主仓库）。
+            await _git("add", "-A", cwd=workspace)
+            code, diff = await _git("diff", "--cached", base_ref, cwd=workspace)
+            patch_path = artifacts_dir / "patch.diff"
+            if code == 0 and diff.strip():
+                patch_path.write_text(diff, encoding="utf-8")
+                artifacts.append(_file_artifact(patch_path, "text/x-diff"))
+                claims.append(
+                    ResultClaim(
+                        claim="produced a reviewable git patch (not merged)",
+                        evidence_refs=[artifacts[-1].ref],
+                    )
+                )
+            else:
+                patch_path.write_text(
+                    "# EMPTY DIFF — worker made no file changes\n", encoding="utf-8"
+                )
+                artifacts.append(_file_artifact(patch_path, "text/x-diff"))
+                notes.append("empty patch: worker 未产生文件改动")
+            # promotion 证据：worktree/branch 保留。
+            _, branch = await _git("rev-parse", "--abbrev-ref", "HEAD", cwd=workspace)
+            notes.append(f"worktree 保留于 {workspace}（branch {branch.strip()}，未合并）")
+        else:
+            notes.append("workspace 非 git 仓库——无 VCS diff（scratch workspace）")
+        bash_log = artifacts_dir / "bash-log.txt"
+        if bash_log.exists() and bash_log.stat().st_size > 0:
+            artifacts.append(_file_artifact(bash_log, "text/plain"))
+            claims.append(
+                ResultClaim(
+                    claim="bash command log (tests/builds run)",
+                    evidence_refs=[artifacts[-1].ref],
+                )
+            )
+        # 媒体产物（sim-builder）：workspace 内新生成的图片/视频。
+        for pattern in ("*.png", "*.gif", "*.mp4"):
+            for media in sorted(Path(workspace).rglob(pattern))[:5]:
+                if ".git" in media.parts or media.stat().st_size == 0:
+                    continue
+                media_type = {"png": "image/png", "gif": "image/gif", "mp4": "video/mp4"}[
+                    media.suffix.lstrip(".")
+                ]
+                artifacts.append(_file_artifact(media, media_type))
+                claims.append(
+                    ResultClaim(
+                        claim=f"generated media artifact {media.name}",
+                        evidence_refs=[artifacts[-1].ref],
+                    )
+                )
+        return artifacts, claims, "；".join(notes)
+
+    # ------------------------------------------------------------------
+    def _write_envelope(
+        self, order: WorkOrderV1, *, cwd: str, artifacts_dir: Path
+    ) -> tuple[Path, str]:
         """只读 WorkOrder envelope（0600）——无 secret：模型快照只含
         provider/model/thinking，凭据由子进程从同一 agentDir 读取。"""
         work_dir = self._home / "work" / order.work_order_id
@@ -129,9 +248,6 @@ class PiManagedAdapter:
         forbidden = ("api_key", "apikey", "key", "token", "secret", "authorization")
         if any(k.lower() in forbidden for k in snapshot):
             raise AdapterError("model snapshot must not carry credentials")
-        cwd = str(order.inputs.get("workspace") or Path.cwd())
-        if not Path(cwd).is_dir():
-            cwd = str(Path.cwd())
         envelope = {
             "work_order_id": order.work_order_id,
             "attempt_id": f"att_{order.lease.lease_id if order.lease else '0'}",
@@ -139,6 +255,7 @@ class PiManagedAdapter:
             "goal": order.goal,
             "instructions": str(order.inputs.get("instructions") or order.goal),
             "cwd": cwd,
+            "artifacts_dir": str(artifacts_dir),
             "budget": {
                 "wall_time_sec": order.budgets.wall_time_sec,
                 "model_tokens": order.budgets.model_tokens,
@@ -164,7 +281,12 @@ class PiManagedAdapter:
         entry: str,
     ) -> WorkResultV1:
         started = datetime.now(UTC)
-        envelope_path, cwd = self._write_envelope(order)
+        # W3：写能力 profile 先准备独立 workspace（git worktree/scratch）。
+        workspace, base_ref = await self._prepare_workspace(order)
+        artifacts_dir = self._home / "work" / order.work_order_id / "artifacts"
+        envelope_path, cwd = self._write_envelope(
+            order, cwd=workspace, artifacts_dir=artifacts_dir
+        )
         env = {
             k: os.environ[k]
             for k in ("PATH", "HOME", "LANG", "LC_ALL", "TZ", "ROSCLAW_HOME")
@@ -271,6 +393,29 @@ class PiManagedAdapter:
             completion_tokens=int(usage_last.get("output_tokens") or 0),
         )
         digest = hashlib.sha256(final_report.encode()).hexdigest()
+        report_artifact = ResultArtifact(
+            ref=f"artifact://text/sha256:{digest[:32]}",
+            media_type="text/plain",
+            digest=f"sha256:{digest}",
+        )
+        artifacts = [report_artifact]
+        claims = [
+            ResultClaim(
+                claim="pi worker produced a final report",
+                evidence_refs=[report_artifact.ref],
+            )
+        ]
+        summary = final_report[:2000]
+        # W3：写能力 profile 收集可审查证据（patch/bash log/媒体）——
+        # promotion 是独立动作，绝不自动合并。
+        if str(order.inputs.get("worker_profile") or "") in WORKBENCH_PROFILES:
+            wb_artifacts, wb_claims, notes = await self._collect_workbench_artifacts(
+                order, workspace, base_ref
+            )
+            artifacts.extend(wb_artifacts)
+            claims.extend(wb_claims)
+            if notes:
+                summary = f"{summary}\n\n[workbench] {notes}"
         return WorkResultV1(
             work_order_id=order.work_order_id,
             worker_id=WORKER_ID,
@@ -278,19 +423,8 @@ class PiManagedAdapter:
             status="COMPLETED",
             started_at=started.isoformat(),
             finished_at=finished.isoformat(),
-            summary=final_report[:2000],
-            artifacts=[
-                ResultArtifact(
-                    ref=f"artifact://text/sha256:{digest[:32]}",
-                    media_type="text/plain",
-                    digest=f"sha256:{digest}",
-                )
-            ],
-            claims=[
-                ResultClaim(
-                    claim="pi worker produced a final report",
-                    evidence_refs=[f"artifact://text/sha256:{digest[:32]}"],
-                )
-            ],
+            summary=summary,
+            artifacts=artifacts,
+            claims=claims,
             usage=usage,
         )

--- a/src/rosclaw/agentd/workers/pi_managed.py
+++ b/src/rosclaw/agentd/workers/pi_managed.py
@@ -66,6 +66,8 @@ class PiManagedAdapter:
     def __init__(self, *, rosclaw_home: Path) -> None:
         self._home = Path(rosclaw_home)
         self._runs: dict[str, tuple[RunHandle, asyncio.Task]] = {}
+        # W4：活动子进程（steer 通道 + pid 文件崩溃对账）。
+        self._procs: dict[str, asyncio.subprocess.Process] = {}
 
     async def probe(self, worker_id: str | None = None) -> WorkerProbeResult:  # noqa: ARG002
         runtime = find_pi_agent_entry()
@@ -126,6 +128,21 @@ class PiManagedAdapter:
         entry = self._runs.pop(handle.work_order_id, None)
         if entry is not None:
             entry[1].cancel()
+
+    async def steer(self, work_order_id: str, note: str) -> bool:
+        """W4：向运行中的 Worker 发送 steer（stdin JSONL）。进程不在
+        （或 stdin 已闭）返回 False——调用方据此诚实降级。"""
+        proc = self._procs.get(work_order_id)
+        if proc is None or proc.returncode is not None or proc.stdin is None:
+            return False
+        try:
+            proc.stdin.write(
+                (json.dumps({"type": "steer", "text": note}, ensure_ascii=False) + "\n").encode()
+            )
+            await proc.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            return False
+        return True
 
     async def reconcile(self, idempotency_key: str) -> str:  # noqa: ARG002
         for _handle, task in self._runs.values():
@@ -307,12 +324,18 @@ class PiManagedAdapter:
             "--headless",
             "--work-order",
             str(envelope_path),
+            stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,
             env=env,
             start_new_session=True,
         )
+        # W4：活动进程登记 + pid 文件（agentd 崩溃后对账——orphan 必须
+        # 可被下一轮启动清掉）。
+        self._procs[order.work_order_id] = proc
+        pid_file = self._home / "work" / order.work_order_id / "child.pid"
+        pid_file.write_text(f"{proc.pid}\n", encoding="utf-8")
         events: list[dict] = []
         final_report = ""
         failure: dict | None = None
@@ -349,6 +372,8 @@ class PiManagedAdapter:
             readers.cancel()
             with contextlib.suppress(Exception):
                 await readers
+            self._procs.pop(order.work_order_id, None)
+            pid_file.unlink(missing_ok=True)
 
         try:
             # startup timeout：attempt_started 必须在限定时间内出现。
@@ -378,6 +403,8 @@ class PiManagedAdapter:
             await _teardown()
             raise
         await readers
+        self._procs.pop(order.work_order_id, None)
+        pid_file.unlink(missing_ok=True)
         finished = datetime.now(UTC)
         if failure is not None:
             raise AdapterError(

--- a/src/rosclaw/agentd/workers/registry.py
+++ b/src/rosclaw/agentd/workers/registry.py
@@ -182,6 +182,14 @@ def pi_worker_card() -> WorkerCardV1:
                 output_schema="rosclaw://schemas/text-result.v1",
                 side_effect_class="none",
             ),
+            # W3 Developer Workbench：写能力限定在独立 worktree/scratch
+            # workspace（sandbox_process）——promotion 是独立审查动作。
+            CapabilityDecl(
+                name="code.develop",
+                input_schema="rosclaw://schemas/text-task.v1",
+                output_schema="rosclaw://schemas/text-result.v1",
+                side_effect_class="sandbox_process",
+            ),
         ],
         constraints=WorkerConstraints(supported_platforms=["linux", "darwin"], max_concurrency=2),
         security=WorkerSecurity(isolation="process"),

--- a/tests/agentd/test_ten_w1.py
+++ b/tests/agentd/test_ten_w1.py
@@ -82,7 +82,9 @@ class TestEnvelopeNoSecrets:
             side_effect_policy=SideEffectPolicy(**{"class": "none"}),
             lease=WorkOrderLease(lease_id="lease_1", issued_at="t", expires_at="t"),
         )
-        path, _cwd = adapter._write_envelope(order)
+        path, _cwd = adapter._write_envelope(
+            order, cwd=str(tmp_path), artifacts_dir=tmp_path / "artifacts"
+        )
         raw = path.read_text()
         assert "sk-" not in raw
         assert "api_key" not in raw.lower()
@@ -120,7 +122,9 @@ class TestEnvelopeNoSecrets:
             lease=WorkOrderLease(lease_id="lease_1", issued_at="t", expires_at="t"),
         )
         with pytest.raises(AdapterError):
-            adapter._write_envelope(order)
+            adapter._write_envelope(
+                order, cwd=str(tmp_path), artifacts_dir=tmp_path / "artifacts"
+            )
 
 
 class TestHeadlessWorkerProtocol:

--- a/tests/agentd/test_ten_w3.py
+++ b/tests/agentd/test_ten_w3.py
@@ -1,0 +1,193 @@
+"""十审 Gate W3 红测试：Developer Workbench（Python 侧）。
+
+红测试先行——修复前必须红：
+1. developer profile 的 delegate 产出 code.develop + sandbox_process +
+   期望 text/x-diff 工件（此前一律 analysis.text + none）。
+2. git 目标 → 独立 worktree（主仓库不被污染）；Worker 改动收进
+   patch.diff 工件（text/x-diff）；promotion 不自动发生。
+3. 空改动诚实：patch.diff 带 EMPTY 标记 + summary 注明。
+4. registry：worker:rosclaw:pi 声明 code.develop/sandbox_process。
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _request, _setup
+
+
+def _git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    (path / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed"],
+        cwd=path,
+        check=True,
+    )
+
+
+def _fake_worker(tmp_path: Path, body: str) -> Path:
+    fake = tmp_path / "fake-entry"
+    fake.write_text(body)
+    fake.chmod(0o755)
+    return fake
+
+
+async def _run_developer_order(service, mission, tmp_path, fake, repo, monkeypatch):
+    from rosclaw.agentd.workers import pi_managed
+
+    monkeypatch.setattr(pi_managed, "find_pi_agent_entry", lambda: ("/bin/sh", str(fake)))
+    adapter = pi_managed.PiManagedAdapter(rosclaw_home=tmp_path / "rh")
+    service._worker_manager._adapters["pi_managed"] = adapter
+
+    from rosclaw.agentd.workers.scheduler import CandidateView
+    from rosclaw.contracts.common import new_id
+    from rosclaw.contracts.worker.order import (
+        BudgetEnvelope,
+        ExpectedOutput,
+        SideEffectPolicy,
+        WorkOrderV1,
+    )
+
+    card = service._registry.get("worker:rosclaw:pi")
+    order = WorkOrderV1(
+        work_order_id=new_id("wo"),
+        mission_id=mission.mission_id,
+        issued_by="test",
+        capability="code.develop",
+        goal="实现功能",
+        inputs={
+            "instructions": "x",
+            "worker_profile": "developer",
+            "workspace": str(repo),
+        },
+        budgets=BudgetEnvelope(wall_time_sec=120, model_tokens=1000),
+        expected_output=ExpectedOutput(artifacts=["text/plain", "text/x-diff"]),
+        side_effect_policy=SideEffectPolicy(**{"class": "sandbox_process"}),
+    )
+    scheduled = service._worker_manager.hire(
+        order,
+        [CandidateView(card=card, registry_status="ENABLED", running_orders=0,
+                       circuit_open=False)],
+    )
+    return await service._worker_manager.run_to_completion(scheduled)
+
+
+class TestDeveloperContract:
+    async def test_delegate_developer_profile_produces_sandbox_order(
+        self, tmp_path: Path
+    ) -> None:
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w3_contract",
+                arguments={
+                    "goal": "改代码",
+                    "worker_profile": "developer",
+                    "workspace": str(tmp_path),
+                    "sync_grace_sec": 0,
+                },
+            )
+        )
+        orders = service._worker_manager.orders_for_mission(mission.mission_id)
+        assert orders, f"未产生订单: {result.summary}"
+        order = orders[0]
+        assert order.capability == "code.develop"
+        assert order.side_effect_policy.class_ == "sandbox_process"
+        assert "text/x-diff" in order.expected_output.artifacts
+        await dispatcher.execute(
+            _request(
+                "rosclaw_cancel_work",
+                mission=mission.mission_id,
+                idem="idem_w3_contract_c",
+                arguments={"work_order_id": order.work_order_id},
+            )
+        )
+        await service.close()
+
+    async def test_registry_declares_code_develop_sandbox(self, tmp_path: Path) -> None:
+        service, _mission = await _setup(tmp_path)
+        card = service._registry.get("worker:rosclaw:pi")
+        dev = next((c for c in card.capabilities if c.name == "code.develop"), None)
+        assert dev is not None
+        assert dev.side_effect_class == "sandbox_process"
+        await service.close()
+
+
+class TestWorktreeAndPatch:
+    async def test_worktree_patch_collected_main_untouched(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        service, mission = await _setup(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git_repo(repo)
+        # fake worker：在 cwd（worktree）写新文件并报告。
+        fake = _fake_worker(
+            tmp_path,
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "echo 'print(\"hello\")' > hello.py\n"
+            'echo \'{"kind":"attempt_finished","report":"已创建 hello.py"}\'\n',
+        )
+        result, report = await _run_developer_order(
+            service, mission, tmp_path, fake, repo, monkeypatch
+        )
+        assert result.status == "COMPLETED", result.summary
+        media_types = {a.media_type for a in result.artifacts}
+        assert "text/x-diff" in media_types, f"缺 patch 工件: {media_types}"
+        # patch 内容真实含新文件。
+        patch_path = tmp_path / "rh" / "work" / result.work_order_id / "artifacts" / "patch.diff"
+        assert patch_path.exists()
+        assert "hello.py" in patch_path.read_text()
+        # promotion 不自动发生：主仓库干净、worktree/branch 保留。
+        assert not (repo / "hello.py").exists()
+        summary = result.summary
+        assert "未合并" in summary
+        assert report.accepted, report.reasons
+        await service.close()
+
+    async def test_empty_patch_honest(self, tmp_path: Path, monkeypatch) -> None:
+        service, mission = await _setup(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git_repo(repo)
+        fake = _fake_worker(
+            tmp_path,
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            'echo \'{"kind":"attempt_finished","report":"分析完毕，无需改动"}\'\n',
+        )
+        result, _report = await _run_developer_order(
+            service, mission, tmp_path, fake, repo, monkeypatch
+        )
+        patch_path = tmp_path / "rh" / "work" / result.work_order_id / "artifacts" / "patch.diff"
+        assert patch_path.exists()
+        assert "EMPTY DIFF" in patch_path.read_text()
+        assert "未产生文件改动" in result.summary
+        await service.close()
+
+    async def test_non_git_workspace_honest_note(self, tmp_path: Path, monkeypatch) -> None:
+        service, mission = await _setup(tmp_path)
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        fake = _fake_worker(
+            tmp_path,
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "echo 'x' > out.txt\n"
+            'echo \'{"kind":"attempt_finished","report":"done"}\'\n',
+        )
+        result, _report = await _run_developer_order(
+            service, mission, tmp_path, fake, plain, monkeypatch
+        )
+        assert "非 git" in result.summary or "无 VCS" in result.summary
+        # 文件写在 scratch workspace，不污染原目录。
+        assert not (plain / "out.txt").exists()
+        await service.close()

--- a/tests/agentd/test_ten_w3.py
+++ b/tests/agentd/test_ten_w3.py
@@ -81,6 +81,49 @@ class TestDeveloperContract:
         self, tmp_path: Path
     ) -> None:
         service, mission = await _setup(tmp_path)
+        if service._registry.status_of("worker:rosclaw:pi") != "ENABLED":
+            # CI 无 node/dist：内置 Worker 按设计 DISABLED——注册 stub
+            # 开发者卡验证合约语义（真实产品路径由 W3 live 覆盖）。
+            from rosclaw.contracts.worker.card import (
+                CapabilityDecl,
+                WorkerCardV1,
+                WorkerConstraints,
+                WorkerHealth,
+                WorkerImplementation,
+                WorkerKind,
+                WorkerProvenance,
+                WorkerSecurity,
+                WorkerTrust,
+            )
+
+            service._registry.register(
+                WorkerCardV1(
+                    worker_id="worker:stub:dev",
+                    display_name="Stub Dev",
+                    kind=WorkerKind.HARNESS,
+                    adapter_type="process_stdio",
+                    adapter_version="1.0.0",
+                    implementation=WorkerImplementation(
+                        product="stub", version="1.0.0", executable_ref="inproc:"
+                    ),
+                    capabilities=[
+                        CapabilityDecl(name="code.develop", side_effect_class="sandbox_process")
+                    ],
+                    constraints=WorkerConstraints(
+                        supported_platforms=["linux"], max_concurrency=4
+                    ),
+                    security=WorkerSecurity(isolation="process"),
+                    health=WorkerHealth(
+                        probe="adapter:ping", heartbeat_interval_sec=15, lease_ttl_sec=3600
+                    ),
+                    provenance=WorkerProvenance(source="test", license="MIT"),
+                    trust=WorkerTrust(initial_level="T3", evidence_count=0),
+                ),
+                actor_id="test",
+            )
+            from tests.agentd.test_ten_w0 import _slow_adapter_module
+
+            service._worker_manager._adapters["process_stdio"] = _slow_adapter_module()()
         dispatcher = PiToolDispatcher(service)
         result = await dispatcher.execute(
             _request(

--- a/tests/agentd/test_ten_w3_live.py
+++ b/tests/agentd/test_ten_w3_live.py
@@ -1,0 +1,85 @@
+"""十审 W3 真实模型验收：developer Worker 在隔离 worktree 真实开发。
+
+无 provider key 时诚实 skip。运行：
+ROSCLAW_KIMI_API_KEY=sk-kimi-... pytest tests/agentd/test_ten_w3_live.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _request, _setup
+
+KIMI_ENV_VARS = ("ROSCLAW_KIMI_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY")
+
+
+def _has_key() -> bool:
+    return any(os.environ.get(v) for v in KIMI_ENV_VARS)
+
+
+@pytest.mark.skipif(not _has_key(), reason="无真实 provider key——诚实 skip")
+class TestLiveDeveloperWorker:
+    async def test_developer_worker_real_change_and_patch(self, tmp_path: Path) -> None:
+        """真实 K3：scratch git 仓库里创建脚本并跑通——patch/bash log
+        工件可校验，主仓库零污染，不自动合并。"""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        (repo / "README.md").write_text("# demo\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init"],
+            cwd=repo,
+            check=True,
+        )
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        started = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w3_live",
+                arguments={
+                    "goal": "在 workspace 里创建 hello.py（打印 hello rosclaw），"
+                    "用 bash 运行 python3 hello.py 确认输出，然后报告",
+                    "worker_id": "worker:rosclaw:pi",
+                    "worker_profile": "developer",
+                    "workspace": str(repo),
+                    "budget": {"wall_time_sec": 300, "model_tokens": 60000},
+                    "sync_grace_sec": 0,
+                },
+            )
+        )
+        assert started.ok, started.summary
+        assert started.status == "STARTED"
+        order = service._worker_manager.orders_for_mission(mission.mission_id)[0]
+        final = None
+        for _ in range(600):
+            current = service._worker_manager.order(order.work_order_id)
+            if current and current.status in ("ACCEPTED", "FAILED", "CANCELLED", "EXPIRED"):
+                final = current
+                break
+            await asyncio.sleep(0.5)
+        assert final is not None, "developer Worker 5 分钟未到终态"
+        assert final.status == "ACCEPTED", f"status={final.status}"
+        # 工件可校验：patch 含 hello.py；bash log 含 python3 运行记录。
+        import json as _json
+
+        from rosclaw.contracts.worker.order import WorkResultV1
+
+        row = service._store.connection.execute(
+            "SELECT result_json FROM work_results WHERE work_order_id = ?",
+            (order.work_order_id,),
+        ).fetchone()
+        result = WorkResultV1(**_json.loads(row["result_json"]))
+        media_types = {a.media_type for a in result.artifacts}
+        assert "text/x-diff" in media_types
+        # 主仓库零污染（promotion 未自动发生）。
+        assert not (repo / "hello.py").exists()
+        await service.close()

--- a/tests/agentd/test_ten_w4.py
+++ b/tests/agentd/test_ten_w4.py
@@ -1,0 +1,245 @@
+"""十审 Gate W4 红测试：steer 通道 / 崩溃对账 / retry lineage / token 预算。
+
+红测试先行——修复前必须红：
+1. _update_work 对运行中的内置 Worker 实时送达 steer（stdin 通道），
+   不再只是落账备注；
+2. agentd 重启对账：非终态单标 FAILED/CANCELLED + pid 文件的孤儿
+   进程组被杀；
+3. rosclaw_retry_work：终态单新 attempt 携带 steer 备注 + parent/root
+   lineage；运行中单拒绝；
+4. mission token 预算：超过 ROSCLAW_WORKER_TOKEN_BUDGET 诚实拒绝。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _request, _setup
+
+
+class TestSteerChannel:
+    async def test_update_delivers_steer_to_running_pi_worker(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        service, mission = await _setup(tmp_path)
+        from rosclaw.agentd.workers import pi_managed
+
+        received = tmp_path / "steer.txt"
+        fake = tmp_path / "fake-entry"
+        fake.write_text(
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "while IFS= read -r line; do\n"
+            f"  echo \"$line\" >> {received}\n"
+            "done\n"
+        )
+        fake.chmod(0o755)
+        monkeypatch.setattr(pi_managed, "find_pi_agent_entry", lambda: ("/bin/sh", str(fake)))
+        adapter = pi_managed.PiManagedAdapter(rosclaw_home=tmp_path)
+        service._worker_manager._adapters["pi_managed"] = adapter
+
+        dispatcher = PiToolDispatcher(service)
+        started = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w4_steer",
+                arguments={
+                    "goal": "长任务",
+                    "worker_id": "worker:rosclaw:pi",
+                    "sync_grace_sec": 0,
+                },
+            )
+        )
+        assert started.status == "STARTED", started.summary
+        wo = service._worker_manager.orders_for_mission(mission.mission_id)[0].work_order_id
+        # 等子进程真正起来（steer 通道注册）。
+        for _ in range(200):
+            if wo in adapter._procs:
+                break
+            await asyncio.sleep(0.05)
+        assert wo in adapter._procs, "worker 子进程未注册"
+        updated = await dispatcher.execute(
+            _request(
+                "rosclaw_update_work",
+                mission=mission.mission_id,
+                idem="idem_w4_steer2",
+                arguments={"work_order_id": wo, "note": "只看 src/ 目录"},
+            )
+        )
+        assert updated.ok
+        assert "实时送达" in updated.summary, updated.summary
+        for _ in range(100):
+            if received.exists() and "只看 src" in received.read_text():
+                break
+            await asyncio.sleep(0.05)
+        assert received.exists() and "steer" in received.read_text()
+        assert "只看 src" in received.read_text()
+        await dispatcher.execute(
+            _request(
+                "rosclaw_cancel_work",
+                mission=mission.mission_id,
+                idem="idem_w4_steer_c",
+                arguments={"work_order_id": wo},
+            )
+        )
+        await service.close()
+
+
+class TestCrashReconciliation:
+    async def test_restart_marks_orphans_and_kills_children(self, tmp_path: Path) -> None:
+        service, mission = await _setup(tmp_path)
+        from rosclaw.agentd.workers.scheduler import CandidateView
+        from rosclaw.contracts.common import new_id
+        from rosclaw.contracts.worker.order import (
+            BudgetEnvelope,
+            ExpectedOutput,
+            SideEffectPolicy,
+            WorkOrderV1,
+        )
+
+        card = service._registry.get("worker:native:basic")
+        order = WorkOrderV1(
+            work_order_id=new_id("wo"),
+            mission_id=mission.mission_id,
+            issued_by="test",
+            capability="analysis.text",
+            goal="x",
+            inputs={"instructions": "x"},
+            budgets=BudgetEnvelope(wall_time_sec=300, model_tokens=1000),
+            expected_output=ExpectedOutput(artifacts=["text/plain"]),
+            side_effect_policy=SideEffectPolicy(**{"class": "none"}),
+        )
+        scheduled = service._worker_manager.hire(
+            order,
+            [CandidateView(card=card, registry_status="ENABLED", running_orders=0,
+                           circuit_open=False)],
+        )
+        assert scheduled.status == "RUNNING"
+        # 伪造 child.pid（真实起个 sleep 进程组当孤儿）。
+        work_dir = tmp_path / "work" / scheduled.work_order_id
+        work_dir.mkdir(parents=True)
+        sleeper = await asyncio.create_subprocess_exec(
+            "/bin/sh", "-c", "sleep 300 & sleep 300",
+            start_new_session=True,
+        )
+        (work_dir / "child.pid").write_text(f"{sleeper.pid}\n")
+        pgid = os.getpgid(sleeper.pid)
+        # 模拟重启：内存 run 注册表清空，直接对账。
+        reconciled = await service.reconcile_workers_on_start()
+        assert scheduled.work_order_id in reconciled
+        current = service._worker_manager.order(scheduled.work_order_id)
+        assert current is not None and current.status == "FAILED"
+        # 孤儿进程组被杀。
+        for _ in range(70):
+            try:
+                os.killpg(pgid, 0)
+            except (ProcessLookupError, PermissionError):
+                break
+            await asyncio.sleep(0.1)
+        with pytest.raises((ProcessLookupError, PermissionError)):
+            os.killpg(pgid, 0)
+        await service.close()
+
+
+class TestRetryWork:
+    async def test_retry_terminal_order_carries_notes_and_lineage(
+        self, tmp_path: Path
+    ) -> None:
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        done = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w4_r1",
+                arguments={"goal": "快任务", "worker_id": "auto"},
+            )
+        )
+        assert done.status == "COMPLETED"
+        old = service._worker_manager.orders_for_mission(mission.mission_id)[0]
+        # 运行中拒绝：先造一个 RUNNING 单？（直接断言终态路径 + 非终态拒绝）
+        retry = await dispatcher.execute(
+            _request(
+                "rosclaw_retry_work",
+                mission=mission.mission_id,
+                idem="idem_w4_r2",
+                arguments={"work_order_id": old.work_order_id},
+            )
+        )
+        assert retry.ok, retry.summary
+        assert retry.status == "STARTED"
+        orders = service._worker_manager.orders_for_mission(mission.mission_id)
+        assert len(orders) == 2
+        child = orders[1]
+        assert child.parent_work_order_id == old.work_order_id
+        assert child.root_work_order_id == old.work_order_id
+        assert old.work_order_id in retry.summary
+        # 非终态单拒绝 retry。
+        from tests.agentd.test_ten_w0 import _register_stub, _slow_adapter_module
+
+        stub = _slow_adapter_module()()
+        _register_stub(service, stub, worker_id="worker:stub:slow", adapter_type="process_stdio")
+        started = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w4_r3",
+                arguments={"goal": "慢任务", "worker_id": "worker:stub:slow"},
+            )
+        )
+        assert started.status == "STARTED"
+        running = service._worker_manager.orders_for_mission(mission.mission_id)[-1]
+        refused = await dispatcher.execute(
+            _request(
+                "rosclaw_retry_work",
+                mission=mission.mission_id,
+                idem="idem_w4_r4",
+                arguments={"work_order_id": running.work_order_id},
+            )
+        )
+        assert not refused.ok and refused.error_code == "NOT_TERMINAL"
+        await dispatcher.execute(
+            _request(
+                "rosclaw_cancel_work",
+                mission=mission.mission_id,
+                idem="idem_w4_r5",
+                arguments={"work_order_id": running.work_order_id},
+            )
+        )
+        await service.close()
+
+
+class TestTokenBudget:
+    async def test_mission_token_budget_exhausted_honest(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # MockModelGateway usage：首单花费 2 tokens——cap=2 时第二单必须被拒。
+        monkeypatch.setenv("ROSCLAW_WORKER_TOKEN_BUDGET", "2")
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        done = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w4_b1",
+                arguments={"goal": "快任务", "worker_id": "auto"},
+            )
+        )
+        assert done.status == "COMPLETED"
+        refused = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_w4_b2",
+                arguments={"goal": "再来一个", "worker_id": "auto"},
+            )
+        )
+        assert not refused.ok
+        assert refused.error_code == "WORKER_BUDGET_EXHAUSTED"
+        await service.close()

--- a/tests/agentd/test_ten_w4.py
+++ b/tests/agentd/test_ten_w4.py
@@ -42,6 +42,12 @@ class TestSteerChannel:
         monkeypatch.setattr(pi_managed, "find_pi_agent_entry", lambda: ("/bin/sh", str(fake)))
         adapter = pi_managed.PiManagedAdapter(rosclaw_home=tmp_path)
         service._worker_manager._adapters["pi_managed"] = adapter
+        # CI 无 node：service 初始化时按探测诚实 DISABLED——本测试自带
+        # fake entry，强制 ENABLED（产品探测路径由 W1 测试覆盖）。
+        if service._registry.status_of("worker:rosclaw:pi") != "ENABLED":
+            service._registry.set_status(
+                "worker:rosclaw:pi", "ENABLED", actor_id="test", reason="test fake entry"
+            )
 
         dispatcher = PiToolDispatcher(service)
         started = await dispatcher.execute(

--- a/tests/agentd/test_ten_w5.py
+++ b/tests/agentd/test_ten_w5.py
@@ -1,0 +1,217 @@
+"""十审 Gate W5 红测试：外部 Worker streaming conformance。
+
+红测试先行——修复前必须红：
+1. claude stream-json / codex JSONL 逐行事件驱动 progress（不再
+   communicate() 到最后）；
+2. startup/idle/wall 超时分离——挂死 Worker 诚实 FAILED；
+3. cwd 来自 WorkOrder workspace（不再固定 ~/.rosclaw）；
+4. read-only 权限档：claude 禁写/禁 bash/禁网络（不再全禁工具）、
+   codex --sandbox read-only。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import stat
+import time
+from pathlib import Path
+
+from rosclaw.agentd.workers.external import ExternalHarnessAdapter
+from rosclaw.agentd.workers.packs import WorkerPackManifest
+from rosclaw.contracts.common import new_id
+from rosclaw.contracts.worker.order import (
+    BudgetEnvelope,
+    ExpectedOutput,
+    SideEffectPolicy,
+    WorkOrderLease,
+    WorkOrderV1,
+)
+
+
+def _pack(product: str, exe: str) -> WorkerPackManifest:
+    return WorkerPackManifest(
+        pack_id=f"fake-{product}",
+        worker_id=f"worker:fake-{product}:local",
+        product=product,
+        display_name="Fake",
+        executable=exe,
+        min_version="0.0.0",
+        install_hint="",
+        license="MIT",
+        capabilities=(("code.repository_analysis", "rosclaw://schemas/text-task.v1"),),
+    )
+
+
+def _script(path: Path, body: str) -> Path:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def _order(tmp_path: Path, pack: WorkerPackManifest, workspace: Path | None = None) -> WorkOrderV1:
+    return WorkOrderV1(
+        work_order_id=new_id("wo"),
+        mission_id="mis_x",
+        issued_by="test",
+        capability="code.repository_analysis",
+        goal="分析",
+        inputs={
+            "instructions": "x",
+            **({"workspace": str(workspace)} if workspace else {}),
+        },
+        budgets=BudgetEnvelope(wall_time_sec=60, model_tokens=1000),
+        expected_output=ExpectedOutput(artifacts=["text/plain"]),
+        side_effect_policy=SideEffectPolicy(**{"class": "none"}),
+        lease=WorkOrderLease(lease_id="lease_1", issued_at="t", expires_at="t"),
+        assigned_to=pack.worker_id,
+    )
+
+
+class TestStreamingProtocol:
+    async def test_claude_stream_lines_drive_progress_and_result(
+        self, tmp_path: Path
+    ) -> None:
+        fake = _script(
+            tmp_path / "fake-claude",
+            "#!/bin/sh\n"
+            'echo \'{"type":"system","subtype":"init"}\'\n'
+            "sleep 0.1\n"
+            'echo \'{"type":"assistant","message":{"role":"assistant"}}\'\n'
+            "sleep 0.1\n"
+            'echo \'{"type":"result","subtype":"success","result":"根因是 X",'
+            '"usage":{"input_tokens":120,"output_tokens":30},"total_cost_usd":0.0004}\'\n',
+        )
+        pack = _pack("claude-code", str(fake))
+        adapter = ExternalHarnessAdapter(cwd=tmp_path)
+        adapter._packs = {pack.worker_id: pack}
+        order = _order(tmp_path, pack)
+        handle = await adapter.start(order, {})
+        result = None
+        for _ in range(100):
+            polled = await adapter.poll(handle)
+            if not hasattr(polled, "progress_seq"):
+                result = polled
+                break
+            await asyncio.sleep(0.05)
+        assert result is not None
+        assert result.status == "COMPLETED"
+        assert "根因是 X" in result.summary
+        assert result.usage.prompt_tokens == 120
+        assert result.usage.cost_microunits == 400
+
+    async def test_codex_jsonl_result(self, tmp_path: Path) -> None:
+        fake = _script(
+            tmp_path / "fake-codex",
+            "#!/bin/sh\n"
+            'echo \'{"type":"turn.started"}\'\n'
+            'echo \'{"type":"item.completed","item":{"type":"agent_message","text":"codex 分析结果"}}\'\n'
+            'echo \'{"type":"turn.completed","usage":{"input_tokens":50,"output_tokens":10}}\'\n',
+        )
+        pack = _pack("codex-cli", str(fake))
+        adapter = ExternalHarnessAdapter(cwd=tmp_path)
+        adapter._packs = {pack.worker_id: pack}
+        order = _order(tmp_path, pack)
+        handle = await adapter.start(order, {})
+        result = None
+        for _ in range(100):
+            polled = await adapter.poll(handle)
+            if not hasattr(polled, "progress_seq"):
+                result = polled
+                break
+            await asyncio.sleep(0.05)
+        assert result is not None
+        assert "codex 分析结果" in result.summary
+        assert result.usage.prompt_tokens == 50
+
+
+class TestTimeouts:
+    async def test_idle_worker_fails_honestly(self, tmp_path: Path, monkeypatch) -> None:
+        from rosclaw.agentd.workers import external
+
+        monkeypatch.setattr(external, "STARTUP_TIMEOUT_SEC", 1.0)
+        monkeypatch.setattr(external, "IDLE_TIMEOUT_SEC", 1.0)
+        fake = _script(
+            tmp_path / "fake-hang",
+            "#!/bin/sh\n"
+            'echo \'{"type":"system","subtype":"init"}\'\n'
+            "sleep 30\n",
+        )
+        pack = _pack("claude-code", str(fake))
+        adapter = ExternalHarnessAdapter(cwd=tmp_path)
+        adapter._packs = {pack.worker_id: pack}
+        order = _order(tmp_path, pack)
+        started = time.monotonic()
+        handle = await adapter.start(order, {})
+        result = None
+        for _ in range(200):
+            polled = await adapter.poll(handle)
+            if not hasattr(polled, "progress_seq"):
+                result = polled
+                break
+            await asyncio.sleep(0.05)
+        elapsed = time.monotonic() - started
+        assert result is not None
+        assert result.status == "FAILED"
+        assert "idle timeout" in result.summary
+        assert elapsed < 15, f"idle 检测耗时 {elapsed:.1f}s"
+
+    async def test_silent_worker_startup_timeout(self, tmp_path: Path, monkeypatch) -> None:
+        from rosclaw.agentd.workers import external
+
+        monkeypatch.setattr(external, "STARTUP_TIMEOUT_SEC", 1.0)
+        fake = _script(tmp_path / "fake-silent", "#!/bin/sh\nsleep 30\n")
+        pack = _pack("claude-code", str(fake))
+        adapter = ExternalHarnessAdapter(cwd=tmp_path)
+        adapter._packs = {pack.worker_id: pack}
+        order = _order(tmp_path, pack)
+        handle = await adapter.start(order, {})
+        result = None
+        for _ in range(200):
+            polled = await adapter.poll(handle)
+            if not hasattr(polled, "progress_seq"):
+                result = polled
+                break
+            await asyncio.sleep(0.05)
+        assert result is not None and result.status == "FAILED"
+        assert "startup timeout" in result.summary
+
+
+class TestWorkspaceAndPermissions:
+    async def test_cwd_is_order_workspace(self, tmp_path: Path) -> None:
+        ws = tmp_path / "target-repo"
+        ws.mkdir()
+        fake = _script(
+            tmp_path / "fake-claude",
+            "#!/bin/sh\n"
+            'echo \'{"type":"system","subtype":"init"}\'\n'
+            'printf \'{"type":"result","result":"cwd=%s","usage":{}}\\n\' "$(pwd)"\n',
+        )
+        pack = _pack("claude-code", str(fake))
+        adapter = ExternalHarnessAdapter(cwd=tmp_path)  # adapter 默认 cwd 不同
+        adapter._packs = {pack.worker_id: pack}
+        order = _order(tmp_path, pack, workspace=ws)
+        handle = await adapter.start(order, {})
+        result = None
+        for _ in range(100):
+            polled = await adapter.poll(handle)
+            if not hasattr(polled, "progress_seq"):
+                result = polled
+                break
+            await asyncio.sleep(0.05)
+        assert result is not None
+        assert str(ws) in result.summary
+
+    def test_command_permission_profiles(self) -> None:
+        adapter = ExternalHarnessAdapter()
+        claude = adapter._command(
+            _pack("claude-code", "claude"), "p"
+        )
+        assert "stream-json" in claude
+        joined = " ".join(claude)
+        assert "--disallowedTools" in joined
+        # read-only 档：禁写/禁 bash/禁网络，但不再全禁（Read/Grep/Glob 可用）。
+        assert '"*"' not in claude and " *" not in joined.split("--disallowedTools")[-1]
+        assert "Write" in joined and "Bash" in joined
+        codex = adapter._command(_pack("codex-cli", "codex"), "p")
+        assert "--sandbox" in codex
+        assert "read-only" in codex


### PR DESCRIPTION
## 十审 Gate W5（栈于 #320/W4 之上，前序合入后只含 W5 commit）

- **官方 streaming 协议**：claude `--output-format stream-json --verbose`、codex `exec --json --sandbox read-only`——stdout/stderr 并发逐行读取，事件驱动真实心跳（不再 `communicate()` 到最后）。
- **三种超时分离**：startup 15s / idle 60s / wall=budget——挂死/静默 Worker 诚实 FAILED。
- **workspace cwd**：来自 WorkOrder inputs.workspace（repository_analysis 目标目录真实可读，不再固定 `~/.rosclaw`）。
- **权限档**：claude 禁 Write/Edit/NotebookEdit/Bash/WebFetch/WebSearch（保留 Read/Grep/Glob——text-only 伪仓库分析变真实只读分析）；codex `--sandbox read-only`；旧单发 JSON 兼容解析。
- **独立配置提示**：delegate STARTED 对外部 harness 明示“独立账号/模型配置”（§10.3）。
- **CI 兼容**：无 Node 环境用 stub 开发者卡验证合约语义（修 #319 Full Regression）。

### 测试
- 红测试 6 项（test_ten_w5.py）：流式进度/双协议结果+usage/idle/startup 超时/workspace cwd/权限档命令构造。
- W0-W5 累计 Python 76 项绿；ruff 全库绿。

### 边界
- live nightly conformance（真实 claude/codex 定期探活）属 CI 运营配置，未建。
- sandbox-write/network 权限档在外部 Worker 上暂不开放（内置 developer Workbench 是唯一写面）。