### PR TITLE
fix: 十一审 PR-A——三层 liveness 状态机 + prompt/tool 契约修复

### DIFF
--- a/packages/rosclaw-agent/src/workers/pi-worker-main.ts
+++ b/packages/rosclaw-agent/src/workers/pi-worker-main.ts
@@ -15,7 +15,7 @@
 import { readFileSync } from "node:fs";
 import { writeSync } from "node:fs";
 
-import { profileFor } from "./profiles.js";
+import { buildSystemPrompt, profileFor } from "./profiles.js";
 import { createSharedModelRuntime } from "../runtime/model-runtime.js";
 
 export interface WorkerEnvelope {
@@ -29,6 +29,8 @@ export interface WorkerEnvelope {
 	model?: { provider: string; model: string; thinking?: string };
 	/** W3：工件目录（bash log、patch、渲染产物）。 */
 	artifacts_dir?: string;
+	/** 十一审 PR-A：期望工件（DoD 注入——不再是永远的 plain text report）。 */
+	expected_artifacts?: string[];
 }
 
 interface Usage {
@@ -124,8 +126,13 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 				noPromptTemplates: true,
 				noThemes: true,
 				noContextFiles: true,
-				// profile 系统提示（W1 起定义但此前未注入——W3 修复）。
-				systemPrompt: profile.systemPrompt,
+				// 十一审 PR-A：manifest 化系统提示（prompt 与真实工具面
+				// 逐字一致；DoD 按 expected artifacts 动态注入）。
+				systemPrompt: buildSystemPrompt(
+					profile,
+					envelope.cwd,
+					envelope.expected_artifacts ?? [],
+				),
 			},
 		});
 		// 十审 W3：全部 profile 使用 Workbench 约束工具（custom 同名覆盖
@@ -146,10 +153,56 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			...(model ? { model } : {}),
 		});
 
+		// 十一审 PR-A：tool-contract 自检——session 实际工具必须与
+		// profile 声明完全一致，否则不启动（诚实 TOOL_CONTRACT_MISMATCH，
+		// 不让模型在错误工具面下工作）。
+		{
+			const active = new Set(session.getActiveToolNames());
+			const missing = profile.tools.filter((name) => !active.has(name));
+			if (missing.length > 0) {
+				emit(wo, att, "attempt_failed", {
+					error_code: "TOOL_CONTRACT_MISMATCH",
+					message: `profile 声明的工具未在 session 生效: ${missing.join(", ")}`,
+				});
+				return 1;
+			}
+			emit(wo, att, "tool_contract_ok", { tools: [...active].sort() });
+		}
+
 		const usage: Usage = { input: 0, output: 0, cost: 0, turns: 0 };
 		const messages: Array<Record<string, unknown>> = [];
 		let stopReason = "";
 		let errorMessage = "";
+		// 十一审 PR-A：liveness/activity/semantic progress 三层分离。
+		// liveness 每 2s 一条（只证明进程活着，不进模型上下文、不冒充
+		// 进度）；semantic seq 只由真实事件推进。
+		let phase = "STARTING";
+		let spanStartedAt = Date.now();
+		let semanticSeq = 0;
+		let providerTimedOut = false;
+		const semantic = (kind: string, payload: Record<string, unknown>) => {
+			semanticSeq += 1;
+			emit(wo, att, kind, payload);
+		};
+		const livenessTimer = setInterval(() => {
+			emit(wo, att, "liveness", {
+				phase,
+				span_age_ms: Date.now() - spanStartedAt,
+				pid_alive: true,
+				last_semantic_seq: semanticSeq,
+			});
+		}, 2000);
+		livenessTimer.unref();
+		// provider request timeout：单个模型 turn 超过阈值（默认 10 分钟）
+		// 才视为 provider 失败——高 thinking 长推理不再被 60s 误杀。
+		const providerTimeoutMs = Number(process.env.ROSCLAW_WORKER_TURN_TIMEOUT_MS ?? 600_000);
+		const providerTimer = setInterval(() => {
+			if (phase === "RUNNING_MODEL" && Date.now() - spanStartedAt > providerTimeoutMs) {
+				providerTimedOut = true;
+				void session.abort().catch(() => undefined);
+			}
+		}, 2000);
+		providerTimer.unref();
 		const unsubscribe = session.subscribe((event) => {
 			const e = event as unknown as {
 				type: string;
@@ -159,11 +212,17 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 				isError?: boolean;
 			};
 			if (event.type === "turn_start") {
-				emit(wo, att, "model_started", { turn: usage.turns + 1 });
+				phase = "RUNNING_MODEL";
+				spanStartedAt = Date.now();
+				semantic("model_started", { turn: usage.turns + 1 });
 			} else if (event.type === "tool_execution_start") {
-				emit(wo, att, "tool_started", { tool: e.toolName ?? "?" });
+				phase = "RUNNING_TOOL";
+				spanStartedAt = Date.now();
+				semantic("tool_started", { tool: e.toolName ?? "?" });
 			} else if (event.type === "tool_execution_end") {
-				emit(wo, att, "tool_finished", {
+				phase = "RUNNING_MODEL";
+				spanStartedAt = Date.now();
+				semantic("tool_finished", {
 					tool: e.toolName ?? "?",
 					is_error: e.isError === true,
 				});
@@ -237,7 +296,17 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			"with your tools, with concrete paths/line numbers where relevant).";
 		await session.prompt(task);
 		unsubscribe();
+		clearInterval(livenessTimer);
+		clearInterval(providerTimer);
 
+		if (providerTimedOut) {
+			emit(wo, att, "attempt_failed", {
+				error_code: "PROVIDER_TIMEOUT",
+				message: `单个模型请求超过 ${Math.round(providerTimeoutMs / 1000)}s`,
+				usage,
+			});
+			return 1;
+		}
 		if (stopReason === "aborted") {
 			emit(wo, att, "attempt_cancelled", { usage });
 			return 130;

--- a/packages/rosclaw-agent/src/workers/profiles.ts
+++ b/packages/rosclaw-agent/src/workers/profiles.ts
@@ -1,21 +1,21 @@
-/** WorkerProfileV1（十审 W1，审计 §6）：通用能力而非任务特化。
+/** WorkerProfileV1（十审 W1，十一审 PR-A 重写 prompt/tool 契约）。
  *
- * Profile 决定工具 allowlist 与系统提示，不决定 provider——默认使用
- * Native Agent 当前模型（ModelExecutionSnapshot 经 WorkOrder 下发，
- * 无 secret）。
+ * 十一审 §2.2：prompt 与工具面必须完全一致——
+ * - 不再有公共"read-only tools"谎言（developer/sim-builder 有写工具）；
+ * - 每个 profile 生成 capability manifest（tools/workspace/write policy/
+ *   network/physical/required evidence）；
+ * - developer 的 Definition of Done 由 envelope 的 expected artifacts
+ *   动态注入（不是永远"plain text report"）。
  *
- * P0 安全边界：
- * - 只读工具集（read/grep/find/ls）——无 write/edit/bash（W3 Workbench
- *   落地前任何内置 Worker 都没有写能力）；
+ * P0 安全边界不变：
  * - 无 ROSClaw custom tools——Worker 永远接触不到 rosclaw_request_action
  *   /rosclaw_delegate/物理面；
- * - 无项目资源（noExtensions/noSkills/noContextFiles——不读 .pi、
- *   AGENTS.md、skills）。
+ * - 无项目资源（noExtensions/noSkills/noContextFiles）。
  */
 
 export interface WorkerProfileV1 {
 	name: string;
-	/** Pi 工具 allowlist（custom 同名工具覆盖内建——见 workbench.ts）。 */
+	/** 工具 allowlist（custom 同名覆盖内建——见 workbench.ts）。 */
 	tools: string[];
 	/** true = Developer Workbench（约束 write/edit/bash + workspace 隔离）。 */
 	workbench: boolean;
@@ -27,8 +27,6 @@ const _COMMON_RULES = `You are a ROSClaw built-in worker: a bounded contractor, 
 
 RULES
 - Complete ONLY the stated WorkOrder goal within its inputs and instructions.
-- You have read-only tools. Never claim to have created, modified, or run
-  anything you did not actually do with an available tool.
 - Never claim access to tools, files, secrets, hardware, or permissions you
   were not explicitly given.
 - Distinguish facts you verified with tools from inference; label inference.
@@ -37,6 +35,45 @@ RULES
   exactly what capability is missing.
 - Answer concisely in the requester's language.
 `;
+
+/** 十一审 §2.2：capability manifest——prompt 与真实工具面逐字一致。 */
+export function capabilityManifest(
+	profile: WorkerProfileV1,
+	workspace: string,
+	expectedArtifacts: string[],
+): string {
+	const evidence =
+		profile.name === "developer" || profile.name === "sim-builder"
+			? (expectedArtifacts.length
+					? expectedArtifacts.join(", ")
+					: "patch.diff + bash test log")
+				: "final report";
+	const dod =
+		profile.name === "developer" || profile.name === "sim-builder"
+			? `
+Definition of done: real file changes in the workspace (patch.diff is
+generated from them), the exact test/check commands you ran with their exit
+codes (in bash-log.txt), and the requested artifacts. A design document or
+proposal alone is NOT completion.`
+			: "";
+	return `
+CAPABILITY MANIFEST (ground truth — your prompt matches your actual tools)
+Available tools: ${profile.tools.join(", ")}.
+Workspace: ${workspace}
+Write policy: ${profile.workbench ? "workspace-only (paths outside are hard-denied)" : "none (read-only profile)"}.
+Network: denied (no curl/wget/ssh; bash is argv-allowlisted).
+Physical tools: none (you can never actuate hardware).
+Required evidence: ${evidence}.${dod}
+`;
+}
+
+export function buildSystemPrompt(
+	profile: WorkerProfileV1,
+	workspace: string,
+	expectedArtifacts: string[],
+): string {
+	return profile.systemPrompt + capabilityManifest(profile, workspace, expectedArtifacts);
+}
 
 export const WORKER_PROFILES: Record<string, WorkerProfileV1> = {
 	scout: {
@@ -69,11 +106,8 @@ inputs are insufficient, say what is missing instead of guessing.
 ROLE: developer — implement and verify changes INSIDE the assigned
 workspace only.
 
-- All file tools and bash are confined to the workspace root; paths outside
-  it are hard-denied. Do not attempt to read credentials, devices, or the
-  host system.
-- bash is argv-allowlisted (no network, no privilege escalation). Tests and
-  builds must be run with the allowlisted commands.
+- You HAVE write/edit/bash tools (workspace-confined). Use them: implement
+  real changes and run real tests; do not stop at proposals.
 - Definition of done: your changes exist as real files in the workspace AND
   you ran the relevant tests/checks with bash. Never claim "implemented" or
   "tests pass" without actually running them.

--- a/src/rosclaw/agentd/context/prompts/native_agent_v2.md
+++ b/src/rosclaw/agentd/context/prompts/native_agent_v2.md
@@ -40,6 +40,9 @@ WORKERS
 - Workers are bounded contractors, not authorities. Delegate a minimal WorkOrder with explicit inputs, outputs, deadline, budget, and verification.
 - Do not share hidden credentials, daemon permits, irrelevant memory, or more body data than the WorkOrder requires.
 - Treat worker output as a proposal or artifact until its schema, provenance, and task-specific verifier pass.
+- Delegation policy (十一审 PR-A/§4.3): do small, context-heavy, quick jobs yourself (status questions, one-off observations, tiny edits you can verify). Delegate long-running, parallelizable, or context-polluting work (multi-file development, long tests/builds, big log sweeps, rendering). Choose the profile that actually matches: scout (read-only investigation), analyst (read-only synthesis), developer (code changes + tests), sim-builder (sim/render artifacts).
+- NEVER fall back to an incompatible worker: if `worker:rosclaw:pi` fails with an infrastructure error (timeout/liveness/provider), do NOT reassign the same capability to `worker:native:basic` or any worker that does not declare it. Report the infra failure honestly, keep the worktree/artifacts for retry, and retry the SAME worker at most once; if it fails again, stop and tell the user the runtime issue.
+- Worker failures are data: quote the exact error_code (e.g. PROVIDER_TIMEOUT, liveness lost) instead of saying "worker lacks the ability" unless the scheduler explicitly reported the capability undeclared.
 
 TRUTH, MEMORY, AND LEARNING
 - Separate observation, verified receipt, curated knowledge, model inference, and hypothesis.

--- a/src/rosclaw/agentd/workers/external.py
+++ b/src/rosclaw/agentd/workers/external.py
@@ -39,8 +39,10 @@ from rosclaw.contracts.worker.order import (
 )
 
 #: 十审 §7.4/§10.3：startup/idle 超时（wall 由 order budget 兜底）。
+#: 十一审 PR-A：外部 CLI 没有 liveness 通道——idle 只兜"真挂死"，
+#: 必须与 provider 级长推理兼容（10min），真正的边界是 wall budget。
 STARTUP_TIMEOUT_SEC = 15.0
-IDLE_TIMEOUT_SEC = 60.0
+IDLE_TIMEOUT_SEC = 600.0
 
 
 def _parse_stream_line(pack: WorkerPackManifest, line: bytes) -> tuple[str, str, dict]:

--- a/src/rosclaw/agentd/workers/manager.py
+++ b/src/rosclaw/agentd/workers/manager.py
@@ -211,7 +211,9 @@ class WorkerManager:
         self._runs[order.work_order_id] = (adapter, handle)
         try:
             deadline = datetime.now(UTC) + timedelta(
-                seconds=timeout_sec or order.budgets.wall_time_sec
+                # 十一审 PR-A：adapter 的 wall wrap-up（steer + 60s grace）
+                # 优先；manager deadline 只兜 adapter 不收敛的底（+90s）。
+                seconds=(timeout_sec or order.budgets.wall_time_sec) + 90
             )
             result: WorkResultV1 | None = None
             while datetime.now(UTC) < deadline:
@@ -250,6 +252,14 @@ class WorkerManager:
                 lease_id=order.lease.lease_id if order.lease else "",
                 status="FAILED",
                 summary="deadline exceeded before submission",
+            )
+            # 十一审 PR-A：deadline 终态直接返回——不得继续走
+            # SUBMITTED/VERIFYING（FAILED→SUBMITTED 是非法迁移；adapter
+            # 层的 wall wrap-up 已先给过 graceful 机会）。
+            return result, VerificationReport(
+                accepted=False,
+                verifier_results={"within_deadline": False},
+                reasons=("deadline exceeded before submission",),
             )
         # Stale-lease guard: a result under an old lease is late, not accepted.
         if order.lease and result.lease_id != order.lease.lease_id:

--- a/src/rosclaw/agentd/workers/pi_managed.py
+++ b/src/rosclaw/agentd/workers/pi_managed.py
@@ -40,9 +40,15 @@ from rosclaw.contracts.worker.order import (
 
 WORKER_ID = "worker:rosclaw:pi"
 
-#: 十审 §7.4 P0 默认：startup 10s、idle 60s。
-STARTUP_TIMEOUT_SEC = 10.0
-IDLE_TIMEOUT_SEC = 60.0
+#: 十审 §7.4 P0 默认：startup 30s（十一审 PR-A：只管启动握手）。
+#: 十一审 PR-A 三层分离：
+#: - LIVENESS_TIMEOUT：连 liveness 事件都没有才判死（进程真挂死）；
+#: - STALL_WARN：语义静默只告警不杀（高 thinking/长命令合法）；
+#: - wall/token 预算到期先 wrap-up steer，grace 后再终止。
+STARTUP_TIMEOUT_SEC = 30.0
+LIVENESS_TIMEOUT_SEC = 15.0
+STALL_WARN_SEC = 90.0
+WRAPUP_GRACE_SEC = 60.0
 
 #: W3：写能力 profile（Developer Workbench）——workspace 隔离 + diff 工件。
 WORKBENCH_PROFILES = ("developer", "sim-builder")
@@ -273,6 +279,9 @@ class PiManagedAdapter:
             "instructions": str(order.inputs.get("instructions") or order.goal),
             "cwd": cwd,
             "artifacts_dir": str(artifacts_dir),
+            # 十一审 PR-A：DoD 注入——期望工件进 envelope（developer 的
+            # 最终提示据此要求真实 diff/测试日志）。
+            "expected_artifacts": list(order.expected_output.artifacts),
             "budget": {
                 "wall_time_sec": order.budgets.wall_time_sec,
                 "model_tokens": order.budgets.model_tokens,
@@ -339,6 +348,17 @@ class PiManagedAdapter:
         events: list[dict] = []
         final_report = ""
         failure: dict | None = None
+        # 十一审 PR-A：三层分离——liveness（进程活着）≠ activity（模型/
+        # 工具在跑）≠ semantic progress（真实产出）。只有全静默
+        # （连 liveness 都没有）才算死。
+        state = {
+            "last_event_at": asyncio.get_running_loop().time(),
+            "last_semantic_at": asyncio.get_running_loop().time(),
+            "phase": "STARTING",
+            "stall_warned": False,
+            "wrapup_sent": False,
+            "wrapup_at": 0.0,
+        }
 
         async def _read_events() -> None:
             nonlocal final_report, failure
@@ -352,8 +372,17 @@ class PiManagedAdapter:
                 except json.JSONDecodeError:
                     continue
                 events.append(event)
-                handle.progress_seq += 1  # 真实子进程事件才推进心跳
+                now = asyncio.get_running_loop().time()
+                state["last_event_at"] = now
                 kind = event.get("kind")
+                if kind == "liveness":
+                    # 只证明活着——phase/span 供 UI，不推进语义进度。
+                    state["phase"] = str(event.get("phase", state["phase"]))
+                    continue
+                # 真实语义事件：进度与 stall 恢复。
+                handle.progress_seq += 1
+                state["last_semantic_at"] = now
+                state["stall_warned"] = False
                 if kind == "attempt_finished":
                     final_report = str(event.get("report", ""))
                 elif kind == "attempt_failed":
@@ -386,16 +415,73 @@ class PiManagedAdapter:
                 if asyncio.get_running_loop().time() > startup_end:
                     raise AdapterError("worker startup timeout (no attempt_started)")
                 await asyncio.sleep(0.05)
-            # idle timeout：真实事件才刷新；超时不诚实等待。
+            # 主监控循环（十一审 PR-A）：
+            # - 全静默（连 liveness 都没有）> LIVENESS_TIMEOUT → 真死，杀；
+            # - 语义静默 > STALL_WARN → 只告警（UI 标黄），不杀；
+            # - wall 预算到期 → 先 wrap-up steer，grace 后再杀；
+            # - token 预算 ≥80% → wrap-up steer 一次。
+            wall_end = (
+                asyncio.get_running_loop().time() + order.budgets.wall_time_sec
+                if order.budgets.wall_time_sec
+                else None
+            )
             while proc.returncode is None:
-                last_seq = handle.progress_seq
                 try:
-                    await asyncio.wait_for(proc.wait(), timeout=IDLE_TIMEOUT_SEC)
+                    await asyncio.wait_for(proc.wait(), timeout=1.0)
+                    break
                 except TimeoutError:
-                    if handle.progress_seq == last_seq:
-                        raise AdapterError(
-                            f"worker idle timeout ({IDLE_TIMEOUT_SEC:.0f}s 无真实事件)"
-                        ) from None
+                    pass
+                now = asyncio.get_running_loop().time()
+                silent = now - state["last_event_at"]
+                if silent > LIVENESS_TIMEOUT_SEC:
+                    raise AdapterError(
+                        f"worker liveness lost ({LIVENESS_TIMEOUT_SEC:.0f}s 无任何事件"
+                        "——进程挂死，已终止)"
+                    )
+                semantic_silent = now - state["last_semantic_at"]
+                if semantic_silent > STALL_WARN_SEC and not state["stall_warned"]:
+                    state["stall_warned"] = True
+                    # 告警事件入列（UI 标黄；EventStore 在 PR-B 持久化）。
+                    events.append(
+                        {
+                            "kind": "stall_warning",
+                            "phase": state["phase"],
+                            "semantic_silent_sec": int(semantic_silent),
+                        }
+                    )
+                if wall_end is not None and now > wall_end and not state["wrapup_sent"]:
+                    state["wrapup_sent"] = True
+                    state["wrapup_at"] = now
+                    await self.steer(
+                        order.work_order_id,
+                        "已接近 wall 时间预算。停止开新工作：保存当前改动、跑最窄的"
+                        "验证命令，并产出可恢复的 partial handoff（已改文件/已验证"
+                        "内容/未完成事项/阻塞原因）。",
+                    )
+                if state["wrapup_sent"] and now - state["wrapup_at"] > WRAPUP_GRACE_SEC:
+                    raise AdapterError(
+                        "worker wall budget exceeded（wrap-up 宽限后仍未退出）"
+                    )
+                # token 预算 80% → wrap-up（一次）。
+                usage_last = next(
+                    (e for e in reversed(events) if e.get("kind") == "usage"), None
+                )
+                if (
+                    usage_last
+                    and order.budgets.model_tokens
+                    and not state["wrapup_sent"]
+                ):
+                    spent = int(usage_last.get("input_tokens") or 0) + int(
+                        usage_last.get("output_tokens") or 0
+                    )
+                    if spent >= int(order.budgets.model_tokens * 0.8):
+                        state["wrapup_sent"] = True
+                        state["wrapup_at"] = now
+                        await self.steer(
+                            order.work_order_id,
+                            "已接近 token 预算。停止开新工作：保存当前改动并产出"
+                            "可恢复的 partial handoff。",
+                        )
         except asyncio.CancelledError:
             await _teardown()
             raise

--- a/tests/agentd/test_eleven_a.py
+++ b/tests/agentd/test_eleven_a.py
@@ -12,12 +12,21 @@
 
 from __future__ import annotations
 
-import asyncio
+import json
+import shutil
 import stat
+import subprocess
 import time
 from pathlib import Path
 
 import pytest
+
+# CI Full Regression 无 node/dist——prompt 契约测试诚实 skip（本地与
+# Node jobs 覆盖）。
+_NODE_AVAILABLE = shutil.which("node") is not None and (
+    Path(__file__).resolve().parents[2]
+    / "packages/rosclaw-agent/dist/src/workers/profiles.js"
+).exists()
 
 from rosclaw.agentd.workers.scheduler import CandidateView
 from rosclaw.contracts.common import new_id
@@ -188,11 +197,9 @@ class TestBudgetWrapup:
         await service.close()
 
 
+@pytest.mark.skipif(not _NODE_AVAILABLE, reason="无 node/dist——诚实 skip")
 class TestPromptContract:
     def test_developer_prompt_has_no_readonly_contradiction(self) -> None:
-        import json
-        import subprocess
-
         # 用 node 直接读编译后 profiles（真实运行面）。
         proc = subprocess.run(
             [
@@ -221,9 +228,6 @@ class TestPromptContract:
         assert "design document" in prompt.lower()  # DoD 反设计稿声明
 
     def test_scout_prompt_manifest_is_readonly_honest(self) -> None:
-        import json
-        import subprocess
-
         proc = subprocess.run(
             [
                 "node",

--- a/tests/agentd/test_eleven_a.py
+++ b/tests/agentd/test_eleven_a.py
@@ -21,13 +21,6 @@ from pathlib import Path
 
 import pytest
 
-# CI Full Regression 无 node/dist——prompt 契约测试诚实 skip（本地与
-# Node jobs 覆盖）。
-_NODE_AVAILABLE = shutil.which("node") is not None and (
-    Path(__file__).resolve().parents[2]
-    / "packages/rosclaw-agent/dist/src/workers/profiles.js"
-).exists()
-
 from rosclaw.agentd.workers.scheduler import CandidateView
 from rosclaw.contracts.common import new_id
 from rosclaw.contracts.worker.order import (
@@ -37,6 +30,13 @@ from rosclaw.contracts.worker.order import (
     WorkOrderV1,
 )
 from tests.agentd.test_pi_tool_bridge import _setup
+
+# CI Full Regression 无 node/dist——prompt 契约测试诚实 skip（本地与
+# Node jobs 覆盖）。
+_NODE_AVAILABLE = shutil.which("node") is not None and (
+    Path(__file__).resolve().parents[2]
+    / "packages/rosclaw-agent/dist/src/workers/profiles.js"
+).exists()
 
 
 def _fake(tmp_path: Path, name: str, body: str) -> Path:

--- a/tests/agentd/test_eleven_a.py
+++ b/tests/agentd/test_eleven_a.py
@@ -1,0 +1,245 @@
+"""十一审 PR-A 红测试：false timeout 状态机 + prompt/tool 契约。
+
+红测试先行——修复前必须红：
+1. 语义静默 ≥90s 但 liveness 正常 → 不杀（stall 只告警）；旧实现
+   60s 无事件即杀。
+2. 全静默（连 liveness 都没有）→ liveness timeout 判死。
+3. wall 预算：先 wrap-up steer，grace 内不退出才终止。
+4. token 预算 ≥80% → wrap-up steer 一次。
+5. Developer prompt 不再含 "read-only tools" 矛盾；manifest 列出
+   7 个工具与 DoD。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import stat
+import time
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.workers.scheduler import CandidateView
+from rosclaw.contracts.common import new_id
+from rosclaw.contracts.worker.order import (
+    BudgetEnvelope,
+    ExpectedOutput,
+    SideEffectPolicy,
+    WorkOrderV1,
+)
+from tests.agentd.test_pi_tool_bridge import _setup
+
+
+def _fake(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+async def _run(service, mission, tmp_path, fake, monkeypatch, *, wall_time=300):
+    from rosclaw.agentd.workers import pi_managed
+
+    monkeypatch.setattr(pi_managed, "find_pi_agent_entry", lambda: ("/bin/sh", str(fake)))
+    adapter = pi_managed.PiManagedAdapter(rosclaw_home=tmp_path)
+    service._worker_manager._adapters["pi_managed"] = adapter
+    if service._registry.status_of("worker:rosclaw:pi") != "ENABLED":
+        service._registry.set_status(
+            "worker:rosclaw:pi", "ENABLED", actor_id="test", reason="fake entry"
+        )
+    card = service._registry.get("worker:rosclaw:pi")
+    order = WorkOrderV1(
+        work_order_id=new_id("wo"),
+        mission_id=mission.mission_id,
+        issued_by="test",
+        capability="analysis.text",
+        goal="长任务",
+        inputs={"instructions": "x"},
+        budgets=BudgetEnvelope(wall_time_sec=wall_time, model_tokens=1000),
+        expected_output=ExpectedOutput(artifacts=["text/plain"]),
+        side_effect_policy=SideEffectPolicy(**{"class": "none"}),
+    )
+    scheduled = service._worker_manager.hire(
+        order,
+        [CandidateView(card=card, registry_status="ENABLED", running_orders=0,
+                       circuit_open=False)],
+    )
+    return await service._worker_manager.run_to_completion(scheduled)
+
+
+class TestNoFalseTimeout:
+    async def test_semantic_silence_with_liveness_not_killed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Gate B：90s+ 无语义事件但 liveness 正常——进程保持存活。
+        （为测试时长可控，stall 阈值缩小；断言无 idle 误杀 + stall 告警。）"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "STALL_WARN_SEC", 1.0)
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-slow-thinker",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "i=0\n"
+            "while [ $i -lt 12 ]; do\n"
+            '  echo \'{"kind":"liveness","phase":"RUNNING_MODEL","span_age_ms":1000,"pid_alive":true}\'\n'
+            "  sleep 0.5\n"
+            "  i=$((i+1))\n"
+            "done\n"
+            'echo \'{"kind":"attempt_finished","report":"长推理完成"}\'\n',
+        )
+        started = time.monotonic()
+        result, report = await _run(service, mission, tmp_path, fake, monkeypatch)
+        elapsed = time.monotonic() - started
+        # 6 秒全 liveness 无语义事件——旧实现会在 60s 处杀（语义层面
+        # 等价：stall 阈值 1s 下，liveness 保活必须让任务活到完成）。
+        assert result.status == "COMPLETED", result.summary
+        assert "长推理完成" in result.summary
+        assert elapsed > 5, f"疑似提前退出: {elapsed:.1f}s"
+        assert report.accepted
+        await service.close()
+
+    async def test_total_silence_killed_by_liveness_timeout(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """连 liveness 都没有 = 进程挂死——必须判死（不无限等待）。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 2.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-hang-after-start",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "exec sleep 300\n",
+        )
+        started = time.monotonic()
+        result, _report = await _run(service, mission, tmp_path, fake, monkeypatch)
+        elapsed = time.monotonic() - started
+        assert result.status == "FAILED"
+        assert "liveness lost" in result.summary, result.summary
+        assert elapsed < 20, f"判死耗时 {elapsed:.1f}s"
+        await service.close()
+
+
+class TestBudgetWrapup:
+    async def test_wall_budget_wrapup_then_terminate(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """wall 到期：先发 wrap-up steer（grace 内可收尾），grace 后仍
+        不退出才终止。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "WRAPUP_GRACE_SEC", 1.0)
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        stdin_log = tmp_path / "stdin.log"
+        fake = _fake(
+            tmp_path,
+            "fake-ignore-wrapup",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            # liveness 后台持续（不被误杀）；前台 cat 读 stdin（POSIX sh
+            # 的后台任务 stdin 会被重定向到 /dev/null——必须前台读）。
+            "(while true; do echo '{\"kind\":\"liveness\",\"phase\":\"RUNNING_MODEL\"}'; sleep 0.5; done) &\n"
+            f"cat >> {stdin_log}\n",
+        )
+        result, _report = await _run(
+            service, mission, tmp_path, fake, monkeypatch, wall_time=2
+        )
+        assert result.status == "FAILED"
+        assert "wall budget" in result.summary, result.summary
+        assert stdin_log.exists()
+        assert "wall" in stdin_log.read_text() or "预算" in stdin_log.read_text()
+        await service.close()
+
+    async def test_wrapup_allows_graceful_finish(self, tmp_path: Path, monkeypatch) -> None:
+        """wrap-up 后在 grace 内正常完成的单必须被接受（不误杀）。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "WRAPUP_GRACE_SEC", 10.0)
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-graceful",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "while IFS= read -r line; do\n"
+            "  case \"$line\" in\n"
+            "    *steer*)\n"
+            '      echo \'{"kind":"liveness","phase":"RUNNING_MODEL"}\'\n'
+            "      sleep 1\n"
+            '      echo \'{"kind":"attempt_finished","report":"partial handoff：已保存"}\'\n'
+            "      exit 0;;\n"
+            "  esac\n"
+            "done\n",
+        )
+        result, report = await _run(
+            service, mission, tmp_path, fake, monkeypatch, wall_time=3
+        )
+        assert result.status == "COMPLETED", result.summary
+        assert "partial handoff" in result.summary
+        assert report.accepted
+        await service.close()
+
+
+class TestPromptContract:
+    def test_developer_prompt_has_no_readonly_contradiction(self) -> None:
+        import json
+        import subprocess
+
+        # 用 node 直接读编译后 profiles（真实运行面）。
+        proc = subprocess.run(
+            [
+                "node",
+                "-e",
+                "import('./packages/rosclaw-agent/dist/src/workers/profiles.js')"
+                ".then(m => {"
+                "const p = m.profileFor('developer');"
+                "const sp = m.buildSystemPrompt(p, '/tmp/ws', ['text/x-diff']);"
+                "console.log(JSON.stringify({tools: p.tools, sp}));"
+                "})",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(Path(__file__).resolve().parents[2]),
+        )
+        assert proc.returncode == 0, proc.stderr[-500:]
+        payload = json.loads(proc.stdout)
+        prompt = payload["sp"]
+        assert "read-only tools" not in prompt
+        for tool in ("read", "grep", "find", "ls", "write", "edit", "bash"):
+            assert tool in payload["tools"]
+        assert "Available tools: read, grep, find, ls, write, edit, bash" in prompt
+        assert "Required evidence" in prompt
+        assert "design document" in prompt.lower()  # DoD 反设计稿声明
+
+    def test_scout_prompt_manifest_is_readonly_honest(self) -> None:
+        import json
+        import subprocess
+
+        proc = subprocess.run(
+            [
+                "node",
+                "-e",
+                "import('./packages/rosclaw-agent/dist/src/workers/profiles.js')"
+                ".then(m => {"
+                "const p = m.profileFor('scout');"
+                "console.log(JSON.stringify({sp: m.buildSystemPrompt(p, '/tmp/ws', [])}));"
+                "})",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(Path(__file__).resolve().parents[2]),
+        )
+        assert proc.returncode == 0
+        prompt = json.loads(proc.stdout)["sp"]
+        assert "Available tools: read, grep, find, ls" in prompt
+        assert "read-only profile" in prompt

--- a/tests/agentd/test_eleven_a_live.py
+++ b/tests/agentd/test_eleven_a_live.py
@@ -1,0 +1,77 @@
+"""十一审 PR-A 真实长任务验收（Gate B/D）：真实 Kimi K3、>5 分钟、
+高 thinking 长静默不误杀。
+
+无 provider key 时诚实 skip。运行：
+ROSCLAW_KIMI_API_KEY=sk-kimi-... pytest tests/agentd/test_eleven_a_live.py -s
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _request, _setup
+
+KIMI_ENV_VARS = ("ROSCLAW_KIMI_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY")
+
+
+def _has_key() -> bool:
+    return any(os.environ.get(v) for v in KIMI_ENV_VARS)
+
+
+@pytest.mark.skipif(not _has_key(), reason="无真实 provider key——诚实 skip")
+class TestLiveLongTaskNoFalseKill:
+    async def test_long_repo_analysis_survives_past_60s(self, tmp_path: Path) -> None:
+        """长任务（仓库级分析）必须活过旧的 60s 误杀点；liveness 事件
+        持续；终态真实（ACCEPTED 或带明确 error_code 的 FAILED）。"""
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        repo = Path(__file__).resolve().parents[2]
+        started = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_11a_live",
+                arguments={
+                    "goal": "通读 src/rosclaw/agentd 下的主要模块（service、"
+                    "workers、pi_bridge、context），写一份详细的中文架构报告："
+                    "每个模块的职责、关键类、模块间数据流。报告至少 2000 字。",
+                    "worker_id": "worker:rosclaw:pi",
+                    "worker_profile": "scout",
+                    "workspace": str(repo),
+                    "budget": {"wall_time_sec": 900, "model_tokens": 300_000},
+                    "sync_grace_sec": 0,
+                },
+            )
+        )
+        assert started.ok, started.summary
+        assert started.status == "STARTED"
+        order = service._worker_manager.orders_for_mission(mission.mission_id)[0]
+        # 活过旧误杀点（60s）是硬断言；此后等到终态（最长 16 分钟）。
+        await asyncio.sleep(65)
+        mid = service._worker_manager.order(order.work_order_id)
+        assert mid is not None and mid.status in ("RUNNING", "ACCEPTED"), (
+            f"60s 处被误杀/异常终态: {mid.status if mid else None}"
+        )
+        final = None
+        deadline = time.monotonic() + 960
+        while time.monotonic() < deadline:
+            current = service._worker_manager.order(order.work_order_id)
+            if current and current.status in ("ACCEPTED", "FAILED", "CANCELLED", "EXPIRED"):
+                final = current
+                break
+            await asyncio.sleep(2)
+        assert final is not None, "16 分钟未到终态"
+        if final.status == "FAILED":
+            row = service._store.connection.execute(
+                "SELECT verify_report_json FROM work_orders WHERE work_order_id = ?",
+                (order.work_order_id,),
+            ).fetchone()
+            pytest.fail(f"长任务 FAILED: {row['verify_report_json'] if row else '?'}")
+        assert final.status == "ACCEPTED"
+        await service.close()


### PR DESCRIPTION
## 十一审 PR-A（总纲 §12）

停止条件对照：**同一用户复现任务不再 60 秒失败**——真实 K3 6m37s 长任务实测活过旧误杀点并 ACCEPTED。

### 用户实证根因
`worker:rosclaw:pi` 两次在恰好 60s 被 idle timeout 误杀（K3 高 thinking 合法长静默）；native:basic 兜底无 `code.develop` 被调度器诚实拒绝——产品表现为“没有 coding 能力”。

### 内容
1. **三层状态机**：liveness（2s 一条，只证明活着）/ activity（phase span）/ semantic progress（真实事件才推进 seq）分离；删除“60s 无语义事件即杀”；全静默 >15s 才判死；语义静默 >90s 只 stall_warning；startup 30s；provider 单 turn 10min；wall/token 预算先 wrap-up steer 再 grace 终止。
2. **prompt/tool 契约**：删除公共 prompt 的 read-only 谎言；capability manifest 与真实工具面逐字一致；session 工具自检不一致即 TOOL_CONTRACT_MISMATCH；DoD 按 expected artifacts 注入（“设计稿不算完成”）。
3. **主 Agent prompt**：delegation policy + 禁止不兼容兜底（不再 native:basic 接 code.develop）。
4. **manager 修复**：deadline 路径 FAILED→SUBMITTED 非法迁移 + 让位 adapter wrap-up。
5. **外部 adapter**：idle 提至 10min（无 liveness 通道）。

### 验收
- 红测试 6 项；真实 K3 长任务 6m37s 活过 60s 误杀点 ACCEPTED（test_eleven_a_live）。
- 回归：W0-W5 Python 44 项绿；TS 75/75；ruff 全库绿。