### PR TITLE
feat: 十一审 PR-D——Workspace 一等状态 + delegation policy（栈于 PR-C 之上）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -31,6 +31,7 @@ import type { LocaleManager } from "../i18n/locale.js";
 import { t as i18nT } from "../i18n/index.js";
 import { EventMirror } from "./event-mirror.js";
 import { WorkerCompletionWatcher } from "../workers/completion-watch.js";
+import { JobsWidget, renderJobLog } from "../workers/job-widget.js";
 import { buildCommandHandlers } from "./commands.js";
 import { guardInput } from "./input-guard.js";
 import { fetchEmbodiedContext, renderTrustedContext } from "./context-injection.js";
@@ -71,7 +72,15 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		let probeTimer: ReturnType<typeof setInterval> | null = null;
 		// 十审 W2：Worker 完成推送——custom message 注入（不冒充用户
 		// 输入），投递账本持久化（重启/compact 不重复、不丢失）。
-		let latestCtx: { isIdle(): boolean; hasUI: boolean; ui: { notify(t: string, k: "info"): void } } | undefined;
+		type LatestCtx = {
+			isIdle(): boolean;
+			hasUI: boolean;
+			ui: {
+				notify(t: string, k: "info" | "warning" | "error"): void;
+				setWidget(key: string, lines: string[] | undefined): void;
+			};
+		};
+		let latestCtx: LatestCtx | undefined;
 		const watcher = new WorkerCompletionWatcher({
 			rosclawHome: options.rosclawHome,
 			active: options.active,
@@ -87,12 +96,25 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 						}
 					: undefined,
 		});
+		// 十一审 PR-C：实时 Job 卡（widget 与 /job log 同一事件源；
+		// 仅 UI 有 ctx 时渲染；内容不变不重绘——idle CPU 红线）。
+		const jobsWidget = new JobsWidget({
+			active: options.active,
+			center,
+			setWidget: (lines) => {
+				if (!latestCtx?.hasUI) return;
+				if (lines === undefined) latestCtx.ui.setWidget("rosclaw-jobs", undefined);
+				else latestCtx.ui.setWidget("rosclaw-jobs", lines);
+			},
+		});
 		pi.on("session_start", async (_event, ctx) => {
 			latestCtx = ctx;
 			watcher.start();
+			jobsWidget.start();
 		});
 		pi.on("session_shutdown", async () => {
 			watcher.stop();
+			jobsWidget.stop();
 		});
 		pi.on("session_start", async (_event, ctx) => {
 			if (!ctx.hasUI) return;
@@ -446,9 +468,10 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				const trimmed = args.trim();
 				const cancelMatch = trimmed.match(/^cancel\s+(\S+)$/);
 				const retryMatch = trimmed.match(/^retry\s+(\S+)$/);
+				const logMatch = trimmed.match(/^log\s+(\S+)$/);
 				const idMatch = trimmed.match(/^(\S+)$/);
-				if (!idMatch && !cancelMatch && !retryMatch) {
-					ctx.ui.notify("用法：/job <wo_id> | /job cancel <wo_id> | /job retry <wo_id>", "warning");
+				if (!idMatch && !cancelMatch && !retryMatch && !logMatch) {
+					ctx.ui.notify("用法：/job <wo_id> | /job log <wo_id> | /job cancel <wo_id> | /job retry <wo_id>", "warning");
 					return;
 				}
 				const state = options.active.current;
@@ -465,6 +488,23 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					actor: { engine: "pi-command" },
 				});
 				try {
+					if (logMatch) {
+						// 十一审 PR-C：事件日志（EventStore tail——不经模型、
+						// 不耗 token；与 widget 同一事件源）。
+						const response = await center.call("pi.worker.events", {
+							work_order_id: logMatch[1],
+							limit: 80,
+						});
+						if (!response.ok) {
+							ctx.ui.notify(`查询失败：${String(response.error ?? "")}`, "error");
+							return;
+						}
+						ctx.ui.notify(renderJobLog(
+							(response.events ?? []) as never,
+							logMatch[1],
+						), "info");
+						return;
+					}
 					if (retryMatch) {
 						const response = await center.call("pi.tools.execute", {
 							request: mkRequest("rosclaw_retry_work", retryMatch[1]),

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -32,6 +32,7 @@ import { t as i18nT } from "../i18n/index.js";
 import { EventMirror } from "./event-mirror.js";
 import { WorkerCompletionWatcher } from "../workers/completion-watch.js";
 import { JobsWidget, renderJobLog } from "../workers/job-widget.js";
+import { WorkspaceStore } from "../session/workspace.js";
 import { buildCommandHandlers } from "./commands.js";
 import { guardInput } from "./input-guard.js";
 import { fetchEmbodiedContext, renderTrustedContext } from "./context-injection.js";
@@ -54,6 +55,9 @@ export interface RosclawExtensionOptions {
 	resumed?: boolean;
 	/** 会话命名（WP-P0-2 标题产品化）：写入 Pi session_info。 */
 	sessionManager?: import("@earendil-works/pi-coding-agent").SessionManager;
+	/** 十一审 PR-D：Workspace 一等状态。 */
+	workspaceStore?: import("../session/workspace.js").WorkspaceStore;
+	workspaceAutoBound?: boolean;
 }
 
 const WORKING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -107,10 +111,55 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				else latestCtx.ui.setWidget("rosclaw-jobs", lines);
 			},
 		});
+		// 十一审 PR-D：Workspace——header 快照 + /workspace 命令（命令层
+		// 直接处理，不进模型）。
+		const workspaceStore = options.workspaceStore ?? new WorkspaceStore(options.rosclawHome);
+		(center.noteWorkspace?.bind(center) as ((d?: string) => void) | undefined)?.(
+			workspaceStore.current ? workspaceStore.displayName() : undefined,
+		);
+		pi.registerCommand("workspace", {
+			description: "项目 workspace：/workspace show | use <path> | recent",
+			handler: async (args, ctx) => {
+				const sub = args.trim();
+				if (!sub || sub === "show") {
+					const current = workspaceStore.current;
+					ctx.ui.notify(
+						current ? `当前 Project：${current}` : "未绑定 Project（从 git 仓库内启动自动绑定，或 /workspace use <path>）",
+						"info",
+					);
+					return;
+				}
+				if (sub === "recent") {
+					const recent = workspaceStore.recent;
+					ctx.ui.notify(
+						recent.length ? `最近的 workspace：\n${recent.join("\n")}` : "（无最近记录）",
+						"info",
+					);
+					return;
+				}
+				const useMatch = sub.match(/^use\s+(.+)$/);
+				if (useMatch) {
+					try {
+						const bound = workspaceStore.bind(useMatch[1]);
+						(center.noteWorkspace?.bind(center) as ((d?: string) => void) | undefined)?.(
+							workspaceStore.displayName(),
+						);
+						ctx.ui.notify(`已绑定 Project：${bound}`, "info");
+					} catch (err) {
+						ctx.ui.notify(`绑定失败：${(err as Error).message}`, "error");
+					}
+					return;
+				}
+				ctx.ui.notify("用法：/workspace show | use <path> | recent", "warning");
+			},
+		});
 		pi.on("session_start", async (_event, ctx) => {
 			latestCtx = ctx;
 			watcher.start();
 			jobsWidget.start();
+			if (options.workspaceAutoBound && workspaceStore.current) {
+				ctx.ui.notify(`已自动绑定 Project：${workspaceStore.current}（/workspace show 查看）`, "info");
+			}
 		});
 		pi.on("session_shutdown", async () => {
 			watcher.stop();

--- a/packages/rosclaw-agent/src/main.ts
+++ b/packages/rosclaw-agent/src/main.ts
@@ -20,6 +20,7 @@ process.env.PI_CODING_AGENT_DIR ??= `${rosclawHomeEnv}/agent`;
 
 interface CliArgs {
 	profile: "developer" | "robot";
+	workspace?: string;
 	initialMessage?: string;
 	print: boolean;
 	missionId?: string;
@@ -38,8 +39,12 @@ function parseArgs(argv: string[]): CliArgs {
 	let resumeSessionPath: string | undefined;
 	let browseSessions = false;
 	let continueLast = false;
+	let workspace: string | undefined;
 	for (let i = 0; i < argv.length; i += 1) {
-		if (argv[i] === "--profile" && argv[i + 1]) {
+		if (argv[i] === "--workspace" && argv[i + 1]) {
+			workspace = argv[i + 1];
+			i += 1;
+		} else if (argv[i] === "--profile" && argv[i + 1]) {
 			profile = argv[i + 1] === "robot" ? "robot" : "developer";
 			i += 1;
 		} else if (argv[i] === "--message" && argv[i + 1]) {
@@ -65,7 +70,7 @@ function parseArgs(argv: string[]): CliArgs {
 		}
 	}
 	return {
-		profile, initialMessage, print, missionId,
+		profile, initialMessage, print, missionId, workspace,
 		resumeSessionId, resumeSessionPath, browseSessions, continueLast,
 	};
 }
@@ -82,7 +87,7 @@ async function main(): Promise<number> {
 	);
 	const { createRosclawRuntime } = await import("./runtime/create-runtime.js");
 	const {
-		profile, initialMessage, print, missionId,
+		profile, initialMessage, print, missionId, workspace,
 		resumeSessionId, resumeSessionPath, browseSessions, continueLast,
 	} = parseArgs(process.argv.slice(2));
 	const rosclawHome = rosclawHomeEnv;
@@ -122,11 +127,18 @@ async function main(): Promise<number> {
 	const isResume = Boolean(
 		resumeSessionId || resumeSessionPath || browseSessions || continueLast,
 	);
+	// 十一审 PR-D：Workspace 一等状态——显式 --workspace > cwd git 自动
+	// 绑定 > 既有绑定。
+	const { WorkspaceStore, resolveStartupWorkspace } = await import("./session/workspace.js");
+	const workspaceStore = new WorkspaceStore(rosclawHome);
+	const startupWs = resolveStartupWorkspace(workspaceStore, workspace, process.cwd());
 	const { runtime, coordinator, leaseManager } = await createRosclawRuntime({
 		cwd: process.cwd(),
 		rosclawHome,
 		profile,
 		version: VERSION,
+		workspaceStore,
+		workspaceAutoBound: startupWs.auto,
 		...(missionId ? { missionId } : {}),
 		...(initialSession ? { sessionManager: initialSession } : {}),
 		...(isResume ? { resumed: true } : {}),

--- a/packages/rosclaw-agent/src/runtime/create-runtime.ts
+++ b/packages/rosclaw-agent/src/runtime/create-runtime.ts
@@ -53,6 +53,9 @@ export interface RosclawRuntimeOptions {
 	sessionManager?: import("@earendil-works/pi-coding-agent").SessionManager;
 	/** WP-P0-3：本次启动是恢复——session_start 展示 Resume Report。 */
 	resumed?: boolean;
+	/** 十一审 PR-D：Workspace 一等状态。 */
+	workspaceStore?: import("../session/workspace.js").WorkspaceStore;
+	workspaceAutoBound?: boolean;
 }
 
 /** native_agent_v2.md：构建期从 Python 源树拷入 dist/prompts（单一事实源）。 */
@@ -177,6 +180,8 @@ export async function createRosclawRuntime(
 								rosclawHome: options.rosclawHome,
 								resumed: options.resumed === true,
 								sessionManager,
+								workspaceStore: options.workspaceStore,
+								workspaceAutoBound: options.workspaceAutoBound === true,
 							}),
 						},
 					],
@@ -217,6 +222,7 @@ export async function createRosclawRuntime(
 					rosclawHome: options.rosclawHome,
 					active,
 					center,
+					workspace: () => options.workspaceStore?.current ?? null,
 				}),
 				// 十审 W0：异步 WorkOrder 协议（按精确 ID 查询/取消）。
 				buildCheckWorkTool({

--- a/packages/rosclaw-agent/src/session/state-center.ts
+++ b/packages/rosclaw-agent/src/session/state-center.ts
@@ -59,6 +59,8 @@ export interface KernelSnapshotV1 {
 	lease_state: LeaseState;
 	operator: OperatorState;
 	action_readiness: ActionReadinessV1;
+	/** 十一审 PR-D：当前绑定 workspace（None=无 Project）。 */
+	workspace?: string;
 }
 
 export interface RobotKitSummary {
@@ -136,6 +138,15 @@ export class ProductStateCenter {
 	}
 
 	/** 当前不可变快照（一次读取，所有 chrome 共享）。 */
+	private workspaceDisplay: string | undefined;
+
+	/** 十一审 PR-D：workspace 绑定变化 → 快照更新（subscribe 统一重绘）。 */
+	noteWorkspace(display: string | undefined): void {
+		if (this.workspaceDisplay === display) return;
+		this.workspaceDisplay = display;
+		this.changed();
+	}
+
 	snapshot(): KernelSnapshotV1 {
 		const state = this.deps.active.current;
 		return {
@@ -153,6 +164,7 @@ export class ProductStateCenter {
 			lease_state: state.leaseState,
 			operator: this.operatorState,
 			action_readiness: this.computeReadiness(),
+			workspace: this.workspaceDisplay,
 		};
 	}
 

--- a/packages/rosclaw-agent/src/session/workspace.ts
+++ b/packages/rosclaw-agent/src/session/workspace.ts
@@ -1,0 +1,106 @@
+/** Workspace 一等状态（十一审 PR-D，总纲 §P0-5）。
+ *
+ * - 状态文件：$ROSCLAW_HOME/agent/workspace.json（current + recent）；
+ * - 启动时：--workspace 显式指定 > cwd 所在 git repo 自动绑定 > 无绑定
+ *   （header 显示 Project —）；
+ * - WorkOrder 的 workspace 默认取绑定值——用户不再需要在自然语言里
+ *   反复给路径；worker 不再去"猜" host path。
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
+
+export interface WorkspaceState {
+	current: string | null;
+	recent: string[];
+}
+
+/** 向上找 git repo root（.git 目录或 worktree 的 .git 文件）。 */
+export function gitRootOf(start: string): string | null {
+	let dir = resolve(start);
+	for (let depth = 0; depth < 32; depth += 1) {
+		if (existsSync(`${dir}/.git`)) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+	return null;
+}
+
+export class WorkspaceStore {
+	private readonly path: string;
+	private state: WorkspaceState;
+
+	constructor(rosclawHome: string) {
+		this.path = `${rosclawHome}/agent/workspace.json`;
+		this.state = this.load();
+	}
+
+	private load(): WorkspaceState {
+		try {
+			if (!existsSync(this.path)) return { current: null, recent: [] };
+			const data = JSON.parse(readFileSync(this.path, "utf-8")) as WorkspaceState;
+			return { current: data.current ?? null, recent: data.recent ?? [] };
+		} catch {
+			return { current: null, recent: [] };
+		}
+	}
+
+	private persist(): void {
+		try {
+			mkdirSync(dirname(this.path), { recursive: true });
+			const tmp = `${this.path}.tmp`;
+			writeFileSync(tmp, JSON.stringify(this.state), { encoding: "utf-8", mode: 0o600 });
+			renameSync(tmp, this.path);
+		} catch {
+			// 状态持久化失败不阻塞会话
+		}
+	}
+
+	get current(): string | null {
+		return this.state.current;
+	}
+
+	get recent(): string[] {
+		return [...this.state.recent];
+	}
+
+	/** 绑定（/workspace use 或启动自动绑定）。返回规范化的绝对路径。 */
+	bind(path: string): string {
+		const abs = isAbsolute(path) ? resolve(path) : resolve(process.cwd(), path);
+		if (!existsSync(abs)) {
+			throw new Error(`路径不存在：${abs}`);
+		}
+		// git 目录自动归一到 repo root。
+		const root = gitRootOf(abs) ?? abs;
+		this.state.current = root;
+		this.state.recent = [root, ...this.state.recent.filter((r) => r !== root)].slice(0, 10);
+		this.persist();
+		return root;
+	}
+
+	unbind(): void {
+		this.state.current = null;
+		this.persist();
+	}
+
+	displayName(): string {
+		return this.state.current ? basename(this.state.current) : "—";
+	}
+}
+
+/** 启动解析：显式 --workspace > cwd git 自动绑定 > 原状态 > null。 */
+export function resolveStartupWorkspace(
+	store: WorkspaceStore,
+	explicit: string | undefined,
+	cwd: string,
+): { bound: string | null; auto: boolean } {
+	if (explicit) {
+		return { bound: store.bind(explicit), auto: false };
+	}
+	const repo = gitRootOf(cwd);
+	if (repo) {
+		return { bound: store.bind(repo), auto: true };
+	}
+	return { bound: store.current, auto: false };
+}

--- a/packages/rosclaw-agent/src/tools/bridge-tools.ts
+++ b/packages/rosclaw-agent/src/tools/bridge-tools.ts
@@ -17,6 +17,9 @@ export interface BridgeToolContext {
 	/** PR-SIX-1：唯一状态中心——工具的桥调用经 center.call（UDS 失败
 	 *  原子降级 kernel/context，不允许局部报错而 Header 保持 FRESH）。 */
 	center: ProductStateCenter;
+	/** 十一审 PR-D：绑定的 workspace（delegate 默认目标——不再让模型
+	 *  在自然语言里猜路径）。 */
+	workspace?: () => string | null;
 }
 
 let requestCounter = 0;

--- a/packages/rosclaw-agent/src/tools/delegate.ts
+++ b/packages/rosclaw-agent/src/tools/delegate.ts
@@ -102,8 +102,14 @@ export function buildDelegateTool(ctx: BridgeToolContext) {
 			// （凭据由子进程从同一 agentDir/auth.json 读取，绝不经 WorkOrder）。
 			const model = (toolCtx as { model?: { provider: string; id: string } } | undefined)?.model;
 			const thinking = (toolCtx as { thinkingLevel?: string } | undefined)?.thinkingLevel;
+			const boundWorkspace = ctx.workspace?.() ?? undefined;
 			const request = buildRequest(ctx, "rosclaw_delegate", {
 				...(params as Record<string, unknown>),
+				// 十一审 PR-D：模型未指定时默认绑定 workspace（一等状态，
+				// 不靠自然语言路径）。
+				...(!(params as Record<string, unknown>).workspace && boundWorkspace
+					? { workspace: boundWorkspace }
+					: {}),
 				work_order_id: workOrderId,
 				...(model
 					? { model_snapshot: { provider: model.provider, model: model.id, ...(thinking ? { thinking } : {}) } }

--- a/packages/rosclaw-agent/src/ui/product-state.ts
+++ b/packages/rosclaw-agent/src/ui/product-state.ts
@@ -62,6 +62,9 @@ export function renderHeader(
 	const sep = chromeSep();
 	const line1Parts = [`ROSClaw ${state.product_version}`, mode];
 	if (state.model) line1Parts.push(state.model);
+	// 十一审 PR-D：Project 一等显示（无绑定显式占位；ASCII 终端降级）。
+	const noWs = chromeSep() === " | " ? "-" : "—";
+	line1Parts.push(`Project ${state.workspace ?? noWs}`);
 	const line1 = line1Parts.join(sep);
 	if (!state.mission_id) {
 		return `${line1}\n${t("chrome.unbound", locale)}`;

--- a/packages/rosclaw-agent/src/workers/job-widget.ts
+++ b/packages/rosclaw-agent/src/workers/job-widget.ts
@@ -1,0 +1,270 @@
+/** TUI 实时 Job 卡（十一审 PR-C，总纲 §P0-4）。
+ *
+ * 常驻 widget：每个 WorkOrder 一行（phase/当前工具/耗时/turn/token），
+ * 数据源是 WorkerEventStore tail（pi.worker.events RPC）——与
+ * `/job log` 同一事件源。liveness 事件驱动 ≤3s 刷新（只证明活着，
+ * 不冒充进度）。
+ *
+ * 渲染样例：
+ *   ● Jobs
+ *   ⠹ Pi Developer · 实现 rollout · 2m17s
+ *      ⎿ bash: pytest tests/sim · 12 tools · 38.4k tok
+ */
+
+import type { ActiveSessionContext } from "../session/active-context.js";
+import type { ProductStateCenter } from "../session/state-center.js";
+
+const POLL_MS = 2000;
+const TERMINAL_KEEP_MS = 10 * 60 * 1000;
+const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+interface OrderProjection {
+	work_order_id: string;
+	assigned_to?: string;
+	status: string;
+	goal?: string;
+}
+
+interface WorkerEvent {
+	seq: number;
+	kind: string;
+	phase?: string;
+	tool?: string;
+	message?: string;
+	is_error?: boolean;
+	input_tokens?: number;
+	output_tokens?: number;
+	turns?: number;
+}
+
+interface JobView {
+	order: OrderProjection;
+	lastTool: string;
+	lastPhase: string;
+	toolCount: number;
+	inputTokens: number;
+	outputTokens: number;
+	turns: number;
+	stall: boolean;
+	lastSeq: number;
+}
+
+function fmtElapsed(ms: number): string {
+	const s = Math.floor(ms / 1000);
+	if (s < 60) return `${s}s`;
+	const m = Math.floor(s / 60);
+	return `${m}m${String(s % 60).padStart(2, "0")}`;
+}
+
+function fmtTokens(n: number): string {
+	if (n < 1000) return `${n}`;
+	if (n < 10000) return `${(n / 1000).toFixed(1)}k`;
+	return `${Math.round(n / 1000)}k`;
+}
+
+function workerLabel(assigned: string | undefined): string {
+	switch (assigned) {
+		case "worker:rosclaw:pi":
+			return "Pi Worker";
+		case "worker:native:basic":
+			return "Native Basic";
+		case "worker:claude-code:local":
+			return "Claude Code";
+		case "worker:codex:local":
+			return "Codex";
+		default:
+			return assigned ?? "?";
+	}
+}
+
+export class JobsWidget {
+	private timer: ReturnType<typeof setInterval> | undefined;
+	private readonly views = new Map<string, JobView>();
+	private readonly startedAt = new Map<string, number>();
+	private readonly terminalAt = new Map<string, number>();
+	private tickCount = 0;
+	private lastRendered = "";
+	/** /job log <id> follow 钉住的展开 job。 */
+	pinned: string | undefined;
+
+	constructor(
+		private readonly deps: {
+			active: ActiveSessionContext;
+			center: ProductStateCenter;
+			setWidget: (lines: string[] | undefined) => void;
+		},
+	) {}
+
+	start(): void {
+		if (this.timer) return;
+		this.timer = setInterval(() => {
+			void this.tick().catch(() => undefined);
+		}, POLL_MS);
+		if (typeof this.timer === "object" && "unref" in this.timer) this.timer.unref();
+	}
+
+	stop(): void {
+		if (this.timer) clearInterval(this.timer);
+		this.timer = undefined;
+		this.views.clear();
+		this.startedAt.clear();
+		this.terminalAt.clear();
+		this.lastRendered = "";
+	}
+
+	private async tailJob(view: JobView): Promise<void> {
+		const response = await this.deps.center.call("pi.worker.events", {
+			work_order_id: view.order.work_order_id,
+			after_seq: view.lastSeq,
+			limit: 50,
+		});
+		const events = (response.events ?? []) as WorkerEvent[];
+		for (const event of events) {
+			view.lastSeq = Math.max(view.lastSeq, event.seq);
+			if (event.kind === "liveness") {
+				if (event.phase) view.lastPhase = event.phase;
+				continue;
+			}
+			if (event.kind === "tool_started" && event.tool) {
+				view.lastTool = event.tool;
+				view.toolCount += 1;
+				view.lastPhase = "RUNNING_TOOL";
+			} else if (event.kind === "tool_finished") {
+				view.lastPhase = "RUNNING_MODEL";
+			} else if (event.kind === "model_started") {
+				view.lastPhase = "RUNNING_MODEL";
+			} else if (event.kind === "tool_progress" && event.message) {
+				view.lastTool = event.message.slice(0, 40);
+			} else if (event.kind === "usage") {
+				view.inputTokens = event.input_tokens ?? view.inputTokens;
+				view.outputTokens = event.output_tokens ?? view.outputTokens;
+				view.turns = event.turns ?? view.turns;
+			} else if (event.kind === "stall_warning") {
+				view.stall = true;
+			}
+		}
+	}
+
+	async tick(): Promise<void> {
+		const missionId = this.deps.active.current.missionId;
+		if (!missionId) {
+			this.render([]);
+			return;
+		}
+		const status = await this.deps.center.call("pi.worker.status", {
+			mission_id: missionId,
+		});
+		const orders = (status.orders ?? []) as OrderProjection[];
+		const now = Date.now();
+		for (const order of orders) {
+			const terminal = ["ACCEPTED", "FAILED", "EXPIRED", "CANCELLED"].includes(order.status);
+			let view = this.views.get(order.work_order_id);
+			if (!view) {
+				view = {
+					order,
+					lastTool: "",
+					lastPhase: "STARTING",
+					toolCount: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					turns: 0,
+					stall: false,
+					lastSeq: 0,
+				};
+				this.views.set(order.work_order_id, view);
+				this.startedAt.set(order.work_order_id, now);
+			}
+			view.order = order;
+			if (!terminal) {
+				await this.tailJob(view);
+				this.terminalAt.delete(order.work_order_id);
+			} else if (!this.terminalAt.has(order.work_order_id)) {
+				this.terminalAt.set(order.work_order_id, now);
+				await this.tailJob(view);
+			}
+		}
+		// 清理：终态超过保留期 / 不属于当前 mission 的视图。
+		for (const [id] of this.views) {
+			const at = this.terminalAt.get(id);
+			if (at !== undefined && now - at > TERMINAL_KEEP_MS) {
+				this.views.delete(id);
+				this.terminalAt.delete(id);
+				this.startedAt.delete(id);
+			}
+		}
+		this.render([...this.views.values()]);
+	}
+
+	private render(views: JobView[]): void {
+		this.tickCount += 1;
+		if (views.length === 0) {
+			if (this.lastRendered !== "") {
+				this.lastRendered = "";
+				this.deps.setWidget(undefined);
+			}
+			return;
+		}
+		const frame = SPINNER[this.tickCount % SPINNER.length];
+		const now = Date.now();
+		const lines: string[] = ["● Jobs"];
+		for (const view of views) {
+			const id = view.order.work_order_id;
+			const status = view.order.status;
+			const terminal = ["ACCEPTED", "FAILED", "EXPIRED", "CANCELLED"].includes(status);
+			const elapsed = fmtElapsed(now - (this.startedAt.get(id) ?? now));
+			const goal = (view.order.goal ?? "").slice(0, 32);
+			const icon = terminal ? (status === "ACCEPTED" ? "✓" : "✗") : frame;
+			const stallMark = view.stall && !terminal ? " · 静默>90s（仍存活）" : "";
+			lines.push(
+				`${icon} ${workerLabel(view.order.assigned_to)} · ${goal} · ${elapsed}${stallMark}`,
+			);
+			const detail = terminal
+				? `${status}${view.turns ? ` · ${view.turns} turns` : ""}`
+				: `${view.lastTool || view.lastPhase}${view.toolCount ? ` · ${view.toolCount} tools` : ""} · ${fmtTokens(view.inputTokens + view.outputTokens)} tok`;
+			lines.push(`   ⎿ ${detail}   [${id.slice(0, 12)}… /job ${id} 查看]`);
+		}
+		const rendered = lines.join("\n");
+		if (rendered !== this.lastRendered) {
+			this.lastRendered = rendered;
+			this.deps.setWidget(lines);
+		}
+	}
+}
+
+/** /job log 渲染（与 widget 同一事件源）。 */
+export function renderJobLog(events: WorkerEvent[], workOrderId: string): string {
+	if (events.length === 0) return `(${workOrderId} 暂无事件)`;
+	const lines: string[] = [];
+	for (const event of events) {
+		switch (event.kind) {
+			case "liveness":
+				continue; // 默认不刷屏——liveness 只供 widget
+			case "tool_started":
+				lines.push(`#${event.seq} ▶ tool ${event.tool}`);
+				break;
+			case "tool_finished":
+				lines.push(`#${event.seq} ✓ tool ${event.tool}${event.is_error ? " (error)" : ""}`);
+				break;
+			case "model_started":
+				lines.push(`#${event.seq} ◌ model turn`);
+				break;
+			case "usage":
+				lines.push(
+					`#${event.seq}   tokens ${fmtTokens(event.input_tokens ?? 0)}↑ ${fmtTokens(event.output_tokens ?? 0)}↓`,
+				);
+				break;
+			case "stall_warning":
+				lines.push(`#${event.seq} ⚠ 语义静默（进程仍存活）`);
+				break;
+			case "attempt_finished":
+				lines.push(`#${event.seq} ■ finished`);
+				break;
+			case "attempt_failed":
+				lines.push(`#${event.seq} ■ failed`);
+				break;
+			default:
+				lines.push(`#${event.seq} ${event.kind}`);
+		}
+	}
+	return lines.join("\n") || "(无可见事件——仅 liveness)";
+}

--- a/packages/rosclaw-agent/src/workers/pi-worker-main.ts
+++ b/packages/rosclaw-agent/src/workers/pi-worker-main.ts
@@ -12,7 +12,7 @@
  * PATH 上的 pi、不加载项目资源。
  */
 
-import { readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { writeSync } from "node:fs";
 
 import { buildSystemPrompt, profileFor } from "./profiles.js";
@@ -54,6 +54,21 @@ function emit(workOrderId: string, attemptId: string, kind: string, payload: Rec
 	});
 	// 直接写 fd 1——console.log 可能被上游库劫持/缓冲。
 	writeSync(1, `${line}\n`);
+}
+
+/** 十一审 PR-B：独立 transcript（会话级证据，不落主对话）。 */
+function makeTranscriptWriter(envelope: WorkerEnvelope) {
+	const dir = envelope.artifacts_dir
+		? `${envelope.artifacts_dir}/..`
+		: `${envelope.cwd}/.rosclaw-work`;
+	const path = `${dir}/transcript.jsonl`;
+	return (record: Record<string, unknown>) => {
+		try {
+			appendFileSync(path, `${JSON.stringify({ ts: new Date().toISOString(), ...record })}\n`, "utf-8");
+		} catch {
+			// transcript 失败不阻塞工作
+		}
+	};
 }
 
 function finalTextOf(messages: Array<Record<string, unknown>>): string {
@@ -203,6 +218,7 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			}
 		}, 2000);
 		providerTimer.unref();
+		const transcript = makeTranscriptWriter(envelope);
 		const unsubscribe = session.subscribe((event) => {
 			const e = event as unknown as {
 				type: string;
@@ -226,8 +242,17 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 					tool: e.toolName ?? "?",
 					is_error: e.isError === true,
 				});
+				transcript({ role: "tool", tool: e.toolName ?? "?", is_error: e.isError === true });
 			} else if (event.type === "message_end" && e.message) {
 				messages.push(e.message as Record<string, unknown>);
+				{
+					const parts = ((e.message as { content?: unknown }).content ?? []) as Array<{ type?: string; text?: string }>;
+					const text = parts.filter((b) => b.type === "text").map((b) => b.text ?? "").join("");
+					transcript({
+						role: e.message.role,
+						text: text.length > 4000 ? `${text.slice(0, 4000)}…[truncated]` : text,
+					});
+				}
 				if (e.message.role === "assistant") {
 					usage.turns += 1;
 					const u = e.message.usage ?? {};

--- a/packages/rosclaw-agent/src/workers/pi-worker-main.ts
+++ b/packages/rosclaw-agent/src/workers/pi-worker-main.ts
@@ -15,7 +15,7 @@
 import { readFileSync } from "node:fs";
 import { writeSync } from "node:fs";
 
-import { profileFor } from "./profiles.js";
+import { buildSystemPrompt, profileFor } from "./profiles.js";
 import { createSharedModelRuntime } from "../runtime/model-runtime.js";
 
 export interface WorkerEnvelope {
@@ -29,6 +29,8 @@ export interface WorkerEnvelope {
 	model?: { provider: string; model: string; thinking?: string };
 	/** W3：工件目录（bash log、patch、渲染产物）。 */
 	artifacts_dir?: string;
+	/** 十一审 PR-A：期望工件（DoD 注入——不再是永远的 plain text report）。 */
+	expected_artifacts?: string[];
 }
 
 interface Usage {
@@ -124,8 +126,13 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 				noPromptTemplates: true,
 				noThemes: true,
 				noContextFiles: true,
-				// profile 系统提示（W1 起定义但此前未注入——W3 修复）。
-				systemPrompt: profile.systemPrompt,
+				// 十一审 PR-A：manifest 化系统提示（prompt 与真实工具面
+				// 逐字一致；DoD 按 expected artifacts 动态注入）。
+				systemPrompt: buildSystemPrompt(
+					profile,
+					envelope.cwd,
+					envelope.expected_artifacts ?? [],
+				),
 			},
 		});
 		// 十审 W3：全部 profile 使用 Workbench 约束工具（custom 同名覆盖
@@ -146,10 +153,56 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			...(model ? { model } : {}),
 		});
 
+		// 十一审 PR-A：tool-contract 自检——session 实际工具必须与
+		// profile 声明完全一致，否则不启动（诚实 TOOL_CONTRACT_MISMATCH，
+		// 不让模型在错误工具面下工作）。
+		{
+			const active = new Set(session.getActiveToolNames());
+			const missing = profile.tools.filter((name) => !active.has(name));
+			if (missing.length > 0) {
+				emit(wo, att, "attempt_failed", {
+					error_code: "TOOL_CONTRACT_MISMATCH",
+					message: `profile 声明的工具未在 session 生效: ${missing.join(", ")}`,
+				});
+				return 1;
+			}
+			emit(wo, att, "tool_contract_ok", { tools: [...active].sort() });
+		}
+
 		const usage: Usage = { input: 0, output: 0, cost: 0, turns: 0 };
 		const messages: Array<Record<string, unknown>> = [];
 		let stopReason = "";
 		let errorMessage = "";
+		// 十一审 PR-A：liveness/activity/semantic progress 三层分离。
+		// liveness 每 2s 一条（只证明进程活着，不进模型上下文、不冒充
+		// 进度）；semantic seq 只由真实事件推进。
+		let phase = "STARTING";
+		let spanStartedAt = Date.now();
+		let semanticSeq = 0;
+		let providerTimedOut = false;
+		const semantic = (kind: string, payload: Record<string, unknown>) => {
+			semanticSeq += 1;
+			emit(wo, att, kind, payload);
+		};
+		const livenessTimer = setInterval(() => {
+			emit(wo, att, "liveness", {
+				phase,
+				span_age_ms: Date.now() - spanStartedAt,
+				pid_alive: true,
+				last_semantic_seq: semanticSeq,
+			});
+		}, 2000);
+		livenessTimer.unref();
+		// provider request timeout：单个模型 turn 超过阈值（默认 10 分钟）
+		// 才视为 provider 失败——高 thinking 长推理不再被 60s 误杀。
+		const providerTimeoutMs = Number(process.env.ROSCLAW_WORKER_TURN_TIMEOUT_MS ?? 600_000);
+		const providerTimer = setInterval(() => {
+			if (phase === "RUNNING_MODEL" && Date.now() - spanStartedAt > providerTimeoutMs) {
+				providerTimedOut = true;
+				void session.abort().catch(() => undefined);
+			}
+		}, 2000);
+		providerTimer.unref();
 		const unsubscribe = session.subscribe((event) => {
 			const e = event as unknown as {
 				type: string;
@@ -159,11 +212,17 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 				isError?: boolean;
 			};
 			if (event.type === "turn_start") {
-				emit(wo, att, "model_started", { turn: usage.turns + 1 });
+				phase = "RUNNING_MODEL";
+				spanStartedAt = Date.now();
+				semantic("model_started", { turn: usage.turns + 1 });
 			} else if (event.type === "tool_execution_start") {
-				emit(wo, att, "tool_started", { tool: e.toolName ?? "?" });
+				phase = "RUNNING_TOOL";
+				spanStartedAt = Date.now();
+				semantic("tool_started", { tool: e.toolName ?? "?" });
 			} else if (event.type === "tool_execution_end") {
-				emit(wo, att, "tool_finished", {
+				phase = "RUNNING_MODEL";
+				spanStartedAt = Date.now();
+				semantic("tool_finished", {
 					tool: e.toolName ?? "?",
 					is_error: e.isError === true,
 				});
@@ -237,7 +296,17 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			"with your tools, with concrete paths/line numbers where relevant).";
 		await session.prompt(task);
 		unsubscribe();
+		clearInterval(livenessTimer);
+		clearInterval(providerTimer);
 
+		if (providerTimedOut) {
+			emit(wo, att, "attempt_failed", {
+				error_code: "PROVIDER_TIMEOUT",
+				message: `单个模型请求超过 ${Math.round(providerTimeoutMs / 1000)}s`,
+				usage,
+			});
+			return 1;
+		}
 		if (stopReason === "aborted") {
 			emit(wo, att, "attempt_cancelled", { usage });
 			return 130;

--- a/packages/rosclaw-agent/src/workers/profiles.ts
+++ b/packages/rosclaw-agent/src/workers/profiles.ts
@@ -1,21 +1,21 @@
-/** WorkerProfileV1（十审 W1，审计 §6）：通用能力而非任务特化。
+/** WorkerProfileV1（十审 W1，十一审 PR-A 重写 prompt/tool 契约）。
  *
- * Profile 决定工具 allowlist 与系统提示，不决定 provider——默认使用
- * Native Agent 当前模型（ModelExecutionSnapshot 经 WorkOrder 下发，
- * 无 secret）。
+ * 十一审 §2.2：prompt 与工具面必须完全一致——
+ * - 不再有公共"read-only tools"谎言（developer/sim-builder 有写工具）；
+ * - 每个 profile 生成 capability manifest（tools/workspace/write policy/
+ *   network/physical/required evidence）；
+ * - developer 的 Definition of Done 由 envelope 的 expected artifacts
+ *   动态注入（不是永远"plain text report"）。
  *
- * P0 安全边界：
- * - 只读工具集（read/grep/find/ls）——无 write/edit/bash（W3 Workbench
- *   落地前任何内置 Worker 都没有写能力）；
+ * P0 安全边界不变：
  * - 无 ROSClaw custom tools——Worker 永远接触不到 rosclaw_request_action
  *   /rosclaw_delegate/物理面；
- * - 无项目资源（noExtensions/noSkills/noContextFiles——不读 .pi、
- *   AGENTS.md、skills）。
+ * - 无项目资源（noExtensions/noSkills/noContextFiles）。
  */
 
 export interface WorkerProfileV1 {
 	name: string;
-	/** Pi 工具 allowlist（custom 同名工具覆盖内建——见 workbench.ts）。 */
+	/** 工具 allowlist（custom 同名覆盖内建——见 workbench.ts）。 */
 	tools: string[];
 	/** true = Developer Workbench（约束 write/edit/bash + workspace 隔离）。 */
 	workbench: boolean;
@@ -27,8 +27,6 @@ const _COMMON_RULES = `You are a ROSClaw built-in worker: a bounded contractor, 
 
 RULES
 - Complete ONLY the stated WorkOrder goal within its inputs and instructions.
-- You have read-only tools. Never claim to have created, modified, or run
-  anything you did not actually do with an available tool.
 - Never claim access to tools, files, secrets, hardware, or permissions you
   were not explicitly given.
 - Distinguish facts you verified with tools from inference; label inference.
@@ -37,6 +35,45 @@ RULES
   exactly what capability is missing.
 - Answer concisely in the requester's language.
 `;
+
+/** 十一审 §2.2：capability manifest——prompt 与真实工具面逐字一致。 */
+export function capabilityManifest(
+	profile: WorkerProfileV1,
+	workspace: string,
+	expectedArtifacts: string[],
+): string {
+	const evidence =
+		profile.name === "developer" || profile.name === "sim-builder"
+			? (expectedArtifacts.length
+					? expectedArtifacts.join(", ")
+					: "patch.diff + bash test log")
+				: "final report";
+	const dod =
+		profile.name === "developer" || profile.name === "sim-builder"
+			? `
+Definition of done: real file changes in the workspace (patch.diff is
+generated from them), the exact test/check commands you ran with their exit
+codes (in bash-log.txt), and the requested artifacts. A design document or
+proposal alone is NOT completion.`
+			: "";
+	return `
+CAPABILITY MANIFEST (ground truth — your prompt matches your actual tools)
+Available tools: ${profile.tools.join(", ")}.
+Workspace: ${workspace}
+Write policy: ${profile.workbench ? "workspace-only (paths outside are hard-denied)" : "none (read-only profile)"}.
+Network: denied (no curl/wget/ssh; bash is argv-allowlisted).
+Physical tools: none (you can never actuate hardware).
+Required evidence: ${evidence}.${dod}
+`;
+}
+
+export function buildSystemPrompt(
+	profile: WorkerProfileV1,
+	workspace: string,
+	expectedArtifacts: string[],
+): string {
+	return profile.systemPrompt + capabilityManifest(profile, workspace, expectedArtifacts);
+}
 
 export const WORKER_PROFILES: Record<string, WorkerProfileV1> = {
 	scout: {
@@ -69,11 +106,8 @@ inputs are insufficient, say what is missing instead of guessing.
 ROLE: developer — implement and verify changes INSIDE the assigned
 workspace only.
 
-- All file tools and bash are confined to the workspace root; paths outside
-  it are hard-denied. Do not attempt to read credentials, devices, or the
-  host system.
-- bash is argv-allowlisted (no network, no privilege escalation). Tests and
-  builds must be run with the allowlisted commands.
+- You HAVE write/edit/bash tools (workspace-confined). Use them: implement
+  real changes and run real tests; do not stop at proposals.
 - Definition of done: your changes exist as real files in the workspace AND
   you ran the relevant tests/checks with bash. Never claim "implemented" or
   "tests pass" without actually running them.

--- a/packages/rosclaw-agent/test/job-widget.test.ts
+++ b/packages/rosclaw-agent/test/job-widget.test.ts
@@ -1,0 +1,126 @@
+/** 十一审 PR-C 红测试：TUI 实时 Job 卡。
+ *
+ * 1. RUNNING job 渲染 phase/工具/耗时/token（来自事件流，不是伪造进度）；
+ * 2. liveness 驱动刷新（phase 更新）；stall_warning 标记；
+ * 3. 终态 ✓/✗ 渲染；
+ * 4. 内容不变不重绘（idle CPU 红线）；
+ * 5. renderJobLog 过滤 liveness、渲染工具事件。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function makeWidget(
+	orders: Array<Record<string, unknown>>,
+	eventsByOrder: Record<string, Array<Record<string, unknown>>>,
+) {
+	const { ActiveSessionContext } = await import("../src/session/active-context.js");
+	const { JobsWidget } = await import("../src/workers/job-widget.js");
+	const active = new ActiveSessionContext({
+		sessionId: "pi_test",
+		missionId: "mis_1",
+		contextRevision: 1,
+		mode: "SIMULATION",
+		profile: "developer",
+		contextState: "FRESH",
+		leaseState: "ACTIVE",
+		actionsAllowed: true,
+	});
+	const widgetCalls: Array<string[] | undefined> = [];
+	const widget = new JobsWidget({
+		active: active as never,
+		center: {
+			call: async (method: string, params?: unknown) => {
+				if (method === "pi.worker.status") return { ok: true, orders };
+				if (method === "pi.worker.events") {
+					const p = params as { work_order_id: string; after_seq?: number };
+					const all = eventsByOrder[p.work_order_id] ?? [];
+					const after = p.after_seq ?? 0;
+					return { ok: true, events: all.filter((e) => (e.seq as number) > after) };
+				}
+				return { ok: true };
+			},
+		} as never,
+		setWidget: (lines) => widgetCalls.push(lines),
+	});
+	return { widget, widgetCalls };
+}
+
+test("RUNNING job 卡渲染工具/耗时/token", async () => {
+	const { widget, widgetCalls } = await makeWidget(
+		[
+			{
+				work_order_id: "wo_abc123456789",
+				assigned_to: "worker:rosclaw:pi",
+				status: "RUNNING",
+				goal: "实现 MuJoCo rollout",
+			},
+		],
+		{
+			wo_abc123456789: [
+				{ seq: 1, kind: "attempt_started" },
+				{ seq: 2, kind: "model_started" },
+				{ seq: 3, kind: "tool_started", tool: "bash" },
+				{ seq: 4, kind: "liveness", phase: "RUNNING_TOOL" },
+				{ seq: 5, kind: "usage", input_tokens: 38400, output_tokens: 2100, turns: 3 },
+			],
+		},
+	);
+	await widget.tick();
+	const lines = widgetCalls.at(-1);
+	assert.ok(lines, "widget 未渲染");
+	const text = lines!.join("\n");
+	assert.match(text, /Pi Worker/);
+	assert.match(text, /实现 MuJoCo rollout/);
+	assert.match(text, /bash/);
+	assert.match(text, /41k tok/);
+	assert.match(text, /\/job wo_abc123456789/);
+});
+
+test("stall_warning 标黄 + 终态 ✓ 渲染", async () => {
+	const { widget, widgetCalls } = await makeWidget(
+		[
+			{ work_order_id: "wo_stall000001", assigned_to: "worker:rosclaw:pi", status: "RUNNING", goal: "长推理" },
+			{ work_order_id: "wo_done0000001", assigned_to: "worker:rosclaw:pi", status: "ACCEPTED", goal: "已完成任务" },
+		],
+		{
+			wo_stall000001: [{ seq: 1, kind: "stall_warning" }],
+			wo_done0000001: [{ seq: 1, kind: "attempt_finished" }],
+		},
+	);
+	await widget.tick();
+	const text = widgetCalls.at(-1)!.join("\n");
+	assert.match(text, /静默>90s（仍存活）/);
+	assert.match(text, /✓ Pi Worker · 已完成任务/);
+});
+
+test("内容不变不重绘（idle CPU 红线）", async () => {
+	const { widget, widgetCalls } = await makeWidget(
+		[{ work_order_id: "wo_idle0000001", assigned_to: "worker:rosclaw:pi", status: "RUNNING", goal: "x" }],
+		{ wo_idle0000001: [] },
+	);
+	await widget.tick();
+	const first = widgetCalls.length;
+	await widget.tick();
+	// spinner 帧变化会改首行 icon——只有 spinner 行的变化允许重绘。
+	const second = widgetCalls.length;
+	assert.ok(second - first <= 1, `无谓重绘: ${first} → ${second}`);
+});
+
+test("renderJobLog 过滤 liveness、渲染工具与完成", async () => {
+	const { renderJobLog } = await import("../src/workers/job-widget.js");
+	const text = renderJobLog(
+		[
+			{ seq: 1, kind: "attempt_started" },
+			{ seq: 2, kind: "liveness", phase: "RUNNING_MODEL" },
+			{ seq: 3, kind: "tool_started", tool: "write" },
+			{ seq: 4, kind: "tool_finished", tool: "write", is_error: false },
+			{ seq: 5, kind: "attempt_finished" },
+		] as never,
+		"wo_x",
+	);
+	assert.ok(!text.includes("liveness"));
+	assert.match(text, /▶ tool write/);
+	assert.match(text, /✓ tool write/);
+	assert.match(text, /■ finished/);
+});

--- a/packages/rosclaw-agent/test/workspace.test.ts
+++ b/packages/rosclaw-agent/test/workspace.test.ts
@@ -1,0 +1,128 @@
+/** 十一审 PR-D 红测试：Workspace 一等状态。
+ *
+ * 1. gitRootOf：repo 内子目录归一到 root；非 git 返回 null；
+ * 2. WorkspaceStore：bind/recent/persist/reload；
+ * 3. resolveStartupWorkspace：显式 > cwd git 自动 > 既有绑定；
+ * 4. delegate 未指定 workspace 时默认注入绑定值；
+ * 5. header 显示 Project 名（无绑定显示 —）。
+ */
+
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+async function makeStore() {
+	const { WorkspaceStore } = await import("../src/session/workspace.js");
+	const home = mkdtempSync(join(tmpdir(), "rh-ws-"));
+	return new WorkspaceStore(home);
+}
+
+function makeRepo(): string {
+	const repo = mkdtempSync(join(tmpdir(), "repo-"));
+	mkdirSync(join(repo, ".git"));
+	mkdirSync(join(repo, "src/deep"), { recursive: true });
+	writeFileSync(join(repo, "README.md"), "x");
+	return repo;
+}
+
+test("gitRootOf 归一 + bind/recent/持久化", async () => {
+	const repo = makeRepo();
+	const { gitRootOf } = await import("../src/session/workspace.js");
+	assert.equal(gitRootOf(join(repo, "src/deep")), repo);
+	assert.equal(gitRootOf("/tmp"), null);
+	const store = await makeStore();
+	const bound = store.bind(join(repo, "src"));
+	assert.equal(bound, repo); // git 归一
+	assert.equal(store.current, repo);
+	assert.deepEqual(store.recent, [repo]);
+	// reload 持久化
+	const { WorkspaceStore } = await import("../src/session/workspace.js");
+	const home = mkdtempSync(join(tmpdir(), "rh-ws-"));
+	const s1 = new WorkspaceStore(home);
+	s1.bind(repo);
+	const s2 = new WorkspaceStore(home);
+	assert.equal(s2.current, repo);
+});
+
+test("resolveStartupWorkspace：显式 > cwd git 自动 > 既有", async () => {
+	const repo = makeRepo();
+	const { resolveStartupWorkspace } = await import("../src/session/workspace.js");
+	const store = await makeStore();
+	// 显式
+	const explicit = resolveStartupWorkspace(store, repo, "/tmp");
+	assert.equal(explicit.bound, repo);
+	assert.equal(explicit.auto, false);
+	// cwd git 自动
+	const store2 = await makeStore();
+	const auto = resolveStartupWorkspace(store2, undefined, join(repo, "src/deep"));
+	assert.equal(auto.bound, repo);
+	assert.equal(auto.auto, true);
+	// 无 git cwd → 用既有绑定
+	const plain = mkdtempSync(join(tmpdir(), "plain-"));
+	const store3 = await makeStore();
+	store3.bind(repo);
+	const keep = resolveStartupWorkspace(store3, undefined, plain);
+	assert.equal(keep.bound, repo);
+	assert.equal(keep.auto, false);
+	// 无 git 无绑定 → null
+	const store4 = await makeStore();
+	const none = resolveStartupWorkspace(store4, undefined, plain);
+	assert.equal(none.bound, null);
+});
+
+test("delegate 默认注入绑定 workspace", async () => {
+	const { ActiveSessionContext } = await import("../src/session/active-context.js");
+	const { buildDelegateTool } = await import("../src/tools/delegate.js");
+	const calls: Array<Record<string, unknown>> = [];
+	const active = new ActiveSessionContext({
+		sessionId: "pi_test",
+		missionId: "mis_1",
+		contextRevision: 1,
+		mode: "SIMULATION",
+		profile: "developer",
+		contextState: "FRESH",
+		leaseState: "ACTIVE",
+		actionsAllowed: true,
+	});
+	const center = {
+		call: async (_method: string, params?: unknown) => {
+			calls.push((params as { request?: { arguments?: Record<string, unknown> } })?.request?.arguments ?? {});
+			return { ok: true, result: { ok: true, status: "STARTED", summary: "WorkOrder: wo_x" } };
+		},
+	};
+	const tool = buildDelegateTool({
+		rosclawHome: "/tmp/rh",
+		active,
+		center,
+		workspace: () => "/home/user/myrepo",
+	} as never);
+	await tool.execute("t1", { goal: "改代码" }, undefined, undefined, {} as never);
+	assert.equal(calls[0].workspace, "/home/user/myrepo");
+	// 模型显式指定时不覆盖。
+	await tool.execute("t2", { goal: "x", workspace: "/other" }, undefined, undefined, {} as never);
+	assert.equal(calls[1].workspace, "/other");
+});
+
+test("header 显示 Project 名（无绑定显示 —）", async () => {
+	const { renderHeader } = await import("../src/ui/product-state.js");
+	const base = {
+		snapshot_seq: 1,
+		product_version: "1.2.0",
+		kernel: "READY",
+		model: "K3",
+		mode: "SIMULATION",
+		context_state: "FRESH",
+		context_revision: 1,
+		lease_state: "ACTIVE",
+		operator: "OFFLINE",
+		action_readiness: { state: "READY", reason_codes: [], snapshot_seq: 1 },
+		mission_id: "mis_1",
+	};
+	const withWs = renderHeader({ ...base, workspace: "rosclaw" } as never, "zh-CN");
+	assert.match(withWs, /Project rosclaw/);
+	const without = renderHeader(base as never, "zh-CN");
+	assert.match(without, /Project —/);
+});

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -571,6 +571,11 @@ def _chat_pi(home: Path, args: argparse.Namespace) -> int:
     argv = [node, entry, "--profile", profile, *resume_argv]
     if mission is not None:
         argv += ["--mission", mission.mission_id]
+    # 十一审 PR-D：chat [PATH]/--workspace → 显式传给 Native Agent
+    # （git root 归一与自动绑定在 TS 侧）。
+    ws_arg = getattr(args, "workspace", None) or getattr(args, "path", None)
+    if ws_arg:
+        argv += ["--workspace", str(Path(ws_arg).expanduser().resolve())]
     # P0-NA-16：产品版本由 Python launcher 显式传给 Node——TS 侧不得
     # 用内部 npm 子包版本冒充 ROSClaw 产品版本。
     from rosclaw import __version__ as _product_version
@@ -1086,6 +1091,10 @@ def add_agent_subparsers(subparsers) -> None:
     p_lp.set_defaults(func=cmd_learning_promote)
 
     p_chat = subparsers.add_parser("chat", help="chat with the Native Agent")
+    # 十一审 PR-D：rosclaw chat [PATH]——Project workspace 一等状态。
+    p_chat.add_argument("path", nargs="?", default=None,
+                        help="项目目录（git 仓库自动绑定为 workspace）")
+    p_chat.add_argument("--workspace", default=None, help="显式指定 workspace 路径")
     p_chat.add_argument("--mission", default=None)
     p_chat.add_argument("--mode", default=None, choices=["SIMULATION", "SHADOW", "REAL"])
     p_chat.add_argument("--goal", default=None)

--- a/src/rosclaw/agentd/context/prompts/native_agent_v2.md
+++ b/src/rosclaw/agentd/context/prompts/native_agent_v2.md
@@ -40,6 +40,9 @@ WORKERS
 - Workers are bounded contractors, not authorities. Delegate a minimal WorkOrder with explicit inputs, outputs, deadline, budget, and verification.
 - Do not share hidden credentials, daemon permits, irrelevant memory, or more body data than the WorkOrder requires.
 - Treat worker output as a proposal or artifact until its schema, provenance, and task-specific verifier pass.
+- Delegation policy (十一审 PR-A/§4.3): do small, context-heavy, quick jobs yourself (status questions, one-off observations, tiny edits you can verify). Delegate long-running, parallelizable, or context-polluting work (multi-file development, long tests/builds, big log sweeps, rendering). Choose the profile that actually matches: scout (read-only investigation), analyst (read-only synthesis), developer (code changes + tests), sim-builder (sim/render artifacts).
+- NEVER fall back to an incompatible worker: if `worker:rosclaw:pi` fails with an infrastructure error (timeout/liveness/provider), do NOT reassign the same capability to `worker:native:basic` or any worker that does not declare it. Report the infra failure honestly, keep the worktree/artifacts for retry, and retry the SAME worker at most once; if it fails again, stop and tell the user the runtime issue.
+- Worker failures are data: quote the exact error_code (e.g. PROVIDER_TIMEOUT, liveness lost) instead of saying "worker lacks the ability" unless the scheduler explicitly reported the capability undeclared.
 
 TRUTH, MEMORY, AND LEARNING
 - Separate observation, verified receipt, curated knowledge, model inference, and hypothesis.

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -961,6 +961,32 @@ class PiBridgeServer:
                 stored += 1
             service._store.connection.commit()
             return {"ok": True, "stored": stored}
+        if method == "pi.worker.events":
+            # 十一审 PR-B：WorkerEventStore tail（轮询即 subscribe——
+            # 文件权威，重启/compact 后仍可读；不进模型、不耗 token）。
+            from rosclaw.agentd.workers.event_store import WorkerEventStore
+
+            work_order_id = str(params.get("work_order_id", ""))
+            order = service._worker_manager.order(work_order_id)
+            if order is None:
+                return {
+                    "ok": False,
+                    "error": "unknown work order",
+                    "code": "WORK_ORDER_NOT_FOUND",
+                }
+            store = WorkerEventStore(service._home)
+            after_seq = int(params.get("after_seq", 0) or 0)
+            limit = min(int(params.get("limit", 100) or 100), 500)
+            events = store.tail(work_order_id, after_seq=after_seq, limit=limit)
+            return {
+                "ok": True,
+                "events": events,
+                "last_seq": events[-1]["seq"] if events else after_seq,
+                "status": order.status,
+                "stderr_tail": store.tail_stderr(work_order_id)
+                if params.get("include_stderr")
+                else "",
+            }
         if method == "pi.worker.status":
             # PNA-4：Worker 状态投影（原位更新 UI 用；只读）。
             # 十审 W2：终态单附验证后摘要/验收结论（completion push 用——

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -324,7 +324,9 @@ class AgentService:
                 "native_inproc": NativeWorkerAdapter(self._gateway),
                 "external_cli": external_adapter,
                 # 十审 W1：内置 Pi headless Worker（与主 Agent 同一模型配置）。
-                "pi_managed": PiManagedAdapter(rosclaw_home=rosclaw_home),
+                "pi_managed": PiManagedAdapter(
+                    rosclaw_home=rosclaw_home, conn=self._store.connection
+                ),
             },
             actor_id=self.actor_id,
             event_recorder=self._record_worker_event,

--- a/src/rosclaw/agentd/workers/event_store.py
+++ b/src/rosclaw/agentd/workers/event_store.py
@@ -1,0 +1,144 @@
+"""WorkerEventStore（十一审 PR-B，总纲 §P0-3）。
+
+每个 attempt 的持久化事件账本（append-only，文件即权威）：
+
+    ~/.rosclaw/work/<work_order_id>/
+      order.json        # envelope（W1 起）
+      state.json        # 当前状态（status/phase/last_seq/updated_at）
+      events.jsonl      # 全部 WorkerEvent（含 liveness/stall_warning）
+      stderr.log        # 子进程 stderr（secret 脱敏后落盘）
+      artifacts/        # patch/bash-log/媒体（W3 起）
+
+- 事件带 work_order_id/attempt_id/seq/kind/ts；
+- stdout/stderr 先过 secret redaction 再持久化；
+- 大文本不进事件（工件化 + preview）；
+- agentd DB 只索引状态——重启/compact 后 tail 仍可读（文件权威）。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_SECRET_PATTERNS = [
+    (re.compile(r"sk-[A-Za-z0-9]{12,}"), "sk-***REDACTED***"),
+    (
+        re.compile(r"(?i)(api[_-]?key|secret|password|token)(\s*[:=]\s*)['\"]?[\w\-]{8,}"),
+        r"\1\2***REDACTED***",
+    ),
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----[^-]*-----END [A-Z ]*PRIVATE KEY-----"), "***REDACTED-KEY***"),
+]
+
+
+def redact(text: str) -> str:
+    for pattern, repl in _SECRET_PATTERNS:
+        text = pattern.sub(repl, text)
+    return text
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class WorkerEventStore:
+    """文件权威的事件账本（agentd 重启后可继续读/写）。"""
+
+    def __init__(self, home: Path) -> None:
+        self._root = Path(home) / "work"
+
+    def _dir(self, work_order_id: str) -> Path:
+        # 防路径穿越：wo_ 前缀 + hex。
+        if not re.fullmatch(r"wo_[A-Za-z0-9]{8,32}", work_order_id):
+            raise ValueError(f"invalid work_order_id {work_order_id!r}")
+        return self._root / work_order_id
+
+    def dir_of(self, work_order_id: str) -> Path:
+        return self._dir(work_order_id)
+
+    # ------------------------------------------------------------------
+    def append_event(
+        self,
+        work_order_id: str,
+        attempt_id: str,
+        kind: str,
+        payload: dict[str, Any],
+    ) -> int:
+        """追加事件（seq 由文件行数推导——重启后续写不重置）。"""
+        d = self._dir(work_order_id)
+        d.mkdir(parents=True, exist_ok=True)
+        events_path = d / "events.jsonl"
+        existing = 0
+        if events_path.exists():
+            with events_path.open("rb") as fh:
+                existing = sum(1 for _ in fh)
+        record = {
+            "work_order_id": work_order_id,
+            "attempt_id": attempt_id,
+            "seq": existing + 1,
+            "kind": kind,
+            "ts": _utcnow(),
+            **{k: v for k, v in payload.items() if k not in ("work_order_id", "attempt_id", "seq", "ts")},
+        }
+        # 大文本工件化：超过 2KiB 的字符串字段只留 preview。
+        for key, value in list(record.items()):
+            if isinstance(value, str) and len(value) > 2048:
+                record[key] = value[:2048] + f"…[+{len(value) - 2048} chars truncated]"
+            elif isinstance(value, str):
+                record[key] = redact(value)
+        with events_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return int(record["seq"])
+
+    def append_stderr(self, work_order_id: str, chunk: str) -> None:
+        d = self._dir(work_order_id)
+        d.mkdir(parents=True, exist_ok=True)
+        with (d / "stderr.log").open("a", encoding="utf-8") as fh:
+            fh.write(redact(chunk))
+
+    def write_state(self, work_order_id: str, state: dict[str, Any]) -> None:
+        d = self._dir(work_order_id)
+        d.mkdir(parents=True, exist_ok=True)
+        state = {**state, "updated_at": _utcnow()}
+        tmp = d / "state.json.tmp"
+        tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(d / "state.json")
+
+    def read_state(self, work_order_id: str) -> dict[str, Any] | None:
+        path = self._dir(work_order_id) / "state.json"
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None
+
+    # ------------------------------------------------------------------
+    def tail(
+        self, work_order_id: str, *, after_seq: int = 0, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """读取 seq > after_seq 的事件（TUI/CLI 轮询即 subscribe）。"""
+        path = self._dir(work_order_id) / "events.jsonl"
+        if not path.exists():
+            return []
+        events: list[dict[str, Any]] = []
+        with path.open(encoding="utf-8") as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if int(event.get("seq", 0)) > after_seq:
+                    events.append(event)
+        return events[-limit:]
+
+    def tail_stderr(self, work_order_id: str, *, max_bytes: int = 4096) -> str:
+        path = self._dir(work_order_id) / "stderr.log"
+        if not path.exists():
+            return ""
+        data = path.read_bytes()
+        return data[-max_bytes:].decode("utf-8", errors="replace")

--- a/src/rosclaw/agentd/workers/external.py
+++ b/src/rosclaw/agentd/workers/external.py
@@ -39,8 +39,10 @@ from rosclaw.contracts.worker.order import (
 )
 
 #: 十审 §7.4/§10.3：startup/idle 超时（wall 由 order budget 兜底）。
+#: 十一审 PR-A：外部 CLI 没有 liveness 通道——idle 只兜"真挂死"，
+#: 必须与 provider 级长推理兼容（10min），真正的边界是 wall budget。
 STARTUP_TIMEOUT_SEC = 15.0
-IDLE_TIMEOUT_SEC = 60.0
+IDLE_TIMEOUT_SEC = 600.0
 
 
 def _parse_stream_line(pack: WorkerPackManifest, line: bytes) -> tuple[str, str, dict]:

--- a/src/rosclaw/agentd/workers/manager.py
+++ b/src/rosclaw/agentd/workers/manager.py
@@ -211,7 +211,9 @@ class WorkerManager:
         self._runs[order.work_order_id] = (adapter, handle)
         try:
             deadline = datetime.now(UTC) + timedelta(
-                seconds=timeout_sec or order.budgets.wall_time_sec
+                # 十一审 PR-A：adapter 的 wall wrap-up（steer + 60s grace）
+                # 优先；manager deadline 只兜 adapter 不收敛的底（+90s）。
+                seconds=(timeout_sec or order.budgets.wall_time_sec) + 90
             )
             result: WorkResultV1 | None = None
             while datetime.now(UTC) < deadline:
@@ -250,6 +252,14 @@ class WorkerManager:
                 lease_id=order.lease.lease_id if order.lease else "",
                 status="FAILED",
                 summary="deadline exceeded before submission",
+            )
+            # 十一审 PR-A：deadline 终态直接返回——不得继续走
+            # SUBMITTED/VERIFYING（FAILED→SUBMITTED 是非法迁移；adapter
+            # 层的 wall wrap-up 已先给过 graceful 机会）。
+            return result, VerificationReport(
+                accepted=False,
+                verifier_results={"within_deadline": False},
+                reasons=("deadline exceeded before submission",),
             )
         # Stale-lease guard: a result under an old lease is late, not accepted.
         if order.lease and result.lease_id != order.lease.lease_id:

--- a/src/rosclaw/agentd/workers/pi_managed.py
+++ b/src/rosclaw/agentd/workers/pi_managed.py
@@ -74,6 +74,10 @@ class PiManagedAdapter:
         self._runs: dict[str, tuple[RunHandle, asyncio.Task]] = {}
         # W4：活动子进程（steer 通道 + pid 文件崩溃对账）。
         self._procs: dict[str, asyncio.subprocess.Process] = {}
+        # 十一审 PR-B：持久化事件账本（文件权威，重启/compact 可读）。
+        from rosclaw.agentd.workers.event_store import WorkerEventStore
+
+        self._events = WorkerEventStore(rosclaw_home)
 
     async def probe(self, worker_id: str | None = None) -> WorkerProbeResult:  # noqa: ARG002
         runtime = find_pi_agent_entry()
@@ -375,6 +379,13 @@ class PiManagedAdapter:
                 now = asyncio.get_running_loop().time()
                 state["last_event_at"] = now
                 kind = event.get("kind")
+                # PR-B：边读边落账本（含 liveness——UI 需要实时流）。
+                self._events.append_event(
+                    order.work_order_id,
+                    str(event.get("attempt_id", "")),
+                    str(kind),
+                    {k: v for k, v in event.items() if k not in ("kind", "attempt_id")},
+                )
                 if kind == "liveness":
                     # 只证明活着——phase/span 供 UI，不推进语义进度。
                     state["phase"] = str(event.get("phase", state["phase"]))
@@ -389,9 +400,15 @@ class PiManagedAdapter:
                     failure = event
 
         async def _drain_stderr() -> None:
+            # PR-B：stderr 脱敏落盘（不再丢弃）。
             assert proc.stderr is not None
-            while await proc.stderr.readline():
-                pass
+            while True:
+                line = await proc.stderr.readline()
+                if not line:
+                    return
+                self._events.append_stderr(
+                    order.work_order_id, line.decode("utf-8", errors="replace")
+                )
 
         readers = asyncio.gather(_read_events(), _drain_stderr())
 
@@ -441,13 +458,15 @@ class PiManagedAdapter:
                 semantic_silent = now - state["last_semantic_at"]
                 if semantic_silent > STALL_WARN_SEC and not state["stall_warned"]:
                     state["stall_warned"] = True
-                    # 告警事件入列（UI 标黄；EventStore 在 PR-B 持久化）。
-                    events.append(
-                        {
-                            "kind": "stall_warning",
-                            "phase": state["phase"],
-                            "semantic_silent_sec": int(semantic_silent),
-                        }
+                    # 告警事件入列 + 落账（UI 标黄）。
+                    stall = {
+                        "kind": "stall_warning",
+                        "phase": state["phase"],
+                        "semantic_silent_sec": int(semantic_silent),
+                    }
+                    events.append(stall)
+                    self._events.append_event(
+                        order.work_order_id, "", "stall_warning", dict(stall)
                     )
                 if wall_end is not None and now > wall_end and not state["wrapup_sent"]:
                     state["wrapup_sent"] = True
@@ -491,6 +510,16 @@ class PiManagedAdapter:
         await readers
         self._procs.pop(order.work_order_id, None)
         pid_file.unlink(missing_ok=True)
+        # PR-B：终态落 state.json（重启对账/tail 可读）。
+        self._events.write_state(
+            order.work_order_id,
+            {
+                "status": "FAILED" if failure is not None else "COMPLETED",
+                "phase": "TERMINAL",
+                "last_seq": handle.progress_seq,
+                "error": failure,
+            },
+        )
         finished = datetime.now(UTC)
         if failure is not None:
             raise AdapterError(

--- a/src/rosclaw/agentd/workers/pi_managed.py
+++ b/src/rosclaw/agentd/workers/pi_managed.py
@@ -40,9 +40,15 @@ from rosclaw.contracts.worker.order import (
 
 WORKER_ID = "worker:rosclaw:pi"
 
-#: 十审 §7.4 P0 默认：startup 10s、idle 60s。
-STARTUP_TIMEOUT_SEC = 10.0
-IDLE_TIMEOUT_SEC = 60.0
+#: 十审 §7.4 P0 默认：startup 30s（十一审 PR-A：只管启动握手）。
+#: 十一审 PR-A 三层分离：
+#: - LIVENESS_TIMEOUT：连 liveness 事件都没有才判死（进程真挂死）；
+#: - STALL_WARN：语义静默只告警不杀（高 thinking/长命令合法）；
+#: - wall/token 预算到期先 wrap-up steer，grace 后再终止。
+STARTUP_TIMEOUT_SEC = 30.0
+LIVENESS_TIMEOUT_SEC = 15.0
+STALL_WARN_SEC = 90.0
+WRAPUP_GRACE_SEC = 60.0
 
 #: W3：写能力 profile（Developer Workbench）——workspace 隔离 + diff 工件。
 WORKBENCH_PROFILES = ("developer", "sim-builder")
@@ -273,6 +279,9 @@ class PiManagedAdapter:
             "instructions": str(order.inputs.get("instructions") or order.goal),
             "cwd": cwd,
             "artifacts_dir": str(artifacts_dir),
+            # 十一审 PR-A：DoD 注入——期望工件进 envelope（developer 的
+            # 最终提示据此要求真实 diff/测试日志）。
+            "expected_artifacts": list(order.expected_output.artifacts),
             "budget": {
                 "wall_time_sec": order.budgets.wall_time_sec,
                 "model_tokens": order.budgets.model_tokens,
@@ -339,6 +348,17 @@ class PiManagedAdapter:
         events: list[dict] = []
         final_report = ""
         failure: dict | None = None
+        # 十一审 PR-A：三层分离——liveness（进程活着）≠ activity（模型/
+        # 工具在跑）≠ semantic progress（真实产出）。只有全静默
+        # （连 liveness 都没有）才算死。
+        state = {
+            "last_event_at": asyncio.get_running_loop().time(),
+            "last_semantic_at": asyncio.get_running_loop().time(),
+            "phase": "STARTING",
+            "stall_warned": False,
+            "wrapup_sent": False,
+            "wrapup_at": 0.0,
+        }
 
         async def _read_events() -> None:
             nonlocal final_report, failure
@@ -352,8 +372,17 @@ class PiManagedAdapter:
                 except json.JSONDecodeError:
                     continue
                 events.append(event)
-                handle.progress_seq += 1  # 真实子进程事件才推进心跳
+                now = asyncio.get_running_loop().time()
+                state["last_event_at"] = now
                 kind = event.get("kind")
+                if kind == "liveness":
+                    # 只证明活着——phase/span 供 UI，不推进语义进度。
+                    state["phase"] = str(event.get("phase", state["phase"]))
+                    continue
+                # 真实语义事件：进度与 stall 恢复。
+                handle.progress_seq += 1
+                state["last_semantic_at"] = now
+                state["stall_warned"] = False
                 if kind == "attempt_finished":
                     final_report = str(event.get("report", ""))
                 elif kind == "attempt_failed":
@@ -386,16 +415,73 @@ class PiManagedAdapter:
                 if asyncio.get_running_loop().time() > startup_end:
                     raise AdapterError("worker startup timeout (no attempt_started)")
                 await asyncio.sleep(0.05)
-            # idle timeout：真实事件才刷新；超时不诚实等待。
+            # 主监控循环（十一审 PR-A）：
+            # - 全静默（连 liveness 都没有）> LIVENESS_TIMEOUT → 真死，杀；
+            # - 语义静默 > STALL_WARN → 只告警（UI 标黄），不杀；
+            # - wall 预算到期 → 先 wrap-up steer，grace 后再杀；
+            # - token 预算 ≥80% → wrap-up steer 一次。
+            wall_end = (
+                asyncio.get_running_loop().time() + order.budgets.wall_time_sec
+                if order.budgets.wall_time_sec
+                else None
+            )
             while proc.returncode is None:
-                last_seq = handle.progress_seq
                 try:
-                    await asyncio.wait_for(proc.wait(), timeout=IDLE_TIMEOUT_SEC)
+                    await asyncio.wait_for(proc.wait(), timeout=1.0)
+                    break
                 except TimeoutError:
-                    if handle.progress_seq == last_seq:
-                        raise AdapterError(
-                            f"worker idle timeout ({IDLE_TIMEOUT_SEC:.0f}s 无真实事件)"
-                        ) from None
+                    pass
+                now = asyncio.get_running_loop().time()
+                silent = now - state["last_event_at"]
+                if silent > LIVENESS_TIMEOUT_SEC:
+                    raise AdapterError(
+                        f"worker liveness lost ({LIVENESS_TIMEOUT_SEC:.0f}s 无任何事件"
+                        "——进程挂死，已终止)"
+                    )
+                semantic_silent = now - state["last_semantic_at"]
+                if semantic_silent > STALL_WARN_SEC and not state["stall_warned"]:
+                    state["stall_warned"] = True
+                    # 告警事件入列（UI 标黄；EventStore 在 PR-B 持久化）。
+                    events.append(
+                        {
+                            "kind": "stall_warning",
+                            "phase": state["phase"],
+                            "semantic_silent_sec": int(semantic_silent),
+                        }
+                    )
+                if wall_end is not None and now > wall_end and not state["wrapup_sent"]:
+                    state["wrapup_sent"] = True
+                    state["wrapup_at"] = now
+                    await self.steer(
+                        order.work_order_id,
+                        "已接近 wall 时间预算。停止开新工作：保存当前改动、跑最窄的"
+                        "验证命令，并产出可恢复的 partial handoff（已改文件/已验证"
+                        "内容/未完成事项/阻塞原因）。",
+                    )
+                if state["wrapup_sent"] and now - state["wrapup_at"] > WRAPUP_GRACE_SEC:
+                    raise AdapterError(
+                        "worker wall budget exceeded（wrap-up 宽限后仍未退出）"
+                    )
+                # token 预算 80% → wrap-up（一次）。
+                usage_last = next(
+                    (e for e in reversed(events) if e.get("kind") == "usage"), None
+                )
+                if (
+                    usage_last
+                    and order.budgets.model_tokens
+                    and not state["wrapup_sent"]
+                ):
+                    spent = int(usage_last.get("input_tokens") or 0) + int(
+                        usage_last.get("output_tokens") or 0
+                    )
+                    if spent >= int(order.budgets.model_tokens * 0.8):
+                        state["wrapup_sent"] = True
+                        state["wrapup_at"] = now
+                        await self.steer(
+                            order.work_order_id,
+                            "已接近 token 预算。停止开新工作：保存当前改动并产出"
+                            "可恢复的 partial handoff。",
+                        )
         except asyncio.CancelledError:
             await _teardown()
             raise

--- a/src/rosclaw/agentd/workers/pi_managed.py
+++ b/src/rosclaw/agentd/workers/pi_managed.py
@@ -69,8 +69,9 @@ async def _git(*args: str, cwd: str | None = None) -> tuple[int, str]:
 class PiManagedAdapter:
     """内置 Pi Worker（每个 WorkOrder 一个 headless 子进程）。"""
 
-    def __init__(self, *, rosclaw_home: Path) -> None:
+    def __init__(self, *, rosclaw_home: Path, conn=None) -> None:
         self._home = Path(rosclaw_home)
+        self._conn = conn  # PR-D：订单 inputs 回写（可选——无则跳过）
         self._runs: dict[str, tuple[RunHandle, asyncio.Task]] = {}
         # W4：活动子进程（steer 通道 + pid 文件崩溃对账）。
         self._procs: dict[str, asyncio.subprocess.Process] = {}
@@ -159,6 +160,26 @@ class PiManagedAdapter:
             if not task.done():
                 return "running"
         return "not_found"
+
+    # ------------------------------------------------------------------
+    def _annotate(self, work_order_id: str, **fields: str) -> None:
+        """订单 inputs 回写（workspace/base_sha 解析快照）——DB 权威。"""
+        conn = self._conn
+        if conn is None:
+            return
+        row = conn.execute(
+            "SELECT order_json FROM work_orders WHERE work_order_id = ?",
+            (work_order_id,),
+        ).fetchone()
+        if row is None:
+            return
+        order = WorkOrderV1(**json.loads(row["order_json"]))
+        inputs = {**dict(order.inputs), **{k: v for k, v in fields.items() if v}}
+        updated = order.model_copy(update={"inputs": inputs})
+        conn.execute(
+            "UPDATE work_orders SET order_json = ?, updated_at = ? WHERE work_order_id = ?",
+            (updated.model_dump_json(), datetime.now(UTC).isoformat(), work_order_id),
+        )
 
     # ------------------------------------------------------------------
     async def _prepare_workspace(self, order: WorkOrderV1) -> tuple[str, Path | None]:
@@ -313,6 +334,9 @@ class PiManagedAdapter:
         started = datetime.now(UTC)
         # W3：写能力 profile 先准备独立 workspace（git worktree/scratch）。
         workspace, base_ref = await self._prepare_workspace(order)
+        # 十一审 PR-D：resolved workspace + base_sha 回写订单（WorkOrder
+        # 引用解析后的快照，不靠自然语言路径）。
+        self._annotate(order.work_order_id, workspace=workspace, base_sha=base_ref or "")
         artifacts_dir = self._home / "work" / order.work_order_id / "artifacts"
         envelope_path, cwd = self._write_envelope(
             order, cwd=workspace, artifacts_dir=artifacts_dir

--- a/tests/agentd/test_eleven_a.py
+++ b/tests/agentd/test_eleven_a.py
@@ -12,12 +12,21 @@
 
 from __future__ import annotations
 
-import asyncio
+import json
+import shutil
 import stat
+import subprocess
 import time
 from pathlib import Path
 
 import pytest
+
+# CI Full Regression 无 node/dist——prompt 契约测试诚实 skip（本地与
+# Node jobs 覆盖）。
+_NODE_AVAILABLE = shutil.which("node") is not None and (
+    Path(__file__).resolve().parents[2]
+    / "packages/rosclaw-agent/dist/src/workers/profiles.js"
+).exists()
 
 from rosclaw.agentd.workers.scheduler import CandidateView
 from rosclaw.contracts.common import new_id
@@ -188,11 +197,9 @@ class TestBudgetWrapup:
         await service.close()
 
 
+@pytest.mark.skipif(not _NODE_AVAILABLE, reason="无 node/dist——诚实 skip")
 class TestPromptContract:
     def test_developer_prompt_has_no_readonly_contradiction(self) -> None:
-        import json
-        import subprocess
-
         # 用 node 直接读编译后 profiles（真实运行面）。
         proc = subprocess.run(
             [
@@ -221,9 +228,6 @@ class TestPromptContract:
         assert "design document" in prompt.lower()  # DoD 反设计稿声明
 
     def test_scout_prompt_manifest_is_readonly_honest(self) -> None:
-        import json
-        import subprocess
-
         proc = subprocess.run(
             [
                 "node",

--- a/tests/agentd/test_eleven_a.py
+++ b/tests/agentd/test_eleven_a.py
@@ -21,13 +21,6 @@ from pathlib import Path
 
 import pytest
 
-# CI Full Regression 无 node/dist——prompt 契约测试诚实 skip（本地与
-# Node jobs 覆盖）。
-_NODE_AVAILABLE = shutil.which("node") is not None and (
-    Path(__file__).resolve().parents[2]
-    / "packages/rosclaw-agent/dist/src/workers/profiles.js"
-).exists()
-
 from rosclaw.agentd.workers.scheduler import CandidateView
 from rosclaw.contracts.common import new_id
 from rosclaw.contracts.worker.order import (
@@ -37,6 +30,13 @@ from rosclaw.contracts.worker.order import (
     WorkOrderV1,
 )
 from tests.agentd.test_pi_tool_bridge import _setup
+
+# CI Full Regression 无 node/dist——prompt 契约测试诚实 skip（本地与
+# Node jobs 覆盖）。
+_NODE_AVAILABLE = shutil.which("node") is not None and (
+    Path(__file__).resolve().parents[2]
+    / "packages/rosclaw-agent/dist/src/workers/profiles.js"
+).exists()
 
 
 def _fake(tmp_path: Path, name: str, body: str) -> Path:

--- a/tests/agentd/test_eleven_a.py
+++ b/tests/agentd/test_eleven_a.py
@@ -1,0 +1,245 @@
+"""十一审 PR-A 红测试：false timeout 状态机 + prompt/tool 契约。
+
+红测试先行——修复前必须红：
+1. 语义静默 ≥90s 但 liveness 正常 → 不杀（stall 只告警）；旧实现
+   60s 无事件即杀。
+2. 全静默（连 liveness 都没有）→ liveness timeout 判死。
+3. wall 预算：先 wrap-up steer，grace 内不退出才终止。
+4. token 预算 ≥80% → wrap-up steer 一次。
+5. Developer prompt 不再含 "read-only tools" 矛盾；manifest 列出
+   7 个工具与 DoD。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import stat
+import time
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.workers.scheduler import CandidateView
+from rosclaw.contracts.common import new_id
+from rosclaw.contracts.worker.order import (
+    BudgetEnvelope,
+    ExpectedOutput,
+    SideEffectPolicy,
+    WorkOrderV1,
+)
+from tests.agentd.test_pi_tool_bridge import _setup
+
+
+def _fake(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+async def _run(service, mission, tmp_path, fake, monkeypatch, *, wall_time=300):
+    from rosclaw.agentd.workers import pi_managed
+
+    monkeypatch.setattr(pi_managed, "find_pi_agent_entry", lambda: ("/bin/sh", str(fake)))
+    adapter = pi_managed.PiManagedAdapter(rosclaw_home=tmp_path)
+    service._worker_manager._adapters["pi_managed"] = adapter
+    if service._registry.status_of("worker:rosclaw:pi") != "ENABLED":
+        service._registry.set_status(
+            "worker:rosclaw:pi", "ENABLED", actor_id="test", reason="fake entry"
+        )
+    card = service._registry.get("worker:rosclaw:pi")
+    order = WorkOrderV1(
+        work_order_id=new_id("wo"),
+        mission_id=mission.mission_id,
+        issued_by="test",
+        capability="analysis.text",
+        goal="长任务",
+        inputs={"instructions": "x"},
+        budgets=BudgetEnvelope(wall_time_sec=wall_time, model_tokens=1000),
+        expected_output=ExpectedOutput(artifacts=["text/plain"]),
+        side_effect_policy=SideEffectPolicy(**{"class": "none"}),
+    )
+    scheduled = service._worker_manager.hire(
+        order,
+        [CandidateView(card=card, registry_status="ENABLED", running_orders=0,
+                       circuit_open=False)],
+    )
+    return await service._worker_manager.run_to_completion(scheduled)
+
+
+class TestNoFalseTimeout:
+    async def test_semantic_silence_with_liveness_not_killed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Gate B：90s+ 无语义事件但 liveness 正常——进程保持存活。
+        （为测试时长可控，stall 阈值缩小；断言无 idle 误杀 + stall 告警。）"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "STALL_WARN_SEC", 1.0)
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-slow-thinker",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "i=0\n"
+            "while [ $i -lt 12 ]; do\n"
+            '  echo \'{"kind":"liveness","phase":"RUNNING_MODEL","span_age_ms":1000,"pid_alive":true}\'\n'
+            "  sleep 0.5\n"
+            "  i=$((i+1))\n"
+            "done\n"
+            'echo \'{"kind":"attempt_finished","report":"长推理完成"}\'\n',
+        )
+        started = time.monotonic()
+        result, report = await _run(service, mission, tmp_path, fake, monkeypatch)
+        elapsed = time.monotonic() - started
+        # 6 秒全 liveness 无语义事件——旧实现会在 60s 处杀（语义层面
+        # 等价：stall 阈值 1s 下，liveness 保活必须让任务活到完成）。
+        assert result.status == "COMPLETED", result.summary
+        assert "长推理完成" in result.summary
+        assert elapsed > 5, f"疑似提前退出: {elapsed:.1f}s"
+        assert report.accepted
+        await service.close()
+
+    async def test_total_silence_killed_by_liveness_timeout(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """连 liveness 都没有 = 进程挂死——必须判死（不无限等待）。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 2.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-hang-after-start",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "exec sleep 300\n",
+        )
+        started = time.monotonic()
+        result, _report = await _run(service, mission, tmp_path, fake, monkeypatch)
+        elapsed = time.monotonic() - started
+        assert result.status == "FAILED"
+        assert "liveness lost" in result.summary, result.summary
+        assert elapsed < 20, f"判死耗时 {elapsed:.1f}s"
+        await service.close()
+
+
+class TestBudgetWrapup:
+    async def test_wall_budget_wrapup_then_terminate(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """wall 到期：先发 wrap-up steer（grace 内可收尾），grace 后仍
+        不退出才终止。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "WRAPUP_GRACE_SEC", 1.0)
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        stdin_log = tmp_path / "stdin.log"
+        fake = _fake(
+            tmp_path,
+            "fake-ignore-wrapup",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            # liveness 后台持续（不被误杀）；前台 cat 读 stdin（POSIX sh
+            # 的后台任务 stdin 会被重定向到 /dev/null——必须前台读）。
+            "(while true; do echo '{\"kind\":\"liveness\",\"phase\":\"RUNNING_MODEL\"}'; sleep 0.5; done) &\n"
+            f"cat >> {stdin_log}\n",
+        )
+        result, _report = await _run(
+            service, mission, tmp_path, fake, monkeypatch, wall_time=2
+        )
+        assert result.status == "FAILED"
+        assert "wall budget" in result.summary, result.summary
+        assert stdin_log.exists()
+        assert "wall" in stdin_log.read_text() or "预算" in stdin_log.read_text()
+        await service.close()
+
+    async def test_wrapup_allows_graceful_finish(self, tmp_path: Path, monkeypatch) -> None:
+        """wrap-up 后在 grace 内正常完成的单必须被接受（不误杀）。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "WRAPUP_GRACE_SEC", 10.0)
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-graceful",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "while IFS= read -r line; do\n"
+            "  case \"$line\" in\n"
+            "    *steer*)\n"
+            '      echo \'{"kind":"liveness","phase":"RUNNING_MODEL"}\'\n'
+            "      sleep 1\n"
+            '      echo \'{"kind":"attempt_finished","report":"partial handoff：已保存"}\'\n'
+            "      exit 0;;\n"
+            "  esac\n"
+            "done\n",
+        )
+        result, report = await _run(
+            service, mission, tmp_path, fake, monkeypatch, wall_time=3
+        )
+        assert result.status == "COMPLETED", result.summary
+        assert "partial handoff" in result.summary
+        assert report.accepted
+        await service.close()
+
+
+class TestPromptContract:
+    def test_developer_prompt_has_no_readonly_contradiction(self) -> None:
+        import json
+        import subprocess
+
+        # 用 node 直接读编译后 profiles（真实运行面）。
+        proc = subprocess.run(
+            [
+                "node",
+                "-e",
+                "import('./packages/rosclaw-agent/dist/src/workers/profiles.js')"
+                ".then(m => {"
+                "const p = m.profileFor('developer');"
+                "const sp = m.buildSystemPrompt(p, '/tmp/ws', ['text/x-diff']);"
+                "console.log(JSON.stringify({tools: p.tools, sp}));"
+                "})",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(Path(__file__).resolve().parents[2]),
+        )
+        assert proc.returncode == 0, proc.stderr[-500:]
+        payload = json.loads(proc.stdout)
+        prompt = payload["sp"]
+        assert "read-only tools" not in prompt
+        for tool in ("read", "grep", "find", "ls", "write", "edit", "bash"):
+            assert tool in payload["tools"]
+        assert "Available tools: read, grep, find, ls, write, edit, bash" in prompt
+        assert "Required evidence" in prompt
+        assert "design document" in prompt.lower()  # DoD 反设计稿声明
+
+    def test_scout_prompt_manifest_is_readonly_honest(self) -> None:
+        import json
+        import subprocess
+
+        proc = subprocess.run(
+            [
+                "node",
+                "-e",
+                "import('./packages/rosclaw-agent/dist/src/workers/profiles.js')"
+                ".then(m => {"
+                "const p = m.profileFor('scout');"
+                "console.log(JSON.stringify({sp: m.buildSystemPrompt(p, '/tmp/ws', [])}));"
+                "})",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(Path(__file__).resolve().parents[2]),
+        )
+        assert proc.returncode == 0
+        prompt = json.loads(proc.stdout)["sp"]
+        assert "Available tools: read, grep, find, ls" in prompt
+        assert "read-only profile" in prompt

--- a/tests/agentd/test_eleven_a_live.py
+++ b/tests/agentd/test_eleven_a_live.py
@@ -1,0 +1,77 @@
+"""十一审 PR-A 真实长任务验收（Gate B/D）：真实 Kimi K3、>5 分钟、
+高 thinking 长静默不误杀。
+
+无 provider key 时诚实 skip。运行：
+ROSCLAW_KIMI_API_KEY=sk-kimi-... pytest tests/agentd/test_eleven_a_live.py -s
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _request, _setup
+
+KIMI_ENV_VARS = ("ROSCLAW_KIMI_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY")
+
+
+def _has_key() -> bool:
+    return any(os.environ.get(v) for v in KIMI_ENV_VARS)
+
+
+@pytest.mark.skipif(not _has_key(), reason="无真实 provider key——诚实 skip")
+class TestLiveLongTaskNoFalseKill:
+    async def test_long_repo_analysis_survives_past_60s(self, tmp_path: Path) -> None:
+        """长任务（仓库级分析）必须活过旧的 60s 误杀点；liveness 事件
+        持续；终态真实（ACCEPTED 或带明确 error_code 的 FAILED）。"""
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        repo = Path(__file__).resolve().parents[2]
+        started = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_11a_live",
+                arguments={
+                    "goal": "通读 src/rosclaw/agentd 下的主要模块（service、"
+                    "workers、pi_bridge、context），写一份详细的中文架构报告："
+                    "每个模块的职责、关键类、模块间数据流。报告至少 2000 字。",
+                    "worker_id": "worker:rosclaw:pi",
+                    "worker_profile": "scout",
+                    "workspace": str(repo),
+                    "budget": {"wall_time_sec": 900, "model_tokens": 300_000},
+                    "sync_grace_sec": 0,
+                },
+            )
+        )
+        assert started.ok, started.summary
+        assert started.status == "STARTED"
+        order = service._worker_manager.orders_for_mission(mission.mission_id)[0]
+        # 活过旧误杀点（60s）是硬断言；此后等到终态（最长 16 分钟）。
+        await asyncio.sleep(65)
+        mid = service._worker_manager.order(order.work_order_id)
+        assert mid is not None and mid.status in ("RUNNING", "ACCEPTED"), (
+            f"60s 处被误杀/异常终态: {mid.status if mid else None}"
+        )
+        final = None
+        deadline = time.monotonic() + 960
+        while time.monotonic() < deadline:
+            current = service._worker_manager.order(order.work_order_id)
+            if current and current.status in ("ACCEPTED", "FAILED", "CANCELLED", "EXPIRED"):
+                final = current
+                break
+            await asyncio.sleep(2)
+        assert final is not None, "16 分钟未到终态"
+        if final.status == "FAILED":
+            row = service._store.connection.execute(
+                "SELECT verify_report_json FROM work_orders WHERE work_order_id = ?",
+                (order.work_order_id,),
+            ).fetchone()
+            pytest.fail(f"长任务 FAILED: {row['verify_report_json'] if row else '?'}")
+        assert final.status == "ACCEPTED"
+        await service.close()

--- a/tests/agentd/test_eleven_b.py
+++ b/tests/agentd/test_eleven_b.py
@@ -11,8 +11,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import json
 import stat
 from pathlib import Path
 

--- a/tests/agentd/test_eleven_b.py
+++ b/tests/agentd/test_eleven_b.py
@@ -1,0 +1,131 @@
+"""十一审 PR-B 红测试：WorkerEventStore 持久化 + tail/subscribe + stderr 脱敏。
+
+红测试先行——修复前必须红：
+1. 事件边运行边落 events.jsonl（含 liveness），seq 连续；
+2. stderr 落盘且 sk-/api_key 被脱敏；
+3. state.json 终态可读；
+4. tail(after_seq) 增量读取（subscribe 语义）；
+5. 新实例（重启语义）仍能读到全部事件（文件权威）；
+6. 大文本字段截断为 preview。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import stat
+from pathlib import Path
+
+from rosclaw.agentd.workers.event_store import WorkerEventStore, redact
+from rosclaw.agentd.workers.scheduler import CandidateView
+from rosclaw.contracts.common import new_id
+from rosclaw.contracts.worker.order import (
+    BudgetEnvelope,
+    ExpectedOutput,
+    SideEffectPolicy,
+    WorkOrderV1,
+)
+from tests.agentd.test_pi_tool_bridge import _setup
+
+
+class TestEventStoreUnit:
+    def test_redact_secret_patterns(self) -> None:
+        assert "sk-" + "x" * 20 not in redact("key is sk-" + "x" * 20)
+        assert "REDACTED" in redact("api_key: abcdefgh12345678")
+        assert redact("normal text") == "normal text"
+
+    def test_append_and_tail_incremental(self, tmp_path: Path) -> None:
+        store = WorkerEventStore(tmp_path)
+        store.append_event("wo_abcdef01", "att_1", "attempt_started", {"worker": "pi"})
+        store.append_event("wo_abcdef01", "att_1", "tool_started", {"tool": "read"})
+        store.append_event("wo_abcdef01", "att_1", "liveness", {"phase": "RUNNING_TOOL"})
+        all_events = store.tail("wo_abcdef01")
+        assert [e["kind"] for e in all_events] == [
+            "attempt_started",
+            "tool_started",
+            "liveness",
+        ]
+        assert [e["seq"] for e in all_events] == [1, 2, 3]
+        assert all(e["attempt_id"] == "att_1" for e in all_events)
+        # 增量（subscribe 语义）。
+        fresh = store.tail("wo_abcdef01", after_seq=2)
+        assert len(fresh) == 1 and fresh[0]["kind"] == "liveness"
+        # 新实例（重启语义）读同一账本。
+        store2 = WorkerEventStore(tmp_path)
+        assert len(store2.tail("wo_abcdef01")) == 3
+        store2.append_event("wo_abcdef01", "att_1", "attempt_finished", {"report": "done"})
+        assert store2.tail("wo_abcdef01")[-1]["seq"] == 4
+
+    def test_stderr_redacted_and_large_text_preview(self, tmp_path: Path) -> None:
+        store = WorkerEventStore(tmp_path)
+        store.append_stderr("wo_abcdef02", "error: key sk-" + "k" * 30 + " boom\n")
+        content = store.tail_stderr("wo_abcdef02")
+        assert "sk-" + "k" * 30 not in content
+        assert "REDACTED" in content
+        store.append_event("wo_abcdef02", "", "big", {"text": "x" * 5000})
+        event = store.tail("wo_abcdef02")[-1]
+        assert "truncated" in event["text"]
+        assert len(event["text"]) < 2200
+
+    def test_state_roundtrip(self, tmp_path: Path) -> None:
+        store = WorkerEventStore(tmp_path)
+        assert store.read_state("wo_abcdef03") is None
+        store.write_state("wo_abcdef03", {"status": "RUNNING", "phase": "RUNNING_TOOL"})
+        state = store.read_state("wo_abcdef03")
+        assert state is not None and state["status"] == "RUNNING"
+        assert "updated_at" in state
+
+
+class TestAdapterPersists:
+    async def test_run_persists_events_stderr_state(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        service, mission = await _setup(tmp_path)
+        from rosclaw.agentd.workers import pi_managed
+
+        fake = tmp_path / "fake-entry"
+        fake.write_text(
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\' \n'
+            "echo 'warning: something odd' >&2\n"
+            'echo \'{"kind":"liveness","phase":"RUNNING_MODEL"}\'\n'
+            'echo \'{"kind":"attempt_finished","report":"完成"}\'\n'
+        )
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+        monkeypatch.setattr(pi_managed, "find_pi_agent_entry", lambda: ("/bin/sh", str(fake)))
+        adapter = pi_managed.PiManagedAdapter(rosclaw_home=tmp_path)
+        service._worker_manager._adapters["pi_managed"] = adapter
+        if service._registry.status_of("worker:rosclaw:pi") != "ENABLED":
+            service._registry.set_status(
+                "worker:rosclaw:pi", "ENABLED", actor_id="test", reason="fake entry"
+            )
+        card = service._registry.get("worker:rosclaw:pi")
+        order = WorkOrderV1(
+            work_order_id=new_id("wo"),
+            mission_id=mission.mission_id,
+            issued_by="test",
+            capability="analysis.text",
+            goal="x",
+            inputs={"instructions": "x"},
+            budgets=BudgetEnvelope(wall_time_sec=60, model_tokens=1000),
+            expected_output=ExpectedOutput(artifacts=["text/plain"]),
+            side_effect_policy=SideEffectPolicy(**{"class": "none"}),
+        )
+        scheduled = service._worker_manager.hire(
+            order,
+            [CandidateView(card=card, registry_status="ENABLED", running_orders=0,
+                           circuit_open=False)],
+        )
+        result, report = await service._worker_manager.run_to_completion(scheduled)
+        assert result.status == "COMPLETED"
+        store = WorkerEventStore(tmp_path)
+        events = store.tail(scheduled.work_order_id)
+        kinds = [e["kind"] for e in events]
+        assert "attempt_started" in kinds
+        assert "liveness" in kinds
+        assert "attempt_finished" in kinds
+        assert "something odd" in store.tail_stderr(scheduled.work_order_id)
+        state = store.read_state(scheduled.work_order_id)
+        assert state is not None and state["status"] == "COMPLETED"
+        assert report.accepted
+        await service.close()


### PR DESCRIPTION
## 十一审 PR-D（总纲 §P0-5）

停止条件对照：**用户不再需要在对话里反复猜 repo path**。

- `rosclaw chat [PATH]` / `--workspace PATH`（Python → node 显式传递）；
- WorkspaceStore（`agent/workspace.json` 0600 原子写）：current + recent(10)；gitRootOf 向上归一；
- 启动优先级：显式 > cwd git 自动绑定（session_start 通知）> 既有绑定；header 显示 `Project <name>`（无绑定显式占位，ASCII 终端降级）；
- `/workspace show|use <path>|recent`——命令层直接处理，不进模型；
- delegate 默认注入绑定 workspace（模型显式指定优先）；订单回写 resolved workspace + base_sha；
- delegation policy（PR-A prompt）：小任务主 Agent 直接做，无不兼容兜底。

红测试 4 项；TS 83/83；ruff 全库绿。