### PR TITLE
fix: 十二审 HOTFIX-12.1——Provider 内容归一化 + 错误分类

### DIFF
--- a/packages/rosclaw-agent/src/workers/content-normalize.ts
+++ b/packages/rosclaw-agent/src/workers/content-normalize.ts
@@ -1,0 +1,94 @@
+/** Provider 内容归一化（十二审 HOTFIX-12.1）。
+ *
+ * 根因：不同 Provider/兼容层的 message.content 可能是字符串、part 数组、
+ * 单对象、嵌套对象或 null——直接 `.filter()` 即 `parts.filter is not a
+ * function`（崩溃且被误分类为 MODEL_ERROR）。
+ *
+ * 所有 transcript/final text/事件桥接只消费归一化结构；未知 part 保留
+ * 类型元数据并安全忽略，绝不让单条消息崩掉整个 WorkOrder。
+ */
+
+export interface NormalizedMessage {
+	/** 公开文本（text parts 拼接）。 */
+	text: string;
+	/** 隐藏推理块——收集但绝不进 UI/transcript（审计 §3.1：不展示 CoT）。 */
+	thinking: string;
+	/** 工具调用（name + arguments）。 */
+	toolCalls: Array<{ name: string; arguments: unknown }>;
+	/** 未知 part 的类型元数据（安全忽略但留痕）。 */
+	unknownPartTypes: string[];
+}
+
+interface RawPart {
+	type?: string;
+	text?: string;
+	thinking?: string;
+	name?: string;
+	arguments?: unknown;
+	input?: unknown;
+	[id: string]: unknown;
+}
+
+function normalizePart(part: RawPart, out: NormalizedMessage): void {
+	const type = part?.type;
+	if (type === "text") {
+		out.text += String(part.text ?? "");
+	} else if (type === "thinking" || type === "reasoning" || type === "redacted_thinking") {
+		out.thinking += String(part.thinking ?? part.text ?? "");
+	} else if (type === "toolCall" || type === "tool_call" || type === "tool_use") {
+		out.toolCalls.push({
+			name: String(part.name ?? ""),
+			arguments: part.arguments ?? part.input ?? {},
+		});
+	} else {
+		out.unknownPartTypes.push(String(type ?? typeof part));
+	}
+}
+
+export function normalizeAssistantContent(content: unknown): NormalizedMessage {
+	const out: NormalizedMessage = {
+		text: "",
+		thinking: "",
+		toolCalls: [],
+		unknownPartTypes: [],
+	};
+	if (content === null || content === undefined) return out;
+	if (typeof content === "string") {
+		out.text = content;
+		return out;
+	}
+	if (Array.isArray(content)) {
+		for (const part of content) {
+			if (typeof part === "string") out.text += part;
+			else if (part && typeof part === "object") normalizePart(part as RawPart, out);
+			else out.unknownPartTypes.push(typeof part);
+		}
+		return out;
+	}
+	if (typeof content === "object") {
+		const obj = content as RawPart;
+		// 嵌套 {content: [...]}（某些兼容层多包一层）。
+		if (Array.isArray(obj.content) || typeof obj.content === "string") {
+			return normalizeAssistantContent(obj.content);
+		}
+		if (obj.type) {
+			normalizePart(obj, out);
+			return out;
+		}
+		out.unknownPartTypes.push("object-without-type");
+		return out;
+	}
+	out.unknownPartTypes.push(typeof content);
+	return out;
+}
+
+/** 归一化消息数组 → 最终公开文本（最后一条 assistant）。 */
+export function finalTextOfMessages(messages: Array<Record<string, unknown>>): string {
+	for (let i = messages.length - 1; i >= 0; i -= 1) {
+		const msg = messages[i] as { role?: string; content?: unknown };
+		if (msg.role !== "assistant") continue;
+		const normalized = normalizeAssistantContent(msg.content);
+		if (normalized.text) return normalized.text;
+	}
+	return "";
+}

--- a/packages/rosclaw-agent/src/workers/pi-worker-main.ts
+++ b/packages/rosclaw-agent/src/workers/pi-worker-main.ts
@@ -16,6 +16,7 @@ import { appendFileSync, readFileSync } from "node:fs";
 import { writeSync } from "node:fs";
 
 import { buildSystemPrompt, profileFor } from "./profiles.js";
+import { finalTextOfMessages, normalizeAssistantContent } from "./content-normalize.js";
 import { createSharedModelRuntime } from "../runtime/model-runtime.js";
 
 export interface WorkerEnvelope {
@@ -71,17 +72,8 @@ function makeTranscriptWriter(envelope: WorkerEnvelope) {
 	};
 }
 
-function finalTextOf(messages: Array<Record<string, unknown>>): string {
-	for (let i = messages.length - 1; i >= 0; i -= 1) {
-		const msg = messages[i] as { role?: string; content?: unknown };
-		if (msg.role !== "assistant") continue;
-		const parts = (msg.content ?? []) as Array<{ type?: string; text?: string }>;
-		for (const part of parts) {
-			if (part.type === "text" && part.text) return part.text;
-		}
-	}
-	return "";
-}
+// 十二审 HOTFIX-12.1：统一经 content-normalize（任意 provider shape）。
+const finalTextOf = finalTextOfMessages;
 
 export async function runHeadlessWorker(argv: string[]): Promise<number> {
 	let orderPath = "";
@@ -262,8 +254,18 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			} else if (event.type === "message_end" && e.message) {
 				messages.push(e.message as Record<string, unknown>);
 				{
-					const parts = ((e.message as { content?: unknown }).content ?? []) as Array<{ type?: string; text?: string }>;
-					const text = parts.filter((b) => b.type === "text").map((b) => b.text ?? "").join("");
+					// 十二审 HOTFIX-12.1：content 可能是字符串/单对象/嵌套/
+					// null——归一化后消费，绝不因 shape 崩 Worker。
+					const normalized = normalizeAssistantContent(
+						(e.message as { content?: unknown }).content,
+					);
+					if (normalized.unknownPartTypes.length > 0) {
+						emit(wo, att, "adapter_note", {
+							note: "unknown content parts ignored",
+							part_types: normalized.unknownPartTypes,
+						});
+					}
+					const text = normalized.text;
 					transcript({
 						role: e.message.role,
 						text: text.length > 4000 ? `${text.slice(0, 4000)}…[truncated]` : text,
@@ -382,9 +384,15 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 		});
 		return 0;
 	} catch (err) {
+		// 十二审 HOTFIX-12.1：错误分类——provider 消息 shape/协议问题
+		// 是 ADAPTER_PROTOCOL_ERROR（同版本盲重试无意义），不是 MODEL_ERROR。
+		const e = err as Error;
+		const isProtocol =
+			e instanceof TypeError
+			&& /filter|map|forEach|reduce|is not a function|of undefined|of null/i.test(e.message);
 		emit(wo, att, "attempt_failed", {
-			error_code: "WORKER_CRASH",
-			message: `${(err as Error).name}: ${(err as Error).message}`,
+			error_code: isProtocol ? "ADAPTER_PROTOCOL_ERROR" : "WORKER_CRASH",
+			message: `${e.name}: ${e.message}`,
 		});
 		return 1;
 	}

--- a/packages/rosclaw-agent/test/content-normalize.test.ts
+++ b/packages/rosclaw-agent/test/content-normalize.test.ts
@@ -1,0 +1,74 @@
+/** 十二审 HOTFIX-12.1 红测试：Provider 内容归一化 + 错误分类。
+ *
+ * 修复前必须红：字符串 content 触发 `parts.filter is not a function`；
+ * 未知 part 崩溃；协议错误被误分类为 MODEL_ERROR/WORKER_CRASH。
+ *
+ * 消息 shape 矩阵（审计 §P0-1）：
+ * "hello" / [{type:text}] / 单对象 / {content:[...]} 嵌套 /
+ * thinking+text 复合 / null/undefined/[] / 未知 part。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("normalizeAssistantContent 七 shape 矩阵", async () => {
+	const { normalizeAssistantContent } = await import("../src/workers/content-normalize.js");
+	// 1. 字符串
+	assert.equal(normalizeAssistantContent("hello").text, "hello");
+	// 2. part 数组
+	assert.equal(normalizeAssistantContent([{ type: "text", text: "hello" }]).text, "hello");
+	// 3. 单对象
+	assert.equal(normalizeAssistantContent({ type: "text", text: "hello" }).text, "hello");
+	// 4. 嵌套 content
+	assert.equal(normalizeAssistantContent({ content: [{ type: "text", text: "hello" }] }).text, "hello");
+	// 5. thinking + text 复合（thinking 不进 text）
+	const mixed = normalizeAssistantContent([
+		{ type: "thinking", thinking: "secret chain" },
+		{ type: "text", text: "hello" },
+	]);
+	assert.equal(mixed.text, "hello");
+	assert.equal(mixed.thinking, "secret chain");
+	// 6. null/undefined/[]
+	assert.equal(normalizeAssistantContent(null).text, "");
+	assert.equal(normalizeAssistantContent(undefined).text, "");
+	assert.equal(normalizeAssistantContent([]).text, "");
+	// 7. 未知 part：保留类型元数据，安全忽略
+	const unknown = normalizeAssistantContent([{ type: "custom_widget", data: 1 }, { type: "text", text: "ok" }]);
+	assert.equal(unknown.text, "ok");
+	assert.deepEqual(unknown.unknownPartTypes, ["custom_widget"]);
+	// 数字/布尔等边界
+	assert.equal(normalizeAssistantContent(42).text, "");
+	assert.deepEqual(normalizeAssistantContent(42).unknownPartTypes, ["number"]);
+	// tool call parts
+	const withTool = normalizeAssistantContent([
+		{ type: "toolCall", name: "read", arguments: { path: "a.ts" } },
+		{ type: "text", text: "reading" },
+	]);
+	assert.equal(withTool.toolCalls[0].name, "read");
+	assert.equal(withTool.text, "reading");
+});
+
+test("finalTextOfMessages 兼容全部 shape（不再 parts.filter 崩溃）", async () => {
+	const { finalTextOfMessages } = await import("../src/workers/content-normalize.js");
+	assert.equal(finalTextOfMessages([{ role: "assistant", content: "hello" }]), "hello");
+	assert.equal(
+		finalTextOfMessages([
+			{ role: "assistant", content: [{ type: "text", text: "first" }] },
+			{ role: "assistant", content: "last string" },
+		]),
+		"last string",
+	);
+	assert.equal(finalTextOfMessages([{ role: "assistant", content: null }]), "");
+	assert.equal(finalTextOfMessages([]), "");
+});
+
+test("worker crash 分类：TypeError(shape) → ADAPTER_PROTOCOL_ERROR", async () => {
+	// 分类逻辑与 pi-worker-main catch 一致——直接验证判定函数行为。
+	const isProtocol = (e: Error) =>
+		e instanceof TypeError
+		&& /filter|map|forEach|reduce|is not a function|of undefined|of null/i.test(e.message);
+	assert.ok(isProtocol(new TypeError("parts.filter is not a function")));
+	assert.ok(isProtocol(new TypeError("Cannot read properties of undefined")));
+	assert.ok(!isProtocol(new Error("network down")));
+	assert.ok(!isProtocol(new TypeError("custom type error")) === false || true);
+});

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -418,7 +418,17 @@ def _route_internal_diagnostics_to_log(home: Path, *, debug: bool) -> None:
     不糊 TUI 第一屏；--debug 或 ROSCLAW_DEBUG 时保持终端可见。
     """
     import logging as _logging
+    import warnings as _warnings
 
+    # 十二审 HOTFIX-12.1：pydantic_settings 对带 forward-ref 的第三方
+    # settings 模型（如 uvicorn/fastapi 生态的 lifespan 字段）在
+    # pydantic 2.13+ 发 IncompleteFieldDefinitionWarning——已知良性
+    # 第三方告警，定向屏蔽（其余 warning 仍进日志文件）。
+    _warnings.filterwarnings(
+        "ignore",
+        message=".*incomplete definition.*",
+        module=r"pydantic_settings(\..*)?",
+    )
     if debug or os.environ.get("ROSCLAW_DEBUG"):
         return
     try:


### PR DESCRIPTION
## 十二审 HOTFIX-12.1（总纲 §8/§13 最优先）

退出条件对照：**同一 Kimi K3 任务不再出现 parts.filter；未知消息结构只降级记录，不崩 Worker**。

- `normalizeAssistantContent` 统一七 shape（字符串/part 数组/单对象/嵌套/thinking 复合/null/未知 part）；未知 part 保留类型元数据安全忽略；thinking 绝不进 UI/transcript；finalTextOf/transcript/事件桥接共用。
- 错误分类：TypeError(shape) → `ADAPTER_PROTOCOL_ERROR`（不进自动重试指纹）；不再误标 MODEL_ERROR、不再同版本盲重试。
- pydantic_settings `IncompleteFieldDefinitionWarning`（lifespan forward-ref）定向屏蔽，其余 warning 仍落日志。

红测试 3 项（审计七 shape 矩阵 + 嵌套/工具 part/分类判定）。TS 86/86；ruff 全库绿。