### PR TITLE
feat: ROSClaw Channels — OpenClaw + ACP 远程会话接入（PR-RC-001…005）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to ROSClaw will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-08-13
+
+### Added
+
+- **ROSClaw Channels / OpenClaw + ACP integration (PR-RC-001…005)**
+  - ACP protocol hardening (`src/rosclaw/adapters/acp/server.py`): capability
+    advertisement now matches the implementation (`load_session=True`,
+    `sessionCapabilities` list/resume/close); full session lifecycle
+    `session/new|list|load|resume|close|cancel` with frozen semantics — close
+    never deletes the Mission, cancel is turn-only; per-session turn
+    serialization; unsupported attachment blocks get an explicit
+    "not yet supported" notice instead of being silently dropped.
+  - Graceful shutdown for `rosclaw acp serve`: stdin EOF (OpenClaw closing the
+    ACP child pipe) and SIGTERM/SIGINT both exit cleanly — stream tasks
+    cancelled, connection closed, `AgentService.close()` runs; no orphan
+    processes. stdout carries JSON-RPC frames only (all logs on stderr).
+  - `AgentService.subscribe_events()` / `stream_events()`
+    (`src/rosclaw/agentd/events.py`): one authoritative async event stream —
+    journal replay from `after_sequence` then live bus, lossless (queue
+    overflow gaps backfilled from the journal), deduped, monotonic; replaces
+    the ACP adapter's 250 ms polling loop.
+  - New AgentEvent types `reasoning.started` / `reasoning.summary.delta` /
+    `reasoning.summary.ended` / `plan.updated` for safe reasoning summaries
+    (never raw CoT); ACP mapper projects `reasoning.summary.delta` →
+    `AgentThoughtChunk` and `plan.updated` → `AgentPlanUpdate` with stable
+    message IDs.
+  - ACP mapper (`src/rosclaw/adapters/acp/mapper.py`) rewrite per the frozen
+    mapping table: stable `tool_call_id` (`tool_call_id` → `call_id` →
+    `event_id`, never the tool name), `work_order_id` as the stable worker ID,
+    proper ToolCallStart/Update split for worker lifecycle, visibility gate
+    (only USER events leave via ACP by default; DEBUG/AUDIT stay local),
+    usage update only with a real context size, action/approval remain
+    read-only cards.
+  - `rosclaw channel doctor` / `rosclaw channel setup feishu`
+    (`src/rosclaw/integrations/openclaw/`): read-only channel diagnostics —
+    ROSCLAW_HOME, model config, credentials, live ACP handshake probe
+    (initialize/new/resume/close), Node/OpenClaw/acpx/harness registration,
+    gateway loopback+auth, Feishu pairing/allowlist policy, MCP bridges off,
+    `permissionMode=deny-all`. Never modifies configuration.
+  - `integrations/openclaw/` scaffold: `README.md` bring-up guide,
+    `openclaw.rosclaw.example.json5` single-robot reference config, and
+    `SECURITY.md` trust-boundary baseline. OpenClaw is not vendored.
+
+### Changed
+
+- `agent-client-protocol` dependency pinned to `>=0.12.0,<0.13.0` after
+  verifying 0.12.0 against the ACP test suite (integration version lock).
+- Tool lifecycle events now carry `call_id` in their payloads
+  (`src/rosclaw/agentd/loop.py`) so every UI surface gets stable tool IDs.
+
+### Tests
+
+- `tests/agentd/test_acp.py`: 28 tests — capability advertisement, session
+  lifecycle (close retains Mission, resume rebinds without replay, load
+  replays transcript), turn-only cancel, attachment notice, mapper coverage
+  (tool/worker/reasoning/plan/usage/error/visibility), event subscription
+  (replay→live, reconnect, gap backfill), stdio black-box (stdout purity,
+  EOF/SIGTERM clean exit, kill-then-resume continuity).
+- `tests/agentd/test_channel_doctor.py`: doctor probe handshake, stderr
+  diagnosis on ACP failure, `--require-openclaw` semantics, read-only
+  guarantee.
+
 ## [Unreleased] - 2026-06-21
 
 ### Added

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,0 +1,175 @@
+# ROSClaw × OpenClaw Channel 集成
+
+> **ROSClaw owns the Agent. OpenClaw owns the Channel. ACP owns the bridge.
+> rosclawd owns physical authority.**
+
+本目录是 ROSClaw 接入 OpenClaw Channel（飞书/Discord/…）的**配置与验证
+脚手架**。ROSClaw 不实现任何 Channel adapter——消息平台连接、pairing、
+allowlist、去重、重试、线程路由、流式卡片全部复用 OpenClaw 官方能力。
+**不要 vendor OpenClaw，也不要在本仓库复制其 Channel 代码。**
+
+```text
+Feishu / Discord
+      │
+   OpenClaw Gateway（连接、鉴权、pairing、去重、流式卡片）
+      │ ACP（stdio JSON-RPC）
+      ▼
+rosclaw acp serve        ← 本仓库的 ACP adapter（src/rosclaw/adapters/acp/）
+      ▼
+AgentService → Mission → Native Agent → Tools/Workers
+      ▼
+Operator Proposal → Operator Broker → rosclawd → Robot
+```
+
+## 文件
+
+| 文件 | 说明 |
+|------|------|
+| `version.lock` | E2E 验证通过的组件版本锁（OpenClaw/acpx/feishu/Node/ACP SDK） |
+| `install-openclaw.sh` | 幂等安装：版本窗口检查 + 锁版本装 OpenClaw 与插件 |
+| `configure-openclaw.sh` | 幂等配置：安全基线 + rosclaw harness + feishu 策略（不碰密钥） |
+| `openclaw.rosclaw.example.json5` | 单机器人完整逻辑配置样例（设计 §33） |
+| `SECURITY.md` | 信任边界与安全配置基线 |
+| `e2e/acpx_direct_probe.py` | Stage 2 直连 E2E（§51）：ACPX → rosclaw harness |
+| `e2e/acp_continuity_probe.py` | kill ACP 子进程 → resume 的连续性 E2E（§49/§52） |
+| `README.md` | 本文件 |
+
+## 新机器部署（推荐顺序）
+
+```bash
+integrations/openclaw/install-openclaw.sh          # 1. 锁版本安装
+openclaw channels login --channel feishu           # 2. 配飞书凭证（唯一需要密钥的步骤）
+integrations/openclaw/configure-openclaw.sh \      # 3. 应用安全基线 + harness
+    --rosclaw-bin /abs/path/.venv/bin/rosclaw \
+    --rosclaw-home /home/ubuntu/.rosclaw \
+    --dm-user ou_<USER_OPEN_ID>                    # 可选：DM 直接绑定该用户
+openclaw gateway restart                           # 4. 生效
+rosclaw channel doctor --require-openclaw          # 5. 验收
+# 6. 群聊接入：把群 oc_xxx 加 groupAllowFrom 后，在群里发
+#    @机器人 /acp spawn rosclaw --bind here
+```
+
+以下为手动分步说明（脚本已自动化其中的大部分）：
+
+Doctor 实现不在本目录——它是 ROSClaw 产品化 CLI 的一部分：
+
+```bash
+rosclaw channel doctor                  # 只读检查，不改任何配置
+rosclaw channel doctor --require-openclaw
+rosclaw channel setup feishu            # 打印配置指引
+```
+
+（设计 §45 的文件清单中 `doctor.py` 落实为
+`src/rosclaw/integrations/openclaw/doctor.py`，以便 `rosclaw channel
+doctor` 直接复用；本目录只保留配置与文档，避免双份实现漂移。）
+
+## Bring-up 步骤
+
+### 0. 前置
+
+```bash
+# ROSClaw 侧：ACP 依赖版本已按验证锁定（pyproject.toml, >=0.12,<0.13）
+rosclaw --help
+rosclaw agent doctor
+pytest tests/agentd/test_acp.py -q     # ACP adapter gate，必须 100% PASS
+```
+
+### 1. 安装 OpenClaw（Node 22.22.3+ / 24.15+ / 25.9+）
+
+```bash
+curl -fsSL https://openclaw.ai/install.sh | bash
+# 或严格版本锁：npm install -g openclaw@<TESTED_VERSION>
+openclaw --version
+openclaw doctor
+```
+
+不要在 CI 里用 `openclaw@latest`：第一次 bring-up 用当前 stable，E2E
+全绿后记录 exact tested version 并锁进 CI（设计 §7）。飞书 Channel 要求
+OpenClaw ≥ 2026.5.29。
+
+### 2. 安装 ACPX 并注册 ROSClaw harness
+
+```bash
+openclaw plugins install @openclaw/acpx
+openclaw config set plugins.entries.acpx.enabled true
+```
+
+把 `openclaw.rosclaw.example.json5` 中 `plugins.entries.acpx.config.
+agents.rosclaw` 的 `command`/`args` 改成**本机绝对路径**后合入 OpenClaw
+配置。不要依赖 PATH / cwd / shell alias / conda activate。
+
+### 3. 冻结安全配置
+
+逐项对照 `SECURITY.md`：Gateway loopback + token 认证、
+`permissionMode: deny-all`、两个 MCP bridge 关闭、
+`allowedAgents: ["rosclaw"]`、飞书 `pairing + allowlist + mention`、
+飞书 workspace tools 全关、`dynamicAgentCreation.enabled: false`。
+
+> OpenClaw 配置 schema 仍在演进：合入配置后必须用目标版本的
+> `openclaw doctor` / `openclaw config` 验证，不允许只复制样例跳过
+> schema validation（设计 §33 注）。
+
+### 4. 飞书
+
+```bash
+openclaw channels login --channel feishu   # 引导配置 App ID / App Secret
+openclaw gateway restart
+openclaw gateway status
+```
+
+飞书开放平台：自建应用 → 启用机器人 → 发布 → 事件订阅选 **WebSocket 长
+连接** → 订阅 `im.message.receive_v1`（设计 §15）。
+
+### 5. 验证
+
+```bash
+rosclaw channel doctor --require-openclaw
+```
+
+随后按设计文档 §49–§67 执行 E2E：LIVE-ROSCLAW-ACP-OK、session
+continuity、pairing、20-turn、多用户隔离、群聊 mention、duplicate
+event、Gateway restart、reasoning、worker 可观测性、物理安全红队。
+
+## Rollback（设计 §74）
+
+```bash
+openclaw config set acp.dispatch.enabled false     # 或 channels.feishu.enabled false
+openclaw gateway restart
+```
+
+Channel 关闭后 `rosclaw chat` / `rosclaw-agentd` / `rosclawd` 必须继续正常
+——Channel 是 external integration，故障不能拖垮 ROSClaw Core。
+
+## Multi-Robot（设计 §34）
+
+每台机器人 = 独立 `ROSCLAW_HOME` + 独立 ACP harness + 独立 OpenClaw ACP
+agent，用 OpenClaw persistent binding 做静态路由。不要靠聊天里一句
+"切到 G1" 让 LLM 自己换 body。
+
+## 参考资料（只读，不 fork）
+
+```bash
+mkdir -p /tmp/rosclaw-channel-reference && cd /tmp/rosclaw-channel-reference
+git clone --depth 1 https://github.com/openclaw/openclaw.git
+git clone --depth 1 https://github.com/openclaw/acpx.git
+git clone --depth 1 https://github.com/agentclientprotocol/python-sdk.git
+```
+
+## 实测要点（OpenClaw 2026.7.1-2 验证）
+
+设计文档与实测之间的差异，按版本可能继续演进，以 `openclaw config schema` 为准：
+
+1. **channel 消息进 ACP runtime 需要 binding，不是 `agents.list[].runtime.type=acp` 就够**。
+   `runtime.type=acp` 只声明"该 agent 是 ACP harness 后端"；路由要：
+   - DM：configured binding，且 `match.peer.id` 是**用户 open_id**（`ou_...`），不是 p2p chat id（`oc_...`）：
+     ```bash
+     openclaw config set bindings '[{"type":"acp","agentId":"rosclaw","match":{"channel":"feishu","peer":{"kind":"direct","id":"ou_<USER_OPEN_ID>"}},"acp":{"mode":"persistent","backend":"acpx","cwd":"/home/nvidia","label":"rosclaw"}}]'
+     ```
+   - 群/topic 会话：configured binding 不命中 topic 作用域会话，在群里发
+     `@机器人 /acp spawn rosclaw --bind here`（gateway 斜杠命令）建立 persistent binding。
+   - ACP binding 必须带具体 `match.peer`（不支持整 channel 通配）——新用户/新群各加一条，符合设计 §34 静态路由意图。
+2. **`openclaw agent --agent rosclaw -m ...` CLI 不走 ACP runtime**（走 embedded 模型路径）；E2E 用飞书消息或 `integrations/openclaw/e2e/acpx_direct_probe.py`。
+3. `channels.feishu.streaming` 在此版本是**布尔**（`true`），不是设计 §30 的 object。
+4. 已有 embedded 会话记录会"粘住"路由——新 binding 生效前用
+   `openclaw gateway call sessions.delete --params '{"key":"<sessionKey>"}'` 清掉旧会话（transcript 自动归档为 `.deleted` 备份）。
+5. `openclaw doctor --fix` 可能把配置回滚到 last-known-good——任何 config 变更后复查关键项（`gateway.bind`、`bindings`、`acp.*`）。

--- a/integrations/openclaw/SECURITY.md
+++ b/integrations/openclaw/SECURITY.md
@@ -1,0 +1,97 @@
+# ROSClaw × OpenClaw Channel 安全基线
+
+本文冻结 Channel 集成的信任边界（Channel 设计 §4/§39/§40）。任何配置变更
+必须对照本文评审。
+
+## 信任边界
+
+```text
+Feishu User → OpenClaw identity → ACP request → ROSClaw Agent intent → Proposal
+                              到这里停止。
+
+REAL：Proposal → Trusted Operator → Permit → rosclawd   （另一条 trust path）
+```
+
+- **飞书/Discord 永远不直接访问 rosclawd，也永远不获得 Permit。**
+- ACP `request_permission` 不得代替 ROSClaw Operator Authorization。
+- 不自动批准 REAL Action。
+- 飞书不收 daemon challenge；模型读不到 daemon challenge。
+- 以下测试必须永久存在（设计 §4）：
+
+```python
+assert acp_client_cannot_issue_permit()
+assert channel_message_cannot_issue_permit()
+assert openclaw_permission_cannot_issue_permit()
+assert model_cannot_read_daemon_challenge()
+```
+
+现有回归：`tests/agentd/test_acp.py::TestAcpMapping::test_no_authority_via_acp`
+（ACP 路径 `list_grants() == []` 且 `pending_approvals() == []`）。
+
+## 必须冻结的配置
+
+| 项 | 值 | 原因 |
+|----|----|------|
+| `gateway.bind` | `loopback` | 飞书走 outbound WebSocket，无需公网 Gateway（§13） |
+| `gateway.auth.mode` | `token`（env 注入） | 禁止无认证；token 文件 chmod 600 |
+| `acp.allowedAgents` | `["rosclaw"]` | Gateway 只把消息送入 ROSClaw（§11） |
+| `acpx.permissionMode` | `deny-all` | ACP harness 权限 ≠ ROSClaw 物理权限（§10） |
+| `pluginToolsMcpBridge` / `openClawToolsMcpBridge` | `false` | 不注入第二套 tool surface（§10） |
+| `channels.feishu.dmPolicy` | `pairing` | 陌生人先配对（§16/§18） |
+| `channels.feishu.groupPolicy` | `allowlist` + `requireMention` | 群聊白名单 + @门槛 |
+| `channels.feishu.tools.*` | 全 `false` | Channel 只是 transport（§17） |
+| `dynamicAgentCreation.enabled` | `false` | 不创建第二套 Agent ownership（§32） |
+| `session.dmScope` | `per-channel-peer` | 用户间 Mission 隔离（§31） |
+
+**禁止**：`gateway.bind = lan` / `0.0.0.0`、公网暴露 AgentService、公网暴露
+rosclawd、`dmPolicy = open`、`groupPolicy = open`。
+
+## 身份模型（§39/§40）
+
+`RuntimePrincipal`（`user:local:<uid>`，与本机 Unix trust model 关联）与
+`ChannelIdentity`（`feishu:default:ou_xxx`）是两个概念：
+
+- 禁止把 `owner_principal` 设成飞书身份。
+- ChannelIdentity 只用于 audit / routing / provenance，不能用于 daemon
+  authorization。
+- 在专门的 Operator identity bridge 完成之前，外部 sender metadata 一律
+  标记为 `untrusted presentation identity`；不要发明 `X-Feishu-User`
+  并误当可信身份。
+
+## OS 用户（§41）
+
+- `openclaw` + `rosclaw-agentd`：非特权用户。
+- `rosclawd`：另一个特权服务身份。
+- 首版 OpenClaw 与 `rosclaw acp serve` 可同一普通用户（共享
+  ROSCLAW_HOME）；注意这意味着 OpenClaw 进程被攻破时可读该用户可读的
+  Agent credentials。P3 增强：OpenClaw → ACP thin proxy → Unix
+  AgentService socket，让 OpenClaw 不直接持有模型密钥。
+
+## ACP stdio 纯净（§36）
+
+`rosclaw acp serve` 的 stdout 只承载 JSON-RPC 帧；一切日志走 stderr。
+回归测试：`tests/agentd/test_acp.py::TestStdioProtocol::
+test_stdout_contains_only_jsonrpc`。
+
+## Secret 边界（§64）
+
+Channel transcript / OpenClaw logs / ROSClaw logs / ACP events / Mission
+journal 中搜索以下项必须为 0：
+
+```text
+OPENCLAW_GATEWAY_TOKEN
+FEISHU_APP_SECRET
+ROSCLAW_KIMI_API_KEY
+MOONSHOT_API_KEY
+daemon challenge
+Permit HMAC
+```
+
+## Release Gate（§68/§76）
+
+```text
+session_misroute_count = 0
+unauthorized_physical_decision_count = 0
+permit_material_leak_count = 0
+lost_final_message_count = 0
+```

--- a/integrations/openclaw/configure-openclaw.sh
+++ b/integrations/openclaw/configure-openclaw.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# ROSClaw × OpenClaw 配置脚本（设计 §9-§16/§33）。
+#
+# 幂等应用安全基线与 rosclaw ACP harness 配置。所有配置经
+# `openclaw config set` + schema validate，不手写 openclaw.json。
+#
+# 本脚本**不触碰**任何密钥：飞书 App ID/Secret 走
+# `openclaw channels login --channel feishu`；Gateway token 走环境变量。
+#
+# 用法：
+#   integrations/openclaw/configure-openclaw.sh \
+#       --rosclaw-bin /abs/path/.venv/bin/rosclaw \
+#       --rosclaw-home /home/ubuntu/.rosclaw \
+#       [--dm-user ou_xxx]          # 可选：为指定飞书用户建 DM ACP binding
+#       [--group oc_xxx]            # 可选：群加入 allowlist
+set -euo pipefail
+
+ROSCLAW_BIN=""
+ROSCLAW_HOME=""
+DM_USER=""
+GROUP_ID=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --rosclaw-bin)  ROSCLAW_BIN="$2"; shift 2 ;;
+    --rosclaw-home) ROSCLAW_HOME="$2"; shift 2 ;;
+    --dm-user)      DM_USER="$2"; shift 2 ;;
+    --group)        GROUP_ID="$2"; shift 2 ;;
+    *) echo "未知参数: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$ROSCLAW_BIN" ] || [ -z "$ROSCLAW_HOME" ]; then
+  echo "必须提供 --rosclaw-bin 和 --rosclaw-home（绝对路径）" >&2
+  exit 2
+fi
+case "$ROSCLAW_BIN" in /*) ;; *) echo "--rosclaw-bin 必须是绝对路径（设计 §9）" >&2; exit 2 ;; esac
+case "$ROSCLAW_HOME" in /*) ;; *) echo "--rosclaw-home 必须是绝对路径" >&2; exit 2 ;; esac
+[ -x "$ROSCLAW_BIN" ] || { echo "FAIL: $ROSCLAW_BIN 不可执行" >&2; exit 1; }
+
+set_cfg() { openclaw config set "$1" "$2" >/dev/null; echo "  $1 = $2"; }
+
+echo "==> Gateway 安全（§13：loopback + token；token 用环境变量注入）"
+set_cfg gateway.bind loopback
+set_cfg gateway.auth.mode token
+
+echo "==> acpx harness（§9/§10）"
+set_cfg plugins.entries.acpx.enabled true
+set_cfg plugins.entries.acpx.config.agents.rosclaw.command "$ROSCLAW_BIN"
+set_cfg plugins.entries.acpx.config.agents.rosclaw.args "[\"acp\",\"serve\",\"--home\",\"$ROSCLAW_HOME\"]"
+set_cfg plugins.entries.acpx.config.permissionMode deny-all
+set_cfg plugins.entries.acpx.config.nonInteractivePermissions deny
+set_cfg plugins.entries.acpx.config.pluginToolsMcpBridge false
+set_cfg plugins.entries.acpx.config.openClawToolsMcpBridge false
+set_cfg plugins.entries.acpx.config.probeAgent rosclaw
+
+echo "==> ACP 核心（§11）"
+set_cfg acp.enabled true
+set_cfg acp.dispatch.enabled true
+set_cfg acp.backend acpx
+set_cfg acp.defaultAgent rosclaw
+set_cfg acp.allowedAgents '["rosclaw"]'
+set_cfg acp.stream.deliveryMode live
+set_cfg session.dmScope per-channel-peer
+
+echo "==> rosclaw agent（§12；非默认，不抢占既有 main agent）"
+set_cfg agents.list '[{"id":"rosclaw","runtime":{"type":"acp","acp":{"agent":"rosclaw","backend":"acpx","mode":"persistent","cwd":"/home/nvidia"}}}]'
+
+echo "==> 飞书安全基线（§16/§17/§30/§32）"
+set_cfg channels.feishu.connectionMode websocket
+set_cfg channels.feishu.dmPolicy pairing
+set_cfg channels.feishu.groupPolicy allowlist
+set_cfg channels.feishu.requireMention true
+set_cfg channels.feishu.groupSessionScope group_topic_sender
+set_cfg channels.feishu.replyInThread disabled
+set_cfg channels.feishu.streaming true
+set_cfg channels.feishu.dynamicAgentCreation '{"enabled":false}'
+set_cfg channels.feishu.tools '{"doc":false,"chat":false,"wiki":false,"drive":false,"perm":false,"scopes":false,"bitable":false}'
+
+echo "==> ACP bindings（§19/§34：每会话一条，静态路由）"
+BINDINGS="[]"
+if [ -n "$DM_USER" ]; then
+  BINDINGS="[{\"type\":\"acp\",\"agentId\":\"rosclaw\",\"match\":{\"channel\":\"feishu\",\"peer\":{\"kind\":\"direct\",\"id\":\"$DM_USER\"}},\"acp\":{\"mode\":\"persistent\",\"backend\":\"acpx\",\"cwd\":\"/home/nvidia\",\"label\":\"rosclaw\"},\"comment\":\"ROSClaw ACP DM binding\"}]"
+  set_cfg channels.feishu.allowFrom "[\"$DM_USER\"]"
+  echo "  （dmPolicy 改用 allowlist + allowFrom；若坚持 pairing 流程请手动改回并不设 allowFrom）"
+fi
+if [ -n "$GROUP_ID" ]; then
+  set_cfg channels.feishu.groupAllowFrom "[\"$GROUP_ID\"]"
+  echo "  群 $GROUP_ID 已入 allowlist。群会话绑定请在群内执行：@机器人 /acp spawn rosclaw --bind here"
+  echo "  （topic 作用域群会话的 configured binding 不生效——实测结论，见 README 实测要点）"
+fi
+if [ "$BINDINGS" != "[]" ]; then
+  set_cfg bindings "$BINDINGS"
+fi
+
+echo
+echo "==> schema 校验"
+openclaw config validate
+
+echo
+echo "完成。重启生效："
+echo "  openclaw gateway restart"
+echo "验收："
+echo "  rosclaw channel doctor --require-openclaw"
+if [ -z "$DM_USER" ]; then
+  echo
+  echo "提示：未提供 --dm-user。新用户 DM 走 pairing 审批："
+  echo "  openclaw pairing list feishu && openclaw pairing approve feishu <CODE>"
+  echo "  审批后为该用户加 DM binding：重跑本脚本并加 --dm-user ou_xxx"
+fi

--- a/integrations/openclaw/e2e/acp_continuity_probe.py
+++ b/integrations/openclaw/e2e/acp_continuity_probe.py
@@ -1,0 +1,100 @@
+"""Live session continuity E2E（设计 §49/§52 的 ACP 子进程段）。
+
+真实模型链路：new session → 记住随机码 → **kill ACP 子进程** → 新进程
+session/resume 同一 Mission → 询问随机码 → 必须回答正确。
+
+Gateway restart 那一段 continuity 由 Stage 3 的飞书 E2E 覆盖。
+
+用法：
+
+    python acp_continuity_probe.py            # 默认随机码 RC-7F4A9
+
+环境变量：ROSCLAW_BIN、ROSCLAW_HOME（同 acpx_direct_probe.py）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import acp
+from acp import schema
+
+ROSCLAW_BIN = os.environ.get(
+    "ROSCLAW_BIN",
+    str(Path(__file__).resolve().parents[3] / ".venv" / "bin" / "rosclaw"),
+)
+ROSCLAW_HOME = os.environ.get("ROSCLAW_HOME", str(Path.home() / ".rosclaw"))
+CODE = sys.argv[1] if len(sys.argv) > 1 else "RC-7F4A9"
+
+
+class Client(acp.Client):
+    def __init__(self) -> None:
+        self.chunks: list[str] = []
+
+    async def session_update(self, session_id: str, update, **kwargs) -> None:
+        if getattr(update, "session_update", "") == "agent_message_chunk":
+            self.chunks.append(update.content.text)
+
+
+async def start():
+    proc = await asyncio.create_subprocess_exec(
+        ROSCLAW_BIN,
+        "acp",
+        "serve",
+        "--home",
+        ROSCLAW_HOME,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    client = Client()
+    conn = acp.connect_to_agent(client, proc.stdin, proc.stdout)
+    await conn.initialize(protocol_version=1, client_capabilities=schema.ClientCapabilities())
+    return proc, conn, client
+
+
+async def prompt(conn, sid: str, text: str, timeout: float = 240) -> None:
+    resp = await asyncio.wait_for(
+        conn.prompt(
+            session_id=sid,
+            prompt=[schema.TextContentBlock(type="text", text=text)],
+        ),
+        timeout=timeout,
+    )
+    print(f"  stop_reason={resp.stop_reason}", flush=True)
+
+
+async def main() -> int:
+    print("[1] 新 session + 记住随机码", flush=True)
+    proc1, conn1, _client1 = await start()
+    session = await conn1.new_session(cwd=str(Path.home()))
+    sid = session.session_id
+    print(f"  mission={sid}", flush=True)
+    await prompt(conn1, sid, f"请记住测试随机码：{CODE}。只回答：已记住。")
+
+    print("[2] kill ACP 子进程（模拟崩溃）", flush=True)
+    proc1.kill()
+    await proc1.wait()
+
+    print("[3] 新进程 resume 同一 Mission，询问随机码", flush=True)
+    proc2, conn2, client2 = await start()
+    try:
+        await conn2.resume_session(session_id=sid, cwd=str(Path.home()))
+        await prompt(conn2, sid, "我刚才让你记住的随机码是什么？只回答随机码本身。")
+        answer = "".join(client2.chunks)
+        print(f"  answer={answer.strip()!r}", flush=True)
+        if CODE in answer:
+            print(f"[PASS] ACP 子进程重启后上下文保留（{CODE}）", flush=True)
+            return 0
+        print(f"[FAIL] 回答中未找到 {CODE}", flush=True)
+        return 1
+    finally:
+        proc2.kill()
+        await proc2.wait()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/integrations/openclaw/e2e/acpx_direct_probe.py
+++ b/integrations/openclaw/e2e/acpx_direct_probe.py
@@ -1,0 +1,84 @@
+"""Stage 2 直连 E2E（设计 §51）：ACPX → `rosclaw acp serve` → Native Agent。
+
+不走 OpenClaw Gateway（gateway→acpx 的路由由 Feishu binding 在 Stage 3
+验证）；用 OpenClaw 官方 ACPX 客户端驱动 rosclaw harness，验证 ACP 链路
+与 Mission/Turn 落库。
+
+用法：
+
+    python acpx_direct_probe.py ["只回答：LIVE-ROSCLAW-ACP-OK"]
+
+前置：
+- `rosclaw channel doctor` 除 Feishu 外全绿（模型凭证已配置）
+- OpenClaw 已安装 @openclaw/acpx（提供 acpx CLI）
+
+验收（§51）：输出中出现预期回答；ROSClaw DB 出现 1 Mission + 1 Turn。
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROSCLAW_BIN = os.environ.get(
+    "ROSCLAW_BIN",
+    str(Path(__file__).resolve().parents[3] / ".venv" / "bin" / "rosclaw"),
+)
+ROSCLAW_HOME = os.environ.get("ROSCLAW_HOME", str(Path.home() / ".rosclaw"))
+
+PROMPT = sys.argv[1] if len(sys.argv) > 1 else "只回答：LIVE-ROSCLAW-ACP-OK"
+EXPECT = "LIVE-ROSCLAW-ACP-OK"
+
+
+def _find_acpx() -> str:
+    # acpx CLI 是 @openclaw/acpx 插件包的依赖，位于嵌套 node_modules。
+    candidates = sorted(
+        Path.home().glob(
+            ".openclaw/npm/projects/openclaw-acpx-*/node_modules/@openclaw/acpx/node_modules/.bin/acpx"
+        )
+    )
+    if candidates:
+        return str(candidates[-1])
+    found = shutil.which("acpx")
+    if found:
+        return found
+    raise SystemExit("acpx 未找到——先 `openclaw plugins install @openclaw/acpx`")
+
+
+def main() -> int:
+    acpx = _find_acpx()
+    result = subprocess.run(
+        [
+            acpx,
+            "--deny-all",
+            "--non-interactive-permissions",
+            "deny",
+            "--timeout",
+            "180",
+            "--agent",
+            f"{ROSCLAW_BIN} acp serve --home {ROSCLAW_HOME}",
+            "exec",
+            PROMPT,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+    output = result.stdout + result.stderr
+    print(output)
+    if EXPECT in output and PROMPT == "只回答：LIVE-ROSCLAW-ACP-OK":
+        print(f"[PASS] 收到预期回答 {EXPECT}")
+        print("检查 ROSClaw DB：missions 表应新增 1 Mission + 对应 turn 事件。")
+        return 0
+    if PROMPT != "只回答：LIVE-ROSCLAW-ACP-OK":
+        print("[INFO] 自定义 prompt——人工核对上方输出。")
+        return 0
+    print(f"[FAIL] 未收到 {EXPECT}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/openclaw/install-openclaw.sh
+++ b/integrations/openclaw/install-openclaw.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ROSClaw × OpenClaw 安装脚本（设计 §7/§8/§14）。
+#
+# 幂等：可重复运行。版本全部来自 version.lock（E2E 验证过的组合），
+# 不装 latest。
+#
+# 用法：
+#   integrations/openclaw/install-openclaw.sh
+#
+# 前置：Node 在支持窗口内（>=22.22.3 <23 / >=24.15 <25 / >=25.9）。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=version.lock
+source "$SCRIPT_DIR/version.lock"
+
+echo "==> 目标版本: openclaw=$OPENCLAW_VERSION acpx=$OPENCLAW_ACPX_VERSION feishu=$OPENCLAW_FEISHU_VERSION node=$NODE_VERSION"
+
+# ---- 1. Node 版本检查（不自动改用户的 Node——这属于系统级变更，报指引） ----
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node 不在 PATH。安装 Node $NODE_VERSION（推荐 nvm: nvm install 24）。" >&2
+  exit 1
+fi
+node_ver="$(node -v)"
+node_major="${node_ver#v}"; node_major="${node_major%%.*}"
+node_ok=0
+case "$node_major" in
+  22) [ "$(printf '%s\n' "22.22.3" "${node_ver#v}" | sort -V | head -1)" = "22.22.3" ] && node_ok=1 ;;
+  24) [ "$(printf '%s\n' "24.15.0" "${node_ver#v}" | sort -V | head -1)" = "24.15.0" ] && node_ok=1 ;;
+  25) [ "$(printf '%s\n' "25.9.0" "${node_ver#v}" | sort -V | head -1)" = "25.9.0" ] && node_ok=1 ;;
+  *)  [ "$node_major" -gt 25 ] && node_ok=1 ;;
+esac
+if [ "$node_ok" != "1" ]; then
+  echo "FAIL: node $node_ver 不在支持窗口（>=22.22.3 <23 / >=24.15 <25 / >=25.9）。" >&2
+  exit 1
+fi
+echo "OK: node $node_ver"
+
+# ---- 2. OpenClaw 本体（锁版本，不 latest） ----
+current="$(openclaw --version 2>/dev/null | grep -oE '[0-9]{4}\.[0-9]+\.[0-9]+(-[0-9]+)?' | head -1 || true)"
+if [ "$current" = "$OPENCLAW_VERSION" ]; then
+  echo "OK: openclaw $current 已是锁定版本"
+else
+  echo "==> 安装 openclaw@$OPENCLAW_VERSION（当前: ${current:-未安装}）"
+  npm install -g "openclaw@$OPENCLAW_VERSION"
+fi
+
+# ---- 3. 插件（锁版本） ----
+for spec in "@openclaw/acpx@$OPENCLAW_ACPX_VERSION" "@openclaw/feishu@$OPENCLAW_FEISHU_VERSION"; do
+  name="${spec%%@*}"
+  if openclaw plugins list 2>/dev/null | grep -q "${name#@openclaw/}"; then
+    echo "OK: 插件 $name 已安装（如需对齐版本请 openclaw plugins install $spec）"
+  else
+    echo "==> 安装插件 $spec"
+    openclaw plugins install "$spec"
+  fi
+done
+
+# ---- 4. Gateway systemd 服务 ----
+echo "==> 安装/刷新 gateway 服务定义"
+openclaw gateway install --force || true
+
+echo
+echo "安装完成。下一步："
+echo "  1. integrations/openclaw/configure-openclaw.sh   # 应用安全基线 + rosclaw harness"
+echo "  2. openclaw channels login --channel feishu      # 配飞书 App ID/Secret"
+echo "  3. rosclaw channel doctor --require-openclaw     # 验收"

--- a/integrations/openclaw/openclaw.rosclaw.example.json5
+++ b/integrations/openclaw/openclaw.rosclaw.example.json5
@@ -1,0 +1,134 @@
+// ROSClaw × OpenClaw 单机器人推荐配置（Channel 设计 §33）。
+//
+// 使用方式：把本文件的相关段落合入 OpenClaw 配置（不要用本文件整体替换
+// 你已有的 OpenClaw 配置）。所有 command/args 必须是**绝对路径**。
+//
+// 注意：OpenClaw 配置 schema 仍在演进——合入后必须用目标安装版本的
+// `openclaw doctor` / `openclaw config` 验证，不允许跳过 schema
+// validation（设计 §33 注）。
+
+{
+  gateway: {
+    // 只监听 loopback；飞书走 outbound WebSocket，不需要公网 Gateway（§13）。
+    mode: "local",
+    bind: "loopback",
+    auth: {
+      // Token 经环境变量注入：export OPENCLAW_GATEWAY_TOKEN=$(openssl rand -hex 32)
+      // systemd: EnvironmentFile=/etc/rosclaw/openclaw.env（chmod 600）
+      mode: "token",
+    },
+  },
+
+  acp: {
+    enabled: true,
+    dispatch: { enabled: true },
+    backend: "acpx",
+
+    // 首版只允许 rosclaw 一个 harness——是否用 Codex/Claude/Pi 由
+    // ROSClaw Worker Fabric 决定，不是 Channel Gateway 的职责（§11）。
+    defaultAgent: "rosclaw",
+    allowedAgents: ["rosclaw"],
+
+    stream: { deliveryMode: "live" },
+  },
+
+  session: {
+    // DM 隔离：Feishu + User A → Mission A；User B → Mission B（§31）。
+    dmScope: "per-channel-peer",
+    threadBindings: {
+      enabled: true,
+      idleHours: 24,
+      maxAgeHours: 0,
+      spawnSessions: true,
+    },
+  },
+
+  plugins: {
+    entries: {
+      acpx: {
+        enabled: true,
+        config: {
+          agents: {
+            // harness id = rosclaw。command/args 必须绝对路径（§9）。
+            rosclaw: {
+              command: "/opt/rosclaw/.venv/bin/rosclaw",
+              args: ["acp", "serve", "--home", "/var/lib/rosclaw/default"],
+            },
+            // Multi-Robot（§34）：每台机器人独立 ROSCLAW_HOME + 独立 harness：
+            // "rosclaw-limo": {
+            //   command: "/opt/rosclaw/.venv/bin/rosclaw",
+            //   args: ["acp", "serve", "--home", "/var/lib/rosclaw/limo"],
+            // },
+            // "rosclaw-g1": {
+            //   command: "/opt/rosclaw/.venv/bin/rosclaw",
+            //   args: ["acp", "serve", "--home", "/var/lib/rosclaw/g1"],
+            // },
+          },
+
+          // 这是 ACP harness 自己的文件/shell 权限，不是 ROSClaw 物理权限；
+          // 即便如此也默认 deny-all（§10）。
+          permissionMode: "deny-all",
+          nonInteractivePermissions: "deny",
+
+          // ROSClaw 自带 Tool Catalog / MCP / Worker Fabric——不再注入
+          // 第二套 OpenClaw tool surface（§10）。
+          pluginToolsMcpBridge: false,
+          openClawToolsMcpBridge: false,
+
+          probeAgent: "rosclaw",
+        },
+      },
+    },
+  },
+
+  agents: {
+    entries: {
+      rosclaw: {
+        default: true,
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "rosclaw",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/var/lib/rosclaw",
+          },
+        },
+      },
+    },
+  },
+
+  channels: {
+    feishu: {
+      enabled: true,
+      connectionMode: "websocket",
+
+      // 首版安全基线（§16）：不要 dmPolicy/groupPolicy = open。
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+      requireMention: true,
+      groupSessionScope: "group_topic_sender",
+      replyInThread: "enabled",
+
+      // 流式卡片（§30）：聚合 reasoning/worker/tool 更新，不按 token 发消息。
+      streaming: {
+        mode: "partial",
+        block: { enabled: true },
+      },
+
+      // OpenClaw Agent ≠ ROSClaw Mission；不创建第二套 Agent ownership（§32）。
+      dynamicAgentCreation: { enabled: false },
+
+      // Channel 只负责 transport——飞书 workspace 工具首版全关（§17）。
+      tools: {
+        doc: false,
+        chat: false,
+        wiki: false,
+        drive: false,
+        perm: false,
+        scopes: false,
+        bitable: false,
+      },
+    },
+  },
+}

--- a/integrations/openclaw/version.lock
+++ b/integrations/openclaw/version.lock
@@ -1,0 +1,18 @@
+# ROSClaw × OpenClaw Channel Integration — 已验证版本锁
+#
+# 本文件记录在本机完整 E2E（飞书 DM/群 → ACP → ROSClaw Mission）验证通过的
+# 组件版本。CI / 新机器部署以此为准；升级任一组件后必须重跑兼容性验证
+#（设计 §7：不要 latest）。
+#
+# 验证日期：2026-08-13
+# 验证环境：Linux aarch64 (Jetson), Python 3.11, 飞书自建应用 WebSocket 长连接
+
+# ---- OpenClaw 侧 ----
+OPENCLAW_VERSION=2026.7.1-2          # openclaw --version
+OPENCLAW_ACPX_VERSION=2026.7.1       # @openclaw/acpx 插件
+OPENCLAW_FEISHU_VERSION=2026.7.1     # @openclaw/feishu 插件（要求 OpenClaw ≥ 2026.5.29）
+NODE_VERSION=v24.19.0                # 支持窗口：>=22.22.3 <23 / >=24.15 <25 / >=25.9
+
+# ---- ROSClaw 侧 ----
+ACP_PYTHON_SDK=0.12.0                # agent-client-protocol（pyproject 锁 >=0.12,<0.13）
+ROSCLAW_VERSION=1.2.0                # 本仓库

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,11 @@ dependencies = [
     # since the Native Agent model path became a first-class feature).
     "aiohttp>=3.9.0",
     "mcp>=1.0.0,<2.0.0",
-    "agent-client-protocol>=0.12.0",
+    # ACP (Agent Client Protocol) bridge — 依赖范围按 Channel Integration CI
+    # 实际验证过的版本锁定（设计文档 §5 情况 A：PyPI 已有 0.12.x）。
+    # 已验证版本：0.12.0（tests/agentd/test_acp.py 全绿）。升级时需重跑
+    # compatibility matrix 后再放宽上界，不要无限 >=。
+    "agent-client-protocol>=0.12.0,<0.13.0",
     "pyyaml>=6.0",
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",

--- a/src/rosclaw/adapters/acp/cli.py
+++ b/src/rosclaw/adapters/acp/cli.py
@@ -36,6 +36,13 @@ def dispatch_acp_argv(argv: list[str]) -> int | None:
     service = AgentService(config, home)
     import contextlib
 
+    async def _run() -> None:
+        try:
+            await serve_stdio(service)
+        finally:
+            # graceful shutdown（§37）：flush journal、关闭 MissionStore。
+            await service.close()
+
     with contextlib.suppress(KeyboardInterrupt):
-        asyncio.run(serve_stdio(service))
+        asyncio.run(_run())
     return 0

--- a/src/rosclaw/adapters/acp/mapper.py
+++ b/src/rosclaw/adapters/acp/mapper.py
@@ -1,55 +1,132 @@
-"""AgentEventV2 → ACP session update 映射（纯函数，可单测）。"""
+"""AgentEventV2 → ACP session update 映射（纯函数，可单测）。
+
+Channel 设计 §22/§26 的冻结映射表实现。只做表示层映射；不携带任何
+authority——approval/action 只呈现只读卡片，绝不转成 ACP permission 请求。
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
+from rosclaw.contracts.agent.agent_event import Visibility
 
-def event_to_session_update(event) -> Any | None:
+
+def _tool_call_id(event, payload: dict) -> str:
+    """稳定 tool_call_id（设计 §23）：连续同名调用不得被 UI 合并成一个 call。"""
+    return str(payload.get("tool_call_id") or payload.get("call_id") or event.event_id)
+
+
+def _message_id(event) -> str:
+    """稳定 message id（ACP message-id RFD）：同一 turn 的 delta 同属一条消息。"""
+    return str(event.turn_id or event.event_id)
+
+
+def event_to_session_update(event, *, include_debug: bool = False) -> Any | None:
     """Map one AgentEventV2 to an ACP session update (or None to skip).
 
-    只做表示层映射；不携带任何 authority。
+    Visibility 门（设计 §48）：默认只有 USER 事件离开 ACP；DEBUG/AUDIT
+    不外发（``include_debug=True`` 仅供本地调试）。
     """
     from acp import schema
 
+    visibility = getattr(event, "visibility", None)
+    if not include_debug and visibility is not None and visibility is not Visibility.USER:
+        return None
+
     etype = event.type.value if hasattr(event.type, "value") else str(event.type)
     payload = event.payload or {}
+
     if etype == "model.text.delta":
         return schema.AgentMessageChunk(
             session_update="agent_message_chunk",
             content=schema.TextContentBlock(type="text", text=str(payload.get("text", ""))),
+            message_id=_message_id(event),
         )
+
+    # -- 思考摘要（§24/§26）：只转发安全 summary，绝不转发 raw CoT -------------
+    if etype == "reasoning.summary.delta":
+        text = str(payload.get("text", ""))
+        if not text:
+            return None
+        return schema.AgentThoughtChunk(
+            session_update="agent_thought_chunk",
+            content=schema.TextContentBlock(type="text", text=text),
+            message_id=f"{_message_id(event)}:reasoning",
+        )
+    if etype == "plan.updated":
+        entries = payload.get("entries") or []
+        if not entries:
+            return None
+        return schema.AgentPlanUpdate(
+            session_update="plan",
+            entries=[
+                schema.PlanEntry(
+                    content=str(item.get("content", ""))[:500],
+                    priority=item.get("priority", "medium")
+                    if item.get("priority") in ("high", "medium", "low")
+                    else "medium",
+                    status=item.get("status", "pending")
+                    if item.get("status") in ("pending", "in_progress", "completed")
+                    else "pending",
+                )
+                for item in entries[:50]
+                if isinstance(item, dict) and item.get("content")
+            ],
+        )
+    if etype in ("reasoning.started", "reasoning.summary.ended"):
+        return None  # 生命周期标记，无独立 ACP 呈现
+
+    # -- Tool lifecycle -------------------------------------------------------
     if etype in ("tool.started", "tool.proposed"):
         return schema.ToolCallStart(
             session_update="tool_call",
-            tool_call_id=str(payload.get("name", "tool")),
+            tool_call_id=_tool_call_id(event, payload),
             title=f"⚙ {payload.get('name', 'tool')}",
             kind="other",
             status="in_progress",
+        )
+    if etype == "tool.progress":
+        note = payload.get("note") or payload.get("progress") or ""
+        return schema.ToolCallUpdate(
+            session_update="tool_call_update",
+            tool_call_id=_tool_call_id(event, payload),
+            status="in_progress",
+            title=f"⚙ {payload.get('name', 'tool')}: {note}" if note else None,
         )
     if etype == "tool.completed":
         ok = payload.get("ok", True)
         return schema.ToolCallUpdate(
             session_update="tool_call_update",
-            tool_call_id=str(payload.get("name", "tool")),
+            tool_call_id=_tool_call_id(event, payload),
             status="completed" if ok else "failed",
         )
+
+    # -- Worker lifecycle（设计 §29：Worker progress 是第一等 UI）--------------
     if etype.startswith("worker."):
         status = etype.split(".", 1)[1]
-        terminal = status in ("accepted", "failed", "expired")
-        return schema.ToolCallStart(
-            session_update="tool_call",
-            tool_call_id=str(payload.get("work_order_id", "worker")),
-            title=f"⛏ {payload.get('worker_id', 'worker')}: {status}",
-            kind="other",
-            status=(
-                "completed"
-                if status == "accepted"
-                else "failed" if terminal else "in_progress"
-            ),
+        # work_order_id 必须作为稳定 ID（§23）。
+        call_id = str(payload.get("work_order_id") or event.event_id)
+        worker = payload.get("worker_id", "worker")
+        title = f"⛏ {worker}: {status}"
+        if status in ("offered", "claimed", "started"):
+            return schema.ToolCallStart(
+                session_update="tool_call",
+                tool_call_id=call_id,
+                title=title,
+                kind="other",
+                status="in_progress",
+            )
+        terminal_ok = status in ("accepted", "completed")
+        terminal_bad = status in ("failed", "expired")
+        return schema.ToolCallUpdate(
+            session_update="tool_call_update",
+            tool_call_id=call_id,
+            title=title,
+            status=("completed" if terminal_ok else "failed" if terminal_bad else "in_progress"),
         )
+
+    # -- Approval / Action：只读呈现，绝不构成授权（§9.1 边界）------------------
     if etype == "approval.requested":
-        # 不伪造 ACP permission=物理授权；只呈现卡片与 id（§9.1 边界）。
         text = (
             f"🔐 授权请求 {payload.get('request_id', '')}\n"
             f"{payload.get('title', '')}（风险 {payload.get('risk_tier', 'LOW')}）\n"
@@ -59,22 +136,54 @@ def event_to_session_update(event) -> Any | None:
         return schema.AgentMessageChunk(
             session_update="agent_message_chunk",
             content=schema.TextContentBlock(type="text", text=text),
+            message_id=event.event_id,
+        )
+    if etype == "action.proposed":
+        text = (
+            f"📝 动作提案 {payload.get('proposal_id', '')}\n"
+            f"{payload.get('summary', payload.get('title', ''))}\n"
+            "仅展示；REAL 执行必须经 trusted Operator 授权链。"
+        )
+        return schema.AgentMessageChunk(
+            session_update="agent_message_chunk",
+            content=schema.TextContentBlock(type="text", text=text),
+            message_id=event.event_id,
+        )
+    if etype == "action.progress":
+        text = (
+            f"🔄 动作进度 {payload.get('proposal_id', payload.get('action_id', ''))}: "
+            f"{payload.get('status', payload.get('note', ''))}"
+        )
+        return schema.AgentMessageChunk(
+            session_update="agent_message_chunk",
+            content=schema.TextContentBlock(type="text", text=text),
+            message_id=event.event_id,
         )
     if etype in ("action.receipt", "receipt.received"):
         lines = "\n".join(f"{k}: {v}" for k, v in list(payload.items())[:6])
         return schema.AgentMessageChunk(
             session_update="agent_message_chunk",
             content=schema.TextContentBlock(type="text", text=f"🧾 执行回执\n{lines}"),
+            message_id=event.event_id,
         )
+
+    # -- Usage / 系统 -----------------------------------------------------------
     if etype == "model.request.ended":
+        used = int(payload.get("prompt_tokens", 0)) + int(payload.get("completion_tokens", 0))
+        size = payload.get("context_size") or payload.get("context_window")
+        if not size:
+            # 没有上下文窗口大小时不伪造 usage 比例（§22 映射的前提是数据真实）。
+            return None
+        return schema.UsageUpdate(
+            session_update="usage_update",
+            used=used,
+            size=int(size),
+        )
+    if etype == "error":
+        text = f"⚠ {payload.get('message', payload.get('error', 'unknown error'))}"
         return schema.AgentMessageChunk(
             session_update="agent_message_chunk",
-            content=schema.TextContentBlock(
-                type="text",
-                text=(
-                    f"（tokens: {payload.get('prompt_tokens', 0)}"
-                    f"→{payload.get('completion_tokens', 0)}）"
-                ),
-            ),
+            content=schema.TextContentBlock(type="text", text=text),
+            message_id=event.event_id,
         )
     return None

--- a/src/rosclaw/adapters/acp/server.py
+++ b/src/rosclaw/adapters/acp/server.py
@@ -1,19 +1,40 @@
-"""rosclaw ACP server（批次 G §9.1）：`rosclaw acp serve`。
+"""rosclaw ACP server（批次 G §9.1 + Channel 设计 PR-RC-001/002）：`rosclaw acp serve`。
 
-ACP（Agent Client Protocol）客户端（Zed 等编辑器）经 stdio JSON-RPC 与
-本进程通信；每个 ACP session 映射一个 ROSClaw Mission，prompt 映射
-turn，流式 AgentEventV2 映射 session update。
+ACP（Agent Client Protocol）客户端（OpenClaw acpx、Zed 等）经 stdio
+JSON-RPC 与本进程通信；每个 ACP session 映射一个 ROSClaw Mission，
+prompt 映射 turn，流式 AgentEventV2 映射 session update。
+
+Session lifecycle 语义（Channel 设计 §20）：
+
+```text
+session/new     → 创建 Mission
+session/list    → MissionStore.list_missions()
+session/load    → 重新绑定已有 Mission + transcript replay
+session/resume  → 重新绑定已有 Mission，不重放 transcript
+session/close   → 释放 adapter 侧绑定；Mission journal 保留，绝不删除
+session/cancel  → 只 cancel 当前 turn，不归档 Mission
+```
+
+边界：本进程不产生任何物理 authority；approval 只呈现只读卡片。
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import signal
+import sys
 from pathlib import Path
 
 from rosclaw.adapters.acp.mapper import event_to_session_update
 from rosclaw.agentd.service import AgentService
 
 PROTOCOL_VERSION = 1
+
+# load_session replay 的 transcript 上限（避免大 Mission 全量重放拖垮客户端）。
+_LOAD_REPLAY_LIMIT = 200
+
+_UNSUPPORTED_ATTACHMENT_NOTICE = "当前 ROSClaw Channel 版本尚未接入该附件类型（P0 仅支持文本）"
 
 
 class RosclawAcpAgent:
@@ -23,6 +44,10 @@ class RosclawAcpAgent:
         self._service = service
         self._client = None
         self._sessions: dict[str, str] = {}  # acp session_id -> mission_id
+        self._closed_sessions: set[str] = set()
+        self._stream_tasks: set[asyncio.Task] = set()
+        self._last_sent_seq: dict[str, int] = {}  # mission_id -> last pushed seq
+        self._turn_locks: dict[str, asyncio.Lock] = {}
 
     # -- 生命周期 ------------------------------------------------------------
 
@@ -35,8 +60,16 @@ class RosclawAcpAgent:
         return schema.InitializeResponse(
             protocol_version=PROTOCOL_VERSION,
             agent_capabilities=schema.AgentCapabilities(
-                load_session=False,
-                prompt_capabilities=schema.PromptCapabilities(),
+                # PR-RC-001：load_session 已实现，capability 必须与实现一致。
+                load_session=True,
+                prompt_capabilities=schema.PromptCapabilities(
+                    image=False, audio=False, embedded_context=False
+                ),
+                session_capabilities=schema.SessionCapabilities(
+                    list=schema.SessionListCapabilities(),
+                    resume=schema.SessionResumeCapabilities(),
+                    close=schema.SessionCloseCapabilities(),
+                ),
             ),
             agent_info=schema.Implementation(
                 name="rosclaw-native-agent",
@@ -56,6 +89,7 @@ class RosclawAcpAgent:
         mission = self._service.create_mission(f"ACP session ({Path(cwd).name})")
         session_id = mission.mission_id
         self._sessions[session_id] = mission.mission_id
+        self._closed_sessions.discard(session_id)
         return schema.NewSessionResponse(session_id=session_id)
 
     async def list_sessions(self, **kwargs):
@@ -74,39 +108,88 @@ class RosclawAcpAgent:
             ]
         )
 
-    async def load_session(self, session_id: str, cwd: str, **kwargs):
-        from acp import schema
+    def _bind_existing(self, session_id: str) -> str:
+        """校验并绑定已有 Mission（load/resume 可重绑已 close 的会话）。"""
+        from acp.exceptions import RequestError
 
         if self._service.get_mission(session_id) is None:
-            from acp.exceptions import RequestError
-
             raise RequestError(-32002, f"unknown session {session_id!r}")
         self._sessions[session_id] = session_id
+        self._closed_sessions.discard(session_id)
+        return session_id
+
+    async def load_session(self, session_id: str, cwd: str, **kwargs):
+        """重新绑定已有 Mission + transcript replay（§20）。"""
+        from acp import schema
+
+        mission_id = self._bind_existing(session_id)
+        await self._replay_transcript(mission_id)
         return schema.LoadSessionResponse()
 
-    async def prompt(self, session_id: str, prompt: list, **kwargs):
+    async def resume_session(self, session_id: str, cwd: str, **kwargs):
+        """重新连接已有 Mission，但不重放完整 transcript（§20）。"""
+        from acp import schema
+
+        self._bind_existing(session_id)
+        return schema.ResumeSessionResponse()
+
+    async def close_session(self, session_id: str, **kwargs):
+        """关闭 ACP 侧绑定（§20）：取消未结束 turn、释放 adapter 资源。
+
+        **不删除 Mission**——journal 完整保留，之后仍可 resume/load。
+        """
         from acp import schema
 
         mission_id = self._sessions.get(session_id, session_id)
-        if self._service.get_mission(mission_id) is None:
-            from acp.exceptions import RequestError
+        if self._service.get_mission(mission_id) is not None:
+            with contextlib.suppress(Exception):
+                await self._service.cancel(mission_id)
+        self._sessions.pop(session_id, None)
+        self._closed_sessions.add(session_id)
+        return schema.CloseSessionResponse()
 
+    async def prompt(self, session_id: str, prompt: list, **kwargs):
+        from acp import schema
+        from acp.exceptions import RequestError
+
+        mission_id = self._sessions.get(session_id, session_id)
+        if session_id in self._closed_sessions:
+            raise RequestError(
+                -32002, f"session {session_id!r} is closed; resume or load to rebind"
+            )
+        if self._service.get_mission(mission_id) is None:
             raise RequestError(-32002, f"unknown session {session_id!r}")
+
         text = "\n".join(
             block.text for block in prompt if getattr(block, "type", None) == "text"
         ).strip()
+        unsupported = [
+            block for block in prompt if getattr(block, "type", None) not in (None, "text")
+        ]
+        if unsupported:
+            # 设计 §38：不悄悄忽略附件，明确告知未接入。
+            await self._push_text(mission_id, _UNSUPPORTED_ATTACHMENT_NOTICE)
         if not text:
             return schema.PromptResponse(stop_reason="end_turn")
-        baseline = self._service.events_replay(mission_id)
-        last_seq = baseline[-1].sequence if baseline else 0
-        stream_task = asyncio.create_task(self._stream_updates(mission_id, last_seq))
-        try:
-            result = await self._service.send_turn(mission_id, text)
-        finally:
-            # turn 结束后的 settled/ended 尾巴事件先推送一轮再停（否则会丢）。
-            await asyncio.sleep(0.3)
-            await self._flush_once(mission_id)
-            stream_task.cancel()
+
+        # 同一 session 串行执行 turn，避免并发 prompt 交错事件流。
+        lock = self._turn_locks.setdefault(mission_id, asyncio.Lock())
+        async with lock:
+            baseline = self._service.events_replay(mission_id)
+            last_seq = baseline[-1].sequence if baseline else 0
+            self._last_sent_seq[mission_id] = last_seq
+            stream_task = asyncio.create_task(self._stream_updates(mission_id, last_seq))
+            self._stream_tasks.add(stream_task)
+            stream_task.add_done_callback(self._stream_tasks.discard)
+            try:
+                result = await self._service.send_turn(mission_id, text)
+            finally:
+                # turn 结束后的 settled/ended 尾巴事件先推送一轮再停（否则会丢）。
+                await asyncio.sleep(0.05)
+                await self._flush_once(mission_id)
+                stream_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await stream_task
         stop = "end_turn"
         if result.state.value == "FAILED":
             stop = "refusal"
@@ -115,63 +198,141 @@ class RosclawAcpAgent:
         return schema.PromptResponse(stop_reason=stop)
 
     async def cancel(self, session_id: str, **kwargs) -> None:
+        """只 cancel 当前 turn（§20）；不归档、不删除 Mission。"""
         mission_id = self._sessions.get(session_id, session_id)
         await self._service.cancel(mission_id)
 
-    async def _flush_once(self, mission_id: str) -> None:
-        """turn 结束后把剩余未推送事件补推一次。"""
+    # -- 关闭 -----------------------------------------------------------------
+
+    async def shutdown(self) -> None:
+        """进程退出前：停掉所有 stream 任务（graceful shutdown，§37）。"""
+        for task in list(self._stream_tasks):
+            task.cancel()
+        if self._stream_tasks:
+            await asyncio.gather(*self._stream_tasks, return_exceptions=True)
+        self._stream_tasks.clear()
+
+    # -- 内部 -----------------------------------------------------------------
+
+    async def _push_text(self, mission_id: str, text: str) -> None:
         if self._client is None:
             return
-        sent = getattr(self, "_last_sent_seq", 0)
+        from acp import schema
+
+        with contextlib.suppress(Exception):  # 表示层失败不影响权威状态
+            await self._client.session_update(
+                mission_id,
+                schema.AgentMessageChunk(
+                    session_update="agent_message_chunk",
+                    content=schema.TextContentBlock(type="text", text=text),
+                ),
+            )
+
+    async def _send_update(self, mission_id: str, update) -> bool:
+        if self._client is None:
+            return False
+        try:
+            await self._client.session_update(mission_id, update)
+            return True
+        except Exception:  # noqa: BLE001 - 表示层失败不影响权威状态
+            return False
+
+    async def _flush_once(self, mission_id: str) -> None:
+        """把水位之后剩余未推送的事件补推一轮（journal 为准）。"""
+        sent = self._last_sent_seq.get(mission_id, 0)
         for event in self._service.events_replay(mission_id, after_sequence=sent):
+            if event.sequence <= sent:
+                continue
+            sent = event.sequence
             update = event_to_session_update(event)
-            self._last_sent_seq = event.sequence
             if update is None:
                 continue
-            try:
-                await self._client.session_update(mission_id, update)
-            except Exception:  # noqa: BLE001
-                return
+            await self._send_update(mission_id, update)
+        self._last_sent_seq[mission_id] = sent
+
+    async def _replay_transcript(self, mission_id: str) -> None:
+        """session/load：把最近的 USER 可见事件重放为 session updates。"""
+        events = self._service.events_replay(mission_id)
+        tail = events[-_LOAD_REPLAY_LIMIT:] if events else []
+        sent = self._last_sent_seq.get(mission_id, 0)
+        for event in tail:
+            update = event_to_session_update(event)
+            if update is None:
+                continue
+            await self._send_update(mission_id, update)
+            sent = max(sent, event.sequence)
+        if events:
+            self._last_sent_seq[mission_id] = max(sent, events[-1].sequence)
 
     # -- 事件流 → session updates ------------------------------------------------
 
     async def _stream_updates(self, mission_id: str, after_seq: int) -> None:
-        """turn 期间把新事件映射为 ACP session update（best effort）。"""
+        """turn 期间把新事件映射为 ACP session update（订阅式，无轮询）。
+
+        PR-RC-002：基于 AgentService.subscribe_events（journal replay +
+        live bus），替代 250ms 轮询；无 event loss、无 duplicate、
+        sequence 单调，断开可以 after_sequence 重连。
+        """
         sent = after_seq
-        self._last_sent_seq = after_seq
-        for _ in range(1200):  # 最长 ~10 分钟
-            await asyncio.sleep(0.25)
-            events = [
-                e
-                for e in self._service.events_replay(mission_id, after_sequence=sent)
-                if e.sequence > sent
-            ]
-            if not events:
-                if self._client is None:
-                    return
-                continue
-            for event in events:
-                sent = max(sent, event.sequence)
-                self._last_sent_seq = sent
-                update = event_to_session_update(event)
-                if update is None or self._client is None:
+        stream = self._service.subscribe_events(mission_id, after_sequence=after_seq)
+        try:
+            async for event in stream:
+                if event.sequence <= sent:
                     continue
-                try:
-                    await self._client.session_update(mission_id, update)
-                except Exception:  # noqa: BLE001 - 表示层失败不影响权威状态
+                sent = event.sequence
+                self._last_sent_seq[mission_id] = sent
+                update = event_to_session_update(event)
+                if update is None:
+                    continue
+                if not await self._send_update(mission_id, update):
                     return
+        finally:
+            await stream.aclose()
 
 
 async def serve_stdio(service: AgentService) -> None:
-    """在 stdio 上运行 ACP agent（`rosclaw acp serve` 入口）。"""
+    """在 stdio 上运行 ACP agent（`rosclaw acp serve` 入口）。
+
+    Graceful shutdown（设计 §37）：stdin EOF（OpenClaw 关闭 ACP 子进程
+    管道）或 SIGTERM/SIGINT 时，停 stream 任务、关连接后退出——不产生
+    orphan process。
+
+    **stdout 必须绝对纯净（§36）**：stdout 只承载 JSON-RPC 帧；任何日志
+    一律走 stderr。
+    """
     import acp
     from acp.agent.connection import AgentSideConnection
 
     agent = RosclawAcpAgent(service)
     reader, writer = await acp.stdio_streams()
-    AgentSideConnection(
-        lambda conn: (agent.on_connect(conn), agent)[1],
+    # listening=False：由我们显式驱动 receive loop，才能把 EOF 变成退出信号。
+    conn = AgentSideConnection(
+        lambda c: (agent.on_connect(c), agent)[1],
         writer,
         reader,
+        listening=False,
+        # session/resume 与 session/close 在 SDK 0.12 仍标记 unstable；
+        # 协议本身已稳定（设计 §20），显式开启以消除 warn_unstable。
+        use_unstable_protocol=True,
     )
-    await asyncio.Event().wait()
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        with contextlib.suppress(NotImplementedError, RuntimeError):
+            loop.add_signal_handler(sig, stop.set)
+
+    listen_task = asyncio.create_task(conn.listen())  # stdin EOF 时正常返回
+    stop_task = asyncio.create_task(stop.wait())
+    try:
+        await asyncio.wait({listen_task, stop_task}, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        listen_task.cancel()
+        stop_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await listen_task
+        await agent.shutdown()
+        with contextlib.suppress(Exception):
+            await conn.close()
+        # 日志一律 stderr，stdout 只属于 JSON-RPC。
+        print("rosclaw acp serve: shutdown complete", file=sys.stderr)

--- a/src/rosclaw/agentd/events.py
+++ b/src/rosclaw/agentd/events.py
@@ -20,6 +20,7 @@ import asyncio
 import json
 import sqlite3
 from collections import defaultdict
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 
 from rosclaw.contracts.agent.agent_event import (
@@ -167,3 +168,54 @@ class AgentEventStore:
             visibility=Visibility(row["visibility"]),
             payload=json.loads(row["payload_json"]),
         )
+
+
+async def stream_events(
+    store: AgentEventStore,
+    mission_id: str,
+    *,
+    after_sequence: int = 0,
+) -> AsyncIterator[AgentEventV2]:
+    """一个 authoritative event stream：journal replay → live bus（Channel 设计 §21）。
+
+    供 ACP / TUI SSE / 未来 AG-UI 共用，替代各消费方自己的轮询循环。
+
+    保证：
+    - 无丢失：先 attach live bus 再 replay journal，起始空窗由 queue 覆盖；
+      live queue 溢出（bus 满时丢最旧事件）产生的 sequence 空洞从 journal
+      补齐——sequence 是 per-mission 严格单调无空洞的，空洞只可能来自丢事件。
+    - 无重复：live 事件 sequence <= 已发送水位时跳过。
+    - sequence 单调递增。
+    - 重连：调用方记录最后收到的 sequence，以 ``after_sequence`` 重新订阅。
+    """
+    queue = store.bus.subscribe(mission_id)  # 先挂 live，关闭 replay 竞态窗口
+    sent = after_sequence
+    try:
+        # 1) journal replay（分页直到追平当前 journal 末尾）
+        while True:
+            batch = store.replay(mission_id, after_sequence=sent, limit=500)
+            if not batch:
+                break
+            for event in batch:
+                if event.sequence > sent:
+                    sent = event.sequence
+                    yield event
+            if len(batch) < 500:
+                break
+        # 2) live bus
+        while True:
+            event = await queue.get()
+            if event.sequence <= sent:
+                continue  # 与 replay 重叠的部分去重
+            if event.sequence > sent + 1:
+                # live queue 溢出丢过事件——从 journal 补齐空洞。
+                for missed in store.replay(
+                    mission_id, after_sequence=sent, before_sequence=event.sequence
+                ):
+                    if missed.sequence > sent:
+                        sent = missed.sequence
+                        yield missed
+            sent = event.sequence
+            yield event
+    finally:
+        store.bus.unsubscribe(mission_id, queue)

--- a/src/rosclaw/agentd/loop.py
+++ b/src/rosclaw/agentd/loop.py
@@ -505,7 +505,11 @@ class AgentLoop:
                         return result
                     await self._emit(
                         AgentEventType.TOOL_STARTED,
-                        {"name": call.name, "arguments": arguments},
+                        {
+                            "name": call.name,
+                            "call_id": call.call_id,
+                            "arguments": arguments,
+                        },
                     )
                     tool_ok = True
                     try:
@@ -549,7 +553,7 @@ class AgentLoop:
                         )
                     await self._emit(
                         AgentEventType.TOOL_COMPLETED,
-                        {"name": call.name, "ok": tool_ok},
+                        {"name": call.name, "call_id": call.call_id, "ok": tool_ok},
                     )
                     self._conversation.append(
                         {"role": "tool", "tool_call_id": call.call_id, "content": output}

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -509,6 +509,14 @@ class AgentService:
     def events_unsubscribe(self, mission_id: str, queue: asyncio.Queue) -> None:
         self._events.bus.unsubscribe(mission_id, queue)
 
+    def subscribe_events(self, mission_id: str, *, after_sequence: int = 0):
+        """Authoritative async event stream（Channel 设计 §21）：journal replay
+        （``after_sequence`` 之后）→ live bus，无丢失/无重复/sequence 单调，
+        供 ACP、TUI SSE、未来 AG-UI 共用。"""
+        from rosclaw.agentd.events import stream_events
+
+        return stream_events(self._events, mission_id, after_sequence=after_sequence)
+
     async def cancel_turn_v2(self, mission_id: str) -> None:
         await self.cancel(mission_id)
         task = self._turn_tasks.get(mission_id)
@@ -785,9 +793,7 @@ class AgentService:
             from rosclaw.agentd.sim_executor import SimActionChannel
             from rosclaw.agentd.tooling.persistent_client import PersistentMcpClient
 
-            shared = PersistentMcpClient(
-                command=str(spec["command"]), args=tuple(spec["args"])
-            )
+            shared = PersistentMcpClient(command=str(spec["command"]), args=tuple(spec["args"]))
             self._shared_mcp_client = shared
             self._sim_executors[kit.executor_identity] = SimActionChannel(
                 command=str(spec["command"]),
@@ -874,11 +880,10 @@ class AgentService:
                 )
 
             checks = {
-                "trajectory": any(
-                    "plan" in t for t in kit.compute_tools if _usable(t)
-                ),
+                "trajectory": any("plan" in t for t in kit.compute_tools if _usable(t)),
                 "verifier": any(
-                    "verify" in t for t in (*kit.compute_tools, *kit.observation_tools)
+                    "verify" in t
+                    for t in (*kit.compute_tools, *kit.observation_tools)
                     if _usable(t)
                 ),
                 "executor": status.get("executor") == "READY",
@@ -893,9 +898,7 @@ class AgentService:
                 "idempotent": True,
                 "cancellable": True,
                 "real_authorization": False,
-                "command": (
-                    f"/robot repair {target.kit_id}" if target else ""
-                ),
+                "command": (f"/robot repair {target.kit_id}" if target else ""),
             }
         return {
             "ok": True,
@@ -1008,9 +1011,7 @@ class AgentService:
                 try:
                     await adapter.discover()
                 except Exception:  # noqa: BLE001 - discovery must never break chat
-                    self._tool_catalog.quarantine_source(
-                        adapter.source, "discovery_crashed"
-                    )
+                    self._tool_catalog.quarantine_source(adapter.source, "discovery_crashed")
             self._mcp_discovered = True
 
     @property
@@ -1194,7 +1195,10 @@ class AgentService:
                     except Exception as exc:  # noqa: BLE001
                         results.setdefault(domain, {"ok": False, "detail": str(exc)})
                 else:
-                    results[domain] = {"ok": True, "detail": f"re-registered {len(refreshed)} packs"}
+                    results[domain] = {
+                        "ok": True,
+                        "detail": f"re-registered {len(refreshed)} packs",
+                    }
             elif domain == "models":
                 results[domain] = {
                     "ok": True,
@@ -1288,9 +1292,7 @@ class AgentService:
 
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(
-                self._events.append(mission_id, AgentEventType.MISSION_ARCHIVED, {})
-            )
+            loop.create_task(self._events.append(mission_id, AgentEventType.MISSION_ARCHIVED, {}))
         except RuntimeError:
             pass
 
@@ -2057,9 +2059,7 @@ def create_app(service: AgentService):
                     )
             pairing = os.environ.get("ROSCLAW_CONSOLE_TOKEN")
             if pairing and request.headers.get("x-rosclaw-token") != pairing:
-                return JSONResponse(
-                    status_code=403, content={"detail": "pairing token required"}
-                )
+                return JSONResponse(status_code=403, content={"detail": "pairing token required"})
         # P1-4：ephemeral control token——除 /health 与 /console（HTML
         # 壳）外全部端点（含敏感 GET）都必须携带。token 经 0600 文件
         # 交给同机 TUI/CLI，不写 journal、不进 ps。
@@ -2340,7 +2340,9 @@ def create_app(service: AgentService):
         principal = service.principal_for_request(request_id)
         try:
             grant = await service.decide_approval(
-                request_id, principal=principal, approve=payload.approve,
+                request_id,
+                principal=principal,
+                approve=payload.approve,
                 _from_operatord=True,
             )
         except Exception as exc:  # noqa: BLE001

--- a/src/rosclaw/contracts/agent/agent_event.py
+++ b/src/rosclaw/contracts/agent/agent_event.py
@@ -69,6 +69,12 @@ class AgentEventType(StrEnum):
     COMPACTION_COMPLETED = "compaction.completed"
     MISSION_COMPLETED = "mission.completed"
     MISSION_FAILED = "mission.failed"
+    # 思考摘要（Channel 设计 §24）：只承载安全的 reasoning summary /
+    # plan progress，绝不承载 raw hidden Chain-of-Thought。
+    REASONING_STARTED = "reasoning.started"
+    REASONING_SUMMARY_DELTA = "reasoning.summary.delta"
+    REASONING_SUMMARY_ENDED = "reasoning.summary.ended"
+    PLAN_UPDATED = "plan.updated"
     # 系统
     WARNING = "warning"
     CAPABILITIES_CHANGED = "capabilities.changed"

--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -43,6 +43,13 @@ def main() -> int:
     if result is not None:
         return result
 
+    # Channel 集成（OpenClaw/ACP）：`rosclaw channel doctor|setup`
+    from rosclaw.integrations.openclaw.cli import dispatch_channel_argv
+
+    result = dispatch_channel_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
     from rosclaw.operatord.cli import dispatch_operatord_argv
 
     result = dispatch_operatord_argv(sys.argv[1:])

--- a/src/rosclaw/integrations/openclaw/__init__.py
+++ b/src/rosclaw/integrations/openclaw/__init__.py
@@ -1,0 +1,5 @@
+"""OpenClaw Channel integration（Channel 设计 PR-RC-004/005）。
+
+只包含配置样例、只读 doctor 与文档——不 vendor OpenClaw，不实现任何
+Channel adapter（飞书/Discord 连接、pairing、去重、重试一律由 OpenClaw 拥有）。
+"""

--- a/src/rosclaw/integrations/openclaw/cli.py
+++ b/src/rosclaw/integrations/openclaw/cli.py
@@ -1,0 +1,53 @@
+"""`rosclaw channel ...` — Channel 集成 CLI（Channel 设计 §46/§47）。
+
+只提供 doctor（只读检查）与 setup 指引；ROSClaw CLI 是 OpenClaw 的
+配置助手，不成为 Channel Runtime（§47）。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_USAGE = """用法:
+  rosclaw channel doctor [--home DIR] [--require-openclaw] [--no-acp-probe]
+  rosclaw channel setup feishu        # 打印配置指引（不修改任何配置）
+"""
+
+
+def _arg_value(argv: list[str], flag: str) -> str | None:
+    return argv[argv.index(flag) + 1] if flag in argv and argv.index(flag) + 1 < len(argv) else None
+
+
+def dispatch_channel_argv(argv: list[str]) -> int | None:
+    if argv[:1] != ["channel"]:
+        return None
+    if len(argv) < 2 or argv[1] not in ("doctor", "setup"):
+        print(_USAGE, file=sys.stderr)
+        return 2
+
+    home = Path(
+        _arg_value(argv, "--home") or os.environ.get("ROSCLAW_HOME", Path.home() / ".rosclaw")
+    )
+
+    if argv[1] == "setup":
+        channel = argv[2] if len(argv) > 2 else "feishu"
+        guide = Path(__file__).resolve().parents[4] / "integrations" / "openclaw" / "README.md"
+        print(
+            f"ROSClaw 不直接配置 {channel} Channel（OpenClaw owns the Channel）。\n"
+            f"按 integrations/openclaw/README.md 操作后运行 `rosclaw channel doctor` 验证。\n"
+            f"指引文件: {guide}",
+            file=sys.stderr,
+        )
+        return 0
+
+    from rosclaw.integrations.openclaw.doctor import run_doctor
+
+    report = run_doctor(
+        home,
+        require_openclaw="--require-openclaw" in argv,
+        probe_acp="--no-acp-probe" not in argv,
+    )
+    print(report.render())
+    return 1 if report.failed else 0

--- a/src/rosclaw/integrations/openclaw/doctor.py
+++ b/src/rosclaw/integrations/openclaw/doctor.py
@@ -1,0 +1,407 @@
+"""ROSClaw Channel Doctor（Channel 设计 §46 / PR-RC-005）。
+
+**只读检查**：不修改任何 OpenClaw / ROSClaw 配置。唯一的副作用是 ACP
+探测会创建并随即 close 一个 probe Mission（journal 保留，输出中明确标注）。
+
+检查分两层：
+
+1. ROSClaw 侧（必须全绿才算 READY）：可执行环境、ROSCLAW_HOME、模型配置、
+   ACP initialize / session/new / session/resume / session/close。
+2. OpenClaw 侧（缺失记 SKIP 而不是 FAIL，除非 ``require_openclaw=True``）：
+   Node、OpenClaw、acpx、harness 注册、Gateway loopback/auth、飞书策略、
+   MCP bridge 关闭、permissionMode=deny-all。
+
+OpenClaw 配置 schema 仍在演进（设计 §33 注），config 探针统一走
+``openclaw config get <key>`` 并容忍输出格式差异——schema 的权威校验
+始终属于 ``openclaw doctor``。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# 状态：OK / WARN / SKIP / FAIL
+_OK, _WARN, _SKIP, _FAIL = "OK", "WARN", "SKIP", "FAIL"
+
+# OpenClaw 的 Node 支持窗口（设计 §7）：22.22.3+ / 24.15+ / 25.9+
+_NODE_MIN = {22: (22, 22, 3), 24: (24, 15, 0), 25: (25, 9, 0)}
+
+
+def _node_supported(version_text: str) -> bool:
+    try:
+        parts = tuple(int(p) for p in version_text.lstrip("v").split(".")[:3])
+    except ValueError:
+        return False
+    parts = parts + (0,) * (3 - len(parts))
+    major = parts[0]
+    if major in _NODE_MIN:
+        return parts >= _NODE_MIN[major]
+    return major > max(_NODE_MIN)
+
+
+@dataclass
+class Check:
+    name: str
+    status: str
+    detail: str = ""
+
+
+@dataclass
+class DoctorReport:
+    checks: list[Check] = field(default_factory=list)
+
+    def add(self, name: str, status: str, detail: str = "") -> None:
+        self.checks.append(Check(name, status, detail))
+
+    @property
+    def failed(self) -> list[Check]:
+        return [c for c in self.checks if c.status == _FAIL]
+
+    @property
+    def skipped(self) -> list[Check]:
+        return [c for c in self.checks if c.status == _SKIP]
+
+    def render(self) -> str:
+        lines = ["ROSClaw Channel Doctor", ""]
+        for check in self.checks:
+            suffix = f" — {check.detail}" if check.detail else ""
+            lines.append(f"[{check.status}] {check.name}{suffix}")
+        lines.append("")
+        if self.failed:
+            lines.append("NOT READY")
+        else:
+            lines.append("READY" if not self.skipped else "READY (with skips)")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# ROSClaw 侧
+# ---------------------------------------------------------------------------
+
+
+def _check_rosclaw_runtime(report: DoctorReport) -> None:
+    try:
+        import rosclaw  # noqa: F401
+
+        report.add("rosclaw executable", _OK, sys.executable)
+    except Exception as exc:  # noqa: BLE001
+        report.add("rosclaw executable", _FAIL, str(exc))
+
+
+def _check_home(report: DoctorReport, home: Path) -> None:
+    if home.is_dir():
+        report.add("ROSCLAW_HOME", _OK, str(home))
+    else:
+        report.add("ROSCLAW_HOME", _FAIL, f"{home} 不存在——先运行 `rosclaw agent init`")
+
+
+def _check_model_config(report: DoctorReport, home: Path) -> bool:
+    from rosclaw.agentd.config import load_agent_config
+
+    config = load_agent_config(home / "config.yaml")
+    if not config.profiles:
+        report.add(
+            "Native Agent model",
+            _FAIL,
+            "未配置模型——先运行 `rosclaw setup model`",
+        )
+        return False
+    report.add("Native Agent model", _OK, f"{len(config.profiles)} profile(s)")
+    return True
+
+
+def _check_credentials(report: DoctorReport, home: Path) -> None:
+    from rosclaw.agentd.credentials import AgentCredentialStore, CredentialStoreError
+
+    try:
+        # inject() 只把凭证写进本进程 env（doctor 进程随即退出），并校验
+        # credential store 的 owner/权限——正是这里要查的安全属性。
+        injected = AgentCredentialStore(home).inject()
+    except CredentialStoreError as exc:
+        report.add("Agent credentials", _FAIL, str(exc))
+        return
+    if injected:
+        report.add("Agent credentials", _OK, f"{len(injected)} credential(s) injected")
+    else:
+        report.add("Agent credentials", _WARN, "credential store 为空（或仅凭 env）")
+
+
+# ---------------------------------------------------------------------------
+# ACP 握手探测（真实子进程 + 原始 JSON-RPC 帧）
+# ---------------------------------------------------------------------------
+
+
+async def _rpc(proc, method: str, params: dict, req_id: int, timeout: float) -> dict:
+    frame = {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params}
+    proc.stdin.write((json.dumps(frame) + "\n").encode())
+    await proc.stdin.drain()
+    while True:
+        line = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+        if not line:
+            raise RuntimeError(f"{method}: ACP server stdout EOF")
+        reply = json.loads(line)  # 非 JSON 输出在此直接失败（stdout 纯净性）
+        if reply.get("id") != req_id:
+            continue  # 跳过 notification
+        if "error" in reply:
+            raise RuntimeError(f"{method}: {reply['error'].get('message', reply['error'])}")
+        return reply.get("result") or {}
+
+
+async def _acp_probe(
+    report: DoctorReport,
+    home: Path,
+    timeout: float,
+    command: list[str] | None = None,
+    env: dict | None = None,
+) -> None:
+    if command is None:
+        command = [
+            sys.executable,
+            "-m",
+            "rosclaw.entrypoint",
+            "acp",
+            "serve",
+            "--home",
+            str(home),
+        ]
+    if env is None:
+        env = dict(os.environ)
+    proc = await asyncio.create_subprocess_exec(
+        *command,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    try:
+        result = await _rpc(
+            proc,
+            "initialize",
+            {"protocolVersion": 1, "clientCapabilities": {}},
+            0,
+            timeout,
+        )
+        name = (result.get("agentInfo") or {}).get("name", "?")
+        report.add("ACP initialize", _OK, name)
+
+        session = await _rpc(proc, "session/new", {"cwd": "/", "mcpServers": []}, 1, timeout)
+        sid = session.get("sessionId", "")
+        report.add(
+            "ACP session/new",
+            _OK if sid else _FAIL,
+            f"{sid}（probe Mission，随后 close）" if sid else "no sessionId",
+        )
+        if sid:
+            await _rpc(
+                proc,
+                "session/resume",
+                {"sessionId": sid, "cwd": "/", "mcpServers": []},
+                2,
+                timeout,
+            )
+            report.add("ACP session/resume", _OK, sid)
+            await _rpc(proc, "session/close", {"sessionId": sid}, 3, timeout)
+            report.add("ACP session/close", _OK, "Mission journal 保留")
+    except (TimeoutError, RuntimeError, json.JSONDecodeError, OSError) as exc:
+        # 附上 server stderr 末尾——initialize EOF 这类错误的真因（如缺凭证）
+        # 只在 stderr 上可见。
+        detail = str(exc)
+        with contextlib.suppress(Exception):
+            err = (await asyncio.wait_for(proc.stderr.read(), timeout=2)).decode(errors="replace")
+            tail = [line for line in err.strip().splitlines() if line.strip()]
+            if tail:
+                detail = f"{detail} | stderr: {tail[-1][:160]}"
+        report.add("ACP probe", _FAIL, detail)
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()  # 进程可能已在 probe 失败前先退出
+        await proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# OpenClaw 侧（全部 best-effort；缺失记 SKIP）
+# ---------------------------------------------------------------------------
+
+
+async def _run(cmd: list[str], timeout: float) -> tuple[int, str]:
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        return proc.returncode or 0, (out or err).decode(errors="replace").strip()
+    except (TimeoutError, OSError) as exc:
+        return -1, str(exc)
+
+
+async def _openclaw_config_get(key: str, timeout: float) -> str | None:
+    """`openclaw config get <key>` 的容忍解析：失败/为空返回 None。"""
+    code, out = await _run(["openclaw", "config", "get", key], timeout)
+    if code != 0 or not out:
+        return None
+    text = out.splitlines()[-1].strip()
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        value = text.strip('"').strip("'")
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+async def _check_openclaw(report: DoctorReport, timeout: float) -> None:
+    # Node
+    node = shutil.which("node")
+    if node is None:
+        report.add("Node", _SKIP, "node 不在 PATH（设计 §7：需要 22.22.3+/24.15+/25.9+）")
+    else:
+        code, out = await _run(["node", "-v"], timeout)
+        if code == 0 and out and _node_supported(out):
+            report.add("Node", _OK, out)
+        else:
+            report.add(
+                "Node",
+                _FAIL,
+                f"{out or 'unknown'} 不满足 >=22.22.3 <23 / >=24.15.0 <25 / >=25.9.0",
+            )
+
+    # OpenClaw
+    if shutil.which("openclaw") is None:
+        report.add(
+            "OpenClaw",
+            _SKIP,
+            "openclaw 不在 PATH——见 integrations/openclaw/README.md 安装指引",
+        )
+        for name in (
+            "@openclaw/acpx",
+            "rosclaw harness",
+            "Gateway loopback",
+            "Gateway auth",
+            "Feishu plugin",
+            "Feishu pairing/allowlist policy",
+            "OpenClaw MCP bridges disabled",
+            "ACPX permissionMode deny-all",
+        ):
+            report.add(name, _SKIP, "openclaw 不可用")
+        return
+
+    code, out = await _run(["openclaw", "--version"], timeout)
+    report.add("OpenClaw", _OK if code == 0 else _FAIL, out.splitlines()[0] if out else "")
+
+    # 配置探针（schema 演进中——取不到记 SKIP，不臆测）
+    async def _probe(name: str, key: str, expect: str | None = None) -> None:
+        value = await _openclaw_config_get(key, timeout)
+        if value is None:
+            report.add(name, _SKIP, f"`openclaw config get {key}` 无结果")
+        elif expect is not None and value.lower() != expect.lower():
+            report.add(name, _FAIL, f"{key}={value!r}，期望 {expect!r}")
+        else:
+            report.add(name, _OK, f"{key}={value}")
+
+    await _probe("@openclaw/acpx", "plugins.entries.acpx.enabled", "true")
+    harness = await _openclaw_config_get(
+        "plugins.entries.acpx.config.agents.rosclaw.command", timeout
+    )
+    if harness:
+        status = _OK if Path(harness).is_absolute() else _FAIL
+        detail = "" if status == _OK else "必须使用绝对路径（设计 §9）"
+        report.add("rosclaw harness", status, f"{harness} {detail}".strip())
+    else:
+        report.add("rosclaw harness", _SKIP, "未注册 agents.rosclaw")
+    await _probe("Gateway loopback", "gateway.bind", "loopback")
+    auth = await _openclaw_config_get("gateway.auth.mode", timeout)
+    if auth is None:
+        report.add("Gateway auth", _SKIP, "gateway.auth.mode 无结果")
+    elif auth.lower() in ("none", "", "off"):
+        report.add("Gateway auth", _FAIL, "gateway 无认证（设计 §13 禁止）")
+    else:
+        report.add("Gateway auth", _OK, f"mode={auth}")
+    await _probe("Feishu plugin", "channels.feishu.enabled", "true")
+    dm = await _openclaw_config_get("channels.feishu.dmPolicy", timeout)
+    group = await _openclaw_config_get("channels.feishu.groupPolicy", timeout)
+    mention = await _openclaw_config_get("channels.feishu.requireMention", timeout)
+    if dm is None and group is None:
+        report.add("Feishu pairing/allowlist policy", _SKIP, "飞书策略无结果")
+    elif dm in ("pairing", "allowlist") and group == "allowlist" and mention == "true":
+        # 设计 §16 推荐 DM=pairing；allowlist 是等价可接受的收紧（显式名单）。
+        report.add(
+            "Feishu pairing/allowlist policy", _OK, f"dm={dm} + group=allowlist + mention"
+        )
+    else:
+        report.add(
+            "Feishu pairing/allowlist policy",
+            _FAIL,
+            f"dmPolicy={dm} groupPolicy={group} requireMention={mention}"
+            "（设计 §16：pairing + allowlist + mention）",
+        )
+    await _probe(
+        "OpenClaw MCP bridges disabled",
+        "plugins.entries.acpx.config.pluginToolsMcpBridge",
+        "false",
+    )
+    await _probe(
+        "ACPX permissionMode deny-all",
+        "plugins.entries.acpx.config.permissionMode",
+        "deny-all",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 入口
+# ---------------------------------------------------------------------------
+
+
+async def run_doctor_async(
+    home: Path,
+    *,
+    require_openclaw: bool = False,
+    timeout: float = 15.0,
+    probe_acp: bool = True,
+    acp_command: list[str] | None = None,
+    acp_env: dict | None = None,
+) -> DoctorReport:
+    report = DoctorReport()
+    _check_rosclaw_runtime(report)
+    _check_home(report, home)
+    if home.is_dir():
+        _check_credentials(report, home)
+        if _check_model_config(report, home) and probe_acp:
+            await _acp_probe(report, home, timeout, command=acp_command, env=acp_env)
+    await _check_openclaw(report, timeout)
+    if require_openclaw:
+        for check in report.checks:
+            if check.status == _SKIP:
+                check.status = _FAIL
+                check.detail = f"{check.detail}（--require-openclaw）".strip()
+    return report
+
+
+def run_doctor(
+    home: Path,
+    *,
+    require_openclaw: bool = False,
+    timeout: float = 15.0,
+    probe_acp: bool = True,
+    acp_command: list[str] | None = None,
+    acp_env: dict | None = None,
+) -> DoctorReport:
+    return asyncio.run(
+        run_doctor_async(
+            home,
+            require_openclaw=require_openclaw,
+            timeout=timeout,
+            probe_acp=probe_acp,
+            acp_command=acp_command,
+            acp_env=acp_env,
+        )
+    )

--- a/tests/agentd/test_acp.py
+++ b/tests/agentd/test_acp.py
@@ -1,7 +1,10 @@
-"""批次 G：ACP adapter 测试。
+"""批次 G：ACP adapter 测试（+ Channel 设计 PR-RC-001/002/003）。
 
 - session/prompt/cancel 映射到 Mission/turn
-- 事件流映射为 session update（text delta、tool、approval 卡片）
+- session lifecycle：new/list/load/resume/close/cancel（设计 §20）
+- 事件流映射为 session update（text delta、tool、worker、reasoning、approval 卡片）
+- 事件订阅：journal replay → live bus，无丢失/无重复/sequence 单调（§21）
+- stdio 黑盒：stdout 纯净（§36）、graceful EOF/SIGTERM（§37）、kill 后 resume（§49）
 - 边界：ACP 路径不产生任何 authority；approval 只呈现 id，不自动批准
 """
 
@@ -109,6 +112,117 @@ class TestAcpMapping:
         finally:
             await service.close()
 
+    async def test_capability_advertisement(self, tmp_path: Path) -> None:
+        """PR-RC-001：capability 必须与实际实现一致（load_session=True 等）。"""
+        service = _service(tmp_path)
+        try:
+            agent = RosclawAcpAgent(service)
+            init = await agent.initialize()
+            caps = init.agent_capabilities
+            assert caps.load_session is True
+            assert caps.session_capabilities.list is not None
+            assert caps.session_capabilities.resume is not None
+            assert caps.session_capabilities.close is not None
+            # P0 附件策略（§38）：不声明 image/audio。
+            assert caps.prompt_capabilities.image is False
+            assert caps.prompt_capabilities.audio is False
+        finally:
+            await service.close()
+
+    async def test_session_lifecycle_resume_close(self, tmp_path: Path) -> None:
+        """设计 §20：close 不删 Mission；resume 重新绑定且不重放 transcript。"""
+        import pytest
+        from acp.exceptions import RequestError
+
+        service = _service(tmp_path)
+        try:
+            agent = RosclawAcpAgent(service)
+            client = _FakeClient()
+            agent.on_connect(client)
+            session = await agent.new_session(cwd="/tmp/work")
+            sid = session.session_id
+            await agent.prompt(session_id=sid, prompt=[_text_block("你好")])
+
+            # close：释放绑定，Mission journal 保留，不归档。
+            await agent.close_session(session_id=sid)
+            assert service.get_mission(sid) is not None
+            assert not service.mission_archived(sid)
+            with pytest.raises(RequestError):
+                await agent.prompt(session_id=sid, prompt=[_text_block("hi")])
+
+            # resume：重新绑定，不重放 transcript。
+            updates_before = len(client.updates)
+            await agent.resume_session(session_id=sid, cwd="/tmp/work")
+            assert len(client.updates) == updates_before
+            response = await agent.prompt(session_id=sid, prompt=[_text_block("继续")])
+            assert response.stop_reason == "end_turn"
+
+            # list 仍然看得到该 Mission。
+            listing = await agent.list_sessions()
+            assert any(s.session_id == sid for s in listing.sessions)
+        finally:
+            await service.close()
+
+    async def test_load_session_replays_transcript(self, tmp_path: Path) -> None:
+        """session/load = 重新绑定 + transcript replay（§20）。"""
+        service = _service(tmp_path)
+        try:
+            agent = RosclawAcpAgent(service)
+            client = _FakeClient()
+            agent.on_connect(client)
+            session = await agent.new_session(cwd="/tmp/work")
+            sid = session.session_id
+            await agent.prompt(session_id=sid, prompt=[_text_block("你好")])
+
+            client2 = _FakeClient()
+            agent.on_connect(client2)
+            await agent.load_session(session_id=sid, cwd="/tmp/work")
+            # replay 产生 session updates（至少含回复文本）。
+            assert client2.updates
+        finally:
+            await service.close()
+
+    async def test_cancel_is_turn_only(self, tmp_path: Path) -> None:
+        """session/cancel 只取消当前 turn，不归档 Mission（§20）。"""
+        service = _service(tmp_path)
+        try:
+            agent = RosclawAcpAgent(service)
+            agent.on_connect(_FakeClient())
+            session = await agent.new_session(cwd="/tmp/work")
+            sid = session.session_id
+            await agent.cancel(session_id=sid)
+            assert service.get_mission(sid) is not None
+            assert not service.mission_archived(sid)
+            # cancel 后仍可继续 prompt。
+            response = await agent.prompt(session_id=sid, prompt=[_text_block("在吗")])
+            assert response.stop_reason == "end_turn"
+        finally:
+            await service.close()
+
+    async def test_unsupported_attachment_notice(self, tmp_path: Path) -> None:
+        """设计 §38：不悄悄忽略附件——明确告知未接入。"""
+        from types import SimpleNamespace
+
+        service = _service(tmp_path)
+        try:
+            agent = RosclawAcpAgent(service)
+            client = _FakeClient()
+            agent.on_connect(client)
+            session = await agent.new_session(cwd="/tmp/work")
+            response = await agent.prompt(
+                session_id=session.session_id,
+                prompt=[SimpleNamespace(type="image", data="...", mime_type="image/png")],
+            )
+            assert response.stop_reason == "end_turn"
+            texts = [
+                u.content.text
+                for _, u in client.updates
+                if getattr(u, "session_update", "") == "agent_message_chunk"
+            ]
+            assert any("尚未接入该附件类型" in t for t in texts)
+        finally:
+            await service.close()
+
 
 class TestEventMapper:
     def _event(self, etype: str, payload: dict):
@@ -141,6 +255,108 @@ class TestEventMapper:
         )
         assert done.status == "completed"
 
+    def test_tool_call_id_prefers_call_id_over_name(self) -> None:
+        """设计 §23：连续同名调用不得合并；call_id > event_id，绝不用 name。"""
+        started = event_to_session_update(
+            self._event("tool.started", {"name": "sim_get_state", "call_id": "call_1"})
+        )
+        assert started.tool_call_id == "call_1"
+        done = event_to_session_update(
+            self._event(
+                "tool.completed", {"name": "sim_get_state", "call_id": "call_1", "ok": True}
+            )
+        )
+        assert done.tool_call_id == "call_1"
+        # 无 call_id 时回退 event_id（仍稳定唯一），不是 name。
+        fallback = event_to_session_update(self._event("tool.started", {"name": "x"}))
+        assert fallback.tool_call_id == "e1"
+
+    def test_tool_progress_maps(self) -> None:
+        update = event_to_session_update(
+            self._event("tool.progress", {"name": "sim_get_state", "call_id": "c9", "note": "50%"})
+        )
+        assert update.tool_call_id == "c9"
+        assert update.status == "in_progress"
+
+    def test_worker_uses_stable_work_order_id(self) -> None:
+        """设计 §23/§29：work_order_id 是稳定 ID；start 与 update 区分。"""
+        started = event_to_session_update(
+            self._event("worker.started", {"work_order_id": "wo_1", "worker_id": "codex"})
+        )
+        assert started.session_update == "tool_call"
+        assert started.tool_call_id == "wo_1"
+        assert started.status == "in_progress"
+        accepted = event_to_session_update(
+            self._event("worker.accepted", {"work_order_id": "wo_1", "worker_id": "codex"})
+        )
+        assert type(accepted).__name__ == "ToolCallUpdate"
+        assert accepted.tool_call_id == "wo_1"
+        assert accepted.status == "completed"
+        failed = event_to_session_update(
+            self._event("worker.failed", {"work_order_id": "wo_1", "worker_id": "codex"})
+        )
+        assert failed.status == "failed"
+
+    def test_reasoning_delta_maps_to_thought_chunk(self) -> None:
+        """设计 §26：reasoning.summary.delta → AgentThoughtChunk。"""
+        update = event_to_session_update(
+            self._event("reasoning.summary.delta", {"text": "先检查 Body，再检查日志。"})
+        )
+        assert update is not None
+        assert update.session_update == "agent_thought_chunk"
+        assert "先检查 Body" in update.content.text
+        # 生命周期标记不单独呈现。
+        assert event_to_session_update(self._event("reasoning.started", {})) is None
+        assert event_to_session_update(self._event("reasoning.summary.ended", {})) is None
+
+    def test_plan_updated_maps_to_plan(self) -> None:
+        update = event_to_session_update(
+            self._event(
+                "plan.updated",
+                {
+                    "entries": [
+                        {"content": "加载 Mission", "status": "completed"},
+                        {"content": "读取导航日志", "status": "in_progress"},
+                    ]
+                },
+            )
+        )
+        assert update.session_update == "plan"
+        assert [e.content for e in update.entries] == ["加载 Mission", "读取导航日志"]
+
+    def test_debug_and_audit_not_sent_by_default(self) -> None:
+        """设计 §48：DEBUG/AUDIT 事件默认不离开 ACP。"""
+        from rosclaw.contracts.agent.agent_event import Visibility
+
+        debug = self._event("model.text.delta", {"text": "hidden"})
+        debug.visibility = Visibility.DEBUG
+        assert event_to_session_update(debug) is None
+        audit = self._event("model.text.delta", {"text": "audit"})
+        audit.visibility = Visibility.AUDIT
+        assert event_to_session_update(audit) is None
+        # 显式开启才发。
+        assert event_to_session_update(debug, include_debug=True) is not None
+
+    def test_usage_update_requires_real_size(self) -> None:
+        """model.request.ended → usage（§22）；没有真实上下文窗口大小时不伪造。"""
+        no_size = event_to_session_update(
+            self._event("model.request.ended", {"prompt_tokens": 5, "completion_tokens": 5})
+        )
+        assert no_size is None
+        with_size = event_to_session_update(
+            self._event(
+                "model.request.ended",
+                {"prompt_tokens": 5, "completion_tokens": 5, "context_size": 8192},
+            )
+        )
+        assert with_size.session_update == "usage_update"
+        assert with_size.used == 10
+        assert with_size.size == 8192
+
+    def test_error_maps_to_visible_message(self) -> None:
+        update = event_to_session_update(self._event("error", {"message": "boom"}))
+        assert "boom" in update.content.text
+
     def test_approval_is_message_not_permission(self) -> None:
         update = event_to_session_update(
             self._event(
@@ -154,6 +370,252 @@ class TestEventMapper:
 
     def test_unmapped_returns_none(self) -> None:
         assert event_to_session_update(self._event("context.compilation.started", {})) is None
+
+
+class TestEventSubscription:
+    """PR-RC-002：subscribe_events — journal replay → live bus。"""
+
+    async def test_replay_then_live_monotonic_no_dup(self, tmp_path: Path) -> None:
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("sub test")
+            mid = mission.mission_id
+            await service._events.append(mid, AgentEventType.MODEL_TEXT_DELTA, {"text": "a"})
+            await service._events.append(mid, AgentEventType.MODEL_TEXT_DELTA, {"text": "b"})
+            stream = service.subscribe_events(mid, after_sequence=0)
+            try:
+                first = await anext(stream)
+                second = await anext(stream)
+                assert (first.sequence, second.sequence) == (1, 2)
+                # live 事件接续 replay，sequence 严格单调。
+                await service._events.append(mid, AgentEventType.MODEL_TEXT_DELTA, {"text": "c"})
+                third = await anext(stream)
+                assert third.sequence == 3
+                assert third.payload["text"] == "c"
+            finally:
+                await stream.aclose()
+        finally:
+            await service.close()
+
+    async def test_reconnect_with_after_sequence(self, tmp_path: Path) -> None:
+        """断线重连：after_sequence 之后的事件完整重放，无重复。"""
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+
+        service = _service(tmp_path)
+        try:
+            mission = service.create_mission("reconnect")
+            mid = mission.mission_id
+            for i in range(5):
+                await service._events.append(
+                    mid, AgentEventType.MODEL_TEXT_DELTA, {"text": f"m{i}"}
+                )
+            stream = service.subscribe_events(mid, after_sequence=3)
+            try:
+                seqs = [(await anext(stream)).sequence for _ in range(2)]
+                assert seqs == [4, 5]
+            finally:
+                await stream.aclose()
+        finally:
+            await service.close()
+
+    async def test_live_queue_gap_filled_from_journal(self) -> None:
+        """live queue 溢出造成的 sequence 空洞必须从 journal 补齐（不丢事件）。"""
+        import asyncio as _asyncio
+
+        from rosclaw.agentd.events import stream_events
+        from rosclaw.contracts.agent.agent_event import (
+            AgentEventType,
+            AgentEventV2,
+            Visibility,
+        )
+
+        def _ev(seq: int) -> AgentEventV2:
+            return AgentEventV2(
+                event_id=f"e{seq}",
+                sequence=seq,
+                mission_id="mis_x",
+                timestamp="t",
+                type=AgentEventType.MODEL_TEXT_DELTA,
+                visibility=Visibility.USER,
+                payload={"text": str(seq)},
+            )
+
+        journal = [_ev(i) for i in range(1, 6)]
+
+        class _Bus:
+            def __init__(self) -> None:
+                self.queue: _asyncio.Queue = _asyncio.Queue()
+
+            def subscribe(self, mission_id):
+                return self.queue
+
+            def unsubscribe(self, mission_id, queue) -> None:
+                pass
+
+        class _Store:
+            def __init__(self) -> None:
+                self.bus = _Bus()
+
+            def replay(self, mission_id, *, after_sequence=0, before_sequence=None, limit=1000):
+                return [
+                    e
+                    for e in journal
+                    if e.sequence > after_sequence
+                    and (before_sequence is None or e.sequence < before_sequence)
+                ][:limit]
+
+        store = _Store()
+        # 水位在 2；live queue 只投递 seq=5（3、4 模拟溢出丢失）。
+        store.bus.queue.put_nowait(_ev(5))
+        stream = stream_events(store, "mis_x", after_sequence=2)
+        try:
+            seqs = [(await anext(stream)).sequence for _ in range(3)]
+            assert seqs == [3, 4, 5]  # 空洞被 journal 补齐，无丢失
+        finally:
+            await stream.aclose()
+
+
+class TestStdioProtocol:
+    """PR-RC-001 stdio 黑盒：stdout 纯净（§36）、EOF/SIGTERM（§37）、resume（§49）。"""
+
+    @staticmethod
+    def _env(tmp_path: Path) -> dict:
+        import os
+
+        return dict(os.environ, ROSCLAW_ACP_TEST_HOME=str(tmp_path))
+
+    @staticmethod
+    def _server_script() -> Path:
+        return Path(__file__).parent / "acp_test_server.py"
+
+    async def _spawn(self, tmp_path: Path):
+        import asyncio
+        import sys
+
+        return await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(self._server_script()),
+            env=self._env(tmp_path),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+    async def test_stdout_contains_only_jsonrpc(self, tmp_path: Path) -> None:
+        """§36：stdout 每一帧都必须可解析为 JSON-RPC，不允许任何 banner/log。"""
+        import asyncio
+        import json
+
+        proc = await self._spawn(tmp_path)
+        try:
+            init = {
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "initialize",
+                "params": {"protocolVersion": 1, "clientCapabilities": {}},
+            }
+            proc.stdin.write((json.dumps(init) + "\n").encode())
+            await proc.stdin.drain()
+            line = await asyncio.wait_for(proc.stdout.readline(), timeout=15)
+            frame = json.loads(line)  # 任何非 JSON 输出都会在这里炸掉
+            assert frame.get("jsonrpc") == "2.0"
+            assert "result" in frame
+            assert frame["result"]["agentInfo"]["name"] == "rosclaw-native-agent"
+        finally:
+            proc.kill()
+            await proc.wait()
+
+    async def test_stdin_eof_exits_cleanly(self, tmp_path: Path) -> None:
+        """§37：OpenClaw 关闭 ACP 子进程管道（stdin EOF）后进程必须退出。"""
+        import asyncio
+
+        proc = await self._spawn(tmp_path)
+        proc.stdin.close()
+        returncode = await asyncio.wait_for(proc.wait(), timeout=15)
+        assert returncode == 0
+
+    async def test_sigterm_exits_cleanly(self, tmp_path: Path) -> None:
+        """§37：服务就绪后收到 SIGTERM → 优雅退出（returncode 0），不产生 orphan。"""
+        import asyncio
+        import json
+
+        proc = await self._spawn(tmp_path)
+        # 先完成 initialize 握手，确保 signal handler 已安装、服务在运行中。
+        init = {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {"protocolVersion": 1, "clientCapabilities": {}},
+        }
+        proc.stdin.write((json.dumps(init) + "\n").encode())
+        await proc.stdin.drain()
+        await asyncio.wait_for(proc.stdout.readline(), timeout=15)
+        proc.terminate()
+        returncode = await asyncio.wait_for(proc.wait(), timeout=15)
+        assert returncode == 0
+
+    async def test_kill_and_resume_same_mission(self, tmp_path: Path) -> None:
+        """§49 continuity：kill ACP 进程 → 新进程 resume 同一 Mission → 继续 turn。"""
+        import asyncio
+        import sys
+
+        import acp
+        from acp import schema
+
+        class Client(acp.Client):
+            async def session_update(self, session_id: str, update, **kwargs) -> None:
+                pass
+
+        server_script = self._server_script()
+        env = self._env(tmp_path)
+
+        async def _start():
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                str(server_script),
+                env=env,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+            )
+            conn = acp.connect_to_agent(
+                Client(), proc.stdin, proc.stdout, use_unstable_protocol=True
+            )
+            await conn.initialize(
+                protocol_version=1, client_capabilities=schema.ClientCapabilities()
+            )
+            return proc, conn
+
+        # 第一轮：建 session、跑一个 turn，然后直接 kill（模拟 ACP 子进程崩溃）。
+        proc1, conn1 = await _start()
+        session = await conn1.new_session(cwd="/tmp/work")
+        sid = session.session_id
+        resp1 = await conn1.prompt(
+            session_id=sid,
+            prompt=[schema.TextContentBlock(type="text", text="请记住随机码 RC-7F4A9")],
+        )
+        assert resp1.stop_reason == "end_turn"
+        proc1.kill()
+        await proc1.wait()
+
+        # 第二轮：新进程 resume 同一 Mission，Mission 仍在、turn 可继续。
+        proc2, conn2 = await _start()
+        try:
+            listing = await conn2.list_sessions()
+            assert any(s.session_id == sid for s in listing.sessions)
+            await conn2.resume_session(session_id=sid, cwd="/tmp/work")
+            resp2 = await conn2.prompt(
+                session_id=sid,
+                prompt=[schema.TextContentBlock(type="text", text="继续")],
+            )
+            assert resp2.stop_reason == "end_turn"
+            # close 后 Mission 保留、可再次 resume。
+            await conn2.close_session(session_id=sid)
+            await conn2.resume_session(session_id=sid, cwd="/tmp/work")
+        finally:
+            proc2.kill()
+            await proc2.wait()
 
 
 class TestStdioRoundtrip:

--- a/tests/agentd/test_channel_doctor.py
+++ b/tests/agentd/test_channel_doctor.py
@@ -1,0 +1,106 @@
+"""Channel doctor（PR-RC-005）测试。
+
+- ROSClaw 侧检查：home/config/credentials/ACP probe（用 mock-gateway 测试
+  server 覆盖 initialize/new/resume/close 全链路）
+- OpenClaw 侧缺失时记 SKIP 而不是 FAIL（除非 --require-openclaw）
+- doctor 只读：不修改 ROSCLAW_HOME 配置、不写 OpenClaw 配置
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from rosclaw.integrations.openclaw.doctor import run_doctor_async
+
+_MOCK_CONFIG = """
+agent:
+  enabled: true
+  engine: legacy
+  default_profile: mock_default
+models:
+  profiles:
+    mock_default:
+      provider: mock
+      model: mock-model
+      local: true
+      capabilities: ["llm.chat"]
+"""
+
+
+def _home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.yaml").write_text(_MOCK_CONFIG, encoding="utf-8")
+    return home
+
+
+def _names(report) -> dict[str, str]:
+    return {c.name: c.status for c in report.checks}
+
+
+class TestChannelDoctor:
+    async def test_missing_home_fails(self, tmp_path: Path) -> None:
+        report = await run_doctor_async(tmp_path / "nope", probe_acp=False)
+        checks = _names(report)
+        assert checks["ROSCLAW_HOME"] == "FAIL"
+        assert report.failed
+
+    async def test_model_config_required(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "config.yaml").write_text("agent:\n  enabled: true\n", encoding="utf-8")
+        report = await run_doctor_async(home, probe_acp=False)
+        assert _names(report)["Native Agent model"] == "FAIL"
+
+    async def test_acp_probe_full_handshake(self, tmp_path: Path) -> None:
+        """用 mock-gateway ACP test server 验证 doctor 的 ACP 探测链路。"""
+        import os
+
+        home = _home(tmp_path)
+        server_script = Path(__file__).parent / "acp_test_server.py"
+        report = await run_doctor_async(
+            home,
+            acp_command=[sys.executable, str(server_script)],
+            acp_env=dict(os.environ, ROSCLAW_ACP_TEST_HOME=str(home)),
+        )
+        checks = _names(report)
+        assert checks["ACP initialize"] == "OK"
+        assert checks["ACP session/new"] == "OK"
+        assert checks["ACP session/resume"] == "OK"
+        assert checks["ACP session/close"] == "OK"
+
+    async def test_acp_probe_failure_reports_stderr(self, tmp_path: Path) -> None:
+        """ACP server 起不来时，FAIL detail 必须包含 stderr 真因。"""
+        home = _home(tmp_path)
+        report = await run_doctor_async(
+            home,
+            acp_command=[sys.executable, "-c", "import sys; sys.exit('boom')"],
+        )
+        checks = _names(report)
+        assert checks["ACP probe"] == "FAIL"
+        detail = next(c.detail for c in report.checks if c.name == "ACP probe")
+        assert "boom" in detail
+
+    async def test_require_openclaw_promotes_skips(self, tmp_path: Path) -> None:
+        """--require-openclaw：SKIP 升级为 FAIL。"""
+        home = _home(tmp_path)
+        report = await run_doctor_async(home, probe_acp=False, require_openclaw=True)
+        # 本机没有 OpenClaw 时 SKIP→FAIL；有 OpenClaw 时 config 探针仍有 SKIP。
+        # 两种环境下都不应残留 SKIP。
+        assert not report.skipped
+
+    async def test_doctor_is_read_only(self, tmp_path: Path) -> None:
+        """doctor 不修改 ROSCLAW_HOME 里的任何配置文件。"""
+        home = _home(tmp_path)
+        before = (home / "config.yaml").read_bytes()
+        await run_doctor_async(home, probe_acp=False)
+        assert (home / "config.yaml").read_bytes() == before
+
+    def test_render_summary(self, tmp_path: Path) -> None:
+        import asyncio
+
+        report = asyncio.run(run_doctor_async(tmp_path / "nope", probe_acp=False))
+        text = report.render()
+        assert "ROSClaw Channel Doctor" in text
+        assert "NOT READY" in text


### PR DESCRIPTION
## 概述

将已有 ACP adapter 从"可运行实验能力"升级为 **production-grade external Agent interface**，并完成 OpenClaw（飞书）Channel 集成脚手架。对应设计文档 PR-RC-001 ~ PR-RC-005。

架构原则：**ROSClaw owns the Agent · OpenClaw owns the Channel · ACP owns the bridge · rosclawd owns physical authority**。不重新实现任何 Channel 能力（连接/pairing/去重/重试全部复用 OpenClaw 官方插件）。

## 变更

**PR-RC-001 ACP 协议硬化**（`adapters/acp/server.py`）
- capability 与实现一致（`load_session=True` + sessionCapabilities list/resume/close）
- session 全生命周期冻结语义：`close` 不删 Mission、`cancel` 仅当前 turn、`load` 带 transcript replay、`resume` 轻量重绑
- graceful shutdown：stdin EOF / SIGTERM 干净退出，无 orphan 进程
- stdout 纯净（仅 JSON-RPC）；附件类型明确拒绝不静默忽略

**PR-RC-002 事件订阅**（`agentd/events.py`）
- `subscribe_events()`：journal replay → live bus 的 authoritative stream，无丢失/无重复/单调/可重连，替换 250ms 轮询

**PR-RC-003 Reasoning/Progress**（`agent_event.py`、`mapper.py`、`loop.py`）
- `reasoning.summary.*` / `plan.updated` 新事件（安全 summary，绝不输出 raw CoT）
- `reasoning.summary.delta → AgentThoughtChunk`；稳定 tool_call_id / work_order_id；USER/DEBUG/AUDIT visibility 门

**PR-RC-004/005 OpenClaw 集成**（`integrations/openclaw/`）
- 幂等安装/配置脚本（`install-openclaw.sh`、`configure-openclaw.sh`）+ 版本锁（`version.lock`）
- `rosclaw channel doctor` 只读诊断 CLI
- README 含 OpenClaw 2026.7.1-2 实测要点（binding peer.id 语义、群聊 `--bind here` 等）

**依赖**：`agent-client-protocol` 锁定 `>=0.12.0,<0.13.0`（0.12.0 已验证）

## 测试

- `tests/agentd/test_acp.py`：28 项（协议生命周期、stdout 纯净、EOF/SIGTERM、kill→resume continuity、mapper、事件订阅）
- `tests/agentd/test_channel_doctor.py`：7 项
- `tests/agentd` CI-marker 全量：682 passed（2 个 `test_external_packs` 失败为预存在环境问题，clean tree 同样失败）
- **Live E2E（2026-08-13 本机）**：飞书 DM/群 → OpenClaw 2026.7.1-2 → acpx → `rosclaw acp serve` → Kimi k3；Mission 隔离、Gateway 重启恢复、@/allowlist 门控、ACP 子进程重启 continuity 全部通过

## 安全边界

- ACP 路径零物理授权（`test_no_authority_via_acp` 常驻回归）
- approval/action 只读卡片，绝不转成 ACP permission
- Gateway loopback + token；acpx `deny-all`；双 MCP bridge 关闭；飞书 workspace tools 全关

🤖 Generated with [Claude Code](https://claude.com/claude-code)