### PR TITLE
fix: 十三审 HOTFIX-13.1——终态计时冻结（服务端权威时间）

### DIFF
--- a/packages/rosclaw-agent/src/workers/job-widget.ts
+++ b/packages/rosclaw-agent/src/workers/job-widget.ts
@@ -23,6 +23,12 @@ interface OrderProjection {
 	assigned_to?: string;
 	status: string;
 	goal?: string;
+	// 十三审 HOTFIX-13.1：服务端权威时间。
+	created_at?: string | null;
+	started_at?: string | null;
+	finished_at?: string | null;
+	duration_ms?: number | null;
+	settled?: boolean;
 }
 
 interface WorkerEvent {
@@ -84,7 +90,6 @@ function workerLabel(assigned: string | undefined): string {
 export class JobsWidget {
 	private timer: ReturnType<typeof setInterval> | undefined;
 	private readonly views = new Map<string, JobView>();
-	private readonly startedAt = new Map<string, number>();
 	private readonly terminalAt = new Map<string, number>();
 	private tickCount = 0;
 	private lastRendered = "";
@@ -111,7 +116,6 @@ export class JobsWidget {
 		if (this.timer) clearInterval(this.timer);
 		this.timer = undefined;
 		this.views.clear();
-		this.startedAt.clear();
 		this.terminalAt.clear();
 		this.lastRendered = "";
 	}
@@ -176,7 +180,6 @@ export class JobsWidget {
 					lastSeq: 0,
 				};
 				this.views.set(order.work_order_id, view);
-				this.startedAt.set(order.work_order_id, now);
 			}
 			view.order = order;
 			if (!terminal) {
@@ -193,7 +196,6 @@ export class JobsWidget {
 			if (at !== undefined && now - at > TERMINAL_KEEP_MS) {
 				this.views.delete(id);
 				this.terminalAt.delete(id);
-				this.startedAt.delete(id);
 			}
 		}
 		this.render([...this.views.values()]);
@@ -215,7 +217,22 @@ export class JobsWidget {
 			const id = view.order.work_order_id;
 			const status = view.order.status;
 			const terminal = ["ACCEPTED", "FAILED", "EXPIRED", "CANCELLED"].includes(status);
-			const elapsed = fmtElapsed(now - (this.startedAt.get(id) ?? now));
+			// 十三审 HOTFIX-13.1：权威计时——终态冻结（finished-started），
+			// 运行态用服务端 started_at；缺 finished_at 的终态显示数据
+			// 错误而非继续计时；TUI 重启显示一致。
+			let elapsed: string;
+			if (terminal) {
+				elapsed = view.order.duration_ms != null
+					? fmtElapsed(view.order.duration_ms)
+					: "时长数据不完整";
+			} else {
+				const startedMs = view.order.started_at
+					? Date.parse(view.order.started_at)
+					: NaN;
+				elapsed = Number.isNaN(startedMs)
+					? "起始时间未知"
+					: fmtElapsed(now - startedMs);
+			}
 			const goal = (view.order.goal ?? "").slice(0, 32);
 			const icon = terminal ? (status === "ACCEPTED" ? "✓" : "✗") : status === "BLOCKED" ? "⚠" : frame;
 			const stallMark = view.stall && !terminal ? " · 静默>90s（仍存活）" : "";

--- a/packages/rosclaw-agent/test/job-widget.test.ts
+++ b/packages/rosclaw-agent/test/job-widget.test.ts
@@ -124,3 +124,48 @@ test("renderJobLog 过滤 liveness、渲染工具与完成", async () => {
 	assert.match(text, /✓ tool write/);
 	assert.match(text, /■ finished/);
 });
+
+test("十三审 HOTFIX-13.1：终态计时冻结（权威 duration，不再增长）", async () => {
+	const { ActiveSessionContext } = await import("../src/session/active-context.js");
+	const { JobsWidget } = await import("../src/workers/job-widget.js");
+	const active = new ActiveSessionContext({
+		sessionId: "pi_test", missionId: "mis_1", contextRevision: 1, mode: "SIMULATION",
+		profile: "developer", contextState: "FRESH", leaseState: "ACTIVE", actionsAllowed: true,
+	});
+	const calls: Array<string[] | undefined> = [];
+	const terminalOrder = {
+		work_order_id: "wo_frozen00001",
+		assigned_to: "worker:rosclaw:pi",
+		status: "FAILED",
+		goal: "被杀的任务",
+		started_at: "2026-08-13T10:00:00+00:00",
+		finished_at: "2026-08-13T10:07:30+00:00",
+		duration_ms: 450_000,
+		settled: true,
+	};
+	const widget = new JobsWidget({
+		active: active as never,
+		center: {
+			call: async (method: string) => {
+				if (method === "pi.worker.status") return { ok: true, orders: [terminalOrder] };
+				return { ok: true, events: [] };
+			},
+		} as never,
+		setWidget: (lines) => calls.push(lines),
+	});
+	await widget.tick();
+	const first = calls.at(-1)!.join("\n");
+	await widget.tick();
+	const second = calls.at(-1)!.join("\n");
+	// 终态 7m30 冻结——两次 tick 渲染完全一致（无 spinner、无增长）。
+	assert.match(first, /7m30/);
+	assert.equal(second, first);
+	assert.ok(!/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(first), "终态卡片仍有 spinner");
+	// 缺 finished_at 的终态：显示数据错误而非继续计时。
+	const broken = { ...terminalOrder, work_order_id: "wo_broken0001", duration_ms: null, finished_at: null };
+	(widget as never as { deps: { center: unknown } }).deps.center = {
+		call: async (method: string) => method === "pi.worker.status" ? { ok: true, orders: [broken] } : { ok: true, events: [] },
+	};
+	await widget.tick();
+	assert.match(calls.at(-1)!.join("\n"), /时长数据不完整/);
+});

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1057,6 +1057,9 @@ class PiBridgeServer:
                     "assigned_to": o.assigned_to,
                     "status": o.status,
                     "goal": o.goal[:120],
+                    # 十三审 HOTFIX-13.1：权威时间（转移日志）——TUI 不得
+                    # 用本地首见时间计时；终态 finished_at 冻结。
+                    **service._worker_manager.order_times(o.work_order_id),
                 }
                 if o.status in ("ACCEPTED", "FAILED", "EXPIRED", "CANCELLED"):
                     row = conn.execute(

--- a/src/rosclaw/agentd/workers/manager.py
+++ b/src/rosclaw/agentd/workers/manager.py
@@ -19,6 +19,7 @@ import asyncio
 import json
 import sqlite3
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from rosclaw.agentd.workers.adapter import RunHandle, WorkerAdapter
 from rosclaw.agentd.workers.scheduler import CandidateView, Scheduler, SchedulingError
@@ -399,6 +400,51 @@ class WorkerManager:
             (worker_id,),
         ).fetchall()
         return [WorkOrderV1(**json.loads(r["order_json"])) for r in rows]
+
+    def order_times(self, work_order_id: str) -> dict[str, Any]:
+        """十三审 HOTFIX-13.1：权威时间——created/started/finished 全部
+        来自转移日志（worker_events 幂等键 wo:STATUS），TUI 不得再
+        用本地第一次看到的时间计时。finished_at 一经写入不可变。"""
+        row = self._conn.execute(
+            "SELECT created_at FROM work_orders WHERE work_order_id = ?",
+            (work_order_id,),
+        ).fetchone()
+        created_at = row["created_at"] if row else None
+        rows = self._conn.execute(
+            "SELECT idempotency_key, occurred_at FROM worker_events "
+            "WHERE idempotency_key LIKE ?",
+            (f"{work_order_id}:%",),
+        ).fetchall()
+        by_status = {}
+        for r in rows:
+            status = r["idempotency_key"].rsplit(":", 1)[-1]
+            by_status[status] = r["occurred_at"]
+        terminal = next(
+            (s for s in ("ACCEPTED", "FAILED", "EXPIRED", "CANCELLED") if s in by_status),
+            None,
+        )
+        started_at = by_status.get("RUNNING")
+        finished_at = by_status.get(terminal) if terminal else None
+        duration_ms = None
+        if started_at and finished_at:
+            from datetime import datetime as _dt
+
+            try:
+                duration_ms = int(
+                    (
+                        _dt.fromisoformat(finished_at) - _dt.fromisoformat(started_at)
+                    ).total_seconds()
+                    * 1000
+                )
+            except ValueError:
+                duration_ms = None
+        return {
+            "created_at": created_at,
+            "started_at": started_at,
+            "finished_at": finished_at,
+            "duration_ms": duration_ms,
+            "settled": terminal is not None,
+        }
 
     def orders_for_mission(self, mission_id: str) -> list[WorkOrderV1]:
         rows = self._conn.execute(


### PR DESCRIPTION
用户实证：FAILED 的 Job 时间还在刷。根因：widget 用 TUI 本地首见时间对终态单也每 2s 重算。

- pi.worker.status 带权威 created/started/finished_at + duration_ms + settled（转移日志幂等键）；
- 终态冻结、无 spinner、不重绘、重启一致；缺 finished_at 显示数据错误；
- 红测试：终态 7m30 两次 tick 渲染一致。