### PR TITLE
fix: 十四审 PR-14.1——WorkerSessionHost 控制协议终止 exit130 循环

### DIFF
--- a/packages/rosclaw-agent/src/workers/pi-worker-main.ts
+++ b/packages/rosclaw-agent/src/workers/pi-worker-main.ts
@@ -464,6 +464,15 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			}
 		};
 		const requestResume = (controlId: string) => {
+			if (hostState === "PAUSE_REQUESTED") {
+				// pause 尚未生效即 resume——撤销暂停：pause 请求方不能
+				// 永远等 PAUSED（统一 ACK RUNNING 收尾）。
+				hostState = "RUNNING";
+				abortReason = null;
+				for (const cid of pendingPauseIds.splice(0)) ack(cid, "RUNNING");
+				ack(controlId, "RUNNING");
+				return;
+			}
 			if (hostState !== "PAUSED") {
 				ack(controlId, "RUNNING");
 				return;

--- a/packages/rosclaw-agent/src/workers/pi-worker-main.ts
+++ b/packages/rosclaw-agent/src/workers/pi-worker-main.ts
@@ -12,7 +12,7 @@
  * PATH 上的 pi、不加载项目资源。
  */
 
-import { appendFileSync, readFileSync } from "node:fs";
+import { appendFileSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { writeSync } from "node:fs";
 
 import { buildSystemPrompt, profileFor } from "./profiles.js";
@@ -382,17 +382,113 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			}
 		});
 
-		// SIGTERM/SIGINT：abort 当前 turn（attempt_cancelled 由父 supervisor
-		// 在进程真正退出后落账——这里尽力 abort，保证 2s 级退出）。
+		// 十四审 PR-14.1：SIGTERM/SIGINT 不再静默映射 exit 130。
+		// prompt 进行中：记录 signal 原因并 abort（prompt 返回后按
+		// SIGNAL_UNKNOWN 落 termination.json——supervisor 据此判
+		// INTERRUPTED_RESUMABLE 而非 FAILED）；空闲（PAUSED 等待中）：
+		// 直接落 AGENTD_SHUTDOWN 并退出（信号即关闭意图）。
+		let inPrompt = false;
+		let abortReason: "pause" | "cancel" | "signal" | null = null;
 		const abort = () => {
-			void session.abort().catch(() => undefined);
+			if (inPrompt) {
+				abortReason = abortReason ?? "signal";
+				void session.abort().catch(() => undefined);
+			} else {
+				writeTermination("AGENTD_SHUTDOWN", "signal while idle", 143);
+				process.exit(143);
+			}
 		};
 		process.on("SIGTERM", abort);
 		process.on("SIGINT", abort);
 
-		// 十审 W4：stdin steer 通道——supervisor 写入单行 JSON
-		// {type:"steer", text} 即转向运行中的 Worker（custom 消息，
-		// 不冒充用户输入）。
+		// termination.json——终态原因唯一权威（总纲 §3.4）。原子写
+		// （tmp+rename）；exit code 只是 Unix 表象，不得当语义。
+		const workDir = envelope.artifacts_dir
+			? `${envelope.artifacts_dir}/..`
+			: `${envelope.cwd}/.rosclaw-work`;
+		function writeTermination(cause: string, detail: string, exitCode: number) {
+			try {
+				const payload = JSON.stringify({
+					schema_version: "rosclaw.worker_termination.v1",
+					cause,
+					detail: redactText(detail).slice(0, 500),
+					exit_code: exitCode,
+					session_file: sessionManager.getSessionFile() ?? "",
+					at: new Date().toISOString(),
+				});
+				writeFileSync(`${workDir}/termination.json.tmp`, payload, "utf-8");
+				renameSync(
+					`${workDir}/termination.json.tmp`,
+					`${workDir}/termination.json`,
+				);
+			} catch {
+				// termination 落盘失败不阻塞退出（supervisor 按 SIGNAL_UNKNOWN 兜底）
+			}
+			emit(wo, att, "termination", { cause, exit_code: exitCode });
+		}
+
+		// 十四审 PR-14.1：WorkerSessionHost 控制状态机（总纲 §3.3）。
+		// RUNNING → PAUSE_REQUESTED →（模型循环真实停止后）PAUSED →
+		// resume → RUNNING（同一 session 继续）。只有 cancel 产生
+		// CANCELLED；pause 后进程必须存活等待控制消息。
+		type HostState = "RUNNING" | "PAUSE_REQUESTED" | "PAUSED";
+		let hostState: HostState = "RUNNING";
+		const pendingPauseIds: string[] = [];
+		let resumeWaiter: (() => void) | null = null;
+		const ack = (controlId: string, state: string) => {
+			emit(wo, att, "control.ack", {
+				control_id: controlId,
+				state,
+				session_id: sessionManager.getSessionFile() ?? "",
+			});
+		};
+		const requestPause = (controlId: string) => {
+			if (hostState === "PAUSED") {
+				ack(controlId, "PAUSED");
+				return;
+			}
+			if (hostState === "PAUSE_REQUESTED") {
+				pendingPauseIds.push(controlId);
+				ack(controlId, "PAUSE_REQUESTED");
+				return;
+			}
+			hostState = "PAUSE_REQUESTED";
+			ack(controlId, "PAUSE_REQUESTED");
+			if (inPrompt) {
+				pendingPauseIds.push(controlId);
+				abortReason = "pause";
+				void session.abort().catch(() => undefined);
+			} else {
+				hostState = "PAUSED";
+				ack(controlId, "PAUSED");
+			}
+		};
+		const requestResume = (controlId: string) => {
+			if (hostState !== "PAUSED") {
+				ack(controlId, "RUNNING");
+				return;
+			}
+			hostState = "RUNNING";
+			ack(controlId, "RUNNING");
+			resumeWaiter?.();
+		};
+		const requestCancel = (controlId: string) => {
+			abortReason = "cancel";
+			if (inPrompt) {
+				ack(controlId, "CANCELLED");
+				void session.abort().catch(() => undefined);
+			} else {
+				// PAUSED/空闲：无 prompt 可 abort——直接按用户取消终止。
+				ack(controlId, "CANCELLED");
+				emit(wo, att, "attempt_cancelled", { usage });
+				writeTermination("USER_CANCELLED", "cancel while paused", 130);
+				process.exit(130);
+			}
+		};
+
+		// stdin 控制通道——supervisor 写入单行 JSON。新协议
+		// control.request（带 control_id，必须 ACK）；legacy pause/extend
+		// 映射进同一状态机（extend = 预算追加 + resume）。
 		process.stdin.setEncoding("utf-8");
 		let stdinBuf = "";
 		process.stdin.on("data", (chunk: string) => {
@@ -402,18 +498,24 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			for (const line of lines) {
 				if (!line.trim()) continue;
 				try {
-					const msg = JSON.parse(line) as { type?: string; text?: string };
-					if (msg.type === "pause") {
-						// 十三审：BUDGET_PAUSED——abort 当前 turn，进程
-						// 存活等待 extend（session/上下文保留）。
-						void session.abort().then(() => {
-							emit(wo, att, "paused", {});
-						}).catch(() => undefined);
+					const msg = JSON.parse(line) as {
+						type?: string;
+						text?: string;
+						control_id?: string;
+						action?: string;
+					};
+					if (msg.type === "control.request" && msg.action) {
+						const cid = msg.control_id || `ctl_${Date.now()}`;
+						if (msg.action === "pause") requestPause(cid);
+						else if (msg.action === "resume") requestResume(cid);
+						else if (msg.action === "cancel") requestCancel(cid);
+					} else if (msg.type === "pause") {
+						// legacy（无 control_id）——同一状态机。
+						requestPause(`ctl_legacy_${Date.now()}`);
 					} else if (msg.type === "extend") {
-						// 预算追加——继续同一会话。
+						// 预算追加——resume 同一会话（若未暂停则空操作 ACK）。
 						emit(wo, att, "extended", { add_tokens: (msg as { add_tokens?: number }).add_tokens ?? 0 });
-						void session.prompt("预算已追加。继续之前的任务——从当前状态接着做，不要从零开始。")
-							.catch(() => undefined);
+						requestResume(`ctl_extend_${Date.now()}`);
 					} else if (msg.type === "answer" && msg.text !== undefined) {
 						const waiter = (globalThis as Record<string, unknown>).__rosclawAnswerWaiter as
 							| { resolve(text: string): void }
@@ -453,49 +555,106 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 		const resumePrefix = envelope.resume_session_file
 			? "这是同一任务的中断恢复（同一 Pi 会话——你的工具历史与上下文还在）。从上次中断处继续；不要从零开始。\n\n"
 			: "";
-		const task =
+		const firstTask =
 			resumePrefix +
 			`WorkOrder goal: ${envelope.goal}\n\n` +
 			`Instructions: ${envelope.instructions || envelope.goal}\n\n` +
 			"Deliverable: a concise final report as plain text (facts verified " +
 			"with your tools, with concrete paths/line numbers where relevant)." +
 			dod;
-		await session.prompt(task);
+		// WorkerSessionHost 主循环（总纲 §3.3）：prompt 返回不是进程终点；
+		// aborted+pause → PAUSED 等待控制；只有完成/失败/取消/信号才退出。
+		let nextPrompt = firstTask;
+		let exitCode: number | null = null;
+		while (exitCode === null) {
+			if (hostState === "PAUSED") {
+				// 进程存活等待 resume/cancel（控制通道与 transcript 保持）。
+				await new Promise<void>((resolve) => {
+					resumeWaiter = () => {
+						resumeWaiter = null;
+						resolve();
+					};
+				});
+				nextPrompt =
+					"控制通道已恢复。继续之前的任务——从当前状态接着做，不要从零开始。";
+			}
+			abortReason = null;
+			stopReason = "";
+			errorMessage = "";
+			inPrompt = true;
+			try {
+				await session.prompt(nextPrompt);
+			} catch (promptErr) {
+				errorMessage = `${(promptErr as Error).name}: ${(promptErr as Error).message}`;
+			}
+			inPrompt = false;
+			// 自审修复：session 文件在首个条目写入后才存在——每个 prompt
+			// 边界回告真实路径（resume 才能拿到有效 checkpoint）。
+			emit(wo, att, "session_persisted", {
+				session_file: sessionManager.getSessionFile() ?? "",
+			});
+
+			if (providerTimedOut) {
+				emit(wo, att, "attempt_failed", {
+					error_code: "PROVIDER_TIMEOUT",
+					message: `单个模型请求超过 ${Math.round(providerTimeoutMs / 1000)}s`,
+					usage,
+				});
+				writeTermination("PROVIDER_TRANSIENT", "provider turn timeout", 1);
+				exitCode = 1;
+				break;
+			}
+			if (stopReason === "aborted") {
+				if (abortReason === "pause") {
+					// 模型循环真实停止——现在才可 ACK PAUSED（进程存活）。
+					hostState = "PAUSED";
+					for (const cid of pendingPauseIds.splice(0)) ack(cid, "PAUSED");
+					emit(wo, att, "paused", {});
+					continue;
+				}
+				if (abortReason === "cancel") {
+					// 只有用户取消产生 CANCELLED。
+					emit(wo, att, "attempt_cancelled", { usage });
+					writeTermination("USER_CANCELLED", "cancel requested", 130);
+					exitCode = 130;
+					break;
+				}
+				// 信号/未知 abort：不是取消也不是失败——中断可恢复。
+				emit(wo, att, "attempt_cancelled", { usage, reason: "signal" });
+				writeTermination("SIGNAL_UNKNOWN", "aborted without control request", 130);
+				exitCode = 130;
+				break;
+			}
+			if (stopReason === "error" || errorMessage) {
+				const transient =
+					/timeout|timed out|429|5\d\d|ECONNRESET|ETIMEDOUT|ENOTFOUND|rate.?limit|overloaded/i.test(
+						errorMessage,
+					);
+				emit(wo, att, "attempt_failed", {
+					error_code: "MODEL_ERROR",
+					message: errorMessage || stopReason,
+					usage,
+				});
+				writeTermination(
+					transient ? "PROVIDER_TRANSIENT" : "PROVIDER_FATAL",
+					errorMessage || stopReason,
+					1,
+				);
+				exitCode = 1;
+				break;
+			}
+			emit(wo, att, "attempt_finished", {
+				report: finalTextOf(messages),
+				usage,
+				model: snapshot ? `${snapshot.provider}/${snapshot.model}` : undefined,
+			});
+			writeTermination("COMPLETED", "", 0);
+			exitCode = 0;
+		}
 		unsubscribe();
 		clearInterval(livenessTimer);
 		clearInterval(providerTimer);
-		// 自审修复：session 文件在首个条目写入后才存在——终态再回告
-		// 一次真实路径（否则 resume 可能拿到空 checkpoint）。
-		emit(wo, att, "session_persisted", {
-			session_file: sessionManager.getSessionFile() ?? "",
-		});
-
-		if (providerTimedOut) {
-			emit(wo, att, "attempt_failed", {
-				error_code: "PROVIDER_TIMEOUT",
-				message: `单个模型请求超过 ${Math.round(providerTimeoutMs / 1000)}s`,
-				usage,
-			});
-			return 1;
-		}
-		if (stopReason === "aborted") {
-			emit(wo, att, "attempt_cancelled", { usage });
-			return 130;
-		}
-		if (stopReason === "error" || errorMessage) {
-			emit(wo, att, "attempt_failed", {
-				error_code: "MODEL_ERROR",
-				message: errorMessage || stopReason,
-				usage,
-			});
-			return 1;
-		}
-		emit(wo, att, "attempt_finished", {
-			report: finalTextOf(messages),
-			usage,
-			model: snapshot ? `${snapshot.provider}/${snapshot.model}` : undefined,
-		});
-		return 0;
+		return exitCode;
 	} catch (err) {
 		// 十二审 HOTFIX-12.1：错误分类——provider 消息 shape/协议问题
 		// 是 ADAPTER_PROTOCOL_ERROR（同版本盲重试无意义），不是 MODEL_ERROR。
@@ -507,6 +666,28 @@ export async function runHeadlessWorker(argv: string[]): Promise<number> {
 			error_code: isProtocol ? "ADAPTER_PROTOCOL_ERROR" : "WORKER_CRASH",
 			message: `${e.name}: ${e.message}`,
 		});
+		// 十四审：崩溃也要落 termination.json（WORKER_CRASH）——try 内的
+		// writeTermination 此处不可见，内联原子写兜底。
+		try {
+			const dir = envelope.artifacts_dir
+				? `${envelope.artifacts_dir}/..`
+				: `${envelope.cwd}/.rosclaw-work`;
+			writeFileSync(
+				`${dir}/termination.json.tmp`,
+				JSON.stringify({
+					schema_version: "rosclaw.worker_termination.v1",
+					cause: "WORKER_CRASH",
+					detail: `${e.name}: ${e.message}`.slice(0, 500),
+					exit_code: 1,
+					session_file: "",
+					at: new Date().toISOString(),
+				}),
+				"utf-8",
+			);
+			renameSync(`${dir}/termination.json.tmp`, `${dir}/termination.json`);
+		} catch {
+			// 落盘失败不阻塞退出
+		}
 		return 1;
 	}
 }

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -459,6 +459,17 @@ class PiToolDispatcher:
                 "hard_deadline_sec 需要显式权威来源（user/benchmark/admin_policy）"
                 "——Worker 有进度就让它继续；wall 时间只是观察指标",
             )
+        # 十四审 PR-14.1（§3.1）：cost_hard_limit 是唯一可暂停进程的预算
+        # 手段——同样需要显式 user/admin_policy 权威；模型自报的
+        # model_tokens 只是遥测，绝不控制进程。
+        if exec_policy.get("cost_hard_limit_tokens") and exec_policy.get(
+            "cost_hard_limit_source"
+        ) not in ("user", "admin_policy"):
+            raise ToolBridgeError(
+                "COST_LIMIT_AUTHORITY_REQUIRED",
+                "cost_hard_limit_tokens 需要显式权威来源（user/admin_policy）"
+                "——token soft target 只做提示，不改变进程状态",
+            )
         # 十二审 PR-12.4：WorkSpecV2——任务类型驱动验收（deliverables
         # 覆盖 profile 默认工件类型）。
         task_type = str(args.get("task_type") or (

--- a/src/rosclaw/agentd/workers/manager.py
+++ b/src/rosclaw/agentd/workers/manager.py
@@ -42,6 +42,7 @@ _RUN_TRANSITIONS: dict[str, frozenset[str]] = {
     "RUNNING": frozenset({
         "SUBMITTED", "FAILED", "EXPIRED", "CANCELLED", "BLOCKED",
         "UNREACHABLE", "INTERRUPTED_RESUMABLE", "BUDGET_PAUSED",
+        "PAUSE_REQUESTED", "PAUSED",
     }),
     "SUBMITTED": frozenset({"VERIFYING", "FAILED"}),
     "VERIFYING": frozenset({"ACCEPTED", "FAILED"}),
@@ -51,6 +52,12 @@ _RUN_TRANSITIONS: dict[str, frozenset[str]] = {
     ),
     "INTERRUPTED_RESUMABLE": frozenset({"RUNNING", "FAILED", "CANCELLED"}),
     "BUDGET_PAUSED": frozenset({"RUNNING", "CANCELLED", "FAILED"}),
+    # 十四审：PAUSE_REQUESTED 只在 ACK 前存在——ACK 后 PAUSED/BUDGET_PAUSED，
+    # ACK 失败回 RUNNING；用户取消任何时刻合法。
+    "PAUSE_REQUESTED": frozenset(
+        {"PAUSED", "BUDGET_PAUSED", "RUNNING", "CANCELLED", "FAILED"}
+    ),
+    "PAUSED": frozenset({"RUNNING", "CANCELLED", "FAILED", "INTERRUPTED_RESUMABLE"}),
     "FAILED": frozenset(),
     "EXPIRED": frozenset(),
     "CANCELLED": frozenset(),

--- a/src/rosclaw/agentd/workers/pi_managed.py
+++ b/src/rosclaw/agentd/workers/pi_managed.py
@@ -22,6 +22,7 @@ import os
 import stat
 from datetime import UTC, datetime
 from pathlib import Path
+from uuid import uuid4
 
 from rosclaw.agentd.pi_entry import find_pi_agent_entry
 from rosclaw.agentd.workers.adapter import (
@@ -30,6 +31,7 @@ from rosclaw.agentd.workers.adapter import (
     WorkerProbeResult,
 )
 from rosclaw.agentd.workers.process import kill_process_tree
+from rosclaw.contracts.worker.control import ERROR_CODE_CAUSES
 from rosclaw.contracts.worker.order import (
     ResultArtifact,
     ResultClaim,
@@ -52,6 +54,11 @@ WRAPUP_GRACE_SEC = 60.0
 #: UNREACHABLE 宽限：全静默 + 零 CPU 进展持续超过该值才按"恢复失败"
 #: 终止并进 INTERRUPTED_RESUMABLE（working 永不杀）。
 UNREACHABLE_GRACE_SEC = 900.0
+#: 十四审 PR-14.1：控制请求 ACK 等待——supervisor 收到 control.ack
+#: 前只能显示 PAUSE_REQUESTED，不得乐观落 PAUSED（总纲 §3.2）。
+CONTROL_ACK_TIMEOUT_SEC = 30.0
+#: 控制取消的优雅退出宽限（ACK/termination.json 落盘）再升级 SIGKILL。
+CANCEL_GRACE_SEC = 5.0
 
 #: W3：写能力 profile（Developer Workbench）——workspace 隔离 + diff 工件。
 WORKBENCH_PROFILES = ("developer", "sim-builder")
@@ -104,6 +111,9 @@ class PiManagedAdapter:
         self._runs: dict[str, tuple[RunHandle, asyncio.Task]] = {}
         # W4：活动子进程（steer 通道 + pid 文件崩溃对账）。
         self._procs: dict[str, asyncio.subprocess.Process] = {}
+        # 十四审 PR-14.1：control.ack 收条（control_id → state）——
+        # request_pause/resume 只认 ACK，不认"stdin 已写"。
+        self._control_acks: dict[str, dict[str, str]] = {}
         # 十一审 PR-B：持久化事件账本（文件权威，重启/compact 可读）。
         from rosclaw.agentd.workers.event_store import WorkerEventStore
 
@@ -164,7 +174,25 @@ class PiManagedAdapter:
                 warnings=["adapter_error"],
             )
 
-    async def cancel(self, handle: RunHandle, reason: str) -> None:  # noqa: ARG002
+    async def cancel(self, handle: RunHandle, reason: str) -> None:
+        # 十四审 PR-14.1：先控制取消——worker 优雅 abort 并落
+        # termination.json(USER_CANCELLED)；宽限内未退出才取消驱动
+        # 任务（_teardown 杀树兜底）。只有用户取消产生 CANCELLED。
+        control_id = await self._send_control(handle.work_order_id, "cancel", reason)
+        if control_id is not None:
+            await self._wait_ack(
+                handle.work_order_id, control_id, "CANCELLED",
+                timeout=CANCEL_GRACE_SEC,
+            )
+            proc = self._procs.get(handle.work_order_id)
+            if proc is not None and proc.returncode is None:
+                # ACK 已回——给 termination.json/exit 一个落盘窗口。
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(proc.wait(), timeout=2.0)
+            proc = self._procs.get(handle.work_order_id)
+            if proc is not None and proc.returncode is not None:
+                # 优雅退出——驱动任务自然收尾（post-exit 映射 CANCELLED）。
+                return
         entry = self._runs.pop(handle.work_order_id, None)
         if entry is not None:
             entry[1].cancel()
@@ -184,34 +212,81 @@ class PiManagedAdapter:
             return False
         return True
 
-    async def pause(self, work_order_id: str) -> bool:
-        """十三审：BUDGET_PAUSED——子进程 abort 当前 turn 并等待
-        （进程存活、liveness 继续、session 保留）。"""
-        proc = self._procs.get(work_order_id)
-        if proc is None or proc.returncode is not None or proc.stdin is None:
-            return False
+    def _read_termination(self, work_order_id: str) -> dict | None:
+        """termination.json（worker 退出前原子落盘的权威终止原因）。"""
+        path = self._home / "work" / work_order_id / "termination.json"
         try:
-            proc.stdin.write(b'{"type":"pause"}\n')
-            await proc.stdin.drain()
-        except (BrokenPipeError, ConnectionResetError):
-            return False
-        return True
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        return data if isinstance(data, dict) else None
 
-    async def extend(self, work_order_id: str, add_tokens: int) -> bool:
-        """十三审：/job extend——追加 token 预算并唤醒暂停的 Worker。"""
+    async def _send_control(self, work_order_id: str, action: str, reason: str = "") -> str | None:
+        """写 control.request（十四审 PR-14.1）——返回 control_id；
+        进程不在/stdin 已闭返回 None。"""
         proc = self._procs.get(work_order_id)
         if proc is None or proc.returncode is not None or proc.stdin is None:
-            return False
+            return None
+        control_id = f"ctl_{uuid4().hex[:12]}"
         try:
             proc.stdin.write(
                 (json.dumps(
-                    {"type": "extend", "add_tokens": add_tokens}, ensure_ascii=False
+                    {
+                        "type": "control.request",
+                        "control_id": control_id,
+                        "action": action,
+                        "mode": "safe",
+                        "reason": reason,
+                    },
+                    ensure_ascii=False,
                 ) + "\n").encode()
             )
             await proc.stdin.drain()
         except (BrokenPipeError, ConnectionResetError):
+            return None
+        return control_id
+
+    async def _wait_ack(
+        self, work_order_id: str, control_id: str, want: str,
+        timeout: float | None = None,
+    ) -> bool:
+        """等 control.ack（state==want）——ACK 是唯一"已生效"证据。"""
+        deadline = asyncio.get_running_loop().time() + (
+            timeout if timeout is not None else CONTROL_ACK_TIMEOUT_SEC
+        )
+        while asyncio.get_running_loop().time() < deadline:
+            acks = self._control_acks.get(work_order_id, {})
+            if acks.get(control_id) == want:
+                return True
+            proc = self._procs.get(work_order_id)
+            if proc is not None and proc.returncode is not None:
+                return False
+            await asyncio.sleep(0.05)
+        return False
+
+    async def request_pause(self, work_order_id: str, *, reason: str = "user") -> bool:
+        """十四审 PR-14.1：控制暂停——发送 control.request pause 并等待
+        control.ack PAUSED（模型循环真实停止、进程存活）才返回 True。"""
+        control_id = await self._send_control(work_order_id, "pause", reason)
+        if control_id is None:
             return False
-        return True
+        return await self._wait_ack(work_order_id, control_id, "PAUSED")
+
+    async def request_resume(self, work_order_id: str) -> bool:
+        """控制恢复——ACK RUNNING 后同一会话继续。"""
+        control_id = await self._send_control(work_order_id, "resume")
+        if control_id is None:
+            return False
+        return await self._wait_ack(work_order_id, control_id, "RUNNING")
+
+    async def pause(self, work_order_id: str) -> bool:
+        """兼容旧调用点——语义即 request_pause（ACK 后才算暂停）。"""
+        return await self.request_pause(work_order_id, reason="budget_hard")
+
+    async def extend(self, work_order_id: str, add_tokens: int) -> bool:  # noqa: ARG002
+        """十三审：/job extend——追加预算并唤醒。十四审：唤醒 = 控制
+        resume（同一 Pi 会话继续）；预算记账由 dispatcher 落 order_json。"""
+        return await self.request_resume(work_order_id)
 
     def _on_waiting_input(self, work_order_id: str) -> None:
         manager = self._manager_ref
@@ -718,6 +793,12 @@ class PiManagedAdapter:
                         self._on_waiting_input(order.work_order_id)
                 elif kind == "session_persisted":
                     state["session_file"] = str(event.get("session_file", ""))
+                elif kind == "control.ack":
+                    # 十四审：ACK 收条——request_pause/resume/cancel 的
+                    # 唯一"已生效"证据。
+                    self._control_acks.setdefault(order.work_order_id, {})[
+                        str(event.get("control_id", ""))
+                    ] = str(event.get("state", ""))
                 elif kind == "answer_received":
                     import contextlib as _cl3
 
@@ -764,14 +845,15 @@ class PiManagedAdapter:
                 if asyncio.get_running_loop().time() > startup_end:
                     raise AdapterError("worker startup timeout (no attempt_started)")
                 await asyncio.sleep(0.05)
-            # 主监控循环（十三审 HOTFIX-13.2——Worker 有证据在工作就
-            # 让它继续；时间只是观察指标）：
+            # 主监控循环（十四审 PR-14.1——Worker 有证据在工作就
+            # 让它继续；soft target 只是观察指标，绝不控制进程）：
             # - 默认无硬截止：hard_deadline 仅在显式权威来源下生效；
             # - 全静默 > LIVENESS_TIMEOUT → 多信号探测（pid/CPU）——
             #   活着 = UNREACHABLE（不杀），死了 = INTERRUPTED_RESUMABLE；
             # - 语义静默 > STALL_WARN → 只告警；
-            # - soft target 到期 → 一次性提醒事件（不干预）；
-            # - token 80% 提醒；100% → BUDGET_PAUSED（暂停待 /job extend）。
+            # - wall/token soft target 到期 → 提醒事件（不干预）；
+            # - 只有 user/admin_policy 权威的 cost_hard_limit 才控制暂停
+            #   （control.ack PAUSED 后才落 BUDGET_PAUSED）。
             policy = order.inputs.get("execution_policy") or {}
             hard_sec = None
             if policy.get("hard_deadline_sec") and policy.get(
@@ -781,9 +863,16 @@ class PiManagedAdapter:
             soft_target_sec = float(
                 policy.get("soft_target_sec") or order.budgets.wall_time_sec or 0
             )
+            # 十四审 §3.1：token soft target 只是遥测——模型自报的
+            # model_tokens 在多 turn 累计下必然误杀，绝不控制进程。
             token_limit = int(
                 policy.get("token_soft_limit") or order.budgets.model_tokens or 0
             )
+            cost_hard_limit = 0
+            if policy.get("cost_hard_limit_tokens") and policy.get(
+                "cost_hard_limit_source"
+            ) in ("user", "admin_policy"):
+                cost_hard_limit = int(policy["cost_hard_limit_tokens"])
             wall_end = (
                 asyncio.get_running_loop().time() + hard_sec if hard_sec else None
             )
@@ -878,7 +967,8 @@ class PiManagedAdapter:
                         order.work_order_id, "", "soft_target_exceeded",
                         {"soft_target_sec": soft_target_sec},
                     )
-                # token：80% 提醒；100% BUDGET_PAUSED（暂停待 extend）。
+                # token soft target：80%/100% 只告警（绝不暂停——总纲
+                # §3.1"预算提醒不是安全审批，不得中断正在做的 Worker"）。
                 usage_last = next(
                     (e for e in reversed(events) if e.get("kind") == "usage"), None
                 )
@@ -886,25 +976,52 @@ class PiManagedAdapter:
                     spent = int(usage_last.get("input_tokens") or 0) + int(
                         usage_last.get("output_tokens") or 0
                     )
-                    if spent >= token_limit and not state.get("budget_paused"):
-                        state["budget_paused"] = True
-                        await self.pause(order.work_order_id)
-                        with contextlib.suppress(Exception):
-                            self._manager_ref._transition(
-                                order.work_order_id, "BUDGET_PAUSED", "token_limit"
-                            )
-                        self._events.append_event(
-                            order.work_order_id, "", "budget_paused",
-                            {"spent": spent, "limit": token_limit},
-                        )
-                    elif (
-                        spent >= int(token_limit * 0.8)
-                        and not state.get("budget_notified")
-                    ):
+                    if spent >= token_limit and not state.get("budget_notified"):
                         state["budget_notified"] = True
                         self._events.append_event(
                             order.work_order_id, "", "budget_warning",
-                            {"spent": spent, "limit": token_limit},
+                            {"spent": spent, "limit": token_limit, "level": "soft"},
+                        )
+                    elif (
+                        spent >= int(token_limit * 0.8)
+                        and not state.get("budget_notified_80")
+                    ):
+                        state["budget_notified_80"] = True
+                        self._events.append_event(
+                            order.work_order_id, "", "budget_warning",
+                            {"spent": spent, "limit": token_limit, "level": "soft"},
+                        )
+                # hard cost limit（显式 user/admin_policy 权威）：到限 →
+                # 控制暂停——先 PAUSE_REQUESTED，ACK PAUSED 后才落
+                # BUDGET_PAUSED；ACK 失败诚实回报（不乐观）。
+                if usage_last and cost_hard_limit:
+                    spent = int(usage_last.get("input_tokens") or 0) + int(
+                        usage_last.get("output_tokens") or 0
+                    )
+                    if spent >= cost_hard_limit and not state.get("budget_paused"):
+                        state["budget_paused"] = True
+                        with contextlib.suppress(Exception):
+                            self._manager_ref._transition(
+                                order.work_order_id, "PAUSE_REQUESTED", "cost_hard_limit"
+                            )
+                        paused = await self.request_pause(
+                            order.work_order_id, reason="budget_hard"
+                        )
+                        with contextlib.suppress(Exception):
+                            if paused:
+                                self._manager_ref._transition(
+                                    order.work_order_id, "BUDGET_PAUSED",
+                                    "cost_hard_limit_ack",
+                                )
+                            else:
+                                self._manager_ref._transition(
+                                    order.work_order_id, "RUNNING",
+                                    "cost_pause_ack_failed",
+                                )
+                        self._events.append_event(
+                            order.work_order_id, "",
+                            "budget_paused" if paused else "budget_pause_failed",
+                            {"spent": spent, "limit": cost_hard_limit, "acked": paused},
                         )
         except asyncio.CancelledError:
             # 十二审 PR-12.5：先收集部分成果再终止（cancel 也要 partial）。
@@ -923,27 +1040,87 @@ class PiManagedAdapter:
             raise
         await readers
         self._procs.pop(order.work_order_id, None)
+        self._control_acks.pop(order.work_order_id, None)
         pid_file.unlink(missing_ok=True)
+        # 十四审 PR-14.1（总纲 §3.4）：termination.json 是终态原因唯一
+        # 权威；exit code 只是 Unix 表象（130 可能是取消/暂停/信号/重启），
+        # 不得直接当 FAILED 或自动重试依据。进程来不及写 → SIGNAL_UNKNOWN。
+        termination = self._read_termination(order.work_order_id)
+        cause = str((termination or {}).get("cause") or "")
+        if not cause:
+            if failure is not None:
+                cause = ERROR_CODE_CAUSES.get(
+                    str(failure.get("error_code", "")), "WORKER_CRASH"
+                )
+            elif final_report or proc.returncode == 0:
+                cause = "COMPLETED"
+            else:
+                cause = "SIGNAL_UNKNOWN"
+        detail = str(
+            (termination or {}).get("detail")
+            or (failure or {}).get("message")
+            or ""
+        )
+        if termination and termination.get("session_file"):
+            state["session_file"] = str(termination["session_file"])
+        interrupted_causes = {
+            "SIGNAL_UNKNOWN", "AGENTD_SHUTDOWN", "USER_PAUSED", "BUDGET_HARD_PAUSED",
+        }
+        terminal_status = (
+            "COMPLETED" if cause == "COMPLETED"
+            else "CANCELLED" if cause == "USER_CANCELLED"
+            else "INTERRUPTED" if cause in interrupted_causes
+            else "FAILED"
+        )
         # PR-B：终态落 state.json（重启对账/tail 可读）。
         self._events.write_state(
             order.work_order_id,
             {
-                "status": "FAILED" if failure is not None else "COMPLETED",
+                "status": terminal_status,
                 "phase": "TERMINAL",
                 "last_seq": handle.progress_seq,
-                "error": failure,
+                "termination_cause": cause,
+                "error": detail or None,
                 # PR-12.3：resume 的恢复点（Pi 原生 session 文件）。
                 "session_file": state.get("session_file", ""),
             },
         )
         finished = datetime.now(UTC)
-        if failure is not None:
-            raise AdapterError(
-                f"worker attempt failed [{failure.get('error_code', '?')}]: "
-                f"{failure.get('message', '')}"
+        if cause in interrupted_causes:
+            # 中断可恢复——不是 FAILED：checkpoint + INTERRUPTED_RESUMABLE。
+            self._write_checkpoint(order, state, "INTERRUPTED", "")
+            with contextlib.suppress(Exception):
+                self._manager_ref._transition(
+                    order.work_order_id, "INTERRUPTED_RESUMABLE", cause.lower()
+                )
+            return WorkResultV1(
+                work_order_id=order.work_order_id,
+                worker_id=WORKER_ID,
+                lease_id=handle.lease_id,
+                status="INTERRUPTED",
+                summary=f"worker 中断（{cause}）——会话/工作区已保留，"
+                "可 /job resume 恢复",
+                warnings=["interrupted_resumable"],
             )
+        if cause == "USER_CANCELLED":
+            # 只有用户取消产生 CANCELLED（控制协议 cancel 动作）。
+            self._write_checkpoint(order, state, "CANCELLED", "")
+            return WorkResultV1(
+                work_order_id=order.work_order_id,
+                worker_id=WORKER_ID,
+                lease_id=handle.lease_id,
+                status="CANCELLED",
+                summary="worker 已被用户取消",
+                warnings=["cancelled"],
+            )
+        if cause != "COMPLETED":
+            # FAILED——摘要携带权威 cause（Native Agent 不得再猜日志归因）。
+            raise AdapterError(f"worker attempt failed [{cause}]: {detail}")
         if not final_report and proc.returncode != 0:
-            raise AdapterError(f"worker exited {proc.returncode} without a final report")
+            # 声称完成但无报告且非零退出——矛盾，按崩溃诚实归类。
+            raise AdapterError(
+                "worker attempt failed [WORKER_CRASH]: 无最终报告"
+            )
         usage_last = next((e for e in reversed(events) if e.get("kind") == "usage"), {})
         usage = WorkUsage(
             wall_time_ms=int((finished - started).total_seconds() * 1000),

--- a/src/rosclaw/contracts/export.py
+++ b/src/rosclaw/contracts/export.py
@@ -36,6 +36,11 @@ from rosclaw.contracts.ui.commands import CommandRequestV1, CommandResultV1, Com
 from rosclaw.contracts.ui.interactions import InteractionRequestV1
 from rosclaw.contracts.ui.snapshots import MissionSnapshotV1
 from rosclaw.contracts.worker.card import WorkerCardV1
+from rosclaw.contracts.worker.control import (
+    ControlAckV1,
+    ControlRequestV1,
+    TerminationV1,
+)
 from rosclaw.contracts.worker.order import WorkOrderV1, WorkResultV1
 
 #: All top-level v1 contracts, keyed by schema stem.
@@ -72,6 +77,9 @@ ALL_CONTRACTS: dict[str, type[ContractModel]] = {
         ArtifactRefV1,
         EvidenceClaimV1,
         WorkOrderV2,
+        ControlRequestV1,
+        ControlAckV1,
+        TerminationV1,
     )
 }
 

--- a/src/rosclaw/contracts/worker/control.py
+++ b/src/rosclaw/contracts/worker/control.py
@@ -1,0 +1,104 @@
+"""Worker 控制协议与终止原因（十四审 PR-14.1，总纲 §3.2/§3.4）。
+
+控制请求必须有 ACK：supervisor 在收到 control.ack 前只能显示
+PAUSE_REQUESTED，不得乐观落 PAUSED。exit code 只是 Unix 表象，
+终态原因唯一权威是 termination.json（TerminationV1）——进程来不及
+写时按 SIGNAL_UNKNOWN → INTERRUPTED_RESUMABLE 处理，绝不直接 FAILED。
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from rosclaw.contracts.common import ContractModel
+
+#: 权威终止原因枚举（总纲 §3.4）——Native Agent 只许展示 cause+证据，
+#: 不得根据日志自由推测。
+TERMINATION_CAUSES = (
+    "COMPLETED",
+    "USER_CANCELLED",
+    "USER_PAUSED",
+    "BUDGET_HARD_PAUSED",
+    "AGENTD_SHUTDOWN",
+    "PROVIDER_TRANSIENT",
+    "PROVIDER_FATAL",
+    "TOOL_FAILED",
+    "DELIVERABLE_REJECTED",
+    "WORKER_CRASH",
+    "SIGNAL_UNKNOWN",
+)
+
+#: attempt_failed error_code → termination cause 的映射（worker 事件
+#: 是次权威——termination.json 缺失时用于归类，绝不落回 "worker exited"）。
+ERROR_CODE_CAUSES = {
+    "MODEL_ERROR": "PROVIDER_FATAL",
+    "MODEL_UNAVAILABLE": "PROVIDER_FATAL",
+    "PROVIDER_TIMEOUT": "PROVIDER_TRANSIENT",
+    "ADAPTER_PROTOCOL_ERROR": "WORKER_CRASH",
+    "TOOL_CONTRACT_MISMATCH": "TOOL_FAILED",
+    "DELIVERABLE_FAILED": "DELIVERABLE_REJECTED",
+    "BLOCKED_PREFLIGHT": "TOOL_FAILED",
+}
+
+#: 控制动作（pause=安全暂停等 resume；cancel=用户取消唯一 CANCELLED 来源；
+#: resume=同一会话继续）。
+CONTROL_ACTIONS = ("pause", "resume", "cancel")
+
+
+class ControlRequestV1(ContractModel):
+    """supervisor → worker（stdin JSONL）。control_id 用于 ACK 对账。"""
+
+    SCHEMA = "rosclaw.worker_control_request.v1"
+
+    schema_version: Literal["rosclaw.worker_control_request.v1"] = (
+        "rosclaw.worker_control_request.v1"
+    )
+    type: Literal["control.request"] = "control.request"
+    control_id: str
+    action: Literal["pause", "resume", "cancel"]
+    mode: Literal["safe", "immediate"] = "safe"
+    reason: str = ""
+
+
+class ControlAckV1(ContractModel):
+    """worker → supervisor（stdout WorkerEvent kind=control.ack）。
+
+    state=PAUSED 表示模型循环已真实停止且进程存活等待 resume——
+    只有此时 supervisor 才可落 PAUSED/BUDGET_PAUSED。"""
+
+    SCHEMA = "rosclaw.worker_control_ack.v1"
+
+    schema_version: Literal["rosclaw.worker_control_ack.v1"] = (
+        "rosclaw.worker_control_ack.v1"
+    )
+    control_id: str
+    state: Literal["PAUSE_REQUESTED", "PAUSED", "RUNNING", "CANCELLED"]
+    session_id: str = ""
+    detail: str = ""
+
+
+class TerminationV1(ContractModel):
+    """termination.json——worker 退出前原子落盘的权威终止原因。"""
+
+    SCHEMA = "rosclaw.worker_termination.v1"
+
+    schema_version: Literal["rosclaw.worker_termination.v1"] = (
+        "rosclaw.worker_termination.v1"
+    )
+    cause: Literal[
+        "COMPLETED",
+        "USER_CANCELLED",
+        "USER_PAUSED",
+        "BUDGET_HARD_PAUSED",
+        "AGENTD_SHUTDOWN",
+        "PROVIDER_TRANSIENT",
+        "PROVIDER_FATAL",
+        "TOOL_FAILED",
+        "DELIVERABLE_REJECTED",
+        "WORKER_CRASH",
+        "SIGNAL_UNKNOWN",
+    ]
+    detail: str = ""
+    exit_code: int = 0
+    session_file: str = ""
+    at: str = ""

--- a/src/rosclaw/contracts/worker/order.py
+++ b/src/rosclaw/contracts/worker/order.py
@@ -24,6 +24,9 @@ WORK_ORDER_STATES = (
     "UNREACHABLE",
     "INTERRUPTED_RESUMABLE",
     "BUDGET_PAUSED",
+    # 十四审：控制请求已发未 ACK（不得乐观落 PAUSED）；用户暂停。
+    "PAUSE_REQUESTED",
+    "PAUSED",
     "SUBMITTED",
     "VERIFYING",
     "ACCEPTED",

--- a/tests/agentd/test_fourteen_1.py
+++ b/tests/agentd/test_fourteen_1.py
@@ -74,30 +74,32 @@ async def _hire(service, mission, tmp_path, fake, monkeypatch, *, wall=60, polic
 
 #: 新控制协议的 fake worker：pause → ACK PAUSED 并空转等待；resume →
 #: ACK RUNNING 并完成。关键：pause 后进程必须活着（Gate 0）。
+#: 注意：stdin 读取者必须在前台（POSIX sh 后台任务 stdin 是 /dev/null）。
 _FAKE_CONTROL = """#!/bin/sh
 echo '{"kind":"attempt_started"}'
 echo '{"kind":"usage","input_tokens":600,"output_tokens":200}'
 (
-  while IFS= read -r line; do
-    case "$line" in
-      *'"action":"pause"'*)
-        cid=$(echo "$line" | sed -n 's/.*"control_id":"\\([^"]*\\)".*/\\1/p')
-        echo "{\\"kind\\":\\"control.ack\\",\\"control_id\\":\\"$cid\\",\\"state\\":\\"PAUSED\\"}"
-        ;;
-      *'"action":"resume"'*)
-        cid=$(echo "$line" | sed -n 's/.*"control_id":"\\([^"]*\\)".*/\\1/p')
-        echo "{\\"kind\\":\\"control.ack\\",\\"control_id\\":\\"$cid\\",\\"state\\":\\"RUNNING\\"}"
-        echo '{"kind":"attempt_finished","report":"同会话继续并完成"}'
-        exit 0
-        ;;
-    esac
+  i=0
+  while [ $i -lt 20 ]; do
+    echo '{"kind":"liveness","phase":"RUNNING_MODEL"}'
+    sleep 0.5
+    i=$((i+1))
   done
 ) &
-for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-  echo '{"kind":"liveness","phase":"RUNNING_MODEL"}'
-  sleep 0.5
+while IFS= read -r line; do
+  case "$line" in
+    *'"action": "pause"'*)
+      cid=$(echo "$line" | sed -n 's/.*"control_id": "\\([^"]*\\)".*/\\1/p')
+      echo "{\\"kind\\":\\"control.ack\\",\\"control_id\\":\\"$cid\\",\\"state\\":\\"PAUSED\\"}"
+      ;;
+    *'"action": "resume"'*)
+      cid=$(echo "$line" | sed -n 's/.*"control_id": "\\([^"]*\\)".*/\\1/p')
+      echo "{\\"kind\\":\\"control.ack\\",\\"control_id\\":\\"$cid\\",\\"state\\":\\"RUNNING\\"}"
+      echo '{"kind":"attempt_finished","report":"同会话继续并完成"}'
+      exit 0
+      ;;
+  esac
 done
-wait
 """
 
 
@@ -127,9 +129,8 @@ class TestSoftTokenNeverPauses:
         result, report = await service._worker_manager.run_to_completion(scheduled)
         assert result.status == "COMPLETED", result.summary
         # 警告存在、暂停不存在。
-        events = service._worker_manager._events.tail(
-            scheduled.work_order_id, limit=500
-        )
+        adapter = service._worker_manager._adapters["pi_managed"]
+        events = adapter._events.tail(scheduled.work_order_id, limit=500)
         kinds = [e["kind"] for e in events]
         assert "budget_warning" in kinds
         assert "budget_paused" not in kinds
@@ -157,7 +158,7 @@ class TestControlProtocolAck:
         )
         # 等 attempt_started 出现（进程起来了）。
         for _ in range(100):
-            if service._worker_manager._events.tail(scheduled.work_order_id):
+            if service._worker_manager._adapters["pi_managed"]._events.tail(scheduled.work_order_id):
                 break
             await asyncio.sleep(0.05)
         # pause：ACK 语义——返回 True 时 worker 必须已确认 PAUSED。
@@ -197,7 +198,7 @@ class TestControlProtocolAck:
             service._worker_manager.run_to_completion(scheduled)
         )
         for _ in range(100):
-            if service._worker_manager._events.tail(scheduled.work_order_id):
+            if service._worker_manager._adapters["pi_managed"]._events.tail(scheduled.work_order_id):
                 break
             await asyncio.sleep(0.05)
         assert not await adapter.request_pause(scheduled.work_order_id, reason="user")
@@ -249,7 +250,7 @@ class TestTerminationCause:
             'echo \'{"kind":"attempt_failed","error_code":"MODEL_ERROR",'
             '"message":"provider 401 unauthorized"}\'\n'
             # 原子写 termination.json（work/<wo>/termination.json）。
-            "TERM_DIR=$(dirname \"$(dirname \"$0\")\")/work\n"
+            "TERM_DIR=$(dirname \"$0\")/work\n"
             "for d in \"$TERM_DIR\"/wo_*; do\n"
             '  echo \'{"cause":"PROVIDER_FATAL","detail":"provider 401"}\''
             ' > "$d/termination.json.tmp"\n'

--- a/tests/agentd/test_fourteen_1.py
+++ b/tests/agentd/test_fourteen_1.py
@@ -1,0 +1,336 @@
+"""十四审 PR-14.1 红测试：终止 exit130 循环 + 控制协议 ACK + 终止原因权威。
+
+红测试先行——修复前必须红：
+1. token soft target 只告警，绝不暂停进程（总纲 §3.1）；
+2. 控制协议必须 ACK：request_pause 在 control.ack PAUSED 前不得声称暂停；
+3. pause 后进程必须存活、resume 后同会话完成（总纲 Gate 0）；
+4. 无 termination.json 的 exit 130 = SIGNAL_UNKNOWN → INTERRUPTED_RESUMABLE，
+   不是 FAILED（exit code 不得直接当语义）；
+5. termination.json 的 PROVIDER_FATAL → FAILED 且摘要带权威 cause；
+6. 显式 hard cost limit（user 权威）才允许预算暂停，且先 ACK 再落
+   BUDGET_PAUSED。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import stat
+from pathlib import Path
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from rosclaw.agentd.workers.scheduler import CandidateView
+from rosclaw.contracts.common import new_id
+from rosclaw.contracts.worker.order import (
+    BudgetEnvelope,
+    ExpectedOutput,
+    SideEffectPolicy,
+    WorkOrderV1,
+)
+from tests.agentd.test_pi_tool_bridge import _request, _setup
+
+
+def _fake(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+async def _hire(service, mission, tmp_path, fake, monkeypatch, *, wall=60, policy=None,
+                tokens=1000):
+    from rosclaw.agentd.workers import pi_managed
+
+    monkeypatch.setattr(pi_managed, "find_pi_agent_entry", lambda: ("/bin/sh", str(fake)))
+    adapter = pi_managed.PiManagedAdapter(
+        rosclaw_home=tmp_path, conn=service._store.connection
+    )
+    service._worker_manager._adapters["pi_managed"] = adapter
+    adapter._manager_ref = service._worker_manager
+    if service._registry.status_of("worker:rosclaw:pi") != "ENABLED":
+        service._registry.set_status(
+            "worker:rosclaw:pi", "ENABLED", actor_id="test", reason="fake entry"
+        )
+    card = service._registry.get("worker:rosclaw:pi")
+    order = WorkOrderV1(
+        work_order_id=new_id("wo"),
+        mission_id=mission.mission_id,
+        issued_by="test",
+        capability="analysis.text",
+        goal="x",
+        inputs={
+            "instructions": "x",
+            **({"execution_policy": policy} if policy else {}),
+        },
+        budgets=BudgetEnvelope(wall_time_sec=wall, model_tokens=tokens),
+        expected_output=ExpectedOutput(artifacts=["text/plain"]),
+        side_effect_policy=SideEffectPolicy(**{"class": "none"}),
+    )
+    return service._worker_manager.hire(
+        order,
+        [CandidateView(card=card, registry_status="ENABLED", running_orders=0,
+                       circuit_open=False)],
+    )
+
+
+#: 新控制协议的 fake worker：pause → ACK PAUSED 并空转等待；resume →
+#: ACK RUNNING 并完成。关键：pause 后进程必须活着（Gate 0）。
+_FAKE_CONTROL = """#!/bin/sh
+echo '{"kind":"attempt_started"}'
+echo '{"kind":"usage","input_tokens":600,"output_tokens":200}'
+(
+  while IFS= read -r line; do
+    case "$line" in
+      *'"action":"pause"'*)
+        cid=$(echo "$line" | sed -n 's/.*"control_id":"\\([^"]*\\)".*/\\1/p')
+        echo "{\\"kind\\":\\"control.ack\\",\\"control_id\\":\\"$cid\\",\\"state\\":\\"PAUSED\\"}"
+        ;;
+      *'"action":"resume"'*)
+        cid=$(echo "$line" | sed -n 's/.*"control_id":"\\([^"]*\\)".*/\\1/p')
+        echo "{\\"kind\\":\\"control.ack\\",\\"control_id\\":\\"$cid\\",\\"state\\":\\"RUNNING\\"}"
+        echo '{"kind":"attempt_finished","report":"同会话继续并完成"}'
+        exit 0
+        ;;
+    esac
+  done
+) &
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  echo '{"kind":"liveness","phase":"RUNNING_MODEL"}'
+  sleep 0.5
+done
+wait
+"""
+
+
+class TestSoftTokenNeverPauses:
+    async def test_soft_token_limit_only_warns(self, tmp_path: Path, monkeypatch) -> None:
+        """token 超 soft target → 只 budget_warning；绝不 BUDGET_PAUSED，
+        进程继续到完成（总纲 §3.1：soft target 不能控制进程状态）。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-token-over",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            'echo \'{"kind":"usage","input_tokens":900,"output_tokens":200}\'\n'
+            "i=0\nwhile [ $i -lt 4 ]; do\n"
+            '  echo \'{"kind":"liveness","phase":"RUNNING_MODEL"}\'\n'
+            "  sleep 0.5\n  i=$((i+1))\ndone\n"
+            'echo \'{"kind":"attempt_finished","report":"做完了"}\'\n',
+        )
+        scheduled = await _hire(
+            service, mission, tmp_path, fake, monkeypatch,
+            policy={"token_soft_limit": 1000},
+        )
+        result, report = await service._worker_manager.run_to_completion(scheduled)
+        assert result.status == "COMPLETED", result.summary
+        # 警告存在、暂停不存在。
+        events = service._worker_manager._events.tail(
+            scheduled.work_order_id, limit=500
+        )
+        kinds = [e["kind"] for e in events]
+        assert "budget_warning" in kinds
+        assert "budget_paused" not in kinds
+        assert service._worker_manager.order(scheduled.work_order_id).status in (
+            "ACCEPTED", "SUBMITTED", "VERIFYING",
+        )
+        await service.close()
+
+
+class TestControlProtocolAck:
+    async def test_pause_ack_then_resume_same_process(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """request_pause 必须等 control.ack PAUSED 才返回 True；pause 后
+        进程存活；request_resume 后同进程完成（Gate 0 核心）。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(tmp_path, "fake-control", _FAKE_CONTROL)
+        scheduled = await _hire(service, mission, tmp_path, fake, monkeypatch)
+        adapter = service._worker_manager._adapters["pi_managed"]
+        driver = asyncio.create_task(
+            service._worker_manager.run_to_completion(scheduled)
+        )
+        # 等 attempt_started 出现（进程起来了）。
+        for _ in range(100):
+            if service._worker_manager._events.tail(scheduled.work_order_id):
+                break
+            await asyncio.sleep(0.05)
+        # pause：ACK 语义——返回 True 时 worker 必须已确认 PAUSED。
+        assert await adapter.request_pause(scheduled.work_order_id, reason="user")
+        proc = adapter._procs[scheduled.work_order_id]
+        assert proc.returncode is None, "pause 后进程退出——exit130 缺陷回归"
+        # resume：同进程继续并完成。
+        assert await adapter.request_resume(scheduled.work_order_id)
+        result, _report = await asyncio.wait_for(driver, 30)
+        assert result.status == "COMPLETED", result.summary
+        assert "同会话继续并完成" in result.summary
+        await service.close()
+
+    async def test_pause_without_ack_returns_false(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """worker 不 ACK（旧协议/异常）→ request_pause 诚实 False，
+        不得乐观声称已暂停。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        monkeypatch.setattr(pi_managed, "CONTROL_ACK_TIMEOUT_SEC", 1.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-no-ack",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "i=0\nwhile [ $i -lt 6 ]; do\n"
+            '  echo \'{"kind":"liveness","phase":"RUNNING_MODEL"}\'\n'
+            "  sleep 0.5\n  i=$((i+1))\ndone\n"
+            'echo \'{"kind":"attempt_finished","report":"done"}\'\n',
+        )
+        scheduled = await _hire(service, mission, tmp_path, fake, monkeypatch)
+        adapter = service._worker_manager._adapters["pi_managed"]
+        driver = asyncio.create_task(
+            service._worker_manager.run_to_completion(scheduled)
+        )
+        for _ in range(100):
+            if service._worker_manager._events.tail(scheduled.work_order_id):
+                break
+            await asyncio.sleep(0.05)
+        assert not await adapter.request_pause(scheduled.work_order_id, reason="user")
+        result, _report = await asyncio.wait_for(driver, 30)
+        assert result.status == "COMPLETED"
+        await service.close()
+
+
+class TestTerminationCause:
+    async def test_bare_exit130_is_interrupted_not_failed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """无 termination.json 的 exit 130 = SIGNAL_UNKNOWN →
+        INTERRUPTED_RESUMABLE（可恢复），绝不是 FAILED（§3.4）。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-exit130",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            'echo \'{"kind":"liveness","phase":"RUNNING_MODEL"}\'\n'
+            "sleep 0.5\n"
+            "exit 130\n",
+        )
+        scheduled = await _hire(service, mission, tmp_path, fake, monkeypatch)
+        result, _report = await service._worker_manager.run_to_completion(scheduled)
+        assert result.status == "INTERRUPTED", result.summary
+        order = service._worker_manager.order(scheduled.work_order_id)
+        assert order.status == "INTERRUPTED_RESUMABLE", order.status
+        await service.close()
+
+    async def test_termination_json_provider_fatal_failed_with_cause(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """termination.json 是终态原因唯一权威——FAILED 摘要必须带
+        结构化 cause（模型不得再猜日志归因，§1.4/§3.4）。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(
+            tmp_path,
+            "fake-provider-fatal",
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            'echo \'{"kind":"attempt_failed","error_code":"MODEL_ERROR",'
+            '"message":"provider 401 unauthorized"}\'\n'
+            # 原子写 termination.json（work/<wo>/termination.json）。
+            "TERM_DIR=$(dirname \"$(dirname \"$0\")\")/work\n"
+            "for d in \"$TERM_DIR\"/wo_*; do\n"
+            '  echo \'{"cause":"PROVIDER_FATAL","detail":"provider 401"}\''
+            ' > "$d/termination.json.tmp"\n'
+            '  mv "$d/termination.json.tmp" "$d/termination.json"\n'
+            "done\n"
+            "exit 1\n",
+        )
+        scheduled = await _hire(service, mission, tmp_path, fake, monkeypatch)
+        result, _report = await service._worker_manager.run_to_completion(scheduled)
+        assert result.status == "FAILED"
+        assert "PROVIDER_FATAL" in result.summary, result.summary
+        assert "worker exited" not in result.summary
+        await service.close()
+
+
+class TestHardCostLimit:
+    async def test_hard_cost_pause_ack_then_extend_completes(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """显式 hard cost limit（user 权威）：到限 → 控制暂停（ACK 后
+        BUDGET_PAUSED）→ extend 追加并 resume → 同进程完成。"""
+        from rosclaw.agentd.workers import pi_managed
+
+        monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
+        service, mission = await _setup(tmp_path)
+        fake = _fake(tmp_path, "fake-hard-cost", _FAKE_CONTROL)
+        scheduled = await _hire(
+            service, mission, tmp_path, fake, monkeypatch,
+            policy={
+                "cost_hard_limit_tokens": 500,
+                "cost_hard_limit_source": "user",
+            },
+        )
+        driver = asyncio.create_task(
+            service._worker_manager.run_to_completion(scheduled)
+        )
+        # 到限后应进入 BUDGET_PAUSED（ACK 已回）。
+        paused = False
+        for _ in range(200):
+            current = service._worker_manager.order(scheduled.work_order_id)
+            if current and current.status == "BUDGET_PAUSED":
+                paused = True
+                break
+            await asyncio.sleep(0.05)
+        assert paused, "hard cost limit 未触发 BUDGET_PAUSED"
+        # 进程必须仍然存活（Gate 0：pause ≠ 终止）。
+        adapter = service._worker_manager._adapters["pi_managed"]
+        proc = adapter._procs[scheduled.work_order_id]
+        assert proc.returncode is None, "budget pause 后进程退出——exit130 回归"
+        # extend = 追加预算 + resume。
+        dispatcher = PiToolDispatcher(service)
+        extended = await dispatcher.execute(
+            _request(
+                "rosclaw_extend_work",
+                mission=mission.mission_id,
+                idem="idem_141_extend",
+                arguments={"work_order_id": scheduled.work_order_id,
+                           "add_tokens": 5000},
+            )
+        )
+        assert extended.ok, extended.summary
+        result, _report = await asyncio.wait_for(driver, 30)
+        assert result.status == "COMPLETED", result.summary
+        await service.close()
+
+    async def test_hard_cost_without_authority_rejected(self, tmp_path: Path) -> None:
+        """cost_hard_limit 无 user/admin_policy 权威 → 硬拒绝（同硬截止
+        权威规则——模型自定数字不能控制进程，§3.1）。"""
+        service, mission = await _setup(tmp_path)
+        dispatcher = PiToolDispatcher(service)
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_delegate",
+                mission=mission.mission_id,
+                idem="idem_141_cost_auth",
+                arguments={
+                    "goal": "x",
+                    "execution_policy": {"cost_hard_limit_tokens": 100},
+                },
+            )
+        )
+        assert not result.ok
+        assert result.error_code == "COST_LIMIT_AUTHORITY_REQUIRED"
+        await service.close()

--- a/tests/agentd/test_fourteen_1_live.py
+++ b/tests/agentd/test_fourteen_1_live.py
@@ -1,0 +1,315 @@
+"""十四审 PR-14.1 Gate 0：跨进程集成验收（真实 Node Worker + Python
+supervisor + mock OpenAI provider——不许用只记录调用的 fake session）。
+
+总纲 §9.2：先写会失败的跨进程集成测试。这里跑的是真实
+`rosclaw-agent worker --headless` 子进程（真实 Pi AgentSession、真实
+session.abort/resume 语义），provider 是本机回环 mock（确定性 SSE）。
+
+无 Node ≥22.19 / dist 未构建 → 诚实 skip（CI 无 Node 环境不假装）。
+
+验收（Gate 0）：
+1. pause → control.ack PAUSED，进程 PID 存活、session file 保持；
+2. resume → 同一 session 继续并完成（attempt_finished，无 exit 130）；
+3. token 超 soft target 只 warning——进程不停、状态不变、正常完成；
+4. SIGKILL（无 termination.json）→ INTERRUPTED_RESUMABLE，不是 FAILED。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_entry import find_pi_agent_entry
+from rosclaw.agentd.workers.scheduler import CandidateView
+from rosclaw.contracts.common import new_id
+from rosclaw.contracts.worker.order import (
+    BudgetEnvelope,
+    ExpectedOutput,
+    SideEffectPolicy,
+    WorkOrderV1,
+)
+from tests.agentd.test_pi_tool_bridge import _setup
+
+
+def _runtime() -> tuple[str, str] | None:
+    try:
+        return find_pi_agent_entry()
+    except Exception:  # noqa: BLE001 - 无 node/dist 诚实 skip
+        return None
+
+
+class _MockProvider:
+    """OpenAI chat-completions mock。usage 只在 turn 末块到达（worker 的
+    usage 事件同理）；tool_call_first=True 时：call1 工具调用+usage
+    （快），call2 慢速长流（告警观察窗）——"工作中超限"场景必需
+    （turn 内 usage 不可见）。"""
+
+    def __init__(self, *, tool_call_first: bool = False) -> None:
+        self.calls = 0
+        self.tool_call_first = tool_call_first
+        self._lock = threading.Lock()
+
+    def handler(self) -> type[BaseHTTPRequestHandler]:
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args) -> None:  # 静默
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                if not self.path.endswith("/chat/completions"):
+                    self.send_error(404)
+                    return
+                length = int(self.headers.get("Content-Length") or 0)
+                self.rfile.read(length)
+                with outer._lock:
+                    outer.calls += 1
+                    call = outer.calls
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Cache-Control", "no-cache")
+                self.end_headers()
+
+                def chunk(content: str, usage: dict | None = None,
+                          extra: dict | None = None,
+                          finish: str = "stop") -> bytes:
+                    delta = {"content": content} if content else {}
+                    if extra:
+                        delta.update(extra)
+                    payload = {
+                        "id": "chatcmpl-mock",
+                        "object": "chat.completion.chunk",
+                        "choices": [{"index": 0, "delta": delta}],
+                    }
+                    if usage is not None:
+                        payload["usage"] = usage
+                        payload["choices"][0]["finish_reason"] = finish
+                    return f"data: {json.dumps(payload)}\n\n".encode()
+
+                import time
+
+                try:
+                    if call == 1 and outer.tool_call_first:
+                        # turn 1：工具调用 + usage（turn 结束即产生 worker
+                        # usage 事件——monitor 在 turn 2 运行中看到超限）。
+                        args = json.dumps({"path": "nonexistent.txt"})
+                        self.wfile.write(chunk("", None, {
+                            "role": "assistant",
+                            "tool_calls": [{
+                                "index": 0,
+                                "id": "call_read1",
+                                "type": "function",
+                                "function": {"name": "read", "arguments": ""},
+                            }],
+                        }))
+                        self.wfile.write(chunk("", None, {
+                            "tool_calls": [{
+                                "index": 0,
+                                "function": {"arguments": args},
+                            }],
+                        }))
+                        self.wfile.write(chunk("", {
+                            "prompt_tokens": 500,
+                            "completion_tokens": 600,
+                            "total_tokens": 1100,
+                        }, finish="tool_calls"))
+                    elif call == 1 or (call == 2 and outer.tool_call_first):
+                        # 慢速长流（约 18s 窗口）——pause/告警观察必须
+                        # 在此期间到达（对 CI/慢机器留出竞态余量）。
+                        self.wfile.write(chunk(""))
+                        self.wfile.flush()
+                        for i in range(120):
+                            self.wfile.write(chunk(f"工作中-{i} "))
+                            self.wfile.flush()
+                            time.sleep(0.15)
+                        self.wfile.write(chunk("", {
+                            "prompt_tokens": 500,
+                            "completion_tokens": 600,
+                            "total_tokens": 1100,
+                        }))
+                    else:
+                        self.wfile.write(chunk("继续并完成：最终报告 DONE-7"))
+                        self.wfile.write(chunk("", {
+                            "prompt_tokens": 800,
+                            "completion_tokens": 50,
+                            "total_tokens": 850,
+                        }))
+                    self.wfile.write(b"data: [DONE]\n\n")
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass  # abort 断流是预期路径
+
+        return Handler
+
+    def start(self) -> int:
+        server = ThreadingHTTPServer(("127.0.0.1", 0), self.handler())
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server.server_address[1]
+
+
+def _write_mock_agent_dir(home: Path, port: int) -> None:
+    agent_dir = home / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "models.json").write_text(
+        json.dumps({
+            "providers": {
+                "mock": {
+                    "baseUrl": f"http://127.0.0.1:{port}/v1",
+                    "api": "openai-completions",
+                    "apiKey": "mock-key",
+                    "compat": {
+                        "supportsDeveloperRole": False,
+                        "supportsReasoningEffort": False,
+                    },
+                    "models": [{"id": "mock-1", "name": "Mock", "reasoning": False}],
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+
+
+async def _hire_real(service, mission, tmp_path, *, policy=None):
+    from rosclaw.agentd.workers import pi_managed
+
+    adapter = pi_managed.PiManagedAdapter(
+        rosclaw_home=tmp_path, conn=service._store.connection
+    )
+    service._worker_manager._adapters["pi_managed"] = adapter
+    adapter._manager_ref = service._worker_manager
+    if service._registry.status_of("worker:rosclaw:pi") != "ENABLED":
+        service._registry.set_status(
+            "worker:rosclaw:pi", "ENABLED", actor_id="test", reason="real entry"
+        )
+    card = service._registry.get("worker:rosclaw:pi")
+    order = WorkOrderV1(
+        work_order_id=new_id("wo"),
+        mission_id=mission.mission_id,
+        issued_by="test",
+        capability="analysis.text",
+        goal="写一份简短报告",
+        inputs={
+            "instructions": "写一份简短报告",
+            "worker_profile": "scout",
+            "model_snapshot": {"provider": "mock", "model": "mock-1"},
+            **({"execution_policy": policy} if policy else {}),
+        },
+        budgets=BudgetEnvelope(wall_time_sec=600, model_tokens=150_000),
+        expected_output=ExpectedOutput(artifacts=["text/plain"]),
+        side_effect_policy=SideEffectPolicy(**{"class": "none"}),
+    )
+    return service._worker_manager.hire(
+        order,
+        [CandidateView(card=card, registry_status="ENABLED", running_orders=0,
+                       circuit_open=False)],
+    )
+
+
+@pytest.mark.skipif(_runtime() is None, reason="无 Node≥22.19/dist——诚实 skip")
+class TestGate0CrossProcess:
+    async def test_pause_resume_same_session_completes(self, tmp_path: Path) -> None:
+        """Gate 0 核心：pause 后进程存活 + session 保持；resume 同会话
+        完成；全程无 exit 130。"""
+        provider = _MockProvider()
+        port = provider.start()
+        _write_mock_agent_dir(tmp_path, port)
+        service, mission = await _setup(tmp_path)
+        scheduled = await _hire_real(service, mission, tmp_path)
+        adapter = service._worker_manager._adapters["pi_managed"]
+        driver = asyncio.create_task(
+            service._worker_manager.run_to_completion(scheduled)
+        )
+        # 等模型流真的开始（mock 慢流窗口内）。
+        started = False
+        for _ in range(600):
+            events = adapter._events.tail(scheduled.work_order_id, limit=500)
+            if any(e["kind"] == "model_started" for e in events):
+                started = True
+                break
+            await asyncio.sleep(0.1)
+        assert started, "worker 未进入模型流"
+        # pause → ACK PAUSED；进程必须存活。
+        assert await adapter.request_pause(scheduled.work_order_id, reason="user")
+        proc = adapter._procs[scheduled.work_order_id]
+        assert proc.returncode is None, "pause 后进程退出——exit130 缺陷回归"
+        session_files = list(
+            (tmp_path / "work" / scheduled.work_order_id / "session").glob("*.jsonl")
+        )
+        assert session_files, "session 未落盘"
+        # resume → 同一 session 继续并完成。
+        assert await adapter.request_resume(scheduled.work_order_id)
+        result, _report = await asyncio.wait_for(driver, 180)
+        assert result.status == "COMPLETED", result.summary
+        assert "DONE-7" in result.summary
+        assert provider.calls >= 2, "resume 未触发新的模型 turn"
+        await service.close()
+
+    async def test_soft_token_target_never_pauses_real(self, tmp_path: Path) -> None:
+        """Gate 0：token 远超 soft target（1）只 warning——进程不停、
+        状态不变、继续工作到完成（不再 exit130）。turn1 工具调用结束
+        即产生 usage(1100>>1)，monitor 在 turn2 慢流期间必须只告警。"""
+        provider = _MockProvider(tool_call_first=True)
+        port = provider.start()
+        _write_mock_agent_dir(tmp_path, port)
+        service, mission = await _setup(tmp_path)
+        scheduled = await _hire_real(
+            service, mission, tmp_path, policy={"token_soft_limit": 1}
+        )
+        adapter = service._worker_manager._adapters["pi_managed"]
+        driver = asyncio.create_task(
+            service._worker_manager.run_to_completion(scheduled)
+        )
+        warned = False
+        for _ in range(600):
+            events = adapter._events.tail(scheduled.work_order_id, limit=500)
+            kinds = [e["kind"] for e in events]
+            if "budget_warning" in kinds:
+                warned = True
+                break
+            if any(e["kind"] == "attempt_finished" for e in events):
+                break
+            await asyncio.sleep(0.1)
+        assert warned, "token 超 soft target 未产生 budget_warning"
+        assert "budget_paused" not in kinds
+        # 告警后 worker 必须仍在工作（turn2 慢流中），没有被停。
+        proc = adapter._procs.get(scheduled.work_order_id)
+        if proc is not None:
+            assert proc.returncode is None, "soft target 到限后进程被停——缺陷回归"
+        result, _report = await asyncio.wait_for(driver, 180)
+        assert result.status == "COMPLETED", result.summary
+        order = service._worker_manager.order(scheduled.work_order_id)
+        assert order.status != "BUDGET_PAUSED"
+        await service.close()
+
+    async def test_sigkill_is_interrupted_resumable(self, tmp_path: Path) -> None:
+        """SIGKILL（无 termination.json）→ INTERRUPTED_RESUMABLE，
+        不是 FAILED（exit code 不得直接当语义）。"""
+        provider = _MockProvider()
+        port = provider.start()
+        _write_mock_agent_dir(tmp_path, port)
+        service, mission = await _setup(tmp_path)
+        scheduled = await _hire_real(service, mission, tmp_path)
+        adapter = service._worker_manager._adapters["pi_managed"]
+        driver = asyncio.create_task(
+            service._worker_manager.run_to_completion(scheduled)
+        )
+        for _ in range(600):
+            events = adapter._events.tail(scheduled.work_order_id, limit=500)
+            if any(e["kind"] == "model_started" for e in events):
+                break
+            await asyncio.sleep(0.1)
+        import signal as _sig
+
+        proc = adapter._procs[scheduled.work_order_id]
+        proc.send_signal(_sig.SIGKILL)
+        result, _report = await asyncio.wait_for(driver, 120)
+        assert result.status == "INTERRUPTED", result.summary
+        order = service._worker_manager.order(scheduled.work_order_id)
+        assert order.status == "INTERRUPTED_RESUMABLE", order.status
+        await service.close()

--- a/tests/agentd/test_thirteen_2.py
+++ b/tests/agentd/test_thirteen_2.py
@@ -10,7 +10,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import stat
 from pathlib import Path
 
@@ -117,7 +116,9 @@ class TestNoDefaultWallKill:
 
 class TestBudgetPause:
     async def test_token_limit_pauses_not_fails(self, tmp_path: Path, monkeypatch) -> None:
-        """token 100% → BUDGET_PAUSED（保留会话，可 extend）。"""
+        """十四审 PR-14.1 语义迁移（总纲 §3.1）：token soft limit 只告警，
+        绝不暂停进程——worker 继续到完成。显式 user 权威的
+        cost_hard_limit 才会 BUDGET_PAUSED（见 test_fourteen_1.py）。"""
         from rosclaw.agentd.workers import pi_managed
 
         monkeypatch.setattr(pi_managed, "LIVENESS_TIMEOUT_SEC", 30.0)
@@ -128,27 +129,19 @@ class TestBudgetPause:
             "#!/bin/sh\n"
             'echo \'{"kind":"attempt_started"}\'\n'
             'echo \'{"kind":"usage","input_tokens":900,"output_tokens":200}\'\n'
-            "while true; do\n"
+            "i=0\nwhile [ $i -lt 4 ]; do\n"
             '  echo \'{"kind":"liveness","phase":"RUNNING_MODEL"}\'\n'
-            "  sleep 0.5\ndone\n",
+            "  sleep 0.5\n  i=$((i+1))\ndone\n"
+            'echo \'{"kind":"attempt_finished","report":"超 soft target 仍然完成"}\'\n',
         )
         scheduled = await _hire(
             service, mission, tmp_path, fake, monkeypatch,
             wall=300,
             policy={"token_soft_limit": 1000},
         )
-        driver = asyncio.create_task(
-            service._worker_manager.run_to_completion(scheduled)
-        )
-        for _ in range(200):
-            current = service._worker_manager.order(scheduled.work_order_id)
-            if current and current.status == "BUDGET_PAUSED":
-                break
-            await asyncio.sleep(0.05)
+        result, _report = await service._worker_manager.run_to_completion(scheduled)
+        # soft target 到 100% 不暂停、不失败——正常完成。
+        assert result.status == "COMPLETED", result.summary
         current = service._worker_manager.order(scheduled.work_order_id)
-        assert current is not None and current.status == "BUDGET_PAUSED", current.status
-        # extend 唤醒（fake 的 stdin 不消费——送达失败则诚实报错也行，
-        # 这里只验证 extend 的预算落账与状态翻转路径）。
-        await service._worker_manager.cancel_order(scheduled.work_order_id, reason="test")
-        await asyncio.wait_for(driver, 10)
+        assert current is not None and current.status != "BUDGET_PAUSED"
         await service.close()

--- a/tests/contracts/golden/rosclaw.worker_control_ack.v1.json
+++ b/tests/contracts/golden/rosclaw.worker_control_ack.v1.json
@@ -1,0 +1,43 @@
+{
+  "additionalProperties": true,
+  "description": "worker → supervisor（stdout WorkerEvent kind=control.ack）。\n\nstate=PAUSED 表示模型循环已真实停止且进程存活等待 resume——\n只有此时 supervisor 才可落 PAUSED/BUDGET_PAUSED。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.worker_control_ack.v1",
+      "default": "rosclaw.worker_control_ack.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "control_id": {
+      "title": "Control Id",
+      "type": "string"
+    },
+    "state": {
+      "enum": [
+        "PAUSE_REQUESTED",
+        "PAUSED",
+        "RUNNING",
+        "CANCELLED"
+      ],
+      "title": "State",
+      "type": "string"
+    },
+    "session_id": {
+      "default": "",
+      "title": "Session Id",
+      "type": "string"
+    },
+    "detail": {
+      "default": "",
+      "title": "Detail",
+      "type": "string"
+    }
+  },
+  "required": [
+    "control_id",
+    "state"
+  ],
+  "title": "rosclaw.worker_control_ack.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.worker_control_ack.v1"
+}

--- a/tests/contracts/golden/rosclaw.worker_control_request.v1.json
+++ b/tests/contracts/golden/rosclaw.worker_control_request.v1.json
@@ -1,0 +1,52 @@
+{
+  "additionalProperties": true,
+  "description": "supervisor → worker（stdin JSONL）。control_id 用于 ACK 对账。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.worker_control_request.v1",
+      "default": "rosclaw.worker_control_request.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "type": {
+      "const": "control.request",
+      "default": "control.request",
+      "title": "Type",
+      "type": "string"
+    },
+    "control_id": {
+      "title": "Control Id",
+      "type": "string"
+    },
+    "action": {
+      "enum": [
+        "pause",
+        "resume",
+        "cancel"
+      ],
+      "title": "Action",
+      "type": "string"
+    },
+    "mode": {
+      "default": "safe",
+      "enum": [
+        "safe",
+        "immediate"
+      ],
+      "title": "Mode",
+      "type": "string"
+    },
+    "reason": {
+      "default": "",
+      "title": "Reason",
+      "type": "string"
+    }
+  },
+  "required": [
+    "control_id",
+    "action"
+  ],
+  "title": "rosclaw.worker_control_request.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.worker_control_request.v1"
+}

--- a/tests/contracts/golden/rosclaw.worker_termination.v1.json
+++ b/tests/contracts/golden/rosclaw.worker_termination.v1.json
@@ -1,0 +1,55 @@
+{
+  "additionalProperties": true,
+  "description": "termination.json——worker 退出前原子落盘的权威终止原因。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.worker_termination.v1",
+      "default": "rosclaw.worker_termination.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "cause": {
+      "enum": [
+        "COMPLETED",
+        "USER_CANCELLED",
+        "USER_PAUSED",
+        "BUDGET_HARD_PAUSED",
+        "AGENTD_SHUTDOWN",
+        "PROVIDER_TRANSIENT",
+        "PROVIDER_FATAL",
+        "TOOL_FAILED",
+        "DELIVERABLE_REJECTED",
+        "WORKER_CRASH",
+        "SIGNAL_UNKNOWN"
+      ],
+      "title": "Cause",
+      "type": "string"
+    },
+    "detail": {
+      "default": "",
+      "title": "Detail",
+      "type": "string"
+    },
+    "exit_code": {
+      "default": 0,
+      "title": "Exit Code",
+      "type": "integer"
+    },
+    "session_file": {
+      "default": "",
+      "title": "Session File",
+      "type": "string"
+    },
+    "at": {
+      "default": "",
+      "title": "At",
+      "type": "string"
+    }
+  },
+  "required": [
+    "cause"
+  ],
+  "title": "rosclaw.worker_termination.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.worker_termination.v1"
+}


### PR DESCRIPTION
## 问题（总纲 §0/§1.2，基线证据 ROSClaw_十四审_基线证据_2026-08-14.md）

pause→session.abort()→外层 prompt 返回 aborted→exit 130 进程退出：状态 BUDGET_PAUSED 但进程已死，extend 永远无效。三次真实任务 14m18s/10m57s/12m45s 均因此失败。

## 修复

- **TS WorkerSessionHost 状态机**：RUNNING→PAUSE_REQUESTED→PAUSED→resume→RUNNING（同一 Pi session）；pause 后进程存活等待控制消息；只有 cancel 产生 CANCELLED；信号 abort 落 SIGNAL_UNKNOWN 不再冒充取消
- **termination.json 原子落盘**（10 枚举）——终态原因唯一权威；exit code 只是 Unix 表象；缺失按 SIGNAL_UNKNOWN→INTERRUPTED_RESUMABLE
- **token soft target 只告警**（总纲 §3.1）；cost_hard_limit 需 user/admin_policy 权威（COST_LIMIT_AUTHORITY_REQUIRED）
- **控制协议 ACK**：supervisor 收到 control.ack 前只 PAUSE_REQUESTED；cancel 先优雅控制再杀树兜底
- 合约：worker_control_request/ack/termination 三 schema + PAUSE_REQUESTED/PAUSED 状态

## 测试（红→绿证据齐全）

| 层 | 结果 |
|---|---|
| test_fourteen_1.py（协议单测） | 7 红→7 绿 |
| Gate 0 跨进程（真实 Node Worker + mock OpenAI provider，test_fourteen_1_live.py） | 3/3：pause/resume 同会话完成、soft token 只告警、SIGKILL→INTERRUPTED_RESUMABLE |
| 十一/十二/十三审回归 + workers | 86 passed（test_thirteen_2 预算测试迁移新语义） |
| TS | 92/92；ruff 全绿；golden 已导出 |

## 真实产品验收

未跑真实 K3——按总纲 §10 本 PR 只宣称代码+测试完成；Gate 2 真实长任务验收在 14.7 后统一进行。