### PR TITLE
feat(how): PR-DF-08 — RecoveryLoop 正式进入 Runtime 生命周期

### DIFF
--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -546,6 +546,21 @@ class Runtime(LifecycleMixin):
                 know_path = self.config.know_store_path or str(
                     workspace_home / "data" / "know" / "seekdb"
                 )
+                # PR-DF-09 (flywheel §28): Knowledge keeps its own logical
+                # store, but the federation coordinates are now actually
+                # passed — shared ID/lineage/evidence references resolve
+                # against the Runtime's data plane instead of env defaults.
+                federation: dict[str, Any] = {}
+                if self._data_plane is not None and self._data_plane.structured_store is not None:
+                    federation["memory_path"] = self.config.seekdb_path
+                    dsn = self.config.seekdb_url
+                    if dsn:
+                        from urllib.parse import urlparse
+
+                        db = urlparse(str(dsn)).path.lstrip("/")
+                        if db:
+                            federation["memory_database"] = db
+                federation["practice_path"] = str(workspace_home / "data" / "practice")
                 service_config = KnowledgeServiceConfig(
                     mode=v2_mode,
                     know_url=self.config.know_url,
@@ -555,14 +570,16 @@ class Runtime(LifecycleMixin):
                     timeout=self.config.knowledge_timeout,
                     know_store_mode=self.config.know_store_mode,
                     know_store_path=know_path,
+                    **federation,
                 )
                 self._knowledge_v2_manager = KnowledgeServiceManager(service_config)
                 self._knowledge_v2 = KnowledgeFacade(
                     self._knowledge_v2_manager, event_bus=self.event_bus
                 )
                 logger.info(
-                    "Knowledge v2 orchestration initialized (mode=%s, memory_store_shared=false)",
+                    "Knowledge v2 orchestration initialized (mode=%s, federation=%s)",
                     v2_mode,
+                    sorted(federation),
                 )
             except Exception as exc:  # noqa: BLE001 - optional integration
                 logger.warning("Knowledge v2 initialization degraded: %s", exc)

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -87,6 +87,10 @@ class RuntimeConfig:
     enable_skill_manager: bool = True
     enable_knowledge: bool = True  # KnowledgeInterface (KNOW module)
     enable_how: bool = True  # HeuristicEngine (HOW module)
+    # PR-DF-08 (flywheel §23): wire the RecoveryLoop into the Runtime
+    # lifecycle.  The loop only learns from verified physics outcomes;
+    # REAL recovery still flows through the full gateway path (§24).
+    enable_recovery_loop: bool = True
     # Versioned Know/How integration. ``disabled`` preserves the legacy
     # adapters as a rollback path; v2 never receives Memory's store.
     knowledge_v2_mode: str = field(
@@ -226,6 +230,7 @@ class Runtime(LifecycleMixin):
         self._memory_repository: Any | None = None  # Memory v2 canonical (PR-DF-05)
         self._memory_gate: Any | None = None
         self._projection_worker: Any | None = None  # PR-DF-07
+        self._recovery_loop: Any | None = None  # PR-DF-08
         self._mcp_drivers: dict[str, Any] = {}
         self._emergency_stop_receipts: dict[str, Any] = {}
         self._emergency_stop_latched = False
@@ -629,6 +634,27 @@ class Runtime(LifecycleMixin):
             except Exception as e:  # noqa: BLE001
                 logger.info(f"Heuristic grounding not available: {e}")
 
+        # PR-DF-08 (flywheel §23): the RecoveryLoop closes
+        # failure → hint → retry → VERIFIED physics outcome → rule efficacy.
+        # It only learns — it never dispatches motion, and REAL recovery
+        # proposals still re-enter through the ActionGateway/permit path
+        # (§24), so the safety control plane is never bypassed.
+        self._recovery_loop = None
+        if (
+            self.config.enable_how
+            and self.config.enable_recovery_loop
+            and self._memory is not None
+            and self._how is not None
+        ):
+            try:
+                from rosclaw.how.recovery_loop import RecoveryLoop
+
+                self._recovery_loop = RecoveryLoop(self.event_bus, self._memory, self._how)
+                self._recovery_loop.subscribe()
+                logger.info("RecoveryLoop subscribed (How recovery learning active)")
+            except Exception as exc:  # noqa: BLE001
+                logger.info("RecoveryLoop not available: %s", exc)
+
         # Initialize Auto Self-Evolution Control Plane
         if self.config.enable_auto:
             try:
@@ -921,6 +947,13 @@ class Runtime(LifecycleMixin):
         if self._event_sink is not None:
             self._event_sink.close()
             self._event_sink = None
+        # PR-DF-08: RecoveryLoop off the bus first (no learning mid-shutdown).
+        if self._recovery_loop is not None:
+            try:
+                self._recovery_loop.unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("RecoveryLoop unsubscribe failed (non-fatal): %s", exc)
+            self._recovery_loop = None
         # PR-DF-07: flush + stop the projection worker before the bridge.
         if self._projection_worker is not None:
             try:

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -225,6 +225,7 @@ class Runtime(LifecycleMixin):
         self._data_plane: Any | None = None  # DataPlaneContext (PR-DF-03)
         self._memory_repository: Any | None = None  # Memory v2 canonical (PR-DF-05)
         self._memory_gate: Any | None = None
+        self._projection_worker: Any | None = None  # PR-DF-07
         self._mcp_drivers: dict[str, Any] = {}
         self._emergency_stop_receipts: dict[str, Any] = {}
         self._emergency_stop_latched = False
@@ -736,6 +737,62 @@ class Runtime(LifecycleMixin):
                     )
             except Exception as facade_exc:  # noqa: BLE001
                 logger.info("Retrieval facade not available: %s", facade_exc)
+            # PR-DF-07 (flywheel §17-18): when the structured store is the
+            # SQLite source of truth and a retrieval backend is configured,
+            # maintain the native SeekDB retrieval projection of
+            # memory_items — rebuildable, never the source of truth.  All
+            # best-effort: a missing pyseekdb or a dead native store leaves
+            # the fields None and changes nothing else.
+            try:
+                storage_cfg = self.config.storage or {}
+                retrieval_cfg = storage_cfg.get("retrieval", {})
+                retrieval_enabled = retrieval_cfg.get(
+                    "enabled", storage_cfg.get("vector_enabled", False)
+                )
+                from rosclaw.memory.seekdb_client import SQLiteStructuredStore as _SQLite
+
+                if retrieval_enabled and isinstance(store, _SQLite):
+                    from rosclaw.storage.seekdb_native import SeekDBEmbeddedRetrievalStore
+                    from rosclaw.storage.seekdb_projection import (
+                        MemoryRetrievalProjection,
+                        MemoryRetrievalProjectionCommitter,
+                    )
+
+                    native_path = retrieval_cfg.get("path") or str(
+                        workspace_home / "data" / "seekdb"
+                    )
+                    ctx.retrieval_store = SeekDBEmbeddedRetrievalStore(path=native_path)
+                    projection_outbox = ctx.outbox
+                    if projection_outbox is not None:
+                        # Target-filtered worker: drains ONLY projection
+                        # records off the shared outbox (the practice
+                        # bridge's worker owns its own target), so the two
+                        # pipelines never race each other's rows.
+                        from rosclaw.storage.outbox import OutboxWorker
+
+                        self._projection_worker = OutboxWorker(
+                            projection_outbox,
+                            MemoryRetrievalProjectionCommitter(ctx.retrieval_store),
+                            target="seekdb_projection",
+                            name="memory-projection-worker",
+                            interval_sec=float(
+                                storage_cfg.get("outbox", {}).get(
+                                    "flush_interval_sec",
+                                    storage_cfg.get("outbox_flush_interval_sec", 5.0),
+                                )
+                            ),
+                        )
+                        self._projection_worker.start()
+                    ctx.memory_projection = MemoryRetrievalProjection(
+                        ctx.retrieval_store, outbox=projection_outbox
+                    )
+                    logger.info(
+                        "Memory retrieval projection: native SeekDB at %s (outbox=%s)",
+                        native_path,
+                        projection_outbox is not None,
+                    )
+            except Exception as proj_exc:  # noqa: BLE001
+                logger.info("Memory retrieval projection not available: %s", proj_exc)
         http_url = self.config.seekdb_http_url
         if http_url:
             try:
@@ -864,6 +921,14 @@ class Runtime(LifecycleMixin):
         if self._event_sink is not None:
             self._event_sink.close()
             self._event_sink = None
+        # PR-DF-07: flush + stop the projection worker before the bridge.
+        if self._projection_worker is not None:
+            try:
+                self._projection_worker.flush(timeout=5.0)
+                self._projection_worker.stop()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Projection worker stop failed (non-fatal): %s", exc)
+            self._projection_worker = None
         # Close SeekDB bridge (and any owned outbox worker) before stopping modules.
         if self._seekdb_bridge is not None and hasattr(self._seekdb_bridge, "close"):
             try:

--- a/src/rosclaw/know/__init__.py
+++ b/src/rosclaw/know/__init__.py
@@ -1,4 +1,11 @@
-"""Compatibility facade for legacy ROSClaw Knowledge integrations.
+"""DEPRECATED package (PR-DF-09 / ADR-0010): legacy Knowledge runtime.
+
+Canonical package: ``rosclaw.knowledge``.  This package stays as the
+compatibility shim for at least one full minor release; import legacy
+symbols via ``rosclaw.knowledge.legacy`` so the eventual physical move is
+invisible to consumers.
+
+Compatibility facade for legacy ROSClaw Knowledge integrations.
 
 Authoritative v2 implementation lives in ``rosclaw-know``. This package is a
 rollback-compatible runtime adapter and must not grow new retrieval algorithms.

--- a/src/rosclaw/knowledge/legacy.py
+++ b/src/rosclaw/knowledge/legacy.py
@@ -1,0 +1,32 @@
+"""Legacy Knowledge runtime — canonical import location (PR-DF-09 / ADR-0010).
+
+``rosclaw.knowledge`` is the canonical Knowledge package.  The pre-v2
+runtime (KnowledgeInterface, TaskCard, EmbodimentCard, VerifierCard, the
+knowledge graph and evidence ingest) lives on in ``rosclaw.know`` for at
+least one full minor release; import it through HERE so the eventual
+physical move is a one-line change for consumers:
+
+    from rosclaw.knowledge.legacy import KnowledgeInterface
+
+New code must not gain dependencies on these symbols — they exist for the
+rollback-only local Knowledge path (v2 mode == "disabled").
+"""
+
+from __future__ import annotations
+
+from rosclaw.know.embodiment_card import EmbodimentCard
+from rosclaw.know.interface import KnowledgeInterface
+from rosclaw.know.task_card import TaskCard
+from rosclaw.know.verifier_card import VerifierCard
+
+# Canonical-in-spirit alias for the legacy entry point (ADR-0010 §4):
+# two "official-looking" Knowledge runtimes must not coexist unnamed.
+LegacyKnowledgeRuntime = KnowledgeInterface
+
+__all__ = [
+    "KnowledgeInterface",
+    "LegacyKnowledgeRuntime",
+    "TaskCard",
+    "EmbodimentCard",
+    "VerifierCard",
+]

--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -81,6 +81,11 @@ def _load_storage_config(args: argparse.Namespace) -> dict[str, Any]:
     outbox_enabled = storage_cfg.get("outbox_enabled", False)
     outbox_path = storage_cfg.get("outbox_path") or str(home / "storage" / "outbox.sqlite")
 
+    # PR-DF-07: retrieval projection section (Config v2) with legacy fallback
+    retrieval_cfg = storage_cfg.get("retrieval", {})
+    retrieval_enabled = retrieval_cfg.get("enabled", storage_cfg.get("vector_enabled", False))
+    retrieval_path = retrieval_cfg.get("path") or str(home / "data" / "seekdb")
+
     practice_data_root = practice_cfg.get("output_dir") or str(get_default_data_root())
 
     return {
@@ -96,6 +101,8 @@ def _load_storage_config(args: argparse.Namespace) -> dict[str, Any]:
         "vector_enabled": storage_cfg.get("vector_enabled", False),
         "outbox_enabled": outbox_enabled,
         "outbox_path": outbox_path,
+        "retrieval_enabled": retrieval_enabled,
+        "retrieval_path": retrieval_path,
         "practice_data_root": practice_data_root,
     }
 
@@ -286,6 +293,34 @@ def _session_event_consistency(
 
 
 @_with_stdout_flush
+def _projection_status(cfg: dict[str, Any], client: Any) -> dict[str, Any] | None:
+    """Retrieval-projection watermark/lag for ``db status`` (PR-DF-07 §18).
+
+    Only meaningful when the structured store is the SQL source of truth and
+    a retrieval backend is enabled; entirely best-effort.
+    """
+    if not cfg.get("retrieval_enabled"):
+        return None
+    result: dict[str, Any] = {"enabled": True, "path": cfg.get("retrieval_path")}
+    try:
+        result["source_count"] = client.count("memory_items")
+    except Exception:  # noqa: BLE001
+        result["source_count"] = None
+    try:
+        from rosclaw.storage.seekdb_native import SeekDBEmbeddedRetrievalStore
+
+        native = SeekDBEmbeddedRetrievalStore(path=cfg["retrieval_path"])
+        native.connect()
+        result["projection_backend"] = type(native).__name__
+        result["projection_count"] = native.count("memory_items")
+        if result["source_count"] is not None:
+            result["lag"] = result["source_count"] - result["projection_count"]
+    except Exception as exc:  # noqa: BLE001
+        result["projection_count"] = None
+        result["error"] = str(exc)
+    return result
+
+
 def cmd_db_status(args: argparse.Namespace) -> int:
     """Show storage backend status and capabilities."""
     cfg = _load_storage_config(args)
@@ -314,6 +349,9 @@ def cmd_db_status(args: argparse.Namespace) -> int:
             extras["outbox"] = outbox_stats
         extras["vector"] = _vector_status(client)
         extras["practice"] = _practice_status(cfg)
+        projection = _projection_status(cfg, client)
+        if projection is not None:
+            extras["projection"] = projection
     finally:
         _close_client(client)
 
@@ -360,6 +398,16 @@ def cmd_db_status(args: argparse.Namespace) -> int:
         print("  Vector:")
         print(f"    enabled:    {vec.get('enabled')}")
         print(f"    warmed:     {vec.get('warmed')}")
+    if extras.get("projection"):
+        proj = extras["projection"]
+        print("  Retrieval projection:")
+        print(f"    backend:    {proj.get('projection_backend')}")
+        print(f"    source:     {proj.get('source_count')}")
+        print(f"    projected:  {proj.get('projection_count')}")
+        if proj.get("lag") is not None:
+            print(f"    lag:        {proj['lag']}")
+        if proj.get("error"):
+            print(f"    error:      {proj['error']}")
     if extras.get("practice"):
         prac = extras["practice"]
         print("  Practice:")

--- a/src/rosclaw/storage/seekdb_projection.py
+++ b/src/rosclaw/storage/seekdb_projection.py
@@ -87,6 +87,42 @@ class MemoryRetrievalProjection:
         self._store.connect()
         self._store.delete(PROJECTION_TABLE, memory_id)
 
+    def status(self, repository: Any | None = None) -> dict[str, Any]:
+        """Projection observability (PR-DF-07 §18): watermark + lag.
+
+        ``source_count`` is the structured-store memory_items watermark (when
+        a repository is given); ``projection_count`` is what the retrieval
+        index currently holds; ``lag`` is the difference.  The projection is
+        a rebuildable projection — lag is an operations signal, never a data
+        loss (rebuild() restores parity from the source of truth).
+        """
+        result: dict[str, Any] = {
+            "projection_backend": type(self._store).__name__,
+            "outbox_enabled": self._outbox is not None,
+        }
+        try:
+            self._store.connect()
+            result["projection_count"] = self._store.count(PROJECTION_TABLE)
+        except Exception as exc:  # noqa: BLE001
+            result["projection_count"] = None
+            result["error"] = str(exc)
+        if repository is not None:
+            try:
+                result["source_count"] = repository._client.count(PROJECTION_TABLE)
+                if result.get("projection_count") is not None:
+                    result["lag"] = result["source_count"] - result["projection_count"]
+            except Exception as exc:  # noqa: BLE001
+                result["source_count"] = None
+                result.setdefault("error", str(exc))
+        if self._outbox is not None:
+            try:
+                stats = self._outbox.stats()
+                result["outbox_pending"] = stats.get("pending")
+                result["outbox_deadletters"] = stats.get("deadletters", stats.get("dead_letters"))
+            except Exception:  # noqa: BLE001
+                pass
+        return result
+
     def rebuild(self, repository: Any, *, batch_size: int = 200) -> dict[str, Any]:
         """Rebuild the whole projection from the SQLite source of truth."""
         started = time.time()

--- a/tests/how/test_recovery_loop_runtime.py
+++ b/tests/how/test_recovery_loop_runtime.py
@@ -1,0 +1,65 @@
+"""PR-DF-08: RecoveryLoop wired into the Runtime lifecycle (flywheel §23-24)."""
+
+from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+
+def _cfg(**over):
+    base = dict(
+        robot_id="sim_test",
+        seekdb_backend="memory",
+        enable_memory=True,
+        enable_practice=False,
+        enable_how=True,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+    )
+    base.update(over)
+    return RuntimeConfig(**base)
+
+
+def test_recovery_loop_subscribed_when_memory_and_how_live():
+    rt = Runtime(_cfg())
+    rt.initialize()
+    try:
+        assert rt._how is not None, "test precondition: how engine built"
+        assert rt._recovery_loop is not None
+        # subscribed to the three loop topics
+        subs = getattr(rt.event_bus, "_subscribers", {})
+        for topic in (
+            "rosclaw.how.recovery_hint.generated",
+            "rosclaw.sandbox.episode.succeeded",
+            "rosclaw.sandbox.episode.failed",
+        ):
+            assert any(
+                getattr(cb, "__self__", None) is rt._recovery_loop
+                for cb in subs.get(topic, [])
+            ), topic
+    finally:
+        rt.stop()
+    # after stop the loop unsubscribes
+    assert rt._recovery_loop is None
+
+
+def test_recovery_loop_absent_without_how():
+    rt = Runtime(_cfg(enable_how=False))
+    rt.initialize()
+    try:
+        assert rt._recovery_loop is None
+    finally:
+        rt.stop()
+
+
+def test_recovery_loop_disabled_by_config():
+    rt = Runtime(_cfg(enable_recovery_loop=False))
+    rt.initialize()
+    try:
+        assert rt._how is not None
+        assert rt._recovery_loop is None
+    finally:
+        rt.stop()

--- a/tests/knowledge/test_consolidation.py
+++ b/tests/knowledge/test_consolidation.py
@@ -1,0 +1,74 @@
+"""PR-DF-09: Knowledge package consolidation — canonical rosclaw.knowledge,
+legacy shim, and federation coordinates actually passed by the Runtime."""
+
+from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+
+def test_legacy_import_surface():
+    from rosclaw.knowledge.legacy import (
+        EmbodimentCard,
+        KnowledgeInterface,
+        LegacyKnowledgeRuntime,
+        TaskCard,
+        VerifierCard,
+    )
+
+    assert LegacyKnowledgeRuntime is KnowledgeInterface
+    for cls in (KnowledgeInterface, TaskCard, EmbodimentCard, VerifierCard):
+        assert cls.__name__.startswith(("Knowledge", "Task", "Embodiment", "Verifier"))
+
+
+def test_know_package_still_importable():
+    import rosclaw.know  # noqa: F401 — compat shim must keep working
+
+    assert "DEPRECATED" in rosclaw.know.__doc__
+
+
+def _cfg(**over):
+    base = dict(
+        robot_id="sim_test",
+        seekdb_backend="memory",
+        enable_memory=False,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=True,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+        knowledge_v2_mode="inprocess",
+    )
+    base.update(over)
+    return RuntimeConfig(**base)
+
+
+def test_runtime_passes_federation_coordinates(tmp_path):
+    rt = Runtime(_cfg(seekdb_path=str(tmp_path / "knowledge.sqlite")))
+    rt.initialize()
+    try:
+        mgr = rt._knowledge_v2_manager
+        assert mgr is not None, "v2 manager should initialize in inprocess mode"
+        cfg = mgr.config
+        assert cfg.memory_path == str(tmp_path / "knowledge.sqlite")
+        assert cfg.practice_path.endswith("data/practice")
+    finally:
+        rt.stop()
+
+
+def test_federation_database_from_dsn(tmp_path):
+    rt = Runtime(
+        _cfg(
+            seekdb_url="mysql://root@127.0.0.1:2881/rosclaw_prod",
+            seekdb_backend="sqlite",
+            seekdb_path=str(tmp_path / "knowledge.sqlite"),
+        )
+    )
+    rt.initialize()
+    try:
+        cfg = rt._knowledge_v2_manager.config
+        assert cfg.memory_database == "rosclaw_prod"
+    finally:
+        rt.stop()

--- a/tests/storage/test_retrieval_projection.py
+++ b/tests/storage/test_retrieval_projection.py
@@ -1,0 +1,142 @@
+"""PR-DF-07: retrieval projection wiring — status watermark/lag, runtime
+assembly, target-filtered outbox drain."""
+
+import time
+
+import pytest
+
+
+def test_projection_status_reports_lag():
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+    from rosclaw.memory.v2.repository import MemoryRepository
+    from rosclaw.storage.seekdb_projection import MemoryRetrievalProjection
+
+    source = InMemoryStructuredStore()
+    source.connect()
+    native = InMemoryStructuredStore()  # stand-in for the native store (count API)
+    native.connect()
+    repo = MemoryRepository(source)
+
+    from rosclaw.memory.v2.models import MemoryItem
+
+    for i in range(3):
+        repo.store(
+            MemoryItem(
+                memory_type="episodic",
+                robot_id="sim",
+                title=f"mem {i}",
+                document=f"doc {i}",
+                evidence_refs=[f"evd_{i}"],
+            )
+        )
+    proj = MemoryRetrievalProjection(native)
+    status = proj.status(repo)
+    assert status["source_count"] == 3
+    assert status["projection_count"] == 0
+    assert status["lag"] == 3
+
+    # project one record; lag closes
+    proj.project(source.query("memory_items", {})[0])
+    status = proj.status(repo)
+    assert status["lag"] == 2
+
+
+def test_projection_outbox_enqueue():
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+    from rosclaw.storage.outbox import OutboxStore
+    from rosclaw.storage.seekdb_projection import MemoryRetrievalProjection
+
+    outbox = OutboxStore(db_path=":memory:")
+    outbox.connect()
+    native = InMemoryStructuredStore()
+    proj = MemoryRetrievalProjection(native, outbox=outbox)
+    proj.project({"id": "mem_1", "title": "t", "document": "d"})
+    stats = outbox.stats()
+    assert stats["pending"] == 1
+    # nothing written to the native store until a worker drains
+    assert native.count("memory_items") == 0
+
+
+def test_target_filtered_worker_drains_only_its_target():
+    """Two pipelines share one outbox; each worker claims only its target."""
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+    from rosclaw.storage.outbox import OutboxStore, OutboxWorker
+    from rosclaw.storage.seekdb_projection import MemoryRetrievalProjectionCommitter
+
+    outbox = OutboxStore(db_path=":memory:")
+    outbox.connect()
+    outbox.enqueue("seekdb_projection", {"id": "mem_a", "title": "a"}, entity_id="mem_a")
+    outbox.enqueue("practice_events", {"id": "evt_1"}, entity_id="evt_1")
+
+    native = InMemoryStructuredStore()
+    worker = OutboxWorker(
+        outbox,
+        MemoryRetrievalProjectionCommitter(native),
+        target="seekdb_projection",
+        interval_sec=0.05,
+    )
+    delivered = worker.flush(timeout=5.0)
+    assert delivered == 1
+    assert native.count("memory_items") == 1
+    # the practice record is untouched for its own worker
+    assert outbox.stats()["pending"] == 1
+
+
+def test_runtime_builds_projection_when_retrieval_enabled(tmp_path):
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    cfg = RuntimeConfig(
+        robot_id="sim_test",
+        seekdb_backend="sqlite",
+        seekdb_path=str(tmp_path / "knowledge.sqlite"),
+        enable_memory=True,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+        storage={"retrieval": {"enabled": True, "path": str(tmp_path / "seekdb")}},
+    )
+    rt = Runtime(cfg)
+    try:
+        rt.initialize()
+    except Exception as exc:  # native store unavailable on this host
+        pytest.skip(f"native SeekDB unavailable: {exc}")
+    assert rt._data_plane is not None
+    assert rt._data_plane.retrieval_store is not None
+    assert rt._data_plane.memory_projection is not None
+    # repository got the projection injected (DF-05 x DF-07 link)
+    assert rt._memory_repository is not None
+    assert rt._memory_repository._projection is rt._data_plane.memory_projection
+    rt.stop()
+    time.sleep(0.1)
+
+
+def test_runtime_projection_disabled_by_default(tmp_path):
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    cfg = RuntimeConfig(
+        robot_id="sim_test",
+        seekdb_backend="sqlite",
+        seekdb_path=str(tmp_path / "knowledge.sqlite"),
+        enable_memory=True,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+    )
+    rt = Runtime(cfg)
+    rt.initialize()
+    assert rt._data_plane.memory_projection is None
+    rt.stop()


### PR DESCRIPTION
数据飞轮序列第 8 步（叠于 #352，§23-24）——总纲点名的'最应该优先接上的模块之一'。

- memory + how 都存活时，Runtime 构造 `RecoveryLoop` 并 subscribe(failure→hint→retry→**已验证物理结果**→rule efficacy);`_do_stop` 先 unsubscribe
- **安全边界不变**（§24)：此环只学习，从不派发动作；REAL 恢复提案仍须重新经过 ActionGateway/Sandbox/Permit/Lease/Verification
- 新 `RuntimeConfig.enable_recovery_loop`（默认 true)，对应 Config v2 的 `how.recovery_loop_enabled`
- RecoveryLoop 自带的可信证据门（simulation receipt + physics executed + receipt verified + data quality）原样保留——物理世界证明成功才学习

测试：新增 3 项（memory+how 存活时订阅三 topic、无 how 不建、配置可关）;tests/how + runtime_coverage 239 全绿；ruff 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)