### PR TITLE
feat(knowledge): PR-DF-10 — KnowledgeUsageTracker 自动反馈闭环

### DIFF
--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -231,6 +231,7 @@ class Runtime(LifecycleMixin):
         self._memory_gate: Any | None = None
         self._projection_worker: Any | None = None  # PR-DF-07
         self._recovery_loop: Any | None = None  # PR-DF-08
+        self._knowledge_usage_tracker: Any | None = None  # PR-DF-10
         self._mcp_drivers: dict[str, Any] = {}
         self._emergency_stop_receipts: dict[str, Any] = {}
         self._emergency_stop_latched = False
@@ -576,6 +577,17 @@ class Runtime(LifecycleMixin):
                 self._knowledge_v2 = KnowledgeFacade(
                     self._knowledge_v2_manager, event_bus=self.event_bus
                 )
+                # PR-DF-10 (flywheel §29-31): automatic ReferencePack → Advice
+                # → Receipt → Feedback loop; conservative verdicts only.
+                try:
+                    from rosclaw.knowledge.usage_tracker import KnowledgeUsageTracker
+
+                    self._knowledge_usage_tracker = KnowledgeUsageTracker(
+                        self.event_bus, self._knowledge_v2
+                    )
+                    self._knowledge_usage_tracker.subscribe()
+                except Exception as track_exc:  # noqa: BLE001
+                    logger.info("Knowledge usage tracker unavailable: %s", track_exc)
                 logger.info(
                     "Knowledge v2 orchestration initialized (mode=%s, federation=%s)",
                     v2_mode,
@@ -964,6 +976,13 @@ class Runtime(LifecycleMixin):
         if self._event_sink is not None:
             self._event_sink.close()
             self._event_sink = None
+        # PR-DF-10: usage tracker off the bus.
+        if self._knowledge_usage_tracker is not None:
+            try:
+                self._knowledge_usage_tracker.unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Usage tracker unsubscribe failed (non-fatal): %s", exc)
+            self._knowledge_usage_tracker = None
         # PR-DF-08: RecoveryLoop off the bus first (no learning mid-shutdown).
         if self._recovery_loop is not None:
             try:

--- a/src/rosclaw/knowledge/facade.py
+++ b/src/rosclaw/knowledge/facade.py
@@ -76,6 +76,11 @@ class KnowledgeFacade:
                 "reference_pack_id": pack.reference_pack_id,
                 "index_version": pack.index_version,
                 "count": len(pack.items),
+                # PR-DF-10: the usage tracker needs unit ids to attribute
+                # feedback to the knowledge actually presented.
+                "knowledge_unit_ids": [
+                    unit_id for item in pack.items for unit_id in item.knowledge_unit_ids
+                ],
             },
         )
         return pack

--- a/src/rosclaw/knowledge/usage_tracker.py
+++ b/src/rosclaw/knowledge/usage_tracker.py
@@ -1,0 +1,159 @@
+"""KnowledgeUsageTracker (PR-DF-10 / flywheel §29-31).
+
+Closes the ReferencePack → Advice → Action → Receipt → Feedback loop that
+previously only existed in CLI/test paths:
+
+    facade.reference_pack() / facade.advise()   (events observed here)
+        ↓  agent acts
+    rosclaw.critic.judgment                      (verified outcome)
+        ↓
+    KnowledgeUsageFeedback  (conservative verdict, §31)
+        ↓  facade.feedback()
+
+Verdict discipline (§31 — conservative by construction):
+  * ``useful``  — knowledge was presented AND the task verified SUCCESS;
+  * ``unknown`` — task failed or the outcome is unattributable.  Automatic
+    feedback NEVER emits ``misleading``/``stale``/``incompatible``: those
+    require verifier attribution, human feedback, or explicit counterfactual
+    evidence, none of which an automated tracker can assert.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import Any
+
+from .feedback_adapter import build_usage_feedback
+
+logger = logging.getLogger("rosclaw.knowledge.usage_tracker")
+
+_PACK_TOPIC = "know.reference_pack.created"
+_ADVICE_TOPIC = "how.advice.created"
+_OUTCOME_TOPIC = "rosclaw.critic.judgment"
+
+
+class KnowledgeUsageTracker:
+    """Track pack/advice usage and emit conservative feedback on outcomes."""
+
+    def __init__(
+        self,
+        event_bus: Any,
+        facade: Any,
+        *,
+        ttl_s: float = 3600.0,
+        max_tracked: int = 1000,
+    ) -> None:
+        self._bus = event_bus
+        self._facade = facade
+        self._ttl_s = ttl_s
+        self._max_tracked = max_tracked
+        self._open: dict[str, dict[str, Any]] = {}
+        self._subscribed = False
+
+    # -- lifecycle ------------------------------------------------------
+
+    def subscribe(self) -> None:
+        if self._bus is None or self._subscribed:
+            return
+        self._bus.subscribe(_PACK_TOPIC, self._on_pack)
+        self._bus.subscribe(_ADVICE_TOPIC, self._on_advice)
+        self._bus.subscribe(_OUTCOME_TOPIC, self._on_outcome)
+        self._subscribed = True
+        logger.info("KnowledgeUsageTracker subscribed")
+
+    def unsubscribe(self) -> None:
+        if self._bus is None or not self._subscribed:
+            return
+        self._bus.unsubscribe(_PACK_TOPIC, self._on_pack)
+        self._bus.unsubscribe(_ADVICE_TOPIC, self._on_advice)
+        self._bus.unsubscribe(_OUTCOME_TOPIC, self._on_outcome)
+        self._subscribed = False
+
+    # -- tracking ---------------------------------------------------------
+
+    def _on_pack(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        pack_id = payload.get("reference_pack_id")
+        if not pack_id:
+            return
+        if len(self._open) >= self._max_tracked:
+            oldest = min(self._open, key=lambda k: self._open[k]["created_at"])
+            del self._open[oldest]
+        self._open[pack_id] = {
+            "reference_pack_id": pack_id,
+            "knowledge_unit_ids": list(payload.get("knowledge_unit_ids") or []),
+            "advice_id": None,
+            "created_at": time.time(),
+        }
+
+    def _on_advice(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        pack_id = payload.get("reference_pack_id")
+        advice_id = payload.get("advice_id")
+        if pack_id and pack_id in self._open and advice_id:
+            self._open[pack_id]["advice_id"] = advice_id
+
+    # -- feedback ---------------------------------------------------------
+
+    def _on_outcome(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        status = str(payload.get("status", "UNKNOWN"))
+        episode_id = payload.get("episode_id")
+        practice_id = payload.get("practice_id")
+        verdict = "useful" if status == "SUCCESS" else "unknown"
+        now = time.time()
+        for pack_id, usage in list(self._open.items()):
+            if now - usage["created_at"] > self._ttl_s:
+                del self._open[pack_id]
+                continue
+            unit_ids = usage["knowledge_unit_ids"] or ["unknown_unit"]
+            for unit_id in unit_ids:
+                self._submit(usage, unit_id, verdict, episode_id, practice_id)
+            del self._open[pack_id]
+
+    def _submit(
+        self,
+        usage: dict[str, Any],
+        unit_id: str,
+        verdict: str,
+        episode_id: Any,
+        practice_id: Any,
+    ) -> None:
+        try:
+            feedback = build_usage_feedback(
+                reference_pack_id=usage["reference_pack_id"],
+                knowledge_unit_id=unit_id,
+                advice_id=usage.get("advice_id"),
+                context_hash=hashlib.sha256(
+                    f"{usage['reference_pack_id']}:{episode_id}:{unit_id}".encode()
+                ).hexdigest(),
+                verdict=verdict,  # type: ignore[arg-type]
+                presented=True,
+                used_by_agent=True,
+                receipt_ref=str(episode_id) if episode_id else None,
+                practice_ref=str(practice_id) if practice_id else None,
+                origin="verifier",
+                reason=None if verdict == "useful" else "outcome unattributed (auto feedback is conservative)",
+            )
+            created = self._facade.feedback(feedback)
+            logger.info(
+                "Knowledge usage feedback: pack=%s unit=%s verdict=%s created=%s",
+                usage["reference_pack_id"],
+                unit_id,
+                verdict,
+                created,
+            )
+        except Exception as exc:  # noqa: BLE001 — feedback must never break execution
+            logger.info("Knowledge usage feedback failed (non-fatal): %s", exc)
+
+    @property
+    def tracked_count(self) -> int:
+        return len(self._open)

--- a/tests/knowledge/test_usage_tracker.py
+++ b/tests/knowledge/test_usage_tracker.py
@@ -1,0 +1,103 @@
+"""PR-DF-10: KnowledgeUsageTracker — automatic conservative feedback loop."""
+
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.knowledge.usage_tracker import KnowledgeUsageTracker
+
+
+class _FakeFacade:
+    def __init__(self):
+        self.feedback_calls = []
+
+    def feedback(self, feedback):
+        self.feedback_calls.append(feedback)
+        return True
+
+
+def _pack_event(bus, pack_id="pack_1", units=("unit_a", "unit_b")):
+    bus.publish(
+        Event(
+            topic="know.reference_pack.created",
+            payload={
+                "reference_pack_id": pack_id,
+                "knowledge_unit_ids": list(units),
+                "count": len(units),
+            },
+        )
+    )
+
+
+def _judgment(bus, status="SUCCESS", episode_id="ep_1"):
+    bus.publish(
+        Event(
+            topic="rosclaw.critic.judgment",
+            payload={"episode_id": episode_id, "status": status, "practice_id": "prac_1"},
+        )
+    )
+
+
+def test_success_emits_useful_feedback_per_unit():
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade)
+    tracker.subscribe()
+    _pack_event(bus)
+    assert tracker.tracked_count == 1
+    _judgment(bus, status="SUCCESS")
+    assert tracker.tracked_count == 0
+    verdicts = [f.verdict for f in facade.feedback_calls]
+    assert verdicts == ["useful", "useful"]
+    fb = facade.feedback_calls[0]
+    assert fb.reference_pack_id == "pack_1"
+    assert fb.receipt_ref == "ep_1"
+    assert fb.practice_ref == "prac_1"
+    assert fb.used_by_agent is True
+    assert fb.origin == "verifier"
+
+
+def test_failure_emits_unknown_never_misleading():
+    """§31: automatic feedback must not over-attribute failures."""
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade)
+    tracker.subscribe()
+    _pack_event(bus, units=("unit_x",))
+    _judgment(bus, status="FAILURE")
+    assert [f.verdict for f in facade.feedback_calls] == ["unknown"]
+
+
+def test_ttl_expiry_closes_without_feedback():
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade, ttl_s=0.0)
+    tracker.subscribe()
+    _pack_event(bus)
+    _judgment(bus, status="SUCCESS")
+    assert facade.feedback_calls == []
+    assert tracker.tracked_count == 0
+
+
+def test_advice_linkage_attaches_advice_id():
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade)
+    tracker.subscribe()
+    _pack_event(bus)
+    bus.publish(
+        Event(
+            topic="how.advice.created",
+            payload={"reference_pack_id": "pack_1", "advice_id": "adv_9"},
+        )
+    )
+    _judgment(bus, status="SUCCESS")
+    assert facade.feedback_calls[0].advice_id == "adv_9"
+
+
+def test_unsubscribe_stops_feedback():
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade)
+    tracker.subscribe()
+    tracker.unsubscribe()
+    _pack_event(bus)
+    _judgment(bus)
+    assert facade.feedback_calls == []


### PR DESCRIPTION
数据飞轮序列第 10 步（叠于 #354，§29-31)。

- 新增 `KnowledgeUsageTracker`：订阅 `know.reference_pack.created` / `how.advice.created` / `rosclaw.critic.judgment`，把'用过什么知识'与'任务验证结果'配对，自动提交 `KnowledgeUsageFeedbackV1`(origin=verifier,receipt_ref/practice_ref 挂血缘）
- facade 的 pack-created 事件载荷新增 `knowledge_unit_ids`（附加字段，向后兼容）
- **保守判定**（§31)：验证成功→`useful`；失败/无归因→`unknown`；自动路径**永不**产出 `misleading`/`stale`/`incompatible`（需要验证器归因或人类反事实证据）
- TTL + 有界跟踪；反馈失败绝不打断执行；Runtime 在 Knowledge v2 装配后挂载、stop 时卸载

测试：新增 5 项；knowledge+runtime 套件绿（1 项预置环境失败已排除，main 可复现）;ruff 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)