### PR TITLE
feat(memory): PR-DF-11 — MemoryInsightService（insight 的生产者）

### DIFF
--- a/src/rosclaw/core/event_topics.py
+++ b/src/rosclaw/core/event_topics.py
@@ -76,6 +76,8 @@ class EventTopics:
     # ── Memory ──
     MEMORY_EXPERIENCE_STORED = "rosclaw.memory.experience.stored"
     MEMORY_WRITE_COMPLETED = "rosclaw.memory.write.completed"
+    # PR-DF-11 (flywheel §25-26): typed insight feed consumed by Auto.
+    MEMORY_INSIGHT_CREATED = "rosclaw.memory.insight"
 
     # ── How / Recovery ──
     HOW_RECOVERY_HINT_GENERATED = "rosclaw.how.recovery_hint.generated"

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -232,6 +232,7 @@ class Runtime(LifecycleMixin):
         self._projection_worker: Any | None = None  # PR-DF-07
         self._recovery_loop: Any | None = None  # PR-DF-08
         self._knowledge_usage_tracker: Any | None = None  # PR-DF-10
+        self._memory_insights: Any | None = None  # PR-DF-11
         self._mcp_drivers: dict[str, Any] = {}
         self._emergency_stop_receipts: dict[str, Any] = {}
         self._emergency_stop_latched = False
@@ -663,6 +664,26 @@ class Runtime(LifecycleMixin):
             except Exception as e:  # noqa: BLE001
                 logger.info(f"Heuristic grounding not available: {e}")
 
+        # PR-DF-11 (flywheel §25-27): the publisher half of
+        # rosclaw.memory.insight — recurring failures with proven recoveries
+        # become typed insights that Auto turns into memory-guided Proposals.
+        self._memory_insights = None
+        if self._memory is not None and data_plane.structured_store is not None:
+            try:
+                from rosclaw.memory.insights import MemoryInsightService
+
+                self._memory_insights = MemoryInsightService(
+                    self.event_bus,
+                    data_plane.structured_store,
+                    robot_id=self.config.robot_id,
+                    failure_threshold=int(self.config.auto.get("trigger_failure_threshold", 3))
+                    if isinstance(getattr(self.config, "auto", None), dict)
+                    else 3,
+                )
+                self._memory_insights.subscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.info("MemoryInsightService not available: %s", exc)
+
         # PR-DF-08 (flywheel §23): the RecoveryLoop closes
         # failure → hint → retry → VERIFIED physics outcome → rule efficacy.
         # It only learns — it never dispatches motion, and REAL recovery
@@ -976,6 +997,13 @@ class Runtime(LifecycleMixin):
         if self._event_sink is not None:
             self._event_sink.close()
             self._event_sink = None
+        # PR-DF-11: insight service off the bus.
+        if self._memory_insights is not None:
+            try:
+                self._memory_insights.unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("MemoryInsightService unsubscribe failed (non-fatal): %s", exc)
+            self._memory_insights = None
         # PR-DF-10: usage tracker off the bus.
         if self._knowledge_usage_tracker is not None:
             try:

--- a/src/rosclaw/memory/insights.py
+++ b/src/rosclaw/memory/insights.py
@@ -1,0 +1,220 @@
+"""MemoryInsightService (PR-DF-11 / flywheel §25-27).
+
+The publisher half of ``rosclaw.memory.insight``: until now Auto subscribed
+to the topic and nothing ever published.  This service watches failure
+observations (critic judgments) and, when a failure recurs, checks the
+structured store for *successful* recovery experience against the same
+failure type — only then does it publish a typed insight:
+
+* ``repeated_failure`` — a failure_type keeps recurring (>= threshold);
+* ``similar_failure_with_patch`` — the recurring failure has a proven
+  recovery (a How rule with successes, or a successful intervention
+  memory).  This is the exact payload Auto's subscriber turns into a
+  memory-guided Proposal (§27).
+
+Insights carry the canonical typed fields (§26): insight_id, insight_type,
+robot_id, body_id, task_id, skill_id, failure_type, evidence_refs,
+memory_refs, recommended_search_space, confidence — plus the legacy field
+names Auto reads today (insight_summary, search_space, failure_id).
+
+Dedup: one insight per (insight_type, skill_id, failure_type) per cooldown
+window so a failure storm doesn't flood Auto with duplicate proposals.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any
+
+from rosclaw.core.event_topics import EventTopics
+
+logger = logging.getLogger("rosclaw.memory.insights")
+
+_DEFAULT_COOLDOWN_S = 900.0
+
+
+class MemoryInsightService:
+    """Generate typed memory insights from recurring failures + proven fixes."""
+
+    def __init__(
+        self,
+        event_bus: Any,
+        structured_store: Any,
+        *,
+        robot_id: str,
+        failure_threshold: int = 3,
+        cooldown_s: float = _DEFAULT_COOLDOWN_S,
+    ) -> None:
+        self._bus = event_bus
+        self._store = structured_store
+        self._robot_id = robot_id
+        self._threshold = failure_threshold
+        self._cooldown_s = cooldown_s
+        self._counts: dict[tuple[str, str], int] = {}
+        self._last_emitted: dict[tuple[str, str, str], float] = {}
+        self._subscribed = False
+
+    # -- lifecycle ------------------------------------------------------
+
+    def subscribe(self) -> None:
+        if self._bus is None or self._subscribed:
+            return
+        self._bus.subscribe(EventTopics.CRITIC_JUDGMENT, self._on_judgment)
+        self._subscribed = True
+        logger.info("MemoryInsightService subscribed")
+
+    def unsubscribe(self) -> None:
+        if self._bus is None or not self._subscribed:
+            return
+        self._bus.unsubscribe(EventTopics.CRITIC_JUDGMENT, self._on_judgment)
+        self._subscribed = False
+
+    # -- observation ------------------------------------------------------
+
+    def _on_judgment(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        status = str(payload.get("status", "UNKNOWN"))
+        if status == "SUCCESS":
+            return
+        context = payload.get("context", {}) if isinstance(payload.get("context"), dict) else {}
+        outcome = context.get("outcome", {}) if isinstance(context.get("outcome"), dict) else {}
+        skill_id = outcome.get("skill_name") or payload.get("skill_id") or "unknown"
+        failure_type = payload.get("reason") or payload.get("failure_type") or "unknown"
+        task_id = payload.get("task_id") or context.get("instruction") or ""
+        episode_id = payload.get("episode_id", "")
+
+        key = (skill_id, failure_type)
+        self._counts[key] = self._counts.get(key, 0) + 1
+        count = self._counts[key]
+        if count < self._threshold:
+            return
+
+        evidence_refs = [f"critic_result:{episode_id}"] if episode_id else []
+        self._maybe_emit(
+            "repeated_failure",
+            skill_id=skill_id,
+            failure_type=failure_type,
+            task_id=task_id,
+            episode_id=episode_id,
+            evidence_refs=evidence_refs,
+            extra={"occurrences": count},
+        )
+        fix = self._find_proven_fix(failure_type)
+        if fix is not None:
+            self._maybe_emit(
+                "similar_failure_with_patch",
+                skill_id=skill_id,
+                failure_type=failure_type,
+                task_id=task_id,
+                episode_id=episode_id,
+                evidence_refs=evidence_refs + fix["evidence_refs"],
+                extra={
+                    "search_space": fix["search_space"],
+                    "memory_refs": fix["memory_refs"],
+                },
+            )
+
+    # -- insight emission ---------------------------------------------------
+
+    def _find_proven_fix(self, failure_type: str) -> dict[str, Any] | None:
+        """A How rule with verified successes, or a successful intervention memory."""
+        if self._store is None:
+            return None
+        try:
+            rules = self._store.query("heuristic_rules", {"failure_type": failure_type})
+            proven = [
+                r
+                for r in rules
+                if isinstance(r.get("success_count"), int) and r["success_count"] > 0
+            ]
+            if proven:
+                best = max(proven, key=lambda r: r["success_count"])
+                search_space = best.get("parameter_patch") or {}
+                if isinstance(search_space, str):
+                    import json
+
+                    try:
+                        search_space = json.loads(search_space)
+                    except ValueError:
+                        search_space = {}
+                return {
+                    "search_space": search_space if isinstance(search_space, dict) else {},
+                    "memory_refs": [f"heuristic_rules:{best.get('id', '')}"],
+                    "evidence_refs": [f"heuristic_rules:{best.get('id', '')}"],
+                }
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("rule lookup failed: %s", exc)
+        try:
+            interventions = self._store.query(
+                "memory_items", {"memory_type": "intervention", "failure_type": failure_type}
+            )
+            successful = [m for m in interventions if m.get("outcome") == "SUCCESS"]
+            if successful:
+                mem = successful[0]
+                return {
+                    "search_space": {},
+                    "memory_refs": [mem.get("id", "")],
+                    "evidence_refs": list(mem.get("evidence_refs") or []),
+                }
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("intervention memory lookup failed: %s", exc)
+        return None
+
+    def _maybe_emit(
+        self,
+        insight_type: str,
+        *,
+        skill_id: str,
+        failure_type: str,
+        task_id: str,
+        episode_id: str,
+        evidence_refs: list[str],
+        extra: dict[str, Any],
+    ) -> None:
+        dedup_key = (insight_type, skill_id, failure_type)
+        now = time.time()
+        if now - self._last_emitted.get(dedup_key, 0.0) < self._cooldown_s:
+            return
+        self._last_emitted[dedup_key] = now
+        search_space = extra.get("search_space", {})
+        summary = (
+            f"failure '{failure_type}' recurred {extra.get('occurrences', self._threshold)}x "
+            f"on skill '{skill_id}'"
+            if insight_type == "repeated_failure"
+            else f"failure '{failure_type}' on skill '{skill_id}' has a proven recovery"
+        )
+        insight = {
+            # canonical typed fields (§26)
+            "insight_id": f"ins_{uuid.uuid4().hex[:16]}",
+            "insight_type": insight_type,
+            "robot_id": self._robot_id,
+            "task_id": task_id,
+            "skill_id": skill_id,
+            "failure_type": failure_type,
+            "evidence_refs": evidence_refs,
+            "memory_refs": extra.get("memory_refs", []),
+            "recommended_search_space": search_space,
+            "confidence": 0.8 if insight_type == "similar_failure_with_patch" else 0.5,
+            "created_at": now,
+            # field names Auto's subscriber consumes today
+            "insight_summary": summary,
+            "search_space": search_space,
+            "failure_id": episode_id,
+        }
+        try:
+            from rosclaw.core.event_bus import Event
+
+            self._bus.publish(
+                Event(
+                    topic=EventTopics.MEMORY_INSIGHT_CREATED,
+                    payload=insight,
+                    source="memory.insights",
+                )
+            )
+            logger.info("memory insight published: %s (%s)", insight_type, dedup_key)
+        except Exception as exc:  # noqa: BLE001
+            logger.info("insight publish failed (non-fatal): %s", exc)

--- a/tests/memory/v2/test_insights.py
+++ b/tests/memory/v2/test_insights.py
@@ -1,0 +1,113 @@
+"""PR-DF-11: MemoryInsightService — the publisher half of rosclaw.memory.insight."""
+
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.core.event_topics import EventTopics
+from rosclaw.memory.insights import MemoryInsightService
+from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+
+
+def _collect(bus):
+    received = []
+    bus.subscribe(EventTopics.MEMORY_INSIGHT_CREATED, lambda e: received.append(e.payload))
+    return received
+
+
+def _failure(bus, skill="pick_cup", reason="slip", episode="ep_1"):
+    bus.publish(
+        Event(
+            topic=EventTopics.CRITIC_JUDGMENT,
+            payload={
+                "episode_id": episode,
+                "status": "FAILURE",
+                "reason": reason,
+                "context": {"outcome": {"skill_name": skill}, "instruction": "pick"},
+            },
+        )
+    )
+
+
+def test_repeated_failure_insight_after_threshold():
+    bus = EventBus()
+    insights = _collect(bus)
+    svc = MemoryInsightService(bus, InMemoryStructuredStore(), robot_id="sim", failure_threshold=3)
+    svc.subscribe()
+    _failure(bus)
+    _failure(bus)
+    assert insights == []  # below threshold
+    _failure(bus)
+    assert [i["insight_type"] for i in insights] == ["repeated_failure"]
+    ins = insights[0]
+    assert ins["skill_id"] == "pick_cup"
+    assert ins["failure_type"] == "slip"
+    assert ins["robot_id"] == "sim"
+    assert ins["evidence_refs"]
+
+
+def test_similar_failure_with_patch_when_rule_proven():
+    bus = EventBus()
+    insights = _collect(bus)
+    store = InMemoryStructuredStore()
+    store.connect()
+    store.insert(
+        "heuristic_rules",
+        {
+            "id": "rule_1",
+            "failure_type": "slip",
+            "success_count": 4,
+            "parameter_patch": {"force_set": [300, 500]},
+        },
+    )
+    svc = MemoryInsightService(bus, store, robot_id="sim", failure_threshold=2)
+    svc.subscribe()
+    _failure(bus)
+    _failure(bus, episode="ep_2")
+    types = [i["insight_type"] for i in insights]
+    assert "similar_failure_with_patch" in types
+    ins = next(i for i in insights if i["insight_type"] == "similar_failure_with_patch")
+    # Auto's consumed fields are present
+    assert ins["search_space"] == {"force_set": [300, 500]}
+    assert ins["insight_summary"]
+    assert ins["failure_id"] == "ep_2"
+    assert ins["memory_refs"] == ["heuristic_rules:rule_1"]
+
+
+def test_no_patch_insight_without_proven_fix():
+    bus = EventBus()
+    insights = _collect(bus)
+    store = InMemoryStructuredStore()
+    store.connect()
+    store.insert(
+        "heuristic_rules",
+        {"id": "rule_weak", "failure_type": "slip", "success_count": 0},
+    )
+    svc = MemoryInsightService(bus, store, robot_id="sim", failure_threshold=2)
+    svc.subscribe()
+    _failure(bus)
+    _failure(bus)
+    assert [i["insight_type"] for i in insights] == ["repeated_failure"]
+
+
+def test_cooldown_dedup():
+    bus = EventBus()
+    insights = _collect(bus)
+    svc = MemoryInsightService(
+        bus, InMemoryStructuredStore(), robot_id="sim", failure_threshold=1, cooldown_s=3600
+    )
+    svc.subscribe()
+    for i in range(5):
+        _failure(bus, episode=f"ep_{i}")
+    assert len(insights) == 1
+
+
+def test_success_judgments_never_generate_insights():
+    bus = EventBus()
+    insights = _collect(bus)
+    svc = MemoryInsightService(bus, InMemoryStructuredStore(), robot_id="sim", failure_threshold=1)
+    svc.subscribe()
+    bus.publish(
+        Event(
+            topic=EventTopics.CRITIC_JUDGMENT,
+            payload={"episode_id": "ep_ok", "status": "SUCCESS", "context": {}},
+        )
+    )
+    assert insights == []


### PR DESCRIPTION
数据飞轮序列第 11 步（叠于 #355，§25-27)——总纲点名：'只有消费者，没有生产者'。

- 新增 `MemoryInsightService`：观察 critic 失败判决，复发达阈值发 `repeated_failure`；若该 failure_type 存在**已验证的恢复经验**(How 规则 success_count>0 或成功 intervention 记忆）则发 `similar_failure_with_patch`——正是 Auto 订阅者生成 memory-guided Proposal 所需的载荷（§27)
- 载荷同时携带 §26 canonical 字段（insight_id/evidence_refs/memory_refs/recommended_search_space/confidence）与 Auto 现读字段（insight_summary/search_space/failure_id)
- 按 (type,skill,failure) 冷却去重，失败风暴不淹 Auto；topic 入 `EventTopics.MEMORY_INSIGHT_CREATED`(§42)
- Runtime 在 memory 初始化后挂载、stop 卸载

测试：新增 5 项；memory+runtime 套件绿；ruff 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)