### PR TITLE
feat(evolution): PR-DF-12 — EvolutionRepository（StructuredStore 为权威，LocalStore 降级 spool）

### DIFF
--- a/src/rosclaw/auto/engine/auto_engine.py
+++ b/src/rosclaw/auto/engine/auto_engine.py
@@ -53,7 +53,18 @@ class AutoEngine:
                 self._auto_context_adapter = AutoContextAdapter(sense_runtime)
             except Exception:
                 pass
-        self.store = LocalStore(self.config.local_store_path)
+        # PR-DF-12 (flywheel §32): the Structured Store is the Evolution
+        # source of truth when one is injected; LocalStore degrades to
+        # cache/offline spool.  storage_backend="local" keeps the legacy
+        # single-file behavior (standalone users without a data plane).
+        if self._seekdb is not None and self.config.storage_backend in ("seekdb", "hybrid"):
+            from rosclaw.evolution.repository import EvolutionRepository
+
+            self.store = EvolutionRepository(
+                self._seekdb, LocalStore(self.config.local_store_path)
+            )
+        else:
+            self.store = LocalStore(self.config.local_store_path)
         # Sprint C: runners
         runner_backend = self.config.runner_backend
         self.local_runner = LocalRunner({"backend": runner_backend, "latency_sec": 0.01})

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -713,8 +713,18 @@ class Runtime(LifecycleMixin):
                 # Reuse Memory's SeekDB client if available
                 if self._memory is not None:
                     seekdb = getattr(self._memory, "seekdb_client", None)
+                # PR-DF-12: with a data plane present, Evolution state goes
+                # to the structured store (LocalStore becomes its spool).
+                auto_storage = (
+                    "hybrid"
+                    if self._data_plane is not None and self._data_plane.structured_store is not None
+                    else "local"
+                )
                 self._auto = AutoPlugin(
-                    config={"local_store_path": str(workspace_home / "data" / "auto")},
+                    config={
+                        "local_store_path": str(workspace_home / "data" / "auto"),
+                        "storage_backend": auto_storage,
+                    },
                     event_bus=self.event_bus,
                     seekdb_client=seekdb,
                     skill_registry=getattr(self._skill_manager, "registry", None)

--- a/src/rosclaw/evolution/repository.py
+++ b/src/rosclaw/evolution/repository.py
@@ -1,0 +1,121 @@
+"""EvolutionRepository (PR-DF-12 / flywheel §32-35).
+
+The Evolution module's canonical state lives in the Structured Store
+(``evolution_records`` table); the legacy ``LocalStore`` JSONL tree is
+demoted to a *cache / offline spool*:
+
+* ``save`` writes the structured store first, then mirrors into the cache;
+  if the store is down the record spools to the cache and the failure is
+  logged — never silently lost, never blocking the engine.
+* ``load`` / ``iterate`` / ``list_keys`` read the store first and fall
+  back to the cache, so an offline SeekDB/SQLite degrades to pre-DF-12
+  behavior (ADR-0009 §4).
+
+The repository deliberately implements the ``LocalStore`` interface
+(``save/load/list_keys/iterate/delete``) so ``AutoEngine`` swaps it in
+without internal changes.  Records are stored as
+``{id: "<namespace>:<key>", namespace, key, data, updated_at}`` — the data
+JSON keeps full provenance (trace/evidence/refs) written by the engine.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Iterator
+from typing import Any
+
+logger = logging.getLogger("rosclaw.evolution.repository")
+
+TABLE = "evolution_records"
+
+
+class EvolutionRepository:
+    """Structured-store-backed Evolution state with a LocalStore spool."""
+
+    def __init__(self, structured_store: Any, cache: Any) -> None:
+        self._store = structured_store
+        self._cache = cache  # LocalStore — cache / offline spool
+
+    @property
+    def base(self):
+        """The spool root — keeps LocalStore introspection compat."""
+        return self._cache.base
+
+    @staticmethod
+    def _row_id(namespace: str, key: str) -> str:
+        return f"{namespace}:{key}"
+
+    # -- LocalStore-compatible interface ---------------------------------
+
+    def save(self, namespace: str, key: str, data: dict) -> None:
+        record = {
+            "id": self._row_id(namespace, key),
+            "namespace": namespace,
+            "key": key,
+            "data": json.dumps(data, default=str),
+            "updated_at": time.time(),
+        }
+        try:
+            self._store.insert(TABLE, record)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "evolution store write failed (%s/%s) — spooled to local cache: %s",
+                namespace,
+                key,
+                exc,
+            )
+        try:
+            self._cache.save(namespace, key, data)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("evolution cache write failed (%s/%s): %s", namespace, key, exc)
+
+    def load(self, namespace: str, key: str) -> dict | None:
+        try:
+            rows = self._store.query(TABLE, {"id": self._row_id(namespace, key)}, limit=1)
+            if rows:
+                return json.loads(rows[0]["data"])
+            # not in the store — maybe it only exists in the spool
+        except Exception as exc:  # noqa: BLE001
+            logger.info("evolution store read failed (%s/%s), using cache: %s", namespace, key, exc)
+        return self._cache.load(namespace, key)
+
+    def list_keys(self, namespace: str) -> list[str]:
+        try:
+            rows = self._store.query(TABLE, {"namespace": namespace}, limit=100_000)
+            keys = [r.get("key") for r in rows if r.get("key")]
+            if keys:
+                return keys
+        except Exception as exc:  # noqa: BLE001
+            logger.info("evolution store list failed (%s), using cache: %s", namespace, exc)
+        return self._cache.list_keys(namespace)
+
+    def iterate(self, namespace: str) -> Iterator[dict]:
+        for key in self.list_keys(namespace):
+            data = self.load(namespace, key)
+            if data is not None:
+                yield data
+
+    def delete(self, namespace: str, key: str) -> bool:
+        deleted = False
+        try:
+            deleted = bool(self._store.delete(TABLE, self._row_id(namespace, key)))
+        except Exception as exc:  # noqa: BLE001
+            logger.info("evolution store delete failed (%s/%s): %s", namespace, key, exc)
+        cache_deleted = self._cache.delete(namespace, key)
+        return deleted or cache_deleted
+
+    # -- observability -----------------------------------------------------
+
+    def stats(self) -> dict[str, Any]:
+        """Namespace counts for storage status/doctor (PR-DF-15 feeds)."""
+        try:
+            rows = self._store.query(TABLE, limit=500_000)
+            counts: dict[str, int] = {}
+            for row in rows:
+                ns = row.get("namespace", "?")
+                counts[ns] = counts.get(ns, 0) + 1
+            return {"backend": type(self._store).__name__, "namespaces": counts}
+        except Exception as exc:  # noqa: BLE001
+            return {"backend": type(self._store).__name__, "error": str(exc)}

--- a/src/rosclaw/memory/seekdb_client.py
+++ b/src/rosclaw/memory/seekdb_client.py
@@ -503,6 +503,19 @@ ROSCLAW_STRUCTURED_SCHEMAS: dict[str, Any] = {
         },
         "indices": ["status", "rule_id", "created_at"],
     },
+    # Evolution module canonical tables (PR-DF-12, ADR-0010 §33-34): the
+    # generic namespace-row shape backing EvolutionRepository.  Legacy
+    # auto_* tables below stay for compat until the migration PR.
+    "evolution_records": {
+        "columns": {
+            "id": "TEXT PRIMARY KEY",
+            "namespace": "TEXT",
+            "key": "TEXT",
+            "data": "TEXT",
+            "updated_at": "REAL",
+        },
+        "indices": ["namespace", "updated_at"],
+    },
     # Auto module tables
     "auto_proposals": {
         "columns": {

--- a/tests/evolution/test_evolution_repository.py
+++ b/tests/evolution/test_evolution_repository.py
@@ -1,0 +1,97 @@
+"""PR-DF-12: EvolutionRepository — structured store canonical, LocalStore spool."""
+
+import json
+
+from rosclaw.auto.storage.local_store import LocalStore
+from rosclaw.evolution.repository import EvolutionRepository
+from rosclaw.memory.seekdb_client import InMemoryStructuredStore, SQLiteStructuredStore
+
+
+def _repo(tmp_path):
+    store = InMemoryStructuredStore()
+    store.connect()
+    cache = LocalStore(str(tmp_path / "auto"))
+    return EvolutionRepository(store, cache), store, cache
+
+
+def test_save_goes_to_store_and_cache(tmp_path):
+    repo, store, cache = _repo(tmp_path)
+    repo.save("proposals", "prop_1", {"task_id": "t1", "hypothesis": "h"})
+    rows = store.query("evolution_records", {"namespace": "proposals"})
+    assert len(rows) == 1
+    assert rows[0]["id"] == "proposals:prop_1"
+    assert json.loads(rows[0]["data"])["hypothesis"] == "h"
+    assert cache.load("proposals", "prop_1")["hypothesis"] == "h"
+
+
+def test_load_reads_store_first(tmp_path):
+    repo, store, cache = _repo(tmp_path)
+    repo.save("experiments", "exp_1", {"result": 0.87})
+    cache.save("experiments", "exp_1", {"result": 0.0})  # stale cache
+    assert repo.load("experiments", "exp_1")["result"] == 0.87
+
+
+def test_store_down_falls_back_to_spool(tmp_path):
+    repo, store, cache = _repo(tmp_path)
+    repo.save("champions", "champ_1", {"skill": "pick", "version": "1.7"})
+
+    class _DeadStore:
+        def query(self, *a, **k):
+            raise ConnectionError("seekdb down")
+
+        def insert(self, *a, **k):
+            raise ConnectionError("seekdb down")
+
+        def delete(self, *a, **k):
+            raise ConnectionError("seekdb down")
+
+    repo._store = _DeadStore()
+    # save spools instead of raising; load/list still work from the spool
+    repo.save("champions", "champ_2", {"skill": "place", "version": "1.0"})
+    assert repo.load("champions", "champ_1")["version"] == "1.7"
+    assert set(repo.list_keys("champions")) == {"champ_1", "champ_2"}
+
+
+def test_sqlite_roundtrip_with_schema(tmp_path):
+    """The evolution_records table exists in ROSCLAW_STRUCTURED_SCHEMAS."""
+    store = SQLiteStructuredStore(str(tmp_path / "knowledge.sqlite"))
+    store.connect()
+    cache = LocalStore(str(tmp_path / "auto"))
+    repo = EvolutionRepository(store, cache)
+    repo.save("patches", "patch_1", {"changes": {"force": 300}})
+    assert repo.load("patches", "patch_1")["changes"] == {"force": 300}
+    assert repo.list_keys("patches") == ["patch_1"]
+    store.disconnect()
+
+
+def test_namespaces_isolated_by_composite_id(tmp_path):
+    repo, store, _ = _repo(tmp_path)
+    repo.save("proposals", "x", {"kind": "proposal"})
+    repo.save("deadends", "x", {"kind": "deadend"})
+    assert repo.load("proposals", "x")["kind"] == "proposal"
+    assert repo.load("deadends", "x")["kind"] == "deadend"
+    assert repo.stats()["namespaces"] == {"proposals": 1, "deadends": 1}
+
+
+def test_auto_engine_uses_repository_when_store_injected(tmp_path):
+    from rosclaw.auto.config import AutoConfig
+    from rosclaw.auto.engine.auto_engine import AutoEngine
+
+    store = InMemoryStructuredStore()
+    store.connect()
+    cfg = AutoConfig(local_store_path=str(tmp_path / "auto"), storage_backend="hybrid")
+    engine = AutoEngine(config=cfg, event_bus=None, seekdb_client=store)
+    assert isinstance(engine.store, EvolutionRepository)
+    engine.store.save("tasks", "task_1", {"goal": "pick"})
+    assert store.count("evolution_records", {"namespace": "tasks"}) == 1
+
+
+def test_auto_engine_local_default_unchanged(tmp_path):
+    from rosclaw.auto.config import AutoConfig
+    from rosclaw.auto.engine.auto_engine import AutoEngine
+
+    store = InMemoryStructuredStore()
+    store.connect()
+    cfg = AutoConfig(local_store_path=str(tmp_path / "auto"))  # storage_backend="local"
+    engine = AutoEngine(config=cfg, event_bus=None, seekdb_client=store)
+    assert isinstance(engine.store, LocalStore)


### PR DESCRIPTION
数据飞轮序列第 12 步（叠于 #356，§32-35)——总纲：'SeekDB 对 Auto 不应只是旁路镜像'。

- 新增 `rosclaw.evolution.repository.EvolutionRepository`:Auto 全命名空间（proposals/patches/experiments/evaluations/champions/deadends/lineage…）写入 structured store 的 `evolution_records` 表（namespace+复合 id，数据 JSON 保留完整 provenance)
- **LocalStore 降级为 cache/offline spool**：写先 store 后镜像，store 挂了写 spool 不丢不堵；读 store 优先、故障回退 spool(ADR-0009 §4 / E2E-6 姿态）
- repository 实现 LocalStore 接口（+`.base` 兼容属性）,AutoEngine 在注入 structured store 且 `storage_backend=seekdb|hybrid` 时无缝换入；Runtime 在数据平面存活时自动请求 hybrid；独立用法 `local` 默认行为零变化
- `stats()` 供 DF-15 的 status/doctor 使用

测试：新增 7 项；evolution+runtime+unit/auto 414 全绿；ruff 绿。

注：本提交经 Git Data API 推送（git transport 不稳定），内容与本地 0de3e53 一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)