### PR TITLE
feat(darwin): PR-DF-13 — Darwin 正式进入 Runtime 生命周期

### DIFF
--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -108,6 +108,10 @@ class RuntimeConfig:
         default_factory=lambda: os.environ.get("ROSCLAW_KNOW_SEEKDB_PATH")
     )
     enable_auto: bool = True  # Self-Evolution Control Plane (AUTO module)
+    # PR-DF-13 (flywheel §39): Darwin evaluation pressure as a first-class
+    # Runtime module.  Off by default — benchmarks are expensive.
+    enable_darwin: bool = False
+    darwin: dict[str, Any] = field(default_factory=dict)  # seeds / episodes
     enable_provider: bool = True
     joint_dof: int = 6
     sampling_rate_hz: int = 1000
@@ -233,6 +237,7 @@ class Runtime(LifecycleMixin):
         self._recovery_loop: Any | None = None  # PR-DF-08
         self._knowledge_usage_tracker: Any | None = None  # PR-DF-10
         self._memory_insights: Any | None = None  # PR-DF-11
+        self._darwin: Any | None = None  # PR-DF-13
         self._mcp_drivers: dict[str, Any] = {}
         self._emergency_stop_receipts: dict[str, Any] = {}
         self._emergency_stop_latched = False
@@ -736,6 +741,34 @@ class Runtime(LifecycleMixin):
                 logger.info("Self-Evolution Control Plane (Auto) initialized")
             except ImportError as e:
                 logger.info(f"Auto module not available: {e}")
+
+        # PR-DF-13 (flywheel §39-40): Darwin enters the Runtime lifecycle,
+        # sharing the event bus and the data plane's structured store so
+        # Evolution experiments land as darwin_benchmarks rows with full
+        # provenance.  Off by default.
+        self._darwin = None
+        if self.config.enable_darwin:
+            try:
+                from rosclaw.darwin.plugin import DarwinPlugin
+
+                self._darwin = DarwinPlugin(
+                    config={
+                        "default_seeds": self.config.darwin.get("seeds", [0, 1, 2])
+                        if isinstance(getattr(self.config, "darwin", None), dict)
+                        else [0, 1, 2],
+                        "default_episodes": self.config.darwin.get("episodes", 50)
+                        if isinstance(getattr(self.config, "darwin", None), dict)
+                        else 50,
+                    }
+                    if isinstance(getattr(self.config, "darwin", None), dict)
+                    else {},
+                    event_bus=self.event_bus,
+                    seekdb_client=data_plane.structured_store,
+                )
+                self._modules.append(self._darwin)
+                logger.info("Darwin evaluation plane initialized")
+            except ImportError as e:
+                logger.info(f"Darwin module not available: {e}")
 
         # Initialize Provider Layer (Capability Router + Guard)
         if self.config.enable_provider and ProviderRegistry is not None:

--- a/tests/darwin/test_runtime_wiring.py
+++ b/tests/darwin/test_runtime_wiring.py
@@ -1,0 +1,46 @@
+"""PR-DF-13: Darwin enters the Runtime lifecycle (flywheel §39-40)."""
+
+from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+
+def _cfg(**over):
+    base = dict(
+        robot_id="sim_test",
+        seekdb_backend="memory",
+        enable_memory=False,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+    )
+    base.update(over)
+    return RuntimeConfig(**base)
+
+
+def test_darwin_off_by_default():
+    rt = Runtime(_cfg())
+    rt.initialize()
+    try:
+        assert rt._darwin is None
+    finally:
+        rt.stop()
+
+
+def test_darwin_wired_when_enabled_with_data_plane():
+    rt = Runtime(_cfg(enable_darwin=True, darwin={"seeds": [0], "episodes": 5}))
+    rt.initialize()
+    try:
+        assert rt._darwin is not None
+        assert rt._darwin.engine is not None
+        # shares the runtime event bus and the data plane structured store
+        assert rt._darwin.engine._bus is rt.event_bus
+        assert rt._darwin.engine._seekdb is rt._data_plane.structured_store
+    finally:
+        rt.stop()
+    assert rt._darwin is None or rt._darwin.engine is not None  # stop is graceful


### PR DESCRIPTION
数据飞轮序列第 13 步（叠于 #359，§39-40)。

- `RuntimeConfig.enable_darwin`（默认关——benchmark 很贵）+ `darwin` 配置字典（seeds/episodes)
- 启用时 Runtime 构造 `DarwinPlugin`，注入共享 EventBus 与数据平面 structured store——Evolution experiment 的 benchmark 结果以完整 provenance 落 `darwin_benchmarks`
- 进入 modules 列表，获得标准 initialize/start/stop 生命周期；Evolution 提出改变、Darwin 评估改变的职责分离不变（§5.5)

测试：新增 2 项（默认关闭、启用后共享 bus+store);darwin+runtime 套件绿；ruff 绿。

注：本提交经 Git Data API 推送（git transport 不稳定），内容与本地 6d17ffd 一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)