### PR TITLE
fix: 14.7 Operator 降级回归——READY 永远显示（旅程 PTY 实证）

### DIFF
--- a/packages/rosclaw-agent/src/ui/product-state.ts
+++ b/packages/rosclaw-agent/src/ui/product-state.ts
@@ -96,6 +96,9 @@ function renderOperator(state: KernelSnapshotV1, locale: EffectiveLocale): strin
 		| undefined;
 	const operatorInvolved =
 		state.mode !== "SIMULATION"
+		// 已初始化的 Operator 永远显示（用户明确启用——降级只针对
+		// 未初始化时的 "Operator Offline" 紧张感）。
+		|| state.operator === "READY"
 		|| readiness?.state === "BLOCKED"
 		|| (readiness?.reason_codes ?? []).some((c) => c.includes("OPERATOR"));
 	if (!operatorInvolved) {


### PR DESCRIPTION
#366 的 SIM Operator 降级把已初始化的 `Operator Ready` 也降成了 `SIM auto`，产品旅程 PTY（operator_bootstrapped_in_tui）红。

修复：降级只针对纯 SIM **未初始化**的 `Operator Offline`（审计原诉的紧张感）；`state.operator === "READY"` 永远显示。

验证：TS 102/102；产品旅程 3/3（6m50s，含 PTY operator-init 腿）。