### PR TITLE
feat: Data Flywheel DF-03..DF-15 合并主干（栈合并事故后的归并 PR）

### DIFF
--- a/docs/reports/ROSCLAW_DATA_FLYWHEEL_REFACTOR_REPORT.md
+++ b/docs/reports/ROSCLAW_DATA_FLYWHEEL_REFACTOR_REPORT.md
@@ -1,0 +1,135 @@
+# ROSClaw Data Flywheel 重构实施报告
+
+- 日期：2026-08-14
+- 依据：《当前 rosclaw seekdb 情况》+《ROSClaw SeekDB-Centric Data Flywheel 重构实施总纲 v1》
+- Baseline commit：`cfa671ad3510b7b0a53cb02cc0c98a394c59ea04`（main 同步点）
+- Baseline 测试：6831 collected（39 deselected）；31 failed / 10 errors 全部为环境预置
+  （venv 缺 `rosclaw_know` 包、agentd/firstboot/readme 的 PATH 依赖等，均在未改动的
+  main 上逐名复现）
+
+## 1. PR 序列与状态
+
+| PR | 分支 | 内容 | 验证 |
+|---|---|---|---|
+| #344 DF-00 | pr-df-00-architecture-freeze | ADR-0009/0010 + DATA_FLYWHEEL.md，零行为 | docs-only |
+| #345 DF-01 | pr-df-01-storage-naming | Storage 命名 12 组 canonical + identity 别名 | 别名恒等 7 项；全量套件逐名比对（1 个 mock 目标回归已修） |
+| #346 DF-02 | pr-df-02-config-v2 | Config v2 + normalize_legacy_config + 镜像 | 8 项新测试 |
+| #347 DF-03 | pr-df-03-dataplane-context | DataPlaneContext 单次装配、逐项故障隔离 | 4 项新测试；335 套件绿 |
+| #348 DF-04 | pr-df-04-practice-facts | EpisodeFactExtractor/PracticeFactIngestor + close 时 verify→extract→ingest | 4 项；practice 194 绿 |
+| #349 DF-05 | pr-df-05-memory-write-path | Critic → MemoryItem(WriteGate→Repository) 主写链 | 4 项；529 套件绿 |
+| #350 DF-06 | pr-df-06-memory-migrate | `rosclaw memory migrate`（真实库实证幂等 11→0） | 2 项 |
+| #352 DF-07 | pr-df-07-retrieval-projection | 检索投影装配 + target 过滤 worker + lag 可观测 | 5 项；511 套件绿 |
+| #353 DF-08 | pr-df-08-recovery-loop | RecoveryLoop 入 Runtime 生命周期 | 3 项；239 绿 |
+| #354 DF-09 | pr-df-09-knowledge-consolidation | knowledge canonical + legacy shim + 联邦坐标 | 4 项 |
+| #355 DF-10 | pr-df-10-knowledge-feedback | KnowledgeUsageTracker 保守自动反馈 | 5 项 |
+| #356 DF-11 | pr-df-11-memory-insight | MemoryInsightService（insight 生产者） | 5 项；342 绿 |
+| #359 DF-12 | pr-df-12-evolution-repository | EvolutionRepository，LocalStore 降级 spool | 7 项；414 绿 |
+| #360 DF-13 | pr-df-13-darwin-runtime | Darwin 入 Runtime（默认关） | 2 项 |
+| #361 DF-14 | pr-df-14-receipt-lineage | execution_receipts + lineage_edges + LineageRepository + ReceiptProjector | 5 项；349 绿 |
+| #362 DF-15 | pr-df-15-observability | doctor 飞轮检查 + /api/data-flywheel + 全栈 ruff 清零 | 5 项；443 绿 |
+
+分支为栈式叠加（每个 PR 的 base 是前一个分支）；按序合并即可，或全部合并后
+统一 rebase 到 main。git transport 不稳定期间，DF-01 修复、DF-07、DF-12、DF-13、
+DF-15 经 Git Data API 推送，内容与本地的对应提交一致。
+
+## 2. Canonical naming mapping（落地版）
+
+见 ADR-0010 表。落地情况：`StructuredStore`/`InMemoryStructuredStore`/
+`SQLiteStructuredStore`/`SeekDBSQLStore`/`ROSCLAW_STRUCTURED_SCHEMAS`/
+`StoreFactory.create_structured_store`/`SeekDBRetrievalStore`(+Embedded/Server)/
+`MemoryRetrievalProjection`(+Committer)/`EpisodeFactExtractor`/`EpisodeFactBundle`/
+`PracticeFactIngestor` —— 全部 canonical 为真实定义，旧名 identity 别名，
+`tests/storage/test_structured_naming.py` 逐项钉死。
+
+`rosclaw.knowledge` canonical、`rosclaw.know` 标记 DEPRECATED shim、
+`rosclaw.knowledge.legacy` 再导出（`LegacyKnowledgeRuntime`）。`rosclaw.evolution`
+获得 `repository.py`；`rosclaw.auto` 未动（orchestrator 迁移留给 DF-16）。
+
+## 3. 新 Data Plane 架构
+
+```
+Runtime._create_data_plane()  (一次)
+  └─ DataPlaneContext
+      ├─ structured_store   SQLite(边缘) / SeekDB SQL(生产) / InMemory(测试)
+      ├─ retrieval_store    SeekDB Native（retrieval 启用且 structured=SQLite 时）
+      ├─ memory_projection  MemoryRetrievalProjection（注入 DF-05 的 Repository）
+      ├─ memory_retrieval   RetrievalFacade（PR-MEM-5 已有）
+      ├─ outbox             OutboxStore（启用时）
+      └─ practice_sink      SeekDBBridge（HTTP，配置时）
+
+Runtime 装配（全部 best-effort、stop 时逆序卸载）：
+  MemoryRepository+WriteGate (DF-05) · RecoveryLoop (DF-08) ·
+  KnowledgeUsageTracker (DF-10) · MemoryInsightService (DF-11) ·
+  ReceiptProjector+LineageRepository (DF-14) · DarwinPlugin (DF-13)
+```
+
+## 4. Config migration
+
+`normalize_legacy_config()`：`runtime.seekdb_backend/url/path`、`memory.backend`、
+`storage.vector_enabled`、`know`、`auto` → canonical section，每条一次性
+`DEPRECATED CONFIG` 警告；canonical 值镜像回 legacy 键，DF-03 前的读者零影响。
+structured 默认路径未动（`~/.rosclaw/data/memory/knowledge.sqlite`）——路径迁移
+需要带数据搬运的独立 PR。
+
+## 5. DB/schema migration
+
+新增表：`evolution_records`（DF-12）、`execution_receipts`（DF-14 §21）、
+`lineage_edges`（DF-14 §36）。`rosclaw memory migrate`（DF-06）完成
+experience_graph → memory_items 迁移，本机真实库实证幂等。
+
+## 6-15. 各管线落地
+
+- **Practice**：close 时 `verify → extract → ingest` 一条链；verify 可观测不阻塞（DF-04）。
+- **Memory**：Critic 判决走 WriteGate→Repository 主写，experience_graph 降为兼容投影（DF-05）；
+  迁移 CLI（DF-06）。
+- **Retrieval**：投影注入 Repository，outbox target 过滤 worker，status/lag/doctor（DF-07/15）。
+- **How**：RecoveryLoop 订阅/退订入 Runtime（DF-08）；物理验证门原样保留。
+- **Knowledge**：联邦坐标实传（DF-09）；UsageTracker 保守反馈（DF-10）。
+- **Insight→Evolution**：publisher 落地，载荷兼容 Auto 现读字段（DF-11）。
+- **Evolution**：EvolutionRepository 结构化权威 + spool（DF-12）。
+- **Darwin**：入 Runtime，默认关（DF-13）。
+- **Lineage**：link/parents/children/ancestors/descendants/trace + ReceiptProjector 自动连边（DF-14）。
+
+## 16. 向后兼容
+
+全部旧类名/配置键/CLI 命令可用；identity 别名有测试钉死；`rosclaw know`/
+`rosclaw auto` CLI 未动；`local` storage_backend 默认不变（standalone 零影响）。
+
+## 17-18. Tests / E2E evidence
+
+新增测试 60+ 项分布各 PR。覆盖的 E2E 要素：幂等重放（DF-05/06）、
+store  outage 降级（DF-03/12/14）、恢复学习门（DF-08 沿用既有物理验证测试）、
+保守反馈判定（DF-10）、跨本体安全沿用 MEM-6/HOW-3 的既有 regime/purpose 测试。
+
+## 19. SeekDB outage evidence
+
+`test_runtime_survives_structured_store_failure`（DF-03）、
+`test_store_down_falls_back_to_spool`（DF-12）、
+`test_receipt_projector_failure_never_raises`（DF-14）、
+`test_doctor_survives_dead_store`（DF-15）。
+
+## 20. 已知限制
+
+- Evolution 实体（proposal/patch/experiment/evaluation/champion）尚未自动写入
+  lineage_edges——目前只有 receipt→action 边由 ReceiptProjector 自动产生；
+  验收六问之六需要 Evolution 侧 link 调用（小增量，见后续建议）。
+- Retrieval projection 的 outbox 路径与 practice bridge 共享 OutboxStore 但各自
+  target 过滤；真正多 sink 的 RoutingCommitter 未做（暂不需要）。
+- DF-16（物理迁移 know/auto/memory.v2 目录）按总纲纪律刻意未做——行为主线刚收敛，
+  物理移动应在合并后独立 PR 进行。
+- `tests/knowledge/test_contracts.py` 在本 venv 因缺 `rosclaw_know` 包无法收集
+  （预置环境问题）。
+
+## 21. 尚未完成项目
+
+- DF-16 物理迁移与 deprecated 清理。
+- Evolution→lineage 自动连边。
+- Dashboard Data Flywheel 的可视化页面（当前为 JSON 端点）。
+- Config v2 在 RuntimeConfig 层的完整消费（当前经镜像键兼容）。
+
+## 22. 后续建议
+
+1. 按栈序合并 #344..#362；合并后跑全量套件 + `rosclaw db doctor`。
+2. 合并后立即做 DF-16（窗口期最短，避免兼容层长期滞留）。
+3. Evolution 实体的 lineage 自动连边 + `rosclaw data lineage champion:<id>` CLI。
+4. 在 7×24 stress rig 上开启 retrieval 投影观察 lag 一周，再考虑默认启用。

--- a/src/rosclaw/auto/engine/auto_engine.py
+++ b/src/rosclaw/auto/engine/auto_engine.py
@@ -53,7 +53,18 @@ class AutoEngine:
                 self._auto_context_adapter = AutoContextAdapter(sense_runtime)
             except Exception:
                 pass
-        self.store = LocalStore(self.config.local_store_path)
+        # PR-DF-12 (flywheel §32): the Structured Store is the Evolution
+        # source of truth when one is injected; LocalStore degrades to
+        # cache/offline spool.  storage_backend="local" keeps the legacy
+        # single-file behavior (standalone users without a data plane).
+        if self._seekdb is not None and self.config.storage_backend in ("seekdb", "hybrid"):
+            from rosclaw.evolution.repository import EvolutionRepository
+
+            self.store = EvolutionRepository(
+                self._seekdb, LocalStore(self.config.local_store_path)
+            )
+        else:
+            self.store = LocalStore(self.config.local_store_path)
         # Sprint C: runners
         runner_backend = self.config.runner_backend
         self.local_runner = LocalRunner({"backend": runner_backend, "latency_sec": 0.01})

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -5029,6 +5029,7 @@ def cmd_memory_ingest(args: argparse.Namespace) -> int:
     print(f"Events:        {result.get('event_count')}")
     print(f"Outcome:       {result.get('outcome')}")
     print("=" * 60)
+    return 0
 
 
 def cmd_memory_migrate(args: argparse.Namespace) -> int:
@@ -5061,7 +5062,6 @@ def cmd_memory_migrate(args: argparse.Namespace) -> int:
         print(f"Deduplicated:  {stats['deduplicated']}")
         print(f"Skipped:       {stats['skipped']}")
         print("=" * 60)
-    return 0
     return 0
 
 

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -3288,14 +3288,14 @@ def cmd_practice_verify_data(args: argparse.Namespace) -> int:
 
 def cmd_practice_distill(args: argparse.Namespace) -> int:
     """Distill raw practice events into knowledge artifacts."""
-    from rosclaw.practice.distiller import PracticeDistiller
+    from rosclaw.practice.distiller import EpisodeFactExtractor
 
     data_root = resolve_practice_data_root(getattr(args, "data_root", None))
     practice_id = args.practice_id
     body_id = getattr(args, "body_id", None)
     write_artifacts = not getattr(args, "no_artifacts", False)
 
-    distiller = PracticeDistiller(data_root)
+    distiller = EpisodeFactExtractor(data_root)
     try:
         result = distiller.distill(practice_id, body_id=body_id, write_artifacts=write_artifacts)
     except ValueError as e:
@@ -3330,14 +3330,14 @@ def cmd_practice_distill(args: argparse.Namespace) -> int:
 
 def cmd_practice_ingest_seekdb(args: argparse.Namespace) -> int:
     """Ingest a distilled practice session into SeekDB."""
-    from rosclaw.practice.seekdb_ingestor import SeekDBIngestor
+    from rosclaw.practice.seekdb_ingestor import PracticeFactIngestor
 
     data_root = resolve_practice_data_root(getattr(args, "data_root", None))
     practice_id = args.practice_id
 
     try:
         client = _practice_seekdb_client(args)
-        ingestor = SeekDBIngestor(data_root, seekdb_client=client)
+        ingestor = PracticeFactIngestor(data_root, seekdb_client=client)
     except Exception as e:
         print(f"[rosclaw-practice] SeekDB connection failed: {e}", file=sys.stderr)
         return 1
@@ -5029,6 +5029,39 @@ def cmd_memory_ingest(args: argparse.Namespace) -> int:
     print(f"Events:        {result.get('event_count')}")
     print(f"Outcome:       {result.get('outcome')}")
     print("=" * 60)
+
+
+def cmd_memory_migrate(args: argparse.Namespace) -> int:
+    """Migrate legacy ``experience_graph`` rows into typed memory items (PR-DF-06).
+
+    Delegates to :meth:`MemoryRepository.migrate_experience_graph`, which is
+    idempotent by content-hash dedup — rerunning never duplicates.
+    """
+    from rosclaw.memory.seekdb_client import SQLiteStructuredStore
+    from rosclaw.memory.v2.repository import MemoryRepository
+
+    db_path = _memory_db_path()
+    if not db_path.exists():
+        print(f"[ROSClaw] Memory database not found: {db_path}", file=sys.stderr)
+        return 1
+    store = SQLiteStructuredStore(str(db_path))
+    store.connect()
+    try:
+        stats = MemoryRepository(store).migrate_experience_graph(limit=args.limit)
+    finally:
+        store.disconnect()
+    if getattr(args, "json", False):
+        print(json.dumps({"from": args.migrate_from, **stats}, indent=2))
+    else:
+        print("=" * 60)
+        print("ROSClaw Memory — Legacy Migration (experience_graph -> memory_items)")
+        print("=" * 60)
+        print(f"Scanned:       {stats['scanned']}")
+        print(f"Migrated:      {stats['migrated']}")
+        print(f"Deduplicated:  {stats['deduplicated']}")
+        print(f"Skipped:       {stats['skipped']}")
+        print("=" * 60)
+    return 0
     return 0
 
 
@@ -8199,6 +8232,22 @@ def main() -> int:
     memory_ingest_parser.add_argument("--episode-id", required=True, help="Episode identifier")
     _add_practice_data_root_argument(memory_ingest_parser)
 
+    # PR-DF-06 (flywheel §15 Phase B): legacy store -> memory_items migration
+    memory_migrate_parser = memory_subparsers.add_parser(
+        "migrate", help="Migrate legacy memory tables into memory_items (idempotent)"
+    )
+    memory_migrate_parser.add_argument(
+        "--from",
+        dest="migrate_from",
+        choices=["experience_graph"],
+        default="experience_graph",
+        help="Legacy table to migrate from",
+    )
+    memory_migrate_parser.add_argument(
+        "--limit", type=int, default=10_000, help="Max legacy rows to scan"
+    )
+    memory_migrate_parser.add_argument("--json", action="store_true", help="JSON output")
+
     # acceptance subcommand (Evo-RPS hardware self-evolution, PR-EVO-HW-1)
     from rosclaw.evolution.hardware.cli import (
         cmd_acceptance_evo_rps_baseline,
@@ -9159,6 +9208,8 @@ def main() -> int:
                 return cmd_memory_explain(args)
             elif args.memory_command == "ingest":
                 return cmd_memory_ingest(args)
+            elif args.memory_command == "migrate":
+                return cmd_memory_migrate(args)
             else:
                 memory_parser.print_help()
                 return 1

--- a/src/rosclaw/core/event_topics.py
+++ b/src/rosclaw/core/event_topics.py
@@ -76,6 +76,12 @@ class EventTopics:
     # ── Memory ──
     MEMORY_EXPERIENCE_STORED = "rosclaw.memory.experience.stored"
     MEMORY_WRITE_COMPLETED = "rosclaw.memory.write.completed"
+    # PR-DF-11 (flywheel §25-26): typed insight feed consumed by Auto.
+    MEMORY_INSIGHT_CREATED = "rosclaw.memory.insight"
+
+    # ── Receipts (PR-DF-14, §21/§42) ──
+    ACTION_RECEIPT = "rosclaw.runtime.action.receipt"  # kernel gateway publication
+    RECEIPT_VERIFIED = "rosclaw.receipt.verified"
 
     # ── How / Recovery ──
     HOW_RECOVERY_HINT_GENERATED = "rosclaw.how.recovery_hint.generated"

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -87,6 +87,10 @@ class RuntimeConfig:
     enable_skill_manager: bool = True
     enable_knowledge: bool = True  # KnowledgeInterface (KNOW module)
     enable_how: bool = True  # HeuristicEngine (HOW module)
+    # PR-DF-08 (flywheel §23): wire the RecoveryLoop into the Runtime
+    # lifecycle.  The loop only learns from verified physics outcomes;
+    # REAL recovery still flows through the full gateway path (§24).
+    enable_recovery_loop: bool = True
     # Versioned Know/How integration. ``disabled`` preserves the legacy
     # adapters as a rollback path; v2 never receives Memory's store.
     knowledge_v2_mode: str = field(
@@ -104,6 +108,10 @@ class RuntimeConfig:
         default_factory=lambda: os.environ.get("ROSCLAW_KNOW_SEEKDB_PATH")
     )
     enable_auto: bool = True  # Self-Evolution Control Plane (AUTO module)
+    # PR-DF-13 (flywheel §39): Darwin evaluation pressure as a first-class
+    # Runtime module.  Off by default — benchmarks are expensive.
+    enable_darwin: bool = False
+    darwin: dict[str, Any] = field(default_factory=dict)  # seeds / episodes
     enable_provider: bool = True
     joint_dof: int = 6
     sampling_rate_hz: int = 1000
@@ -222,6 +230,16 @@ class Runtime(LifecycleMixin):
         self._episode_recorder: Any | None = None
         self._sandbox_practice_bridge: Any | None = None
         self._seekdb_bridge: Any | None = None
+        self._data_plane: Any | None = None  # DataPlaneContext (PR-DF-03)
+        self._memory_repository: Any | None = None  # Memory v2 canonical (PR-DF-05)
+        self._memory_gate: Any | None = None
+        self._projection_worker: Any | None = None  # PR-DF-07
+        self._recovery_loop: Any | None = None  # PR-DF-08
+        self._knowledge_usage_tracker: Any | None = None  # PR-DF-10
+        self._memory_insights: Any | None = None  # PR-DF-11
+        self._darwin: Any | None = None  # PR-DF-13
+        self._lineage: Any | None = None  # PR-DF-14
+        self._receipt_projector: Any | None = None
         self._mcp_drivers: dict[str, Any] = {}
         self._emergency_stop_receipts: dict[str, Any] = {}
         self._emergency_stop_latched = False
@@ -264,9 +282,17 @@ class Runtime(LifecycleMixin):
             else Path(self.config.timeline_output_dir).expanduser().resolve()
         )
 
+        # PR-DF-03 (ADR-0009 §2): the data plane is assembled exactly once.
+        # Modules receive their parts from the context by dependency
+        # injection; the bare ``seekdb`` local below is kept ONLY so the
+        # pre-DF-03 call sites in this method stay readable, and always
+        # points at ``data_plane.structured_store``.
+        data_plane = self._create_data_plane(workspace_home)
+        self._data_plane = data_plane
+
         # Legacy store shared by Memory, Auto, SkillManager, and rollback-only
         # Know/How adapters. Know/How v2 never receives this object.
-        seekdb: Any | None = None
+        seekdb: Any | None = data_plane.structured_store
 
         # Initialize EventBus subscriptions for internal coordination
         self._setup_internal_subscriptions()
@@ -387,26 +413,7 @@ class Runtime(LifecycleMixin):
             try:
                 from rosclaw.memory.interface import MemoryInterface
 
-                seekdb = self._create_seekdb_client()
-                retrieval_facade = None
-                try:
-                    # PR-MEM-5: unified retrieval facade — the canonical
-                    # ACTIVE index serves Memory/KNOW/HOW queries when the
-                    # knowledge backend is native SeekDB; the SQLite store
-                    # is the declared lexical fallback.  Construction never
-                    # loads model weights and never fails memory init.
-                    from rosclaw.memory.seekdb_client import SQLiteStructuredStore
-                    from rosclaw.memory.v2.runtime_retrieval import build_retrieval_facade
-                    from rosclaw.storage.seekdb_native import SeekDBRetrievalStore
-
-                    native = seekdb if isinstance(seekdb, SeekDBRetrievalStore) else None
-                    sqlite = seekdb if isinstance(seekdb, SQLiteStructuredStore) else None
-                    if native is not None or sqlite is not None:
-                        retrieval_facade = build_retrieval_facade(
-                            native_store=native, sqlite_store=sqlite
-                        )
-                except Exception as facade_exc:  # noqa: BLE001
-                    logger.info("Retrieval facade not available: %s", facade_exc)
+                retrieval_facade = data_plane.memory_retrieval
                 self._memory = MemoryInterface(
                     robot_id=self.config.robot_id,
                     event_bus=self.event_bus,
@@ -414,6 +421,24 @@ class Runtime(LifecycleMixin):
                     embodied_memory=self.config.embodied_memory,
                     retrieval_facade=retrieval_facade,
                 )
+                # PR-DF-05 (flywheel §12-14): the canonical Memory write path
+                # — MemoryItem -> WriteGate -> Repository over the SAME
+                # structured store.  Built once here; failures degrade to the
+                # legacy experience_graph projection only.
+                self._memory_repository = None
+                self._memory_gate = None
+                try:
+                    from rosclaw.memory.v2.gate import MemoryWriteGate
+                    from rosclaw.memory.v2.repository import MemoryRepository
+
+                    if data_plane.structured_store is not None:
+                        self._memory_repository = MemoryRepository(
+                            data_plane.structured_store,
+                            projection=data_plane.memory_projection,
+                        )
+                        self._memory_gate = MemoryWriteGate(self._memory_repository)
+                except Exception as gate_exc:  # noqa: BLE001
+                    logger.info("Memory canonical write path unavailable: %s", gate_exc)
                 self._modules.append(self._memory)
                 if self._sense is not None:
                     self._memory.set_sense_runtime(self._sense)
@@ -438,47 +463,8 @@ class Runtime(LifecycleMixin):
             except ImportError as e:
                 logger.info(f"UnifiedTimeline not available: {e}")
 
-            # Optional SeekDB bridge for practice event persistence
-            self._seekdb_bridge = None
-            http_url = self.config.seekdb_http_url
-            if http_url:
-                try:
-                    from rosclaw.practice.seekdb_bridge import SeekDBBridge
-                    from rosclaw.storage.outbox import OutboxStore
-
-                    outbox_enabled = self.config.storage.get("outbox_enabled", False)
-                    if outbox_enabled:
-                        outbox_path = self.config.storage.get(
-                            "outbox_path",
-                            str(workspace_home / "storage" / "outbox.sqlite"),
-                        )
-                        outbox = OutboxStore(
-                            db_path=outbox_path,
-                            max_records=self.config.storage.get("outbox_max_records", 100_000),
-                        )
-                        outbox.connect()
-                        self._seekdb_bridge = SeekDBBridge(
-                            seekdb_url=http_url,
-                            fallback_dir=self.config.seekdb_fallback_dir,
-                            outbox=outbox,
-                        )
-                        # Bridge owns the worker when only outbox is passed.
-                        logger.info(
-                            "SeekDBBridge initialized at %s with outbox (%s)",
-                            http_url,
-                            outbox_path,
-                        )
-                    else:
-                        self._seekdb_bridge = SeekDBBridge(
-                            seekdb_url=http_url,
-                            fallback_dir=self.config.seekdb_fallback_dir,
-                        )
-                        logger.info("SeekDBBridge initialized at %s", http_url)
-                except ImportError as e:
-                    logger.info(f"rosclaw_practice not installed, SeekDB integration disabled: {e}")
-                except Exception as e:
-                    logger.warning(f"SeekDBBridge initialization failed: {e}")
-
+            # Practice event sink + outbox come from the data plane (PR-DF-03).
+            self._seekdb_bridge = data_plane.practice_sink
             seekdb_bridge = self._seekdb_bridge
 
             # Initialize EpisodeRecorder for artifact management
@@ -569,6 +555,21 @@ class Runtime(LifecycleMixin):
                 know_path = self.config.know_store_path or str(
                     workspace_home / "data" / "know" / "seekdb"
                 )
+                # PR-DF-09 (flywheel §28): Knowledge keeps its own logical
+                # store, but the federation coordinates are now actually
+                # passed — shared ID/lineage/evidence references resolve
+                # against the Runtime's data plane instead of env defaults.
+                federation: dict[str, Any] = {}
+                if self._data_plane is not None and self._data_plane.structured_store is not None:
+                    federation["memory_path"] = self.config.seekdb_path
+                    dsn = self.config.seekdb_url
+                    if dsn:
+                        from urllib.parse import urlparse
+
+                        db = urlparse(str(dsn)).path.lstrip("/")
+                        if db:
+                            federation["memory_database"] = db
+                federation["practice_path"] = str(workspace_home / "data" / "practice")
                 service_config = KnowledgeServiceConfig(
                     mode=v2_mode,
                     know_url=self.config.know_url,
@@ -578,14 +579,27 @@ class Runtime(LifecycleMixin):
                     timeout=self.config.knowledge_timeout,
                     know_store_mode=self.config.know_store_mode,
                     know_store_path=know_path,
+                    **federation,
                 )
                 self._knowledge_v2_manager = KnowledgeServiceManager(service_config)
                 self._knowledge_v2 = KnowledgeFacade(
                     self._knowledge_v2_manager, event_bus=self.event_bus
                 )
+                # PR-DF-10 (flywheel §29-31): automatic ReferencePack → Advice
+                # → Receipt → Feedback loop; conservative verdicts only.
+                try:
+                    from rosclaw.knowledge.usage_tracker import KnowledgeUsageTracker
+
+                    self._knowledge_usage_tracker = KnowledgeUsageTracker(
+                        self.event_bus, self._knowledge_v2
+                    )
+                    self._knowledge_usage_tracker.subscribe()
+                except Exception as track_exc:  # noqa: BLE001
+                    logger.info("Knowledge usage tracker unavailable: %s", track_exc)
                 logger.info(
-                    "Knowledge v2 orchestration initialized (mode=%s, memory_store_shared=false)",
+                    "Knowledge v2 orchestration initialized (mode=%s, federation=%s)",
                     v2_mode,
+                    sorted(federation),
                 )
             except Exception as exc:  # noqa: BLE001 - optional integration
                 logger.warning("Knowledge v2 initialization degraded: %s", exc)
@@ -657,6 +671,47 @@ class Runtime(LifecycleMixin):
             except Exception as e:  # noqa: BLE001
                 logger.info(f"Heuristic grounding not available: {e}")
 
+        # PR-DF-11 (flywheel §25-27): the publisher half of
+        # rosclaw.memory.insight — recurring failures with proven recoveries
+        # become typed insights that Auto turns into memory-guided Proposals.
+        self._memory_insights = None
+        if self._memory is not None and data_plane.structured_store is not None:
+            try:
+                from rosclaw.memory.insights import MemoryInsightService
+
+                self._memory_insights = MemoryInsightService(
+                    self.event_bus,
+                    data_plane.structured_store,
+                    robot_id=self.config.robot_id,
+                    failure_threshold=int(self.config.auto.get("trigger_failure_threshold", 3))
+                    if isinstance(getattr(self.config, "auto", None), dict)
+                    else 3,
+                )
+                self._memory_insights.subscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.info("MemoryInsightService not available: %s", exc)
+
+        # PR-DF-08 (flywheel §23): the RecoveryLoop closes
+        # failure → hint → retry → VERIFIED physics outcome → rule efficacy.
+        # It only learns — it never dispatches motion, and REAL recovery
+        # proposals still re-enter through the ActionGateway/permit path
+        # (§24), so the safety control plane is never bypassed.
+        self._recovery_loop = None
+        if (
+            self.config.enable_how
+            and self.config.enable_recovery_loop
+            and self._memory is not None
+            and self._how is not None
+        ):
+            try:
+                from rosclaw.how.recovery_loop import RecoveryLoop
+
+                self._recovery_loop = RecoveryLoop(self.event_bus, self._memory, self._how)
+                self._recovery_loop.subscribe()
+                logger.info("RecoveryLoop subscribed (How recovery learning active)")
+            except Exception as exc:  # noqa: BLE001
+                logger.info("RecoveryLoop not available: %s", exc)
+
         # Initialize Auto Self-Evolution Control Plane
         if self.config.enable_auto:
             try:
@@ -665,8 +720,18 @@ class Runtime(LifecycleMixin):
                 # Reuse Memory's SeekDB client if available
                 if self._memory is not None:
                     seekdb = getattr(self._memory, "seekdb_client", None)
+                # PR-DF-12: with a data plane present, Evolution state goes
+                # to the structured store (LocalStore becomes its spool).
+                auto_storage = (
+                    "hybrid"
+                    if self._data_plane is not None and self._data_plane.structured_store is not None
+                    else "local"
+                )
                 self._auto = AutoPlugin(
-                    config={"local_store_path": str(workspace_home / "data" / "auto")},
+                    config={
+                        "local_store_path": str(workspace_home / "data" / "auto"),
+                        "storage_backend": auto_storage,
+                    },
                     event_bus=self.event_bus,
                     seekdb_client=seekdb,
                     skill_registry=getattr(self._skill_manager, "registry", None)
@@ -678,6 +743,34 @@ class Runtime(LifecycleMixin):
                 logger.info("Self-Evolution Control Plane (Auto) initialized")
             except ImportError as e:
                 logger.info(f"Auto module not available: {e}")
+
+        # PR-DF-13 (flywheel §39-40): Darwin enters the Runtime lifecycle,
+        # sharing the event bus and the data plane's structured store so
+        # Evolution experiments land as darwin_benchmarks rows with full
+        # provenance.  Off by default.
+        self._darwin = None
+        if self.config.enable_darwin:
+            try:
+                from rosclaw.darwin.plugin import DarwinPlugin
+
+                self._darwin = DarwinPlugin(
+                    config={
+                        "default_seeds": self.config.darwin.get("seeds", [0, 1, 2])
+                        if isinstance(getattr(self.config, "darwin", None), dict)
+                        else [0, 1, 2],
+                        "default_episodes": self.config.darwin.get("episodes", 50)
+                        if isinstance(getattr(self.config, "darwin", None), dict)
+                        else 50,
+                    }
+                    if isinstance(getattr(self.config, "darwin", None), dict)
+                    else {},
+                    event_bus=self.event_bus,
+                    seekdb_client=data_plane.structured_store,
+                )
+                self._modules.append(self._darwin)
+                logger.info("Darwin evaluation plane initialized")
+            except ImportError as e:
+                logger.info(f"Darwin module not available: {e}")
 
         # Initialize Provider Layer (Capability Router + Guard)
         if self.config.enable_provider and ProviderRegistry is not None:
@@ -728,6 +821,152 @@ class Runtime(LifecycleMixin):
             )
 
         logger.info("Initialization complete")
+
+    def _create_data_plane(self, workspace_home: Any) -> Any:
+        """Assemble the :class:`DataPlaneContext` exactly once (PR-DF-03).
+
+        Every piece is best-effort: a data-plane failure must never take the
+        robot down (ADR-0009 §4) — the affected field stays None and the
+        corresponding module degrades exactly as it did before this context
+        existed.
+        """
+        from rosclaw.storage.context import DataPlaneContext
+
+        ctx = DataPlaneContext()
+        try:
+            ctx.structured_store = self._create_seekdb_client()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Data plane: structured store unavailable: %s", exc)
+        store = ctx.structured_store
+        if store is not None:
+            try:
+                # PR-MEM-5: unified retrieval facade — the canonical ACTIVE
+                # index serves Memory/KNOW/HOW queries when the knowledge
+                # backend is native SeekDB; the SQLite store is the declared
+                # lexical fallback.  Construction never loads model weights
+                # and never fails memory init.
+                from rosclaw.memory.seekdb_client import SQLiteStructuredStore
+                from rosclaw.memory.v2.runtime_retrieval import build_retrieval_facade
+                from rosclaw.storage.seekdb_native import SeekDBRetrievalStore
+
+                if isinstance(store, SeekDBRetrievalStore):
+                    ctx.retrieval_store = store
+                sqlite = store if isinstance(store, SQLiteStructuredStore) else None
+                if ctx.retrieval_store is not None or sqlite is not None:
+                    ctx.memory_retrieval = build_retrieval_facade(
+                        native_store=ctx.retrieval_store, sqlite_store=sqlite
+                    )
+            except Exception as facade_exc:  # noqa: BLE001
+                logger.info("Retrieval facade not available: %s", facade_exc)
+            # PR-DF-07 (flywheel §17-18): when the structured store is the
+            # SQLite source of truth and a retrieval backend is configured,
+            # maintain the native SeekDB retrieval projection of
+            # memory_items — rebuildable, never the source of truth.  All
+            # best-effort: a missing pyseekdb or a dead native store leaves
+            # the fields None and changes nothing else.
+            try:
+                storage_cfg = self.config.storage or {}
+                retrieval_cfg = storage_cfg.get("retrieval", {})
+                retrieval_enabled = retrieval_cfg.get(
+                    "enabled", storage_cfg.get("vector_enabled", False)
+                )
+                from rosclaw.memory.seekdb_client import SQLiteStructuredStore as _SQLite
+
+                if retrieval_enabled and isinstance(store, _SQLite):
+                    from rosclaw.storage.seekdb_native import SeekDBEmbeddedRetrievalStore
+                    from rosclaw.storage.seekdb_projection import (
+                        MemoryRetrievalProjection,
+                        MemoryRetrievalProjectionCommitter,
+                    )
+
+                    native_path = retrieval_cfg.get("path") or str(
+                        workspace_home / "data" / "seekdb"
+                    )
+                    ctx.retrieval_store = SeekDBEmbeddedRetrievalStore(path=native_path)
+                    projection_outbox = ctx.outbox
+                    if projection_outbox is not None:
+                        # Target-filtered worker: drains ONLY projection
+                        # records off the shared outbox (the practice
+                        # bridge's worker owns its own target), so the two
+                        # pipelines never race each other's rows.
+                        from rosclaw.storage.outbox import OutboxWorker
+
+                        self._projection_worker = OutboxWorker(
+                            projection_outbox,
+                            MemoryRetrievalProjectionCommitter(ctx.retrieval_store),
+                            target="seekdb_projection",
+                            name="memory-projection-worker",
+                            interval_sec=float(
+                                storage_cfg.get("outbox", {}).get(
+                                    "flush_interval_sec",
+                                    storage_cfg.get("outbox_flush_interval_sec", 5.0),
+                                )
+                            ),
+                        )
+                        self._projection_worker.start()
+                    ctx.memory_projection = MemoryRetrievalProjection(
+                        ctx.retrieval_store, outbox=projection_outbox
+                    )
+                    logger.info(
+                        "Memory retrieval projection: native SeekDB at %s (outbox=%s)",
+                        native_path,
+                        projection_outbox is not None,
+                    )
+            except Exception as proj_exc:  # noqa: BLE001
+                logger.info("Memory retrieval projection not available: %s", proj_exc)
+        # PR-DF-14 (flywheel §21/§36): receipt projection + lineage graph.
+        # Async index only — the authorization path never consults it.
+        try:
+            from rosclaw.storage.lineage import LineageRepository
+            from rosclaw.storage.receipts import ReceiptProjector
+
+            if ctx.structured_store is not None:
+                self._lineage = LineageRepository(ctx.structured_store)
+                self._receipt_projector = ReceiptProjector(
+                    self.event_bus, ctx.structured_store, lineage=self._lineage
+                )
+                self._receipt_projector.subscribe()
+        except Exception as exc:  # noqa: BLE001
+            logger.info("Receipt projection unavailable: %s", exc)
+        http_url = self.config.seekdb_http_url
+        if http_url:
+            try:
+                from rosclaw.practice.seekdb_bridge import SeekDBBridge
+                from rosclaw.storage.outbox import OutboxStore
+
+                outbox_enabled = self.config.storage.get("outbox_enabled", False)
+                if outbox_enabled:
+                    outbox_path = self.config.storage.get(
+                        "outbox_path",
+                        str(workspace_home / "storage" / "outbox.sqlite"),
+                    )
+                    ctx.outbox = OutboxStore(
+                        db_path=outbox_path,
+                        max_records=self.config.storage.get("outbox_max_records", 100_000),
+                    )
+                    ctx.outbox.connect()
+                    ctx.practice_sink = SeekDBBridge(
+                        seekdb_url=http_url,
+                        fallback_dir=self.config.seekdb_fallback_dir,
+                        outbox=ctx.outbox,
+                    )
+                    # Bridge owns the worker when only outbox is passed.
+                    logger.info(
+                        "SeekDBBridge initialized at %s with outbox (%s)",
+                        http_url,
+                        outbox_path,
+                    )
+                else:
+                    ctx.practice_sink = SeekDBBridge(
+                        seekdb_url=http_url,
+                        fallback_dir=self.config.seekdb_fallback_dir,
+                    )
+                    logger.info("SeekDBBridge initialized at %s", http_url)
+            except ImportError as e:
+                logger.info(f"rosclaw_practice not installed, SeekDB integration disabled: {e}")
+            except Exception as e:
+                logger.warning(f"SeekDBBridge initialization failed: {e}")
+        return ctx
 
     def _create_seekdb_client(self) -> Any:
         """Create the legacy Memory/Auto/Skill store (not the Know v2 store).
@@ -817,6 +1056,42 @@ class Runtime(LifecycleMixin):
         if self._event_sink is not None:
             self._event_sink.close()
             self._event_sink = None
+        # PR-DF-14: receipt projector off the bus.
+        if self._receipt_projector is not None:
+            try:
+                self._receipt_projector.unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("ReceiptProjector unsubscribe failed (non-fatal): %s", exc)
+            self._receipt_projector = None
+        # PR-DF-11: insight service off the bus.
+        if self._memory_insights is not None:
+            try:
+                self._memory_insights.unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("MemoryInsightService unsubscribe failed (non-fatal): %s", exc)
+            self._memory_insights = None
+        # PR-DF-10: usage tracker off the bus.
+        if self._knowledge_usage_tracker is not None:
+            try:
+                self._knowledge_usage_tracker.unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Usage tracker unsubscribe failed (non-fatal): %s", exc)
+            self._knowledge_usage_tracker = None
+        # PR-DF-08: RecoveryLoop off the bus first (no learning mid-shutdown).
+        if self._recovery_loop is not None:
+            try:
+                self._recovery_loop.unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("RecoveryLoop unsubscribe failed (non-fatal): %s", exc)
+            self._recovery_loop = None
+        # PR-DF-07: flush + stop the projection worker before the bridge.
+        if self._projection_worker is not None:
+            try:
+                self._projection_worker.flush(timeout=5.0)
+                self._projection_worker.stop()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Projection worker stop failed (non-fatal): %s", exc)
+            self._projection_worker = None
         # Close SeekDB bridge (and any owned outbox worker) before stopping modules.
         if self._seekdb_bridge is not None and hasattr(self._seekdb_bridge, "close"):
             try:
@@ -1053,6 +1328,19 @@ class Runtime(LifecycleMixin):
             if reason:
                 tags.append(reason.replace(" ", "_"))
 
+            # PR-DF-05: the canonical write — CriticJudgment becomes an
+            # evidence-backed MemoryItem through the WriteGate.  The legacy
+            # store_experience call below stays as the compatibility
+            # projection (Phase A of the experience_graph retirement, §15).
+            self._store_critic_memory_item(
+                episode_id=episode_id,
+                status=status,
+                reward=reward,
+                reason=reason,
+                skill_name=skill_name,
+                instruction=instruction,
+                tags=tags,
+            )
             self._memory.store_experience(
                 event_id=episode_id,
                 event_type="praxis",
@@ -1074,6 +1362,76 @@ class Runtime(LifecycleMixin):
             )
         except Exception as e:
             logger.info(f"Critic judgment Memory sync failed (non-fatal): {e}")
+
+    def _store_critic_memory_item(
+        self,
+        *,
+        episode_id: str,
+        status: str,
+        reward: float,
+        reason: str,
+        skill_name: str,
+        instruction: str,
+        tags: list[str],
+    ) -> str | None:
+        """Write one critic judgment as an evidence-backed MemoryItem (PR-DF-05 §14).
+
+        The WriteGate decides STORE/MERGE/UPDATE/IGNORE/QUARANTINE exactly as
+        the session distiller's candidates; application mirrors
+        ``distill_events``.  Idempotent: repository content-hash dedup makes
+        a repeated judgment a no-op.  Returns the memory_id or None.
+        """
+        if self._memory_gate is None or self._memory_repository is None:
+            return None
+        try:
+            from rosclaw.memory.v2.models import MemoryItem, MemoryType
+
+            failed = status != "SUCCESS"
+            memory_type = MemoryType.FAILURE.value if failed else MemoryType.EPISODIC.value
+            title = (
+                f"Critic: {skill_name} {status}"
+                + (f" — {reason}" if failed and reason else "")
+            )
+            document = (
+                f"Critic judgment for skill '{skill_name}' (robot {self.config.robot_id}): "
+                f"status={status} reward={reward}."
+                + (f" Reason: {reason}." if reason else "")
+                + (f" Instruction: {instruction}." if instruction else "")
+            )
+            item = MemoryItem(
+                memory_type=memory_type,
+                robot_id=self.config.robot_id,
+                title=title,
+                document=document,
+                episode_id=episode_id,
+                skill_id=skill_name if skill_name != "unknown" else None,
+                outcome=status,
+                reward=reward,
+                failure_type=(reason or None) if failed else None,
+                evidence_refs=[f"critic_result:{episode_id}"],
+                tags=list(tags),
+                metadata={
+                    "source_event_type": "critic_judgment",
+                    "evidence_type": "critic_result",
+                    "source": "runtime_critic",
+                },
+            )
+            decision = self._memory_gate.evaluate(item)
+            if decision.decision == "STORE":
+                return self._memory_repository.store(item)
+            if decision.decision == "MERGE" and decision.target_memory_id:
+                self._memory_repository.merge_into(decision.target_memory_id, item)
+                return decision.target_memory_id
+            if decision.decision == "UPDATE" and decision.target_memory_id:
+                self._memory_repository.supersede(decision.target_memory_id, item)
+                return decision.target_memory_id
+            if decision.decision == "QUARANTINE":
+                item.status = "quarantined"
+                return self._memory_repository.store(item)
+            return None  # IGNORE
+        except Exception as exc:  # noqa: BLE001 — memory write never breaks the loop
+            logger.info("Critic MemoryItem write failed (non-fatal): %s", exc)
+            return None
 
     def _on_agent_command(self, event: Event) -> None:
         """Handle agent commands - route to appropriate module."""

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -679,13 +679,16 @@ class Runtime(LifecycleMixin):
             try:
                 from rosclaw.memory.insights import MemoryInsightService
 
+                _auto_cfg = getattr(self.config, "auto", None)
                 self._memory_insights = MemoryInsightService(
                     self.event_bus,
                     data_plane.structured_store,
                     robot_id=self.config.robot_id,
-                    failure_threshold=int(self.config.auto.get("trigger_failure_threshold", 3))
-                    if isinstance(getattr(self.config, "auto", None), dict)
-                    else 3,
+                    failure_threshold=(
+                        int(_auto_cfg.get("trigger_failure_threshold", 3))
+                        if isinstance(_auto_cfg, dict)
+                        else 3
+                    ),
                 )
                 self._memory_insights.subscribe()
             except Exception as exc:  # noqa: BLE001

--- a/src/rosclaw/dashboard/web_server.py
+++ b/src/rosclaw/dashboard/web_server.py
@@ -522,6 +522,72 @@ class DashboardWebServer:
         async def snapshot() -> dict[str, Any]:
             return self.server.get_snapshot()
 
+        @self.app.get("/api/data-flywheel")
+        async def api_data_flywheel() -> dict[str, Any]:
+            """Data Flywheel observability (PR-DF-15 §44): one aggregate view
+            of the data plane — storage backends, memory/evolution/receipt/
+            lineage counts, outbox, retrieval projection lag.  All probes are
+            best-effort; a down database reports an error field, never a 500.
+            """
+            import argparse
+
+            from rosclaw.storage.cli import _load_storage_config, _projection_status
+            from rosclaw.storage.factory import StoreFactory
+
+            cfg = _load_storage_config(argparse.Namespace(backend=None, url=None, path=None))
+            result: dict[str, Any] = {"backend": cfg["backend"]}
+            client = None
+            try:
+                client = StoreFactory.create_structured_store(
+                    backend=cfg["backend"],
+                    url=cfg["url"],
+                    path=cfg["path"],
+                    pool_size=cfg["pool_size"],
+                )
+                client.connect()
+                result["structured_store_connected"] = True
+
+                def _count(table: str) -> int | None:
+                    try:
+                        return client.count(table)
+                    except Exception:  # noqa: BLE001
+                        return None
+
+                result["memory"] = {
+                    "items": _count("memory_items"),
+                    "evidence": _count("memory_evidence"),
+                }
+                result["evolution_records"] = _count("evolution_records")
+                result["execution_receipts"] = _count("execution_receipts")
+                result["lineage_edges"] = _count("lineage_edges")
+                result["auto_proposals"] = _count("auto_proposals")
+                result["darwin_benchmarks"] = _count("darwin_benchmarks")
+                try:
+                    proj = _projection_status(cfg, client)
+                except Exception as proj_exc:  # noqa: BLE001
+                    proj = {"error": str(proj_exc)}
+                if proj is not None:
+                    result["retrieval_projection"] = proj
+            except Exception as exc:  # noqa: BLE001
+                result["structured_store_connected"] = False
+                result["error"] = str(exc)
+            finally:
+                if client is not None:
+                    import contextlib
+
+                    with contextlib.suppress(Exception):
+                        client.disconnect()
+            if cfg.get("outbox_enabled"):
+                try:
+                    from rosclaw.storage.outbox import OutboxStore
+
+                    outbox = OutboxStore(db_path=cfg["outbox_path"])
+                    outbox.connect()
+                    result["outbox"] = outbox.stats()
+                except Exception as exc:  # noqa: BLE001
+                    result["outbox"] = {"error": str(exc)}
+            return result
+
         @self.app.get("/evolution/evo-rps/{experiment_id}")
         async def evolution_evo_rps_page(experiment_id: str) -> Any:
             from rosclaw.evolution.hardware.dashboard_data import (

--- a/src/rosclaw/evolution/repository.py
+++ b/src/rosclaw/evolution/repository.py
@@ -1,0 +1,121 @@
+"""EvolutionRepository (PR-DF-12 / flywheel §32-35).
+
+The Evolution module's canonical state lives in the Structured Store
+(``evolution_records`` table); the legacy ``LocalStore`` JSONL tree is
+demoted to a *cache / offline spool*:
+
+* ``save`` writes the structured store first, then mirrors into the cache;
+  if the store is down the record spools to the cache and the failure is
+  logged — never silently lost, never blocking the engine.
+* ``load`` / ``iterate`` / ``list_keys`` read the store first and fall
+  back to the cache, so an offline SeekDB/SQLite degrades to pre-DF-12
+  behavior (ADR-0009 §4).
+
+The repository deliberately implements the ``LocalStore`` interface
+(``save/load/list_keys/iterate/delete``) so ``AutoEngine`` swaps it in
+without internal changes.  Records are stored as
+``{id: "<namespace>:<key>", namespace, key, data, updated_at}`` — the data
+JSON keeps full provenance (trace/evidence/refs) written by the engine.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Iterator
+from typing import Any
+
+logger = logging.getLogger("rosclaw.evolution.repository")
+
+TABLE = "evolution_records"
+
+
+class EvolutionRepository:
+    """Structured-store-backed Evolution state with a LocalStore spool."""
+
+    def __init__(self, structured_store: Any, cache: Any) -> None:
+        self._store = structured_store
+        self._cache = cache  # LocalStore — cache / offline spool
+
+    @property
+    def base(self):
+        """The spool root — keeps LocalStore introspection compat."""
+        return self._cache.base
+
+    @staticmethod
+    def _row_id(namespace: str, key: str) -> str:
+        return f"{namespace}:{key}"
+
+    # -- LocalStore-compatible interface ---------------------------------
+
+    def save(self, namespace: str, key: str, data: dict) -> None:
+        record = {
+            "id": self._row_id(namespace, key),
+            "namespace": namespace,
+            "key": key,
+            "data": json.dumps(data, default=str),
+            "updated_at": time.time(),
+        }
+        try:
+            self._store.insert(TABLE, record)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "evolution store write failed (%s/%s) — spooled to local cache: %s",
+                namespace,
+                key,
+                exc,
+            )
+        try:
+            self._cache.save(namespace, key, data)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("evolution cache write failed (%s/%s): %s", namespace, key, exc)
+
+    def load(self, namespace: str, key: str) -> dict | None:
+        try:
+            rows = self._store.query(TABLE, {"id": self._row_id(namespace, key)}, limit=1)
+            if rows:
+                return json.loads(rows[0]["data"])
+            # not in the store — maybe it only exists in the spool
+        except Exception as exc:  # noqa: BLE001
+            logger.info("evolution store read failed (%s/%s), using cache: %s", namespace, key, exc)
+        return self._cache.load(namespace, key)
+
+    def list_keys(self, namespace: str) -> list[str]:
+        try:
+            rows = self._store.query(TABLE, {"namespace": namespace}, limit=100_000)
+            keys = [r.get("key") for r in rows if r.get("key")]
+            if keys:
+                return keys
+        except Exception as exc:  # noqa: BLE001
+            logger.info("evolution store list failed (%s), using cache: %s", namespace, exc)
+        return self._cache.list_keys(namespace)
+
+    def iterate(self, namespace: str) -> Iterator[dict]:
+        for key in self.list_keys(namespace):
+            data = self.load(namespace, key)
+            if data is not None:
+                yield data
+
+    def delete(self, namespace: str, key: str) -> bool:
+        deleted = False
+        try:
+            deleted = bool(self._store.delete(TABLE, self._row_id(namespace, key)))
+        except Exception as exc:  # noqa: BLE001
+            logger.info("evolution store delete failed (%s/%s): %s", namespace, key, exc)
+        cache_deleted = self._cache.delete(namespace, key)
+        return deleted or cache_deleted
+
+    # -- observability -----------------------------------------------------
+
+    def stats(self) -> dict[str, Any]:
+        """Namespace counts for storage status/doctor (PR-DF-15 feeds)."""
+        try:
+            rows = self._store.query(TABLE, limit=500_000)
+            counts: dict[str, int] = {}
+            for row in rows:
+                ns = row.get("namespace", "?")
+                counts[ns] = counts.get(ns, 0) + 1
+            return {"backend": type(self._store).__name__, "namespaces": counts}
+        except Exception as exc:  # noqa: BLE001
+            return {"backend": type(self._store).__name__, "error": str(exc)}

--- a/src/rosclaw/know/__init__.py
+++ b/src/rosclaw/know/__init__.py
@@ -1,4 +1,11 @@
-"""Compatibility facade for legacy ROSClaw Knowledge integrations.
+"""DEPRECATED package (PR-DF-09 / ADR-0010): legacy Knowledge runtime.
+
+Canonical package: ``rosclaw.knowledge``.  This package stays as the
+compatibility shim for at least one full minor release; import legacy
+symbols via ``rosclaw.knowledge.legacy`` so the eventual physical move is
+invisible to consumers.
+
+Compatibility facade for legacy ROSClaw Knowledge integrations.
 
 Authoritative v2 implementation lives in ``rosclaw-know``. This package is a
 rollback-compatible runtime adapter and must not grow new retrieval algorithms.

--- a/src/rosclaw/knowledge/facade.py
+++ b/src/rosclaw/knowledge/facade.py
@@ -76,6 +76,11 @@ class KnowledgeFacade:
                 "reference_pack_id": pack.reference_pack_id,
                 "index_version": pack.index_version,
                 "count": len(pack.items),
+                # PR-DF-10: the usage tracker needs unit ids to attribute
+                # feedback to the knowledge actually presented.
+                "knowledge_unit_ids": [
+                    unit_id for item in pack.items for unit_id in item.knowledge_unit_ids
+                ],
             },
         )
         return pack

--- a/src/rosclaw/knowledge/legacy.py
+++ b/src/rosclaw/knowledge/legacy.py
@@ -1,0 +1,32 @@
+"""Legacy Knowledge runtime — canonical import location (PR-DF-09 / ADR-0010).
+
+``rosclaw.knowledge`` is the canonical Knowledge package.  The pre-v2
+runtime (KnowledgeInterface, TaskCard, EmbodimentCard, VerifierCard, the
+knowledge graph and evidence ingest) lives on in ``rosclaw.know`` for at
+least one full minor release; import it through HERE so the eventual
+physical move is a one-line change for consumers:
+
+    from rosclaw.knowledge.legacy import KnowledgeInterface
+
+New code must not gain dependencies on these symbols — they exist for the
+rollback-only local Knowledge path (v2 mode == "disabled").
+"""
+
+from __future__ import annotations
+
+from rosclaw.know.embodiment_card import EmbodimentCard
+from rosclaw.know.interface import KnowledgeInterface
+from rosclaw.know.task_card import TaskCard
+from rosclaw.know.verifier_card import VerifierCard
+
+# Canonical-in-spirit alias for the legacy entry point (ADR-0010 §4):
+# two "official-looking" Knowledge runtimes must not coexist unnamed.
+LegacyKnowledgeRuntime = KnowledgeInterface
+
+__all__ = [
+    "KnowledgeInterface",
+    "LegacyKnowledgeRuntime",
+    "TaskCard",
+    "EmbodimentCard",
+    "VerifierCard",
+]

--- a/src/rosclaw/knowledge/usage_tracker.py
+++ b/src/rosclaw/knowledge/usage_tracker.py
@@ -1,0 +1,159 @@
+"""KnowledgeUsageTracker (PR-DF-10 / flywheel §29-31).
+
+Closes the ReferencePack → Advice → Action → Receipt → Feedback loop that
+previously only existed in CLI/test paths:
+
+    facade.reference_pack() / facade.advise()   (events observed here)
+        ↓  agent acts
+    rosclaw.critic.judgment                      (verified outcome)
+        ↓
+    KnowledgeUsageFeedback  (conservative verdict, §31)
+        ↓  facade.feedback()
+
+Verdict discipline (§31 — conservative by construction):
+  * ``useful``  — knowledge was presented AND the task verified SUCCESS;
+  * ``unknown`` — task failed or the outcome is unattributable.  Automatic
+    feedback NEVER emits ``misleading``/``stale``/``incompatible``: those
+    require verifier attribution, human feedback, or explicit counterfactual
+    evidence, none of which an automated tracker can assert.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import Any
+
+from .feedback_adapter import build_usage_feedback
+
+logger = logging.getLogger("rosclaw.knowledge.usage_tracker")
+
+_PACK_TOPIC = "know.reference_pack.created"
+_ADVICE_TOPIC = "how.advice.created"
+_OUTCOME_TOPIC = "rosclaw.critic.judgment"
+
+
+class KnowledgeUsageTracker:
+    """Track pack/advice usage and emit conservative feedback on outcomes."""
+
+    def __init__(
+        self,
+        event_bus: Any,
+        facade: Any,
+        *,
+        ttl_s: float = 3600.0,
+        max_tracked: int = 1000,
+    ) -> None:
+        self._bus = event_bus
+        self._facade = facade
+        self._ttl_s = ttl_s
+        self._max_tracked = max_tracked
+        self._open: dict[str, dict[str, Any]] = {}
+        self._subscribed = False
+
+    # -- lifecycle ------------------------------------------------------
+
+    def subscribe(self) -> None:
+        if self._bus is None or self._subscribed:
+            return
+        self._bus.subscribe(_PACK_TOPIC, self._on_pack)
+        self._bus.subscribe(_ADVICE_TOPIC, self._on_advice)
+        self._bus.subscribe(_OUTCOME_TOPIC, self._on_outcome)
+        self._subscribed = True
+        logger.info("KnowledgeUsageTracker subscribed")
+
+    def unsubscribe(self) -> None:
+        if self._bus is None or not self._subscribed:
+            return
+        self._bus.unsubscribe(_PACK_TOPIC, self._on_pack)
+        self._bus.unsubscribe(_ADVICE_TOPIC, self._on_advice)
+        self._bus.unsubscribe(_OUTCOME_TOPIC, self._on_outcome)
+        self._subscribed = False
+
+    # -- tracking ---------------------------------------------------------
+
+    def _on_pack(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        pack_id = payload.get("reference_pack_id")
+        if not pack_id:
+            return
+        if len(self._open) >= self._max_tracked:
+            oldest = min(self._open, key=lambda k: self._open[k]["created_at"])
+            del self._open[oldest]
+        self._open[pack_id] = {
+            "reference_pack_id": pack_id,
+            "knowledge_unit_ids": list(payload.get("knowledge_unit_ids") or []),
+            "advice_id": None,
+            "created_at": time.time(),
+        }
+
+    def _on_advice(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        pack_id = payload.get("reference_pack_id")
+        advice_id = payload.get("advice_id")
+        if pack_id and pack_id in self._open and advice_id:
+            self._open[pack_id]["advice_id"] = advice_id
+
+    # -- feedback ---------------------------------------------------------
+
+    def _on_outcome(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        status = str(payload.get("status", "UNKNOWN"))
+        episode_id = payload.get("episode_id")
+        practice_id = payload.get("practice_id")
+        verdict = "useful" if status == "SUCCESS" else "unknown"
+        now = time.time()
+        for pack_id, usage in list(self._open.items()):
+            if now - usage["created_at"] > self._ttl_s:
+                del self._open[pack_id]
+                continue
+            unit_ids = usage["knowledge_unit_ids"] or ["unknown_unit"]
+            for unit_id in unit_ids:
+                self._submit(usage, unit_id, verdict, episode_id, practice_id)
+            del self._open[pack_id]
+
+    def _submit(
+        self,
+        usage: dict[str, Any],
+        unit_id: str,
+        verdict: str,
+        episode_id: Any,
+        practice_id: Any,
+    ) -> None:
+        try:
+            feedback = build_usage_feedback(
+                reference_pack_id=usage["reference_pack_id"],
+                knowledge_unit_id=unit_id,
+                advice_id=usage.get("advice_id"),
+                context_hash=hashlib.sha256(
+                    f"{usage['reference_pack_id']}:{episode_id}:{unit_id}".encode()
+                ).hexdigest(),
+                verdict=verdict,  # type: ignore[arg-type]
+                presented=True,
+                used_by_agent=True,
+                receipt_ref=str(episode_id) if episode_id else None,
+                practice_ref=str(practice_id) if practice_id else None,
+                origin="verifier",
+                reason=None if verdict == "useful" else "outcome unattributed (auto feedback is conservative)",
+            )
+            created = self._facade.feedback(feedback)
+            logger.info(
+                "Knowledge usage feedback: pack=%s unit=%s verdict=%s created=%s",
+                usage["reference_pack_id"],
+                unit_id,
+                verdict,
+                created,
+            )
+        except Exception as exc:  # noqa: BLE001 — feedback must never break execution
+            logger.info("Knowledge usage feedback failed (non-fatal): %s", exc)
+
+    @property
+    def tracked_count(self) -> int:
+        return len(self._open)

--- a/src/rosclaw/memory/insights.py
+++ b/src/rosclaw/memory/insights.py
@@ -1,0 +1,220 @@
+"""MemoryInsightService (PR-DF-11 / flywheel §25-27).
+
+The publisher half of ``rosclaw.memory.insight``: until now Auto subscribed
+to the topic and nothing ever published.  This service watches failure
+observations (critic judgments) and, when a failure recurs, checks the
+structured store for *successful* recovery experience against the same
+failure type — only then does it publish a typed insight:
+
+* ``repeated_failure`` — a failure_type keeps recurring (>= threshold);
+* ``similar_failure_with_patch`` — the recurring failure has a proven
+  recovery (a How rule with successes, or a successful intervention
+  memory).  This is the exact payload Auto's subscriber turns into a
+  memory-guided Proposal (§27).
+
+Insights carry the canonical typed fields (§26): insight_id, insight_type,
+robot_id, body_id, task_id, skill_id, failure_type, evidence_refs,
+memory_refs, recommended_search_space, confidence — plus the legacy field
+names Auto reads today (insight_summary, search_space, failure_id).
+
+Dedup: one insight per (insight_type, skill_id, failure_type) per cooldown
+window so a failure storm doesn't flood Auto with duplicate proposals.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any
+
+from rosclaw.core.event_topics import EventTopics
+
+logger = logging.getLogger("rosclaw.memory.insights")
+
+_DEFAULT_COOLDOWN_S = 900.0
+
+
+class MemoryInsightService:
+    """Generate typed memory insights from recurring failures + proven fixes."""
+
+    def __init__(
+        self,
+        event_bus: Any,
+        structured_store: Any,
+        *,
+        robot_id: str,
+        failure_threshold: int = 3,
+        cooldown_s: float = _DEFAULT_COOLDOWN_S,
+    ) -> None:
+        self._bus = event_bus
+        self._store = structured_store
+        self._robot_id = robot_id
+        self._threshold = failure_threshold
+        self._cooldown_s = cooldown_s
+        self._counts: dict[tuple[str, str], int] = {}
+        self._last_emitted: dict[tuple[str, str, str], float] = {}
+        self._subscribed = False
+
+    # -- lifecycle ------------------------------------------------------
+
+    def subscribe(self) -> None:
+        if self._bus is None or self._subscribed:
+            return
+        self._bus.subscribe(EventTopics.CRITIC_JUDGMENT, self._on_judgment)
+        self._subscribed = True
+        logger.info("MemoryInsightService subscribed")
+
+    def unsubscribe(self) -> None:
+        if self._bus is None or not self._subscribed:
+            return
+        self._bus.unsubscribe(EventTopics.CRITIC_JUDGMENT, self._on_judgment)
+        self._subscribed = False
+
+    # -- observation ------------------------------------------------------
+
+    def _on_judgment(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        status = str(payload.get("status", "UNKNOWN"))
+        if status == "SUCCESS":
+            return
+        context = payload.get("context", {}) if isinstance(payload.get("context"), dict) else {}
+        outcome = context.get("outcome", {}) if isinstance(context.get("outcome"), dict) else {}
+        skill_id = outcome.get("skill_name") or payload.get("skill_id") or "unknown"
+        failure_type = payload.get("reason") or payload.get("failure_type") or "unknown"
+        task_id = payload.get("task_id") or context.get("instruction") or ""
+        episode_id = payload.get("episode_id", "")
+
+        key = (skill_id, failure_type)
+        self._counts[key] = self._counts.get(key, 0) + 1
+        count = self._counts[key]
+        if count < self._threshold:
+            return
+
+        evidence_refs = [f"critic_result:{episode_id}"] if episode_id else []
+        self._maybe_emit(
+            "repeated_failure",
+            skill_id=skill_id,
+            failure_type=failure_type,
+            task_id=task_id,
+            episode_id=episode_id,
+            evidence_refs=evidence_refs,
+            extra={"occurrences": count},
+        )
+        fix = self._find_proven_fix(failure_type)
+        if fix is not None:
+            self._maybe_emit(
+                "similar_failure_with_patch",
+                skill_id=skill_id,
+                failure_type=failure_type,
+                task_id=task_id,
+                episode_id=episode_id,
+                evidence_refs=evidence_refs + fix["evidence_refs"],
+                extra={
+                    "search_space": fix["search_space"],
+                    "memory_refs": fix["memory_refs"],
+                },
+            )
+
+    # -- insight emission ---------------------------------------------------
+
+    def _find_proven_fix(self, failure_type: str) -> dict[str, Any] | None:
+        """A How rule with verified successes, or a successful intervention memory."""
+        if self._store is None:
+            return None
+        try:
+            rules = self._store.query("heuristic_rules", {"failure_type": failure_type})
+            proven = [
+                r
+                for r in rules
+                if isinstance(r.get("success_count"), int) and r["success_count"] > 0
+            ]
+            if proven:
+                best = max(proven, key=lambda r: r["success_count"])
+                search_space = best.get("parameter_patch") or {}
+                if isinstance(search_space, str):
+                    import json
+
+                    try:
+                        search_space = json.loads(search_space)
+                    except ValueError:
+                        search_space = {}
+                return {
+                    "search_space": search_space if isinstance(search_space, dict) else {},
+                    "memory_refs": [f"heuristic_rules:{best.get('id', '')}"],
+                    "evidence_refs": [f"heuristic_rules:{best.get('id', '')}"],
+                }
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("rule lookup failed: %s", exc)
+        try:
+            interventions = self._store.query(
+                "memory_items", {"memory_type": "intervention", "failure_type": failure_type}
+            )
+            successful = [m for m in interventions if m.get("outcome") == "SUCCESS"]
+            if successful:
+                mem = successful[0]
+                return {
+                    "search_space": {},
+                    "memory_refs": [mem.get("id", "")],
+                    "evidence_refs": list(mem.get("evidence_refs") or []),
+                }
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("intervention memory lookup failed: %s", exc)
+        return None
+
+    def _maybe_emit(
+        self,
+        insight_type: str,
+        *,
+        skill_id: str,
+        failure_type: str,
+        task_id: str,
+        episode_id: str,
+        evidence_refs: list[str],
+        extra: dict[str, Any],
+    ) -> None:
+        dedup_key = (insight_type, skill_id, failure_type)
+        now = time.time()
+        if now - self._last_emitted.get(dedup_key, 0.0) < self._cooldown_s:
+            return
+        self._last_emitted[dedup_key] = now
+        search_space = extra.get("search_space", {})
+        summary = (
+            f"failure '{failure_type}' recurred {extra.get('occurrences', self._threshold)}x "
+            f"on skill '{skill_id}'"
+            if insight_type == "repeated_failure"
+            else f"failure '{failure_type}' on skill '{skill_id}' has a proven recovery"
+        )
+        insight = {
+            # canonical typed fields (§26)
+            "insight_id": f"ins_{uuid.uuid4().hex[:16]}",
+            "insight_type": insight_type,
+            "robot_id": self._robot_id,
+            "task_id": task_id,
+            "skill_id": skill_id,
+            "failure_type": failure_type,
+            "evidence_refs": evidence_refs,
+            "memory_refs": extra.get("memory_refs", []),
+            "recommended_search_space": search_space,
+            "confidence": 0.8 if insight_type == "similar_failure_with_patch" else 0.5,
+            "created_at": now,
+            # field names Auto's subscriber consumes today
+            "insight_summary": summary,
+            "search_space": search_space,
+            "failure_id": episode_id,
+        }
+        try:
+            from rosclaw.core.event_bus import Event
+
+            self._bus.publish(
+                Event(
+                    topic=EventTopics.MEMORY_INSIGHT_CREATED,
+                    payload=insight,
+                    source="memory.insights",
+                )
+            )
+            logger.info("memory insight published: %s (%s)", insight_type, dedup_key)
+        except Exception as exc:  # noqa: BLE001
+            logger.info("insight publish failed (non-fatal): %s", exc)

--- a/src/rosclaw/memory/seekdb_client.py
+++ b/src/rosclaw/memory/seekdb_client.py
@@ -503,6 +503,65 @@ ROSCLAW_STRUCTURED_SCHEMAS: dict[str, Any] = {
         },
         "indices": ["status", "rule_id", "created_at"],
     },
+    # Execution receipts (PR-DF-14, flywheel §21): the data-plane projection
+    # of kernel ExecutionReceipts.  rosclawd's own ledgers stay authoritative
+    # — this table is an async index, never consulted for authorization.
+    "execution_receipts": {
+        "columns": {
+            "id": "TEXT PRIMARY KEY",
+            "receipt_id": "TEXT",
+            "action_id": "TEXT",
+            "trace_id": "TEXT",
+            "session_id": "TEXT",
+            "practice_id": "TEXT",
+            "episode_id": "TEXT",
+            "robot_id": "TEXT",
+            "body_id": "TEXT",
+            "capability_id": "TEXT",
+            "execution_mode": "TEXT",
+            "final_state": "TEXT",
+            "acknowledgement_stage": "TEXT",
+            "evidence_level": "TEXT",
+            "evidence_domain": "TEXT",
+            "dispatched_at": "REAL",
+            "observed_at": "REAL",
+            "verified_at": "REAL",
+            "artifact_refs": "TEXT",
+            "verification_refs": "TEXT",
+            "schema_version": "TEXT",
+            "created_at": "REAL",
+        },
+        "indices": ["action_id", "trace_id", "practice_id", "episode_id", "final_state"],
+    },
+    # Lineage edges (PR-DF-14, flywheel §36-38): the typed ancestry graph
+    # answering "why is this champion v1.7" down to the physical receipt.
+    "lineage_edges": {
+        "columns": {
+            "id": "TEXT PRIMARY KEY",
+            "from_type": "TEXT",
+            "from_id": "TEXT",
+            "relation": "TEXT",
+            "to_type": "TEXT",
+            "to_id": "TEXT",
+            "trace_id": "TEXT",
+            "metadata": "TEXT",
+            "created_at": "REAL",
+        },
+        "indices": ["from_id", "to_id", "relation", "trace_id"],
+    },
+    # Evolution module canonical tables (PR-DF-12, ADR-0010 §33-34): the
+    # generic namespace-row shape backing EvolutionRepository.  Legacy
+    # auto_* tables below stay for compat until the migration PR.
+    "evolution_records": {
+        "columns": {
+            "id": "TEXT PRIMARY KEY",
+            "namespace": "TEXT",
+            "key": "TEXT",
+            "data": "TEXT",
+            "updated_at": "REAL",
+        },
+        "indices": ["namespace", "updated_at"],
+    },
     # Auto module tables
     "auto_proposals": {
         "columns": {

--- a/src/rosclaw/practice/config.py
+++ b/src/rosclaw/practice/config.py
@@ -191,3 +191,6 @@ class PracticeSummary:
     mcap_path: Path | None = None
     seekdb_committed: bool | None = None
     failure_labels: list[str] = field(default_factory=list)
+    # PR-DF-04: session-close fact-pipeline observation
+    # (verify passed/errors/warnings); None = verify did not run.
+    fact_verify: dict | None = None

--- a/src/rosclaw/practice/coordinator.py
+++ b/src/rosclaw/practice/coordinator.py
@@ -19,7 +19,7 @@ from rosclaw.practice.artifact_store import ArtifactStore
 from rosclaw.practice.config import PracticeConfig, PracticeSession, PracticeSummary
 from rosclaw.practice.ids import generate_episode_id, generate_session_id
 from rosclaw.practice.schemas import PracticeEventEnvelope
-from rosclaw.practice.seekdb_ingestor import SeekDBIngestor
+from rosclaw.practice.seekdb_ingestor import PracticeFactIngestor
 from rosclaw.practice.storage.catalog import PracticeCatalog
 from rosclaw.practice.storage.layout import PracticeLayout, generate_practice_id
 from rosclaw.practice.writers.jsonl_writer import JsonlWriter
@@ -390,8 +390,14 @@ class PracticeCoordinator(LifecycleMixin):
                 except Exception as e:
                     logger.error("Failed to insert episode into catalog v2: %s", e)
 
-                # Auto-ingest into SeekDB when a SQL DSN is configured so the
-                # Knowledge Plane is populated immediately after a session finishes.
+                # PR-DF-04 (data flywheel §19): session close runs the fact
+                # pipeline as one observable chain —
+                #   verify raw data → extract facts → structured ingest.
+                # Verification is recorded on the summary and never blocks
+                # the close; a failed verification still ingests (the facts
+                # say what the data showed, including its defects) but the
+                # report is there for ``practice verify``/doctor to surface.
+                self._verify_session_facts()
                 if seekdb_sql_enabled:
                     try:
                         report = self._ingest_seekdb()
@@ -681,17 +687,44 @@ class PracticeCoordinator(LifecycleMixin):
 
         return StoreFactory.create_structured_store(url=url)
 
+    def _verify_session_facts(self) -> Any:
+        """Verify raw session data at close (PR-DF-04): idempotent, non-blocking,
+        observable.  Returns the VerificationReport or None on any failure."""
+        if self._session is None:
+            return None
+        try:
+            from rosclaw.practice.verifier import PracticeVerifier
+
+            report = PracticeVerifier(self.config.data_root).verify(self._session.practice_id)
+            errors = sum(1 for i in report.issues if i.level == "error")
+            warnings = sum(1 for i in report.issues if i.level == "warning")
+            if self._summary is not None:
+                self._summary.fact_verify = {
+                    "passed": report.passed,
+                    "errors": errors,
+                    "warnings": warnings,
+                }
+            if not report.passed:
+                logger.warning(
+                    "Session %s fact-verify: %d errors, %d warnings",
+                    self._session.practice_id, errors, warnings,
+                )
+            return report
+        except Exception as exc:  # noqa: BLE001
+            logger.info("Session fact-verify unavailable: %s", exc)
+            return None
+
     def _ingest_seekdb(self) -> Any:
-        """Distill and ingest the current session into SeekDB."""
-        from rosclaw.practice.distiller import PracticeDistiller
+        """Extract facts and ingest the current session into SeekDB."""
+        from rosclaw.practice.distiller import EpisodeFactExtractor
 
         client = self._make_seekdb_client()
         if client is None:
             raise ValueError("SeekDB enabled but no URL configured")
         if self._session is None:
             raise ValueError("No active session to ingest")
-        distiller = PracticeDistiller(self.config.data_root)
-        ingestor = SeekDBIngestor(
+        distiller = EpisodeFactExtractor(self.config.data_root)
+        ingestor = PracticeFactIngestor(
             self.config.data_root,
             seekdb_client=client,
             layout=self.layout,

--- a/src/rosclaw/practice/distiller.py
+++ b/src/rosclaw/practice/distiller.py
@@ -1,9 +1,9 @@
 """Practice distillation: turn raw events into structured knowledge.
 
-``PracticeDistiller`` reads a practice session's events and produces distilled
+``EpisodeFactExtractor`` reads a practice session's events and produces distilled
 artifacts such as body cognition, failure summaries, how-interventions,
 candidate policies, and promotion results. These artifacts can then be ingested
-into SeekDB by ``SeekDBIngestor``.
+into SeekDB by ``PracticeFactIngestor``.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ def _utc_now_iso() -> str:
 
 
 @dataclass
-class DistillationResult:
+class EpisodeFactBundle:
     practice_id: str
     session_id: str
     episode_id: str | None
@@ -42,13 +42,24 @@ class DistillationResult:
     artifact_refs: dict[str, str] = field(default_factory=dict)
 
 
-class PracticeDistiller:
-    """Distill raw practice events into knowledge artifacts."""
+class EpisodeFactExtractor:
+    """Extract the facts of what happened from a finished practice session.
+
+    Canonical name (PR-DF-04 / ADR-0010 §6): Practice owns *facts* —
+    episode summary, failure facts, body observations, intervention facts,
+    sim2real facts, candidate/promotion facts, artifact refs.  Deciding what
+    is worth *remembering* belongs to Memory (MemoryDistiller / WriteGate),
+    not here.  Output: :class:`EpisodeFactBundle`.
+    """
 
     def __init__(self, data_root: Path | str):
         self._data_root = Path(data_root)
         self._layout = PracticeLayout(self._data_root)
         self._artifact_store = ArtifactStore(self._data_root, layout=self._layout)
+
+    def extract(self, practice_id: str, **kwargs: Any) -> EpisodeFactBundle:
+        """Canonical verb (PR-DF-04): extract the EpisodeFactBundle."""
+        return self.distill(practice_id, **kwargs)
 
     def distill(
         self,
@@ -56,7 +67,7 @@ class PracticeDistiller:
         *,
         body_id: str | None = None,
         write_artifacts: bool = True,
-    ) -> DistillationResult:
+    ) -> EpisodeFactBundle:
         """Distill one practice session."""
         catalog = PracticeCatalog(self._layout.catalog_db_path)
         try:
@@ -103,8 +114,8 @@ class PracticeDistiller:
         episode_id: str | None,
         events: list[dict[str, Any]],
         body_id: str | None,
-    ) -> DistillationResult:
-        result = DistillationResult(
+    ) -> EpisodeFactBundle:
+        result = EpisodeFactBundle(
             practice_id=practice_id,
             session_id=session_id,
             episode_id=episode_id,
@@ -214,7 +225,7 @@ class PracticeDistiller:
             "contact_distribution": contact_distribution,
         }
 
-    def _write_distilled_artifacts(self, result: DistillationResult) -> None:
+    def _write_distilled_artifacts(self, result: EpisodeFactBundle) -> None:
         session_id = result.session_id
         episode_id = result.episode_id
 
@@ -277,3 +288,8 @@ class PracticeDistiller:
                 artifact_type="sim2real_deltas",
             )
             result.artifact_refs["sim2real_deltas"] = record.path
+
+
+# ADR-0010 compatibility aliases (PR-DF-04): pre-rename names.
+PracticeDistiller = EpisodeFactExtractor
+DistillationResult = EpisodeFactBundle

--- a/src/rosclaw/practice/seekdb_ingestor.py
+++ b/src/rosclaw/practice/seekdb_ingestor.py
@@ -1,6 +1,6 @@
 """SeekDB ingestion for distilled ROSClaw Practice results.
 
-``SeekDBIngestor`` takes the output of ``PracticeDistiller`` (or distill a
+``PracticeFactIngestor`` takes the output of ``EpisodeFactExtractor`` (or distill a
 practice on demand) and writes the structured knowledge into the SeekDB
 Knowledge Plane. All writes are idempotent: repeating an ingestion with the
 same episode/failure/candidate/promotion IDs updates the existing records.
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from rosclaw.memory.seekdb_client import InMemoryStructuredStore, StructuredStore
-from rosclaw.practice.distiller import DistillationResult, PracticeDistiller
+from rosclaw.practice.distiller import EpisodeFactBundle, EpisodeFactExtractor
 from rosclaw.practice.storage.catalog import PracticeCatalog
 from rosclaw.practice.storage.layout import PracticeLayout
 
@@ -55,11 +55,11 @@ def _iso_to_timestamp(value: str | float | int | None) -> float:
         return time.time()
 
 
-class SeekDBIngestor:
+class PracticeFactIngestor:
     """Ingest distilled practice results into SeekDB.
 
     Usage:
-        ingestor = SeekDBIngestor("/data/rosclaw/practice")
+        ingestor = PracticeFactIngestor("/data/rosclaw/practice")
         report = ingestor.ingest_practice("prac_...")
         ingestor.close()
     """
@@ -82,7 +82,7 @@ class SeekDBIngestor:
         if self._owns_connection:
             self._client.disconnect()
 
-    def __enter__(self) -> SeekDBIngestor:
+    def __enter__(self) -> PracticeFactIngestor:
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
@@ -92,7 +92,7 @@ class SeekDBIngestor:
         self,
         practice_id: str,
         *,
-        distillation_result: DistillationResult | None = None,
+        distillation_result: EpisodeFactBundle | None = None,
         robot_id: str | None = None,
         task_id: str | None = None,
     ) -> IngestionReport:
@@ -109,7 +109,7 @@ class SeekDBIngestor:
             task_id = task_id or practice.get("task_id") or practice.get("task_name")
 
             if distillation_result is None:
-                distiller = PracticeDistiller(self._data_root)
+                distiller = EpisodeFactExtractor(self._data_root)
                 distillation_result = distiller.distill(practice_id, write_artifacts=False)
 
             report = IngestionReport(
@@ -436,3 +436,7 @@ class SeekDBIngestor:
             "metadata": metadata or {},
         }
         return self._client.insert("artifacts", record)
+
+
+# ADR-0010 compatibility alias (PR-DF-04): pre-rename name.
+SeekDBIngestor = PracticeFactIngestor

--- a/src/rosclaw/practice/storage/layout.py
+++ b/src/rosclaw/practice/storage/layout.py
@@ -173,6 +173,9 @@ class PracticeLayout:
             manifest["status"]["reward"] = summary.reward
             manifest["status"]["failure_labels"] = summary.failure_labels
             manifest["seekdb"]["committed"] = summary.seekdb_committed
+            # PR-DF-04: session-close fact-pipeline observation (verify step)
+            if getattr(summary, "fact_verify", None) is not None:
+                manifest["fact_verify"] = summary.fact_verify
             if summary.mcap_path is not None:
                 manifest["artifacts"]["mcap"] = str(summary.mcap_path)
         path = self.manifest_path(session.practice_id)

--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -81,6 +81,11 @@ def _load_storage_config(args: argparse.Namespace) -> dict[str, Any]:
     outbox_enabled = storage_cfg.get("outbox_enabled", False)
     outbox_path = storage_cfg.get("outbox_path") or str(home / "storage" / "outbox.sqlite")
 
+    # PR-DF-07: retrieval projection section (Config v2) with legacy fallback
+    retrieval_cfg = storage_cfg.get("retrieval", {})
+    retrieval_enabled = retrieval_cfg.get("enabled", storage_cfg.get("vector_enabled", False))
+    retrieval_path = retrieval_cfg.get("path") or str(home / "data" / "seekdb")
+
     practice_data_root = practice_cfg.get("output_dir") or str(get_default_data_root())
 
     return {
@@ -96,6 +101,8 @@ def _load_storage_config(args: argparse.Namespace) -> dict[str, Any]:
         "vector_enabled": storage_cfg.get("vector_enabled", False),
         "outbox_enabled": outbox_enabled,
         "outbox_path": outbox_path,
+        "retrieval_enabled": retrieval_enabled,
+        "retrieval_path": retrieval_path,
         "practice_data_root": practice_data_root,
     }
 
@@ -285,6 +292,34 @@ def _session_event_consistency(
     return event_count, events_lines, consistent, timeline_exists
 
 
+def _projection_status(cfg: dict[str, Any], client: Any) -> dict[str, Any] | None:
+    """Retrieval-projection watermark/lag for ``db status`` (PR-DF-07 §18).
+
+    Only meaningful when the structured store is the SQL source of truth and
+    a retrieval backend is enabled; entirely best-effort.
+    """
+    if not cfg.get("retrieval_enabled"):
+        return None
+    result: dict[str, Any] = {"enabled": True, "path": cfg.get("retrieval_path")}
+    try:
+        result["source_count"] = client.count("memory_items")
+    except Exception:  # noqa: BLE001
+        result["source_count"] = None
+    try:
+        from rosclaw.storage.seekdb_native import SeekDBEmbeddedRetrievalStore
+
+        native = SeekDBEmbeddedRetrievalStore(path=cfg["retrieval_path"])
+        native.connect()
+        result["projection_backend"] = type(native).__name__
+        result["projection_count"] = native.count("memory_items")
+        if result["source_count"] is not None:
+            result["lag"] = result["source_count"] - result["projection_count"]
+    except Exception as exc:  # noqa: BLE001
+        result["projection_count"] = None
+        result["error"] = str(exc)
+    return result
+
+
 @_with_stdout_flush
 def cmd_db_status(args: argparse.Namespace) -> int:
     """Show storage backend status and capabilities."""
@@ -314,6 +349,9 @@ def cmd_db_status(args: argparse.Namespace) -> int:
             extras["outbox"] = outbox_stats
         extras["vector"] = _vector_status(client)
         extras["practice"] = _practice_status(cfg)
+        projection = _projection_status(cfg, client)
+        if projection is not None:
+            extras["projection"] = projection
     finally:
         _close_client(client)
 
@@ -360,6 +398,16 @@ def cmd_db_status(args: argparse.Namespace) -> int:
         print("  Vector:")
         print(f"    enabled:    {vec.get('enabled')}")
         print(f"    warmed:     {vec.get('warmed')}")
+    if extras.get("projection"):
+        proj = extras["projection"]
+        print("  Retrieval projection:")
+        print(f"    backend:    {proj.get('projection_backend')}")
+        print(f"    source:     {proj.get('source_count')}")
+        print(f"    projected:  {proj.get('projection_count')}")
+        if proj.get("lag") is not None:
+            print(f"    lag:        {proj['lag']}")
+        if proj.get("error"):
+            print(f"    error:      {proj['error']}")
     if extras.get("practice"):
         prac = extras["practice"]
         print("  Practice:")
@@ -613,6 +661,96 @@ def _native_seekdb_checks(
         dsn = f"{deployment.get('user')}@{deployment.get('host')}:{deployment.get('port')}/{deployment.get('database')}"
         checks.append(("dsn auth", f"authenticated as {dsn}", True))
         result["seekdb"]["dsn"] = dsn
+
+
+def _flywheel_checks(
+    cfg: dict[str, Any],
+    client: Any,
+    checks: list[tuple[str, str, bool]],
+    issues: list[str],
+) -> None:
+    """Data-flywheel integrity checks for db doctor (PR-DF-15 §45-46).
+
+    All best-effort: every probe degrades to a skipped check, never a crash.
+    """
+    if client is None:
+        return
+
+    # Memory integrity (§46): ACTIVE memory_items must carry evidence.
+    try:
+        items = client.query("memory_items", {"status": "active"}, limit=100_000)
+        if items:
+            orphan = 0
+            for item in items:
+                evd = client.query("memory_evidence", {"memory_id": item["id"]}, limit=1)
+                refs = item.get("evidence_refs")
+                if not evd and not refs:
+                    orphan += 1
+            checks.append(("memory evidence", f"{orphan} orphan of {len(items)}", orphan == 0))
+            if orphan:
+                issues.append(f"{orphan} ACTIVE memory_items have no evidence rows.")
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Lineage (§36/§45): receipts that never got a lineage edge.
+    try:
+        receipts = client.query("execution_receipts", limit=100_000)
+        if receipts:
+            edges = client.query("lineage_edges", limit=500_000)
+            linked = {e.get("from_id") for e in edges}
+            missing = sum(1 for r in receipts if r.get("id") not in linked)
+            checks.append(
+                ("lineage edges", f"{missing} receipt(s) unlinked of {len(receipts)}", missing == 0)
+            )
+            if missing:
+                issues.append(f"{missing} execution_receipts have no lineage edges.")
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Retrieval projection (§18/§45): source vs projected watermark lag.
+    if cfg.get("retrieval_enabled"):
+        try:
+            source = client.count("memory_items")
+            projected = None
+            error = None
+            try:
+                from rosclaw.storage.seekdb_native import SeekDBEmbeddedRetrievalStore
+
+                native = SeekDBEmbeddedRetrievalStore(path=cfg["retrieval_path"])
+                native.connect()
+                projected = native.count("memory_items")
+            except Exception as exc:  # noqa: BLE001
+                error = str(exc)
+            if projected is None:
+                checks.append(("retrieval projection", f"unavailable: {error}", False))
+                issues.append(f"Retrieval projection unavailable: {error}")
+            else:
+                lag = source - projected
+                checks.append(
+                    ("projection lag", f"{lag} (source {source} / projected {projected})", lag == 0)
+                )
+                if lag != 0:
+                    issues.append(
+                        f"Retrieval projection lag {lag} — run the projection rebuild/catch-up."
+                    )
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Outbox health (§45): pending + dead letters.
+    if cfg.get("outbox_enabled"):
+        try:
+            from rosclaw.storage.outbox import OutboxStore
+
+            outbox = OutboxStore(db_path=cfg["outbox_path"])
+            outbox.connect()
+            stats = outbox.stats()
+            pending = stats.get("pending", 0)
+            dead = stats.get("deadletters", stats.get("dead_letters", 0)) or 0
+            checks.append(("outbox", f"pending={pending} dead={dead}", dead == 0))
+            if dead:
+                issues.append(f"Outbox has {dead} dead-letter record(s).")
+        except Exception:  # noqa: BLE001
+            pass
 
 
 @_with_stdout_flush
@@ -891,6 +1029,10 @@ def cmd_db_doctor(args: argparse.Namespace) -> int:
             }
         except Exception as exc:  # noqa: BLE001
             issues.append(f"Latest session consistency check failed: {exc}")
+
+    # PR-DF-15: data-flywheel integrity checks (memory evidence, lineage,
+    # projection lag, outbox dead letters)
+    _flywheel_checks(cfg, client, checks, issues)
 
     if client is not None:
         _close_client(client)

--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -300,6 +300,11 @@ def _projection_status(cfg: dict[str, Any], client: Any) -> dict[str, Any] | Non
     """
     if not cfg.get("retrieval_enabled"):
         return None
+    # Never create or open a store that doesn't exist: opening an empty path
+    # would initialize one (side effect), and an unrelated host store with a
+    # different embedding profile reads as a false failure (DF-15 CI audit).
+    if not Path(str(cfg.get("retrieval_path") or "")).exists():
+        return None
     result: dict[str, Any] = {"enabled": True, "path": cfg.get("retrieval_path")}
     try:
         result["source_count"] = client.count("memory_items")
@@ -708,7 +713,7 @@ def _flywheel_checks(
         pass
 
     # Retrieval projection (§18/§45): source vs projected watermark lag.
-    if cfg.get("retrieval_enabled"):
+    if cfg.get("retrieval_enabled") and Path(str(cfg.get("retrieval_path") or "")).exists():
         try:
             source = client.count("memory_items")
             projected = None

--- a/src/rosclaw/storage/context.py
+++ b/src/rosclaw/storage/context.py
@@ -1,0 +1,67 @@
+"""Data Plane context (PR-DF-03 / ADR-0009 / ADR-0010).
+
+``DataPlaneContext`` is the single, explicit holder for the Runtime's data
+plane.  It replaces the historical pattern of a bare ``seekdb = ...`` local
+variable being threaded through Memory / Skill / Knowledge / How / Auto —
+a variable whose backend semantics were impossible to determine at the use
+site.
+
+The Runtime builds the context exactly once in ``_create_data_plane()`` and
+modules receive the parts they need by dependency injection.  Field types
+are kept as ``Any`` at the boundary where the concrete classes are optional
+imports (native SeekDB, the retrieval facade) so that importing this module
+never pulls heavy dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from rosclaw.memory.seekdb_client import StructuredStore
+
+
+@dataclass
+class DataPlaneContext:
+    """The Runtime's data plane, initialized once (ADR-0009 §2).
+
+    Attributes:
+        structured_store: canonical structured source of truth
+            (SQLite edge / SeekDB SQL production / InMemory tests).
+        retrieval_store: the SeekDB native retrieval store when the
+            structured store itself is native (None otherwise).
+        outbox: the transactional outbox for non-safety-realtime writes,
+            when enabled.
+        memory_projection: Memory -> retrieval-index projection
+            (rebuildable; never the source of truth).
+        memory_retrieval: the unified MemoryRetrievalFacade serving
+            Memory/KNOW/HOW/AUTO queries, when available.
+        practice_sink: the Practice event sink (HTTP bridge), when configured.
+    """
+
+    structured_store: StructuredStore | None = None
+    retrieval_store: Any | None = None
+    outbox: Any | None = None
+    memory_projection: Any | None = None
+    memory_retrieval: Any | None = None
+    practice_sink: Any | None = None
+
+    def capabilities(self) -> dict[str, Any]:
+        """Observability snapshot for storage status/doctor (DF-07/DF-15)."""
+        from rosclaw.storage.factory import StoreFactory
+
+        store = self.structured_store
+        caps = StoreFactory.capabilities(store) if store is not None else {}
+        return {
+            "structured_backend": type(store).__name__ if store is not None else None,
+            **caps,
+            "retrieval_store": type(self.retrieval_store).__name__
+            if self.retrieval_store is not None
+            else None,
+            "outbox_enabled": self.outbox is not None,
+            "memory_projection": self.memory_projection is not None,
+            "memory_retrieval": self.memory_retrieval is not None,
+            "practice_sink": type(self.practice_sink).__name__
+            if self.practice_sink is not None
+            else None,
+        }

--- a/src/rosclaw/storage/lineage.py
+++ b/src/rosclaw/storage/lineage.py
@@ -1,0 +1,145 @@
+"""LineageRepository (PR-DF-14 / flywheel §36-38).
+
+The typed ancestry graph over the ``lineage_edges`` table.  Answers the
+acceptance questions — "why is this champion v1.7?" — by walking:
+
+    Champion → Evaluation → Experiment → Patch → Proposal
+             → MemoryInsight → Memory → Episode → Receipt
+
+Relations (§36): derived_from / observed_in / supported_by / proposed_from /
+patched_by / evaluated_by / promoted_from / supersedes / recovered_by /
+generated_from.
+
+An edge reads ``from --relation--> to``: e.g.
+``link("champion", "champ_1", "promoted_from", "evaluation", "eval_9")``.
+Writes are idempotent on (from, relation, to).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from typing import Any
+
+TABLE = "lineage_edges"
+
+
+class LineageRepository:
+    """Directed typed lineage graph on the structured store."""
+
+    def __init__(self, structured_store: Any) -> None:
+        self._store = structured_store
+
+    # -- write ------------------------------------------------------------
+
+    def link(
+        self,
+        from_type: str,
+        from_id: str,
+        relation: str,
+        to_type: str,
+        to_id: str,
+        *,
+        trace_id: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Create an edge; idempotent on (from, relation, to)."""
+        existing = self._store.query(
+            TABLE,
+            {"from_id": from_id, "relation": relation, "to_id": to_id},
+            limit=1,
+        )
+        if existing:
+            return existing[0]["id"]
+        edge_id = f"lin_{uuid.uuid4().hex[:16]}"
+        self._store.insert(
+            TABLE,
+            {
+                "id": edge_id,
+                "from_type": from_type,
+                "from_id": from_id,
+                "relation": relation,
+                "to_type": to_type,
+                "to_id": to_id,
+                "trace_id": trace_id,
+                "metadata": json.dumps(metadata or {}, default=str),
+                "created_at": time.time(),
+            },
+        )
+        return edge_id
+
+    # -- read ---------------------------------------------------------------
+
+    def parents(self, entity_type: str, entity_id: str) -> list[dict[str, Any]]:
+        """Edges pointing AWAY from this entity toward its sources."""
+        return self._store.query(TABLE, {"from_id": entity_id}, limit=10_000)
+
+    def children(self, entity_type: str, entity_id: str) -> list[dict[str, Any]]:
+        """Edges pointing AT this entity (things derived from it)."""
+        return self._store.query(TABLE, {"to_id": entity_id}, limit=10_000)
+
+    def ancestors(self, entity_type: str, entity_id: str, *, max_depth: int = 32) -> list[dict[str, Any]]:
+        """BFS over parents(); cycle-safe, depth-capped."""
+        seen: set[str] = set()
+        out: list[dict[str, Any]] = []
+        frontier = [entity_id]
+        depth = 0
+        while frontier and depth < max_depth:
+            depth += 1
+            nxt: list[str] = []
+            for fid in frontier:
+                for edge in self.parents(entity_type, fid):
+                    eid = edge["id"]
+                    if eid in seen:
+                        continue
+                    seen.add(eid)
+                    out.append(edge)
+                    to_id = edge.get("to_id")
+                    if to_id and to_id not in (nxt or []):
+                        nxt.append(to_id)
+            frontier = nxt
+        return out
+
+    def descendants(self, entity_type: str, entity_id: str, *, max_depth: int = 32) -> list[dict[str, Any]]:
+        """BFS over children(); cycle-safe, depth-capped."""
+        seen: set[str] = set()
+        out: list[dict[str, Any]] = []
+        frontier = [entity_id]
+        depth = 0
+        while frontier and depth < max_depth:
+            depth += 1
+            nxt = []
+            for fid in frontier:
+                for edge in self.children(entity_type, fid):
+                    eid = edge["id"]
+                    if eid in seen:
+                        continue
+                    seen.add(eid)
+                    out.append(edge)
+                    from_id = edge.get("from_id")
+                    if from_id:
+                        nxt.append(from_id)
+            frontier = nxt
+        return out
+
+    def trace(self, entity_type: str, entity_id: str) -> dict[str, Any]:
+        """The formatted ancestry chain for CLI/reporting (§38)."""
+        chain = []
+        current_type, current_id = entity_type, entity_id
+        visited = {current_id}
+        while True:
+            edges = [e for e in self.parents(current_type, current_id) if e["to_id"] not in visited]
+            if not edges:
+                break
+            edge = edges[0]
+            chain.append(
+                {
+                    "relation": edge["relation"],
+                    "to_type": edge["to_type"],
+                    "to_id": edge["to_id"],
+                }
+            )
+            visited.add(edge["to_id"])
+            current_type, current_id = edge["to_type"], edge["to_id"]
+        return {"root": {"type": entity_type, "id": entity_id}, "chain": chain}

--- a/src/rosclaw/storage/receipts.py
+++ b/src/rosclaw/storage/receipts.py
@@ -1,0 +1,130 @@
+"""ReceiptProjector (PR-DF-14 / flywheel §21-22).
+
+Async projection of kernel ExecutionReceipts into the data plane's
+``execution_receipts`` table, plus the first lineage edges
+(``action --generated_from--> receipt``).
+
+Safety red line (§22): this table is an *index for learning and audit*.
+rosclawd's permit/action ledgers stay the only authorization authority;
+nothing in the dispatch or E-stop path may ever wait on this projection.
+Writes are idempotent on receipt identity and failures are logged, never
+raised into the execution path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+from rosclaw.core.event_topics import EventTopics
+
+from .lineage import LineageRepository
+
+logger = logging.getLogger("rosclaw.storage.receipts")
+
+TABLE = "execution_receipts"
+
+
+class ReceiptProjector:
+    """Project action receipts into the structured store (+ lineage)."""
+
+    def __init__(
+        self,
+        event_bus: Any,
+        structured_store: Any,
+        lineage: LineageRepository | None = None,
+    ) -> None:
+        self._bus = event_bus
+        self._store = structured_store
+        self._lineage = lineage
+        self._subscribed = False
+
+    def subscribe(self) -> None:
+        if self._bus is None or self._subscribed:
+            return
+        self._bus.subscribe(EventTopics.ACTION_RECEIPT, self._on_receipt)
+        self._subscribed = True
+        logger.info("ReceiptProjector subscribed")
+
+    def unsubscribe(self) -> None:
+        if self._bus is None or not self._subscribed:
+            return
+        self._bus.unsubscribe(EventTopics.ACTION_RECEIPT, self._on_receipt)
+        self._subscribed = False
+
+    def _on_receipt(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        try:
+            self.project(payload, trace_id=getattr(event, "trace_id", "") or "")
+        except Exception as exc:  # noqa: BLE001 — projection must never break execution
+            logger.info("receipt projection failed (non-fatal): %s", exc)
+
+    def project(self, receipt: dict[str, Any], *, trace_id: str = "") -> str | None:
+        """Upsert one receipt record; returns the row id (idempotent)."""
+        action_id = receipt.get("action_id", "")
+        row_id = f"rcpt_{action_id}" if action_id else None
+        if row_id is None:
+            logger.warning("receipt without action_id — projection skipped")
+            return None
+        record = {
+            "id": row_id,
+            "receipt_id": row_id,
+            "action_id": action_id,
+            "trace_id": receipt.get("trace_id") or trace_id,
+            "session_id": receipt.get("session_id"),
+            "practice_id": receipt.get("practice_id"),
+            "episode_id": receipt.get("episode_id"),
+            "robot_id": receipt.get("robot_id"),
+            "body_id": receipt.get("body_id"),
+            "capability_id": receipt.get("capability_id"),
+            "execution_mode": _enum_value(receipt.get("mode") or receipt.get("execution_mode")),
+            "final_state": _enum_value(receipt.get("final_state")),
+            "acknowledgement_stage": _enum_value(receipt.get("acknowledgement_stage")),
+            "evidence_level": _enum_value(receipt.get("evidence_level")),
+            "evidence_domain": _enum_value(receipt.get("evidence_domain")),
+            "dispatched_at": _ts(receipt.get("started_at")),
+            "observed_at": _ts(receipt.get("finished_at")),
+            "verified_at": _ts((receipt.get("verification_result") or {}).get("verified_at")),
+            "artifact_refs": json.dumps(receipt.get("artifacts") or [], default=str),
+            "verification_refs": json.dumps(
+                (receipt.get("verification_result") or {}).get("evidence_refs") or [], default=str
+            ),
+            "schema_version": receipt.get("schema_version", ""),
+            "created_at": time.time(),
+        }
+        self._store.insert(TABLE, record)
+        if self._lineage is not None and action_id:
+            self._lineage.link(
+                "receipt",
+                row_id,
+                "generated_from",
+                "action",
+                action_id,
+                trace_id=record["trace_id"] or "",
+            )
+        return row_id
+
+
+def _enum_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(getattr(value, "value", value))
+
+
+def _ts(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        from datetime import datetime
+
+        if isinstance(value, datetime):
+            return value.timestamp()
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        return None

--- a/src/rosclaw/storage/seekdb_projection.py
+++ b/src/rosclaw/storage/seekdb_projection.py
@@ -87,6 +87,42 @@ class MemoryRetrievalProjection:
         self._store.connect()
         self._store.delete(PROJECTION_TABLE, memory_id)
 
+    def status(self, repository: Any | None = None) -> dict[str, Any]:
+        """Projection observability (PR-DF-07 §18): watermark + lag.
+
+        ``source_count`` is the structured-store memory_items watermark (when
+        a repository is given); ``projection_count`` is what the retrieval
+        index currently holds; ``lag`` is the difference.  The projection is
+        a rebuildable projection — lag is an operations signal, never a data
+        loss (rebuild() restores parity from the source of truth).
+        """
+        result: dict[str, Any] = {
+            "projection_backend": type(self._store).__name__,
+            "outbox_enabled": self._outbox is not None,
+        }
+        try:
+            self._store.connect()
+            result["projection_count"] = self._store.count(PROJECTION_TABLE)
+        except Exception as exc:  # noqa: BLE001
+            result["projection_count"] = None
+            result["error"] = str(exc)
+        if repository is not None:
+            try:
+                result["source_count"] = repository._client.count(PROJECTION_TABLE)
+                if result.get("projection_count") is not None:
+                    result["lag"] = result["source_count"] - result["projection_count"]
+            except Exception as exc:  # noqa: BLE001
+                result["source_count"] = None
+                result.setdefault("error", str(exc))
+        if self._outbox is not None:
+            try:
+                stats = self._outbox.stats()
+                result["outbox_pending"] = stats.get("pending")
+                result["outbox_deadletters"] = stats.get("deadletters", stats.get("dead_letters"))
+            except Exception:  # noqa: BLE001
+                pass
+        return result
+
     def rebuild(self, repository: Any, *, batch_size: int = 200) -> dict[str, Any]:
         """Rebuild the whole projection from the SQLite source of truth."""
         started = time.time()

--- a/tests/darwin/test_runtime_wiring.py
+++ b/tests/darwin/test_runtime_wiring.py
@@ -1,0 +1,46 @@
+"""PR-DF-13: Darwin enters the Runtime lifecycle (flywheel §39-40)."""
+
+from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+
+def _cfg(**over):
+    base = dict(  # noqa: C408 — kwargs spread pattern
+        robot_id="sim_test",
+        seekdb_backend="memory",
+        enable_memory=False,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+    )
+    base.update(over)
+    return RuntimeConfig(**base)
+
+
+def test_darwin_off_by_default():
+    rt = Runtime(_cfg())
+    rt.initialize()
+    try:
+        assert rt._darwin is None
+    finally:
+        rt.stop()
+
+
+def test_darwin_wired_when_enabled_with_data_plane():
+    rt = Runtime(_cfg(enable_darwin=True, darwin={"seeds": [0], "episodes": 5}))
+    rt.initialize()
+    try:
+        assert rt._darwin is not None
+        assert rt._darwin.engine is not None
+        # shares the runtime event bus and the data plane structured store
+        assert rt._darwin.engine._bus is rt.event_bus
+        assert rt._darwin.engine._seekdb is rt._data_plane.structured_store
+    finally:
+        rt.stop()
+    assert rt._darwin is None or rt._darwin.engine is not None  # stop is graceful

--- a/tests/evolution/test_evolution_repository.py
+++ b/tests/evolution/test_evolution_repository.py
@@ -1,0 +1,97 @@
+"""PR-DF-12: EvolutionRepository — structured store canonical, LocalStore spool."""
+
+import json
+
+from rosclaw.auto.storage.local_store import LocalStore
+from rosclaw.evolution.repository import EvolutionRepository
+from rosclaw.memory.seekdb_client import InMemoryStructuredStore, SQLiteStructuredStore
+
+
+def _repo(tmp_path):
+    store = InMemoryStructuredStore()
+    store.connect()
+    cache = LocalStore(str(tmp_path / "auto"))
+    return EvolutionRepository(store, cache), store, cache
+
+
+def test_save_goes_to_store_and_cache(tmp_path):
+    repo, store, cache = _repo(tmp_path)
+    repo.save("proposals", "prop_1", {"task_id": "t1", "hypothesis": "h"})
+    rows = store.query("evolution_records", {"namespace": "proposals"})
+    assert len(rows) == 1
+    assert rows[0]["id"] == "proposals:prop_1"
+    assert json.loads(rows[0]["data"])["hypothesis"] == "h"
+    assert cache.load("proposals", "prop_1")["hypothesis"] == "h"
+
+
+def test_load_reads_store_first(tmp_path):
+    repo, store, cache = _repo(tmp_path)
+    repo.save("experiments", "exp_1", {"result": 0.87})
+    cache.save("experiments", "exp_1", {"result": 0.0})  # stale cache
+    assert repo.load("experiments", "exp_1")["result"] == 0.87
+
+
+def test_store_down_falls_back_to_spool(tmp_path):
+    repo, store, cache = _repo(tmp_path)
+    repo.save("champions", "champ_1", {"skill": "pick", "version": "1.7"})
+
+    class _DeadStore:
+        def query(self, *a, **k):
+            raise ConnectionError("seekdb down")
+
+        def insert(self, *a, **k):
+            raise ConnectionError("seekdb down")
+
+        def delete(self, *a, **k):
+            raise ConnectionError("seekdb down")
+
+    repo._store = _DeadStore()
+    # save spools instead of raising; load/list still work from the spool
+    repo.save("champions", "champ_2", {"skill": "place", "version": "1.0"})
+    assert repo.load("champions", "champ_1")["version"] == "1.7"
+    assert set(repo.list_keys("champions")) == {"champ_1", "champ_2"}
+
+
+def test_sqlite_roundtrip_with_schema(tmp_path):
+    """The evolution_records table exists in ROSCLAW_STRUCTURED_SCHEMAS."""
+    store = SQLiteStructuredStore(str(tmp_path / "knowledge.sqlite"))
+    store.connect()
+    cache = LocalStore(str(tmp_path / "auto"))
+    repo = EvolutionRepository(store, cache)
+    repo.save("patches", "patch_1", {"changes": {"force": 300}})
+    assert repo.load("patches", "patch_1")["changes"] == {"force": 300}
+    assert repo.list_keys("patches") == ["patch_1"]
+    store.disconnect()
+
+
+def test_namespaces_isolated_by_composite_id(tmp_path):
+    repo, store, _ = _repo(tmp_path)
+    repo.save("proposals", "x", {"kind": "proposal"})
+    repo.save("deadends", "x", {"kind": "deadend"})
+    assert repo.load("proposals", "x")["kind"] == "proposal"
+    assert repo.load("deadends", "x")["kind"] == "deadend"
+    assert repo.stats()["namespaces"] == {"proposals": 1, "deadends": 1}
+
+
+def test_auto_engine_uses_repository_when_store_injected(tmp_path):
+    from rosclaw.auto.config import AutoConfig
+    from rosclaw.auto.engine.auto_engine import AutoEngine
+
+    store = InMemoryStructuredStore()
+    store.connect()
+    cfg = AutoConfig(local_store_path=str(tmp_path / "auto"), storage_backend="hybrid")
+    engine = AutoEngine(config=cfg, event_bus=None, seekdb_client=store)
+    assert isinstance(engine.store, EvolutionRepository)
+    engine.store.save("tasks", "task_1", {"goal": "pick"})
+    assert store.count("evolution_records", {"namespace": "tasks"}) == 1
+
+
+def test_auto_engine_local_default_unchanged(tmp_path):
+    from rosclaw.auto.config import AutoConfig
+    from rosclaw.auto.engine.auto_engine import AutoEngine
+
+    store = InMemoryStructuredStore()
+    store.connect()
+    cfg = AutoConfig(local_store_path=str(tmp_path / "auto"))  # storage_backend="local"
+    engine = AutoEngine(config=cfg, event_bus=None, seekdb_client=store)
+    assert isinstance(engine.store, LocalStore)

--- a/tests/how/test_recovery_loop_runtime.py
+++ b/tests/how/test_recovery_loop_runtime.py
@@ -1,0 +1,65 @@
+"""PR-DF-08: RecoveryLoop wired into the Runtime lifecycle (flywheel §23-24)."""
+
+from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+
+def _cfg(**over):
+    base = dict(  # noqa: C408 — kwargs spread pattern
+        robot_id="sim_test",
+        seekdb_backend="memory",
+        enable_memory=True,
+        enable_practice=False,
+        enable_how=True,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+    )
+    base.update(over)
+    return RuntimeConfig(**base)
+
+
+def test_recovery_loop_subscribed_when_memory_and_how_live():
+    rt = Runtime(_cfg())
+    rt.initialize()
+    try:
+        assert rt._how is not None, "test precondition: how engine built"
+        assert rt._recovery_loop is not None
+        # subscribed to the three loop topics
+        subs = getattr(rt.event_bus, "_subscribers", {})
+        for topic in (
+            "rosclaw.how.recovery_hint.generated",
+            "rosclaw.sandbox.episode.succeeded",
+            "rosclaw.sandbox.episode.failed",
+        ):
+            assert any(
+                getattr(cb, "__self__", None) is rt._recovery_loop
+                for cb in subs.get(topic, [])
+            ), topic
+    finally:
+        rt.stop()
+    # after stop the loop unsubscribes
+    assert rt._recovery_loop is None
+
+
+def test_recovery_loop_absent_without_how():
+    rt = Runtime(_cfg(enable_how=False))
+    rt.initialize()
+    try:
+        assert rt._recovery_loop is None
+    finally:
+        rt.stop()
+
+
+def test_recovery_loop_disabled_by_config():
+    rt = Runtime(_cfg(enable_recovery_loop=False))
+    rt.initialize()
+    try:
+        assert rt._how is not None
+        assert rt._recovery_loop is None
+    finally:
+        rt.stop()

--- a/tests/knowledge/test_consolidation.py
+++ b/tests/knowledge/test_consolidation.py
@@ -1,0 +1,74 @@
+"""PR-DF-09: Knowledge package consolidation — canonical rosclaw.knowledge,
+legacy shim, and federation coordinates actually passed by the Runtime."""
+
+from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+
+def test_legacy_import_surface():
+    from rosclaw.knowledge.legacy import (
+        EmbodimentCard,
+        KnowledgeInterface,
+        LegacyKnowledgeRuntime,
+        TaskCard,
+        VerifierCard,
+    )
+
+    assert LegacyKnowledgeRuntime is KnowledgeInterface
+    for cls in (KnowledgeInterface, TaskCard, EmbodimentCard, VerifierCard):
+        assert cls.__name__.startswith(("Knowledge", "Task", "Embodiment", "Verifier"))
+
+
+def test_know_package_still_importable():
+    import rosclaw.know  # noqa: F401 — compat shim must keep working
+
+    assert "DEPRECATED" in rosclaw.know.__doc__
+
+
+def _cfg(**over):
+    base = dict(  # noqa: C408 — kwargs spread pattern
+        robot_id="sim_test",
+        seekdb_backend="memory",
+        enable_memory=False,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=True,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+        knowledge_v2_mode="inprocess",
+    )
+    base.update(over)
+    return RuntimeConfig(**base)
+
+
+def test_runtime_passes_federation_coordinates(tmp_path):
+    rt = Runtime(_cfg(seekdb_path=str(tmp_path / "knowledge.sqlite")))
+    rt.initialize()
+    try:
+        mgr = rt._knowledge_v2_manager
+        assert mgr is not None, "v2 manager should initialize in inprocess mode"
+        cfg = mgr.config
+        assert cfg.memory_path == str(tmp_path / "knowledge.sqlite")
+        assert cfg.practice_path.endswith("data/practice")
+    finally:
+        rt.stop()
+
+
+def test_federation_database_from_dsn(tmp_path):
+    rt = Runtime(
+        _cfg(
+            seekdb_url="mysql://root@127.0.0.1:2881/rosclaw_prod",
+            seekdb_backend="sqlite",
+            seekdb_path=str(tmp_path / "knowledge.sqlite"),
+        )
+    )
+    rt.initialize()
+    try:
+        cfg = rt._knowledge_v2_manager.config
+        assert cfg.memory_database == "rosclaw_prod"
+    finally:
+        rt.stop()

--- a/tests/knowledge/test_usage_tracker.py
+++ b/tests/knowledge/test_usage_tracker.py
@@ -1,0 +1,103 @@
+"""PR-DF-10: KnowledgeUsageTracker — automatic conservative feedback loop."""
+
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.knowledge.usage_tracker import KnowledgeUsageTracker
+
+
+class _FakeFacade:
+    def __init__(self):
+        self.feedback_calls = []
+
+    def feedback(self, feedback):
+        self.feedback_calls.append(feedback)
+        return True
+
+
+def _pack_event(bus, pack_id="pack_1", units=("unit_a", "unit_b")):
+    bus.publish(
+        Event(
+            topic="know.reference_pack.created",
+            payload={
+                "reference_pack_id": pack_id,
+                "knowledge_unit_ids": list(units),
+                "count": len(units),
+            },
+        )
+    )
+
+
+def _judgment(bus, status="SUCCESS", episode_id="ep_1"):
+    bus.publish(
+        Event(
+            topic="rosclaw.critic.judgment",
+            payload={"episode_id": episode_id, "status": status, "practice_id": "prac_1"},
+        )
+    )
+
+
+def test_success_emits_useful_feedback_per_unit():
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade)
+    tracker.subscribe()
+    _pack_event(bus)
+    assert tracker.tracked_count == 1
+    _judgment(bus, status="SUCCESS")
+    assert tracker.tracked_count == 0
+    verdicts = [f.verdict for f in facade.feedback_calls]
+    assert verdicts == ["useful", "useful"]
+    fb = facade.feedback_calls[0]
+    assert fb.reference_pack_id == "pack_1"
+    assert fb.receipt_ref == "ep_1"
+    assert fb.practice_ref == "prac_1"
+    assert fb.used_by_agent is True
+    assert fb.origin == "verifier"
+
+
+def test_failure_emits_unknown_never_misleading():
+    """§31: automatic feedback must not over-attribute failures."""
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade)
+    tracker.subscribe()
+    _pack_event(bus, units=("unit_x",))
+    _judgment(bus, status="FAILURE")
+    assert [f.verdict for f in facade.feedback_calls] == ["unknown"]
+
+
+def test_ttl_expiry_closes_without_feedback():
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade, ttl_s=0.0)
+    tracker.subscribe()
+    _pack_event(bus)
+    _judgment(bus, status="SUCCESS")
+    assert facade.feedback_calls == []
+    assert tracker.tracked_count == 0
+
+
+def test_advice_linkage_attaches_advice_id():
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade)
+    tracker.subscribe()
+    _pack_event(bus)
+    bus.publish(
+        Event(
+            topic="how.advice.created",
+            payload={"reference_pack_id": "pack_1", "advice_id": "adv_9"},
+        )
+    )
+    _judgment(bus, status="SUCCESS")
+    assert facade.feedback_calls[0].advice_id == "adv_9"
+
+
+def test_unsubscribe_stops_feedback():
+    bus = EventBus()
+    facade = _FakeFacade()
+    tracker = KnowledgeUsageTracker(bus, facade)
+    tracker.subscribe()
+    tracker.unsubscribe()
+    _pack_event(bus)
+    _judgment(bus)
+    assert facade.feedback_calls == []

--- a/tests/memory/v2/test_critic_write_path.py
+++ b/tests/memory/v2/test_critic_write_path.py
@@ -1,0 +1,104 @@
+"""PR-DF-05: Memory canonical write path — critic judgments become
+evidence-backed MemoryItems through the WriteGate; experience_graph stays
+as the compatibility projection (Phase A)."""
+
+import json
+
+from rosclaw.core.event_bus import Event
+from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+
+def _runtime(store):
+    cfg = RuntimeConfig(
+        robot_id="sim_test",
+        seekdb_backend="memory",
+        enable_memory=True,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+    )
+    rt = Runtime(cfg)
+    from unittest.mock import patch
+
+    with patch.object(Runtime, "_create_seekdb_client", return_value=store):
+        rt.initialize()
+    return rt
+
+
+def _judgment(bus, episode_id="ep_1", status="SUCCESS", reward=0.9, reason=""):
+    bus.publish(
+        Event(
+            topic="rosclaw.critic.judgment",
+            payload={
+                "episode_id": episode_id,
+                "status": status,
+                "reward": reward,
+                "reason": reason,
+                "context": {"outcome": {"skill_name": "pick_cup"}, "instruction": "pick the cup"},
+            },
+        )
+    )
+
+
+def test_critic_judgment_writes_memory_item():
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+
+    store = InMemoryStructuredStore()
+    store.connect()
+    rt = _runtime(store)
+    assert rt._memory_gate is not None and rt._memory_repository is not None
+
+    _judgment(rt.event_bus, episode_id="ep_ok", status="SUCCESS", reward=0.9)
+    items = store.query("memory_items", {})
+    assert len(items) == 1
+    item = items[0]
+    assert item["memory_type"] == "episodic"
+    assert item["episode_id"] == "ep_ok"
+    assert item["reward"] == 0.9
+    # evidence-backed (§12): ACTIVE memory must carry evidence rows
+    evd = store.query("memory_evidence", {"memory_id": item["id"]})
+    assert evd, "memory_items row without evidence"
+    # compat projection also ran
+    assert store.count("experience_graph", {}) >= 1
+
+
+def test_critic_failure_becomes_failure_memory_with_evidence():
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+
+    store = InMemoryStructuredStore()
+    store.connect()
+    rt = _runtime(store)
+    _judgment(rt.event_bus, episode_id="ep_bad", status="FAILURE", reward=0.1, reason="slip")
+    items = store.query("memory_items", {"memory_type": "failure"})
+    assert len(items) == 1
+    assert items[0]["failure_type"] == "slip"
+    refs = items[0]["evidence_refs"]
+    if isinstance(refs, str):
+        refs = json.loads(refs)
+    assert refs == ["critic_result:ep_bad"]
+
+
+def test_critic_write_is_idempotent():
+    """E2E-7 flavor: replaying the same judgment must not duplicate memory."""
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+
+    store = InMemoryStructuredStore()
+    store.connect()
+    rt = _runtime(store)
+    _judgment(rt.event_bus, episode_id="ep_same", status="SUCCESS", reward=0.5)
+    _judgment(rt.event_bus, episode_id="ep_same", status="SUCCESS", reward=0.5)
+    assert store.count("memory_items", {}) == 1
+
+
+def test_memory_items_absent_when_store_missing():
+    """Data-plane failure → legacy projection only, loop unbroken (ADR-0009 §4)."""
+    rt = _runtime(None)
+    assert rt._memory_gate is None
+    _judgment(rt.event_bus)  # must not raise

--- a/tests/memory/v2/test_insights.py
+++ b/tests/memory/v2/test_insights.py
@@ -1,0 +1,113 @@
+"""PR-DF-11: MemoryInsightService — the publisher half of rosclaw.memory.insight."""
+
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.core.event_topics import EventTopics
+from rosclaw.memory.insights import MemoryInsightService
+from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+
+
+def _collect(bus):
+    received = []
+    bus.subscribe(EventTopics.MEMORY_INSIGHT_CREATED, lambda e: received.append(e.payload))
+    return received
+
+
+def _failure(bus, skill="pick_cup", reason="slip", episode="ep_1"):
+    bus.publish(
+        Event(
+            topic=EventTopics.CRITIC_JUDGMENT,
+            payload={
+                "episode_id": episode,
+                "status": "FAILURE",
+                "reason": reason,
+                "context": {"outcome": {"skill_name": skill}, "instruction": "pick"},
+            },
+        )
+    )
+
+
+def test_repeated_failure_insight_after_threshold():
+    bus = EventBus()
+    insights = _collect(bus)
+    svc = MemoryInsightService(bus, InMemoryStructuredStore(), robot_id="sim", failure_threshold=3)
+    svc.subscribe()
+    _failure(bus)
+    _failure(bus)
+    assert insights == []  # below threshold
+    _failure(bus)
+    assert [i["insight_type"] for i in insights] == ["repeated_failure"]
+    ins = insights[0]
+    assert ins["skill_id"] == "pick_cup"
+    assert ins["failure_type"] == "slip"
+    assert ins["robot_id"] == "sim"
+    assert ins["evidence_refs"]
+
+
+def test_similar_failure_with_patch_when_rule_proven():
+    bus = EventBus()
+    insights = _collect(bus)
+    store = InMemoryStructuredStore()
+    store.connect()
+    store.insert(
+        "heuristic_rules",
+        {
+            "id": "rule_1",
+            "failure_type": "slip",
+            "success_count": 4,
+            "parameter_patch": {"force_set": [300, 500]},
+        },
+    )
+    svc = MemoryInsightService(bus, store, robot_id="sim", failure_threshold=2)
+    svc.subscribe()
+    _failure(bus)
+    _failure(bus, episode="ep_2")
+    types = [i["insight_type"] for i in insights]
+    assert "similar_failure_with_patch" in types
+    ins = next(i for i in insights if i["insight_type"] == "similar_failure_with_patch")
+    # Auto's consumed fields are present
+    assert ins["search_space"] == {"force_set": [300, 500]}
+    assert ins["insight_summary"]
+    assert ins["failure_id"] == "ep_2"
+    assert ins["memory_refs"] == ["heuristic_rules:rule_1"]
+
+
+def test_no_patch_insight_without_proven_fix():
+    bus = EventBus()
+    insights = _collect(bus)
+    store = InMemoryStructuredStore()
+    store.connect()
+    store.insert(
+        "heuristic_rules",
+        {"id": "rule_weak", "failure_type": "slip", "success_count": 0},
+    )
+    svc = MemoryInsightService(bus, store, robot_id="sim", failure_threshold=2)
+    svc.subscribe()
+    _failure(bus)
+    _failure(bus)
+    assert [i["insight_type"] for i in insights] == ["repeated_failure"]
+
+
+def test_cooldown_dedup():
+    bus = EventBus()
+    insights = _collect(bus)
+    svc = MemoryInsightService(
+        bus, InMemoryStructuredStore(), robot_id="sim", failure_threshold=1, cooldown_s=3600
+    )
+    svc.subscribe()
+    for i in range(5):
+        _failure(bus, episode=f"ep_{i}")
+    assert len(insights) == 1
+
+
+def test_success_judgments_never_generate_insights():
+    bus = EventBus()
+    insights = _collect(bus)
+    svc = MemoryInsightService(bus, InMemoryStructuredStore(), robot_id="sim", failure_threshold=1)
+    svc.subscribe()
+    bus.publish(
+        Event(
+            topic=EventTopics.CRITIC_JUDGMENT,
+            payload={"episode_id": "ep_ok", "status": "SUCCESS", "context": {}},
+        )
+    )
+    assert insights == []

--- a/tests/memory/v2/test_migrate_cli.py
+++ b/tests/memory/v2/test_migrate_cli.py
@@ -1,0 +1,63 @@
+"""PR-DF-06: rosclaw memory migrate — legacy experience_graph -> memory_items."""
+
+import json
+import sys
+
+from rosclaw.cli import main
+from rosclaw.memory.seekdb_client import SQLiteStructuredStore
+
+
+def _seed_legacy(db_path, rows=3):
+    store = SQLiteStructuredStore(str(db_path))
+    store.connect()
+    for i in range(rows):
+        store.insert(
+            "experience_graph",
+            {
+                "id": f"exp_{i}",
+                "robot_id": "sim_test",
+                "event_type": "praxis",
+                "instruction": f"task {i}",
+                "outcome": "failure" if i == 0 else "success",
+                "error_details": "slip" if i == 0 else None,
+                "timestamp": 1700000000.0 + i,
+            },
+        )
+    store.disconnect()
+    return store
+
+
+def test_migrate_cli_and_idempotency(tmp_path, monkeypatch, capsys):
+    home = tmp_path / ".rosclaw"
+    monkeypatch.setenv("ROSCLAW_HOME", str(home))
+    db = home / "memory" / "seekdb.sqlite"
+    db.parent.mkdir(parents=True)
+    _seed_legacy(db)
+
+    monkeypatch.setattr(sys, "argv", ["rosclaw", "memory", "migrate", "--json"])
+    assert main() == 0
+    first = json.loads(capsys.readouterr().out)
+    assert first["from"] == "experience_graph"
+    assert first["scanned"] == 3
+    assert first["migrated"] == 3
+
+    # failure outcome maps to failure memory; the rest episodic
+    store = SQLiteStructuredStore(str(db))
+    store.connect()
+    assert store.count("memory_items", {"memory_type": "failure"}) == 1
+    assert store.count("memory_items", {"memory_type": "episodic"}) == 2
+    store.disconnect()
+
+    # rerun: nothing duplicates
+    monkeypatch.setattr(sys, "argv", ["rosclaw", "memory", "migrate", "--json"])
+    assert main() == 0
+    second = json.loads(capsys.readouterr().out)
+    assert second["migrated"] == 0
+    assert second["deduplicated"] == 3
+
+
+def test_migrate_missing_db_is_clean_error(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ROSCLAW_HOME", str(tmp_path / ".rosclaw"))
+    monkeypatch.setattr(sys, "argv", ["rosclaw", "memory", "migrate"])
+    assert main() == 1
+    assert "not found" in capsys.readouterr().err

--- a/tests/practice/test_fact_pipeline.py
+++ b/tests/practice/test_fact_pipeline.py
@@ -1,0 +1,105 @@
+"""PR-DF-04: Practice fact pipeline — canonical names + session-close verify."""
+
+import tempfile
+import time
+from pathlib import Path
+
+from rosclaw.practice.config import PracticeConfig, SourceConfig
+from rosclaw.practice.coordinator import PracticeCoordinator
+
+
+def test_canonical_names_and_aliases():
+    from rosclaw.practice.distiller import (
+        DistillationResult,
+        EpisodeFactBundle,
+        EpisodeFactExtractor,
+        PracticeDistiller,
+    )
+    from rosclaw.practice.seekdb_ingestor import PracticeFactIngestor, SeekDBIngestor
+
+    assert PracticeDistiller is EpisodeFactExtractor
+    assert DistillationResult is EpisodeFactBundle
+    assert SeekDBIngestor is PracticeFactIngestor
+    assert hasattr(EpisodeFactExtractor, "extract")
+
+
+def test_extract_returns_fact_bundle():
+    """The canonical verb produces the fact bundle from a closed session."""
+    from rosclaw.practice.distiller import EpisodeFactBundle, EpisodeFactExtractor
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = PracticeConfig(
+            robot_id="test_bot",
+            task_name="pick cup",
+            data_root=tmp,
+            sources=SourceConfig(agent=True),
+            mock=True,
+            publish_to_event_bus=False,
+        )
+        coord = PracticeCoordinator(cfg)
+        coord.initialize()
+        coord.start()
+        time.sleep(0.3)
+        coord.stop()
+        practice_id = coord.summary.practice_id
+
+        bundle = EpisodeFactExtractor(tmp).extract(practice_id, write_artifacts=False)
+        assert isinstance(bundle, EpisodeFactBundle)
+        assert bundle.practice_id == practice_id
+        assert bundle.session_id
+
+
+def test_session_close_runs_fact_verify():
+    """PR-DF-04 §19: session close = verify → extract → ingest; the verify
+    outcome is recorded on the summary (observable) and never blocks close."""
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = PracticeConfig(
+            robot_id="test_bot",
+            task_name="pick cup",
+            data_root=tmp,
+            sources=SourceConfig(agent=True, runtime=True),
+            mock=True,
+            publish_to_event_bus=False,
+        )
+        coord = PracticeCoordinator(cfg)
+        coord.initialize()
+        coord.start()
+        time.sleep(0.3)
+        coord.stop()
+
+        summary = coord.summary
+        assert summary is not None
+        assert summary.fact_verify is not None
+        assert summary.fact_verify["passed"] is True
+        assert summary.fact_verify["errors"] == 0
+        # the manifest was written after the pipeline and carries the record
+        manifest = (Path(tmp) / "sessions" / summary.practice_id / "manifest.yaml").read_text()
+        assert "fact_verify" in manifest
+
+
+def test_fact_verify_failure_does_not_block_close():
+    """A verifier exception degrades to None — the session still closes."""
+    from unittest.mock import patch
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = PracticeConfig(
+            robot_id="test_bot",
+            task_name="pick cup",
+            data_root=tmp,
+            sources=SourceConfig(agent=True),
+            mock=True,
+            publish_to_event_bus=False,
+        )
+        coord = PracticeCoordinator(cfg)
+        coord.initialize()
+        coord.start()
+        time.sleep(0.2)
+        with patch(
+            "rosclaw.practice.verifier.PracticeVerifier.verify",
+            side_effect=RuntimeError("verifier exploded"),
+        ):
+            coord.stop()
+        summary = coord.summary
+        assert summary is not None
+        assert summary.fact_verify is None
+        assert summary.outcome == "SUCCESS"

--- a/tests/storage/test_data_plane_context.py
+++ b/tests/storage/test_data_plane_context.py
@@ -1,0 +1,80 @@
+"""PR-DF-03: DataPlaneContext — single assembly, per-piece fault isolation."""
+
+from unittest.mock import MagicMock, patch
+
+from rosclaw.storage.context import DataPlaneContext
+
+
+def test_context_defaults_all_none():
+    ctx = DataPlaneContext()
+    assert ctx.structured_store is None
+    assert ctx.retrieval_store is None
+    assert ctx.outbox is None
+    assert ctx.memory_projection is None
+    assert ctx.memory_retrieval is None
+    assert ctx.practice_sink is None
+
+
+def test_capabilities_snapshot_names_backends():
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+
+    ctx = DataPlaneContext(structured_store=InMemoryStructuredStore())
+    caps = ctx.capabilities()
+    assert caps["structured_backend"] == "InMemoryStructuredStore"
+    assert caps["outbox_enabled"] is False
+    assert caps["memory_retrieval"] is False
+    assert caps["practice_sink"] is None
+
+
+def test_runtime_assembles_data_plane_once():
+    """Runtime.initialize populates _data_plane and memory uses its store."""
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    cfg = RuntimeConfig(
+        robot_id="sim_test",
+        seekdb_backend="memory",
+        enable_memory=True,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+    )
+    rt = Runtime(cfg)
+    store = MagicMock()
+    with patch.object(Runtime, "_create_seekdb_client", return_value=store) as create:
+        rt.initialize()
+    assert create.call_count <= 1  # assembled once, not per-module
+    assert rt._data_plane is not None
+    assert rt._data_plane.structured_store is store
+
+
+def test_runtime_survives_structured_store_failure():
+    """ADR-0009 §4: a data-plane failure must never take the Runtime down."""
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    cfg = RuntimeConfig(
+        robot_id="sim_test",
+        seekdb_backend="memory",
+        enable_memory=False,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+    )
+    rt = Runtime(cfg)
+    with patch.object(Runtime, "_create_seekdb_client", side_effect=RuntimeError("db dead")):
+        rt.initialize()  # must not raise
+    assert rt._data_plane is not None
+    assert rt._data_plane.structured_store is None

--- a/tests/storage/test_flywheel_observability.py
+++ b/tests/storage/test_flywheel_observability.py
@@ -1,0 +1,116 @@
+"""PR-DF-15: observability — db doctor flywheel checks + dashboard endpoint."""
+
+
+from rosclaw.memory.seekdb_client import SQLiteStructuredStore
+from rosclaw.storage.cli import _flywheel_checks
+
+
+def _make_cfg(tmp_path, **over):
+    cfg = {
+        "backend": "sqlite",
+        "path": str(tmp_path / "knowledge.sqlite"),
+        "retrieval_enabled": False,
+        "outbox_enabled": False,
+        "outbox_path": str(tmp_path / "outbox.sqlite"),
+        "retrieval_path": str(tmp_path / "seekdb"),
+    }
+    cfg.update(over)
+    return cfg
+
+
+def test_doctor_flags_active_memory_without_evidence(tmp_path):
+    store = SQLiteStructuredStore(str(tmp_path / "knowledge.sqlite"))
+    store.connect()
+    store.insert(
+        "memory_items",
+        {
+            "id": "mem_orphan",
+            "memory_type": "episodic",
+            "robot_id": "sim",
+            "title": "t",
+            "document": "d",
+            "status": "active",
+            "content_hash": "x",
+        },
+    )
+    checks, issues = [], []
+    _flywheel_checks(_make_cfg(tmp_path), store, checks, issues)
+    names = [c[0] for c in checks]
+    assert "memory evidence" in names
+    assert any("no evidence" in i for i in issues)
+    store.disconnect()
+
+
+def test_doctor_clean_when_evidence_present(tmp_path):
+    store = SQLiteStructuredStore(str(tmp_path / "knowledge.sqlite"))
+    store.connect()
+    store.insert(
+        "memory_items",
+        {
+            "id": "mem_ok",
+            "memory_type": "episodic",
+            "robot_id": "sim",
+            "title": "t",
+            "document": "d",
+            "status": "active",
+            "content_hash": "y",
+        },
+    )
+    store.insert(
+        "memory_evidence",
+        {"id": "evd_1", "memory_id": "mem_ok", "evidence_type": "practice_event"},
+    )
+    checks, issues = [], []
+    _flywheel_checks(_make_cfg(tmp_path), store, checks, issues)
+    mem = next(c for c in checks if c[0] == "memory evidence")
+    assert mem[2] is True
+    assert not issues
+    store.disconnect()
+
+
+def test_doctor_flags_unlinked_receipts(tmp_path):
+    store = SQLiteStructuredStore(str(tmp_path / "knowledge.sqlite"))
+    store.connect()
+    store.insert("execution_receipts", {"id": "rcpt_1", "action_id": "a1"})
+    checks, issues = [], []
+    _flywheel_checks(_make_cfg(tmp_path), store, checks, issues)
+    lin = next(c for c in checks if c[0] == "lineage edges")
+    assert lin[2] is False
+    assert any("lineage" in i for i in issues)
+    store.disconnect()
+
+
+def test_doctor_survives_dead_store(tmp_path):
+    class _Dead:
+        def query(self, *a, **k):
+            raise ConnectionError("down")
+
+        def count(self, *a, **k):
+            raise ConnectionError("down")
+
+    checks, issues = [], []
+    _flywheel_checks(_make_cfg(tmp_path), _Dead(), checks, issues)  # must not raise
+
+
+def test_dashboard_flywheel_endpoint(tmp_path, monkeypatch):
+    """The aggregate endpoint reports store counts without a runtime."""
+    monkeypatch.setenv("ROSCLAW_HOME", str(tmp_path / ".rosclaw"))
+    store = SQLiteStructuredStore(str(tmp_path / ".rosclaw" / "data" / "memory" / "knowledge.sqlite"))
+    store.connect()
+    store.insert(
+        "memory_items",
+        {"id": "m1", "memory_type": "episodic", "robot_id": "sim", "title": "t",
+         "document": "d", "status": "active", "content_hash": "z"},
+    )
+    store.disconnect()
+
+    import asyncio
+
+    from rosclaw.dashboard.web_server import DashboardWebServer
+
+    server = DashboardWebServer()
+    routes = {r.path: r.endpoint for r in server.app.routes}
+    assert "/api/data-flywheel" in routes
+    payload = asyncio.run(routes["/api/data-flywheel"]())
+    assert payload["structured_store_connected"] is True
+    assert payload["memory"]["items"] == 1

--- a/tests/storage/test_lineage_receipts.py
+++ b/tests/storage/test_lineage_receipts.py
@@ -1,0 +1,113 @@
+"""PR-DF-14: execution_receipts + lineage_edges — projector and repository."""
+
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.core.event_topics import EventTopics
+from rosclaw.memory.seekdb_client import InMemoryStructuredStore, SQLiteStructuredStore
+from rosclaw.storage.lineage import LineageRepository
+from rosclaw.storage.receipts import ReceiptProjector
+
+
+def _store():
+    s = InMemoryStructuredStore()
+    s.connect()
+    return s
+
+
+def test_lineage_link_parents_children_trace():
+    repo = LineageRepository(_store())
+    repo.link("champion", "champ_1", "promoted_from", "evaluation", "eval_9")
+    repo.link("evaluation", "eval_9", "evaluated_by", "experiment", "exp_3")
+    repo.link("experiment", "exp_3", "derived_from", "patch", "patch_2")
+
+    parents = repo.parents("champion", "champ_1")
+    assert parents[0]["to_id"] == "eval_9"
+    children = repo.children("patch", "patch_2")
+    assert children[0]["from_id"] == "exp_3"
+
+    trace = repo.trace("champion", "champ_1")
+    kinds = [(c["to_type"], c["to_id"]) for c in trace["chain"]]
+    assert kinds == [("evaluation", "eval_9"), ("experiment", "exp_3"), ("patch", "patch_2")]
+
+
+def test_lineage_link_idempotent_and_cycle_safe():
+    repo = LineageRepository(_store())
+    a = repo.link("memory", "m1", "derived_from", "episode", "e1")
+    b = repo.link("memory", "m1", "derived_from", "episode", "e1")
+    assert a == b
+    # cycle: e1 -> m1 while m1 -> e1 exists; ancestors must terminate
+    repo.link("episode", "e1", "observed_in", "memory", "m1")
+    chain = repo.ancestors("memory", "m1")
+    assert len(chain) <= 3
+
+
+def test_receipt_projector_writes_and_links():
+    store = _store()
+    bus = EventBus()
+    lineage = LineageRepository(store)
+    proj = ReceiptProjector(bus, store, lineage=lineage)
+    proj.subscribe()
+    bus.publish(
+        Event(
+            topic=EventTopics.ACTION_RECEIPT,
+            payload={
+                "action_id": "act_1",
+                "trace_id": "trace_1",
+                "mode": "REAL",
+                "final_state": "SUCCEEDED",
+                "body_id": "rh56_right",
+                "capability_id": "rh56.single_step",
+                "evidence_level": "task_verified",
+                "evidence_domain": "hardware",
+                "episode_id": "ep_1",
+                "practice_id": "prac_1",
+                "artifacts": ["file:///tmp/x.mcap"],
+            },
+            trace_id="trace_1",
+        )
+    )
+    rows = store.query("execution_receipts", {"action_id": "act_1"})
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["execution_mode"] == "REAL"
+    assert row["evidence_domain"] == "hardware"
+    assert row["trace_id"] == "trace_1"
+    # lineage edge receipt -> action
+    edges = store.query("lineage_edges", {"from_id": "rcpt_act_1"})
+    assert edges and edges[0]["relation"] == "generated_from"
+    assert edges[0]["to_id"] == "act_1"
+    # idempotent re-delivery
+    proj.project({"action_id": "act_1", "final_state": "SUCCEEDED"})
+    assert store.count("execution_receipts", {"action_id": "act_1"}) == 1
+
+
+def test_receipt_projector_failure_never_raises():
+    class _DeadStore:
+        def insert(self, *a, **k):
+            raise ConnectionError("down")
+
+        def query(self, *a, **k):
+            raise ConnectionError("down")
+
+    bus = EventBus()
+    proj = ReceiptProjector(bus, _DeadStore(), lineage=None)
+    proj.subscribe()
+    bus.publish(
+        Event(topic=EventTopics.ACTION_RECEIPT, payload={"action_id": "act_x"})
+    )  # must not raise
+
+
+def test_schemas_in_structured_store(tmp_path):
+    """execution_receipts + lineage_edges exist in the SQLite schema set."""
+    store = SQLiteStructuredStore(str(tmp_path / "k.sqlite"))
+    store.connect()
+    store.insert(
+        "execution_receipts", {"id": "r1", "action_id": "a1", "final_state": "SUCCEEDED"}
+    )
+    store.insert(
+        "lineage_edges",
+        {"id": "l1", "from_type": "receipt", "from_id": "r1", "relation": "generated_from",
+         "to_type": "action", "to_id": "a1"},
+    )
+    assert store.count("execution_receipts", {}) == 1
+    assert store.count("lineage_edges", {}) == 1
+    store.disconnect()

--- a/tests/storage/test_retrieval_projection.py
+++ b/tests/storage/test_retrieval_projection.py
@@ -1,0 +1,142 @@
+"""PR-DF-07: retrieval projection wiring — status watermark/lag, runtime
+assembly, target-filtered outbox drain."""
+
+import time
+
+import pytest
+
+
+def test_projection_status_reports_lag():
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+    from rosclaw.memory.v2.repository import MemoryRepository
+    from rosclaw.storage.seekdb_projection import MemoryRetrievalProjection
+
+    source = InMemoryStructuredStore()
+    source.connect()
+    native = InMemoryStructuredStore()  # stand-in for the native store (count API)
+    native.connect()
+    repo = MemoryRepository(source)
+
+    from rosclaw.memory.v2.models import MemoryItem
+
+    for i in range(3):
+        repo.store(
+            MemoryItem(
+                memory_type="episodic",
+                robot_id="sim",
+                title=f"mem {i}",
+                document=f"doc {i}",
+                evidence_refs=[f"evd_{i}"],
+            )
+        )
+    proj = MemoryRetrievalProjection(native)
+    status = proj.status(repo)
+    assert status["source_count"] == 3
+    assert status["projection_count"] == 0
+    assert status["lag"] == 3
+
+    # project one record; lag closes
+    proj.project(source.query("memory_items", {})[0])
+    status = proj.status(repo)
+    assert status["lag"] == 2
+
+
+def test_projection_outbox_enqueue():
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+    from rosclaw.storage.outbox import OutboxStore
+    from rosclaw.storage.seekdb_projection import MemoryRetrievalProjection
+
+    outbox = OutboxStore(db_path=":memory:")
+    outbox.connect()
+    native = InMemoryStructuredStore()
+    proj = MemoryRetrievalProjection(native, outbox=outbox)
+    proj.project({"id": "mem_1", "title": "t", "document": "d"})
+    stats = outbox.stats()
+    assert stats["pending"] == 1
+    # nothing written to the native store until a worker drains
+    assert native.count("memory_items") == 0
+
+
+def test_target_filtered_worker_drains_only_its_target():
+    """Two pipelines share one outbox; each worker claims only its target."""
+    from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+    from rosclaw.storage.outbox import OutboxStore, OutboxWorker
+    from rosclaw.storage.seekdb_projection import MemoryRetrievalProjectionCommitter
+
+    outbox = OutboxStore(db_path=":memory:")
+    outbox.connect()
+    outbox.enqueue("seekdb_projection", {"id": "mem_a", "title": "a"}, entity_id="mem_a")
+    outbox.enqueue("practice_events", {"id": "evt_1"}, entity_id="evt_1")
+
+    native = InMemoryStructuredStore()
+    worker = OutboxWorker(
+        outbox,
+        MemoryRetrievalProjectionCommitter(native),
+        target="seekdb_projection",
+        interval_sec=0.05,
+    )
+    delivered = worker.flush(timeout=5.0)
+    assert delivered == 1
+    assert native.count("memory_items") == 1
+    # the practice record is untouched for its own worker
+    assert outbox.stats()["pending"] == 1
+
+
+def test_runtime_builds_projection_when_retrieval_enabled(tmp_path):
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    cfg = RuntimeConfig(
+        robot_id="sim_test",
+        seekdb_backend="sqlite",
+        seekdb_path=str(tmp_path / "knowledge.sqlite"),
+        enable_memory=True,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+        storage={"retrieval": {"enabled": True, "path": str(tmp_path / "seekdb")}},
+    )
+    rt = Runtime(cfg)
+    try:
+        rt.initialize()
+    except Exception as exc:  # native store unavailable on this host
+        pytest.skip(f"native SeekDB unavailable: {exc}")
+    assert rt._data_plane is not None
+    assert rt._data_plane.retrieval_store is not None
+    assert rt._data_plane.memory_projection is not None
+    # repository got the projection injected (DF-05 x DF-07 link)
+    assert rt._memory_repository is not None
+    assert rt._memory_repository._projection is rt._data_plane.memory_projection
+    rt.stop()
+    time.sleep(0.1)
+
+
+def test_runtime_projection_disabled_by_default(tmp_path):
+    from rosclaw.core.runtime import Runtime, RuntimeConfig
+
+    cfg = RuntimeConfig(
+        robot_id="sim_test",
+        seekdb_backend="sqlite",
+        seekdb_path=str(tmp_path / "knowledge.sqlite"),
+        enable_memory=True,
+        enable_practice=False,
+        enable_how=False,
+        enable_auto=False,
+        enable_knowledge=False,
+        enable_skill_manager=False,
+        enable_provider=False,
+        enable_sense=False,
+        enable_firewall=False,
+        enable_event_persistence=False,
+        enable_tracing=False,
+    )
+    rt = Runtime(cfg)
+    rt.initialize()
+    assert rt._data_plane.memory_projection is None
+    rt.stop()


### PR DESCRIPTION
## 这是什么

数据飞轮 DF-03…DF-15 的全部内容归并为一个对 main 的 PR。**背景（如实说明）**：栈式合并过程中 `gh pr edit --base` 因 GraphQL 报错静默失败，子 PR 被合进了各自的父分支而非 main；且我的合并脚本在 update-branch 后、CI 注册前把空 rollup 误判为全绿。本 PR 是纠正：全部内容以**本地完整验证过的栈顶**为准（与远端缠结分支内容一致），与 main 已干净合并。

已在 main 的：#344 (DF-00 docs)、#345 (DF-01 命名)、#346 (DF-02 config v2)。本 PR 含 DF-03…DF-15 全部增量（36 文件）：

- DataPlaneContext 单次装配（DF-03）
- Practice close 时 verify→extract→ingest（DF-04）
- Critic→MemoryItem canonical 主写链（DF-05）
- `rosclaw memory migrate`（DF-06）
- 检索投影 + target 隔离 worker + lag（DF-07）
- RecoveryLoop / KnowledgeUsageTracker / MemoryInsightService / Darwin 入 Runtime（DF-08/10/11/13）
- Knowledge 包合并 + 联邦坐标（DF-09）
- EvolutionRepository（LocalStore 降级 spool，DF-12）
- execution_receipts + lineage_edges + ReceiptProjector + LineageRepository（DF-14）
- doctor 飞轮检查 + /api/data-flywheel（DF-15）
- 实施报告 `docs/reports/ROSCLAW_DATA_FLYWHEEL_REFACTOR_REPORT.md`（§65）

## 验证

- 本地目标套件 443 绿（storage/memory/practice/how/knowledge/darwin/evolution/runtime）
- `ruff check src tests`：All checks passed（含 CI 抓出的 DF-01 兼容问题的修复：模块属性还原 + 旧名 patch 点恢复——body 端到端测试在 CI 的 AttributeError 与 0==2 均已定位修复）
- mypy src/rosclaw：无问题
- 全量套件在本树上的结果见评论（跑完即贴）

## 善后计划

合并后：关闭/删除缠结的栈分支与未合并的 #353/#361，并在各原 PR 评论指向本 PR。DF-16（物理迁移）随后独立进行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)