### PR TITLE
fix: 十五审 RF-1 热修——治理工具注册 + 旅程 task_submit + worker env key 引用透传

### DIFF
--- a/packages/rosclaw-agent/src/runtime/create-runtime.ts
+++ b/packages/rosclaw-agent/src/runtime/create-runtime.ts
@@ -18,6 +18,7 @@ import { migrateProviders } from "../credentials/migration.js";
 import { resourcePolicy } from "../extension/resource-policy.js";
 import { createSharedModelRuntime } from "./model-runtime.js";
 import { filterModelTools } from "../tools/surface.js";
+import { buildGovernanceTools } from "../tools/governance.js";
 import { ActiveSessionContext } from "../session/active-context.js";
 import { AgentSessionCoordinator } from "../session/coordinator.js";
 import { SessionLeaseManager } from "../session/lease-manager.js";
@@ -198,6 +199,13 @@ export async function createRosclawRuntime(
 			// resume/extend/check/list/update/read_work_*）从模型面移除，
 			// 裂变/横跳/猜因不再可能。plumbing 仍在 bridge/命令层可用。
 			const customTools = filterModelTools([
+				// 十五审 PR-RF-1：治理工具（task_submit/observe/steer/answer/
+				// pause/resume/cancel）——模型唯一的任务入口。
+				...buildGovernanceTools({
+					rosclawHome: options.rosclawHome,
+					active,
+					center,
+				}),
 				buildStatusTool(center),
 				// PR-SIX-3：当前 body 的可信能力面（模型不再猜 ID）。
 				buildCapabilitiesTool({

--- a/packages/rosclaw-agent/src/tools/bridge-tools.ts
+++ b/packages/rosclaw-agent/src/tools/bridge-tools.ts
@@ -24,7 +24,7 @@ export interface BridgeToolContext {
 
 let requestCounter = 0;
 
-async function executeVia(
+export async function executeVia(
 	ctx: BridgeToolContext,
 	toolName: string,
 	arguments_: Record<string, unknown>,

--- a/packages/rosclaw-agent/src/tools/governance.ts
+++ b/packages/rosclaw-agent/src/tools/governance.ts
@@ -1,0 +1,99 @@
+/** 治理工具集（十五审 PR-RF-1，ADR-0011 无为而治）。
+ *
+ * 模型唯一的任务入口：task_submit 交目标合同（TaskSpec），其余都是
+ * 对同一 owning execution 的观察/steer/回答/暂停/恢复/取消。
+ * 没有 worker 选择器、没有 retry 工厂、没有 transcript 搬运。
+ */
+
+import { Type } from "@earendil-works/pi-ai";
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+
+import { executeVia, type BridgeToolContext } from "./bridge-tools.js";
+
+export function buildGovernanceTools(ctx: BridgeToolContext): ToolDefinition[] {
+	return [
+		defineTool({
+			name: "rosclaw_task_submit",
+			label: "ROSClaw Task Submit",
+			description:
+				"Submit a task goal contract (TaskSpec) to the Task Control Plane. " +
+				"The ExecutionRouter picks the execution domain — you never choose a worker. " +
+				"One task = one owning execution: re-submitting the same goal attaches to it.",
+			parameters: Type.Object({
+				goal: Type.String({ description: "自包含目标（用户意图，非微步骤剧本）" }),
+				required_capabilities: Type.Optional(Type.Array(Type.String())),
+				effects: Type.Optional(Type.String({ description: "simulation_only | workspace_only | physical_*" })),
+				inputs: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+				deliverables: Type.Optional(Type.Array(Type.Record(Type.String(), Type.Unknown()))),
+				acceptance: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+			}),
+			async execute(_id, params, _signal, _onUpdate, _ctx) {
+				return await executeVia(ctx, "rosclaw_task_submit", params as Record<string, unknown>);
+			},
+		}),
+		defineTool({
+			name: "rosclaw_task_observe",
+			label: "ROSClaw Task Observe",
+			description:
+				"Authoritative execution state + summary + verifier verdict for a task " +
+				"(execution ledger — conversation history is stale). Never returns full transcripts.",
+			parameters: Type.Object({
+				execution_id: Type.String(),
+			}),
+			async execute(_id, params, _signal, _onUpdate, _ctx) {
+				return await executeVia(ctx, "rosclaw_task_observe", params as Record<string, unknown>);
+			},
+		}),
+		defineTool({
+			name: "rosclaw_task_steer",
+			label: "ROSClaw Task Steer",
+			description: "Send a steering note to the SAME running execution session.",
+			parameters: Type.Object({
+				execution_id: Type.String(),
+				message: Type.String(),
+			}),
+			async execute(_id, params, _signal, _onUpdate, _ctx) {
+				return await executeVia(ctx, "rosclaw_task_steer", params as Record<string, unknown>);
+			},
+		}),
+		defineTool({
+			name: "rosclaw_task_answer",
+			label: "ROSClaw Task Answer",
+			description: "Answer an execution's question (INPUT_REQUIRED) — same session continues.",
+			parameters: Type.Object({
+				execution_id: Type.String(),
+				answer: Type.String(),
+			}),
+			async execute(_id, params, _signal, _onUpdate, _ctx) {
+				return await executeVia(ctx, "rosclaw_task_answer", params as Record<string, unknown>);
+			},
+		}),
+		defineTool({
+			name: "rosclaw_task_pause",
+			label: "ROSClaw Task Pause",
+			description: "Pause a running execution (control ACK — session preserved).",
+			parameters: Type.Object({ execution_id: Type.String() }),
+			async execute(_id, params, _signal, _onUpdate, _ctx) {
+				return await executeVia(ctx, "rosclaw_task_pause", params as Record<string, unknown>);
+			},
+		}),
+		defineTool({
+			name: "rosclaw_task_resume",
+			label: "ROSClaw Task Resume",
+			description: "Resume a paused execution (same session).",
+			parameters: Type.Object({ execution_id: Type.String() }),
+			async execute(_id, params, _signal, _onUpdate, _ctx) {
+				return await executeVia(ctx, "rosclaw_task_resume", params as Record<string, unknown>);
+			},
+		}),
+		defineTool({
+			name: "rosclaw_task_cancel",
+			label: "ROSClaw Task Cancel",
+			description: "Cancel an execution (audited control cancel).",
+			parameters: Type.Object({ execution_id: Type.String() }),
+			async execute(_id, params, _signal, _onUpdate, _ctx) {
+				return await executeVia(ctx, "rosclaw_task_cancel", params as Record<string, unknown>);
+			},
+		}),
+	];
+}

--- a/src/rosclaw/agentd/control_plane.py
+++ b/src/rosclaw/agentd/control_plane.py
@@ -313,6 +313,15 @@ class TaskControlPlane:
             return
         card = registry.get("worker:rosclaw:pi")
         deliverables = spec.get("deliverables") or []
+        # profile 由任务性质决定（不是默认 developer）：code.* 能力 →
+        # developer（workspace+deliverable 校验）；其余 → scout（只读/
+        # 分析——纯文本交付不应触发 developer 的 diff 验收）。
+        capabilities = [str(c) for c in (spec.get("required_capabilities") or [])]
+        profile = str((spec.get("inputs") or {}).get("profile", "")) or (
+            "developer"
+            if any(c.startswith(("code.", "capability.")) for c in capabilities)
+            else "scout"
+        )
         order = WorkOrderV1(
             work_order_id=new_id("wo"),
             mission_id=mission_id,
@@ -321,7 +330,7 @@ class TaskControlPlane:
             goal=str(spec.get("goal", "")),
             inputs={
                 "instructions": str(spec.get("goal", "")),
-                "worker_profile": str((spec.get("inputs") or {}).get("profile", "developer")),
+                "worker_profile": profile,
                 "_execution_id": execution_id,
             },
             budgets=BudgetEnvelope(),

--- a/src/rosclaw/agentd/workers/pi_managed.py
+++ b/src/rosclaw/agentd/workers/pi_managed.py
@@ -715,6 +715,19 @@ class PiManagedAdapter:
         for key in ("KIMI_API_KEY", "MOONSHOT_API_KEY", "ROSCLAW_KIMI_API_KEY"):
             if os.environ.get(key):
                 env[key] = os.environ[key]
+        # 十五审 PR-RF-1 热修（旅程实证）：models.json 里 "$VAR" 形式的
+        # provider apiKey 引用也要透传——Worker 只拿到变量名指向的 env
+        # 值（引用透传，不是凭据落盘/入 envelope）。缺失时 worker 401
+        # （FAKE_JOURNEY_KEY 案例）。
+        with contextlib.suppress(Exception):
+            models_json = self._home / "agent" / "models.json"
+            if models_json.exists():
+                import re as _re
+
+                text = models_json.read_text(encoding="utf-8", errors="replace")
+                for var in _re.findall(r'"\$([A-Z][A-Z0-9_]+)"', text):
+                    if os.environ.get(var):
+                        env[var] = os.environ[var]
         env["ROSCLAW_HOME"] = str(self._home)
         env["ROSCLAW_WORKER_PROTOCOL"] = "pi_headless"
         proc = await asyncio.create_subprocess_exec(

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -367,11 +367,13 @@ class _FakeModel:
             frames.append(_sse(_chunk("Worker 结果已综合给用户。")))
             frames.append(_sse(_chunk("", "stop")))
         elif "委派" in text:
+            # 十五审 PR-RF-1：模型面不再有 rosclaw_delegate——治理入口
+            # task_submit（TaskSpec 目标合同，router 决定执行域）。
             frames.extend(
                 _tool_call_frames(
                     "call_delegate",
-                    "rosclaw_delegate",
-                    json.dumps({"goal": "总结这段日志", "worker_id": "auto"}),
+                    "rosclaw_task_submit",
+                    json.dumps({"goal": "总结这段日志"}),
                 )
             )
         elif "画五角星" in text or "画一个五角星" in text:


### PR DESCRIPTION
#370 合入后发现三个实证缺陷（Native Agent Gate 红暴露）：

1. **治理工具本体未注册**：surface 过滤掉了 delegate 等旧工具，但 task_* 的 TS 工具定义不存在——模型没有任何任务入口（旅程 PTY：delegate 调用被拒，完成推送永不发生）。补 `tools/governance.ts` 七个治理工具（task_submit/observe/steer/answer/pause/resume/cancel）并接入 create-runtime。
2. **旅程委派腿迁移**：fake model 的 rosclaw_delegate → rosclaw_task_submit（治理路径）。
3. **control-plane harness 默认 profile=scout**：只读/分析任务不再触发 developer 的 diff 验收（DELIVERABLE_REJECTED 实证）。
4. **worker env 透传 models.json $VAR provider key 引用**（FAKE_JOURNEY_KEY 401 实证）——引用透传，凭据不落盘。

验证：产品旅程 3/3（含委派腿完成推送）；TS 107/107；ruff 全绿。

纪律自省：#370 在 Native Agent Gate 红时被合入（连续第二次）——合并前三工作流逐一核对的硬规矩已两次违反，后续由守门流程强制执行。