### PR TITLE
feat: 十五审 RF-4/RF-6/RF-8 + 自审修正 + 合并守门

### DIFF
--- a/packages/rosclaw-agent/src/agent_runtime/acp-client.ts
+++ b/packages/rosclaw-agent/src/agent_runtime/acp-client.ts
@@ -21,7 +21,7 @@ interface JsonRpcRequest {
 interface PendingRequest {
 	resolve: (value: Record<string, unknown>) => void;
 	reject: (error: Error) => void;
-	timer: NodeJS.Timeout;
+	timer?: NodeJS.Timeout;
 }
 
 const REQUEST_TIMEOUT_MS = 30_000;
@@ -44,7 +44,7 @@ export class AcpClient {
 		proc.on("exit", (code) => {
 			// 进程退出：所有挂起请求诚实失败（绝不悬挂）。
 			for (const [, p] of this.pending) {
-				clearTimeout(p.timer);
+				if (p.timer) clearTimeout(p.timer);
 				p.reject(new Error(`harness exited (code ${code})`));
 			}
 			this.pending.clear();
@@ -67,7 +67,7 @@ export class AcpClient {
 				const p = this.pending.get(msg.id);
 				if (p) {
 					this.pending.delete(msg.id);
-					clearTimeout(p.timer);
+					if (p.timer) clearTimeout(p.timer);
 					if (msg.error !== undefined) {
 						const err = msg.error as { code?: number; message?: string };
 						p.reject(new Error(`ACP error ${err.code}: ${err.message ?? ""}`));
@@ -107,14 +107,23 @@ export class AcpClient {
 		this.proc.stdin!.write(`${JSON.stringify(msg)}\n`);
 	}
 
-	private request(method: string, params?: unknown): Promise<Record<string, unknown>> {
+	private request(
+		method: string,
+		params?: unknown,
+		timeoutMs: number | null = REQUEST_TIMEOUT_MS,
+	): Promise<Record<string, unknown>> {
 		const id = this.nextId++;
 		return new Promise((resolvePromise, rejectPromise) => {
-			const timer = setTimeout(() => {
-				this.pending.delete(id);
-				rejectPromise(new Error(`ACP ${method} timeout`));
-			}, REQUEST_TIMEOUT_MS);
-			this.pending.set(id, { resolve: resolvePromise, reject: rejectPromise, timer });
+			// timeoutMs=null：session/prompt 是长任务——绝不按固定墙钟
+			// 杀（ADR-0011：无默认 wall-clock kill）。
+			const pending: PendingRequest = { resolve: resolvePromise, reject: rejectPromise };
+			if (timeoutMs !== null) {
+				pending.timer = setTimeout(() => {
+					this.pending.delete(id);
+					rejectPromise(new Error(`ACP ${method} timeout`));
+				}, timeoutMs);
+			}
+			this.pending.set(id, pending);
 			this.sendRaw({ jsonrpc: "2.0", id, method, params });
 		});
 	}
@@ -142,7 +151,7 @@ export class AcpClient {
 		const result = await this.request("session/prompt", {
 			sessionId,
 			prompt: [{ type: "text", text }],
-		});
+		}, null);
 		return { stopReason: String(result.stopReason ?? "unknown") };
 	}
 
@@ -166,7 +175,7 @@ export class AcpClient {
 	dispose(): void {
 		this.proc.kill("SIGTERM");
 		for (const [, p] of this.pending) {
-			clearTimeout(p.timer);
+			if (p.timer) clearTimeout(p.timer);
 			p.reject(new Error("client disposed"));
 		}
 		this.pending.clear();

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -743,10 +743,40 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			await ctx.ui.custom<boolean>((_tui, _theme, _kb, done) => {
 				return new TasksCenterComponent({
 					fetchJobs: async () => {
-						const r = await center.call("pi.worker.jobs", {
-							mission_id: state.missionId,
-						});
-						return (r.jobs ?? []) as never;
+						// 十五审 PR-RF-8：execution 级卡为主（Task Control Plane
+						// 权威）；execution 关联的 WorkOrder 折叠进 attempts，
+						// 游离 worker 单（legacy/delegate 路径）仍单独成卡。
+						const [jobsRes, execRes] = await Promise.all([
+							center.call("pi.worker.jobs", { mission_id: state.missionId }),
+							center.call("pi.task.executions", { mission_id: state.missionId }),
+						]);
+						const jobs = (jobsRes.jobs ?? []) as Array<Record<string, unknown>>;
+						const execs = (execRes.executions ?? []) as Array<Record<string, unknown>>;
+						const linked = new Set(
+							execs.map((e) => String(e.work_order_id ?? "")).filter(Boolean),
+						);
+						const execCards = execs.map((e) => ({
+							root_job_id: String(e.execution_id),
+							goal: String(e.goal ?? ""),
+							state: String(e.state ?? ""),
+							runtime: String(e.runtime ?? ""),
+							attempts: e.work_order_id
+								? [{
+									work_order_id: String(e.work_order_id),
+									seq: 1,
+									actor: "control-plane",
+									status: String(e.state ?? ""),
+									termination_cause: "",
+								}]
+								: [],
+						}));
+						const orphanJobs = jobs.filter(
+							(j) => !linked.has(String(j.root_job_id ?? ""))
+								&& !(j.attempts as Array<{ work_order_id?: string }> ?? []).some(
+									(a) => linked.has(String(a.work_order_id ?? "")),
+								),
+						);
+						return [...execCards, ...orphanJobs] as never;
 					},
 					fetchEvents: async (wo, afterSeq, limit) => {
 						const r = await center.call("pi.worker.events", {

--- a/packages/rosclaw-agent/src/workers/tasks-center.ts
+++ b/packages/rosclaw-agent/src/workers/tasks-center.ts
@@ -32,6 +32,8 @@ export interface JobCard {
 	goal: string;
 	state: string;
 	attempts: AttemptInfo[];
+	/** 十五审 PR-RF-8：execution 级卡片的执行主体（runtime/executor）。 */
+	runtime?: string;
 }
 
 export interface TasksCenterDeps {
@@ -75,7 +77,7 @@ const TERMINAL = new Set(["ACCEPTED", "FAILED", "EXPIRED", "CANCELLED"]);
 const RETRYABLE = new Set(["INTERRUPTED_RESUMABLE", "FAILED", "CANCELLED", "EXPIRED"]);
 
 function icon(state: string): string {
-	if (state === "ACCEPTED") return "✓";
+	if (state === "ACCEPTED" || state === "SUCCEEDED") return "✓";
 	if (TERMINAL.has(state)) return "✗";
 	if (state === "BLOCKED" || state === "PAUSED" || state === "BUDGET_PAUSED") return "⚠";
 	return "●";
@@ -311,8 +313,12 @@ export class TasksCenterComponent implements Component {
 			const mark = idx === this.selected ? ">" : " ";
 			const latest = this.targetAttempt(card);
 			const elapsed = fmtElapsedMs(latest?.duration_ms);
+			const who = card.runtime ? ` · ${card.runtime}` : "";
+			const attempts = card.attempts.length
+				? ` · attempt ${card.attempts.length}/${card.attempts.length}`
+				: "";
 			out.push(
-				`│ ${mark} ${icon(card.state)} ${card.goal.slice(0, 34)} · ${card.state}${elapsed ? ` · ${elapsed}` : ""} · attempt ${card.attempts.length}/${card.attempts.length}`,
+				`│ ${mark} ${icon(card.state)} ${card.goal.slice(0, 34)}${who} · ${card.state}${elapsed ? ` · ${elapsed}` : ""}${attempts}`,
 			);
 			if (this.expanded && idx === this.selected) {
 				for (const a of card.attempts) {

--- a/scripts/check-pr-green.sh
+++ b/scripts/check-pr-green.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# 合并守门（十五审纪律修正）：三个工作流在目标分支最新 commit 上
+# 全部 completed/success 才输出 GREEN——#366/#370 的教训：只看 CI/CD
+# 一行导致 Gate 红被合入两次。
+# 用法：scripts/check-pr-green.sh <branch>
+set -eu
+BRANCH="${1:?usage: check-pr-green.sh <branch>}"
+SHA=$(gh api "repos/ros-claw/rosclaw/branches/$BRANCH" --jq '.commit.sha[:7]')
+echo "branch=$BRANCH head=$SHA"
+FAIL=0
+for WF in "CI/CD" "Native Agent Gate" "First Boot Acceptance"; do
+  LINE=$(gh api "repos/ros-claw/rosclaw/actions/runs?branch=$BRANCH&per_page=10" \
+    --jq "[.workflow_runs[] | select(.name==\"$WF\" and (.head_sha | startswith(\"$SHA\")))] | sort_by(.created_at) | last | \"\(.status)/\(.conclusion)\"")
+  echo "  $WF: $LINE"
+  [ "$LINE" = "completed/success" ] || FAIL=1
+done
+if [ "$FAIL" = "0" ]; then
+  echo "GREEN——可以合并"
+else
+  echo "NOT GREEN——禁止合并" >&2
+  exit 1
+fi

--- a/src/rosclaw/agentd/acp_driver.py
+++ b/src/rosclaw/agentd/acp_driver.py
@@ -12,8 +12,11 @@ terminal 请求一律结构化拒绝（RF-4 sandbox 后按白名单开放）。
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import os
 import shutil
+from pathlib import Path
 from typing import Any
 
 #: ACP Harness 注册表（二进制 → runtime id）。
@@ -30,19 +33,73 @@ def acp_binary_for(runtime: str) -> str | None:
     return shutil.which(binary)
 
 
+#: 十五审 PR-RF-4（总纲 §9）：Harness Sandbox——隔离 workspace/HOME/
+#: TMP，凭据只给目标 harness，无 ROS/DDS/设备/rosclawd socket。
+#: 本机无 bwrap/unshare（Worker workbench 已实证），隔离在进程环境层
+#: 实现——不假装有 OS 容器。
+_SANDBOX_ENV_KEEP = ("PATH", "LANG", "LC_ALL", "TERM", "TZ")
+#: 绝不泄漏给 harness 的变量前缀（rosclaw 私有面/物理面）。
+_SANDBOX_ENV_DENY_PREFIX = ("ROSCLAW_", "ROS_", "RMW_", "CYCLONEDDS", "FASTRTPS")
+
+
+def prepare_sandbox_home(
+    work_dir: Path, *, harness_config_dirs: list[str] | None = None
+) -> Path:
+    """构造隔离 sandbox：work_dir/{home,workspace,tmp}。
+
+    harness_config_dirs：目标 harness 自己的配置目录（如 .claude）——
+    symlink 进 sandbox HOME（凭据只给目标 harness）；rosclaw 自身的
+    agent/auth.json 永不进 sandbox。
+    """
+    work_dir = Path(work_dir)
+    home = work_dir / "home"
+    workspace = work_dir / "workspace"
+    tmp = work_dir / "tmp"
+    for d in (home, workspace, tmp):
+        d.mkdir(parents=True, exist_ok=True)
+    for name in harness_config_dirs or []:
+        src = Path.home() / name
+        if src.is_dir():
+            link = home / name
+            if not link.exists():
+                link.symlink_to(src)
+    return work_dir
+
+
+def sandbox_env(work_dir: Path) -> dict[str, str]:
+    """最小 env：白名单基础变量 + 隔离 HOME/TMPDIR；拒绝 rosclaw/
+    ROS/DDS 前缀（红队测试锁定）。"""
+    env = {k: os.environ[k] for k in _SANDBOX_ENV_KEEP if k in os.environ}
+    env["HOME"] = str(Path(work_dir) / "home")
+    env["TMPDIR"] = str(Path(work_dir) / "tmp")
+    for key in list(env):
+        if key.startswith(_SANDBOX_ENV_DENY_PREFIX):
+            del env[key]
+    return env
+
+
 class AcpHarnessDriver:
     """一个 ACP session 的驱动（单 execution 单 session——Gate 3）。"""
 
-    def __init__(self, runtime: str, *, cwd: str, event_sink) -> None:
+    def __init__(
+        self, runtime: str, *, cwd: str, event_sink,
+        sandbox_home: Path | None = None,
+    ) -> None:
         self._runtime = runtime
         self._cwd = cwd
         self._sink = event_sink  # async (kind, payload) -> None
+        # PR-RF-4：sandbox 根（work/<exec>）；None 时退化为传入 cwd
+        # （兼容旧调用——新执行路径必须给）。
+        self._sandbox = Path(sandbox_home) if sandbox_home else None
         self._proc: asyncio.subprocess.Process | None = None
         self._next_id = 1
         self._pending: dict[int, asyncio.Future] = {}
         self._reader_task: asyncio.Task | None = None
 
-    async def _request(self, method: str, params: dict | None = None) -> dict:
+    async def _request(
+        self, method: str, params: dict | None = None, *,
+        timeout: float | None = 120,
+    ) -> dict:
         assert self._proc is not None and self._proc.stdin is not None
         request_id = self._next_id
         self._next_id += 1
@@ -55,37 +112,53 @@ class AcpHarnessDriver:
         )
         self._proc.stdin.write(f"{line}\n".encode())
         await self._proc.stdin.drain()
-        return await asyncio.wait_for(future, timeout=120)
+        # timeout=None：session/prompt 是长任务（30min+）——绝不按固定
+        # 墙钟杀（ADR-0011：无默认 wall-clock kill）。
+        if timeout is None:
+            return await future
+        return await asyncio.wait_for(future, timeout=timeout)
 
     async def _read_loop(self) -> None:
         assert self._proc is not None and self._proc.stdout is not None
-        while True:
-            line = await self._proc.stdout.readline()
-            if not line:
-                return
-            try:
-                msg = json.loads(line.decode("utf-8", errors="replace"))
-            except json.JSONDecodeError:
-                continue
-            if "id" in msg and ("result" in msg or "error" in msg):
-                future = self._pending.pop(msg["id"], None)
-                if future is not None and not future.done():
-                    if "error" in msg:
-                        err = msg["error"]
-                        future.set_exception(
-                            RuntimeError(
-                                f"ACP error {err.get('code')}: {err.get('message')}"
+        try:
+            while True:
+                line = await self._proc.stdout.readline()
+                if not line:
+                    return
+                try:
+                    msg = json.loads(line.decode("utf-8", errors="replace"))
+                except json.JSONDecodeError:
+                    continue
+                if "id" in msg and ("result" in msg or "error" in msg):
+                    future = self._pending.pop(msg["id"], None)
+                    if future is not None and not future.done():
+                        if "error" in msg:
+                            err = msg["error"]
+                            future.set_exception(
+                                RuntimeError(
+                                    f"ACP error {err.get('code')}: {err.get('message')}"
+                                )
                             )
-                        )
-                    else:
-                        future.set_result(msg["result"])
-            elif msg.get("method") == "session/update":
-                params = msg.get("params") or {}
-                update = params.get("update") or {}
-                await self._on_update(params.get("sessionId", ""), update)
-            elif "method" in msg and "id" in msg:
-                # Harness → client 请求：MVP 结构化拒绝（RF-4 后白名单）。
-                await self._respond_error(msg["id"], msg["method"])
+                        else:
+                            future.set_result(msg["result"])
+                elif msg.get("method") == "session/update":
+                    params = msg.get("params") or {}
+                    update = params.get("update") or {}
+                    # sink 异常绝不杀事件读者（否则 prompt 永悬）——
+                    # 事件丢失只是观测缺口，不是控制失败。
+                    with contextlib.suppress(Exception):
+                        await self._on_update(params.get("sessionId", ""), update)
+                elif "method" in msg and "id" in msg:
+                    # Harness → client 请求：MVP 结构化拒绝（RF-4 后白名单）。
+                    await self._respond_error(msg["id"], msg["method"])
+        finally:
+            # 读者死亡/EOF：所有挂起请求诚实失败（绝不悬挂）。
+            for _id, future in self._pending.items():
+                if not future.done():
+                    future.set_exception(
+                        RuntimeError("ACP event reader stopped")
+                    )
+            self._pending.clear()
 
     async def _respond_error(self, request_id: Any, method: str) -> None:
         assert self._proc is not None and self._proc.stdin is not None
@@ -105,8 +178,10 @@ class AcpHarnessDriver:
         tag = str(update.get("sessionUpdate", ""))
         if tag == "agent_message_chunk":
             content = update.get("content") or {}
+            # 2000 字上限（卡片摘要另行截断——事件面不做 160 字式
+            # 过度裁剪，十四审 §1.6 教训）。
             await self._sink("message_delta", {
-                "text": str(content.get("text", ""))[-200:],
+                "text": str(content.get("text", ""))[-2000:],
             })
         elif tag == "tool_call":
             await self._sink("tool_started", {
@@ -132,12 +207,22 @@ class AcpHarnessDriver:
                 "stop_reason": "not_installed",
                 "detail": f"ACP Harness {self._runtime} 未安装（preflight 失败）",
             }
+        # PR-RF-4：sandbox 化启动——隔离 workspace/HOME/TMP、最小 env、
+        # 无 ROSCLAW_/ROS_/DDS 变量、独立进程组。
+        if self._sandbox is not None:
+            prepare_sandbox_home(self._sandbox)
+            cwd = str(self._sandbox / "workspace")
+            env = sandbox_env(self._sandbox)
+        else:
+            cwd = self._cwd
+            env = None
         self._proc = await asyncio.create_subprocess_exec(
             binary,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=self._cwd,
+            cwd=cwd,
+            env=env,
             start_new_session=True,
         )
         self._reader_task = asyncio.create_task(self._read_loop())
@@ -151,13 +236,13 @@ class AcpHarnessDriver:
                 "clientInfo": {"name": "rosclaw", "version": "1.0"},
             })
             session = await self._request(
-                "session/new", {"cwd": self._cwd, "mcpServers": []}
+                "session/new", {"cwd": cwd, "mcpServers": []}
             )
             session_id = str(session["sessionId"])
             result = await self._request("session/prompt", {
                 "sessionId": session_id,
                 "prompt": [{"type": "text", "text": goal}],
-            })
+            }, timeout=None)
             stop = str(result.get("stopReason", "unknown"))
             return {
                 "ok": stop in ("end_turn", "max_tokens", "refusal"),

--- a/src/rosclaw/agentd/codex_driver.py
+++ b/src/rosclaw/agentd/codex_driver.py
@@ -1,0 +1,187 @@
+"""Codex app-server 驱动（十五审 PR-RF-5，ADR-0011）。
+
+Codex 的优化原生路径（runtime=harness:codex-app-server）：
+`codex app-server`（stdio JSONL JSON-RPC）——initialize → initialized
+通知 → thread/start（或 thread/resume 恢复）→ turn/start → 流式
+item/* 通知 → turn/completed。approvalPolicy=never + sandbox=
+workspaceWrite + cwd 隔离（RF-4 sandbox env）。
+
+不解析 ANSI/PTY；事件只来自协议通知。codex 二进制缺失 → 诚实
+not_installed（preflight 失败不创建执行）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import shutil
+from pathlib import Path
+
+from rosclaw.agentd.acp_driver import prepare_sandbox_home, sandbox_env
+
+
+def codex_binary() -> str | None:
+    return shutil.which("codex")
+
+
+class CodexAppServerDriver:
+    """一个 Codex thread 的驱动（单 execution 单 thread——Gate 3）。"""
+
+    def __init__(
+        self, *, cwd: str, event_sink, sandbox_home: Path | None = None
+    ) -> None:
+        self._cwd = cwd
+        self._sink = event_sink
+        self._sandbox = Path(sandbox_home) if sandbox_home else None
+        self._proc: asyncio.subprocess.Process | None = None
+        self._next_id = 1
+        self._pending: dict[int, asyncio.Future] = {}
+        self._reader_task: asyncio.Task | None = None
+        self._turn_done: asyncio.Future | None = None
+
+    async def _send(self, msg: dict) -> None:
+        assert self._proc is not None and self._proc.stdin is not None
+        self._proc.stdin.write((json.dumps(msg) + "\n").encode())
+        await self._proc.stdin.drain()
+
+    async def _request(
+        self, method: str, params: dict | None = None, *,
+        timeout: float | None = 120,
+    ) -> dict:
+        request_id = self._next_id
+        self._next_id += 1
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        self._pending[request_id] = future
+        await self._send({
+            "method": method, "id": request_id, "params": params or {},
+        })
+        if timeout is None:
+            return await future
+        return await asyncio.wait_for(future, timeout=timeout)
+
+    async def _read_loop(self) -> None:
+        assert self._proc is not None and self._proc.stdout is not None
+        try:
+            while True:
+                line = await self._proc.stdout.readline()
+                if not line:
+                    return
+                try:
+                    msg = json.loads(line.decode("utf-8", errors="replace"))
+                except json.JSONDecodeError:
+                    continue
+                if "id" in msg and ("result" in msg or "error" in msg):
+                    future = self._pending.pop(msg["id"], None)
+                    if future is not None and not future.done():
+                        if "error" in msg:
+                            err = msg["error"]
+                            future.set_exception(
+                                RuntimeError(
+                                    f"app-server error {err.get('code')}: "
+                                    f"{err.get('message')}"
+                                )
+                            )
+                        else:
+                            future.set_result(msg["result"])
+                elif "method" in msg:
+                    with contextlib.suppress(Exception):
+                        await self._on_notification(msg["method"], msg.get("params") or {})
+        finally:
+            for _id, future in self._pending.items():
+                if not future.done():
+                    future.set_exception(RuntimeError("app-server reader stopped"))
+            self._pending.clear()
+
+    async def _on_notification(self, method: str, params: dict) -> None:
+        if method == "turn/completed":
+            # turn 终态通知——run() 等待的唯一完成信号（无墙钟超时）。
+            if self._turn_done is not None and not self._turn_done.done():
+                self._turn_done.set_result(params.get("turn") or {})
+            return
+        if method == "item/agentMessage/delta":
+            await self._sink("message_delta", {
+                "text": str(params.get("delta", ""))[-2000:],
+            })
+        elif method == "item/started":
+            item = params.get("item") or {}
+            if str(item.get("type", "")) not in ("agentMessage",):
+                await self._sink("tool_started", {
+                    "tool": str(item.get("type", "?")),
+                    "tool_call_id": str(item.get("id", "")),
+                })
+        elif method == "item/completed":
+            item = params.get("item") or {}
+            if str(item.get("type", "")) not in ("agentMessage",):
+                await self._sink("tool_finished", {
+                    "tool_call_id": str(item.get("id", "")),
+                    "status": str(item.get("status", "")),
+                })
+
+    async def run(self, goal: str) -> dict:
+        """跑到 turn/completed——返回 {ok, stop_reason, detail}。"""
+        binary = codex_binary()
+        if binary is None:
+            return {
+                "ok": False,
+                "stop_reason": "not_installed",
+                "detail": "codex CLI 未安装（preflight 失败，未创建执行）",
+            }
+        if self._sandbox is not None:
+            prepare_sandbox_home(self._sandbox)
+            cwd = str(self._sandbox / "workspace")
+            env = sandbox_env(self._sandbox)
+            # Codex 自己的 home 限定在 sandbox（登录态由调用方经
+            # harness_config_dirs=[".codex"] 注入）。
+            env["CODEX_HOME"] = str(self._sandbox / "home" / ".codex")
+        else:
+            cwd = self._cwd
+            env = None
+        self._proc = await asyncio.create_subprocess_exec(
+            binary, "app-server",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+            start_new_session=True,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+        try:
+            await self._request("initialize", {
+                "clientInfo": {"name": "rosclaw", "version": "1.0"},
+            })
+            await self._send({"method": "initialized"})
+            thread = await self._request("thread/start", {
+                "cwd": cwd,
+                "approvalPolicy": "never",
+                "sandbox": "workspaceWrite",
+            })
+            thread_obj = thread.get("thread") or {}
+            thread_id = str(thread_obj.get("id", ""))
+            loop = asyncio.get_running_loop()
+            self._turn_done = loop.create_future()
+            turn = await self._request("turn/start", {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": goal}],
+            })
+            turn_obj = turn.get("turn") or {}
+            # turn/start 立即返回——真正的终态在 turn/completed 通知
+            # （长任务不按墙钟杀）。
+            completed = await self._turn_done
+            status = str(completed.get("status", "unknown"))
+            return {
+                "ok": status in ("completed", "idle"),
+                "stop_reason": status,
+                "detail": f"thread {thread_id} turn {turn_obj.get('id', '?')} {status}",
+            }
+        except (RuntimeError, TimeoutError) as exc:
+            return {"ok": False, "stop_reason": "error", "detail": str(exc)[:300]}
+        finally:
+            if self._proc is not None and self._proc.returncode is None:
+                self._proc.terminate()
+            if self._reader_task is not None:
+                self._reader_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._reader_task

--- a/src/rosclaw/agentd/control_plane.py
+++ b/src/rosclaw/agentd/control_plane.py
@@ -105,9 +105,14 @@ class ExecutionRouter:
 
     @staticmethod
     def _preferred_harness() -> str:
-        """启动前健康选择：已安装的 ACP Harness 优先于内置 Pi。"""
+        """启动前健康选择（readiness preflight）：Codex app-server 原生
+        路径优先（需二进制+自有登录配置），其次 ACP Harness，否则
+        内置 Pi。"""
         import shutil
+        from pathlib import Path
 
+        if shutil.which("codex") and (Path.home() / ".codex").exists():
+            return "harness:codex-app-server"
         for binary, runtime in (
             ("claude-code-acp", "harness:acp:claude-local"),
             ("pi-acp", "harness:acp:pi-acp"),
@@ -350,12 +355,46 @@ class TaskControlPlane:
     async def _drive_harness(
         self, execution_id: str, mission_id: str, spec: dict, route: dict
     ) -> None:
-        """Harness 域：ACP runtime 走协议驱动（PR-RF-3）；pi-builtin 走
-        现有 worker manager（RF-9 前保留）。"""
+        """Harness 域：codex app-server 原生路径（RF-5）/ACP（RF-3）/
+        pi-builtin（RF-9 前保留）。"""
+        if route["runtime"] == "harness:codex-app-server":
+            await self._drive_codex(execution_id, spec)
+            return
         if route["runtime"].startswith("harness:acp:"):
             await self._drive_acp(execution_id, spec, route["runtime"])
             return
         await self._drive_pi_builtin(execution_id, mission_id, spec)
+
+    async def _drive_codex(self, execution_id: str, spec: dict) -> None:
+        """Codex app-server：单 thread 单 turn；sandbox（RF-4）+ 原生
+        thread/resume/compaction。事件落 EventStore。"""
+        from rosclaw.agentd.codex_driver import CodexAppServerDriver, codex_binary
+
+        if codex_binary() is None:
+            self._update_state(
+                execution_id, "BLOCKED",
+                summary="codex CLI 未安装——preflight 失败，未创建执行",
+            )
+            return
+        self._update_state(execution_id, "RUNNING")
+        from rosclaw.agentd.workers.event_store import WorkerEventStore
+
+        events = WorkerEventStore(self._service._home)
+
+        async def sink(kind: str, payload: dict) -> None:
+            events.append_event(execution_id, "", kind, payload)
+
+        driver = CodexAppServerDriver(
+            cwd=str(self._service._home),
+            event_sink=sink,
+            sandbox_home=self._service._home / "work" / execution_id,
+        )
+        result = await driver.run(str(spec.get("goal", "")))
+        self._update_state(
+            execution_id,
+            "SUCCEEDED" if result["ok"] else "FAILED",
+            summary=result["detail"][:500],
+        )
 
     async def _drive_acp(
         self, execution_id: str, spec: dict, runtime: str

--- a/src/rosclaw/agentd/control_plane.py
+++ b/src/rosclaw/agentd/control_plane.py
@@ -230,6 +230,10 @@ class TaskControlPlane:
         try:
             if route["domain"] == "executor" and route["runtime"] == "executor:simulation":
                 await self._drive_simulation(execution_id, mission_id, spec)
+            elif route["domain"] == "executor":
+                # RF-6：其余 executor runtime（body-observer 等）走确定性
+                # capability 调用——不落 harness（不开 Agent Worker）。
+                await self._drive_capability_executor(execution_id, spec, route)
             elif route["domain"] == "physical":
                 self._update_state(
                     execution_id, "BLOCKED",
@@ -242,6 +246,45 @@ class TaskControlPlane:
             raise
         except Exception as exc:  # noqa: BLE001 - 执行失败是数据
             self._update_state(execution_id, "FAILED", summary=str(exc)[:500])
+
+    async def _drive_capability_executor(
+        self, execution_id: str, spec: dict, route: dict
+    ) -> None:
+        """RF-6：确定性 capability 执行域（robot.observe.* 等）——经
+        tool registry 直接调用，零 Agent Worker，结果即证据。"""
+        service = self._service
+        inputs = spec.get("inputs") or {}
+        capability_id = str(
+            inputs.get("capability_id")
+            or (spec.get("required_capabilities") or [""])[0]
+        )
+        if not capability_id:
+            self._update_state(
+                execution_id, "BLOCKED",
+                summary="executor 任务缺 capability_id——编译期失败，未执行",
+            )
+            return
+        await service._ensure_mcp_discovered()
+        self._update_state(execution_id, "RUNNING")
+        try:
+            raw = await service._tool_registry.execute(
+                capability_id, dict(inputs.get("arguments") or {})
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._update_state(
+                execution_id, "FAILED",
+                summary=f"capability {capability_id} 执行失败: {exc}"[:400],
+            )
+            return
+        text = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False)
+        self._update_state(
+            execution_id, "SUCCEEDED",
+            summary=text[:500],
+            artifacts_json=json.dumps(
+                {"capability": capability_id, "result": text[:2000]},
+                ensure_ascii=False,
+            ),
+        )
 
     async def _drive_simulation(
         self, execution_id: str, mission_id: str, spec: dict
@@ -404,7 +447,16 @@ class TaskControlPlane:
                 execution_id, "INTERRUPTED",
                 summary=result.summary[:500],
             )
-        else:
+        elif result.status == "CANCELLED":
+            # 用户取消是 CANCELLED——绝不能落成 FAILED（自审修复：
+            # task_cancel 后 driver 收尾曾把 CANCELLED 覆盖成 FAILED）。
             self._update_state(
-                execution_id, "FAILED", summary=result.summary[:500]
+                execution_id, "CANCELLED",
+                summary=result.summary[:500] or "已取消",
             )
+        else:
+            current = self._get(execution_id)
+            if current and current["state"] != "CANCELLED":
+                self._update_state(
+                    execution_id, "FAILED", summary=result.summary[:500]
+                )

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1164,6 +1164,25 @@ class PiBridgeServer:
             # 一张卡，attempts 内部聚合）。
             mission_id = str(params.get("mission_id", ""))
             return {"ok": True, "jobs": worker_jobs_projection(service, mission_id)}
+        if method == "pi.task.executions":
+            # 十五审 PR-RF-8：execution 级任务卡（Task Control Plane 是
+            # 权威——一个任务一张卡，WorkOrder 折叠为内部细节）。
+            mission_id = str(params.get("mission_id", ""))
+            plane = service._task_control_plane
+            cards = []
+            for row in plane.executions_for(mission_id):
+                spec = json.loads(row["spec_json"])
+                cards.append({
+                    "execution_id": row["execution_id"],
+                    "goal": str(spec.get("goal", ""))[:120],
+                    "state": row["state"],
+                    "runtime": row["runtime"],
+                    "domain": row["domain"],
+                    "summary": (row.get("summary") or "")[:500],
+                    "work_order_id": row.get("work_order_id") or "",
+                    "created_at": row["created_at"],
+                })
+            return {"ok": True, "executions": cards}
         if method == "pi.worker.control":
             # 十四审 PR-14.4：pause/resume/cancel——ACK 语义（不乐观）。
             result = await worker_control(

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -1850,6 +1850,16 @@ class AgentService:
 
         with _cl.suppress(Exception):
             await self._worker_manager.shutdown()
+        # 十五审自审：control-plane 驱动任务也要取消（否则 close 后
+        # 仍在写已关闭的 DB/跑已杀的进程）。
+        plane = getattr(self, "_task_control_plane", None)
+        if plane is not None:
+            for driver in list(plane._drivers.values()):
+                driver.cancel()
+            if plane._drivers:
+                with _cl.suppress(Exception):
+                    await asyncio.gather(*plane._drivers.values(), return_exceptions=True)
+                plane._drivers.clear()
         for task in list(getattr(self, "_worker_bg_tasks", {}).values()):
             task.cancel()
         if getattr(self, "_worker_bg_tasks", None):

--- a/tests/agentd/test_fifteen_rf4.py
+++ b/tests/agentd/test_fifteen_rf4.py
@@ -88,6 +88,8 @@ class TestHarnessSandbox:
         original = mod.acp_binary_for
         mod.acp_binary_for = lambda _runtime: str(shim)
         # 宿主环境放毒：如果这些变量泄漏给 harness 就是缺陷。
+        # 必须恢复——污染会经进程 env 泄漏到后续测试（CI 实证）。
+        _saved_home = os.environ.get("ROSCLAW_HOME")
         os.environ["ROSCLAW_HOME"] = str(tmp_path)
         try:
             driver = AcpHarnessDriver(
@@ -99,6 +101,10 @@ class TestHarnessSandbox:
             result = await driver.run("probe")
         finally:
             mod.acp_binary_for = original
+            if _saved_home is None:
+                os.environ.pop("ROSCLAW_HOME", None)
+            else:
+                os.environ["ROSCLAW_HOME"] = _saved_home
         assert result["ok"], result
         assert seen, "probe 未回传环境"
         report = seen[-1]

--- a/tests/agentd/test_fifteen_rf4.py
+++ b/tests/agentd/test_fifteen_rf4.py
@@ -1,0 +1,123 @@
+"""十五审 PR-RF-4 红测试：Harness Sandbox（总纲 §9）。
+
+红测试先行——修复前必须红：
+1. ACP Harness 进程 env 不含 ROSCLAW_HOME/宿主 HOME/ROS/DDS 变量；
+2. cwd 是隔离 workspace（不是 rosclaw home 也不是用户目录）；
+3. 凭据只给目标 Harness（symlink 其自身配置，不暴露 rosclaw agent
+   auth.json）；
+4. Harness 侧 fs/terminal/permission 请求按策略拒绝或限制在
+   workspace 内（fail-closed 默认）；
+5. 进程树统一清理。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import stat
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.acp_driver import AcpHarnessDriver
+
+
+def _node() -> str | None:
+    return shutil.which("node")
+
+
+#: 红队 fake server：启动即把 env/cwd 实况经 session/update 回传。
+_PROBE_SERVER = r"""
+function send(msg) { process.stdout.write(JSON.stringify(msg) + "\n"); }
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  const lines = buffer.split("\n");
+  buffer = lines.pop() ?? "";
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const msg = JSON.parse(line);
+    if (msg.method === "initialize") {
+      send({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: 1, agentCapabilities: {} } });
+    } else if (msg.method === "session/new") {
+      send({ jsonrpc: "2.0", id: msg.id, result: { sessionId: "sess_probe" } });
+    } else if (msg.method === "session/prompt") {
+      const report = {
+        home: process.env.HOME || "",
+        rosclaw_home: process.env.ROSCLAW_HOME || "",
+        has_ros: Boolean(process.env.ROS_DISTRO || process.env.DDS_VER),
+        cwd: process.cwd(),
+        tmpdir: process.env.TMPDIR || "",
+      };
+      send({ jsonrpc: "2.0", method: "session/update", params: {
+        sessionId: msg.params.sessionId,
+        update: { sessionUpdate: "agent_message_chunk",
+                  content: { type: "text", text: JSON.stringify(report) } },
+      }});
+      setTimeout(() => send({ jsonrpc: "2.0", id: msg.id, result: { stopReason: "end_turn" } }), 20);
+    }
+  }
+});
+process.stdin.setEncoding("utf-8");
+"""
+
+
+@pytest.mark.skipif(_node() is None, reason="无 Node——诚实 skip")
+class TestHarnessSandbox:
+    async def test_sandbox_env_isolation(self, tmp_path: Path) -> None:
+        """Harness 只能看到隔离环境——宿主 HOME/ROSCLAW_HOME/ROS 不泄漏。"""
+        server = tmp_path / "probe.mjs"
+        server.write_text(_PROBE_SERVER)
+        shim = tmp_path / "probe-shim"
+        shim.write_text(f'#!/bin/sh\nexec {_node()} "{server}"\n')
+        shim.chmod(shim.stat().st_mode | stat.S_IXUSR)
+        seen: list[dict] = []
+
+        async def sink(kind: str, payload: dict) -> None:
+            if kind == "message_delta" and payload.get("text"):
+                seen.append(json.loads(payload["text"]))
+
+        import rosclaw.agentd.acp_driver as mod
+
+        original = mod.acp_binary_for
+        mod.acp_binary_for = lambda _runtime: str(shim)
+        # 宿主环境放毒：如果这些变量泄漏给 harness 就是缺陷。
+        os.environ["ROSCLAW_HOME"] = str(tmp_path)
+        try:
+            driver = AcpHarnessDriver(
+                "harness:acp:claude-local",
+                cwd=str(tmp_path),
+                event_sink=sink,
+                sandbox_home=tmp_path / "work" / "exec_1",
+            )
+            result = await driver.run("probe")
+        finally:
+            mod.acp_binary_for = original
+        assert result["ok"], result
+        assert seen, "probe 未回传环境"
+        report = seen[-1]
+        assert report["rosclaw_home"] == "", (
+            f"ROSCLAW_HOME 泄漏给 harness: {report['rosclaw_home']}"
+        )
+        assert report["home"] != str(Path.home()), "宿主 HOME 泄漏"
+        assert not report["has_ros"], "ROS/DDS 环境泄漏"
+        assert "work" in report["cwd"] and "exec_1" in report["cwd"], (
+            f"cwd 不是隔离 workspace: {report['cwd']}"
+        )
+        assert report["tmpdir"] and "exec_1" in report["tmpdir"], (
+            f"TMPDIR 未隔离: {report['tmpdir']}"
+        )
+
+    async def test_harness_config_scoped(self, tmp_path: Path) -> None:
+        """sandbox HOME 只含目标 harness 自己的配置（不暴露 rosclaw
+        agent auth.json）。"""
+        from rosclaw.agentd.acp_driver import prepare_sandbox_home
+
+        sandbox = prepare_sandbox_home(
+            tmp_path / "work" / "exec_2", harness_config_dirs=[".claude"]
+        )
+        assert (sandbox / "home").is_dir()
+        # rosclaw 自身的 agent 凭据目录绝不出现在 sandbox。
+        assert not (sandbox / "home" / ".rosclaw").exists()

--- a/tests/agentd/test_fifteen_rf4.py
+++ b/tests/agentd/test_fifteen_rf4.py
@@ -12,7 +12,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import shutil
@@ -76,8 +75,13 @@ class TestHarnessSandbox:
         seen: list[dict] = []
 
         async def sink(kind: str, payload: dict) -> None:
+            # 驱动侧文本可能截断——解析失败不破坏 sink（事件读者健壮性
+            # 也是本测试的一部分）。
             if kind == "message_delta" and payload.get("text"):
-                seen.append(json.loads(payload["text"]))
+                import contextlib
+
+                with contextlib.suppress(json.JSONDecodeError):
+                    seen.append(json.loads(payload["text"]))
 
         import rosclaw.agentd.acp_driver as mod
 

--- a/tests/agentd/test_fifteen_rf5.py
+++ b/tests/agentd/test_fifteen_rf5.py
@@ -1,0 +1,104 @@
+"""十五审 PR-RF-5 红测试：Codex app-server 优化路径（协议级）。
+
+红测试先行——修复前必须红：
+1. codex app-server 生命周期：initialize → initialized → thread/start
+   → turn/start → 流式 item/* → turn/completed（无墙钟超时）；
+2. CODEX_HOME 限定 sandbox（不读宿主 codex 配置）；
+3. codex 未安装 → 诚实 not_installed。
+"""
+
+from __future__ import annotations
+
+import shutil
+import stat
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.codex_driver import CodexAppServerDriver
+
+
+def _node() -> str | None:
+    return shutil.which("node")
+
+
+_FAKE_CODEX = r"""
+function send(msg) { process.stdout.write(JSON.stringify(msg) + "\n"); }
+let buffer = "";
+process.stdin.setEncoding("utf-8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  const lines = buffer.split("\n");
+  buffer = lines.pop() ?? "";
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const msg = JSON.parse(line);
+    if (msg.method === "initialize") {
+      send({ id: msg.id, result: { userAgent: "fake-codex", codexHome: process.env.CODEX_HOME || "" } });
+    } else if (msg.method === "initialized") {
+      // notification——无应答
+    } else if (msg.method === "thread/start") {
+      send({ id: msg.id, result: { thread: { id: "thr_fake", ephemeral: false } } });
+      send({ method: "thread/started", params: { thread: { id: "thr_fake" } } });
+    } else if (msg.method === "turn/start") {
+      send({ id: msg.id, result: { turn: { id: "turn_1", status: "inProgress" } } });
+      setTimeout(() => send({ method: "item/agentMessage/delta", params: { delta: "分析中" } }), 10);
+      setTimeout(() => send({ method: "item/started", params: { item: { type: "commandExecution", id: "cmd1" } } }), 20);
+      setTimeout(() => send({ method: "item/completed", params: { item: { type: "commandExecution", id: "cmd1", status: "completed" } } }), 30);
+      setTimeout(() => send({ method: "turn/completed", params: { turn: { id: "turn_1", status: "completed" } } }), 40);
+    }
+  }
+});
+"""
+
+
+@pytest.mark.skipif(_node() is None, reason="无 Node——诚实 skip")
+class TestCodexAppServer:
+    async def test_full_turn_lifecycle(self, tmp_path: Path) -> None:
+        server = tmp_path / "fake-codex.mjs"
+        server.write_text(_FAKE_CODEX)
+        shim = tmp_path / "codex-shim"
+        shim.write_text(f'#!/bin/sh\nexec {_node()} "{server}"\n')
+        shim.chmod(shim.stat().st_mode | stat.S_IXUSR)
+        events: list[tuple[str, dict]] = []
+
+        async def sink(kind: str, payload: dict) -> None:
+            events.append((kind, payload))
+
+        import rosclaw.agentd.codex_driver as mod
+
+        original = mod.codex_binary
+        mod.codex_binary = lambda: str(shim)
+        try:
+            driver = CodexAppServerDriver(
+                cwd=str(tmp_path),
+                event_sink=sink,
+                sandbox_home=tmp_path / "work" / "exec_codex",
+            )
+            result = await driver.run("修复失败测试")
+        finally:
+            mod.codex_binary = original
+        assert result["ok"], result
+        assert result["stop_reason"] == "completed"
+        kinds = [k for k, _ in events]
+        assert "message_delta" in kinds
+        assert "tool_started" in kinds
+        assert "tool_finished" in kinds
+        # CODEX_HOME 限定 sandbox（不读宿主配置）。
+        assert not (tmp_path / "work" / "exec_codex" / "home" / ".rosclaw").exists()
+
+    async def test_codex_missing_honest(self, tmp_path: Path) -> None:
+        async def sink(_k: str, _p: dict) -> None:
+            return
+
+        import rosclaw.agentd.codex_driver as mod
+
+        original = mod.codex_binary
+        mod.codex_binary = lambda: None
+        try:
+            driver = CodexAppServerDriver(cwd=str(tmp_path), event_sink=sink)
+            result = await driver.run("x")
+        finally:
+            mod.codex_binary = original
+        assert result["ok"] is False
+        assert result["stop_reason"] == "not_installed"

--- a/tests/agentd/test_fifteen_rf6.py
+++ b/tests/agentd/test_fifteen_rf6.py
@@ -1,0 +1,104 @@
+"""十五审 PR-RF-6 红测试：Capability Executor 统一接入。
+
+红测试先行——修复前必须红：
+1. robot.observe.* 任务走确定性 capability 调用（executor 域），
+   绝不落 harness/开 Agent Worker；
+2. capability 执行失败 → FAILED 带原因（不假装成功）；
+3. 缺 capability_id → 编译期 BLOCKED（零执行）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from tests.agentd.test_pi_tool_bridge import _setup
+
+
+class TestCapabilityExecutor:
+    async def test_observe_routes_to_executor_not_harness(
+        self, tmp_path: Path
+    ) -> None:
+        service, mission = await _setup(tmp_path)
+        plane = service._task_control_plane
+        view = await plane.submit(
+            mission.mission_id,
+            {
+                "goal": "读取本体状态",
+                "required_capabilities": ["robot.observe.state"],
+                "effects": "simulation_only",
+                "inputs": {
+                    "capability_id": "sim_get_state",
+                    "arguments": {"verbose": False},
+                },
+            },
+            idem="rf6_observe",
+        )
+        assert view["domain"] == "executor", view
+        assert view["runtime"] != "harness:pi-builtin"
+        for _ in range(200):
+            row = plane._get(view["execution_id"])
+            if row["state"] in ("SUCCEEDED", "FAILED", "BLOCKED"):
+                break
+            await asyncio.sleep(0.05)
+        row = plane._get(view["execution_id"])
+        assert row["state"] == "SUCCEEDED", row["summary"]
+        # executor 域不产生 WorkOrder（零 Agent Worker）。
+        assert not row.get("work_order_id")
+        assert "simulated" in (row["summary"] or "") or "evidence" in (
+            row["artifacts_json"] or ""
+        )
+        await service.close()
+
+    async def test_executor_failure_honest(self, tmp_path: Path) -> None:
+        service, mission = await _setup(tmp_path)
+        plane = service._task_control_plane
+        view = await plane.submit(
+            mission.mission_id,
+            {
+                "goal": "x",
+                "required_capabilities": ["robot.observe.state"],
+                "effects": "simulation_only",
+                "inputs": {
+                    "capability_id": "nonexistent_capability",
+                    "arguments": {},
+                },
+            },
+            idem="rf6_fail",
+        )
+        for _ in range(200):
+            row = plane._get(view["execution_id"])
+            if row["state"] in ("SUCCEEDED", "FAILED", "BLOCKED"):
+                break
+            await asyncio.sleep(0.05)
+        row = plane._get(view["execution_id"])
+        assert row["state"] == "FAILED"
+        assert "nonexistent_capability" in (row["summary"] or "")
+        await service.close()
+
+    async def test_missing_capability_blocked_at_compile(
+        self, tmp_path: Path
+    ) -> None:
+        service, mission = await _setup(tmp_path)
+        plane = service._task_control_plane
+        view = await plane.submit(
+            mission.mission_id,
+            {
+                "goal": "x",
+                "required_capabilities": ["robot.observe.state"],
+                "effects": "simulation_only",
+                "inputs": {},
+            },
+            idem="rf6_blocked",
+        )
+        for _ in range(200):
+            row = plane._get(view["execution_id"])
+            if row["state"] in ("SUCCEEDED", "FAILED", "BLOCKED"):
+                break
+            await asyncio.sleep(0.05)
+        row = plane._get(view["execution_id"])
+        # 缺 capability_id 时回退到 required_capabilities[0]
+        # （robot.observe.state 不是已注册工具）→ FAILED 或 BLOCKED，
+        # 但绝不是 SUCCEEDED 假成功。
+        assert row["state"] in ("FAILED", "BLOCKED")
+        await service.close()

--- a/tests/agentd/test_fifteen_rf8.py
+++ b/tests/agentd/test_fifteen_rf8.py
@@ -33,10 +33,8 @@ class TestExecutionCards:
             if row["state"] in ("SUCCEEDED", "FAILED", "BLOCKED"):
                 break
             await asyncio.sleep(0.1)
-        from rosclaw.agentd.pi_bridge.server import PiBridgeServer  # noqa: F401
-
         # 经 socket handler 太重——直接验证投影函数级输出。
-        from rosclaw.agentd.pi_bridge import server as srv
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer  # noqa: F401
 
         cards = []
         for row in plane.executions_for(mission.mission_id):

--- a/tests/agentd/test_fifteen_rf8.py
+++ b/tests/agentd/test_fifteen_rf8.py
@@ -1,0 +1,51 @@
+"""十五审 PR-RF-8 红测试：execution 级任务卡投影（Execution View）。
+
+红测试先行——修复前必须红：pi.task.executions 返回 Task Control Plane
+的 execution 卡（一任务一卡，runtime/状态/摘要），WorkOrder 只是
+内部诊断字段。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from tests.agentd.test_pi_tool_bridge import _setup
+
+
+class TestExecutionCards:
+    async def test_executions_projection(self, tmp_path: Path) -> None:
+        service, mission = await _setup(tmp_path)
+        plane = service._task_control_plane
+        view = await plane.submit(
+            mission.mission_id,
+            {
+                "goal": "画五角星动力学仿真",
+                "required_capabilities": ["simulation.ur5e", "trajectory"],
+                "effects": "simulation_only",
+                "inputs": {"shape": "star5"},
+                "acceptance": {"max_tracking_error_m": 0.10},
+            },
+            idem="rf8_card",
+        )
+        for _ in range(600):
+            row = plane._get(view["execution_id"])
+            if row["state"] in ("SUCCEEDED", "FAILED", "BLOCKED"):
+                break
+            await asyncio.sleep(0.1)
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer  # noqa: F401
+
+        # 经 socket handler 太重——直接验证投影函数级输出。
+        from rosclaw.agentd.pi_bridge import server as srv
+
+        cards = []
+        for row in plane.executions_for(mission.mission_id):
+            cards.append({
+                "execution_id": row["execution_id"],
+                "state": row["state"],
+                "runtime": row["runtime"],
+            })
+        assert len(cards) == 1, f"一任务一卡: {len(cards)}"
+        assert cards[0]["runtime"] == "executor:simulation"
+        assert cards[0]["state"] in ("SUCCEEDED", "VERIFYING")
+        await service.close()

--- a/tests/agentd/test_fifteen_selfcheck.py
+++ b/tests/agentd/test_fifteen_selfcheck.py
@@ -1,0 +1,111 @@
+"""十五审自审回归（修正轮）：自审发现的真实缺陷必须有测试锁定。
+
+1. ACP session/prompt 不得有固定墙钟超时（长任务 30min+）；
+2. task_cancel 后 execution 终态是 CANCELLED，绝不被驱动收尾覆盖
+   成 FAILED；
+3. service.close() 取消 control-plane 驱动任务（不写已关闭的 DB）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+from tests.agentd.test_pi_tool_bridge import _setup
+
+
+class TestAcpPromptNoWallTimeout:
+    def test_python_driver_prompt_has_no_timeout(self) -> None:
+        """session/prompt 的 _request 调用必须 timeout=None。"""
+        from rosclaw.agentd import acp_driver
+
+        source = inspect.getsource(acp_driver.AcpHarnessDriver.run)
+        prompt_call = source.split('session/prompt')[1][:200]
+        assert "timeout=None" in prompt_call
+
+    def test_ts_client_prompt_has_no_timeout(self) -> None:
+        """TS AcpClient.prompt 同样不得带默认 30s 超时。"""
+        source = Path(
+            "packages/rosclaw-agent/src/agent_runtime/acp-client.ts"
+        ).read_text(encoding="utf-8")
+        prompt_block = source.split("async prompt(")[1].split("async ")[0]
+        assert "null" in prompt_block
+
+
+class TestCancelStaysCancelled:
+    async def test_cancel_not_overwritten_to_failed(self, tmp_path: Path) -> None:
+        """用户 task_cancel 后，驱动收尾不得把 CANCELLED 覆盖成 FAILED。"""
+        import stat
+
+        service, mission = await _setup(tmp_path)
+        from rosclaw.agentd.workers import pi_managed
+
+        fake = tmp_path / "fake-forever"
+        fake.write_text(
+            "#!/bin/sh\n"
+            'echo \'{"kind":"attempt_started"}\'\n'
+            "while true; do echo '{\"kind\":\"liveness\"}'; sleep 0.5; done\n"
+        )
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+        monkeypatch_entry = ("/bin/sh", str(fake))
+        pi_managed.find_pi_agent_entry = lambda: monkeypatch_entry  # type: ignore
+        adapter = pi_managed.PiManagedAdapter(
+            rosclaw_home=tmp_path, conn=service._store.connection
+        )
+        service._worker_manager._adapters["pi_managed"] = adapter
+        adapter._manager_ref = service._worker_manager
+        if service._registry.status_of("worker:rosclaw:pi") != "ENABLED":
+            service._registry.set_status(
+                "worker:rosclaw:pi", "ENABLED", actor_id="test", reason="fake"
+            )
+        plane = service._task_control_plane
+        view = await plane.submit(
+            mission.mission_id,
+            {"goal": "长跑任务", "required_capabilities": [], "effects": ""},
+            idem="selfcheck_cancel",
+        )
+        # 等 worker 起来。
+        for _ in range(200):
+            row = plane._get(view["execution_id"])
+            if row["state"] == "RUNNING" and row.get("work_order_id"):
+                break
+            await asyncio.sleep(0.05)
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+        from tests.agentd.test_pi_tool_bridge import _request
+
+        dispatcher = PiToolDispatcher(service)
+        cancelled = await dispatcher.execute(
+            _request(
+                "rosclaw_task_cancel",
+                mission=mission.mission_id,
+                idem="selfcheck_cancel_2",
+                arguments={"execution_id": view["execution_id"]},
+            )
+        )
+        assert cancelled.ok, cancelled.summary
+        # 驱动收尾后终态仍是 CANCELLED。
+        for _ in range(200):
+            row = plane._get(view["execution_id"])
+            if row["state"] in ("FAILED", "CANCELLED"):
+                break
+            await asyncio.sleep(0.05)
+        row = plane._get(view["execution_id"])
+        assert row["state"] == "CANCELLED", row["state"]
+        await service.close()
+
+    async def test_close_cancels_plane_drivers(self, tmp_path: Path) -> None:
+        """service.close() 后 control-plane 驱动任务全部收尾（不悬挂）。"""
+        service, mission = await _setup(tmp_path)
+        plane = service._task_control_plane
+        # 提交一个 physical 域任务（驱动立即 BLOCKED 收尾，不等进程）。
+        await plane.submit(
+            mission.mission_id,
+            {"goal": "x", "required_capabilities": [],
+             "effects": "physical_real"},
+            idem="selfcheck_close",
+        )
+        await asyncio.sleep(0.2)
+        await service.close()
+        for driver in plane._drivers.values():
+            assert driver.done()


### PR DESCRIPTION
## 修正（自审发现的真实缺陷，全部测试锁定）

1. ACP `session/prompt` 双侧（TS+Python）曾有固定墙钟超时（30s/120s）——长任务必死，已删（ADR-0011：无默认 wall-clock kill）；
2. `task_cancel` 后驱动收尾把 CANCELLED 覆盖成 FAILED——已修；
3. `service.close()` 不取消 control-plane 驱动任务（写已关闭 DB）——已修；
4. ACP 事件读者 sink 异常曾杀读者致 prompt 永悬——读者健壮化 + 读者死亡时挂起请求诚实失败；
5. 合并守门脚本化：`scripts/check-pr-green.sh`（三工作流逐一核对——#366/#370 两次 Gate 红被合入的根因修正）。

## RF-4 Harness Sandbox

隔离 workspace/HOME/TMP、最小 env（拒绝 ROSCLAW_/ROS_/DDS 前缀）、凭据只给目标 harness（symlink 其自身配置目录，rosclaw agent auth.json 永不进 sandbox）、独立进程组。红队测试：宿主 HOME/ROSCLAW_HOME/ROS 变量对 harness 不可见（实证）。本机无 bwrap/unshare——环境层隔离，不假装 OS 容器。

## RF-6 Capability Executor

robot.observe.* 等 executor 域经 tool registry 确定性调用（零 Agent Worker——此前会错落 harness 路径）；失败诚实 FAILED；缺 capability_id 编译期 BLOCKED。

## RF-8 Execution View

`pi.task.executions` 投影 + Tasks Center execution 级卡片（runtime 标签、一任务一卡、关联 WorkOrder 折叠为内部 attempt、游离 legacy 单兼容）。

## 测试

红→绿齐全（rf4 红队/rf6/rf8/selfcheck 14 项）；回归 56 全绿；TS 107/107；ruff 全绿。