### PR TITLE
DF-17: full typed evolution lineage graph

### DIFF
--- a/docs/reports/data-flywheel-phase2/DF-17-full-evolution-lineage.md
+++ b/docs/reports/data-flywheel-phase2/DF-17-full-evolution-lineage.md
@@ -1,0 +1,100 @@
+# DF-17 — Full Evolution Lineage (implementation note)
+
+Phase-II P0 per `seekdb优化v2.md` §8–§14. Closes gap P0-2: lineage had a
+table and a repository, but not a full typed graph.
+
+## What landed
+
+### §8 Typed vocabulary — `src/rosclaw/storage/lineage_types.py` (new)
+
+- `LineageEntityType` StrEnum: action / receipt / practice / episode /
+  memory / memory_insight / failure / diagnosis / proposal / patch /
+  experiment / darwin_benchmark / evaluation / champion / dead_end / skill.
+- `LineageRelation` StrEnum: derived_from / generated_from / observed_in /
+  supported_by / diagnosed_from / proposed_from / patched_from / tested_by /
+  evaluated_from / promoted_from / rejected_from / recovered_by / supersedes.
+- Canonical orientation (§8.5): **child/derived → parent/source**. The
+  ReceiptProjector's existing receipt → action edge already matches this.
+
+### §8.3–8.4, §11 LineageRepository — `src/rosclaw/storage/lineage.py`
+
+- `parents()`/`children()` now filter by `entity_type` AND `entity_id`;
+  before, the type parameter was decorative.
+- Idempotency key extended to the 5-field tuple
+  (from_type, from_id, relation, to_type, to_id).
+- `ancestors()`/`descendants()`/`trace()` walk (type, id) pairs, not bare
+  ids, so same-id-different-type entities cannot cross-contaminate a walk.
+- New `trace_graph(type, id, max_depth=16, max_nodes=500)`: full ancestry
+  DAG (nodes + edges + `truncated` flag), cycle-safe, capped so a
+  pathological graph cannot blow up the CLI.
+
+### §9 AutoEngine auto-linking — `src/rosclaw/auto/engine/auto_engine.py`
+
+- New constructor kwarg `lineage_repository` (default None → standalone
+  behavior unchanged), threaded through `AutoPlugin`.
+- Every edge write is best-effort (`contextlib.suppress`) — lineage can
+  never break the evolution flow:
+  - Failure --generated_from--> action (praxis event); plus
+    --derived_from--> memory_insight when `evidence["insight_id"]` present.
+  - Diagnosis --diagnosed_from--> failure.
+  - Proposal --proposed_from--> typed `source_refs` (new kwarg;
+    falls back to the `failure_case_id` argument).
+  - Patch --patched_from--> proposal.
+  - Experiment --derived_from--> patch (graph kept minimal; proposal is
+    reachable through the patch).
+  - Evaluation --evaluated_from--> experiment, plus --supported_by--> each
+    simulation receipt (`darwin_benchmark` type when the receipt carries a
+    benchmark marker).
+  - Champion --promoted_from--> evaluation.
+  - DeadEnd --rejected_from--> typed source via new `source_type`/`source_id`
+    kwargs.
+
+### §10 MemoryInsight → Memory — `src/rosclaw/memory/insights.py`
+
+- `MemoryInsightService` accepts `lineage_repository`; every emitted
+  insight links --derived_from--> each ref in `memory_refs` (all of them,
+  not just the JSON attribute). `heuristic_rules:<id>` refs link with type
+  `heuristic_rule`; bare ids link as `memory`.
+
+### §12 CLI — `rosclaw data lineage <type>:<id>`
+
+- New `data` command group (`src/rosclaw/storage/cli.py`,
+  `add_data_subparser`), wired in `src/rosclaw/cli.py`.
+- Text output renders the DAG as an indented tree with relation labels;
+  nodes revisited through a second path render "(see above)" so cycles
+  stay finite. `--json` emits the raw trace_graph payload for the
+  Dashboard. `--max-depth`/`--max-nodes` override the caps.
+
+### Runtime wiring — `src/rosclaw/core/runtime.py`
+
+- The data plane's `LineageRepository` (DF-14) is now injected into both
+  `AutoPlugin` and `MemoryInsightService`. Ordering is safe:
+  `_create_data_plane` (which builds the repository) runs at the top of
+  `_do_initialize`, before module wiring.
+
+## Tests (§13 + §14) — `tests/storage/test_full_lineage.py`
+
+Named set: `test_lineage_type_sensitive`, `test_lineage_idempotent`,
+`test_lineage_multi_parent`, `test_lineage_cycle_safe`,
+`test_trace_graph_branches`, `test_proposal_failure_link`,
+`test_patch_proposal_link`, `test_experiment_patch_link`,
+`test_evaluation_experiment_link`, `test_champion_evaluation_link`,
+`test_deadend_source_link` — plus `source_refs` proposal linking, the
+no-repo no-op path, insight→memory multi-link, CLI tree rendering, and
+CLI bad-entity rejection.
+
+Golden E2E (`test_golden_lineage_champion_to_receipt`): Receipt → Episode
+→ Memory → Insight → Proposal → Patch → Experiment → Evaluation →
+Champion, then `trace_graph("champion", id)` contains the receipt, memory,
+proposal, evaluation, insight, and episode ids. 六问之六 passes.
+
+## Deliberate deviations / notes
+
+- Experiment links only to its patch (not also the proposal), per §9.5's
+  "keep the graph minimal" option — the proposal is one hop away.
+- `source_refs` accepts dicts (`{"type", "id"}`) or objects with
+  `type`/`id` attributes, so a future typed EntityRef drops in without a
+  signature change.
+- Baseline champions created without an `evaluation_id` simply get no
+  promoted_from edge (empty-id guard), which matches their provenance-free
+  nature.

--- a/src/rosclaw/auto/engine/auto_engine.py
+++ b/src/rosclaw/auto/engine/auto_engine.py
@@ -6,6 +6,8 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
+from rosclaw.storage.lineage_types import LineageEntityType, LineageRelation
+
 from ..config import AutoConfig
 from ..core import (
     AutoTask,
@@ -39,12 +41,18 @@ class AutoEngine:
         seekdb_client: Any | None = None,
         skill_registry: Any | None = None,
         sense_runtime: Any | None = None,
+        lineage_repository: Any | None = None,
     ):
         self.config = config or AutoConfig()
         self._event_bus = event_bus
         self._seekdb = seekdb_client
         self._skill_registry = skill_registry
         self._sense_runtime = sense_runtime
+        # PR-DF-17 (phase-II §9): the typed lineage graph.  When injected,
+        # every create_* method records child/derived -> parent/source edges
+        # so "why is this champion v1.7?" is answerable from lineage_edges.
+        # None keeps the standalone behavior (no structured data plane).
+        self._lineage_repo = lineage_repository
         self._auto_context_adapter: Any | None = None
         if sense_runtime is not None:
             try:
@@ -85,6 +93,20 @@ class AutoEngine:
         self._promotion_authorizations: dict[str, dict[str, Any]] = {}
         # Event publishing
         self.publisher = AutoPublisher(event_bus=event_bus)
+
+    def _lineage_link(
+        self,
+        from_type: str,
+        from_id: str,
+        relation: str,
+        to_type: str,
+        to_id: str,
+    ) -> None:
+        """Best-effort lineage edge; never breaks the evolution flow."""
+        if self._lineage_repo is None or not from_id or not to_id:
+            return
+        with contextlib.suppress(Exception):
+            self._lineage_repo.link(str(from_type), from_id, str(relation), str(to_type), to_id)
 
     # ------------------------------------------------------------------
     # Task management
@@ -147,6 +169,25 @@ class AutoEngine:
             evidence=evidence,
         )
         self._save("failures", fc.id, fc.to_dict())
+        # §9.1: Failure --generated_from--> PraxisEvent (action), and
+        # Failure --derived_from--> MemoryInsight when the failure was
+        # raised from an insight rather than a live praxis event.
+        self._lineage_link(
+            LineageEntityType.FAILURE,
+            fc.id,
+            LineageRelation.GENERATED_FROM,
+            LineageEntityType.ACTION,
+            praxis_event_id,
+        )
+        insight_id = evidence.get("insight_id") or evidence.get("memory_insight_id") or ""
+        if insight_id:
+            self._lineage_link(
+                LineageEntityType.FAILURE,
+                fc.id,
+                LineageRelation.DERIVED_FROM,
+                LineageEntityType.MEMORY_INSIGHT,
+                insight_id,
+            )
         return fc
 
     def list_failures(self, task_id: str | None = None) -> list[FailureCase]:
@@ -175,6 +216,14 @@ class AutoEngine:
             recommended_search_space=search_space or {},
         )
         self._save("diagnoses", diag.id, diag.to_dict())
+        # §9.2: Diagnosis --diagnosed_from--> Failure
+        self._lineage_link(
+            LineageEntityType.DIAGNOSIS,
+            diag.id,
+            LineageRelation.DIAGNOSED_FROM,
+            LineageEntityType.FAILURE,
+            failure_id,
+        )
         return diag
 
     # ------------------------------------------------------------------
@@ -189,6 +238,7 @@ class AutoEngine:
         search_space: dict,
         patch_type: str = "skill_parameter_patch",
         source: str = "failure_guided",
+        source_refs: list[dict] | None = None,
     ) -> Proposal:
         prop = Proposal(
             id=f"prop_{uuid.uuid4().hex[:8]}",
@@ -201,6 +251,20 @@ class AutoEngine:
             required_gates=["sandbox_check", "multi_seed_eval", "regression_check"],
         )
         self._save("proposals", prop.id, prop.to_dict())
+        # §9.3: Proposal --proposed_from--> typed source refs (Failure,
+        # MemoryInsight, ...).  source_refs supersedes the bare source
+        # string; without refs we fall back to the failure case argument.
+        refs = source_refs or (
+            [{"type": str(LineageEntityType.FAILURE), "id": failure_case_id}]
+            if failure_case_id
+            else []
+        )
+        for ref in refs:
+            ref_type = ref.get("type", "") if isinstance(ref, dict) else getattr(ref, "type", "")
+            ref_id = ref.get("id", "") if isinstance(ref, dict) else getattr(ref, "id", "")
+            self._lineage_link(
+                LineageEntityType.PROPOSAL, prop.id, LineageRelation.PROPOSED_FROM, ref_type, ref_id
+            )
         if self.publisher:
             self.publisher.proposal_created(
                 proposal_id=prop.id,
@@ -252,6 +316,14 @@ class AutoEngine:
             human_approval_required=(patch_type == "code_patch"),
         )
         self._save("patches", patch.id, patch.to_dict())
+        # §9.4: Patch --patched_from--> Proposal
+        self._lineage_link(
+            LineageEntityType.PATCH,
+            patch.id,
+            LineageRelation.PATCHED_FROM,
+            LineageEntityType.PROPOSAL,
+            proposal_id,
+        )
         if self._seekdb is not None:
             with contextlib.suppress(Exception):
                 self._seekdb.insert(
@@ -297,6 +369,15 @@ class AutoEngine:
             promotion={"min_success_improvement": 0.05, "max_collision_increase": 0.0},
         )
         self._save("experiments", exp.id, exp.to_dict())
+        # §9.5: Experiment --derived_from--> Patch (graph kept minimal:
+        # the proposal is reachable through the patch's patched_from edge)
+        self._lineage_link(
+            LineageEntityType.EXPERIMENT,
+            exp.id,
+            LineageRelation.DERIVED_FROM,
+            LineageEntityType.PATCH,
+            patch_id,
+        )
         return exp
 
     def run_experiment(self, experiment: ExperimentSpec, runner: str = "local") -> dict:
@@ -397,6 +478,33 @@ class AutoEngine:
             decision=gate_result.decision,
         )
         self._save("evaluations", ev.id, ev.to_dict())
+        # §9.6: Evaluation --evaluated_from--> Experiment, plus
+        # --supported_by--> each simulation/darwin receipt that backs it.
+        self._lineage_link(
+            LineageEntityType.EVALUATION,
+            ev.id,
+            LineageRelation.EVALUATED_FROM,
+            LineageEntityType.EXPERIMENT,
+            experiment_id,
+        )
+        for receipt in simulation_receipts or []:
+            if not isinstance(receipt, dict):
+                continue
+            receipt_id = (
+                receipt.get("id") or receipt.get("receipt_id") or receipt.get("action_id") or ""
+            )
+            receipt_type = (
+                LineageEntityType.DARWIN_BENCHMARK
+                if receipt.get("benchmark_id") or receipt.get("darwin")
+                else LineageEntityType.RECEIPT
+            )
+            self._lineage_link(
+                LineageEntityType.EVALUATION,
+                ev.id,
+                LineageRelation.SUPPORTED_BY,
+                receipt_type,
+                receipt_id,
+            )
         if gate_result.passed and experiment is not None and task is not None:
             self._promotion_authorizations[ev.id] = {
                 "experiment_id": experiment.id,
@@ -481,6 +589,14 @@ class AutoEngine:
             result="champion",
             metrics=metrics,
         )
+        # §9.7: Champion --promoted_from--> Evaluation
+        self._lineage_link(
+            LineageEntityType.CHAMPION,
+            champ.id,
+            LineageRelation.PROMOTED_FROM,
+            LineageEntityType.EVALUATION,
+            evaluation_id,
+        )
         if self.publisher:
             self.publisher.champion_promoted(
                 champion_id=champ.id,
@@ -534,7 +650,13 @@ class AutoEngine:
         return self.champion_store.list_champions(task_id)
 
     def register_deadend(
-        self, task_id: str, direction: str, rejection_reason: str, evidence: list[str] | None = None
+        self,
+        task_id: str,
+        direction: str,
+        rejection_reason: str,
+        evidence: list[str] | None = None,
+        source_type: str = "",
+        source_id: str = "",
     ) -> DeadEnd:
         de = DeadEnd(
             id=f"de_{uuid.uuid4().hex[:8]}",
@@ -544,6 +666,16 @@ class AutoEngine:
             evidence=evidence or [],
         )
         self._save("deadends", de.id, de.to_dict())
+        # §9.8: DeadEnd --rejected_from--> its typed source (Evaluation,
+        # Experiment, ...), not just a free-text direction/reason.
+        if source_type and source_id:
+            self._lineage_link(
+                LineageEntityType.DEAD_END,
+                de.id,
+                LineageRelation.REJECTED_FROM,
+                source_type,
+                source_id,
+            )
         if self.publisher:
             self.publisher.deadend_registered(
                 deadend_id=de.id,

--- a/src/rosclaw/auto/plugin.py
+++ b/src/rosclaw/auto/plugin.py
@@ -33,6 +33,7 @@ class AutoPlugin(LifecycleMixin):
         seekdb_client: Any | None = None,
         skill_registry: Any | None = None,
         sense_runtime: Any | None = None,
+        lineage_repository: Any | None = None,
     ):
         super().__init__()
         self.config = AutoConfig.from_dict(config or {})
@@ -43,6 +44,7 @@ class AutoPlugin(LifecycleMixin):
         self._seekdb_client = seekdb_client
         self._skill_registry = skill_registry
         self._sense_runtime = sense_runtime
+        self._lineage_repository = lineage_repository
 
     def _do_initialize(self) -> None:
         """Initialize engine and connect to runtime context."""
@@ -52,6 +54,7 @@ class AutoPlugin(LifecycleMixin):
             seekdb_client=self._seekdb_client,
             skill_registry=self._skill_registry,
             sense_runtime=self._sense_runtime,
+            lineage_repository=self._lineage_repository,
         )
         self.publisher = AutoPublisher(event_bus=self._event_bus)
         self.subscriber = AutoSubscriber(engine=self.engine, event_bus=self._event_bus)

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -79,7 +79,14 @@ from rosclaw.sense.cli import (
     cmd_sense_watch,
 )
 from rosclaw.skill.cli import add_skill_hub_parsers
-from rosclaw.storage.cli import add_db_subparser, cmd_db_doctor, cmd_db_reconcile, cmd_db_status
+from rosclaw.storage.cli import (
+    add_data_subparser,
+    add_db_subparser,
+    cmd_data_lineage,
+    cmd_db_doctor,
+    cmd_db_reconcile,
+    cmd_db_status,
+)
 
 
 def _dispatch_lerobot_cli(command: str, *args: Any) -> int:
@@ -7153,6 +7160,9 @@ def main() -> int:
     # db (storage diagnostics)
     db_parser = add_db_subparser(subparsers)
 
+    # data (data flywheel queries, PR-DF-17)
+    data_parser = add_data_subparser(subparsers)
+
     # profile
     profile_parser = subparsers.add_parser("profile", help="Profile management")
     profile_subparsers = profile_parser.add_subparsers(dest="profile_command")
@@ -9296,6 +9306,12 @@ def main() -> int:
                 return cmd_db_reconcile(args)
             else:
                 db_parser.print_help()
+                return 1
+        elif args.command == "data":
+            if args.data_command == "lineage":
+                return cmd_data_lineage(args)
+            else:
+                data_parser.print_help()
                 return 1
         elif args.command == "know":
             if args.know_command == "search":

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -689,6 +689,7 @@ class Runtime(LifecycleMixin):
                         if isinstance(_auto_cfg, dict)
                         else 3
                     ),
+                    lineage_repository=self._lineage,
                 )
                 self._memory_insights.subscribe()
             except Exception as exc:  # noqa: BLE001
@@ -741,6 +742,7 @@ class Runtime(LifecycleMixin):
                     if self._skill_manager
                     else None,
                     sense_runtime=self._sense,
+                    lineage_repository=self._lineage,
                 )
                 self._modules.append(self._auto)
                 logger.info("Self-Evolution Control Plane (Auto) initialized")

--- a/src/rosclaw/memory/insights.py
+++ b/src/rosclaw/memory/insights.py
@@ -46,12 +46,17 @@ class MemoryInsightService:
         robot_id: str,
         failure_threshold: int = 3,
         cooldown_s: float = _DEFAULT_COOLDOWN_S,
+        lineage_repository: Any = None,
     ) -> None:
         self._bus = event_bus
         self._store = structured_store
         self._robot_id = robot_id
         self._threshold = failure_threshold
         self._cooldown_s = cooldown_s
+        # PR-DF-17 (phase-II §10): MemoryInsight --derived_from--> Memory
+        # edges for every contributing memory; memory_refs stays the JSON
+        # attribute, lineage_edges is the traversable relation.
+        self._lineage = lineage_repository
         self._counts: dict[tuple[str, str], int] = {}
         self._last_emitted: dict[tuple[str, str, str], float] = {}
         self._subscribed = False
@@ -218,3 +223,31 @@ class MemoryInsightService:
             logger.info("memory insight published: %s (%s)", insight_type, dedup_key)
         except Exception as exc:  # noqa: BLE001
             logger.info("insight publish failed (non-fatal): %s", exc)
+        self._link_sources(insight["insight_id"], insight["memory_refs"])
+
+    def _link_sources(self, insight_id: str, memory_refs: list[str]) -> None:
+        """MemoryInsight --derived_from--> each contributing memory (§10)."""
+        if self._lineage is None:
+            return
+        from rosclaw.storage.lineage_types import LineageEntityType, LineageRelation
+
+        for ref in memory_refs:
+            ref = str(ref)
+            if not ref:
+                continue
+            if ref.startswith("heuristic_rules:"):
+                entity_type, entity_id = "heuristic_rule", ref.split(":", 1)[1]
+            else:
+                entity_type, entity_id = str(LineageEntityType.MEMORY), ref
+            if not entity_id:
+                continue
+            try:
+                self._lineage.link(
+                    str(LineageEntityType.MEMORY_INSIGHT),
+                    insight_id,
+                    str(LineageRelation.DERIVED_FROM),
+                    entity_type,
+                    entity_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("insight lineage link failed (non-fatal): %s", exc)

--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -1358,6 +1358,112 @@ def cmd_db_reconcile(args: argparse.Namespace) -> int:
     return 0 if all_passed else 1
 
 
+# ---------------------------------------------------------------------------
+# rosclaw data lineage (PR-DF-17 / phase-II §12)
+# ---------------------------------------------------------------------------
+
+
+def _render_lineage_tree(graph: dict[str, Any]) -> list[str]:
+    """Render the trace_graph DAG as an indented text tree (§12 text output).
+
+    Nodes revisited through a second path are annotated instead of expanded
+    again, so cycles render finitely.
+    """
+    root = graph.get("root", "")
+    children: dict[str, list[tuple[str, str]]] = {}
+    labels: dict[str, str] = {}
+    for node in graph.get("nodes", []):
+        labels[f"{node['type']}:{node['id']}"] = f"{node['type'].title()} {node['id']}"
+    for edge in graph.get("edges", []):
+        children.setdefault(edge["from"], []).append((edge["relation"], edge["to"]))
+
+    lines = [labels.get(root, root)]
+    seen = {root}
+
+    def _walk(node: str, prefix: str) -> None:
+        kids = children.get(node, [])
+        for idx, (relation, child) in enumerate(kids):
+            last = idx == len(kids) - 1
+            connector = "└─ " if last else "├─ "
+            label = labels.get(child, child)
+            if child in seen:
+                lines.append(f"{prefix}{connector}{relation} {label} (see above)")
+                continue
+            seen.add(child)
+            lines.append(f"{prefix}{connector}{relation} {label}")
+            _walk(child, prefix + ("   " if last else "│  "))
+
+    _walk(root, "")
+    if graph.get("truncated"):
+        lines.append("... (truncated: node cap reached)")
+    return lines
+
+
+@_with_stdout_flush
+def cmd_data_lineage(args: argparse.Namespace) -> int:
+    """Print the typed ancestry graph for an entity (``type:id``)."""
+    entity = getattr(args, "entity", "") or ""
+    if ":" not in entity:
+        print(
+            "[rosclaw data lineage] entity must be '<type>:<id>' (e.g. champion:champ_xxx)",
+            file=sys.stderr,
+        )
+        return 2
+    entity_type, entity_id = entity.split(":", 1)
+    if not entity_type or not entity_id:
+        print("[rosclaw data lineage] entity type and id must both be non-empty", file=sys.stderr)
+        return 2
+
+    cfg = _load_storage_config(args)
+    try:
+        client = _create_client(cfg)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[rosclaw data lineage] Failed to create backend: {exc}", file=sys.stderr)
+        return 1
+    try:
+        from rosclaw.storage.lineage import LineageRepository
+
+        repo = LineageRepository(client)
+        graph = repo.trace_graph(
+            entity_type,
+            entity_id,
+            max_depth=getattr(args, "max_depth", 16),
+            max_nodes=getattr(args, "max_nodes", 500),
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[rosclaw data lineage] trace failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        _close_client(client)
+
+    if args.json:
+        print(json.dumps(graph, indent=2))
+    else:
+        for line in _render_lineage_tree(graph):
+            print(line)
+    return 0
+
+
+def add_data_subparser(subparsers: Any) -> Any:
+    """Add ``rosclaw data`` subcommands (PR-DF-17)."""
+    data_parser = subparsers.add_parser("data", help="Data flywheel queries")
+    data_subparsers = data_parser.add_subparsers(dest="data_command")
+
+    lineage_parser = data_subparsers.add_parser(
+        "lineage", help="Trace the typed lineage graph for an entity"
+    )
+    lineage_parser.add_argument(
+        "entity", help="Entity reference '<type>:<id>' (e.g. champion:champ_xxx)"
+    )
+    lineage_parser.add_argument("--json", action="store_true", help="Output JSON")
+    lineage_parser.add_argument("--max-depth", type=int, default=16, help="Max ancestry depth")
+    lineage_parser.add_argument("--max-nodes", type=int, default=500, help="Max graph nodes")
+    lineage_parser.add_argument("--backend", default=None, help="Override backend")
+    lineage_parser.add_argument("--url", default=None, help="Override SQL URL")
+    lineage_parser.add_argument("--path", default=None, help="Override SQLite path")
+    return data_parser
+
+
 def add_db_subparser(subparsers: Any) -> Any:
     """Add ``rosclaw db`` subcommands."""
     db_parser = subparsers.add_parser("db", help="Storage backend diagnostics")

--- a/src/rosclaw/storage/lineage.py
+++ b/src/rosclaw/storage/lineage.py
@@ -1,4 +1,4 @@
-"""LineageRepository (PR-DF-14 / flywheel §36-38).
+"""LineageRepository (PR-DF-14 / flywheel §36-38; typed in PR-DF-17 / §8).
 
 The typed ancestry graph over the ``lineage_edges`` table.  Answers the
 acceptance questions — "why is this champion v1.7?" — by walking:
@@ -6,13 +6,15 @@ acceptance questions — "why is this champion v1.7?" — by walking:
     Champion → Evaluation → Experiment → Patch → Proposal
              → MemoryInsight → Memory → Episode → Receipt
 
-Relations (§36): derived_from / observed_in / supported_by / proposed_from /
-patched_by / evaluated_by / promoted_from / supersedes / recovered_by /
-generated_from.
+Relations are the canonical ``LineageRelation`` vocabulary (§8.2); entity
+types are the canonical ``LineageEntityType`` vocabulary (§8.1).
 
-An edge reads ``from --relation--> to``: e.g.
+An edge reads ``from --relation--> to`` in the child/derived → parent/source
+orientation (§8.5): e.g.
 ``link("champion", "champ_1", "promoted_from", "evaluation", "eval_9")``.
-Writes are idempotent on (from, relation, to).
+Writes are idempotent on the 5-field key
+(from_type, from_id, relation, to_type, to_id) — two entities of different
+types may share an id namespace, so the type is part of identity.
 """
 
 from __future__ import annotations
@@ -44,10 +46,16 @@ class LineageRepository:
         trace_id: str = "",
         metadata: dict[str, Any] | None = None,
     ) -> str:
-        """Create an edge; idempotent on (from, relation, to)."""
+        """Create an edge; idempotent on (from_type, from_id, relation, to_type, to_id)."""
         existing = self._store.query(
             TABLE,
-            {"from_id": from_id, "relation": relation, "to_id": to_id},
+            {
+                "from_type": from_type,
+                "from_id": from_id,
+                "relation": relation,
+                "to_type": to_type,
+                "to_id": to_id,
+            },
             limit=1,
         )
         if existing:
@@ -73,63 +81,73 @@ class LineageRepository:
 
     def parents(self, entity_type: str, entity_id: str) -> list[dict[str, Any]]:
         """Edges pointing AWAY from this entity toward its sources."""
-        return self._store.query(TABLE, {"from_id": entity_id}, limit=10_000)
+        return self._store.query(
+            TABLE, {"from_type": entity_type, "from_id": entity_id}, limit=10_000
+        )
 
     def children(self, entity_type: str, entity_id: str) -> list[dict[str, Any]]:
         """Edges pointing AT this entity (things derived from it)."""
-        return self._store.query(TABLE, {"to_id": entity_id}, limit=10_000)
+        return self._store.query(TABLE, {"to_type": entity_type, "to_id": entity_id}, limit=10_000)
 
-    def ancestors(self, entity_type: str, entity_id: str, *, max_depth: int = 32) -> list[dict[str, Any]]:
+    def ancestors(
+        self, entity_type: str, entity_id: str, *, max_depth: int = 32
+    ) -> list[dict[str, Any]]:
         """BFS over parents(); cycle-safe, depth-capped."""
         seen: set[str] = set()
         out: list[dict[str, Any]] = []
-        frontier = [entity_id]
+        frontier = [(entity_type, entity_id)]
         depth = 0
         while frontier and depth < max_depth:
             depth += 1
-            nxt: list[str] = []
-            for fid in frontier:
-                for edge in self.parents(entity_type, fid):
+            nxt: list[tuple[str, str]] = []
+            for ftype, fid in frontier:
+                for edge in self.parents(ftype, fid):
                     eid = edge["id"]
                     if eid in seen:
                         continue
                     seen.add(eid)
                     out.append(edge)
-                    to_id = edge.get("to_id")
-                    if to_id and to_id not in (nxt or []):
-                        nxt.append(to_id)
+                    node = (edge.get("to_type", ""), edge.get("to_id", ""))
+                    if node[1] and node not in nxt:
+                        nxt.append(node)
             frontier = nxt
         return out
 
-    def descendants(self, entity_type: str, entity_id: str, *, max_depth: int = 32) -> list[dict[str, Any]]:
+    def descendants(
+        self, entity_type: str, entity_id: str, *, max_depth: int = 32
+    ) -> list[dict[str, Any]]:
         """BFS over children(); cycle-safe, depth-capped."""
         seen: set[str] = set()
         out: list[dict[str, Any]] = []
-        frontier = [entity_id]
+        frontier = [(entity_type, entity_id)]
         depth = 0
         while frontier and depth < max_depth:
             depth += 1
-            nxt = []
-            for fid in frontier:
-                for edge in self.children(entity_type, fid):
+            nxt: list[tuple[str, str]] = []
+            for ftype, fid in frontier:
+                for edge in self.children(ftype, fid):
                     eid = edge["id"]
                     if eid in seen:
                         continue
                     seen.add(eid)
                     out.append(edge)
-                    from_id = edge.get("from_id")
-                    if from_id:
-                        nxt.append(from_id)
+                    node = (edge.get("from_type", ""), edge.get("from_id", ""))
+                    if node[1]:
+                        nxt.append(node)
             frontier = nxt
         return out
 
     def trace(self, entity_type: str, entity_id: str) -> dict[str, Any]:
-        """The formatted ancestry chain for CLI/reporting (§38)."""
+        """The single-path ancestry chain for CLI/reporting (§38)."""
         chain = []
         current_type, current_id = entity_type, entity_id
-        visited = {current_id}
+        visited = {(current_type, current_id)}
         while True:
-            edges = [e for e in self.parents(current_type, current_id) if e["to_id"] not in visited]
+            edges = [
+                e
+                for e in self.parents(current_type, current_id)
+                if (e["to_type"], e["to_id"]) not in visited
+            ]
             if not edges:
                 break
             edge = edges[0]
@@ -140,6 +158,62 @@ class LineageRepository:
                     "to_id": edge["to_id"],
                 }
             )
-            visited.add(edge["to_id"])
+            visited.add((edge["to_type"], edge["to_id"]))
             current_type, current_id = edge["to_type"], edge["to_id"]
         return {"root": {"type": entity_type, "id": entity_id}, "chain": chain}
+
+    def trace_graph(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        max_depth: int = 16,
+        max_nodes: int = 500,
+    ) -> dict[str, Any]:
+        """The full ancestry DAG rooted at this entity (§11).
+
+        Unlike :meth:`trace` (first-parent chain), this walks every parent
+        branch.  Returns nodes (with type/id/depth) and edges (with relation)
+        so callers can render trees, JSON, or feed a visualizer.  Cycle-safe;
+        caps prevent pathological fan-out.
+        """
+        root_key = f"{entity_type}:{entity_id}"
+        nodes: dict[str, dict[str, Any]] = {
+            root_key: {"type": entity_type, "id": entity_id, "depth": 0}
+        }
+        edges: list[dict[str, Any]] = []
+        seen_edges: set[str] = set()
+        frontier = [(entity_type, entity_id, 0)]
+        truncated = False
+        while frontier:
+            ftype, fid, depth = frontier.pop(0)
+            if depth >= max_depth:
+                continue
+            for edge in self.parents(ftype, fid):
+                eid = edge["id"]
+                if eid in seen_edges:
+                    continue
+                seen_edges.add(eid)
+                to_type, to_id = edge["to_type"], edge["to_id"]
+                to_key = f"{to_type}:{to_id}"
+                edges.append(
+                    {
+                        "from": f"{ftype}:{fid}",
+                        "relation": edge["relation"],
+                        "to": to_key,
+                    }
+                )
+                if len(nodes) >= max_nodes:
+                    truncated = True
+                    break
+                if to_key not in nodes:
+                    nodes[to_key] = {"type": to_type, "id": to_id, "depth": depth + 1}
+                    frontier.append((to_type, to_id, depth + 1))
+            if truncated:
+                break
+        return {
+            "root": root_key,
+            "nodes": list(nodes.values()),
+            "edges": edges,
+            "truncated": truncated,
+        }

--- a/src/rosclaw/storage/lineage_types.py
+++ b/src/rosclaw/storage/lineage_types.py
@@ -1,0 +1,52 @@
+"""Typed lineage vocabulary (PR-DF-17 / phase-II §8.1-8.2).
+
+Canonical orientation (§8.5): child/derived -> parent/source.
+A Champion points at the Evaluation it was promoted from, never the other
+way around.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class LineageEntityType(StrEnum):
+    ACTION = "action"
+    RECEIPT = "receipt"
+    PRACTICE = "practice"
+    EPISODE = "episode"
+
+    MEMORY = "memory"
+    MEMORY_INSIGHT = "memory_insight"
+
+    FAILURE = "failure"
+    DIAGNOSIS = "diagnosis"
+    PROPOSAL = "proposal"
+    PATCH = "patch"
+    EXPERIMENT = "experiment"
+    DARWIN_BENCHMARK = "darwin_benchmark"
+    EVALUATION = "evaluation"
+
+    CHAMPION = "champion"
+    DEAD_END = "dead_end"
+
+    SKILL = "skill"
+
+
+class LineageRelation(StrEnum):
+    DERIVED_FROM = "derived_from"
+    GENERATED_FROM = "generated_from"
+    OBSERVED_IN = "observed_in"
+    SUPPORTED_BY = "supported_by"
+
+    DIAGNOSED_FROM = "diagnosed_from"
+    PROPOSED_FROM = "proposed_from"
+    PATCHED_FROM = "patched_from"
+    TESTED_BY = "tested_by"
+    EVALUATED_FROM = "evaluated_from"
+
+    PROMOTED_FROM = "promoted_from"
+    REJECTED_FROM = "rejected_from"
+
+    RECOVERED_BY = "recovered_by"
+    SUPERSEDES = "supersedes"

--- a/tests/storage/test_full_lineage.py
+++ b/tests/storage/test_full_lineage.py
@@ -1,0 +1,338 @@
+"""PR-DF-17 (phase-II §8-§14): typed full evolution lineage.
+
+Covers the named test set (§13) plus the golden lineage E2E (§14):
+Receipt → Episode → Memory → Insight → Proposal → Patch → Experiment
+→ Evaluation → Champion must be traceable from the champion down.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from rosclaw.auto.config import AutoConfig
+from rosclaw.auto.engine.auto_engine import AutoEngine
+from rosclaw.core.event_bus import EventBus
+from rosclaw.core.event_topics import EventTopics
+from rosclaw.memory.insights import MemoryInsightService
+from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+from rosclaw.storage.cli import _render_lineage_tree
+from rosclaw.storage.lineage import LineageRepository
+
+
+def _store():
+    s = InMemoryStructuredStore()
+    s.connect()
+    return s
+
+
+def _engine(tmp_path, repo) -> AutoEngine:
+    return AutoEngine(
+        config=AutoConfig(local_store_path=str(tmp_path / "auto")),
+        lineage_repository=repo,
+    )
+
+
+def _edge(repo, from_type, from_id, relation):
+    edges = repo.parents(from_type, from_id)
+    match = [e for e in edges if e["relation"] == relation]
+    assert match, f"missing edge {from_type}:{from_id} --{relation}-->"
+    return match[0]
+
+
+# -- §13 repository behavior -------------------------------------------------
+
+
+def test_lineage_type_sensitive():
+    """Same id under two types must not cross-contaminate queries (§8.3)."""
+    repo = LineageRepository(_store())
+    repo.link("memory", "x1", "derived_from", "episode", "e1")
+    repo.link("patch", "x1", "patched_from", "proposal", "p1")
+
+    mem_parents = repo.parents("memory", "x1")
+    assert len(mem_parents) == 1
+    assert mem_parents[0]["to_type"] == "episode"
+    patch_parents = repo.parents("patch", "x1")
+    assert len(patch_parents) == 1
+    assert patch_parents[0]["to_type"] == "proposal"
+    # children() is type-sensitive too
+    assert repo.children("episode", "e1")[0]["from_type"] == "memory"
+    assert repo.children("memory", "x1") == []
+
+
+def test_lineage_idempotent():
+    """5-field key: identical edge dedups, type-different edge does not (§8.4)."""
+    store = _store()
+    repo = LineageRepository(store)
+    a = repo.link("memory", "m1", "derived_from", "episode", "e1")
+    b = repo.link("memory", "m1", "derived_from", "episode", "e1")
+    assert a == b
+    assert store.count("lineage_edges", {}) == 1
+    # same ids but a different from_type is a DIFFERENT edge
+    repo.link("memory_insight", "m1", "derived_from", "episode", "e1")
+    assert store.count("lineage_edges", {}) == 2
+
+
+def test_lineage_multi_parent():
+    """One insight derived from several memories keeps every parent (§10)."""
+    repo = LineageRepository(_store())
+    for mem in ("mem_a", "mem_b", "mem_c"):
+        repo.link("memory_insight", "ins_1", "derived_from", "memory", mem)
+    parents = repo.parents("memory_insight", "ins_1")
+    assert {e["to_id"] for e in parents} == {"mem_a", "mem_b", "mem_c"}
+    ancestors = repo.ancestors("memory_insight", "ins_1")
+    assert {e["to_id"] for e in ancestors} >= {"mem_a", "mem_b", "mem_c"}
+
+
+def test_lineage_cycle_safe():
+    repo = LineageRepository(_store())
+    repo.link("memory", "m1", "derived_from", "episode", "e1")
+    repo.link("episode", "e1", "derived_from", "memory", "m1")
+    graph = repo.trace_graph("memory", "m1")
+    assert len(graph["edges"]) == 2  # terminates, no infinite walk
+    assert len(repo.ancestors("memory", "m1")) == 2
+
+
+def test_trace_graph_branches():
+    """trace_graph walks every parent branch, not just the first (§11)."""
+    repo = LineageRepository(_store())
+    repo.link("champion", "c1", "promoted_from", "evaluation", "ev1")
+    repo.link("evaluation", "ev1", "evaluated_from", "experiment", "ex1")
+    repo.link("evaluation", "ev1", "supported_by", "darwin_benchmark", "db1")
+    repo.link("experiment", "ex1", "derived_from", "patch", "pt1")
+
+    graph = repo.trace_graph("champion", "c1")
+    node_ids = {n["id"] for n in graph["nodes"]}
+    assert node_ids == {"c1", "ev1", "ex1", "db1", "pt1"}
+    assert graph["truncated"] is False
+    rels = {(e["from"], e["relation"], e["to"]) for e in graph["edges"]}
+    assert ("evaluation:ev1", "supported_by", "darwin_benchmark:db1") in rels
+    # node cap truncates honestly
+    capped = repo.trace_graph("champion", "c1", max_nodes=3)
+    assert capped["truncated"] is True
+    assert len(capped["nodes"]) <= 3
+
+
+# -- §13 engine link tests ----------------------------------------------------
+
+
+def test_proposal_failure_link(tmp_path):
+    repo = LineageRepository(_store())
+    engine = _engine(tmp_path, repo)
+    fc = engine.create_failure_case("act_1", "task_1", "skill_1")
+    prop = engine.create_proposal(fc.id, "task_1", "skill_1", "h", {"x": [1, 2]})
+    edge = _edge(repo, "proposal", prop.id, "proposed_from")
+    assert edge["to_type"] == "failure" and edge["to_id"] == fc.id
+    # failure itself points at its praxis event (§9.1)
+    gen = _edge(repo, "failure", fc.id, "generated_from")
+    assert gen["to_type"] == "action" and gen["to_id"] == "act_1"
+
+
+def test_proposal_memory_insight_source_refs(tmp_path):
+    """§9.3: typed source_refs replace the bare source string."""
+    repo = LineageRepository(_store())
+    engine = _engine(tmp_path, repo)
+    prop = engine.create_proposal(
+        "",
+        "task_1",
+        "skill_1",
+        "h",
+        {"x": [1, 2]},
+        source="memory_guided",
+        source_refs=[{"type": "memory_insight", "id": "ins_9"}],
+    )
+    edge = _edge(repo, "proposal", prop.id, "proposed_from")
+    assert edge["to_type"] == "memory_insight" and edge["to_id"] == "ins_9"
+
+
+def test_patch_proposal_link(tmp_path):
+    repo = LineageRepository(_store())
+    engine = _engine(tmp_path, repo)
+    prop = engine.create_proposal("f1", "task_1", "skill_1", "h", {"x": [1]})
+    patch = engine.create_patch(prop.id, "skill_1", [{"k": "x", "v": 2}])
+    edge = _edge(repo, "patch", patch.id, "patched_from")
+    assert edge["to_type"] == "proposal" and edge["to_id"] == prop.id
+
+
+def test_experiment_patch_link(tmp_path):
+    repo = LineageRepository(_store())
+    engine = _engine(tmp_path, repo)
+    patch = engine.create_patch("p1", "skill_1", [{"k": "x", "v": 2}])
+    exp = engine.create_experiment("p1", patch.id, "task_1", "skill_0", "skill_1")
+    edge = _edge(repo, "experiment", exp.id, "derived_from")
+    assert edge["to_type"] == "patch" and edge["to_id"] == patch.id
+
+
+def _persisted_experiment(engine, tmp_path):
+    """An experiment whose task + experiment provenance resolves."""
+    task = engine.create_task("task_1", "rh56", "skill_1")
+    patch = engine.create_patch("p1", "skill_1", [{"k": "x", "v": 2}])
+    return engine.create_experiment("p1", patch.id, task.id, "skill_0", "skill_1")
+
+
+def test_evaluation_experiment_link(tmp_path):
+    repo = LineageRepository(_store())
+    engine = _engine(tmp_path, repo)
+    exp = _persisted_experiment(engine, tmp_path)
+    ev = engine.create_evaluation(
+        exp.id,
+        {"success_rate": 0.5},
+        {"success_rate": 0.7},
+        simulation_receipts=[{"id": "rcpt_sim_1"}],
+    )
+    edge = _edge(repo, "evaluation", ev.id, "evaluated_from")
+    assert edge["to_type"] == "experiment" and edge["to_id"] == exp.id
+    sup = _edge(repo, "evaluation", ev.id, "supported_by")
+    assert sup["to_type"] == "receipt" and sup["to_id"] == "rcpt_sim_1"
+
+
+def test_champion_evaluation_link(tmp_path):
+    repo = LineageRepository(_store())
+    engine = _engine(tmp_path, repo)
+    champ = engine.promote_champion(
+        "skill_1",
+        "task_1",
+        "baseline",
+        {"success_rate": 0.5},
+        evaluation_id="eval_1",
+    )
+    edge = _edge(repo, "champion", champ.id, "promoted_from")
+    assert edge["to_type"] == "evaluation" and edge["to_id"] == "eval_1"
+
+
+def test_deadend_source_link(tmp_path):
+    repo = LineageRepository(_store())
+    engine = _engine(tmp_path, repo)
+    de = engine.register_deadend(
+        "task_1",
+        "raise force",
+        "collision risk",
+        source_type="evaluation",
+        source_id="eval_7",
+    )
+    edge = _edge(repo, "dead_end", de.id, "rejected_from")
+    assert edge["to_type"] == "evaluation" and edge["to_id"] == "eval_7"
+
+
+def test_engine_without_lineage_repo_is_noop(tmp_path):
+    """Standalone AutoEngine (no data plane) must work unchanged."""
+    engine = _engine(tmp_path, None)
+    fc = engine.create_failure_case("act_1", "task_1", "skill_1")
+    prop = engine.create_proposal(fc.id, "task_1", "skill_1", "h", {})
+    assert prop.id
+
+
+# -- §10 insight → memory links ------------------------------------------------
+
+
+def test_memory_insight_links_all_source_memories():
+    store = _store()
+    repo = LineageRepository(store)
+    bus = EventBus()
+    svc = MemoryInsightService(bus, store, robot_id="rh56", lineage_repository=repo, cooldown_s=0.0)
+    published: list[dict] = []
+    bus.subscribe(EventTopics.MEMORY_INSIGHT_CREATED, lambda e: published.append(e.payload))
+    svc._maybe_emit(
+        "similar_failure_with_patch",
+        skill_id="skill_1",
+        failure_type="force overshoot",
+        task_id="task_1",
+        episode_id="ep_1",
+        evidence_refs=["critic_result:ep_1"],
+        extra={"memory_refs": ["mem_a", "mem_b"], "search_space": {}},
+    )
+    assert published, "insight was not published"
+    ins_id = published[0]["insight_id"]
+    parents = repo.parents("memory_insight", ins_id)
+    assert {e["to_id"] for e in parents} == {"mem_a", "mem_b"}
+    assert all(e["relation"] == "derived_from" for e in parents)
+
+
+# -- §12 CLI rendering ----------------------------------------------------------
+
+
+def test_cli_tree_rendering_branches():
+    repo = LineageRepository(_store())
+    repo.link("champion", "champ_8f31", "promoted_from", "evaluation", "eval_2d17")
+    repo.link("evaluation", "eval_2d17", "evaluated_from", "experiment", "exp_91c2")
+    repo.link("evaluation", "eval_2d17", "supported_by", "darwin_benchmark", "darwin_1")
+    graph = repo.trace_graph("champion", "champ_8f31")
+    lines = _render_lineage_tree(graph)
+    assert lines[0] == "Champion champ_8f31"
+    text = "\n".join(lines)
+    assert "promoted_from Evaluation eval_2d17" in text
+    assert "evaluated_from Experiment exp_91c2" in text
+    assert "supported_by Darwin_Benchmark darwin_1" in text or "darwin_1" in text
+
+
+def test_cmd_data_lineage_rejects_bad_entity():
+    from rosclaw.storage.cli import cmd_data_lineage
+
+    args = argparse.Namespace(entity="no-colon", json=False)
+    assert cmd_data_lineage(args) == 2
+
+
+# -- §14 golden lineage E2E ------------------------------------------------------
+
+
+def test_golden_lineage_champion_to_receipt(tmp_path):
+    """六问之六: champion traces all the way back to the receipt (§14)."""
+    store = _store()
+    repo = LineageRepository(store)
+    bus = EventBus()
+
+    # Receipt → Episode → Memory (practice/memory half, from DF-14/16B)
+    repo.link("receipt", "rcpt_1", "generated_from", "action", "act_1")
+    repo.link("episode", "ep_1", "supported_by", "receipt", "rcpt_1")
+    repo.link("memory", "mem_1", "derived_from", "episode", "ep_1")
+
+    # Memory → Insight (DF-17 §10)
+    svc = MemoryInsightService(bus, store, robot_id="rh56", lineage_repository=repo, cooldown_s=0.0)
+    published: list[dict] = []
+    bus.subscribe(EventTopics.MEMORY_INSIGHT_CREATED, lambda e: published.append(e.payload))
+    svc._maybe_emit(
+        "similar_failure_with_patch",
+        skill_id="skill_1",
+        failure_type="force overshoot",
+        task_id="task_1",
+        episode_id="ep_1",
+        evidence_refs=["critic_result:ep_1"],
+        extra={"memory_refs": ["mem_1"], "search_space": {"force": [200, 300]}},
+    )
+    ins_id = published[0]["insight_id"]
+
+    # Insight → Proposal → Patch → Experiment → Evaluation → Champion
+    engine = _engine(tmp_path, repo)
+    task = engine.create_task("task_1", "rh56", "skill_1")
+    prop = engine.create_proposal(
+        "",
+        task.id,
+        "skill_1",
+        "lower force avoids overshoot",
+        {"force": [200, 300]},
+        source="memory_guided",
+        source_refs=[{"type": "memory_insight", "id": ins_id}],
+    )
+    patch = engine.create_patch(prop.id, "skill_1", [{"k": "force", "v": 250}])
+    exp = engine.create_experiment(prop.id, patch.id, task.id, "skill_0", "skill_1")
+    ev = engine.create_evaluation(
+        exp.id,
+        {"success_rate": 0.5, "collision_rate": 0.1},
+        {"success_rate": 0.7, "collision_rate": 0.1},
+        simulation_receipts=[{"id": "rcpt_1"}],
+    )
+    champ = engine.promote_champion(
+        "skill_1",
+        task.id,
+        "baseline",
+        {"success_rate": 0.7},
+        evaluation_id=ev.id,
+    )
+
+    graph = repo.trace_graph("champion", champ.id)
+    node_ids = {n["id"] for n in graph["nodes"]}
+    assert "rcpt_1" in node_ids  # receipt reachable
+    assert "mem_1" in node_ids  # memory reachable
+    assert prop.id in node_ids  # proposal reachable
+    assert ev.id in node_ids  # evaluation reachable
+    assert ins_id in node_ids  # insight reachable
+    assert "ep_1" in node_ids  # episode reachable


### PR DESCRIPTION
## Summary

Phase-II P0 per `seekdb优化v2.md` §8–§14. Closes gap **P0-2**: `lineage_edges` had a table and a repository, but not a full typed graph. After this PR, "why is this champion v1.7?" is answerable from the champion down to the receipt (六问之六).

- **§8 typed vocabulary** — new `storage/lineage_types.py`: `LineageEntityType` / `LineageRelation` StrEnums; canonical orientation **child/derived → parent/source**.
- **§8.3/§8.4/§11 repository** — `parents()`/`children()` are now type-sensitive; idempotency key extended to `(from_type, from_id, relation, to_type, to_id)`; walks keyed on `(type, id)`; new `trace_graph()` returns the full ancestry DAG (`max_depth=16`, `max_nodes=500`, honest `truncated` flag).
- **§9 AutoEngine auto-linking** — injected `lineage_repository` (default `None` = standalone unchanged); every `create_*` records edges: failure→action(+insight), diagnosis→failure, proposal→typed `source_refs` (new kwarg), patch→proposal, experiment→patch, evaluation→experiment + `supported_by` receipts, champion→evaluation, deadend→typed source (new `source_type`/`source_id`). All best-effort — lineage never breaks evolution.
- **§10 insights** — `MemoryInsightService` links each insight to **all** contributing memories (`memory_refs` stays the JSON attribute; `lineage_edges` is the traversable relation).
- **§12 CLI** — `rosclaw data lineage <type>:<id>` with indented tree output and `--json` for the Dashboard.
- **Runtime** — the DF-14 data-plane `LineageRepository` is injected into `AutoPlugin` and `MemoryInsightService` (ordering safe: `_create_data_plane` runs first).

## Tests

- `tests/storage/test_full_lineage.py`: the full §13 named set (`type_sensitive`, `idempotent`, `multi_parent`, `cycle_safe`, `trace_graph_branches`, `proposal_failure_link`, `patch_proposal_link`, `experiment_patch_link`, `evaluation_experiment_link`, `champion_evaluation_link`, `deadend_source_link`) + source_refs, no-repo no-op, insight multi-memory links, CLI rendering/rejection.
- **§14 golden E2E**: Receipt→Episode→Memory→Insight→Proposal→Patch→Experiment→Evaluation→Champion; `trace_graph("champion", id)` contains receipt/memory/proposal/evaluation/insight/episode ids.
- Local: 339 passed (storage + unit/auto + insights), `ruff check src tests` clean, mypy clean on touched modules.

Implementation note: `docs/reports/data-flywheel-phase2/DF-17-full-evolution-lineage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)