### PR TITLE
DF-18: Runtime Config v2 native consumption

### DIFF
--- a/docs/reports/data-flywheel-phase2/DF-18-config-v2-native.md
+++ b/docs/reports/data-flywheel-phase2/DF-18-config-v2-native.md
@@ -1,0 +1,76 @@
+# DF-18 — Runtime Config v2 native consumption (implementation note)
+
+Phase-II P0 per `seekdb优化v2.md` §15–§16. Closes gap P0-3: Config v2
+existed as file format (DF-02) but the Runtime still read legacy flat
+fields and dict-shaped sections.
+
+## What landed
+
+### §15.1 typed models — `src/rosclaw/config/models.py` (new)
+
+`StructuredStoreConfig` (backend/path/dsn/pool_size),
+`RetrievalStoreConfig` (enabled/backend/mode/path/host/port/database),
+`OutboxConfig` (enabled/path/batch_size/flush_interval_sec/max_records),
+`ArtifactStoreConfig`, `StorageConfig` (the four above),
+`KnowledgeConfig` (enabled/mode/store_mode/store_path/url/api_key/
+timeout/curated_registry_enabled), `EvolutionConfig`
+(enabled/require_human_approval/allow_code_patch/
+trigger_failure_threshold), `DarwinConfig` (enabled/seeds/episodes).
+All with `from_dict`.
+
+§16 honored: the structured default path stays
+`~/.rosclaw/data/memory/knowledge.sqlite` — no data move in this PR.
+
+### §15.4 legacy compat — `src/rosclaw/config/compat.py` (new)
+
+The only place pre-DF-18 shapes are interpreted.  RuntimeConfig's
+`__post_init__` calls the four `normalize_*_config()` functions exactly
+once.  Precedence: an explicitly passed typed model (or an explicit dict
+key) always wins; flat legacy fields (`seekdb_backend/path/url`,
+`know_store_mode/path`, `enable_auto`, `enable_darwin`,
+`enable_knowledge`, dict `storage` flat keys) only fill slots the caller
+never set.  DEPRECATED CONFIG is logged once per legacy key actually
+applied.
+
+### RuntimeConfig (core/runtime.py)
+
+- New typed fields: `storage` (StorageConfig | dict | None),
+  `knowledge`, `evolution`, and `darwin` (DarwinConfig | dict | None).
+- `__post_init__` normalizes all four, then **mirrors the typed values
+  back onto the legacy flat fields** so pre-DF-18 readers (tests,
+  episode recorder, external constructors) keep observing consistent
+  values — same philosophy as DF-02's `_mirror_legacy_sections`.
+
+### §15.5 Runtime reads typed only
+
+All internal reads switched: `storage.structured.backend/path/dsn/
+pool_size`, `storage.retrieval.enabled/path`, `storage.outbox.*`,
+`knowledge.enabled/mode/store_mode/store_path/url/api_key/timeout/
+curated_registry_enabled`, `evolution.enabled/trigger_failure_threshold`,
+`darwin.enabled/seeds/episodes`.  A source-discipline test greps
+runtime.py for the forbidden legacy reads.
+
+### §15.6 bare `seekdb` eliminated
+
+The three `seekdb = getattr(self._memory, ...)` compat locals are gone;
+modules receive `data_plane.structured_store` explicitly (Memory-held
+client as the no-data-plane fallback — same object when a data plane
+exists).  `grep -n "seekdb =" runtime.py` → 0 results (pinned by test).
+
+### loader — `src/rosclaw/config/loader.py`
+
+`load_typed_configs(home)` → (storage, knowledge, evolution, darwin)
+from rosclaw.yaml for CLI/entrypoint callers, reusing FirstbootConfig's
+file-format normalization.
+
+## Tests — `tests/config/test_typed_config.py` (12 tests)
+
+Model defaults/from_dict; legacy flat fold; dict-section fold; enable
+flags; darwin dict; typed-wins precedence; mirror-back; plain-construction
+defaults unchanged; runtime source discipline (§15.5/§15.6 greps);
+loader on legacy yaml + missing file.
+
+Full affected suites (core/firstboot/darwin/knowledge/auto/memory-v2/
+storage/e2e): 594 passed, 1 pre-existing host-env failure
+(`test_service_discovery` — local rosclaw-know predates `rosclaw_know.store`;
+fails identically on main; CI installs the newer package).

--- a/src/rosclaw/config/__init__.py
+++ b/src/rosclaw/config/__init__.py
@@ -1,0 +1,41 @@
+"""Typed runtime configuration (PR-DF-18 / phase-II §15).
+
+Canonical in-process config models.  Pre-DF-18 shapes (flat
+``seekdb_*`` fields, dict ``storage``/``darwin`` sections) are accepted
+only at the RuntimeConfig constructor boundary and folded into these
+models once by ``rosclaw.config.compat``.
+"""
+
+from rosclaw.config.compat import (
+    normalize_darwin_config,
+    normalize_evolution_config,
+    normalize_knowledge_config,
+    normalize_storage_config,
+)
+from rosclaw.config.loader import load_typed_configs
+from rosclaw.config.models import (
+    ArtifactStoreConfig,
+    DarwinConfig,
+    EvolutionConfig,
+    KnowledgeConfig,
+    OutboxConfig,
+    RetrievalStoreConfig,
+    StorageConfig,
+    StructuredStoreConfig,
+)
+
+__all__ = [
+    "ArtifactStoreConfig",
+    "DarwinConfig",
+    "EvolutionConfig",
+    "KnowledgeConfig",
+    "OutboxConfig",
+    "RetrievalStoreConfig",
+    "StorageConfig",
+    "StructuredStoreConfig",
+    "load_typed_configs",
+    "normalize_darwin_config",
+    "normalize_evolution_config",
+    "normalize_knowledge_config",
+    "normalize_storage_config",
+]

--- a/src/rosclaw/config/compat.py
+++ b/src/rosclaw/config/compat.py
@@ -1,0 +1,130 @@
+"""Legacy → typed config normalization (PR-DF-18 / phase-II §15.4).
+
+The ONLY place pre-DF-18 shapes are interpreted: flat RuntimeConfig
+fields (``seekdb_backend``/``seekdb_path``/``seekdb_url``,
+``know_store_mode``/``know_store_path``, ``enable_auto``,
+``enable_darwin``, ``enable_knowledge``) and the dict-shaped
+``storage``/``darwin`` sections.  RuntimeConfig.__post_init__ calls these
+exactly once; the rest of the runtime reads typed models only.
+
+Precedence: an explicitly-passed typed model (or a dict key) always wins;
+legacy flat fields only fill slots the caller never set.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .models import (
+    DarwinConfig,
+    EvolutionConfig,
+    KnowledgeConfig,
+    StorageConfig,
+)
+
+logger = logging.getLogger("rosclaw.config.compat")
+
+_LOGGED: set[str] = set()
+
+
+def _deprecated_once(legacy: str, canonical: str) -> None:
+    key = f"{legacy}->{canonical}"
+    if key in _LOGGED:
+        return
+    _LOGGED.add(key)
+    logger.warning(
+        "DEPRECATED CONFIG: %s -> %s (accepted once; migrate to the typed field)",
+        legacy,
+        canonical,
+    )
+
+
+def normalize_storage_config(value: Any, *, legacy: Any) -> StorageConfig:
+    """Fold ``storage`` (dict | StorageConfig | None) + flat seekdb_* fields."""
+    if isinstance(value, StorageConfig):
+        return value
+    data = value if isinstance(value, dict) else {}
+    cfg = StorageConfig.from_dict(data)
+
+    # Flat dict keys from the pre-v2 storage section.
+    if "pool_size" in data:
+        cfg.structured.pool_size = int(data["pool_size"])
+    if "vector_enabled" in data:
+        cfg.retrieval.enabled = bool(data["vector_enabled"])
+        _deprecated_once("storage.vector_enabled", "storage.retrieval.enabled")
+    if "outbox_enabled" in data:
+        cfg.outbox.enabled = bool(data["outbox_enabled"])
+        _deprecated_once("storage.outbox_enabled", "storage.outbox.enabled")
+    if "outbox_path" in data:
+        cfg.outbox.path = data["outbox_path"]
+    if "outbox_max_records" in data:
+        cfg.outbox.max_records = int(data["outbox_max_records"])
+    if "outbox_flush_interval_sec" in data:
+        cfg.outbox.flush_interval_sec = float(data["outbox_flush_interval_sec"])
+
+    # Flat RuntimeConfig seekdb_* fields only fill unset slots.
+    structured = data.get("structured", {}) if isinstance(data.get("structured"), dict) else {}
+    if "backend" not in structured:
+        backend = getattr(legacy, "seekdb_backend", None)
+        if backend:
+            cfg.structured.backend = backend
+    if "path" not in structured:
+        path = getattr(legacy, "seekdb_path", None)
+        if path:
+            cfg.structured.path = path
+    if "dsn" not in structured:
+        dsn = getattr(legacy, "seekdb_url", None)
+        if dsn:
+            cfg.structured.dsn = dsn
+    return cfg
+
+
+def normalize_knowledge_config(value: Any, *, legacy: Any) -> KnowledgeConfig:
+    if isinstance(value, KnowledgeConfig):
+        return value
+    data = value if isinstance(value, dict) else {}
+    cfg = KnowledgeConfig.from_dict(data)
+    if "enabled" not in data:
+        cfg.enabled = bool(getattr(legacy, "enable_knowledge", True))
+    if "mode" not in data:
+        cfg.mode = getattr(legacy, "knowledge_v2_mode", "disabled") or "disabled"
+    if "store_mode" not in data:
+        store_mode = getattr(legacy, "know_store_mode", None)
+        if store_mode:
+            cfg.store_mode = store_mode
+    if "store_path" not in data:
+        store_path = getattr(legacy, "know_store_path", None)
+        if store_path:
+            cfg.store_path = store_path
+    if "url" not in data:
+        cfg.url = getattr(legacy, "know_url", None)
+    if "api_key" not in data:
+        cfg.api_key = getattr(legacy, "know_api_key", None)
+    if "timeout" not in data:
+        cfg.timeout = float(getattr(legacy, "knowledge_timeout", 15.0))
+    if "curated_registry_enabled" not in data:
+        cfg.curated_registry_enabled = bool(
+            getattr(legacy, "know_curated_registry_enabled", False)
+        )
+    return cfg
+
+
+def normalize_evolution_config(value: Any, *, legacy: Any) -> EvolutionConfig:
+    if isinstance(value, EvolutionConfig):
+        return value
+    data = value if isinstance(value, dict) else {}
+    cfg = EvolutionConfig.from_dict(data)
+    if "enabled" not in data:
+        cfg.enabled = bool(getattr(legacy, "enable_auto", True))
+    return cfg
+
+
+def normalize_darwin_config(value: Any, *, legacy: Any) -> DarwinConfig:
+    if isinstance(value, DarwinConfig):
+        return value
+    data = value if isinstance(value, dict) else {}
+    cfg = DarwinConfig.from_dict(data)
+    if "enabled" not in data:
+        cfg.enabled = bool(getattr(legacy, "enable_darwin", False))
+    return cfg

--- a/src/rosclaw/config/loader.py
+++ b/src/rosclaw/config/loader.py
@@ -1,0 +1,49 @@
+"""Typed runtime config loader (PR-DF-18 / phase-II §15.1).
+
+Builds the canonical typed config models from a firstboot rosclaw.yaml
+(which ``FirstbootConfig`` has already normalized to the Config v2
+sections).  Intended for CLI/entrypoint code that wants typed configs
+without constructing a Runtime first.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    DarwinConfig,
+    EvolutionConfig,
+    KnowledgeConfig,
+    StorageConfig,
+)
+
+
+def load_typed_configs(
+    home: Path,
+) -> tuple[StorageConfig, KnowledgeConfig, EvolutionConfig, DarwinConfig]:
+    """Load (storage, knowledge, evolution, darwin) from rosclaw.yaml.
+
+    Missing/partial files yield defaults; the file-format legacy sections
+    are already folded by ``FirstbootConfig._normalize_legacy_config``.
+    """
+    from rosclaw.firstboot.config import FirstbootConfig, load_rosclaw_yaml
+
+    raw: dict[str, Any] = load_rosclaw_yaml(home)
+    fb = FirstbootConfig(
+        workspace=raw.get("workspace", {}),
+        runtime=raw.get("runtime", {}),
+        memory=raw.get("memory", {}),
+        knowledge=raw.get("knowledge", {}),
+        evolution=raw.get("evolution", {}),
+        darwin=raw.get("darwin", {}),
+        storage=raw.get("storage", {}),
+        know=raw.get("know", {}),
+        auto=raw.get("auto", {}),
+    )
+    return (
+        StorageConfig.from_dict(fb.storage),
+        KnowledgeConfig.from_dict(fb.knowledge),
+        EvolutionConfig.from_dict(fb.evolution),
+        DarwinConfig.from_dict(fb.darwin),
+    )

--- a/src/rosclaw/config/models.py
+++ b/src/rosclaw/config/models.py
@@ -1,0 +1,175 @@
+"""Typed Runtime configuration models (PR-DF-18 / phase-II §15.1-15.3).
+
+These are the canonical in-process config objects.  The flat legacy
+RuntimeConfig fields (seekdb_backend, know_store_mode, enable_auto, ...)
+and the dict-shaped ``storage``/``darwin`` sections exist only as
+constructor inputs; ``rosclaw.config.compat`` folds them into these
+models exactly once.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _default_structured_path() -> str:
+    # Deliberately the pre-v2 data location (phase-II §16: no path move
+    # in DF-18 — a move needs its own migration PR with a mover).
+    from rosclaw.firstboot.workspace import get_rosclaw_home
+
+    return str(get_rosclaw_home() / "data" / "memory" / "knowledge.sqlite")
+
+
+@dataclass
+class StructuredStoreConfig:
+    backend: str = "sqlite"
+    path: str | None = None
+    dsn: str | None = None
+    pool_size: int = 4
+
+    def __post_init__(self) -> None:
+        if self.path is None:
+            self.path = _default_structured_path()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StructuredStoreConfig:
+        return cls(
+            backend=data.get("backend", "sqlite"),
+            path=data.get("path"),
+            dsn=data.get("dsn"),
+            pool_size=int(data.get("pool_size", 4)),
+        )
+
+
+@dataclass
+class RetrievalStoreConfig:
+    enabled: bool = False
+    backend: str = "seekdb_native"
+    mode: str = "embedded"
+    path: str | None = None
+    host: str | None = None
+    port: int = 2881
+    database: str = "rosclaw"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RetrievalStoreConfig:
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            backend=data.get("backend", "seekdb_native"),
+            mode=data.get("mode", "embedded"),
+            path=data.get("path"),
+            host=data.get("host"),
+            port=int(data.get("port", 2881)),
+            database=data.get("database", "rosclaw"),
+        )
+
+
+@dataclass
+class OutboxConfig:
+    enabled: bool = False
+    path: str | None = None
+    batch_size: int = 100
+    flush_interval_sec: float = 5.0
+    max_records: int = 100_000
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OutboxConfig:
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            path=data.get("path"),
+            batch_size=int(data.get("batch_size", 100)),
+            flush_interval_sec=float(data.get("flush_interval_sec", 5.0)),
+            max_records=int(data.get("max_records", 100_000)),
+        )
+
+
+@dataclass
+class ArtifactStoreConfig:
+    backend: str = "filesystem"
+    root: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArtifactStoreConfig:
+        return cls(backend=data.get("backend", "filesystem"), root=data.get("root"))
+
+
+@dataclass
+class StorageConfig:
+    structured: StructuredStoreConfig = field(default_factory=StructuredStoreConfig)
+    retrieval: RetrievalStoreConfig = field(default_factory=RetrievalStoreConfig)
+    outbox: OutboxConfig = field(default_factory=OutboxConfig)
+    artifacts: ArtifactStoreConfig = field(default_factory=ArtifactStoreConfig)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StorageConfig:
+        return cls(
+            structured=StructuredStoreConfig.from_dict(data.get("structured", {})),
+            retrieval=RetrievalStoreConfig.from_dict(data.get("retrieval", {})),
+            outbox=OutboxConfig.from_dict(data.get("outbox", {})),
+            artifacts=ArtifactStoreConfig.from_dict(data.get("artifacts", {})),
+        )
+
+
+@dataclass
+class KnowledgeConfig:
+    enabled: bool = True
+    mode: str = "disabled"  # versioned Know/How integration mode
+    store_mode: str = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_KNOW_STORE_MODE", "embedded")
+    )
+    store_path: str | None = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_KNOW_SEEKDB_PATH")
+    )
+    url: str | None = field(default_factory=lambda: os.environ.get("ROSCLAW_KNOW_URL"))
+    api_key: str | None = field(
+        default_factory=lambda: os.environ.get("ROSCLAW_KNOW_API_KEY")
+    )
+    timeout: float = 15.0
+    curated_registry_enabled: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> KnowledgeConfig:
+        return cls(
+            enabled=bool(data.get("enabled", True)),
+            mode=data.get("mode", "disabled"),
+            store_mode=data.get("store_mode", "embedded"),
+            store_path=data.get("store_path"),
+            url=data.get("url"),
+            api_key=data.get("api_key"),
+            timeout=float(data.get("timeout", 15.0)),
+            curated_registry_enabled=bool(data.get("curated_registry_enabled", False)),
+        )
+
+
+@dataclass
+class EvolutionConfig:
+    enabled: bool = True
+    require_human_approval: bool = True
+    allow_code_patch: bool = False
+    trigger_failure_threshold: int = 3
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvolutionConfig:
+        return cls(
+            enabled=bool(data.get("enabled", True)),
+            require_human_approval=bool(data.get("require_human_approval", True)),
+            allow_code_patch=bool(data.get("allow_code_patch", False)),
+            trigger_failure_threshold=int(data.get("trigger_failure_threshold", 3)),
+        )
+
+
+@dataclass
+class DarwinConfig:
+    enabled: bool = False
+    seeds: list[int] = field(default_factory=lambda: [0, 1, 2])
+    episodes: int = 50
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DarwinConfig:
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            seeds=list(data.get("seeds", [0, 1, 2])),
+            episodes=int(data.get("episodes", 50)),
+        )

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -111,7 +111,7 @@ class RuntimeConfig:
     # PR-DF-13 (flywheel §39): Darwin evaluation pressure as a first-class
     # Runtime module.  Off by default — benchmarks are expensive.
     enable_darwin: bool = False
-    darwin: dict[str, Any] = field(default_factory=dict)  # seeds / episodes
+    darwin: Any = None  # rosclaw.config.DarwinConfig | dict | None (PR-DF-18)
     enable_provider: bool = True
     joint_dof: int = 6
     sampling_rate_hz: int = 1000
@@ -173,7 +173,14 @@ class RuntimeConfig:
     sandbox_artifact_root: str | None = None
     # Storage-layer tunables (Phase 1+).  Keys: pool_size, vector_enabled,
     # outbox_enabled, outbox_max_records, outbox_flush_interval_sec.
-    storage: dict[str, Any] = field(default_factory=dict)
+    # PR-DF-18 (phase-II §15): canonical form is the typed StorageConfig;
+    # a dict (or None) is folded once by __post_init__ via
+    # rosclaw.config.compat, together with the flat seekdb_* fields above.
+    storage: Any = None
+    # Typed canonical configs (PR-DF-18 §15.2).  ``None`` means "derive
+    # from the legacy flat fields"; an explicitly passed model always wins.
+    knowledge: Any = None  # rosclaw.config.KnowledgeConfig | dict | None
+    evolution: Any = None  # rosclaw.config.EvolutionConfig | dict | None
     # Persist all EventBus events to ~/.rosclaw/events/live.jsonl for dashboard tail
     enable_event_persistence: bool = True
     # Structured ROSClaw Trace. Model/tool I/O is redacted by default.
@@ -184,6 +191,37 @@ class RuntimeConfig:
     trace_queue_size: int = 4096
     trace_rotate_mb: float = 64.0
     trace_home: str | None = None
+
+    def __post_init__(self) -> None:
+        """Fold legacy shapes into the typed configs exactly once (PR-DF-18 §15.4).
+
+        After this runs, Runtime internals read ONLY the typed models
+        (``storage.structured.*``, ``knowledge.*``, ``evolution.*``,
+        ``darwin.*``).  The legacy flat fields are then mirrored FROM the
+        typed models so pre-DF-18 readers keep observing consistent values.
+        """
+        from rosclaw.config import (
+            normalize_darwin_config,
+            normalize_evolution_config,
+            normalize_knowledge_config,
+            normalize_storage_config,
+        )
+
+        self.storage = normalize_storage_config(self.storage, legacy=self)
+        self.knowledge = normalize_knowledge_config(self.knowledge, legacy=self)
+        self.evolution = normalize_evolution_config(self.evolution, legacy=self)
+        self.darwin = normalize_darwin_config(self.darwin, legacy=self)
+
+        # Mirror back onto the legacy flat fields (ADR-0010 compat).
+        self.seekdb_backend = self.storage.structured.backend
+        if self.storage.structured.path:
+            self.seekdb_path = self.storage.structured.path
+        self.seekdb_url = self.storage.structured.dsn
+        self.know_store_mode = self.knowledge.store_mode
+        self.know_store_path = self.knowledge.store_path
+        self.enable_knowledge = self.knowledge.enabled
+        self.enable_auto = self.evolution.enabled
+        self.enable_darwin = self.darwin.enabled
 
 
 class Runtime(LifecycleMixin):
@@ -268,10 +306,13 @@ class Runtime(LifecycleMixin):
             else get_rosclaw_home().expanduser().resolve()
         )
         default_home = get_rosclaw_home().expanduser().resolve()
-        if Path(self.config.seekdb_path).expanduser().resolve() == (
+        structured_cfg = self.config.storage.structured
+        if Path(structured_cfg.path).expanduser().resolve() == (
             default_home / "data" / "memory" / "knowledge.sqlite"
         ):
-            self.config.seekdb_path = str(workspace_home / "data" / "memory" / "knowledge.sqlite")
+            structured_cfg.path = str(workspace_home / "data" / "memory" / "knowledge.sqlite")
+            # keep the legacy mirror consistent for pre-DF-18 readers
+            self.config.seekdb_path = structured_cfg.path
         if Path(self.config.seekdb_fallback_dir).expanduser().resolve() == (
             default_home / "data" / "practice" / "fallback"
         ):
@@ -540,11 +581,12 @@ class Runtime(LifecycleMixin):
             except ImportError as e:
                 logger.info(f"SkillManager module not available: {e}")
 
-        v2_mode = self.config.knowledge_v2_mode.casefold().strip()
+        knowledge_cfg = self.config.knowledge
+        v2_mode = str(knowledge_cfg.mode).casefold().strip()
         if v2_mode not in {"disabled", "service", "inprocess"}:
             logger.warning("Invalid knowledge_v2_mode=%r; disabling v2", v2_mode)
             v2_mode = "disabled"
-        if v2_mode != "disabled" and (self.config.enable_knowledge or self.config.enable_how):
+        if v2_mode != "disabled" and (knowledge_cfg.enabled or self.config.enable_how):
             try:
                 from rosclaw.knowledge import KnowledgeFacade
                 from rosclaw.knowledge.service_manager import (
@@ -552,7 +594,7 @@ class Runtime(LifecycleMixin):
                     KnowledgeServiceManager,
                 )
 
-                know_path = self.config.know_store_path or str(
+                know_path = knowledge_cfg.store_path or str(
                     workspace_home / "data" / "know" / "seekdb"
                 )
                 # PR-DF-09 (flywheel §28): Knowledge keeps its own logical
@@ -561,8 +603,8 @@ class Runtime(LifecycleMixin):
                 # against the Runtime's data plane instead of env defaults.
                 federation: dict[str, Any] = {}
                 if self._data_plane is not None and self._data_plane.structured_store is not None:
-                    federation["memory_path"] = self.config.seekdb_path
-                    dsn = self.config.seekdb_url
+                    federation["memory_path"] = structured_cfg.path
+                    dsn = structured_cfg.dsn
                     if dsn:
                         from urllib.parse import urlparse
 
@@ -572,12 +614,12 @@ class Runtime(LifecycleMixin):
                 federation["practice_path"] = str(workspace_home / "data" / "practice")
                 service_config = KnowledgeServiceConfig(
                     mode=v2_mode,
-                    know_url=self.config.know_url,
+                    know_url=knowledge_cfg.url,
                     how_url=self.config.how_url,
-                    know_api_key=self.config.know_api_key or "",
+                    know_api_key=knowledge_cfg.api_key or "",
                     how_api_key=self.config.how_api_key or "",
-                    timeout=self.config.knowledge_timeout,
-                    know_store_mode=self.config.know_store_mode,
+                    timeout=knowledge_cfg.timeout,
+                    know_store_mode=knowledge_cfg.store_mode,
                     know_store_path=know_path,
                     **federation,
                 )
@@ -605,26 +647,32 @@ class Runtime(LifecycleMixin):
                 logger.warning("Knowledge v2 initialization degraded: %s", exc)
 
         # Rollback-only local KnowledgeInterface. v2 never receives Memory's store.
-        if self.config.enable_knowledge and v2_mode == "disabled":
+        if knowledge_cfg.enabled and v2_mode == "disabled":
             try:
                 from rosclaw.know.interface import KnowledgeInterface
                 from rosclaw.know.storage import seed_knowledge_graph
 
-                # Reuse Memory's SeekDB client if available
-                if self._memory is not None:
-                    seekdb = getattr(self._memory, "seekdb_client", None)
+                # Modules take the data plane's structured store explicitly
+                # (PR-DF-18 §15.6 — no bare `seekdb` compat locals); the
+                # Memory-held client is the same object when a data plane
+                # exists, and stays the fallback when it does not.
+                structured_store = data_plane.structured_store or (
+                    getattr(self._memory, "seekdb_client", None)
+                    if self._memory is not None
+                    else None
+                )
                 self._knowledge = KnowledgeInterface(
                     robot_id=self.config.robot_id,
                     event_bus=self.event_bus,
-                    seekdb_client=seekdb,
-                    use_rosclaw_know_registry=self.config.know_curated_registry_enabled,
+                    seekdb_client=structured_store,
+                    use_rosclaw_know_registry=knowledge_cfg.curated_registry_enabled,
                     memory_interface=self._memory,
                 )
                 self._modules.append(self._knowledge)
                 logger.info("Knowledge Grounding (KnowledgeInterface) initialized")
                 # Seed knowledge_graph with baseline data
-                if seekdb is not None:
-                    seed_knowledge_graph(seekdb)
+                if structured_store is not None:
+                    seed_knowledge_graph(structured_store)
 
                 # Spawn KnowledgeBatchEngine + AssetsLoader.  Both
                 # are inert when rosclaw-know is not installed; failures
@@ -662,10 +710,12 @@ class Runtime(LifecycleMixin):
         # Rollback-only local How path. How v2 is advisory through KnowledgeFacade.
         if self.config.enable_how and v2_mode == "disabled":
             try:
-                # Reuse Memory's SeekDB client if available
-                if self._memory is not None:
-                    seekdb = getattr(self._memory, "seekdb_client", None)
-                self._how = self._create_how_engine(seekdb)
+                structured_store = data_plane.structured_store or (
+                    getattr(self._memory, "seekdb_client", None)
+                    if self._memory is not None
+                    else None
+                )
+                self._how = self._create_how_engine(structured_store)
                 if self._how is not None:
                     self._modules.append(self._how)
             except Exception as e:  # noqa: BLE001
@@ -679,16 +729,11 @@ class Runtime(LifecycleMixin):
             try:
                 from rosclaw.memory.insights import MemoryInsightService
 
-                _auto_cfg = getattr(self.config, "auto", None)
                 self._memory_insights = MemoryInsightService(
                     self.event_bus,
                     data_plane.structured_store,
                     robot_id=self.config.robot_id,
-                    failure_threshold=(
-                        int(_auto_cfg.get("trigger_failure_threshold", 3))
-                        if isinstance(_auto_cfg, dict)
-                        else 3
-                    ),
+                    failure_threshold=self.config.evolution.trigger_failure_threshold,
                 )
                 self._memory_insights.subscribe()
             except Exception as exc:  # noqa: BLE001
@@ -716,27 +761,26 @@ class Runtime(LifecycleMixin):
                 logger.info("RecoveryLoop not available: %s", exc)
 
         # Initialize Auto Self-Evolution Control Plane
-        if self.config.enable_auto:
+        if self.config.evolution.enabled:
             try:
                 from rosclaw.auto.plugin import AutoPlugin
 
-                # Reuse Memory's SeekDB client if available
-                if self._memory is not None:
-                    seekdb = getattr(self._memory, "seekdb_client", None)
-                # PR-DF-12: with a data plane present, Evolution state goes
-                # to the structured store (LocalStore becomes its spool).
-                auto_storage = (
-                    "hybrid"
-                    if self._data_plane is not None and self._data_plane.structured_store is not None
-                    else "local"
+                # Evolution state goes to the data plane's structured store
+                # when one exists (LocalStore degrades to its spool, DF-12);
+                # the Memory-held client is the same object, or the fallback.
+                structured_store = data_plane.structured_store or (
+                    getattr(self._memory, "seekdb_client", None)
+                    if self._memory is not None
+                    else None
                 )
+                auto_storage = "hybrid" if structured_store is not None else "local"
                 self._auto = AutoPlugin(
                     config={
                         "local_store_path": str(workspace_home / "data" / "auto"),
                         "storage_backend": auto_storage,
                     },
                     event_bus=self.event_bus,
-                    seekdb_client=seekdb,
+                    seekdb_client=structured_store,
                     skill_registry=getattr(self._skill_manager, "registry", None)
                     if self._skill_manager
                     else None,
@@ -752,21 +796,15 @@ class Runtime(LifecycleMixin):
         # Evolution experiments land as darwin_benchmarks rows with full
         # provenance.  Off by default.
         self._darwin = None
-        if self.config.enable_darwin:
+        if self.config.darwin.enabled:
             try:
                 from rosclaw.darwin.plugin import DarwinPlugin
 
                 self._darwin = DarwinPlugin(
                     config={
-                        "default_seeds": self.config.darwin.get("seeds", [0, 1, 2])
-                        if isinstance(getattr(self.config, "darwin", None), dict)
-                        else [0, 1, 2],
-                        "default_episodes": self.config.darwin.get("episodes", 50)
-                        if isinstance(getattr(self.config, "darwin", None), dict)
-                        else 50,
-                    }
-                    if isinstance(getattr(self.config, "darwin", None), dict)
-                    else {},
+                        "default_seeds": self.config.darwin.seeds,
+                        "default_episodes": self.config.darwin.episodes,
+                    },
                     event_bus=self.event_bus,
                     seekdb_client=data_plane.structured_store,
                 )
@@ -868,21 +906,17 @@ class Runtime(LifecycleMixin):
             # best-effort: a missing pyseekdb or a dead native store leaves
             # the fields None and changes nothing else.
             try:
-                storage_cfg = self.config.storage or {}
-                retrieval_cfg = storage_cfg.get("retrieval", {})
-                retrieval_enabled = retrieval_cfg.get(
-                    "enabled", storage_cfg.get("vector_enabled", False)
-                )
+                retrieval_cfg = self.config.storage.retrieval
                 from rosclaw.memory.seekdb_client import SQLiteStructuredStore as _SQLite
 
-                if retrieval_enabled and isinstance(store, _SQLite):
+                if retrieval_cfg.enabled and isinstance(store, _SQLite):
                     from rosclaw.storage.seekdb_native import SeekDBEmbeddedRetrievalStore
                     from rosclaw.storage.seekdb_projection import (
                         MemoryRetrievalProjection,
                         MemoryRetrievalProjectionCommitter,
                     )
 
-                    native_path = retrieval_cfg.get("path") or str(
+                    native_path = retrieval_cfg.path or str(
                         workspace_home / "data" / "seekdb"
                     )
                     ctx.retrieval_store = SeekDBEmbeddedRetrievalStore(path=native_path)
@@ -899,12 +933,7 @@ class Runtime(LifecycleMixin):
                             MemoryRetrievalProjectionCommitter(ctx.retrieval_store),
                             target="seekdb_projection",
                             name="memory-projection-worker",
-                            interval_sec=float(
-                                storage_cfg.get("outbox", {}).get(
-                                    "flush_interval_sec",
-                                    storage_cfg.get("outbox_flush_interval_sec", 5.0),
-                                )
-                            ),
+                            interval_sec=float(self.config.storage.outbox.flush_interval_sec),
                         )
                         self._projection_worker.start()
                     ctx.memory_projection = MemoryRetrievalProjection(
@@ -937,15 +966,14 @@ class Runtime(LifecycleMixin):
                 from rosclaw.practice.seekdb_bridge import SeekDBBridge
                 from rosclaw.storage.outbox import OutboxStore
 
-                outbox_enabled = self.config.storage.get("outbox_enabled", False)
-                if outbox_enabled:
-                    outbox_path = self.config.storage.get(
-                        "outbox_path",
-                        str(workspace_home / "storage" / "outbox.sqlite"),
+                outbox_cfg = self.config.storage.outbox
+                if outbox_cfg.enabled:
+                    outbox_path = outbox_cfg.path or str(
+                        workspace_home / "storage" / "outbox.sqlite"
                     )
                     ctx.outbox = OutboxStore(
                         db_path=outbox_path,
-                        max_records=self.config.storage.get("outbox_max_records", 100_000),
+                        max_records=outbox_cfg.max_records,
                     )
                     ctx.outbox.connect()
                     ctx.practice_sink = SeekDBBridge(
@@ -980,12 +1008,13 @@ class Runtime(LifecycleMixin):
         """
         from rosclaw.storage.factory import StoreFactory
 
+        structured = self.config.storage.structured
         client = StoreFactory.create_structured_store(
-            backend=self.config.seekdb_backend,
-            url=self.config.seekdb_url,
-            path=self.config.seekdb_path,
-            pool_size=self.config.storage.get("pool_size", 4),
-            vector_enabled=self.config.storage.get("vector_enabled", False),
+            backend=structured.backend,
+            url=structured.dsn,
+            path=structured.path,
+            pool_size=structured.pool_size,
+            vector_enabled=self.config.storage.retrieval.enabled,
         )
         capabilities = StoreFactory.capabilities(client)
         logger.info(

--- a/tests/config/test_typed_config.py
+++ b/tests/config/test_typed_config.py
@@ -1,0 +1,179 @@
+"""PR-DF-18 (phase-II §15): typed Config v2 as the Runtime's native config.
+
+Proves the legacy fold happens exactly once at the constructor boundary,
+typed models win over legacy fields, the legacy mirror stays consistent
+for pre-DF-18 readers, and runtime.py carries no legacy reads / bare
+``seekdb`` locals (§15.5/§15.6).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from rosclaw.config import (
+    DarwinConfig,
+    EvolutionConfig,
+    KnowledgeConfig,
+    StorageConfig,
+    load_typed_configs,
+)
+from rosclaw.core.runtime import RuntimeConfig
+
+RUNTIME_PY = Path(__file__).resolve().parents[2] / "src" / "rosclaw" / "core" / "runtime.py"
+
+
+# -- models ------------------------------------------------------------
+
+
+def test_storage_model_defaults_keep_pre_v2_path():
+    cfg = StorageConfig()
+    assert cfg.structured.backend == "sqlite"
+    assert cfg.structured.path.endswith("data/memory/knowledge.sqlite")  # §16: no path move
+    assert cfg.retrieval.enabled is False
+    assert cfg.outbox.batch_size == 100
+    assert cfg.artifacts.backend == "filesystem"
+
+
+def test_models_from_dict():
+    storage = StorageConfig.from_dict(
+        {
+            "structured": {"backend": "mysql", "dsn": "mysql://root@h:2881/db"},
+            "retrieval": {"enabled": True, "port": 2882},
+            "outbox": {"enabled": True, "batch_size": 50},
+        }
+    )
+    assert storage.structured.backend == "mysql"
+    assert storage.structured.dsn == "mysql://root@h:2881/db"
+    assert storage.retrieval.enabled is True and storage.retrieval.port == 2882
+    assert storage.outbox.enabled is True and storage.outbox.batch_size == 50
+    assert KnowledgeConfig.from_dict({"enabled": False, "mode": "service"}).mode == "service"
+    assert EvolutionConfig.from_dict({"trigger_failure_threshold": 5}).trigger_failure_threshold == 5
+    assert DarwinConfig.from_dict({"enabled": True, "seeds": [9], "episodes": 3}).seeds == [9]
+
+
+# -- §15.4 legacy fold (once, at the boundary) -------------------------
+
+
+def test_legacy_flat_seekdb_fields_fold_into_typed():
+    cfg = RuntimeConfig(
+        seekdb_backend="mysql",
+        seekdb_url="mysql://root@127.0.0.1:2881/rosclaw",
+        seekdb_path="/tmp/k.sqlite",
+    )
+    assert cfg.storage.structured.backend == "mysql"
+    assert cfg.storage.structured.dsn == "mysql://root@127.0.0.1:2881/rosclaw"
+    assert cfg.storage.structured.path == "/tmp/k.sqlite"
+
+
+def test_legacy_dict_storage_folds():
+    cfg = RuntimeConfig(
+        storage={
+            "pool_size": 8,
+            "vector_enabled": True,
+            "outbox_enabled": True,
+            "outbox_max_records": 5000,
+            "outbox_flush_interval_sec": 1.5,
+        }
+    )
+    assert cfg.storage.structured.pool_size == 8
+    assert cfg.storage.retrieval.enabled is True
+    assert cfg.storage.outbox.enabled is True
+    assert cfg.storage.outbox.max_records == 5000
+    assert cfg.storage.outbox.flush_interval_sec == 1.5
+
+
+def test_legacy_enable_flags_fold():
+    cfg = RuntimeConfig(enable_auto=False, enable_darwin=True, enable_knowledge=False)
+    assert cfg.evolution.enabled is False
+    assert cfg.darwin.enabled is True
+    assert cfg.knowledge.enabled is False
+
+
+def test_legacy_darwin_dict_folds():
+    cfg = RuntimeConfig(darwin={"seeds": [7, 8], "episodes": 9})
+    assert cfg.darwin.seeds == [7, 8] and cfg.darwin.episodes == 9
+
+
+def test_typed_config_wins_over_legacy():
+    typed = StorageConfig.from_dict({"structured": {"backend": "memory"}})
+    cfg = RuntimeConfig(storage=typed, seekdb_backend="mysql")
+    assert cfg.storage.structured.backend == "memory"
+
+
+# -- mirror-back (pre-DF-18 readers stay consistent) --------------------
+
+
+def test_legacy_fields_mirror_typed():
+    cfg = RuntimeConfig(
+        storage=StorageConfig.from_dict({"structured": {"backend": "mysql"}}),
+        darwin=DarwinConfig(enabled=True),
+        evolution=EvolutionConfig(enabled=False),
+    )
+    assert cfg.seekdb_backend == "mysql"
+    assert cfg.enable_darwin is True
+    assert cfg.enable_auto is False
+
+
+def test_defaults_unchanged_for_plain_construction():
+    cfg = RuntimeConfig()
+    assert cfg.storage.structured.backend == "sqlite"
+    assert cfg.evolution.enabled is True
+    assert cfg.darwin.enabled is False
+    assert cfg.knowledge.enabled is True
+    assert cfg.knowledge.mode == "disabled"
+
+
+# -- §15.5/§15.6 runtime source discipline -------------------------------
+
+
+def test_runtime_has_no_legacy_config_reads_or_bare_seekdb():
+    src = RUNTIME_PY.read_text(encoding="utf-8")
+    assert not re.search(r"^\s*seekdb\s*=", src, re.MULTILINE), "bare `seekdb =` local (§15.6)"
+    body = src.split("def __post_init__", 1)[-1]  # field defaults keep legacy names as INPUTS
+    for forbidden in (
+        "self.config.seekdb_backend",
+        "self.config.seekdb_url",
+        "self.config.enable_auto",
+        "self.config.enable_darwin",
+        "self.config.know_store_mode",
+        "self.config.storage.get(",
+        "self.config.darwin.get(",
+    ):
+        assert forbidden not in body, f"legacy read {forbidden} survived (§15.5)"
+
+
+# -- loader ---------------------------------------------------------------
+
+
+def test_load_typed_configs_from_legacy_yaml(tmp_path):
+    home = tmp_path / "home"
+    (home / "config").mkdir(parents=True)
+    (home / "config" / "rosclaw.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "1.0",
+                "workspace": {"home": str(home)},
+                "runtime": {"seekdb_backend": "mysql", "seekdb_url": "mysql://root@h:2881/db"},
+                "storage": {"vector_enabled": True},
+                "auto": {"enabled": True, "trigger_failure_threshold": 5},
+            }
+        ),
+        encoding="utf-8",
+    )
+    storage, knowledge, evolution, darwin = load_typed_configs(home)
+    assert storage.structured.backend == "mysql"
+    assert storage.structured.dsn == "mysql://root@h:2881/db"
+    assert storage.retrieval.enabled is True
+    assert evolution.trigger_failure_threshold == 5
+    assert knowledge.enabled is True
+    assert darwin.episodes == 50
+
+
+def test_load_typed_configs_missing_file_is_defaults(tmp_path):
+    storage, knowledge, evolution, darwin = load_typed_configs(tmp_path / "nope")
+    assert storage.structured.backend == "sqlite"
+    assert evolution.trigger_failure_threshold == 3
+    assert darwin.enabled is False

--- a/tests/test_runtime_coverage.py
+++ b/tests/test_runtime_coverage.py
@@ -2238,6 +2238,8 @@ class TestHowInitialization:
     def test_how_skipped_when_no_seekdb(self, fresh_runtime, caplog):
         import logging
 
+        from rosclaw.storage.context import DataPlaneContext
+
         rt = fresh_runtime
         cfg = RuntimeConfig(
             enable_firewall=False,
@@ -2250,8 +2252,15 @@ class TestHowInitialization:
             enable_provider=False,
         )
         rt = Runtime(config=cfg)
-        # Memory will initialize but we'll mock it to have no seekdb_client
-        with patch("rosclaw.memory.interface.MemoryInterface") as mock_mem_cls:
+        # Memory initializes but has no client, and the data plane has no
+        # structured store at all (PR-DF-18: modules resolve the store from
+        # the data plane first) -> no store anywhere, How must skip.
+        with (
+            patch("rosclaw.memory.interface.MemoryInterface") as mock_mem_cls,
+            patch.object(
+                Runtime, "_create_data_plane", return_value=DataPlaneContext()
+            ),
+        ):
             mock_mem = MagicMock()
             mock_mem.seekdb_client = None
             mock_mem_cls.return_value = mock_mem
@@ -2294,6 +2303,8 @@ class TestKnowledgeInitialization:
             mock_seed.assert_called_once()
 
     def test_knowledge_no_seekdb(self, fresh_runtime):
+        from rosclaw.storage.context import DataPlaneContext
+
         rt = fresh_runtime
         cfg = RuntimeConfig(
             enable_firewall=False,
@@ -2306,10 +2317,15 @@ class TestKnowledgeInitialization:
             enable_provider=False,
         )
         rt = Runtime(config=cfg)
+        # No store anywhere: Memory degraded + data plane without a
+        # structured store (PR-DF-18 resolution order) -> seed must not run.
         with (
             patch("rosclaw.memory.interface.MemoryInterface") as mock_mem_cls,
             patch("rosclaw.know.interface.KnowledgeInterface") as mock_know_cls,
             patch("rosclaw.know.storage.seed_knowledge_graph") as mock_seed,
+            patch.object(
+                Runtime, "_create_data_plane", return_value=DataPlaneContext()
+            ),
         ):
             mock_mem = MagicMock()
             mock_mem.seekdb_client = None


### PR DESCRIPTION
## Summary

Phase-II P0 per `seekdb优化v2.md` §15–§16. Closes gap **P0-3**: Config v2 existed as a file format (DF-02) but Runtime still read legacy flat fields and dict-shaped sections. After this PR the typed config is the Runtime's only internal vocabulary.

- **`src/rosclaw/config/` package** — `models.py` (StorageConfig/KnowledgeConfig/EvolutionConfig/DarwinConfig with from_dict), `compat.py` (the ONLY place legacy shapes are folded — once, in `RuntimeConfig.__post_init__`; typed models always win over legacy fields), `loader.py` (`load_typed_configs(home)` from rosclaw.yaml).
- **§15.5** — runtime.py reads typed configs only (`storage.structured.*`, `storage.retrieval.*`, `storage.outbox.*`, `knowledge.*`, `evolution.*`, `darwin.*`); legacy flat fields are mirrored FROM the typed models so pre-DF-18 readers stay consistent (same philosophy as DF-02's `_mirror_legacy_sections`).
- **§15.6** — bare `seekdb =` locals eliminated; Knowledge/How/Auto receive `data_plane.structured_store` explicitly. `grep -n "seekdb =" runtime.py` → 0 (pinned by a source-discipline test).
- **§16** — no data-path move: structured default stays `~/.rosclaw/data/memory/knowledge.sqlite`.

## Compat

All legacy constructor kwargs keep working (`RuntimeConfig(seekdb_backend=..., storage={...}, darwin={...}, enable_auto=False)`): folded once, logged DEPRECATED once per applied key, mirrored back onto the legacy attributes.

## Tests

- `tests/config/test_typed_config.py` (12): model defaults/from_dict, legacy fold, dict fold, flags, precedence, mirror-back, defaults, §15.5/§15.6 source greps, loader on legacy yaml + missing file.
- Affected suites (core/firstboot/darwin/knowledge/auto/memory-v2/storage/e2e): **594 passed**, 1 pre-existing host-env failure (`test_service_discovery` needs a newer rosclaw-know than this host has; fails identically on `main`; CI installs the newer package).
- `ruff check` + `mypy` clean on all touched modules.

Implementation note: `docs/reports/data-flywheel-phase2/DF-18-config-v2-native.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
