### PR TITLE
DF-19: DataReconciler — recovery after store outages

### DIFF
--- a/docs/reports/data-flywheel-phase2/DF-19-data-reconciliation.md
+++ b/docs/reports/data-flywheel-phase2/DF-19-data-reconciliation.md
@@ -1,0 +1,66 @@
+# DF-19 — Data Reconciliation (implementation note)
+
+Phase-II P0/P1 per `seekdb优化v2.md` §17–§26. Phase I proved the Runtime
+survives store outages; DF-19 proves the other half: **when the store
+comes back, the data comes back.**
+
+## What landed
+
+### §21 PracticeCatalog reconcile ledger
+
+Seven new columns on `practices` (schema + `_LEGACY_TABLES` auto-migration):
+`fact_ingested`, `memory_distilled`, `last_fact_ingest_at`,
+`last_memory_distill_at`, `fact_ingest_error`, `memory_distill_error`,
+`reconcile_required`. New module helpers `reconcile_catalog_path()` and
+`update_reconcile_fields()` — raw-sqlite, best-effort, never raising; the
+`reconcile_required="auto"` update clears the flag only when BOTH sides
+are done (SET-clause CASE sees OLD row values in SQLite, so the in-flight
+flags are folded in as parameters — caught by test).
+
+### Writers mark the ledger
+
+- `MemoryDistillationService._work` marks `memory_distilled` on success
+  and `reconcile_required=1` + error on failure (§20: no fake "memory
+  stored" while the store is down — the ledger records the debt instead).
+- `PracticeFactIngestor` marks `fact_ingested` alongside the existing
+  `seekdb_committed`, and auto-clears the flag.
+
+### §22 DataReconciler — `src/rosclaw/storage/reconciler.py`
+
+- `reconcile_practice(id)`: fact ingest (PracticeFactIngestor, idempotent
+  by entity ids) + memory distill (the DF-16B `_work` path, idempotent by
+  content hash at the write gate).  The close-time fact-verify verdict is
+  **recomputed** with the idempotent PracticeVerifier — an empty
+  fact_verify would trip the quality policy's FAIL branch and quarantine
+  everything (caught by test).
+- `reconcile_memory()`: discovers `reconcile_required=1 OR
+  (fact_ingested=0 AND seekdb_committed=0) OR memory_distilled=0` and
+  processes each.  Legacy rows already committed count as fact-done.
+- `reconcile_projection()`: lag check vs source watermark, rebuild to
+  parity (fault class B).
+- `reconcile_evolution_spool()` (§25): enumerate LocalStore cache, upsert
+  missing/newer into `evolution_records`, verify, mark synced in a
+  `_reconcile` namespace.  Local copies are never deleted.
+
+### §23 CLI — `rosclaw data reconcile`
+
+`--practice ID`, `--all` (default), `--dry-run`, `--json`, `--data-root`,
+`--spool-path`, plus the usual backend overrides.  Exit 1 when anything
+remains unreconciled.
+
+## §26 fault E2E — `tests/storage/test_data_reconciler.py` (10 tests)
+
+- Case 1: retrieval down → lag = source → rebuild → lag 0 (dry-run
+  writes nothing).
+- Case 2: structured down → no fake memory, `reconcile_required=1` →
+  recovery → processed, flags cleared, and 3× reconcile = 0 duplicates
+  (Case 3 folded in per §24).
+- Case 4: crash between practice close and distill → reconciler
+  discovers the pending practice and finishes it.
+- §25: spool upserts missing/newer, sync marks written, local copies
+  kept, second run a noop.
+- Catalog columns, dry-run, projection/spool skips, CLI JSON run against
+  a real SQLite store.
+
+Full affected suites (storage/practice/memory-v2/e2e/runtime-coverage/
+flywheel-recorder): **787 passed**.

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -83,6 +83,7 @@ from rosclaw.storage.cli import (
     add_data_subparser,
     add_db_subparser,
     cmd_data_lineage,
+    cmd_data_reconcile,
     cmd_db_doctor,
     cmd_db_reconcile,
     cmd_db_status,
@@ -9310,6 +9311,8 @@ def main() -> int:
         elif args.command == "data":
             if args.data_command == "lineage":
                 return cmd_data_lineage(args)
+            elif args.data_command == "reconcile":
+                return cmd_data_reconcile(args)
             else:
                 data_parser.print_help()
                 return 1

--- a/src/rosclaw/memory/v2/distillation_service.py
+++ b/src/rosclaw/memory/v2/distillation_service.py
@@ -26,6 +26,7 @@ import logging
 import queue
 import threading
 import time
+from pathlib import Path
 from typing import Any
 
 from rosclaw.core.event_topics import EventTopics
@@ -200,6 +201,7 @@ class MemoryDistillationService:
                 len(result["merged"]),
                 result["quarantined"],
             )
+            self._mark_catalog(session_dir, practice_id, ok=True)
         except Exception as exc:  # noqa: BLE001 — T8: corrupt session -> ledger error, never crash
             logger.warning("distillation failed for %s: %s", practice_id, exc)
             self._ledger_write(
@@ -211,6 +213,45 @@ class MemoryDistillationService:
                     "last_error": str(exc)[:500],
                 },
             )
+            self._mark_catalog(session_dir, practice_id, ok=False, error=str(exc)[:500])
+
+    @staticmethod
+    def _mark_catalog(
+        session_dir: str, practice_id: str, *, ok: bool, error: str | None = None
+    ) -> None:
+        """DF-19 (§20-21): annotate the offline reconcile ledger in the catalog.
+
+        On failure the practice is flagged ``reconcile_required`` so
+        ``rosclaw data reconcile`` can find it after the store recovers;
+        on success the flag clears only when fact ingest is also done.
+        """
+        try:
+            from rosclaw.practice.storage.catalog import (
+                reconcile_catalog_path,
+                update_reconcile_fields,
+            )
+
+            data_root = Path(session_dir).parent.parent
+            catalog_path = reconcile_catalog_path(data_root)
+            if ok:
+                update_reconcile_fields(
+                    catalog_path,
+                    practice_id,
+                    {
+                        "memory_distilled": 1,
+                        "last_memory_distill_at": time.time(),
+                        "memory_distill_error": None,
+                        "reconcile_required": "auto",
+                    },
+                )
+            else:
+                update_reconcile_fields(
+                    catalog_path,
+                    practice_id,
+                    {"reconcile_required": 1, "memory_distill_error": error or "failed"},
+                )
+        except Exception:  # noqa: BLE001 — ledger marking never breaks the data path
+            pass
 
     # -- quality policy (§5.10) ------------------------------------------
 

--- a/src/rosclaw/practice/seekdb_ingestor.py
+++ b/src/rosclaw/practice/seekdb_ingestor.py
@@ -213,12 +213,26 @@ class PracticeFactIngestor:
                 except Exception as exc:
                     logger.warning("Failed to update candidate status: %s", exc)
 
-            # Mark catalog as committed
+            # Mark catalog as committed + reconcile-ledger fact side (DF-19 §21)
             try:
-                catalog.update_practice(practice_id, {"seekdb_committed": 1})
+                catalog.update_practice(
+                    practice_id,
+                    {
+                        "seekdb_committed": 1,
+                        "fact_ingested": 1,
+                        "last_fact_ingest_at": time.time(),
+                        "fact_ingest_error": None,
+                    },
+                )
             except Exception as exc:
                 logger.warning("Failed to update catalog seekdb_committed: %s", exc)
                 report.errors.append(f"catalog_commit: {exc}")
+            # Clear reconcile_required only when the memory side is also done.
+            from rosclaw.practice.storage.catalog import update_reconcile_fields
+
+            update_reconcile_fields(
+                catalog._db_path, practice_id, {"reconcile_required": "auto"}
+            )
 
             if report.errors:
                 report.success = any(

--- a/src/rosclaw/practice/storage/catalog.py
+++ b/src/rosclaw/practice/storage/catalog.py
@@ -30,6 +30,86 @@ def _is_transient_flush_error(exc: Exception) -> bool:
     return "locked" in message or "busy" in message
 
 
+# ---------------------------------------------------------------------------
+# DF-19 (phase-II §21): offline reconcile ledger helpers
+#
+# These are lightweight raw-sqlite updaters shared by the distillation
+# service, the fact ingestor, and the DataReconciler CLI.  They deliberately
+# do NOT instantiate PracticeCatalog (its batch writers are heavyweight for
+# a two-column flag update) and never raise: a ledger-marking failure must
+# not break the data path it annotates.
+# ---------------------------------------------------------------------------
+
+_RECONCILE_COLUMNS = {
+    "fact_ingested",
+    "memory_distilled",
+    "last_fact_ingest_at",
+    "last_memory_distill_at",
+    "fact_ingest_error",
+    "memory_distill_error",
+    "reconcile_required",
+}
+
+
+def reconcile_catalog_path(data_root: str | Path) -> Path:
+    """Catalog location used by PracticeLayout (indexes/ with legacy fallback)."""
+    root = Path(data_root)
+    indexes = root / "indexes" / "practice_catalog.sqlite"
+    legacy = root / "practice_catalog.sqlite"
+    return indexes if indexes.exists() or not legacy.exists() else legacy
+
+
+def update_reconcile_fields(
+    catalog_path: str | Path,
+    practice_id: str,
+    fields: dict[str, Any],
+) -> None:
+    """Best-effort reconcile-ledger update; swallows every error.
+
+    Recognizes the §21 columns plus the computed ``reconcile_required``
+    clear: pass ``reconcile_required="auto"`` to clear the flag only when
+    both fact ingest and memory distillation are done.
+    """
+    path = Path(catalog_path)
+    if not path.exists():
+        return
+    sets: list[str] = []
+    values: list[Any] = []
+    for key, value in fields.items():
+        if key not in _RECONCILE_COLUMNS:
+            continue
+        if key == "reconcile_required" and value == "auto":
+            # SET-clause expressions see the OLD row values in SQLite, so the
+            # just-updated fact/memory flags from THIS call must be folded in
+            # explicitly as parameters.
+            fact_now = 1 if fields.get("fact_ingested") == 1 else 0
+            memory_now = 1 if fields.get("memory_distilled") == 1 else 0
+            sets.append(
+                "reconcile_required = CASE WHEN "
+                "(COALESCE(fact_ingested, 0) = 1 OR COALESCE(seekdb_committed, 0) = 1 OR ?) "
+                "AND (COALESCE(memory_distilled, 0) = 1 OR ?) THEN 0 ELSE 1 END"
+            )
+            values.extend((fact_now, memory_now))
+            continue
+        sets.append(f"{key} = ?")
+        values.append(value)
+    if not sets:
+        return
+    try:
+        conn = sqlite3.connect(str(path), timeout=5.0)
+        try:
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute(
+                f"UPDATE practices SET {', '.join(sets)} WHERE practice_id = ?",
+                (*values, practice_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001
+        logger.info("reconcile ledger update failed for %s: %s", practice_id, exc)
+
+
 class _BatchWriter:
     """Threaded batch inserter for catalog tables.
 
@@ -281,7 +361,14 @@ class PracticeCatalog:
         events_jsonl_path TEXT,
         replay_path TEXT,
         failure_report_path TEXT,
-        seekdb_committed INTEGER
+        seekdb_committed INTEGER,
+        fact_ingested INTEGER DEFAULT 0,
+        memory_distilled INTEGER DEFAULT 0,
+        last_fact_ingest_at REAL,
+        last_memory_distill_at REAL,
+        fact_ingest_error TEXT,
+        memory_distill_error TEXT,
+        reconcile_required INTEGER DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS events (
@@ -412,6 +499,14 @@ class PracticeCatalog:
             "replay_path",
             "failure_report_path",
             "seekdb_committed",
+            # DF-19 (phase-II §21): offline reconcile ledger
+            "fact_ingested",
+            "memory_distilled",
+            "last_fact_ingest_at",
+            "last_memory_distill_at",
+            "fact_ingest_error",
+            "memory_distill_error",
+            "reconcile_required",
         ],
         "events": [
             "event_id",

--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -1444,8 +1444,94 @@ def cmd_data_lineage(args: argparse.Namespace) -> int:
     return 0
 
 
+@_with_stdout_flush
+def cmd_data_reconcile(args: argparse.Namespace) -> int:
+    """Catch up everything the store is owed after an outage (DF-19)."""
+    cfg = _load_storage_config(args)
+    data_root = getattr(args, "data_root", None) or cfg["practice_data_root"]
+    try:
+        client = _create_client(cfg)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[rosclaw data reconcile] Failed to create backend: {exc}", file=sys.stderr)
+        return 1
+
+    retrieval_store = None
+    if cfg.get("retrieval_enabled") and Path(str(cfg.get("retrieval_path") or "")).exists():
+        try:
+            from rosclaw.storage.seekdb_native import SeekDBEmbeddedRetrievalStore
+
+            retrieval_store = SeekDBEmbeddedRetrievalStore(path=cfg["retrieval_path"])
+        except Exception as exc:  # noqa: BLE001
+            print(f"[rosclaw data reconcile] retrieval store unavailable: {exc}", file=sys.stderr)
+
+    evolution_cache = None
+    spool_path = getattr(args, "spool_path", None)
+    try:  # default spool always considered; empty dirs are a noop
+        from rosclaw.auto.storage.local_store import LocalStore
+
+        evolution_cache = LocalStore(spool_path or str(cfg["home"] / "data" / "auto"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"[rosclaw data reconcile] evolution spool unavailable: {exc}", file=sys.stderr)
+
+    try:
+        from rosclaw.storage.reconciler import DataReconciler
+
+        reconciler = DataReconciler(
+            structured_store=client,
+            data_root=data_root,
+            retrieval_store=retrieval_store,
+            evolution_cache=evolution_cache,
+        )
+        report = reconciler.reconcile_all(
+            practice_id=getattr(args, "practice", None),
+            dry_run=getattr(args, "dry_run", False),
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[rosclaw data reconcile] reconcile failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        _close_client(client)
+
+    if getattr(args, "json", False):
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        memory = report.get("memory", {})
+        if "practices" in memory:
+            print(
+                f"memory: pending={memory.get('pending_before')} "
+                f"processed={memory.get('processed')} "
+                f"still_required={memory.get('still_required')}"
+            )
+        else:
+            print(f"memory: practice {memory.get('practice_id')} processed={memory.get('processed')}")
+            for name, step in (memory.get("steps") or {}).items():
+                print(f"  {name}: {step}")
+        proj = report.get("projection", {})
+        if proj.get("skipped"):
+            print(f"projection: skipped ({proj['skipped']})")
+        else:
+            print(
+                f"projection: lag {proj.get('lag_before')} -> {proj.get('lag_after', proj.get('action'))}"
+            )
+        spool = report.get("evolution_spool", {})
+        if spool.get("skipped"):
+            print(f"evolution spool: skipped ({spool['skipped']})")
+        else:
+            print(
+                f"evolution spool: upserted={spool.get('upserted')} "
+                f"current={spool.get('skipped_current')} errors={spool.get('errors')}"
+            )
+        if report.get("dry_run"):
+            print("(dry-run: no writes performed)")
+    failed = bool(
+        (report.get("memory", {}).get("still_required") or 0) > 0
+        or (report.get("evolution_spool", {}).get("errors") or 0) > 0
+    )
+    return 1 if failed else 0
+
+
 def add_data_subparser(subparsers: Any) -> Any:
-    """Add ``rosclaw data`` subcommands (PR-DF-17)."""
+    """Add ``rosclaw data`` subcommands (PR-DF-17/DF-19)."""
     data_parser = subparsers.add_parser("data", help="Data flywheel queries")
     data_subparsers = data_parser.add_subparsers(dest="data_command")
 
@@ -1461,6 +1547,28 @@ def add_data_subparser(subparsers: Any) -> Any:
     lineage_parser.add_argument("--backend", default=None, help="Override backend")
     lineage_parser.add_argument("--url", default=None, help="Override SQL URL")
     lineage_parser.add_argument("--path", default=None, help="Override SQLite path")
+
+    reconcile_parser = data_subparsers.add_parser(
+        "reconcile",
+        help="Catch up fact ingest / memory distillation / projection / evolution spool after an outage (DF-19)",
+    )
+    reconcile_parser.add_argument("--practice", default=None, help="Reconcile one practice id")
+    reconcile_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Reconcile every pending practice (default when --practice is omitted)",
+    )
+    reconcile_parser.add_argument(
+        "--dry-run", action="store_true", help="Report what would be reconciled without writes"
+    )
+    reconcile_parser.add_argument("--json", action="store_true", help="Output JSON")
+    reconcile_parser.add_argument("--data-root", default=None, help="Practice data root")
+    reconcile_parser.add_argument(
+        "--spool-path", default=None, help="Evolution LocalStore spool (default: ~/.rosclaw/data/auto)"
+    )
+    reconcile_parser.add_argument("--backend", default=None, help="Override backend")
+    reconcile_parser.add_argument("--url", default=None, help="Override SQL URL")
+    reconcile_parser.add_argument("--path", default=None, help="Override SQLite path")
     return data_parser
 
 

--- a/src/rosclaw/storage/reconciler.py
+++ b/src/rosclaw/storage/reconciler.py
@@ -1,0 +1,390 @@
+"""DataReconciler (PR-DF-19 / phase-II §17-§26).
+
+Phase I proved the Runtime survives store outages.  DF-19 proves the
+other half: **when the store comes back, the data comes back.**
+
+Recovery sources (§18-§20), per fault class:
+
+* Structured Store down → Practice raw artifacts (events.jsonl /
+  episode.json / manifest) are the original truth; the catalog's §21
+  reconcile ledger (fact_ingested / memory_distilled /
+  reconcile_required) records what still owes the store.
+* Retrieval Store down → the structured SoT is fine; a projection
+  rebuild/catch-up restores parity (lag is an ops signal, never loss).
+* Evolution spool → LocalStore cache entries missing-or-newer are
+  upserted into the structured store and marked synced (never deleted —
+  the cache stays a cache).
+
+Every step is idempotent (§24): fact ingest dedups by entity ids,
+distillation dedups by content hash at the write gate, lineage links
+dedup on the 5-field key, projection upserts by memory id.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from rosclaw.practice.storage.catalog import (
+    reconcile_catalog_path,
+    update_reconcile_fields,
+)
+
+logger = logging.getLogger("rosclaw.storage.reconciler")
+
+LEDGER_TABLE = "memory_distillation_runs"
+_EVOLUTION_TABLE = "evolution_records"
+_SPOOL_SYNC_NAMESPACE = "_reconcile"
+
+
+def _manifest_hash(session_dir: Path) -> str:
+    """The manifest hash the distillation ledger keys on (best-effort)."""
+    manifest = session_dir / "manifest.yaml"
+    if not manifest.exists():
+        return ""
+    try:
+        text = manifest.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            if line.startswith(("manifest_hash:", "sha256:")):
+                return line.split(":", 1)[1].strip().strip('"').strip("'")
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+    except OSError:
+        return ""
+
+
+class DataReconciler:
+    """Catch-up engine for the four fault classes (§18)."""
+
+    def __init__(
+        self,
+        *,
+        structured_store: Any,
+        data_root: str | Path,
+        retrieval_store: Any | None = None,
+        evolution_cache: Any | None = None,
+        lineage: Any | None = None,
+    ) -> None:
+        self._store = structured_store
+        self._data_root = Path(data_root)
+        self._retrieval_store = retrieval_store
+        self._evolution_cache = evolution_cache
+        self._lineage = lineage
+
+    # ------------------------------------------------------------------
+    # catalog access (read-only, raw sqlite — no batch writers)
+    # ------------------------------------------------------------------
+
+    def _catalog_rows(self, practice_id: str | None = None) -> list[dict[str, Any]]:
+        catalog_path = reconcile_catalog_path(self._data_root)
+        if not catalog_path.exists():
+            return []
+        conn = sqlite3.connect(f"file:{catalog_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            if practice_id:
+                rows = conn.execute(
+                    "SELECT * FROM practices WHERE practice_id = ?", (practice_id,)
+                ).fetchall()
+            else:
+                rows = conn.execute("SELECT * FROM practices").fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def pending_practices(self) -> list[dict[str, Any]]:
+        """Catalog rows that still owe the store work (§20 discovery)."""
+        out = []
+        for row in self._catalog_rows():
+            fact_done = bool(row.get("fact_ingested")) or bool(row.get("seekdb_committed"))
+            memory_done = bool(row.get("memory_distilled"))
+            if row.get("reconcile_required") or not fact_done or not memory_done:
+                out.append(row)
+        return out
+
+    # ------------------------------------------------------------------
+    # §22: reconcile_practice — fact ingest + memory distill for one session
+    # ------------------------------------------------------------------
+
+    def reconcile_practice(
+        self, practice_id: str, *, dry_run: bool = False
+    ) -> dict[str, Any]:
+        rows = self._catalog_rows(practice_id)
+        if not rows:
+            return {"practice_id": practice_id, "processed": False, "error": "not in catalog"}
+        row = rows[0]
+        session_dir = self._data_root / "sessions" / practice_id
+        result: dict[str, Any] = {
+            "practice_id": practice_id,
+            "processed": False,
+            "dry_run": dry_run,
+            "fact_ingested_before": bool(row.get("fact_ingested") or row.get("seekdb_committed")),
+            "memory_distilled_before": bool(row.get("memory_distilled")),
+            "steps": {},
+        }
+        catalog_path = reconcile_catalog_path(self._data_root)
+
+        # -- fact ingest (idempotent by entity ids) ----------------------
+        if result["fact_ingested_before"]:
+            result["steps"]["fact_ingest"] = "already_done"
+        elif dry_run:
+            result["steps"]["fact_ingest"] = "would_run"
+        else:
+            try:
+                from rosclaw.practice.seekdb_ingestor import PracticeFactIngestor
+
+                with PracticeFactIngestor(self._data_root, seekdb_client=self._store) as ing:
+                    report = ing.ingest_practice(practice_id)
+                result["steps"]["fact_ingest"] = {
+                    "success": report.success,
+                    "tables": report.table_counts,
+                    "errors": report.errors,
+                }
+                if not report.success:
+                    update_reconcile_fields(
+                        catalog_path,
+                        practice_id,
+                        {"reconcile_required": 1, "fact_ingest_error": "; ".join(report.errors)[:400]},
+                    )
+            except Exception as exc:  # noqa: BLE001
+                result["steps"]["fact_ingest"] = {"success": False, "error": str(exc)}
+                update_reconcile_fields(
+                    catalog_path,
+                    practice_id,
+                    {"reconcile_required": 1, "fact_ingest_error": str(exc)[:400]},
+                )
+
+        # -- memory distill (idempotent by content hash at the gate) -----
+        if result["memory_distilled_before"]:
+            result["steps"]["memory_distill"] = "already_done"
+        elif not session_dir.exists():
+            result["steps"]["memory_distill"] = "skipped_no_session_dir"
+        elif dry_run:
+            result["steps"]["memory_distill"] = "would_run"
+        else:
+            try:
+                self._distill_session(practice_id, session_dir, row)
+                ledger = self._distill_ledger_status(practice_id, session_dir)
+                result["steps"]["memory_distill"] = ledger
+            except Exception as exc:  # noqa: BLE001
+                result["steps"]["memory_distill"] = {"status": "failed", "error": str(exc)}
+
+        result["processed"] = True
+        if not dry_run:
+            after = self._catalog_rows(practice_id)
+            if after:
+                result["reconcile_required_after"] = bool(after[0].get("reconcile_required"))
+        return result
+
+    def _distill_session(
+        self, practice_id: str, session_dir: Path, catalog_row: dict[str, Any]
+    ) -> None:
+        """Run the DF-16B distillation work path synchronously for one session."""
+        from rosclaw.memory.v2.distillation_service import MemoryDistillationService
+        from rosclaw.memory.v2.gate import MemoryWriteGate
+        from rosclaw.memory.v2.repository import MemoryRepository
+
+        repository = MemoryRepository(self._store)
+        gate = MemoryWriteGate(repository)
+        service = MemoryDistillationService(None, repository, gate, lineage=self._lineage)
+        service._work(
+            {
+                "practice_id": practice_id,
+                "session_id": catalog_row.get("session_id"),
+                "episode_id": catalog_row.get("episode_id"),
+                "session_dir": str(session_dir),
+                "manifest_hash": _manifest_hash(session_dir),
+                "fact_verify": self._fact_verify(practice_id),
+                "_reconciled": True,
+            }
+        )
+
+    def _fact_verify(self, practice_id: str) -> dict[str, Any]:
+        """Recompute the close-time fact verdict (verifier is idempotent, DF-04).
+
+        An empty ``fact_verify`` payload would trip the quality policy's FAIL
+        branch and quarantine every candidate — reconstruct the real verdict
+        from the raw session instead.
+        """
+        try:
+            from rosclaw.practice.verifier import PracticeVerifier
+
+            report = PracticeVerifier(self._data_root).verify(practice_id)
+            return {
+                "passed": report.passed,
+                "errors": sum(1 for i in report.issues if i.level == "error"),
+                "warnings": sum(1 for i in report.issues if i.level == "warning"),
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.info("fact re-verify unavailable for %s: %s", practice_id, exc)
+            return {}
+
+    def _distill_ledger_status(self, practice_id: str, session_dir: Path) -> dict[str, Any]:
+        """Read the ledger row this reconcile just wrote (status verdict)."""
+        manifest_hash = _manifest_hash(session_dir) or "nohash"
+        try:
+            rows = self._store.query(
+                LEDGER_TABLE, {"id": f"{practice_id}:{manifest_hash}"}, limit=1
+            )
+            if rows:
+                return {
+                    "status": rows[0].get("status"),
+                    "stored": rows[0].get("stored_count"),
+                    "merged": rows[0].get("merged_count"),
+                    "error": rows[0].get("last_error"),
+                }
+        except Exception as exc:  # noqa: BLE001
+            return {"status": "unknown", "error": str(exc)}
+        return {"status": "unknown"}
+
+    # ------------------------------------------------------------------
+    # §22: reconcile_memory — every practice that owes distillation/ingest
+    # ------------------------------------------------------------------
+
+    def reconcile_memory(self, *, dry_run: bool = False, limit: int = 1000) -> dict[str, Any]:
+        pending = self.pending_practices()[:limit]
+        results = [
+            self.reconcile_practice(row["practice_id"], dry_run=dry_run) for row in pending
+        ]
+        processed = sum(1 for r in results if r.get("processed"))
+        still_required = sum(1 for r in results if r.get("reconcile_required_after"))
+        return {
+            "pending_before": len(pending),
+            "processed": processed,
+            "still_required": still_required,
+            "dry_run": dry_run,
+            "practices": results,
+        }
+
+    # ------------------------------------------------------------------
+    # §22 / fault class B: reconcile_projection — retrieval catch-up
+    # ------------------------------------------------------------------
+
+    def reconcile_projection(self, *, dry_run: bool = False) -> dict[str, Any]:
+        if self._retrieval_store is None:
+            return {"skipped": "no retrieval store"}
+        from rosclaw.memory.v2.repository import MemoryRepository
+        from rosclaw.storage.seekdb_projection import MemoryRetrievalProjection
+
+        repository = MemoryRepository(self._store)
+        projection = MemoryRetrievalProjection(self._retrieval_store)
+        before = projection.status(repository)
+        result: dict[str, Any] = {
+            "lag_before": before.get("lag"),
+            "source_count": before.get("source_count"),
+            "projection_count_before": before.get("projection_count"),
+            "dry_run": dry_run,
+        }
+        if dry_run:
+            result["action"] = "would_rebuild" if before.get("lag") else "noop"
+            return result
+        if before.get("lag"):
+            rebuild = projection.rebuild(repository)
+            after = projection.status(repository)
+            result["rebuilt"] = rebuild.get("rebuilt")
+            result["lag_after"] = after.get("lag")
+        else:
+            result["action"] = "noop"
+            result["lag_after"] = before.get("lag", 0)
+        return result
+
+    # ------------------------------------------------------------------
+    # §22/§25: reconcile_evolution_spool — LocalStore cache -> structured
+    # ------------------------------------------------------------------
+
+    def reconcile_evolution_spool(self, *, dry_run: bool = False) -> dict[str, Any]:
+        cache = self._evolution_cache
+        if cache is None:
+            return {"skipped": "no evolution cache"}
+        base = Path(cache.base)
+        stats: dict[str, Any] = {
+            "namespaces": {},
+            "upserted": 0,
+            "skipped_current": 0,
+            "errors": 0,
+            "dry_run": dry_run,
+        }
+        namespaces = sorted(p.name for p in base.iterdir() if p.is_dir()) if base.exists() else []
+        for namespace in namespaces:
+            if namespace == _SPOOL_SYNC_NAMESPACE:
+                continue
+            ns_stats = {"upserted": 0, "current": 0, "errors": 0}
+            for key in cache.list_keys(namespace):
+                try:
+                    outcome = self._reconcile_spool_entry(namespace, key, dry_run=dry_run)
+                    ns_stats["upserted" if outcome == "upserted" else outcome] += 1
+                    if outcome == "upserted":
+                        stats["upserted"] += 1
+                    elif outcome == "current":
+                        stats["skipped_current"] += 1
+                    else:
+                        stats["errors"] += 1
+                except Exception as exc:  # noqa: BLE001
+                    logger.info("spool reconcile failed for %s/%s: %s", namespace, key, exc)
+                    ns_stats["errors"] += 1
+                    stats["errors"] += 1
+            stats["namespaces"][namespace] = ns_stats
+        return stats
+
+    def _reconcile_spool_entry(self, namespace: str, key: str, *, dry_run: bool) -> str:
+        """Upsert one cache entry when missing/newer in the store; mark synced."""
+        cache = self._evolution_cache
+        data = cache.load(namespace, key)
+        if data is None:
+            return "current"
+        cache_mtime = (Path(cache.base) / namespace / f"{key}.json").stat().st_mtime
+        row_id = f"{namespace}:{key}"
+        store_updated_at = 0.0
+        try:
+            rows = self._store.query(_EVOLUTION_TABLE, {"id": row_id}, limit=1)
+            if rows:
+                store_updated_at = float(rows[0].get("updated_at") or 0.0)
+        except Exception as exc:  # noqa: BLE001
+            logger.info("spool compare failed for %s: %s", row_id, exc)
+            return "errors"
+        synced = cache.load(_SPOOL_SYNC_NAMESPACE, row_id) or {}
+        already_synced = float(synced.get("synced_at") or 0.0) >= cache_mtime and store_updated_at > 0
+        if already_synced or store_updated_at >= cache_mtime:
+            return "current"
+        if dry_run:
+            return "upserted"
+        # Upsert missing/newer (§25), verify, mark synced — never delete.
+        self._store.insert(
+            _EVOLUTION_TABLE,
+            {
+                "id": row_id,
+                "namespace": namespace,
+                "key": key,
+                "data": json.dumps(data, default=str),
+                "updated_at": time.time(),
+            },
+        )
+        rows = self._store.query(_EVOLUTION_TABLE, {"id": row_id}, limit=1)
+        if not rows:
+            return "errors"
+        cache.save(_SPOOL_SYNC_NAMESPACE, row_id, {"synced_at": time.time(), "namespace": namespace})
+        return "upserted"
+
+    # ------------------------------------------------------------------
+    # one-shot: everything
+    # ------------------------------------------------------------------
+
+    def reconcile_all(
+        self, *, practice_id: str | None = None, dry_run: bool = False
+    ) -> dict[str, Any]:
+        if practice_id:
+            memory = self.reconcile_practice(practice_id, dry_run=dry_run)
+        else:
+            memory = self.reconcile_memory(dry_run=dry_run)
+        projection = self.reconcile_projection(dry_run=dry_run)
+        spool = self.reconcile_evolution_spool(dry_run=dry_run)
+        return {
+            "dry_run": dry_run,
+            "memory": memory,
+            "projection": projection,
+            "evolution_spool": spool,
+        }

--- a/tests/storage/test_data_reconciler.py
+++ b/tests/storage/test_data_reconciler.py
@@ -1,0 +1,331 @@
+"""PR-DF-19 (phase-II §17-§26): DataReconciler — recovery after store outages.
+
+Fault E2E coverage (§26):
+* Case 1: retrieval down -> projection lag -> rebuild -> lag 0
+* Case 2: structured down -> reconcile_required ledger -> catch-up, 0 dup
+* Case 3: repeated reconcile runs -> counts unchanged (idempotency §24)
+* Case 4: crash between practice close and distill -> discovered + finished
+Plus the §21 catalog ledger columns and the §25 evolution spool replay.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+from rosclaw.memory.v2.gate import MemoryWriteGate
+from rosclaw.memory.v2.repository import MemoryRepository
+from rosclaw.practice.config import PracticeConfig, SourceConfig
+from rosclaw.practice.coordinator import PracticeCoordinator
+from rosclaw.storage.reconciler import DataReconciler
+
+
+def _store():
+    s = InMemoryStructuredStore()
+    s.connect()
+    return s
+
+
+def _make_session(data_root, task="slide puck"):
+    cfg = PracticeConfig(
+        robot_id="sim_bot",
+        task_name=task,
+        data_root=str(data_root),
+        sources=SourceConfig(agent=True, runtime=True),
+        mock=True,
+        publish_to_event_bus=False,
+    )
+    coord = PracticeCoordinator(cfg)
+    coord.initialize()
+    coord.start()
+    time.sleep(0.3)
+    coord.stop()
+    return coord.summary
+
+
+def _reconciler(store, data_root, **kw):
+    return DataReconciler(structured_store=store, data_root=data_root, **kw)
+
+
+# -- §21 catalog ledger columns ----------------------------------------------
+
+
+def test_catalog_has_reconcile_columns(tmp_path):
+    summary = _make_session(tmp_path)
+    rows = DataReconciler(
+        structured_store=_store(), data_root=tmp_path
+    )._catalog_rows(summary.practice_id)
+    assert rows, "practice row missing"
+    for col in (
+        "fact_ingested",
+        "memory_distilled",
+        "last_fact_ingest_at",
+        "last_memory_distill_at",
+        "fact_ingest_error",
+        "memory_distill_error",
+        "reconcile_required",
+    ):
+        assert col in rows[0], f"column {col} missing"
+
+
+# -- §22/§24 reconcile_practice + idempotency ---------------------------------
+
+
+def test_reconcile_practice_end_to_end_and_idempotent(tmp_path):
+    summary = _make_session(tmp_path)
+    store = _store()
+    rec = _reconciler(store, tmp_path)
+
+    pending = rec.pending_practices()
+    assert any(r["practice_id"] == summary.practice_id for r in pending)
+
+    result = rec.reconcile_practice(summary.practice_id)
+    assert result["processed"] is True
+    assert result["steps"]["memory_distill"]["status"] == "completed"
+    episodes_before = store.count("episodes", {})
+    memories_before = store.count("memory_items", {})
+    assert memories_before >= 1, "distillation must store at least the episode memory"
+
+    row = rec._catalog_rows(summary.practice_id)[0]
+    assert row["fact_ingested"] == 1
+    assert row["memory_distilled"] == 1
+    assert row["reconcile_required"] == 0
+
+    # §24: reconcile again — 0 duplicate facts / memories
+    again = rec.reconcile_practice(summary.practice_id)
+    assert again["steps"]["fact_ingest"] == "already_done"
+    assert again["steps"]["memory_distill"] == "already_done"
+    assert store.count("episodes", {}) == episodes_before
+    assert store.count("memory_items", {}) == memories_before
+
+
+def test_reconcile_dry_run_writes_nothing(tmp_path):
+    summary = _make_session(tmp_path)
+    store = _store()
+    rec = _reconciler(store, tmp_path)
+    result = rec.reconcile_practice(summary.practice_id, dry_run=True)
+    assert result["steps"]["fact_ingest"] == "would_run"
+    assert result["steps"]["memory_distill"] == "would_run"
+    assert store.count("memory_items", {}) == 0
+    assert store.count("episodes", {}) == 0
+
+
+# -- §26 Case 2: structured down -> ledger -> catch-up ------------------------
+
+
+class _DeadStore:
+    def __init__(self, inner):
+        self._inner = inner
+        self.alive = False
+
+    def insert(self, *a, **k):
+        if not self.alive:
+            raise ConnectionError("structured store down")
+        return self._inner.insert(*a, **k)
+
+    def query(self, *a, **k):
+        return self._inner.query(*a, **k)
+
+    def count(self, *a, **k):
+        return self._inner.count(*a, **k)
+
+
+def test_case2_structured_down_marks_and_recovers(tmp_path):
+    from rosclaw.memory.v2.distillation_service import MemoryDistillationService
+
+    inner = _store()
+    dead = _DeadStore(inner)
+    summary = _make_session(tmp_path)
+
+    # structured down: distillation must fail loudly into the ledger, never
+    # fake a stored memory
+    repo = MemoryRepository(dead)
+    svc = MemoryDistillationService(None, repo, MemoryWriteGate(repo))
+    svc._work(
+        {
+            "practice_id": summary.practice_id,
+            "session_id": "sess_1",
+            "episode_id": "ep_1",
+            "session_dir": str(tmp_path / "sessions" / summary.practice_id),
+            "manifest_hash": "",
+        }
+    )
+    assert inner.count("memory_items", {}) == 0, "no fake memory stored while down"
+    row = DataReconciler(structured_store=inner, data_root=tmp_path)._catalog_rows(
+        summary.practice_id
+    )[0]
+    assert row["reconcile_required"] == 1
+    assert row["memory_distilled"] == 0
+
+    # store recovers: reconcile catches everything up
+    dead.alive = True
+    rec = _reconciler(inner, tmp_path)
+    report = rec.reconcile_memory()
+    assert report["processed"] == 1
+    assert inner.count("memory_items", {}) >= 1
+    row = rec._catalog_rows(summary.practice_id)[0]
+    assert row["reconcile_required"] == 0
+
+    # Case 3 (§26): repeated reconcile leaves counts unchanged
+    memories = inner.count("memory_items", {})
+    episodes = inner.count("episodes", {})
+    rec.reconcile_memory()
+    rec.reconcile_memory()
+    assert inner.count("memory_items", {}) == memories
+    assert inner.count("episodes", {}) == episodes
+
+
+# -- §26 Case 4: crash between practice close and distill ---------------------
+
+
+def test_case4_crash_before_distill_discovered_and_finished(tmp_path):
+    summary = _make_session(tmp_path)  # practice closed, process "dies" here
+    store = _store()
+    rec = _reconciler(store, tmp_path)
+
+    # restart: reconciler discovers the pending practice and finishes it
+    pending = rec.pending_practices()
+    assert [r["practice_id"] for r in pending] == [summary.practice_id]
+    report = rec.reconcile_memory()
+    assert report["processed"] == 1
+    assert store.count("memory_items", {}) >= 1
+    assert rec.pending_practices() == []
+
+
+# -- §26 Case 1: retrieval down -> projection lag -> rebuild ------------------
+
+
+class _FakeRetrievalStore:
+    def __init__(self):
+        self.rows = {}
+
+    def connect(self):
+        return None
+
+    def insert(self, table, record):
+        self.rows[record["id"]] = record
+        return record["id"]
+
+    def insert_many(self, table, records):
+        for r in records:
+            self.rows[r["id"]] = r
+        return len(records)
+
+    def refresh_index(self, table):
+        return None
+
+    def count(self, table):
+        return len(self.rows)
+
+
+def test_case1_projection_lag_rebuilds_to_zero(tmp_path):
+    summary = _make_session(tmp_path)
+    store = _store()
+    # ingest + distill while retrieval is "down" (no projection writes)
+    rec_no_retrieval = _reconciler(store, tmp_path)
+    rec_no_retrieval.reconcile_practice(summary.practice_id)
+    source = store.count("memory_items", {})
+    assert source >= 1
+
+    retrieval = _FakeRetrievalStore()  # empty: lag = source
+    rec = _reconciler(store, tmp_path, retrieval_store=retrieval)
+    status = rec.reconcile_projection(dry_run=True)
+    assert status["lag_before"] == source
+    assert status["action"] == "would_rebuild"
+
+    done = rec.reconcile_projection()
+    assert done["rebuilt"] == source
+    assert done["lag_after"] == 0
+
+
+def test_projection_skipped_without_retrieval_store(tmp_path):
+    rec = _reconciler(_store(), tmp_path)
+    assert rec.reconcile_projection()["skipped"] == "no retrieval store"
+
+
+# -- §25 evolution spool replay ------------------------------------------------
+
+
+def test_evolution_spool_reconcile_upserts_and_marks_synced(tmp_path):
+    from rosclaw.auto.storage.local_store import LocalStore
+
+    store = _store()
+    cache = LocalStore(str(tmp_path / "auto"))
+    cache.save("proposals", "prop_1", {"id": "prop_1", "hypothesis": "h1"})
+    cache.save("patches", "patch_1", {"id": "patch_1"})
+    # one record already in the store (current — must not be re-upserted)
+    store.insert(
+        "evolution_records",
+        {
+            "id": "proposals:prop_0",
+            "namespace": "proposals",
+            "key": "prop_0",
+            "data": json.dumps({"id": "prop_0"}),
+            "updated_at": time.time() + 100,
+        },
+    )
+    cache.save("proposals", "prop_0", {"id": "prop_0"})
+
+    rec = _reconciler(store, tmp_path, evolution_cache=cache)
+    dry = rec.reconcile_evolution_spool(dry_run=True)
+    assert dry["upserted"] == 2
+    assert store.count("evolution_records", {}) == 1, "dry-run must not write"
+
+    done = rec.reconcile_evolution_spool()
+    assert done["upserted"] == 2
+    assert done["skipped_current"] == 1
+    assert store.count("evolution_records", {}) == 3
+    rows = store.query("evolution_records", {"id": "proposals:prop_1"})
+    assert json.loads(rows[0]["data"])["hypothesis"] == "h1"
+    # local copies stay (cache remains a cache), sync marks written
+    assert cache.load("proposals", "prop_1") is not None
+    assert cache.load("_reconcile", "proposals:prop_1") is not None
+    # second run is a noop
+    again = rec.reconcile_evolution_spool()
+    assert again["upserted"] == 0
+
+
+def test_evolution_spool_skipped_without_cache(tmp_path):
+    rec = _reconciler(_store(), tmp_path)
+    assert rec.reconcile_evolution_spool()["skipped"] == "no evolution cache"
+
+
+# -- CLI ------------------------------------------------------------------------
+
+
+def test_cmd_data_reconcile_json(tmp_path, capsys):
+    summary = _make_session(tmp_path)
+    store_path = tmp_path / "k.sqlite"
+    from rosclaw.memory.seekdb_client import SQLiteStructuredStore
+
+    store = SQLiteStructuredStore(str(store_path))
+    store.connect()
+    store.disconnect()
+
+    import argparse
+
+    from rosclaw.storage.cli import cmd_data_reconcile
+
+    args = argparse.Namespace(
+        practice=summary.practice_id,
+        all=False,
+        dry_run=False,
+        json=True,
+        data_root=str(tmp_path),
+        spool_path=str(tmp_path / "auto"),
+        backend="sqlite",
+        url=None,
+        path=str(store_path),
+    )
+    rc = cmd_data_reconcile(args)
+    out = capsys.readouterr().out
+    report = json.loads(out[out.index("{"):])
+    assert rc == 0
+    assert report["memory"]["processed"] is True
+    assert report["memory"]["steps"]["memory_distill"]["status"] == "completed"
+
+    store2 = SQLiteStructuredStore(str(store_path))
+    store2.connect()
+    assert store2.count("memory_items", {}) >= 1
+    store2.disconnect()


### PR DESCRIPTION
## Summary

Phase-II per `seekdb优化v2.md` §17–§26. Phase I proved the Runtime survives store outages; DF-19 proves the other half: **when the store comes back, the data comes back.**

- **§21 PracticeCatalog reconcile ledger** — `fact_ingested` / `memory_distilled` / `last_*_at` / `*_error` / `reconcile_required` columns (schema + auto-migration); raw-sqlite best-effort helpers; auto-clear only when both sides done.
- **Writers mark the ledger** — `MemoryDistillationService` (success / failure+error; never fakes "memory stored" while down), `PracticeFactIngestor`.
- **`DataReconciler`** (`storage/reconciler.py`) — `reconcile_practice` (fact ingest + memory distill, fact-verify **recomputed** via the idempotent verifier so the quality policy doesn't quarantine everything), `reconcile_memory` (debt discovery incl. legacy `seekdb_committed`), `reconcile_projection` (lag rebuild), `reconcile_evolution_spool` (§25 cache→structured upsert + sync marks, local copies never deleted).
- **CLI** — `rosclaw data reconcile [--practice ID] [--all] [--dry-run] [--json]`.

## Tests (§26 fault E2E + §24 idempotency) — 10 new

- Case 1: retrieval down → lag = source → rebuild → lag 0
- Case 2: structured down → no fake memory, `reconcile_required=1` → recovery → flags cleared
- Case 3: 3× reconcile → 0 duplicate facts/memories
- Case 4: crash between practice close and distill → discovered + finished
- §25 spool replay (upsert missing/newer, sync marks, noop second run), dry-run, skips, CLI JSON on a real SQLite store

Affected suites (storage/practice/memory-v2/e2e/runtime-coverage/flywheel-recorder): **787 passed**. `ruff` + `mypy` clean.

Two non-obvious fixes the tests caught: SQLite SET-clause CASE reads OLD row values (auto-clear parameters), and an empty `fact_verify` payload trips the distill quality policy's FAIL branch (recompute the verdict instead).

Implementation note: `docs/reports/data-flywheel-phase2/DF-19-data-reconciliation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
