### PR TITLE
DF-21: Knowledge Usage Ledger — observe before ranking

### DIFF
--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -84,6 +84,7 @@ from rosclaw.storage.cli import (
     add_db_subparser,
     cmd_data_lineage,
     cmd_data_reconcile,
+    cmd_data_usage,
     cmd_db_doctor,
     cmd_db_reconcile,
     cmd_db_status,
@@ -9313,6 +9314,8 @@ def main() -> int:
                 return cmd_data_lineage(args)
             elif args.data_command == "reconcile":
                 return cmd_data_reconcile(args)
+            elif args.data_command == "usage":
+                return cmd_data_usage(args)
             else:
                 data_parser.print_help()
                 return 1

--- a/src/rosclaw/core/runtime.py
+++ b/src/rosclaw/core/runtime.py
@@ -650,10 +650,18 @@ class Runtime(LifecycleMixin):
                 # PR-DF-10 (flywheel §29-31): automatic ReferencePack → Advice
                 # → Receipt → Feedback loop; conservative verdicts only.
                 try:
+                    from rosclaw.knowledge.usage_ledger import KnowledgeUsageLedger
                     from rosclaw.knowledge.usage_tracker import KnowledgeUsageTracker
 
+                    # PR-DF-21 (§32): durable usage observation when a
+                    # structured store exists; None keeps DF-10 behavior.
+                    usage_ledger = (
+                        KnowledgeUsageLedger(data_plane.structured_store)
+                        if data_plane.structured_store is not None
+                        else None
+                    )
                     self._knowledge_usage_tracker = KnowledgeUsageTracker(
-                        self.event_bus, self._knowledge_v2
+                        self.event_bus, self._knowledge_v2, usage_ledger=usage_ledger
                     )
                     self._knowledge_usage_tracker.subscribe()
                 except Exception as track_exc:  # noqa: BLE001

--- a/src/rosclaw/knowledge/usage_ledger.py
+++ b/src/rosclaw/knowledge/usage_ledger.py
@@ -1,0 +1,141 @@
+"""KnowledgeUsageLedger (PR-DF-21 / phase-II §32).
+
+The durable observation layer for knowledge utility: every
+ReferencePack presentation, Advice usage, and conservative outcome
+verdict lands as a ``knowledge_usage_events`` row so per-Knowledge-Unit
+utility can be measured BEFORE any ranking formula exists (§32.3 —
+observe first; semantic relevance × evidence quality × body
+applicability × freshness × historical utility comes later, with data).
+
+Verdict vocabulary (§32.1): presented / used / useful / unknown /
+stale / incompatible / misleading.  Automatic tracking only ever emits
+presented / used / useful / unknown — the negative attributions require
+verifier or human evidence (same discipline as PR-DF-10).
+
+All writes are best-effort: the ledger NEVER breaks the execution path.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any
+
+logger = logging.getLogger("rosclaw.knowledge.usage_ledger")
+
+TABLE = "knowledge_usage_events"
+
+VERDICT_PRESENTED = "presented"
+VERDICT_USED = "used"
+VERDICT_USEFUL = "useful"
+VERDICT_UNKNOWN = "unknown"
+VERDICT_STALE = "stale"
+VERDICT_INCOMPATIBLE = "incompatible"
+VERDICT_MISLEADING = "misleading"
+
+_AGGREGATE_KEYS = (
+    "presented_count",
+    "used_count",
+    "useful_count",
+    "unknown_count",
+    "incompatible_count",
+    "stale_count",
+    "misleading_count",
+    "verified_success_count",
+    "verified_failure_count",
+)
+
+
+class KnowledgeUsageLedger:
+    """Append-only usage event log + per-unit aggregation (§32.2)."""
+
+    def __init__(self, structured_store: Any) -> None:
+        self._store = structured_store
+
+    # -- write -------------------------------------------------------------
+
+    def record(
+        self,
+        verdict: str,
+        *,
+        reference_pack_id: str = "",
+        knowledge_unit_id: str = "",
+        advice_id: str | None = None,
+        trace_id: str = "",
+        practice_id: str | None = None,
+        episode_id: str | None = None,
+        receipt_id: str | None = None,
+        robot_id: str = "",
+        body_id: str = "",
+        task_id: str = "",
+        skill_id: str = "",
+        confidence: float | None = None,
+    ) -> str | None:
+        """Append one usage event; returns the event id, None on failure."""
+        try:
+            event_id = f"use_{uuid.uuid4().hex[:16]}"
+            self._store.insert(
+                TABLE,
+                {
+                    "id": event_id,
+                    "usage_id": f"{reference_pack_id}:{knowledge_unit_id}",
+                    "reference_pack_id": reference_pack_id,
+                    "knowledge_unit_id": knowledge_unit_id,
+                    "advice_id": advice_id,
+                    "trace_id": trace_id,
+                    "practice_id": practice_id,
+                    "episode_id": episode_id,
+                    "receipt_id": receipt_id,
+                    "robot_id": robot_id,
+                    "body_id": body_id,
+                    "task_id": task_id,
+                    "skill_id": skill_id,
+                    "verdict": verdict,
+                    "confidence": confidence,
+                    "created_at": time.time(),
+                },
+            )
+            return event_id
+        except Exception as exc:  # noqa: BLE001 — observation never breaks execution
+            logger.info("knowledge usage ledger write failed (non-fatal): %s", exc)
+            return None
+
+    # -- read (§32.2 aggregation) -------------------------------------------
+
+    def aggregate(self, knowledge_unit_id: str | None = None) -> dict[str, dict[str, Any]]:
+        """Per-unit counters (§32.2).
+
+        presented/used come from the pack/advice stages; useful/unknown
+        from outcome verdicts; verified_success/failure count outcomes by
+        task result (useful ⇒ verified success, unknown ⇒ unverified).
+        """
+        filters = {"knowledge_unit_id": knowledge_unit_id} if knowledge_unit_id else {}
+        try:
+            rows = self._store.query(TABLE, filters, limit=500_000)
+        except Exception as exc:  # noqa: BLE001
+            logger.info("knowledge usage aggregate failed: %s", exc)
+            return {}
+        out: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            unit = row.get("knowledge_unit_id") or "unknown_unit"
+            entry = out.setdefault(unit, dict.fromkeys(_AGGREGATE_KEYS, 0))
+            verdict = row.get("verdict")
+            if verdict == VERDICT_PRESENTED:
+                entry["presented_count"] += 1
+            elif verdict == VERDICT_USED:
+                entry["used_count"] += 1
+            elif verdict == VERDICT_USEFUL:
+                entry["useful_count"] += 1
+                entry["verified_success_count"] += 1
+            elif verdict == VERDICT_UNKNOWN:
+                entry["unknown_count"] += 1
+            elif verdict == VERDICT_INCOMPATIBLE:
+                entry["incompatible_count"] += 1
+                entry["verified_failure_count"] += 1
+            elif verdict == VERDICT_STALE:
+                entry["stale_count"] += 1
+            elif verdict == VERDICT_MISLEADING:
+                entry["misleading_count"] += 1
+                entry["verified_failure_count"] += 1
+        return out

--- a/src/rosclaw/knowledge/usage_tracker.py
+++ b/src/rosclaw/knowledge/usage_tracker.py
@@ -44,11 +44,15 @@ class KnowledgeUsageTracker:
         *,
         ttl_s: float = 3600.0,
         max_tracked: int = 1000,
+        usage_ledger: Any = None,
     ) -> None:
         self._bus = event_bus
         self._facade = facade
         self._ttl_s = ttl_s
         self._max_tracked = max_tracked
+        # PR-DF-21 (phase-II §32): durable usage observation.  None keeps
+        # the DF-10 in-memory-only behavior (no data plane present).
+        self._ledger = usage_ledger
         self._open: dict[str, dict[str, Any]] = {}
         self._subscribed = False
 
@@ -88,7 +92,24 @@ class KnowledgeUsageTracker:
             "knowledge_unit_ids": list(payload.get("knowledge_unit_ids") or []),
             "advice_id": None,
             "created_at": time.time(),
+            "trace_id": str(payload.get("trace_id") or getattr(event, "trace_id", "") or ""),
+            "robot_id": str(payload.get("robot_id") or ""),
+            "body_id": str(payload.get("body_id") or ""),
+            "task_id": str(payload.get("task_id") or ""),
+            "skill_id": str(payload.get("skill_id") or ""),
         }
+        if self._ledger is not None:
+            for unit_id in self._open[pack_id]["knowledge_unit_ids"] or ["unknown_unit"]:
+                self._ledger.record(
+                    "presented",
+                    reference_pack_id=pack_id,
+                    knowledge_unit_id=unit_id,
+                    trace_id=self._open[pack_id]["trace_id"],
+                    robot_id=self._open[pack_id]["robot_id"],
+                    body_id=self._open[pack_id]["body_id"],
+                    task_id=self._open[pack_id]["task_id"],
+                    skill_id=self._open[pack_id]["skill_id"],
+                )
 
     def _on_advice(self, event: Any) -> None:
         payload = getattr(event, "payload", None)
@@ -98,6 +119,20 @@ class KnowledgeUsageTracker:
         advice_id = payload.get("advice_id")
         if pack_id and pack_id in self._open and advice_id:
             self._open[pack_id]["advice_id"] = advice_id
+            usage = self._open[pack_id]
+            if self._ledger is not None:
+                for unit_id in usage["knowledge_unit_ids"] or ["unknown_unit"]:
+                    self._ledger.record(
+                        "used",
+                        reference_pack_id=pack_id,
+                        knowledge_unit_id=unit_id,
+                        advice_id=advice_id,
+                        trace_id=usage["trace_id"],
+                        robot_id=usage["robot_id"],
+                        body_id=usage["body_id"],
+                        task_id=usage["task_id"],
+                        skill_id=usage["skill_id"],
+                    )
 
     # -- feedback ---------------------------------------------------------
 
@@ -117,6 +152,20 @@ class KnowledgeUsageTracker:
             unit_ids = usage["knowledge_unit_ids"] or ["unknown_unit"]
             for unit_id in unit_ids:
                 self._submit(usage, unit_id, verdict, episode_id, practice_id)
+                if self._ledger is not None:
+                    self._ledger.record(
+                        verdict,
+                        reference_pack_id=pack_id,
+                        knowledge_unit_id=unit_id,
+                        advice_id=usage.get("advice_id"),
+                        trace_id=usage["trace_id"],
+                        practice_id=practice_id,
+                        episode_id=episode_id,
+                        robot_id=usage["robot_id"],
+                        body_id=usage["body_id"],
+                        task_id=usage["task_id"],
+                        skill_id=usage["skill_id"],
+                    )
             del self._open[pack_id]
 
     def _submit(

--- a/src/rosclaw/memory/seekdb_client.py
+++ b/src/rosclaw/memory/seekdb_client.py
@@ -530,6 +530,30 @@ ROSCLAW_STRUCTURED_SCHEMAS: dict[str, Any] = {
         },
         "indices": ["practice_id", "status", "created_at"],
     },
+    # Knowledge usage ledger (PR-DF-21, phase-II §32.1): durable observation
+    # of ReferencePack/Advice usage and conservative verdicts.  Observation
+    # only — NO ranking formula consumes this yet (§32.3).
+    "knowledge_usage_events": {
+        "columns": {
+            "id": "TEXT PRIMARY KEY",
+            "usage_id": "TEXT",
+            "reference_pack_id": "TEXT",
+            "knowledge_unit_id": "TEXT",
+            "advice_id": "TEXT",
+            "trace_id": "TEXT",
+            "practice_id": "TEXT",
+            "episode_id": "TEXT",
+            "receipt_id": "TEXT",
+            "robot_id": "TEXT",
+            "body_id": "TEXT",
+            "task_id": "TEXT",
+            "skill_id": "TEXT",
+            "verdict": "TEXT",
+            "confidence": "REAL",
+            "created_at": "REAL",
+        },
+        "indices": ["knowledge_unit_id", "reference_pack_id", "verdict", "created_at"],
+    },
     # Execution receipts (PR-DF-14, flywheel §21): the data-plane projection
     # of kernel ExecutionReceipts.  rosclawd's own ledgers stay authoritative
     # — this table is an async index, never consulted for authorization.

--- a/src/rosclaw/storage/cli.py
+++ b/src/rosclaw/storage/cli.py
@@ -1530,8 +1530,45 @@ def cmd_data_reconcile(args: argparse.Namespace) -> int:
     return 1 if failed else 0
 
 
+@_with_stdout_flush
+def cmd_data_usage(args: argparse.Namespace) -> int:
+    """Per-Knowledge-Unit usage aggregation (DF-21 §32.2 — observation only)."""
+    cfg = _load_storage_config(args)
+    try:
+        client = _create_client(cfg)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[rosclaw data usage] Failed to create backend: {exc}", file=sys.stderr)
+        return 1
+    try:
+        from rosclaw.knowledge.usage_ledger import KnowledgeUsageLedger
+
+        report = KnowledgeUsageLedger(client).aggregate(
+            getattr(args, "unit", None) or None
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[rosclaw data usage] aggregate failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        _close_client(client)
+
+    if getattr(args, "json", False):
+        print(json.dumps(report, indent=2))
+    else:
+        if not report:
+            print("no knowledge usage events recorded")
+        for unit, counts in sorted(report.items()):
+            print(
+                f"{unit}: presented={counts['presented_count']} used={counts['used_count']} "
+                f"useful={counts['useful_count']} unknown={counts['unknown_count']} "
+                f"stale={counts['stale_count']} incompatible={counts['incompatible_count']} "
+                f"misleading={counts['misleading_count']} "
+                f"verified+={counts['verified_success_count']} verified-={counts['verified_failure_count']}"
+            )
+    return 0
+
+
 def add_data_subparser(subparsers: Any) -> Any:
-    """Add ``rosclaw data`` subcommands (PR-DF-17/DF-19)."""
+    """Add ``rosclaw data`` subcommands (PR-DF-17/DF-19/DF-21)."""
     data_parser = subparsers.add_parser("data", help="Data flywheel queries")
     data_subparsers = data_parser.add_subparsers(dest="data_command")
 
@@ -1569,6 +1606,15 @@ def add_data_subparser(subparsers: Any) -> Any:
     reconcile_parser.add_argument("--backend", default=None, help="Override backend")
     reconcile_parser.add_argument("--url", default=None, help="Override SQL URL")
     reconcile_parser.add_argument("--path", default=None, help="Override SQLite path")
+
+    usage_parser = data_subparsers.add_parser(
+        "usage", help="Per-Knowledge-Unit usage aggregation (DF-21, observation only)"
+    )
+    usage_parser.add_argument("--unit", default=None, help="Filter to one knowledge_unit_id")
+    usage_parser.add_argument("--json", action="store_true", help="Output JSON")
+    usage_parser.add_argument("--backend", default=None, help="Override backend")
+    usage_parser.add_argument("--url", default=None, help="Override SQL URL")
+    usage_parser.add_argument("--path", default=None, help="Override SQLite path")
     return data_parser
 
 

--- a/tests/knowledge/test_usage_ledger.py
+++ b/tests/knowledge/test_usage_ledger.py
@@ -1,0 +1,121 @@
+"""PR-DF-21 (phase-II §32): Knowledge Usage Ledger — observe before ranking."""
+
+from __future__ import annotations
+
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.knowledge.usage_ledger import KnowledgeUsageLedger
+from rosclaw.knowledge.usage_tracker import KnowledgeUsageTracker
+from rosclaw.memory.seekdb_client import InMemoryStructuredStore, SQLiteStructuredStore
+
+
+def _store():
+    s = InMemoryStructuredStore()
+    s.connect()
+    return s
+
+
+def test_schema_in_structured_store(tmp_path):
+    store = SQLiteStructuredStore(str(tmp_path / "k.sqlite"))
+    store.connect()
+    store.insert(
+        "knowledge_usage_events",
+        {"id": "use_1", "knowledge_unit_id": "ku_1", "verdict": "useful"},
+    )
+    assert store.count("knowledge_usage_events", {}) == 1
+    store.disconnect()
+
+
+def test_ledger_record_and_aggregate():
+    store = _store()
+    ledger = KnowledgeUsageLedger(store)
+    ledger.record("presented", reference_pack_id="rp_1", knowledge_unit_id="ku_a")
+    ledger.record("used", reference_pack_id="rp_1", knowledge_unit_id="ku_a", advice_id="adv_1")
+    ledger.record("useful", reference_pack_id="rp_1", knowledge_unit_id="ku_a", episode_id="ep_1")
+    ledger.record("unknown", reference_pack_id="rp_2", knowledge_unit_id="ku_a")
+    ledger.record("misleading", reference_pack_id="rp_3", knowledge_unit_id="ku_b")
+    ledger.record("incompatible", reference_pack_id="rp_4", knowledge_unit_id="ku_b")
+
+    agg = ledger.aggregate()
+    assert agg["ku_a"]["presented_count"] == 1
+    assert agg["ku_a"]["used_count"] == 1
+    assert agg["ku_a"]["useful_count"] == 1
+    assert agg["ku_a"]["unknown_count"] == 1
+    assert agg["ku_a"]["verified_success_count"] == 1
+    assert agg["ku_a"]["verified_failure_count"] == 0
+    assert agg["ku_b"]["misleading_count"] == 1
+    assert agg["ku_b"]["incompatible_count"] == 1
+    assert agg["ku_b"]["verified_failure_count"] == 2
+
+    only_a = ledger.aggregate("ku_a")
+    assert set(only_a) == {"ku_a"}
+
+
+def test_ledger_write_never_breaks_on_dead_store():
+    class _Dead:
+        def insert(self, *a, **k):
+            raise ConnectionError("down")
+
+        def query(self, *a, **k):
+            raise ConnectionError("down")
+
+    ledger = KnowledgeUsageLedger(_Dead())
+    assert ledger.record("presented", knowledge_unit_id="ku_x") is None
+    assert ledger.aggregate() == {}
+
+
+def test_tracker_records_all_stages():
+    store = _store()
+    bus = EventBus()
+    tracker = KnowledgeUsageTracker(bus, facade=None, usage_ledger=KnowledgeUsageLedger(store))
+    tracker.subscribe()
+
+    bus.publish(
+        Event(
+            topic="know.reference_pack.created",
+            payload={
+                "reference_pack_id": "rp_1",
+                "knowledge_unit_ids": ["ku_a", "ku_b"],
+                "robot_id": "rh56",
+                "task_id": "slide",
+            },
+        )
+    )
+    bus.publish(
+        Event(
+            topic="how.advice.created",
+            payload={"reference_pack_id": "rp_1", "advice_id": "adv_1"},
+        )
+    )
+    bus.publish(
+        Event(
+            topic="rosclaw.critic.judgment",
+            payload={"status": "SUCCESS", "episode_id": "ep_1", "practice_id": "prac_1"},
+        )
+    )
+
+    rows = store.query("knowledge_usage_events", {})
+    verdicts = sorted(r["verdict"] for r in rows)
+    assert verdicts == ["presented", "presented", "used", "used", "useful", "useful"]
+    agg = KnowledgeUsageLedger(store).aggregate()
+    assert agg["ku_a"]["useful_count"] == 1
+    assert agg["ku_a"]["verified_success_count"] == 1
+    row = rows[0]
+    assert row["robot_id"] == "rh56"
+    assert row["task_id"] == "slide"
+    outcome_row = [r for r in rows if r["verdict"] == "useful"][0]
+    assert outcome_row["episode_id"] == "ep_1"
+    assert outcome_row["practice_id"] == "prac_1"
+    assert outcome_row["advice_id"] == "adv_1"
+
+
+def test_tracker_without_ledger_keeps_df10_behavior():
+    bus = EventBus()
+    tracker = KnowledgeUsageTracker(bus, facade=None)  # no ledger
+    tracker.subscribe()
+    bus.publish(
+        Event(
+            topic="know.reference_pack.created",
+            payload={"reference_pack_id": "rp_x", "knowledge_unit_ids": ["ku_x"]},
+        )
+    )
+    assert tracker.tracked_count == 1


### PR DESCRIPTION
## Summary

Phase-II §32: durable observation of knowledge utility — **before** any ranking formula (§32.3 explicitly defers `semantic relevance × evidence quality × body applicability × freshness × historical utility` until there's data).

- **`knowledge_usage_events` table** (§32.1): pack/unit/advice ids, trace/practice/episode/receipt refs, robot/body/task/skill context, verdict, confidence.
- **`KnowledgeUsageLedger`** — append-only record + §32.2 per-unit aggregation (presented/used/useful/unknown/incompatible/stale/misleading + verified success/failure); best-effort writes never break execution (dead-store test).
- **`KnowledgeUsageTracker`** records presented/used/verdict stages when a data plane is present; `None` keeps DF-10 in-memory behavior. Runtime wires the ledger from `data_plane.structured_store`.
- **CLI**: `rosclaw data usage [--unit ID] [--json]`.

## Tests

5 new (schema on real SQLite, record+aggregate, dead-store never-breaks, full tracker stages → rows with context, no-ledger compat). Affected suites (knowledge/storage/core): **295 passed**. `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
