### PR TITLE
DF-22: Memory Insight 2.0 — dead-end guard, skill trends, harmful patterns

### DIFF
--- a/docs/reports/data-flywheel-phase2/DF-22-insight-2.md
+++ b/docs/reports/data-flywheel-phase2/DF-22-insight-2.md
@@ -1,0 +1,48 @@
+# DF-22 — Memory Insight 2.0 (implementation note)
+
+Phase-II P1 per `seekdb优化v2.md` §33.
+
+## What landed
+
+### Detectors (MemoryInsightService)
+
+- **`known_dead_end_revisited`** (the endorsed one): subscribes to
+  `rosclaw.auto.proposal.created`, matches the hypothesis against
+  registered DeadEnds (token Jaccard over direction+rejection_reason,
+  CJK bigrams included, +0.2 skill-name boost, ≥0.5 to fire).  Carries
+  `recommended_action`: **skip** (≥0.8) / **narrow_search** (≥0.5),
+  `dead_end_refs`, `similarity`, plus a `derived_from` lineage edge to
+  the dead_end entity.
+- **`skill_regression` / `skill_improvement`**: rolling 20-outcome
+  window per skill; regression when the first half ≥0.6 and the recent
+  half ≤0.3 (improvement mirrors).
+- **`harmful_recovery_pattern`**: a proven fix exists yet failures
+  reach 2× the threshold — the fix is not working; emitted as an
+  escalation AFTER the patch hint (dedup is per type; the test pins
+  ordering).
+
+### Auto side — Evolution stops re-hitting the wall
+
+- `AutoEngine.apply_dead_end_guard(proposal_id, insight)`: skip →
+  status `rejected`; narrow_search → `dead_end_narrow_review` gate;
+  otherwise `dead_end_stronger_evidence` gate.  The guard (insight id,
+  refs, similarity) is recorded on the proposal so the evaluation path
+  can see WHY.
+- `AutoSubscriber._on_memory_insight` dispatches the new type to the
+  guard instead of minting yet another proposal.
+
+### Bug found by the full-loop test
+
+`AutoPublisher`'s events lost their subclass fields on the bus:
+`EventEnvelope.to_dict()` only serializes envelope fields, so
+`proposal_id` / `hypothesis_statement` / `metrics` / `direction`
+arrived as an empty `payload`.  All three publishers now fill the
+payload dict explicitly (additive, compat-safe).  The insight detector
+reads envelope fields + nested payload.
+
+## Tests — `tests/memory/v2/test_insights_2.py` (9)
+
+skip/narrow/no-emit tiers, lineage link, regression+improvement,
+harmful escalation ordering, guard actions (skip/narrow/stronger/
+missing), and the full bus loop proposal→insight→guard on the SAME
+proposal.  DF-11 + unit/auto suites: 147 passed, ruff/mypy clean.

--- a/src/rosclaw/auto/engine/auto_engine.py
+++ b/src/rosclaw/auto/engine/auto_engine.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import copy
+import logging
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -25,6 +26,8 @@ from ..events.publishers import AutoPublisher
 from ..promotion import ChampionStore, LineageTracker, PromotionGate, RollbackManager
 from ..runners import DarwinRunner, LocalRunner, SandboxRunner
 from ..storage import LocalStore
+
+logger = logging.getLogger("rosclaw.auto.engine")
 
 
 class AutoEngine:
@@ -294,6 +297,44 @@ class AutoEngine:
         if task:
             return [p for p in all_p if p.task == task]
         return all_p
+
+    def apply_dead_end_guard(self, proposal_id: str, insight: dict) -> bool:
+        """DF-22 (§33): react to known_dead_end_revisited.
+
+        skip → reject the proposal; narrow_search → gate it for a narrowed
+        review; anything else → require stronger evidence.  The guard is
+        recorded on the proposal so the evaluation path can see WHY.
+        """
+        data = self._load("proposals", proposal_id)
+        if not data:
+            return False
+        action = insight.get("recommended_action") or "stronger_evidence"
+        data["dead_end_guard"] = {
+            "insight_id": insight.get("insight_id", ""),
+            "action": action,
+            "dead_end_refs": insight.get("dead_end_refs", []),
+            "similarity": insight.get("similarity"),
+        }
+        if action == "skip":
+            data["status"] = "rejected"
+        else:
+            gate = (
+                "dead_end_narrow_review"
+                if action == "narrow_search"
+                else "dead_end_stronger_evidence"
+            )
+            gates = list(data.get("required_gates", []))
+            if gate not in gates:
+                gates.append(gate)
+            data["required_gates"] = gates
+        self._save("proposals", proposal_id, data)
+        logger.info(
+            "dead-end guard applied to proposal %s: %s (refs=%s)",
+            proposal_id,
+            action,
+            insight.get("dead_end_refs"),
+        )
+        return True
 
     # ------------------------------------------------------------------
     # Patch

--- a/src/rosclaw/auto/events/publishers.py
+++ b/src/rosclaw/auto/events/publishers.py
@@ -55,6 +55,15 @@ class AutoPublisher:
             task_id=task_id,
             target_skill_id=target_skill_id,
             hypothesis_statement=hypothesis_statement,
+            # The base EventEnvelope.to_dict() serializes only envelope
+            # fields — subclass fields must ALSO go into the payload dict
+            # or they are silently lost on the bus (DF-22 found this).
+            payload={
+                "proposal_id": proposal_id,
+                "task_id": task_id,
+                "target_skill_id": target_skill_id,
+                "hypothesis_statement": hypothesis_statement,
+            },
         )
         self._publish(event)
 
@@ -68,6 +77,13 @@ class AutoPublisher:
             task_id=task_id,
             level=level,
             metrics=metrics,
+            payload={
+                "champion_id": champion_id,
+                "skill_id": skill_id,
+                "task_id": task_id,
+                "level": level,
+                "metrics": metrics,
+            },
         )
         self._publish(event)
 
@@ -80,5 +96,11 @@ class AutoPublisher:
             task_id=task_id,
             direction=direction,
             rejection_reason=rejection_reason,
+            payload={
+                "deadend_id": deadend_id,
+                "task_id": task_id,
+                "direction": direction,
+                "rejection_reason": rejection_reason,
+            },
         )
         self._publish(event)

--- a/src/rosclaw/auto/events/subscribers.py
+++ b/src/rosclaw/auto/events/subscribers.py
@@ -196,6 +196,16 @@ class AutoSubscriber:
     def _on_memory_insight(self, event: Any) -> None:
         p = self._extract_payload(event)
         insight_type = p.get("insight_type", "")
+        if insight_type == "known_dead_end_revisited":
+            # DF-22: the proposal this insight points at gets guarded, not
+            # another proposal — skip / narrow / stronger evidence (§33).
+            applied = self.engine.apply_dead_end_guard(p.get("failure_id", ""), p)
+            logger.info(
+                "AutoSubscriber: dead-end guard on proposal %s applied=%s",
+                p.get("failure_id", ""),
+                applied,
+            )
+            return
         if insight_type != "similar_failure_with_patch":
             return
         task_id = p.get("task_id", "")

--- a/src/rosclaw/memory/insights.py
+++ b/src/rosclaw/memory/insights.py
@@ -1,4 +1,4 @@
-"""MemoryInsightService (PR-DF-11 / flywheel §25-27).
+"""MemoryInsightService (PR-DF-11 / flywheel §25-27; Insight 2.0 in PR-DF-22 / §33).
 
 The publisher half of ``rosclaw.memory.insight``: until now Auto subscribed
 to the topic and nothing ever published.  This service watches failure
@@ -11,6 +11,16 @@ failure type — only then does it publish a typed insight:
   recovery (a How rule with successes, or a successful intervention
   memory).  This is the exact payload Auto's subscriber turns into a
   memory-guided Proposal (§27).
+
+Insight 2.0 detectors (§33):
+* ``known_dead_end_revisited`` — a new proposal looks like a registered
+  DeadEnd (same task, high direction/hypothesis similarity).  Carries
+  ``recommended_action``: skip / narrow_search / stronger_evidence so
+  Evolution stops re-hitting the same wall instead of grinding again.
+* ``skill_regression`` / ``skill_improvement`` — a skill's rolling
+  outcome window turned against (or toward) success.
+* ``harmful_recovery_pattern`` — a "proven" fix exists yet failures
+  keep recurring well past the threshold: the fix is not working.
 
 Insights carry the canonical typed fields (§26): insight_id, insight_type,
 robot_id, body_id, task_id, skill_id, failure_type, evidence_refs,
@@ -33,6 +43,59 @@ from rosclaw.core.event_topics import EventTopics
 logger = logging.getLogger("rosclaw.memory.insights")
 
 _DEFAULT_COOLDOWN_S = 900.0
+
+_STOP_TOKENS = {
+    "the", "a", "an", "to", "of", "and", "or", "in", "on", "for", "with",
+    "by", "is", "be", "it", "this", "that", "from", "as", "at",
+}
+
+
+def _tokens(text: str) -> set[str]:
+    """Word tokens (latin) plus CJK bigrams for the dead-end similarity check."""
+    import re
+
+    out: set[str] = set()
+    for word in re.findall(r"[A-Za-z][A-Za-z0-9_+-]{1,}", text.lower()):
+        if word not in _STOP_TOKENS:
+            out.add(word)
+    cjk = re.findall(r"[一-鿿]+", text)
+    for chunk in cjk:
+        out.update(chunk[i : i + 2] for i in range(max(1, len(chunk) - 1)))
+    return out
+
+
+def _summaries(
+    insight_type: str, skill_id: str, failure_type: str, extra: dict[str, Any]
+) -> str:
+    if insight_type == "repeated_failure":
+        return (
+            f"failure '{failure_type}' recurred {extra.get('occurrences', 3)}x "
+            f"on skill '{skill_id}'"
+        )
+    if insight_type == "similar_failure_with_patch":
+        return f"failure '{failure_type}' on skill '{skill_id}' has a proven recovery"
+    if insight_type == "known_dead_end_revisited":
+        return (
+            f"proposal on skill '{skill_id}' resembles a known dead end "
+            f"({extra.get('dead_end_direction', '')}; recommended: "
+            f"{extra.get('recommended_action', 'skip')})"
+        )
+    if insight_type == "skill_regression":
+        return (
+            f"skill '{skill_id}' regressed: success "
+            f"{extra.get('previous_success_rate')} -> {extra.get('recent_success_rate')}"
+        )
+    if insight_type == "skill_improvement":
+        return (
+            f"skill '{skill_id}' improved: success "
+            f"{extra.get('previous_success_rate')} -> {extra.get('recent_success_rate')}"
+        )
+    if insight_type == "harmful_recovery_pattern":
+        return (
+            f"recovery pattern for '{failure_type}' on skill '{skill_id}' "
+            "is not working (failures persist past 2x threshold)"
+        )
+    return f"{insight_type} on skill '{skill_id}'"
 
 
 class MemoryInsightService:
@@ -59,6 +122,8 @@ class MemoryInsightService:
         self._lineage = lineage_repository
         self._counts: dict[tuple[str, str], int] = {}
         self._last_emitted: dict[tuple[str, str, str], float] = {}
+        # DF-22: rolling outcome windows for skill_regression/improvement
+        self._outcomes: dict[str, list[bool]] = {}
         self._subscribed = False
 
     # -- lifecycle ------------------------------------------------------
@@ -67,6 +132,7 @@ class MemoryInsightService:
         if self._bus is None or self._subscribed:
             return
         self._bus.subscribe(EventTopics.CRITIC_JUDGMENT, self._on_judgment)
+        self._bus.subscribe("rosclaw.auto.proposal.created", self._on_proposal_created)
         self._subscribed = True
         logger.info("MemoryInsightService subscribed")
 
@@ -74,6 +140,7 @@ class MemoryInsightService:
         if self._bus is None or not self._subscribed:
             return
         self._bus.unsubscribe(EventTopics.CRITIC_JUDGMENT, self._on_judgment)
+        self._bus.unsubscribe("rosclaw.auto.proposal.created", self._on_proposal_created)
         self._subscribed = False
 
     # -- observation ------------------------------------------------------
@@ -83,11 +150,19 @@ class MemoryInsightService:
         if not isinstance(payload, dict):
             return
         status = str(payload.get("status", "UNKNOWN"))
-        if status == "SUCCESS":
-            return
         context = payload.get("context", {}) if isinstance(payload.get("context"), dict) else {}
         outcome = context.get("outcome", {}) if isinstance(context.get("outcome"), dict) else {}
         skill_id = outcome.get("skill_name") or payload.get("skill_id") or "unknown"
+
+        # DF-22: rolling outcome window for skill_regression/improvement —
+        # tracked for SUCCESS and non-SUCCESS alike before the failure path.
+        window = self._outcomes.setdefault(skill_id, [])
+        window.append(status == "SUCCESS")
+        del window[:-20]
+        self._maybe_emit_skill_trend(skill_id, window, payload)
+
+        if status == "SUCCESS":
+            return
         failure_type = payload.get("reason") or payload.get("failure_type") or "unknown"
         task_id = payload.get("task_id") or context.get("instruction") or ""
         episode_id = payload.get("episode_id", "")
@@ -110,6 +185,27 @@ class MemoryInsightService:
         )
         fix = self._find_proven_fix(failure_type)
         if fix is not None:
+            if count >= self._threshold * 2:
+                # DF-22 harmful_recovery_pattern: a "proven" fix exists yet
+                # failures keep recurring well past the threshold — the fix
+                # is not actually working for this failure mode.
+                self._maybe_emit(
+                    "harmful_recovery_pattern",
+                    skill_id=skill_id,
+                    failure_type=failure_type,
+                    task_id=task_id,
+                    episode_id=episode_id,
+                    evidence_refs=evidence_refs + fix["evidence_refs"],
+                    extra={
+                        "occurrences": count,
+                        "memory_refs": fix["memory_refs"],
+                        "summary_hint": (
+                            f"recovery {fix['memory_refs']} did not stop "
+                            f"'{failure_type}' ({count}x)"
+                        ),
+                    },
+                )
+                return
             self._maybe_emit(
                 "similar_failure_with_patch",
                 skill_id=skill_id,
@@ -122,6 +218,114 @@ class MemoryInsightService:
                     "memory_refs": fix["memory_refs"],
                 },
             )
+
+    # -- DF-22 detectors ------------------------------------------------------
+
+    def _maybe_emit_skill_trend(
+        self, skill_id: str, window: list[bool], payload: dict[str, Any]
+    ) -> None:
+        """skill_regression / skill_improvement from the rolling window."""
+        if len(window) < 10:
+            return
+        first = window[: len(window) // 2]
+        second = window[len(window) // 2 :]
+        first_rate = sum(first) / len(first)
+        second_rate = sum(second) / len(second)
+        episode_id = payload.get("episode_id", "")
+        evidence_refs = [f"critic_result:{episode_id}"] if episode_id else []
+        if first_rate >= 0.6 and second_rate <= 0.3:
+            self._maybe_emit(
+                "skill_regression",
+                skill_id=skill_id,
+                failure_type="skill_regression",
+                task_id=payload.get("task_id", ""),
+                episode_id=episode_id,
+                evidence_refs=evidence_refs,
+                extra={
+                    "window": len(window),
+                    "previous_success_rate": round(first_rate, 3),
+                    "recent_success_rate": round(second_rate, 3),
+                },
+            )
+        elif first_rate <= 0.3 and second_rate >= 0.6:
+            self._maybe_emit(
+                "skill_improvement",
+                skill_id=skill_id,
+                failure_type="skill_improvement",
+                task_id=payload.get("task_id", ""),
+                episode_id=episode_id,
+                evidence_refs=evidence_refs,
+                extra={
+                    "window": len(window),
+                    "previous_success_rate": round(first_rate, 3),
+                    "recent_success_rate": round(second_rate, 3),
+                },
+            )
+
+    def _on_proposal_created(self, event: Any) -> None:
+        """known_dead_end_revisited (§33): don't re-hit a registered wall."""
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            return
+        # AutoProposalCreatedEvent publishes envelope fields at top level and
+        # the proposal specifics in the nested payload dict — read both.
+        details = {**payload, **(payload.get("payload") or {})}
+        hit = self._find_similar_dead_end(
+            str(details.get("task_id") or ""),
+            str(details.get("hypothesis_statement") or ""),
+            str(details.get("target_skill_id") or ""),
+        )
+        if hit is None:
+            return
+        dead_end, similarity = hit
+        action = "skip" if similarity >= 0.8 else "narrow_search"
+        proposal_id = str(details.get("proposal_id") or "")
+        self._maybe_emit(
+            "known_dead_end_revisited",
+            skill_id=str(details.get("target_skill_id") or "unknown"),
+            failure_type="known_dead_end_revisited",
+            task_id=str(details.get("task_id") or ""),
+            episode_id=proposal_id,
+            evidence_refs=[f"dead_end:{dead_end.get('id', '')}"],
+            extra={
+                "dead_end_refs": [dead_end.get("id", "")],
+                "recommended_action": action,
+                "similarity": round(similarity, 3),
+                "dead_end_direction": dead_end.get("direction", ""),
+            },
+        )
+
+    def _find_similar_dead_end(
+        self, task_id: str, hypothesis: str, skill_id: str
+    ) -> tuple[dict[str, Any], float] | None:
+        """Best dead-end match over (direction + rejection_reason) tokens."""
+        if self._store is None or not hypothesis:
+            return None
+        try:
+            dead_ends = list(self._store.query("dead_ends", {}, limit=100_000))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("dead_end lookup failed: %s", exc)
+            return None
+        hyp_tokens = _tokens(hypothesis)
+        if not hyp_tokens:
+            return None
+        best: tuple[dict[str, Any], float] | None = None
+        for dead_end in dead_ends:
+            if task_id and dead_end.get("task_id") not in (None, "", task_id):
+                continue
+            ref_tokens = _tokens(
+                f"{dead_end.get('direction', '')} {dead_end.get('rejection_reason', '')}"
+            )
+            if not ref_tokens:
+                continue
+            jaccard = len(hyp_tokens & ref_tokens) / len(hyp_tokens | ref_tokens)
+            if skill_id and skill_id in str(dead_end.get("direction", "")):
+                jaccard = min(1.0, jaccard + 0.2)
+            if best is None or jaccard > best[1]:
+                best = (dead_end, jaccard)
+        if best is not None and best[1] >= 0.5:
+            return best
+        return None
 
     # -- insight emission ---------------------------------------------------
 
@@ -186,11 +390,11 @@ class MemoryInsightService:
             return
         self._last_emitted[dedup_key] = now
         search_space = extra.get("search_space", {})
-        summary = (
-            f"failure '{failure_type}' recurred {extra.get('occurrences', self._threshold)}x "
-            f"on skill '{skill_id}'"
-            if insight_type == "repeated_failure"
-            else f"failure '{failure_type}' on skill '{skill_id}' has a proven recovery"
+        summary = extra.get("summary_hint") or _summaries(insight_type, skill_id, failure_type, extra)
+        confidence = (
+            0.8
+            if insight_type in ("similar_failure_with_patch", "known_dead_end_revisited")
+            else 0.5
         )
         insight = {
             # canonical typed fields (§26)
@@ -203,8 +407,12 @@ class MemoryInsightService:
             "evidence_refs": evidence_refs,
             "memory_refs": extra.get("memory_refs", []),
             "recommended_search_space": search_space,
-            "confidence": 0.8 if insight_type == "similar_failure_with_patch" else 0.5,
+            "confidence": confidence,
             "created_at": now,
+            # DF-22 extension fields (absent for the DF-11 types)
+            "dead_end_refs": extra.get("dead_end_refs", []),
+            "recommended_action": extra.get("recommended_action", ""),
+            "similarity": extra.get("similarity"),
             # field names Auto's subscriber consumes today
             "insight_summary": summary,
             "search_space": search_space,
@@ -224,6 +432,24 @@ class MemoryInsightService:
         except Exception as exc:  # noqa: BLE001
             logger.info("insight publish failed (non-fatal): %s", exc)
         self._link_sources(insight["insight_id"], insight["memory_refs"])
+        for dead_end_ref in insight["dead_end_refs"]:
+            self._link_typed(insight["insight_id"], "dead_end", str(dead_end_ref))
+
+    def _link_typed(self, insight_id: str, entity_type: str, entity_id: str) -> None:
+        if self._lineage is None or not entity_id:
+            return
+        from rosclaw.storage.lineage_types import LineageEntityType, LineageRelation
+
+        try:
+            self._lineage.link(
+                str(LineageEntityType.MEMORY_INSIGHT),
+                insight_id,
+                str(LineageRelation.DERIVED_FROM),
+                entity_type,
+                entity_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("insight lineage link failed (non-fatal): %s", exc)
 
     def _link_sources(self, insight_id: str, memory_refs: list[str]) -> None:
         """MemoryInsight --derived_from--> each contributing memory (§10)."""

--- a/tests/memory/v2/test_insights_2.py
+++ b/tests/memory/v2/test_insights_2.py
@@ -1,0 +1,328 @@
+"""PR-DF-22 (phase-II §33): Memory Insight 2.0.
+
+known_dead_end_revisited (proposal → similar DeadEnd → guard),
+skill_regression / skill_improvement (rolling outcome windows),
+harmful_recovery_pattern (proven fix that isn't working).
+"""
+
+from __future__ import annotations
+
+import time
+
+from rosclaw.auto.config import AutoConfig
+from rosclaw.auto.engine.auto_engine import AutoEngine
+from rosclaw.auto.events.subscribers import AutoSubscriber
+from rosclaw.core.event_bus import Event, EventBus
+from rosclaw.core.event_topics import EventTopics
+from rosclaw.memory.insights import MemoryInsightService
+from rosclaw.memory.seekdb_client import InMemoryStructuredStore
+from rosclaw.storage.lineage import LineageRepository
+
+PROPOSAL_TOPIC = "rosclaw.auto.proposal.created"
+
+
+def _store():
+    s = InMemoryStructuredStore()
+    s.connect()
+    return s
+
+
+def _service(bus, store, lineage=None, cooldown=0.0):
+    return MemoryInsightService(
+        bus, store, robot_id="rh56", cooldown_s=cooldown, lineage_repository=lineage
+    )
+
+
+def _judgment(bus, skill, status, failure="force overshoot", episode="ep_1"):
+    bus.publish(
+        Event(
+            topic=EventTopics.CRITIC_JUDGMENT,
+            payload={
+                "status": status,
+                "skill_id": skill,
+                "reason": failure,
+                "episode_id": episode,
+            },
+        )
+    )
+
+
+def _collect(bus):
+    seen: list[dict] = []
+    bus.subscribe(EventTopics.MEMORY_INSIGHT_CREATED, lambda e: seen.append(e.payload))
+    return seen
+
+
+# -- known_dead_end_revisited -------------------------------------------------
+
+
+def test_dead_end_revisited_skip_at_high_similarity():
+    store = _store()
+    store.insert(
+        "dead_ends",
+        {
+            "id": "de_1",
+            "task_id": "slide puck",
+            "direction": "raise force collisions",
+            "rejection_reason": "",
+            "registered_at": time.time(),
+        },
+    )
+    bus = EventBus()
+    svc = _service(bus, store)
+    svc.subscribe()
+    seen = _collect(bus)
+
+    bus.publish(
+        Event(
+            topic=PROPOSAL_TOPIC,
+            payload={
+                "proposal_id": "prop_1",
+                "task_id": "slide puck",
+                "target_skill_id": "slide",
+                "hypothesis_statement": "raise force collisions",
+            },
+        )
+    )
+    assert len(seen) == 1
+    ins = seen[0]
+    assert ins["insight_type"] == "known_dead_end_revisited"
+    assert ins["recommended_action"] == "skip"
+    assert ins["dead_end_refs"] == ["de_1"]
+    assert ins["similarity"] >= 0.8
+    assert ins["failure_id"] == "prop_1"
+
+
+def test_dead_end_revisited_narrow_at_mid_similarity():
+    store = _store()
+    store.insert(
+        "dead_ends",
+        {
+            "id": "de_2",
+            "task_id": "slide puck",
+            "direction": "increase force",
+            "rejection_reason": "collisions",
+            "registered_at": time.time(),
+        },
+    )
+    bus = EventBus()
+    svc = _service(bus, store)
+    svc.subscribe()
+    seen = _collect(bus)
+
+    bus.publish(
+        Event(
+            topic=PROPOSAL_TOPIC,
+            payload={
+                "proposal_id": "prop_2",
+                "task_id": "slide puck",
+                "target_skill_id": "slide",
+                "hypothesis_statement": "increase force",
+            },
+        )
+    )
+    assert len(seen) == 1
+    assert seen[0]["recommended_action"] == "narrow_search"
+
+
+def test_no_insight_for_dissimilar_proposal():
+    store = _store()
+    store.insert(
+        "dead_ends",
+        {
+            "id": "de_3",
+            "task_id": "slide puck",
+            "direction": "raise force",
+            "rejection_reason": "collisions",
+            "registered_at": time.time(),
+        },
+    )
+    bus = EventBus()
+    svc = _service(bus, store)
+    svc.subscribe()
+    seen = _collect(bus)
+    bus.publish(
+        Event(
+            topic=PROPOSAL_TOPIC,
+            payload={
+                "proposal_id": "prop_3",
+                "task_id": "slide puck",
+                "target_skill_id": "slide",
+                "hypothesis_statement": "reduce inter-round cooldown interval",
+            },
+        )
+    )
+    assert seen == []
+
+
+def test_dead_end_insight_lineage_link():
+    store = _store()
+    lineage = LineageRepository(store)
+    store.insert(
+        "dead_ends",
+        {
+            "id": "de_4",
+            "task_id": "slide",
+            "direction": "raise force setpoint above 400",
+            "rejection_reason": "collisions",
+            "registered_at": time.time(),
+        },
+    )
+    bus = EventBus()
+    svc = _service(bus, store, lineage=lineage)
+    svc.subscribe()
+    seen = _collect(bus)
+    bus.publish(
+        Event(
+            topic=PROPOSAL_TOPIC,
+            payload={
+                "proposal_id": "prop_4",
+                "task_id": "slide",
+                "target_skill_id": "slide",
+                "hypothesis_statement": "raise force setpoint above 400",
+            },
+        )
+    )
+    assert seen
+    parents = lineage.parents("memory_insight", seen[0]["insight_id"])
+    assert any(p["to_type"] == "dead_end" and p["to_id"] == "de_4" for p in parents)
+
+
+# -- skill trend -----------------------------------------------------------------
+
+
+def test_skill_regression_and_improvement():
+    bus = EventBus()
+    svc = _service(bus, _store())
+    svc.subscribe()
+    seen = _collect(bus)
+
+    # regression: 6 successes then 4 failures (first-half 1.0 -> second-half 0.25)
+    for _ in range(6):
+        _judgment(bus, "slide", "SUCCESS")
+    for _ in range(4):
+        _judgment(bus, "slide", "FAILED")
+    regression = [s for s in seen if s["insight_type"] == "skill_regression"]
+    assert regression, "skill_regression not emitted"
+    assert regression[0]["skill_id"] == "slide"
+
+    # improvement: 6 failures then 4 successes on another skill
+    for _ in range(6):
+        _judgment(bus, "pour", "FAILED")
+    for _ in range(4):
+        _judgment(bus, "pour", "SUCCESS")
+    improvement = [s for s in seen if s["insight_type"] == "skill_improvement"]
+    assert improvement, "skill_improvement not emitted"
+
+
+# -- harmful recovery pattern -----------------------------------------------------
+
+
+def _seed_proven_rule(store):
+    store.insert(
+        "heuristic_rules",
+        {
+            "id": "rule_1",
+            "failure_type": "force overshoot",
+            "success_count": 5,
+            "parameter_patch": {"force": 250},
+        },
+    )
+
+
+def test_harmful_pattern_when_fix_not_working():
+    store = _store()
+    _seed_proven_rule(store)
+    bus = EventBus()
+    svc = _service(bus, store)
+    svc.subscribe()
+    seen = _collect(bus)
+    for i in range(6):  # 2x threshold(3)
+        _judgment(bus, "slide", "FAILED", episode=f"ep_{i}")
+    kinds = [s["insight_type"] for s in seen]
+    assert "harmful_recovery_pattern" in kinds
+    # the escalation doesn't retract the patch hint emitted at threshold —
+    # harmful is emitted at 2x threshold AFTER it (dedup is per type)
+    assert kinds.index("similar_failure_with_patch") < kinds.index(
+        "harmful_recovery_pattern"
+    )
+
+
+def test_patch_insight_below_harmful_threshold():
+    store = _store()
+    _seed_proven_rule(store)
+    bus = EventBus()
+    svc = _service(bus, store)
+    svc.subscribe()
+    seen = _collect(bus)
+    for i in range(3):  # exactly threshold
+        _judgment(bus, "slide", "FAILED", episode=f"ep_{i}")
+    kinds = {s["insight_type"] for s in seen}
+    assert "similar_failure_with_patch" in kinds
+    assert "harmful_recovery_pattern" not in kinds
+
+
+# -- Auto side: apply_dead_end_guard ----------------------------------------------
+
+
+def _engine(tmp_path, bus=None):
+    return AutoEngine(
+        config=AutoConfig(local_store_path=str(tmp_path / "auto")), event_bus=bus
+    )
+
+
+def test_apply_dead_end_guard_actions(tmp_path):
+    engine = _engine(tmp_path)
+    prop = engine.create_proposal("", "slide", "slide", "raise force", {"force": [400]})
+    insight = {
+        "insight_id": "ins_1",
+        "recommended_action": "skip",
+        "dead_end_refs": ["de_1"],
+        "similarity": 0.9,
+    }
+    assert engine.apply_dead_end_guard(prop.id, insight) is True
+    data = engine._load("proposals", prop.id)
+    assert data["status"] == "rejected"
+    assert data["dead_end_guard"]["dead_end_refs"] == ["de_1"]
+
+    prop2 = engine.create_proposal("", "slide", "slide", "raise force", {"force": [400]})
+    engine.apply_dead_end_guard(prop2.id, {**insight, "recommended_action": "narrow_search"})
+    data2 = engine._load("proposals", prop2.id)
+    assert "dead_end_narrow_review" in data2["required_gates"]
+
+    prop3 = engine.create_proposal("", "slide", "slide", "raise force", {"force": [400]})
+    engine.apply_dead_end_guard(prop3.id, {**insight, "recommended_action": ""})
+    data3 = engine._load("proposals", prop3.id)
+    assert "dead_end_stronger_evidence" in data3["required_gates"]
+
+    assert engine.apply_dead_end_guard("prop_missing", insight) is False
+
+
+def test_full_loop_proposal_to_guard(tmp_path):
+    """proposal.created -> insight -> subscriber guards the SAME proposal."""
+    store = _store()
+    bus = EventBus()
+    svc = _service(bus, store)
+    svc.subscribe()
+    engine = _engine(tmp_path, bus=bus)
+    subscriber = AutoSubscriber(engine=engine, event_bus=bus)
+    subscriber.subscribe_all()
+
+    store.insert(
+        "dead_ends",
+        {
+            "id": "de_9",
+            "task_id": "slide",
+            "direction": "raise force setpoint above 400",
+            "rejection_reason": "collisions",
+            "registered_at": time.time(),
+        },
+    )
+    prop = engine.create_proposal(
+        "", "slide", "slide", "raise force setpoint above 400", {"force": [400]}
+    )  # publishes rosclaw.auto.proposal.created via engine.publisher? (bus wired)
+
+    # engine.publisher only fires when AutoEngine got an event_bus — it did.
+    data = engine._load("proposals", prop.id)
+    assert data.get("dead_end_guard", {}).get("action") == "skip"
+    assert data["status"] == "rejected"


### PR DESCRIPTION
## Summary

Phase-II §33: expand insight detection beyond `repeated_failure` / `similar_failure_with_patch`.

- **`known_dead_end_revisited`** (the endorsed one): on `rosclaw.auto.proposal.created`, token/CJK-bigram similarity vs registered DeadEnds → insight with `recommended_action` **skip** (≥0.8) / **narrow_search** (≥0.5), `dead_end_refs`, and a `derived_from` lineage edge to the dead_end. Evolution reacts instead of re-hitting the wall: `AutoEngine.apply_dead_end_guard` — skip→reject, narrow→`dead_end_narrow_review` gate, else `dead_end_stronger_evidence` gate; `AutoSubscriber` dispatches.
- **`skill_regression` / `skill_improvement`** from rolling 20-outcome windows per skill.
- **`harmful_recovery_pattern`**: a proven fix exists yet failures reach 2× threshold — escalation emitted AFTER the patch hint (ordering pinned by test).
- **Bug fix (found by the full-loop test)**: `AutoPublisher` lost subclass fields on the bus — `EventEnvelope.to_dict()` serializes envelope fields only, so `proposal_id`/`hypothesis_statement`/`metrics`/`direction` arrived as empty `payload`. All three publishers now fill payload dicts (additive, compat-safe).

## Tests

9 new in `tests/memory/v2/test_insights_2.py` (action tiers, lineage, trends, harmful ordering, guard actions, full proposal→insight→guard loop). DF-11 + unit/auto suites: **147 passed**, ruff/mypy clean.

Implementation note: `docs/reports/data-flywheel-phase2/DF-22-insight-2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
