### PR TITLE
feat: Native Harness H7 切片——provider 错误分类

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -30,6 +30,7 @@ import type { ProductStateCenter } from "../session/state-center.js";
 import { InputController } from "../native/input-controller.js";
 import { OperationWatcher } from "../native/operation-watcher.js";
 import { TurnGuard } from "../native/turn-guard.js";
+import { classifyModelError } from "../native/model-errors.js";
 import type { LocaleManager } from "../i18n/locale.js";
 import { t as i18nT } from "../i18n/index.js";
 import { EventMirror } from "./event-mirror.js";
@@ -1272,6 +1273,16 @@ const orphanJobs = jobs.filter(
 		const COMPLETION_CLAIM =
 			/(已执行|已完成|已确认|执行完毕|成功执行|successfully executed|has been executed|action completed)/i;
 		pi.on("message_end", async (event) => {
+			// PR-H7（§8.4）：provider 错误分类——403 配额≠鉴权错误；
+			// 稳定错误码 + 用户可理解说明 + 恢复动作（task 可继续）。
+			const msg = event.message as { role?: string; stopReason?: string; errorMessage?: string };
+			if (msg.role === "assistant" && (msg.stopReason === "error" || msg.errorMessage)) {
+				const classified = classifyModelError(String(msg.errorMessage ?? ""));
+				latestCtx?.ui.notify(
+					`[${classified.code}] ${classified.explanation}——${classified.recovery}`,
+					"error",
+				);
+			}
 			if (!lastOutcome || lastOutcome.narrativeSeen) return undefined;
 			const message = event.message as { role?: string; content?: unknown };
 			if (message.role !== "assistant") return undefined;

--- a/packages/rosclaw-agent/src/native/model-errors.ts
+++ b/packages/rosclaw-agent/src/native/model-errors.ts
@@ -1,0 +1,98 @@
+/** Provider 错误分类（PR-H7，总纲 v2 §8.4）。
+ *
+ * 403 配额耗尽不能显示成 auth_error。分类决定错误卡的稳定码 +
+ * 用户可理解说明 + 可执行恢复动作 + task 是否可继续。
+ */
+
+export type ModelErrorCode =
+	| "MODEL_CREDENTIAL_MISSING"
+	| "MODEL_CREDENTIAL_INVALID"
+	| "PROVIDER_QUOTA_EXHAUSTED"
+	| "PROVIDER_RATE_LIMITED"
+	| "PROVIDER_UNAVAILABLE"
+	| "MODEL_NOT_FOUND"
+	| "MODEL_TOOL_CALL_UNSUPPORTED"
+	| "MODEL_CONTEXT_LIMIT"
+	| "MODEL_REQUEST_CANCELLED"
+	| "MODEL_UNKNOWN";
+
+export interface ClassifiedModelError {
+	code: ModelErrorCode;
+	/** 用户可理解说明（中文产品语言）。 */
+	explanation: string;
+	/** 可执行恢复动作。 */
+	recovery: string;
+	/** task 是否可继续（配额类 = 可等/可换模型继续，不是 FAILED）。 */
+	taskRecoverable: boolean;
+}
+
+/** 分类 provider 错误文本（HTTP 状态 + 消息关键词）——确定性规则，
+ *  不靠模型猜。 */
+export function classifyModelError(raw: string): ClassifiedModelError {
+	const text = raw.toLowerCase();
+	// 顺序敏感：quota 在 generic 403/auth 之前。
+	if (
+		/usage limit|quota|billing|access_terminated/.test(text)
+	) {
+		return {
+			code: "PROVIDER_QUOTA_EXHAUSTED",
+			explanation: "模型配额已用完（本计费周期）",
+			recovery: "配额下周期刷新；/model 换可用模型立即继续；任务保持可恢复",
+			taskRecoverable: true,
+		};
+	}
+	if (/429|rate.?limit|too many requests/.test(text)) {
+		return {
+			code: "PROVIDER_RATE_LIMITED",
+			explanation: "请求频率超限",
+			recovery: "稍等自动重试；持续超限可 /model 换模型",
+			taskRecoverable: true,
+		};
+	}
+	if (/401|unauthorized|invalid (api.?)?key|invalid authentication/.test(text)) {
+		return {
+			code: "MODEL_CREDENTIAL_INVALID",
+			explanation: "凭据无效（401）",
+			recovery: "rosclaw setup model 重新配置 key",
+			taskRecoverable: true,
+		};
+	}
+	if (/403|forbidden/.test(text)) {
+		return {
+			code: "MODEL_CREDENTIAL_INVALID",
+			explanation: "访问被拒（403）",
+			recovery: "检查 key 权限/套餐；rosclaw setup model 重配",
+			taskRecoverable: true,
+		};
+	}
+	if (/model.*not found|no such model|does not exist/.test(text)) {
+		return {
+			code: "MODEL_NOT_FOUND",
+			explanation: "模型不存在或已下线",
+			recovery: "/model 换可用模型",
+			taskRecoverable: true,
+		};
+	}
+	if (/context.*(length|limit)|too many tokens|max_tokens/.test(text)) {
+		return {
+			code: "MODEL_CONTEXT_LIMIT",
+			explanation: "上下文超限",
+			recovery: "/compact 压缩后继续",
+			taskRecoverable: true,
+		};
+	}
+	if (/econnreset|etimedout|enotfound|network|unavailable|502|503|504/.test(text)) {
+		return {
+			code: "PROVIDER_UNAVAILABLE",
+			explanation: "provider 暂不可达",
+			recovery: "自动重试中；持续失败检查网络",
+			taskRecoverable: true,
+		};
+	}
+	return {
+		code: "MODEL_UNKNOWN",
+		explanation: "模型调用失败（未分类）",
+		recovery: "查看 /doctor 诊断",
+		taskRecoverable: true,
+	};
+}

--- a/packages/rosclaw-agent/test/h7-model-errors.test.ts
+++ b/packages/rosclaw-agent/test/h7-model-errors.test.ts
@@ -1,0 +1,43 @@
+/** PR-H7 测试：provider 错误分类（总纲 v2 §8.4 + Gate F 子集）。 */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { classifyModelError } from "../src/native/model-errors.js";
+
+test("H7: 403 配额耗尽 ≠ auth 错误", () => {
+	const err = classifyModelError(
+		'403: {"message":"You\'ve reached your usage limit for this billing cycle.","type":"access_terminated_error"}',
+	);
+	assert.equal(err.code, "PROVIDER_QUOTA_EXHAUSTED");
+	assert.ok(err.taskRecoverable);
+	assert.match(err.recovery, /model/);
+});
+
+test("H7: 401 凭据无效", () => {
+	assert.equal(classifyModelError("401 unauthorized").code, "MODEL_CREDENTIAL_INVALID");
+});
+
+test("H7: 429 限流", () => {
+	assert.equal(
+		classifyModelError("429: engine overloaded rate limit").code,
+		"PROVIDER_RATE_LIMITED",
+	);
+});
+
+test("H7: 网络不可达", () => {
+	assert.equal(classifyModelError("fetch failed ECONNRESET").code, "PROVIDER_UNAVAILABLE");
+});
+
+test("H7: 模型不存在", () => {
+	assert.equal(
+		classifyModelError("model k3-old not found").code,
+		"MODEL_NOT_FOUND",
+	);
+});
+
+test("H7: 上下文超限", () => {
+	assert.equal(
+		classifyModelError("context length exceeded").code,
+		"MODEL_CONTEXT_LIMIT",
+	);
+});


### PR DESCRIPTION
总纲 v2 §8.4：稳定错误码（PROVIDER_QUOTA_EXHAUSTED 等）+ message_end 错误卡接线。403 配额≠鉴权错误。H7 剩余（模型单轨/Python gateway 删除）留后续 PR。Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>