### PR TITLE
feat: Native Harness H8——Task Activity/Logs/Artifacts 产品视图 + Pi 品牌清零

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -31,6 +31,12 @@ import { InputController } from "../native/input-controller.js";
 import { OperationWatcher } from "../native/operation-watcher.js";
 import { TurnGuard } from "../native/turn-guard.js";
 import { classifyModelError } from "../native/model-errors.js";
+import {
+	renderArtifactList,
+	renderOperationLogs,
+	renderTaskActivity,
+	type KernelEvent,
+} from "../native/task-activity.js";
 import type { LocaleManager } from "../i18n/locale.js";
 import { t as i18nT } from "../i18n/index.js";
 import { EventMirror } from "./event-mirror.js";
@@ -500,7 +506,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			},
 		});
 		pi.registerCommand("newtask", {
-			description: "开始新任务（当前任务保持可恢复）——/new 是 Pi 会话内建，冲突实测后取 /newtask",
+			description: "开始新任务（当前任务保持可恢复）",
 			handler: async (_args, ctx) => {
 				inputController.forceNewNext = true;
 				ctx.ui.notify("下一条消息将开始新任务", "info");
@@ -577,6 +583,92 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				} catch (err) {
 					ctx.ui.notify(`查询失败：${(err as Error).message}`, "error");
 				}
+			},
+		});
+
+		// -- PR-H8：Task Activity/Logs/Artifacts（数据全部来自 TaskKernel
+		//    事件流/产物账本，不经 LLM——假进度不可能） --------------------
+		const fetchTaskEvents = async (): Promise<KernelEvent[]> => {
+			if (!inputController.currentTaskId) return [];
+			const result = await center.call("pi.kernel.events", {
+				task_id: inputController.currentTaskId,
+				after_seq: 0,
+			});
+			return (result.events ?? []) as KernelEvent[];
+		};
+		pi.registerCommand("activity", {
+			description: "当前任务活动（阶段时间线——来自任务账本，非模型总结）",
+			handler: async (_args, ctx) => {
+				if (!inputController.currentTaskId) {
+					ctx.ui.notify("当前没有绑定任务", "warning");
+					return;
+				}
+				try {
+					const events = await fetchTaskEvents();
+					ctx.ui.notify(renderTaskActivity(events).join("\n"), "info");
+				} catch (err) {
+					ctx.ui.notify(`查询失败：${(err as Error).message}`, "error");
+				}
+			},
+		});
+		pi.registerCommand("logs", {
+			description: "当前任务后台进程输出（operation 日志尾部）",
+			handler: async (_args, ctx) => {
+				if (!inputController.currentTaskId) {
+					ctx.ui.notify("当前没有绑定任务", "warning");
+					return;
+				}
+				try {
+					const events = await fetchTaskEvents();
+					ctx.ui.notify(renderOperationLogs(events).join("\n"), "info");
+				} catch (err) {
+					ctx.ui.notify(`查询失败：${(err as Error).message}`, "error");
+				}
+			},
+		});
+		pi.registerCommand("artifacts", {
+			description: "当前任务交付物列表（登记才算交付）",
+			handler: async (_args, ctx) => {
+				if (!inputController.currentTaskId) {
+					ctx.ui.notify("当前没有绑定任务", "warning");
+					return;
+				}
+				try {
+					const result = await center.call("pi.kernel.artifacts", {
+						task_id: inputController.currentTaskId,
+					});
+					const artifacts = (result.artifacts ?? []) as Array<Record<string, unknown>>;
+					ctx.ui.notify(renderArtifactList(artifacts).join("\n"), "info");
+				} catch (err) {
+					ctx.ui.notify(`查询失败：${(err as Error).message}`, "error");
+				}
+			},
+		});
+		// Ctrl+T：Task Activity 常驻 widget 开关（turn_end 自动刷新——
+		// 内容不变不重绘由 setWidget 侧保证）。
+		let activityWidgetOn = false;
+		const refreshActivityWidget = async (): Promise<void> => {
+			if (!activityWidgetOn || !latestCtx?.hasUI) return;
+			if (!inputController.currentTaskId) {
+				latestCtx.ui.setWidget("rosclaw-activity", ["（当前没有绑定任务）"]);
+				return;
+			}
+			try {
+				const events = await fetchTaskEvents();
+				latestCtx.ui.setWidget("rosclaw-activity", renderTaskActivity(events));
+			} catch {
+				// 桥暂不可用——保留旧内容，下回合再刷。
+			}
+		};
+		pi.registerShortcut("ctrl+t", {
+			description: "打开/关闭任务活动视图",
+			handler: async (ctx) => {
+				activityWidgetOn = !activityWidgetOn;
+				if (!activityWidgetOn) {
+					ctx.ui.setWidget("rosclaw-activity", undefined);
+					return;
+				}
+				await refreshActivityWidget();
 			},
 		});
 
@@ -1302,6 +1394,8 @@ const orphanJobs = jobs.filter(
 		});
 		pi.on("turn_end", async () => {
 			await turnGuard.onTurnEnd();
+			// PR-H8：Task Activity widget 回合后自动刷新（开启时）。
+			await refreshActivityWidget();
 			if (lastOutcome?.conflictClaim) {
 				pi.appendEntry("rosclaw.action_conflict", {
 					claim: lastOutcome.conflictClaim,

--- a/packages/rosclaw-agent/src/native/task-activity.ts
+++ b/packages/rosclaw-agent/src/native/task-activity.ts
@@ -1,0 +1,142 @@
+/** Task Activity 渲染（PR-H8，总纲 v2 §20）——TUI 任务进度视图。
+ *
+ * 数据全部来自 TaskKernel 事件流/产物账本，不经 LLM 总结（假进度
+ * 不可能：模型说什么不影响这里显示什么）。
+ *
+ * - renderTaskActivity：阶段行（任务开始/修订/进程/产物/验收/终态）。
+ *   operation.output 不进 Activity——逐行输出归 /logs，否则刷屏。
+ * - renderOperationLogs：operation.output 尾部文本。
+ * - renderArtifactList：产物名/路径/大小/哈希短码；空 → 诚实空态。
+ */
+
+export interface KernelEvent {
+	seq: number;
+	event_type: string;
+	payload: Record<string, unknown>;
+}
+
+function short(id: unknown, head = 12): string {
+	return String(id ?? "").slice(0, head);
+}
+
+function firstLine(text: unknown, max = 60): string {
+	const line = String(text ?? "").split("\n")[0].trim();
+	return line.length > max ? `${line.slice(0, max)}…` : line;
+}
+
+/** kernel 事件 → 中文阶段行（按 seq 顺序）。 */
+export function renderTaskActivity(events: KernelEvent[]): string[] {
+	const sorted = [...events].sort((a, b) => a.seq - b.seq);
+	const lines: string[] = [];
+	for (const event of sorted) {
+		const p = event.payload;
+		switch (event.event_type) {
+			case "task.started":
+				lines.push(`▶ 任务开始：${firstLine(p.goal)}`);
+				break;
+			case "task.revised":
+				lines.push(
+					`✎ 修订 r${String(p.revision ?? "?")}：${firstLine(p.delta)}`,
+				);
+				break;
+			case "task.state_changed":
+				// 中间状态转换噪音大——只在非 ACTIVE 时提示。
+				if (String(p.to ?? "") !== "ACTIVE") {
+					lines.push(`… 状态：${String(p.from ?? "?")} → ${String(p.to ?? "?")}`);
+				}
+				break;
+			case "task.terminal":
+				lines.push(
+					`■ 终态：${String(p.state ?? "?")}`
+					+ (p.reason ? `（${firstLine(p.reason, 40)}）` : ""),
+				);
+				break;
+			case "operation.started": {
+				const argv = Array.isArray(p.argv) ? p.argv.join(" ") : "";
+				lines.push(
+					`▸ 进程启动 [${short(p.operation_id)}]：${firstLine(argv)}`,
+				);
+				break;
+			}
+			case "operation.completed":
+				lines.push(`✓ 进程完成 [${short(p.operation_id)}]`);
+				break;
+			case "operation.failed":
+				lines.push(
+					`✗ 进程失败 [${short(p.operation_id)}]`
+					+ (p.failure_code ? `（${String(p.failure_code)}）` : "")
+					+ (p.error ? `：${firstLine(p.error, 40)}` : ""),
+				);
+				break;
+			case "artifact.created":
+				lines.push(
+					`◆ 产物：${String(p.path ?? "").split("/").pop() ?? ""}`
+					+ `（${String(p.bytes ?? "?")} 字节）`,
+				);
+				break;
+			case "verification.completed": {
+				if (String(p.status) === "PASS") {
+					const checks = Array.isArray(p.checks) ? p.checks.length : 0;
+					lines.push(`✓ 验收通过（${checks} 项检查）`);
+				} else {
+					const failures = Array.isArray(p.failures) ? p.failures : [];
+					lines.push(
+						`✗ 验收未过：${failures.map((f) => firstLine(f, 40)).join("；")}`,
+					);
+				}
+				break;
+			}
+			default:
+				// 未知事件类型不上 Activity（output 等噪音归 /logs）。
+				break;
+		}
+	}
+	if (!lines.length) lines.push("（还没有任务活动）");
+	return lines;
+}
+
+/** operation.output 尾部渲染（/logs）。 */
+export function renderOperationLogs(
+	events: KernelEvent[],
+	limit = 40,
+): string[] {
+	const sorted = [...events].sort((a, b) => a.seq - b.seq);
+	const lines: string[] = [];
+	let currentOp = "";
+	for (const event of sorted) {
+		const p = event.payload;
+		if (event.event_type === "operation.started") {
+			currentOp = short(p.operation_id);
+			const argv = Array.isArray(p.argv) ? p.argv.join(" ") : "";
+			lines.push(`$ [${currentOp}] ${firstLine(argv, 80)}`);
+		} else if (event.event_type === "operation.output") {
+			for (const raw of String(p.text ?? "").split("\n")) {
+				if (raw.trim()) lines.push(`  [${currentOp}] ${raw}`);
+			}
+		} else if (
+			event.event_type === "operation.completed"
+			|| event.event_type === "operation.failed"
+		) {
+			lines.push(
+				`  [${short(p.operation_id)}] → ${String(p.state ?? "?")}`
+				+ (p.failure_code ? `（${String(p.failure_code)}）` : ""),
+			);
+		}
+	}
+	if (!lines.length) lines.push("（还没有后台进程输出）");
+	return lines.slice(-limit);
+}
+
+/** 产物账本渲染（/artifacts）。 */
+export function renderArtifactList(
+	artifacts: Array<Record<string, unknown>>,
+): string[] {
+	if (!artifacts.length) return ["（当前任务无产物登记）"];
+	return artifacts.map((a) => {
+		const name = String(a.path ?? "").split("/").pop() ?? "";
+		const size = Number(a.size_bytes ?? 0);
+		const sha = String(a.sha256 ?? "").slice(0, 7);
+		const media = String(a.media_type ?? "");
+		return `◆ ${name}  ${size} 字节  sha:${sha}  ${media}`.trimEnd();
+	});
+}

--- a/packages/rosclaw-agent/test/h8-tui.test.ts
+++ b/packages/rosclaw-agent/test/h8-tui.test.ts
@@ -1,0 +1,103 @@
+/** PR-H8 红测试（TS）：Task Activity/Logs/Artifacts 渲染 + 品牌扫描。
+ *
+ * 红测试先行——实现前必须红：
+ * 1. renderTaskActivity：kernel 事件 → 中文阶段行（task.started、
+ *    operation 系、artifact.created、verification.completed、
+ *    task.terminal）；operation.output 不进 Activity（太吵——归 /logs）。
+ * 2. renderOperationLogs：operation.output 尾部文本。
+ * 3. renderArtifactList：产物名/路径/大小/哈希短码；空 → 诚实空行。
+ * 4. 品牌扫描：extension 用户可见 description 不得出现 "Pi"（Gate A：
+ *    用户 UI 中 Pi 品牌出现次数为 0）。
+ */
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+	renderArtifactList,
+	renderOperationLogs,
+	renderTaskActivity,
+	type KernelEvent,
+} from "../src/native/task-activity.js";
+
+function ev(seq: number, event_type: string, payload: Record<string, unknown>): KernelEvent {
+	return { seq, event_type, payload };
+}
+
+test("H8: Activity 渲染阶段行（output 不进 Activity）", () => {
+	const lines = renderTaskActivity([
+		ev(1, "task.started", { goal: "画五角星" }),
+		ev(2, "operation.started", { operation_id: "op_1", kind: "process", argv: ["python3", "sim.py"] }),
+		ev(3, "operation.output", { text: "rendering...\n" }),
+		ev(4, "operation.completed", { operation_id: "op_1", state: "SUCCEEDED", failure_code: "" }),
+		ev(5, "artifact.created", { artifact_id: "art_1", path: "/ws/star.gif", bytes: 2048 }),
+		ev(6, "verification.completed", { verification_id: "vrf_1", status: "PASS", checks: [{}, {}] }),
+		ev(7, "task.terminal", { state: "SUCCEEDED", reason: "verification_passed" }),
+	]);
+	const joined = lines.join("\n");
+	assert.match(joined, /任务开始/);
+	assert.match(joined, /画五角星/);
+	assert.match(joined, /进程/);
+	assert.match(joined, /sim\.py/);
+	assert.match(joined, /star\.gif/);
+	assert.match(joined, /2048/);
+	assert.match(joined, /验收/);
+	assert.match(joined, /SUCCEEDED/);
+	// operation.output 不进 Activity（归 /logs——否则刷屏）。
+	assert.ok(!joined.includes("rendering..."), "output 不应进 Activity");
+});
+
+test("H8: 失败与修订也上 Activity", () => {
+	const lines = renderTaskActivity([
+		ev(1, "task.revised", { revision: 2, delta: "改成红色" }),
+		ev(2, "operation.failed", { operation_id: "op_9", state: "FAILED", failure_code: "exit_1" }),
+		ev(3, "verification.completed", { status: "FAIL", failures: ["缺少产物 star.gif"] }),
+	]);
+	const joined = lines.join("\n");
+	assert.match(joined, /修订|r2/);
+	assert.match(joined, /改成红色/);
+	assert.match(joined, /exit_1/);
+	assert.match(joined, /缺少产物/);
+});
+
+test("H8: Logs 渲染 operation.output 尾部", () => {
+	const lines = renderOperationLogs([
+		ev(1, "operation.started", { operation_id: "op_1", kind: "process", argv: ["python3", "sim.py"] }),
+		ev(2, "operation.output", { text: "line-1\n" }),
+		ev(3, "operation.output", { text: "line-2\n" }),
+		ev(4, "operation.completed", { operation_id: "op_1", state: "SUCCEEDED", failure_code: "" }),
+	]);
+	const joined = lines.join("\n");
+	assert.match(joined, /line-1/);
+	assert.match(joined, /line-2/);
+	assert.match(joined, /op_1/);
+});
+
+test("H8: Artifacts 列表与诚实空态", () => {
+	const empty = renderArtifactList([]);
+	assert.match(empty.join("\n"), /没有产物|无产物/);
+	const lines = renderArtifactList([
+		{ artifact_id: "art_abcdef123456", path: "/ws/star.gif", media_type: "image/gif", sha256: "deadbeefcafe", size_bytes: 2048 },
+	]);
+	const joined = lines.join("\n");
+	assert.match(joined, /star\.gif/);
+	assert.match(joined, /2048/);
+	assert.match(joined, /deadbee/);
+});
+
+test("H8: 用户可见命令/快捷键 description 无 Pi 品牌（Gate A）", () => {
+	const candidates = [
+		join(import.meta.dirname, "../src/extension/index.ts"), // 源码直跑
+		join(import.meta.dirname, "../../src/extension/index.ts"), // dist/test 编译后
+	];
+	const sourcePath = candidates.find((p) => existsSync(p));
+	assert.ok(sourcePath, "找不到 extension/index.ts 源码");
+	const source = readFileSync(sourcePath, "utf-8");
+	const leaks: string[] = [];
+	// registerCommand/registerShortcut 的 description 字面量。
+	for (const m of source.matchAll(/description:\s*"([^"]*)"/g)) {
+		if (/\bPi\b/.test(m[1])) leaks.push(m[1]);
+	}
+	assert.deepEqual(leaks, [], `用户可见 description 含 Pi 品牌：${leaks.join(" | ")}`);
+});

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1225,6 +1225,17 @@ class PiBridgeServer:
                 reason=str(params.get("reason", "")),
             )
             return {"ok": True}
+        if method == "pi.kernel.artifacts":
+            # PR-H8：/artifacts——产物账本（登记才算交付，模型口头提到
+            # 不算）。
+            conn = service._store.connection
+            rows = conn.execute(
+                "SELECT artifact_id, task_id, path, media_type, sha256, "
+                "size_bytes, created_at FROM artifacts WHERE task_id = ? "
+                "ORDER BY created_at",
+                (str(params.get("task_id", "")),),
+            ).fetchall()
+            return {"ok": True, "artifacts": [dict(r) for r in rows]}
         if method == "pi.op.start":
             # PR-H3（§11.4）：长 operation 立即返回 operation_id——
             # 进度/输出经 task_events 流，终态经 followUp 注入一次。

--- a/tests/agentd/test_h8_tui_journey.py
+++ b/tests/agentd/test_h8_tui_journey.py
@@ -1,0 +1,229 @@
+"""PR-H8 红测试：Task Activity/Logs/Artifacts 产品旅程（总纲 v2 §20 PR-H8）。
+
+真实链路：PTY `rosclaw chat` → 假模型编排（write → process_start →
+rosclaw_artifact_register → rosclaw_task_finish）→ 主会话真实执行 →
+用户用 /activity /logs /artifacts 三个命令查看任务进度——数据全部
+来自 TaskKernel 事件流/产物账本（不经 LLM 总结）。
+
+红测试先行：/activity /logs /artifacts 命令实现前必须红。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_entry import find_pi_agent_entry
+from tests.agentd.test_product_journey import (
+    PtySession,
+    _chunk,
+    _sse,
+    _tool_call_frames,
+)
+
+pytestmark = pytest.mark.skipif(
+    not find_pi_agent_entry(),
+    reason="无 Node/dist（CI 全回归 job 未构建）——诚实 skip",
+)
+
+
+class _FullJourneyFake:
+    """write → process_start → artifact_register → task_finish → 回答。"""
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    def answer(self, body: dict) -> bytes:
+        self.requests.append(body)
+        messages = body.get("messages", [])
+        if not body.get("stream"):
+            return json.dumps(
+                {
+                    "id": "chatcmpl-fake",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "fake-k3",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "pong"},
+                        "finish_reason": "stop",
+                    }],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 5},
+                },
+            ).encode()
+        has_tool_result = bool(messages) and messages[-1].get("role") == "tool"
+        if has_tool_result:
+            call_id = str(messages[-1].get("tool_call_id", ""))
+            nxt = {
+                "call_write": (
+                    "call_op", "process_start",
+                    {"command": "echo h8-operation-marker"},
+                ),
+                "call_op": (
+                    "call_art", "rosclaw_artifact_register",
+                    {"path": "report.txt", "media_type": "text/plain"},
+                ),
+                "call_art": (
+                    "call_fin", "rosclaw_task_finish",
+                    {"summary": "报告已生成并验收"},
+                ),
+            }.get(call_id)
+            if nxt is not None:
+                frames = _tool_call_frames(nxt[0], nxt[1], json.dumps(nxt[2]))
+                frames.append(b"data: [DONE]\n\n")
+                return b"".join(frames)
+            # task_finish 后（及 operation followUp 回合）→ 最终回答
+            frames = [
+                _sse(_chunk("任务完成：report.txt 已交付。")),
+                _sse(_chunk("", "stop")),
+                b"data: [DONE]\n\n",
+            ]
+            return b"".join(frames)
+        frames = _tool_call_frames(
+            "call_write", "write",
+            json.dumps({"path": "report.txt", "content": "h8-report-body\n"}),
+        )
+        frames.append(b"data: [DONE]\n\n")
+        return b"".join(frames)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    fake: _FullJourneyFake
+
+    def log_message(self, *args) -> None:  # 静默
+        return
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        payload = self.fake.answer(body)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.fake = _FullJourneyFake()
+        handler = type("H", (_Handler,), {"fake": self.fake})
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.server.server_address[1]
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1"
+
+    def close(self) -> None:
+        self.server.shutdown()
+
+
+def _prepare_home(tmp_path: Path, base_url: str) -> tuple[Path, dict[str, str]]:
+    home = tmp_path / "rh"
+    (home / "run").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "agent:\n  enabled: true\n  default_profile: embodied_default\n"
+        "models:\n  backend: legacy\n  profiles:\n    embodied_default:\n"
+        "      provider: kimi_code\n      model: fake-k3\n"
+        f"      base_url: {base_url}\n"
+        "      api_key_ref: env:FAKE_JOURNEY_KEY\n"
+        "      capabilities: [llm.chat, llm.structured_decision, llm.tool_use]\n",
+        encoding="utf-8",
+    )
+    (home / "agent").mkdir(parents=True, exist_ok=True)
+    (home / "agent" / "settings.json").write_text(
+        json.dumps({"defaultProvider": "journey-fake", "defaultModel": "fake-k3"}),
+        encoding="utf-8",
+    )
+    (home / "agent" / "models.json").write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "journey-fake": {
+                        "name": "Journey Fake",
+                        "baseUrl": base_url,
+                        "api": "openai-completions",
+                        "apiKey": "$FAKE_JOURNEY_KEY",
+                        "models": [{
+                            "id": "fake-k3",
+                            "name": "Fake K3",
+                            "contextWindow": 8192,
+                            "maxTokens": 4096,
+                        }],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = dict(
+        os.environ,
+        ROSCLAW_HOME=str(home),
+        TERM="xterm",
+        FAKE_JOURNEY_KEY="sk-fake-journey",
+        ROSCLAW_UI_LOCALE="zh-CN",
+    )
+    return home, env
+
+
+class TestTaskActivityJourney:
+    def test_activity_logs_artifacts_commands(self, tmp_path: Path) -> None:
+        """一条任务走完后，/activity /logs /artifacts 都给出账本数据。"""
+        fake = _FakeServer()
+        home, env = _prepare_home(tmp_path, fake.base_url)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        session = PtySession(
+            [sys.executable, "-m", "rosclaw.entrypoint", "chat"],
+            env, log_path=tmp_path / "pty-h8.log", cwd=workspace,
+        )
+        try:
+            session.expect(b"ROSClaw Native Agent", timeout=120)
+            session.send("生成 report.txt 并交付\r")
+            session.expect("任务完成：report.txt 已交付".encode(), timeout=240)
+            produced = list(tmp_path.rglob("report.txt"))
+            assert produced, "write 工具未真实落盘"
+
+            # /activity：阶段行来自 task_events（任务开始/进程/产物/验收）。
+            session.send("/activity\r")
+            session.expect("任务开始".encode(), timeout=30)
+            session.expect("验收".encode(), timeout=30)
+
+            # /logs：operation 输出（echo 的 marker）。
+            session.send("/logs\r")
+            session.expect("h8-operation-marker".encode(), timeout=30)
+
+            # /artifacts：产物账本（report.txt + sha 短码）。
+            session.send("/artifacts\r")
+            session.expect("report.txt".encode(), timeout=30)
+
+            # 账本侧对账：任务 SUCCEEDED + 产物行存在。
+            db_path = home / "agentd" / "missions.db"
+            assert db_path.exists()
+            db = sqlite3.connect(db_path)
+            try:
+                state = db.execute(
+                    "SELECT state FROM tasks ORDER BY created_at DESC LIMIT 1"
+                ).fetchone()
+                assert state and state[0] == "SUCCEEDED", f"任务终态异常: {state}"
+                arts = db.execute(
+                    "SELECT COUNT(*) FROM artifacts"
+                ).fetchone()[0]
+                assert arts >= 1, "产物账本为空"
+            finally:
+                db.close()
+
+            session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
+            session.proc.wait(timeout=30)
+        finally:
+            session.stop()
+            fake.close()

--- a/tests/agentd/test_h8_tui_journey.py
+++ b/tests/agentd/test_h8_tui_journey.py
@@ -200,11 +200,11 @@ class TestTaskActivityJourney:
 
             # /logs：operation 输出（echo 的 marker）。
             session.send("/logs\r")
-            session.expect("h8-operation-marker".encode(), timeout=30)
+            session.expect(b"h8-operation-marker", timeout=30)
 
             # /artifacts：产物账本（report.txt + sha 短码）。
             session.send("/artifacts\r")
-            session.expect("report.txt".encode(), timeout=30)
+            session.expect(b"report.txt", timeout=30)
 
             # 账本侧对账：任务 SUCCEEDED + 产物行存在。
             db_path = home / "agentd" / "missions.db"


### PR DESCRIPTION
## PR-H8（总纲 v2 §20）

- **task-activity.ts**：TaskKernel 事件流 → 中文阶段时间线（任务开始/修订/进程/产物/验收/终态）——数据不经 LLM 总结，假进度不可能；operation.output 不进 Activity（归 /logs）
- **/activity /logs /artifacts** 三个命令 + **Ctrl+T** 常驻 widget（turn_end 自动刷新）
- **pi.kernel.artifacts** 桥方法（产物账本——登记才算交付，模型口头提到不算）
- 用户可见 description 的 Pi 品牌清零 + 结构扫描测试（Gate A：用户 UI 中 Pi 品牌出现 0 次）

## 红→绿证据

- TS：渲染器红（模块不存在）→ 5/5 绿
- PTY journey：红（`/activity` 未识别，39s 超时——任务全链真实走完）→ 1/1 绿（8.6s）：write→process_start→artifact_register→task_finish 真实执行后 /activity 显示阶段行、/logs 显示 operation marker、/artifacts 显示产物+sha

🤖 Generated with [Claude Code](https://claude.com/claude-code)