### PR TITLE
fix: PR-N0 事故固化与假成功熔断（N 总纲 §15/§17 第一条指令）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -487,10 +487,10 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					return;
 				}
 				try {
-					await center.call("pi.kernel.transition", {
+					// PR-N0：/done = 用户接受（user_accepted_at）——此后
+					// 新消息开新任务；未接受的 SUCCEEDED 被用户修正重开。
+					await center.call("pi.kernel.accept", {
 						task_id: inputController.currentTaskId,
-						state: "SUCCEEDED",
-						reason: "user_accepted",
 					});
 					ctx.ui.notify(
 						`任务已接受（${inputController.currentTaskId.slice(0, 14)}…）`,

--- a/packages/rosclaw-agent/src/tools/product-pack.ts
+++ b/packages/rosclaw-agent/src/tools/product-pack.ts
@@ -34,15 +34,13 @@ export function buildProductPackTools(ctx: BridgeToolContext): ToolDefinition[] 
 			label: "ROSClaw Task Finish",
 			description:
 				"Finish the current task: the verifier really runs (registered " +
-				"artifacts checked by content hash, acceptance checked). " +
-				"REPAIR_REQUIRED returns failures — fix in the SAME task, then " +
-				"finish again. Zero evidence never succeeds.",
+				"artifacts checked by content hash; the acceptance frozen at " +
+				"task creation is checked — you CANNOT pass new acceptance " +
+				"rules here). REPAIR_REQUIRED returns failures — fix in the " +
+				"SAME task, then finish again. Zero evidence never succeeds.",
 			parameters: Type.Object({
 				summary: Type.String({ description: "完成摘要（用户可见）" }),
 				artifact_ids: Type.Optional(Type.Array(Type.String())),
-				acceptance: Type.Optional(Type.Record(Type.String(), Type.Unknown(), {
-					description: "结构化验收：{required_files:[...]} 或 {run:{argv:[...]}}",
-				})),
 			}),
 			async execute(_id, params, _signal, _onUpdate, _toolCtx) {
 				return await executeVia(ctx, "rosclaw_task_finish", params as Record<string, unknown>);

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1002,6 +1002,13 @@ class PiBridgeServer:
                 str(params.get("session_ref", "")),
             )
             return {"ok": True, "task": task}
+        if method == "pi.kernel.accept":
+            # PR-N0：/done 用户接受（与系统验收 accepted_at 区分）。
+            try:
+                service._task_kernel.accept_task(str(params.get("task_id", "")))
+            except ValueError as exc:
+                return {"ok": False, "error": str(exc)}
+            return {"ok": True}
         if method == "pi.kernel.transition":
             kernel = service._task_kernel
             kernel.transition(

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rosclaw.agentd.pi_bridge.session_binding import SessionBindingStore
@@ -437,29 +436,38 @@ class PiToolDispatcher:
         path = str(request.arguments.get("path", ""))
         if not path:
             raise ToolBridgeError("INVALID_ARGUMENTS", "path required")
-        # 相对路径解析：会话 cwd（模型实际干活的目录）优先，任务
-        # 工作区兜底（§10.1 workspace 固定，但主会话 cwd=用户项目根
-        # 时写入发生在那里——登记必须找到真实文件）。
+        # PR-N0：确定性解析——相对路径依次按会话 cwd（模型实际工作
+        # 目录）与任务 workspace 解析成绝对路径后交 kernel；两处都不
+        # 存在时报错列出两个实际根（禁止反复猜路径）。真正的单一事实
+        # 源（ActiveTaskContext）在 PR-N1。
         from pathlib import Path as _Path
 
         session_cwd = str(request.arguments.get("cwd", "") or "")
+        task_ws = str(task["workspace_path"])
         if _Path(path).is_absolute():
             resolved = path
         elif session_cwd and (_Path(session_cwd) / path).exists():
             resolved = str(_Path(session_cwd) / path)
+        elif (_Path(task_ws) / path).exists():
+            resolved = str(_Path(task_ws) / path)
         else:
-            resolved = str(_Path(task["workspace_path"]) / path)
+            raise ToolBridgeError(
+                "ARTIFACT_MISSING",
+                f"artifact 不存在: {path}（已查会话目录 {session_cwd or '—'} "
+                f"与任务工作区 {task_ws}）",
+            )
         try:
             artifact = kernel.register_artifact(
                 task_id=task["task_id"], path=resolved,
                 media_type=str(request.arguments.get("media_type", "application/octet-stream")),
+                producer="model:rosclaw_artifact_register",
             )
         except ValueError as exc:
             raise ToolBridgeError("ARTIFACT_MISSING", str(exc)) from exc
         return PiToolResultV1(
             request_id=request.request_id,
             ok=True, status="REGISTERED",
-            summary=f"交付物已登记：{Path(resolved).name}（{artifact['size_bytes']}B）artifact_id={artifact['artifact_id']}",
+            summary=f"交付物已登记：{_Path(artifact['path']).name}（{artifact['size_bytes']}B）artifact_id={artifact['artifact_id']}",
         )
 
     async def _task_finish(self, request: PiToolRequestV1) -> PiToolResultV1:
@@ -475,8 +483,8 @@ class PiToolDispatcher:
             artifact_ids=[
                 str(a) for a in (request.arguments.get("artifact_ids") or [])
             ],
-            acceptance=dict(request.arguments.get("acceptance") or {}),
         )
+
         if result["status"] == "SUCCEEDED":
             return PiToolResultV1(
                 request_id=request.request_id, ok=True, status="SUCCEEDED",
@@ -606,10 +614,12 @@ class PiToolDispatcher:
         args = request.arguments
         goal = str(args.get("goal", "")).strip()
         parameters = args.get("parameters")
-        if goal != "draw_shape" or not isinstance(parameters, dict):
+        if goal not in ("simulate_trajectory", "draw_shape") or not isinstance(
+            parameters, dict
+        ):
             raise ToolBridgeError(
                 "UNKNOWN_CAPABILITY",
-                f"未知确定性任务 {goal!r}——当前支持 draw_shape"
+                f"未知确定性任务 {goal!r}——当前支持 simulate_trajectory"
                 "（其余长任务走 rosclaw_execute/process_start）",
             )
         service = self._service
@@ -681,9 +691,11 @@ class PiToolDispatcher:
                 import contextlib as _cl
 
                 with _cl.suppress(ValueError):
-                    # 产物文件缺失由验收 failures 表达
+                    # 产物文件缺失由验收 failures 表达；受信管道登记
+                    # （producer=kernel——PR-N0 行为任务必须有此证据）。
                     service._task_kernel.register_artifact(
-                        task_id=task["task_id"], path=path, media_type=media
+                        task_id=task["task_id"], path=path, media_type=media,
+                        producer="kernel:sim_pipeline",
                     )
         state = "VERIFIED" if not failures else "FAILED"
         payload = {

--- a/src/rosclaw/storage/migrations/028_n0_acceptance_freeze.sql
+++ b/src/rosclaw/storage/migrations/028_n0_acceptance_freeze.sql
@@ -1,0 +1,12 @@
+-- 028: PR-N0 假成功熔断——证据 provenance + 用户接受。
+--
+-- artifacts.producer：登记来源（'kernel:<pipeline>' = 受信管道内
+-- 部登记；'model:<tool>' = 模型工具调用）。机器人行为任务的
+-- SUCCEEDED 必须含至少一个受信管道产物（模型自产证据不算数）。
+--
+-- tasks.user_accepted_at：用户 /done 接受时间（与 accepted_at 区分
+-- ——accepted_at 是系统验收通过时间）。SUCCEEDED 但未经用户接受
+-- 的任务被用户修正消息重开（revision+1，旧 verification 作废）；
+-- 接受后任务永久关闭。
+ALTER TABLE artifacts ADD COLUMN producer TEXT NOT NULL DEFAULT 'model:tool';
+ALTER TABLE tasks ADD COLUMN user_accepted_at TEXT;

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -94,8 +94,54 @@ class TaskKernel:
             "ORDER BY t.created_at DESC LIMIT 1",
             (mission_id, session_ref),
         ).fetchone()
-        if active is not None and active["state"] in TASK_TERMINAL:
-            active = None  # 已终态的 task 不再收 revision
+        if (
+            active is not None
+            and active["state"] in TASK_TERMINAL
+            and not (
+                active["state"] == "SUCCEEDED"
+                and not active["user_accepted_at"]
+            )
+        ):
+            active = None  # 已终态且（非 SUCCEEDED 或已被用户接受）
+        if active is not None and active["state"] == "SUCCEEDED":
+            # PR-N0：SUCCEEDED 但未经 /done 接受 → 用户修正消息重开
+            # 同一任务（revision+1、状态回 RUNNING、旧 verification
+            # 立即作废——幽灵成功熔断）。
+            task_id = str(active["task_id"])
+            revision = int(active["active_revision"]) + 1
+            now = datetime.now(UTC).isoformat()
+            self._conn.execute(
+                "INSERT INTO task_revisions (task_id, revision, "
+                "user_message_id, goal_delta, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (task_id, revision, message_id, text, now),
+            )
+            self._conn.execute(
+                "UPDATE tasks SET active_revision = ?, state = 'RUNNING', "
+                "updated_at = ? WHERE task_id = ?",
+                (revision, now, task_id),
+            )
+            superseded = self._conn.execute(
+                "UPDATE verifications SET status = 'SUPERSEDED' "
+                "WHERE task_id = ? AND status = 'PASS'",
+                (task_id,),
+            ).rowcount
+            self._emit(task_id, "verification.superseded",
+                       {"count": superseded, "reason": "user_rejected"},
+                       session_ref=session_ref)
+            self._emit(task_id, "task.revised",
+                       {"revision": revision, "delta": text[:200],
+                        "reopened_from": "SUCCEEDED"},
+                       session_ref=session_ref)
+            return {
+                "task_id": task_id,
+                "revision": revision,
+                "created_task": False,
+                "replayed": False,
+                "reopened": True,
+                "workspace_path": str(active["workspace_path"]),
+                "state": "RUNNING",
+            }
         if active is not None and force_new:
             self._conn.execute(
                 "UPDATE task_session_bindings SET active = 0 "
@@ -264,12 +310,27 @@ class TaskKernel:
     def register_artifact(
         self, *, task_id: str, path: str, media_type: str,
         producer_operation_id: str = "",
+        producer: str = "model:tool",
     ) -> dict[str, Any]:
         """登记交付物：实读文件算 sha256/size（不存在的文件拒绝登记）。
-        登记才进交付列表——模型口头提到不算。"""
+        登记才进交付列表——模型口头提到不算。
+
+        PR-N0：producer 区分受信管道（'kernel:<pipeline>'——内核内部
+        登记）与模型工具调用（'model:<tool>'）；相对路径只按任务
+        workspace 根解析（禁止按 session cwd 猜——cwd 分裂是事故
+        根因之一），找不到时报错带实际解析根。"""
+        task = self.get_task(task_id)
+        if task is None:
+            raise ValueError(f"unknown task {task_id!r}")
+        workspace = Path(str(task["workspace_path"])).resolve()
         file = Path(path)
+        if not file.is_absolute():
+            file = workspace / file
+        file = file.resolve()
         if not file.exists():
-            raise ValueError(f"artifact 不存在: {path}")
+            raise ValueError(
+                f"artifact 不存在: {path}（解析根: {workspace}）"
+            )
         content = file.read_bytes()
         artifact_id = new_id("art")
         now = datetime.now(UTC).isoformat()
@@ -283,10 +344,10 @@ class TaskKernel:
         }
         self._conn.execute(
             "INSERT INTO artifacts (artifact_id, task_id, path, media_type, "
-            "sha256, size_bytes, producer_operation_id, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "sha256, size_bytes, producer_operation_id, producer, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (artifact_id, task_id, str(file), media_type, record["sha256"],
-             len(content), producer_operation_id or None, now),
+             len(content), producer_operation_id or None, producer, now),
         )
         self._emit(task_id, "artifact.created",
                    {"artifact_id": artifact_id, "path": str(file),
@@ -295,19 +356,29 @@ class TaskKernel:
 
     def finish_task(
         self, *, task_id: str, summary: str, artifact_ids: list[str],
-        acceptance: dict | None = None,
     ) -> dict[str, Any]:
         """FinishRequest（§12.1）：验收真跑 → SUCCEEDED / REPAIR_REQUIRED。
-        终态幂等（重放不重复验证、不覆盖）。"""
+        终态幂等（重放不重复验证、不覆盖——返回原 receipt id）。
+
+        PR-N0 熔断：
+        - 验收条件只读任务创建时冻结值（模型收尾不得改规则）；
+        - 机器人行为任务（body_id 非空）必须含受信管道证据
+          （kernel 内部登记的产物）——模型自产证据不算数。
+        """
         task = self.get_task(task_id)
         if task is None:
             raise ValueError(f"unknown task {task_id!r}")
         if task["state"] in TASK_TERMINAL:
-            # 幂等：SUCCEEDED 重放返回既有终态。
+            # 幂等：SUCCEEDED 重放返回既有终态 + 原 receipt。
+            prior = self._conn.execute(
+                "SELECT verification_id FROM verifications WHERE task_id = ? "
+                "AND status = 'PASS' ORDER BY rowid DESC LIMIT 1",
+                (task_id,),
+            ).fetchone()
             return {
                 "status": task["state"],
                 "already_terminal": True,
-                "verification_id": "",
+                "verification_id": str(prior["verification_id"]) if prior else "",
             }
         artifacts = [
             dict(r)
@@ -319,11 +390,23 @@ class TaskKernel:
         ] if artifact_ids else []
         from rosclaw.task_kernel.verifier import verdict_for
 
+        rev_row = self._conn.execute(
+            "SELECT acceptance_json FROM task_revisions WHERE task_id = ? "
+            "AND revision = ?",
+            (task_id, int(task["active_revision"])),
+        ).fetchone()
+        frozen = json.loads(str(rev_row["acceptance_json"])) if rev_row else {}
+        trusted_present = any(
+            str(a.get("producer") or "").startswith("kernel:")
+            for a in artifacts
+        )
         verdict = verdict_for(
             artifacts=artifacts,
-            acceptance=acceptance or {},
+            acceptance=frozen,
             workspace=Path(task["workspace_path"]),
             summary=summary,
+            require_trusted_evidence=bool(task["body_id"]),
+            trusted_evidence_present=trusted_present,
         )
         now = datetime.now(UTC).isoformat()
         if verdict["status"] == "PASS":
@@ -352,6 +435,40 @@ class TaskKernel:
             "failures": verdict["failures"],
             "checks": verdict["checks"],
         }
+
+    def set_acceptance(self, task_id: str, acceptance: dict) -> None:
+        """验收条件在任务创建/修订时冻结（PR-N0）——finish 不接受
+        模型临时传入的新规则。"""
+        task = self.get_task(task_id)
+        if task is None:
+            raise ValueError(f"unknown task {task_id!r}")
+        self._conn.execute(
+            "UPDATE task_revisions SET acceptance_json = ? "
+            "WHERE task_id = ? AND revision = ?",
+            (json.dumps(acceptance, ensure_ascii=False), task_id,
+             int(task["active_revision"])),
+        )
+        self._emit(task_id, "acceptance.frozen",
+                   {"revision": int(task["active_revision"])})
+
+    def accept_task(self, task_id: str) -> None:
+        """/done：用户接受（PR-N0）——SUCCEEDED 永久关闭；此后新消息
+        开新任务，不污染已接受结果。"""
+        task = self.get_task(task_id)
+        if task is None:
+            raise ValueError(f"unknown task {task_id!r}")
+        if task["state"] != "SUCCEEDED":
+            raise ValueError(
+                f"任务未验收通过（{task['state']}）——不能接受"
+            )
+        if task["user_accepted_at"]:
+            return  # 幂等
+        now = datetime.now(UTC).isoformat()
+        self._conn.execute(
+            "UPDATE tasks SET user_accepted_at = ? WHERE task_id = ?",
+            (now, task_id),
+        )
+        self._emit(task_id, "task.accepted", {"accepted_at": now})
 
     def block_task(
         self, *, task_id: str, reason_code: str, detail: str,

--- a/src/rosclaw/task_kernel/verifier.py
+++ b/src/rosclaw/task_kernel/verifier.py
@@ -96,10 +96,20 @@ def verdict_for(
     acceptance: dict,
     workspace: Path,
     summary: str,
+    require_trusted_evidence: bool = False,
+    trusted_evidence_present: bool = False,
 ) -> dict[str, Any]:
     """统一判定。返回 {status, checks, failures}——status:
-    PASS / REPAIR_REQUIRED（零证据即 REPAIR_REQUIRED，绝不 PASS）。"""
+    PASS / REPAIR_REQUIRED（零证据即 REPAIR_REQUIRED，绝不 PASS）。
+
+    PR-N0：require_trusted_evidence（机器人行为任务）时必须有受信
+    管道证据（kernel 内部登记的产物）——模型自产证据不算数。"""
     failures = verify_artifacts(artifacts, workspace)
+    if require_trusted_evidence and not trusted_evidence_present:
+        failures.append(
+            "TRUSTED_EVIDENCE_MISSING: 机器人行为任务缺受信管道的独立"
+            "验证证据——模型自产 artifact 不算数"
+        )
     checks = len(artifacts)
     acc_checks, acc_failures = verify_acceptance(acceptance, workspace)
     checks += acc_checks

--- a/tests/agentd/test_h2_task_kernel.py
+++ b/tests/agentd/test_h2_task_kernel.py
@@ -86,6 +86,9 @@ class TestInputTransaction:
             message_id="msg_1", text="画五角星", cwd=str(tmp_path),
         )
         kernel.transition(first["task_id"], "SUCCEEDED", reason="verified")
+        # PR-N0：用户 /done 接受后，新消息才开新任务（未接受则重开
+        # 同一任务的 revision——幽灵成功熔断）。
+        kernel.accept_task(first["task_id"])
         second = kernel.bind_message(
             mission_id="m1", session_ref="s1", backend_native_id="n1",
             message_id="msg_2", text="再画一个圆", cwd=str(tmp_path),

--- a/tests/agentd/test_n0_no_false_success.py
+++ b/tests/agentd/test_n0_no_false_success.py
@@ -1,0 +1,236 @@
+"""PR-N0 红测试（总纲 N 方案 §15/§17 第一条指令）：事故固化与假成功熔断。
+
+以 2026-08-20 UR5e 五角星事故为 P0：错误简化资产被 verifier 宣布成功、
+task_finish 可临时修改 acceptance、artifact cwd 分裂、用户否定后旧成功
+仍有效——四个问题必须先红后绿，绝不降低验收标准。
+
+红测试清单（修复前必须全红）：
+1. 机器人行为任务只有模型自产 artifact（无受信管道证据）→ 不得
+   SUCCEEDED；
+2. task_finish 不得携带 acceptance（验收在任务创建时冻结）；
+3. artifact 相对路径只按任务 workspace 根解析（不存在时打印实际
+   解析根）；
+4. SUCCEEDED 未获用户接受（/done）时，用户修正消息 → 同一任务新
+   revision + 旧 verification 立即作废；接受后新消息 → 新任务；
+5. 同一 verifier 输入重复运行结果完全一致（确定性）。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from rosclaw.task_kernel.service import TaskKernel
+
+
+def _kernel(tmp_path: Path) -> TaskKernel:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    from rosclaw.storage.migrations import MigrationRunner
+
+    MigrationRunner().apply(conn, "sqlite")
+    return TaskKernel(conn, tmp_path)
+
+
+def _bind(kernel: TaskKernel, tmp_path: Path, *, text: str = "画五角星",
+          body_id: str = "sim/ur5e", message_id: str = "m1") -> str:
+    bound = kernel.bind_message(
+        mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+        message_id=message_id, text=text, cwd=str(tmp_path),
+        mode="SIMULATION", body_id=body_id,
+    )
+    return str(bound["task_id"])
+
+
+def _write_artifact(kernel: TaskKernel, task_id: str, name: str,
+                    content: bytes) -> dict:
+    """经模型工具路径登记（producer 不可信——模拟事故中的手写脚本产物）。"""
+    task = kernel.get_task(task_id)
+    assert task is not None
+    path = Path(task["workspace_path"]) / name
+    path.write_bytes(content)
+    return kernel.register_artifact(
+        task_id=task_id, path=str(path), media_type="image/gif",
+        producer="model:rosclaw_artifact_register",
+    )
+
+
+class TestNoFalseSuccess:
+    def test_model_produced_only_artifacts_cannot_succeed_robot_task(
+        self, tmp_path: Path
+    ) -> None:
+        """事故核心：全部产物由模型手写脚本产出（producer 不可信）——
+        机器人行为任务不得 SUCCEEDED（需要受信管道的独立验证证据）。"""
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path)
+        art = _write_artifact(kernel, task_id, "star.gif", b"GIF89a" + b"x" * 2048)
+        result = kernel.finish_task(
+            task_id=task_id, summary="五角星画好了", artifact_ids=[art["artifact_id"]],
+        )
+        assert result["status"] != "SUCCEEDED", (
+            "模型自产证据竟让机器人行为任务 SUCCEEDED——幽灵成功"
+        )
+        task = kernel.get_task(task_id)
+        assert task is not None and task["state"] != "SUCCEEDED"
+
+    def test_trusted_pipeline_evidence_can_succeed(self, tmp_path: Path) -> None:
+        """对照组：受信管道产物（kernel 内部登记）→ 可以 SUCCEEDED。"""
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path)
+        task = kernel.get_task(task_id)
+        assert task is not None
+        path = Path(task["workspace_path"]) / "star.gif"
+        path.write_bytes(b"GIF89a" + b"x" * 2048)
+        art = kernel.register_artifact(
+            task_id=task_id, path=str(path), media_type="image/gif",
+            producer="kernel:sim_pipeline",
+        )
+        result = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        assert result["status"] == "SUCCEEDED", result
+
+    def test_finish_rejects_acceptance_param(self, tmp_path: Path) -> None:
+        """task_finish 删除 acceptance 参数——验收在任务创建时冻结，
+        做题人不得临时修改评分标准。"""
+        import inspect
+
+        from rosclaw.task_kernel.service import TaskKernel as K
+
+        sig = inspect.signature(K.finish_task)
+        assert "acceptance" not in sig.parameters, (
+            "finish_task 仍接受 acceptance——模型可在收尾时自定义验收"
+        )
+
+    def test_finish_reads_frozen_creation_acceptance(self, tmp_path: Path) -> None:
+        """验收条件在 bind 时冻结——finish 不接受新规则，也不丢创建时
+        的规则（required_files 缺失必须 FAIL）。"""
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path, body_id="")
+        # 创建时冻结的验收：必须交付 report.txt。
+        kernel.set_acceptance(task_id, {"required_files": ["report.txt"]})
+        task = kernel.get_task(task_id)
+        assert task is not None
+        path = Path(task["workspace_path"]) / "other.txt"
+        path.write_text("irrelevant", encoding="utf-8")
+        art = kernel.register_artifact(
+            task_id=task_id, path=str(path), media_type="text/plain",
+        )
+        result = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        assert result["status"] != "SUCCEEDED", "创建时冻结的验收被忽略"
+        # 补齐后同 revision 可通过。
+        (Path(task["workspace_path"]) / "report.txt").write_text(
+            "ok", encoding="utf-8"
+        )
+        result2 = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        assert result2["status"] == "SUCCEEDED", result2
+
+    def test_artifact_relative_path_single_root(self, tmp_path: Path) -> None:
+        """相对路径只按任务 workspace 根解析（禁止按 session cwd 猜）；
+        不存在时报错必须含实际解析根。"""
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path)
+        task = kernel.get_task(task_id)
+        assert task is not None
+        ws = Path(task["workspace_path"])
+        (ws / "out.txt").write_text("ok", encoding="utf-8")
+        art = kernel.register_artifact(
+            task_id=task_id, path="out.txt", media_type="text/plain",
+        )
+        assert Path(art["path"]).resolve() == (ws / "out.txt").resolve()
+        try:
+            kernel.register_artifact(
+                task_id=task_id, path="missing.txt", media_type="text/plain",
+            )
+            raise AssertionError("不存在的 artifact 竟登记成功")
+        except ValueError as exc:
+            assert str(ws) in str(exc), f"错误未含解析根: {exc}"
+
+    def test_user_rejection_reopens_revision_and_invalidates_receipt(
+        self, tmp_path: Path
+    ) -> None:
+        """SUCCEEDED 未获用户接受（/done）时，用户修正消息 → 同一任务
+        revision+1 + 状态回 RUNNING + 旧 verification 立即作废。"""
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path, body_id="")
+        task = kernel.get_task(task_id)
+        assert task is not None
+        path = Path(task["workspace_path"]) / "report.txt"
+        path.write_text("v1", encoding="utf-8")
+        art = kernel.register_artifact(
+            task_id=task_id, path=str(path), media_type="text/plain",
+        )
+        result = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        assert result["status"] == "SUCCEEDED"
+        verification_id = result["verification_id"]
+        # 用户否定（未经 /done 接受）→ revision 2，旧 receipt 作废。
+        bound = kernel.bind_message(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            message_id="m2", text="不对，画错了，重来", cwd=str(tmp_path),
+        )
+        assert bound["task_id"] == task_id, "否定竟裂变成新任务"
+        assert bound["revision"] == 2
+        task2 = kernel.get_task(task_id)
+        assert task2 is not None and task2["state"] not in ("SUCCEEDED",), (
+            f"用户否定后任务仍宣称成功: {task2['state']}"
+        )
+        row = kernel._conn.execute(
+            "SELECT status FROM verifications WHERE verification_id = ?",
+            (verification_id,),
+        ).fetchone()
+        assert row is not None and row["status"] != "PASS", (
+            "旧 verification 在用户否定后仍有效"
+        )
+
+    def test_accepted_task_stays_closed(self, tmp_path: Path) -> None:
+        """/done 接受后：新消息开新任务（不污染已接受结果）。"""
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path, body_id="")
+        task = kernel.get_task(task_id)
+        assert task is not None
+        path = Path(task["workspace_path"]) / "report.txt"
+        path.write_text("v1", encoding="utf-8")
+        art = kernel.register_artifact(
+            task_id=task_id, path=str(path), media_type="text/plain",
+        )
+        result = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        assert result["status"] == "SUCCEEDED"
+        kernel.accept_task(task_id)  # /done
+        bound = kernel.bind_message(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            message_id="m2", text="新目标", cwd=str(tmp_path),
+        )
+        assert bound["task_id"] != task_id, "已接受任务被新消息污染"
+        task1 = kernel.get_task(task_id)
+        assert task1 is not None and task1["state"] == "SUCCEEDED"
+
+    def test_identical_input_deterministic_verdict(self, tmp_path: Path) -> None:
+        """同一输入重复验证，结果完全一致（验收不得有随机性）。"""
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path, body_id="")
+        task = kernel.get_task(task_id)
+        assert task is not None
+        path = Path(task["workspace_path"]) / "report.txt"
+        path.write_text("v1", encoding="utf-8")
+        art = kernel.register_artifact(
+            task_id=task_id, path=str(path), media_type="text/plain",
+        )
+        r1 = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        r2 = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        assert r1["status"] == r2["status"] == "SUCCEEDED"
+        assert r2.get("already_terminal"), "终态重放必须幂等"
+        assert r2["verification_id"] == r1["verification_id"], (
+            "重复验证竟产生新 receipt"
+        )


### PR DESCRIPTION
以 2026-08-20 UR5e 五角星事故为 P0。红测试先行（8 红证据）→ 最小修复 → 8 绿，未降低验收标准。

## 四个事故问题 → 熔断

1. **错误资产被宣布成功**：机器人行为任务（body_id 非空）只有模型自产 artifact → 不得 SUCCEEDED（TRUSTED_EVIDENCE_MISSING）；受信管道（kernel: producer）产物才可证明行为任务。
2. **task_finish 可修改 acceptance**：参数三处全删（内核签名/Product Pack schema/dispatcher 透传）；验收在任务创建时冻结（task_revisions.acceptance_json + kernel.set_acceptance）。
3. **artifact cwd 分裂**：确定性解析（会话 cwd → 任务 workspace），失败时列出两个实际根；kernel 相对路径只按任务 workspace 解析且错误含解析根。
4. **用户否定后旧成功仍有效**：SUCCEEDED 未经 /done 接受时修正消息 → 同一任务 revision+1 + 状态回 RUNNING + 旧 verification 全部 SUPERSEDED；/done 后新消息开新任务。
5. 终态重放返回原 verification_id（同一输入同一 receipt）。

## 其他

- migration 028（artifacts.producer + tasks.user_accepted_at）
- /done → pi.kernel.accept（用户接受 vs 系统验收分离）
- rosclaw_task 接受 prompt 文档名 simulate_trajectory（H9b 契约断裂修复）

## 验证

- N0 红测试 8/8 绿；kernel/verifier/execute/checkpoint 邻接 31 全绿；TS 127/127；PTY h1/h4/h8 全绿；ruff 全绿。

## 未验证事项

- 真实 K3 五角星旅程在本 PR 之上未重跑（key 配额时段外再验）；PR-N1（ActiveTaskContext 唯一工作区）才会把会话 cwd 与任务工作区彻底合一——本 PR 的确定性双根解析是过渡态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)