### PR TITLE
feat: PR-N2——恢复 Pi 的可信上下文与签名 Skill（N 总纲 §PR-N2）

### DIFF
--- a/packages/rosclaw-agent/scripts/copy-assets.mjs
+++ b/packages/rosclaw-agent/scripts/copy-assets.mjs
@@ -15,3 +15,12 @@ if (!existsSync(from)) {
 }
 copyFileSync(from, join(targetDir, "native_agent_v2.md"));
 console.log(`copied prompt from ${from}`);
+
+// PR-N2：内置签名 Skill 进 dist（dist/skills/）。
+import { cpSync } from "node:fs";
+const skillsSource = join(pkgRoot, "skills");
+const skillsTarget = join(pkgRoot, "dist", "skills");
+if (existsSync(skillsSource)) {
+	cpSync(skillsSource, skillsTarget, { recursive: true });
+	console.log("copied skills");
+}

--- a/packages/rosclaw-agent/skills/manifest.json
+++ b/packages/rosclaw-agent/skills/manifest.json
@@ -1,0 +1,5 @@
+{
+ "skills": {
+  "rosclaw-embodied": "46137af04c351d15cb6c29678ff5a39c7b824c14afc5299f8dd19130b9ccea6a"
+ }
+}

--- a/packages/rosclaw-agent/skills/rosclaw-embodied/SKILL.md
+++ b/packages/rosclaw-agent/skills/rosclaw-embodied/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: rosclaw-embodied
+description: ROSClaw 具身任务纪律——权威资产、证据验收、安全分层的精简操作手册（何时用：任何涉及机器人/仿真/动作的任务）
+---
+
+# ROSClaw 具身任务纪律
+
+## 权威资产
+
+- 机器人模型只认 e-URDF-Zoo 权威资产（`e-urdf-zoo/<robot>/robot.mjcf.xml`）；
+  测试 fixture（tests/fixtures/）与简化模型绝不出现在交付证据里。
+- 不确定资产来源时先调查：`rosclaw robot list` / 读取 sandbox/loader
+  源码确认解析顺序，不从 / 全盘搜索同名文件。
+
+## 证据与验收
+
+- 交付物必须登记（rosclaw_artifact_register）——口头提到不算。
+- 验收条件在任务创建时冻结；task_finish 不接受新规则。
+- 机器人行为任务的完成必须有受信管道的独立验证证据；
+  手写脚本的输出不算行为证据。
+- 用户否定结果后任务重开 revision——不得沿用旧 receipt 宣称成功。
+
+## 安全分层
+
+- 纯计算/封闭本地仿真：自动执行。
+- 真机动作：必须走 rosclaw_execute/request_action 的 admission 链
+  （rosclawd + permit + operator），任何其他路径都不是执行权威。
+- 仿真失败先读结构化诊断，按真实 Schema 修正参数；同一调用同一
+  参数不机械重试。

--- a/packages/rosclaw-agent/src/extension/bundled-skills.ts
+++ b/packages/rosclaw-agent/src/extension/bundled-skills.ts
@@ -1,0 +1,64 @@
+/** ROSClaw 内置签名 Skill 校验（PR-N2）。
+ *
+ * skills/manifest.json 记录每个 SKILL.md 的 sha256——加载前逐一
+ * 校验；篡改/缺失 manifest 条目的 Skill 排除并给诊断（诚实降级，
+ * 不静默加载）。
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+export interface BundledSkillsResult {
+	/** digest 校验通过的 skill 名。 */
+	verified: string[];
+	/** 被排除的 skill（含原因——诚实诊断）。 */
+	excluded: Array<{ name: string; reason: string }>;
+	/** 可传给 Pi additionalSkillPaths 的目录（仅含通过校验的）。 */
+	skillPaths: string[];
+}
+
+export function verifyBundledSkills(skillsDir: string): BundledSkillsResult {
+	const manifestPath = join(skillsDir, "manifest.json");
+	const verified: string[] = [];
+	const excluded: Array<{ name: string; reason: string }> = [];
+	if (!existsSync(manifestPath)) {
+		return {
+			verified, skillPaths: [],
+			excluded: [{ name: "*", reason: "manifest.json 缺失——全部排除（fail closed）" }],
+		};
+	}
+	let manifest: { skills?: Record<string, string> };
+	try {
+		manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as typeof manifest;
+	} catch (err) {
+		return {
+			verified, skillPaths: [],
+			excluded: [{ name: "*", reason: `manifest.json 解析失败：${(err as Error).message}` }],
+		};
+	}
+	const declared = manifest.skills ?? {};
+	for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const skillFile = join(skillsDir, entry.name, "SKILL.md");
+		if (!existsSync(skillFile)) continue;
+		const expected = declared[entry.name];
+		if (!expected) {
+			excluded.push({ name: entry.name, reason: "不在 manifest——未声明的内置 Skill 不加载" });
+			continue;
+		}
+		const actual = createHash("sha256")
+			.update(readFileSync(skillFile, "utf-8"))
+			.digest("hex");
+		if (actual !== expected) {
+			excluded.push({ name: entry.name, reason: `digest 不符（manifest ${expected.slice(0, 12)}… != 实际 ${actual.slice(0, 12)}…）——疑似篡改，排除` });
+			continue;
+		}
+		verified.push(entry.name);
+	}
+	return {
+		verified,
+		excluded,
+		skillPaths: verified.map((name) => join(skillsDir, name)),
+	};
+}

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -399,14 +399,18 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		});
 
 		// -- 每轮注入最新具身上下文（PNA-2，规格 §14.2） ---------------------------
-		pi.on("before_agent_start", async (_event, ctx) => {
+		pi.on("before_agent_start", async (event, ctx) => {
 			// header 模型名取真实当前 model（P0-NA-16：同一快照语义）。
 			const current = ctx.model as { name?: string; id?: string } | undefined;
 			const display = current ? String(current.name ?? current.id ?? "") : "";
 			if (display) center.noteModel(display);
 			const missionId = options.active.current.missionId;
 			if (!missionId) {
-				return { systemPrompt: options.systemPrompt };
+				// PR-N2：用事件携带的 Pi 组装提示词（含可信项目上下文 +
+				// 内置签名 Skill + cwd）——此前每轮整体替换为
+				// options.systemPrompt，Pi 加载的 context/skills 被丢弃
+				// （"恢复项目认知"的事故根因之一）。
+				return { systemPrompt: event.systemPrompt ?? options.systemPrompt };
 			}
 			const fetched = await fetchEmbodiedContext(
 				options.rosclawHome,
@@ -425,7 +429,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			// chrome 刷新由 active.subscribe → center → refreshChrome 统一
 			// 完成（applyEnvelope/markContextStale 都会触发）。
 			return {
-				systemPrompt: options.systemPrompt,
+				systemPrompt: event.systemPrompt ?? options.systemPrompt,
 				message: {
 					customType: "rosclaw.embodied_context",
 					content: renderTrustedContext(fetched),

--- a/packages/rosclaw-agent/src/extension/resource-policy.ts
+++ b/packages/rosclaw-agent/src/extension/resource-policy.ts
@@ -1,21 +1,33 @@
-/** 资源安全策略（PNA-9，规格 §10）。
+/** 资源安全策略（PR-N2 重构，N 总纲 §PR-N2）——四通道拆分。
  *
- * - robot：机器人/SHADOW/REAL——全部项目资源禁止，凭据 env-only；
- * - developer：桌面开发/SIM——允许用户级主题，项目资源仍需显式批准
- *   （默认不加载 .pi/extensions、AGENTS.md、~/.agents/skills）；
- * - worker：headless 原生 Worker——无 ROS 网络/控制 socket/机器人设备，
- *   仅 WorkOrder 指定目录的只读文件工具（本包内不启用任何文件工具，
- *   worker sandbox 的文件能力由 WorkerPack 侧实现并验证）。
+ * 旧五连布尔（noExtensions/noSkills/noPromptTemplates/noThemes/
+ * noContextFiles）把"可信只读项目上下文"和"任意可执行扩展"一刀切
+ * 全关——Native Agent 因此失去成熟 Harness 的项目认知入口。
+ *
+ * 拆分语义：
+ * - contextFiles："off" | "trusted-readonly"——AGENTS.md/CLAUDE.md
+ *   等只读上下文在信任根内允许（来源/路径/大小预算见
+ *   trustFilterContextFiles）；
+ * - skills："off" | "bundled-signed"——任意项目 Skill 不加载；仅
+ *   ROSClaw 内置且 digest 校验通过的 Skill（bundled-skills.ts）；
+ * - promptTemplates："off"——项目提示模板是文本注入面，默认关；
+ * - extensions："off"——任意项目可执行扩展默认禁（后续显式批准
+ *   机制另行开放）；
+ * - executables："off"——项目 hooks/脚本类可执行资源默认禁。
  */
 
 export type ResourceProfile = "robot" | "developer" | "worker";
 
+export type ChannelPolicy = "off" | "trusted-readonly" | "bundled-signed";
+
 export interface ResourcePolicy {
-	noExtensions: boolean;
-	noSkills: boolean;
-	noPromptTemplates: boolean;
-	noThemes: boolean;
-	noContextFiles: boolean;
+	contextFiles: ChannelPolicy;
+	skills: ChannelPolicy;
+	promptTemplates: "off";
+	extensions: "off";
+	executables: "off";
+	/** 用户主题（纯展示，非项目面）。 */
+	themes: boolean;
 	credentialPolicy: "env-only" | "file-0600";
 	allowBash: boolean;
 	allowFileTools: boolean;
@@ -25,36 +37,68 @@ export function resourcePolicy(profile: ResourceProfile): ResourcePolicy {
 	switch (profile) {
 		case "robot":
 			return {
-				noExtensions: true,
-				noSkills: true,
-				noPromptTemplates: true,
-				noThemes: true,
-				noContextFiles: true,
+				contextFiles: "off",
+				skills: "off",
+				promptTemplates: "off",
+				extensions: "off",
+				executables: "off",
+				themes: false,
 				credentialPolicy: "env-only",
 				allowBash: false,
 				allowFileTools: false,
 			};
 		case "developer":
 			return {
-				noExtensions: true, // 项目扩展默认不加载（显式批准机制后续批次）
-				noSkills: true,
-				noPromptTemplates: true,
-				noThemes: false, // 用户主题允许
-				noContextFiles: true, // AGENTS.md 不注入（具身注入走 envelope）
+				contextFiles: "trusted-readonly",
+				skills: "bundled-signed",
+				promptTemplates: "off",
+				extensions: "off",
+				executables: "off",
+				themes: true,
 				credentialPolicy: "file-0600",
 				allowBash: false,
 				allowFileTools: false,
 			};
 		case "worker":
 			return {
-				noExtensions: true,
-				noSkills: true,
-				noPromptTemplates: true,
-				noThemes: true,
-				noContextFiles: true,
+				contextFiles: "off",
+				skills: "off",
+				promptTemplates: "off",
+				extensions: "off",
+				executables: "off",
+				themes: false,
 				credentialPolicy: "env-only",
 				allowBash: false,
-				allowFileTools: false, // WorkerPack 侧按 WorkOrder 授权
+				allowFileTools: false,
 			};
 	}
+}
+
+/** 上下文文件信任过滤（来源+路径+大小预算；超预算/出根剔除并诊断）。 */
+export function trustFilterContextFiles(
+	files: Array<{ path: string; content: string }>,
+	options: { allowedRoots: string[]; maxTotalBytes: number },
+): { kept: Array<{ path: string; content: string }>; diagnostics: string[] } {
+	const kept: Array<{ path: string; content: string }> = [];
+	const diagnostics: string[] = [];
+	let total = 0;
+	for (const file of files) {
+		const inRoot = options.allowedRoots.some(
+			(root) => file.path === root || file.path.startsWith(root + "/"),
+		);
+		if (!inRoot) {
+			diagnostics.push(`剔除（出信任根）：${file.path}`);
+			continue;
+		}
+		const bytes = Buffer.byteLength(file.content, "utf-8");
+		if (total + bytes > options.maxTotalBytes) {
+			diagnostics.push(
+				`剔除（超预算 ${options.maxTotalBytes}B）：${file.path}（${bytes}B）`,
+			);
+			continue;
+		}
+		total += bytes;
+		kept.push(file);
+	}
+	return { kept, diagnostics };
 }

--- a/packages/rosclaw-agent/src/runtime/create-runtime.ts
+++ b/packages/rosclaw-agent/src/runtime/create-runtime.ts
@@ -14,7 +14,8 @@ import {
 	SettingsManager,
 	type AgentSessionRuntime,
 } from "@earendil-works/pi-coding-agent";
-import { resourcePolicy } from "../extension/resource-policy.js";
+import { resourcePolicy, trustFilterContextFiles } from "../extension/resource-policy.js";
+import { verifyBundledSkills } from "../extension/bundled-skills.js";
 import { createSharedModelRuntime } from "./model-runtime.js";
 import { filterModelTools, MODEL_TOOL_NAMES } from "../tools/surface.js";
 import { buildWorkspacePackTools } from "../tools/workspace-pack.js";
@@ -153,13 +154,34 @@ export async function createRosclawRuntime(
 					// PNA-9：profile 化资源策略（robot 全禁；developer 仅用户
 					// 主题；项目 .pi/AGENTS.md/skills 一律不加载）。
 					...(function () {
+						// PR-N2（N 总纲 §PR-N2）：四通道拆分——可信只读
+						// 上下文恢复（trustFilterContextFiles 按根+预算
+						// 过滤）；内置签名 Skill 经 digest 校验后走
+						// additionalSkillPaths；任意项目扩展/模板/可执行
+						// 资源仍关。
 						const policy = resourcePolicy(options.profile);
+						const skillsDir = new URL("../../skills/", import.meta.url).pathname;
+						const bundled = policy.skills === "bundled-signed"
+							? verifyBundledSkills(skillsDir)
+							: { verified: [], excluded: [], skillPaths: [] };
 						return {
-							noExtensions: policy.noExtensions,
-							noSkills: policy.noSkills,
-							noPromptTemplates: policy.noPromptTemplates,
-							noThemes: policy.noThemes,
-							noContextFiles: policy.noContextFiles,
+							noExtensions: true,
+							noSkills: policy.skills === "off",
+							noPromptTemplates: true,
+							noThemes: !policy.themes,
+							noContextFiles: policy.contextFiles === "off",
+							additionalSkillPaths: bundled.skillPaths,
+							agentsFilesOverride: (base: { agentsFiles: Array<{ path: string; content: string }> }) => {
+								const allowed = [
+									options.taskContext.workspaceRoot,
+									options.taskContext.productRoot,
+								];
+								const filtered = trustFilterContextFiles(base.agentsFiles, {
+									allowedRoots: allowed,
+									maxTotalBytes: 64 * 1024,
+								});
+								return { agentsFiles: filtered.kept };
+							},
 						};
 					})(),
 					extensionFactories: [

--- a/packages/rosclaw-agent/test/n2-resource-policy.test.ts
+++ b/packages/rosclaw-agent/test/n2-resource-policy.test.ts
@@ -1,0 +1,85 @@
+/** PR-N2 红测试：恢复 Pi 的可信上下文与 Skill（N 总纲 §PR-N2）。
+ *
+ * 红测试先行——修复前必须红：
+ * 1. ResourcePolicy 拆分 context/skill/extension/executable 四通道
+ *    （旧布尔五连删）；
+ * 2. developer：可信 AGENTS.md/CLAUDE.md 允许；任意项目 Skill/扩展/
+ *    提示模板仍关；ROSClaw 内置签名 Skill 允许；
+ * 3. robot：全关（不变）；
+ * 4. 内置 Skill manifest digest 校验——篡改即排除 + 诊断；
+ * 5. 上下文信任过滤：出根/超限文件被剔除且带 path+size 诊断。
+ */
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+	resourcePolicy,
+	trustFilterContextFiles,
+} from "../src/extension/resource-policy.js";
+import { verifyBundledSkills } from "../src/extension/bundled-skills.js";
+
+test("N2: developer 拆分策略——可信上下文允许 + 项目可执行仍关", () => {
+	const p = resourcePolicy("developer");
+	assert.equal(p.contextFiles, "trusted-readonly");
+	assert.equal(p.skills, "bundled-signed");
+	assert.equal(p.extensions, "off");
+	assert.equal(p.promptTemplates, "off");
+	assert.equal(p.executables, "off");
+});
+
+test("N2: robot 全关不变", () => {
+	const p = resourcePolicy("robot");
+	assert.equal(p.contextFiles, "off");
+	assert.equal(p.skills, "off");
+	assert.equal(p.extensions, "off");
+	assert.equal(p.promptTemplates, "off");
+	assert.equal(p.executables, "off");
+});
+
+test("N2: 内置 Skill digest 校验——篡改即排除", () => {
+	const root = mkdtempSync(join(tmpdir(), "n2-skill-"));
+	const skillDir = join(root, "skills", "rosclaw-embodied");
+	mkdirSync(skillDir, { recursive: true });
+	const content = "---\nname: rosclaw-embodied\ndescription: 具身任务纪律\n---\n\n# 具身\n";
+	writeFileSync(join(skillDir, "SKILL.md"), content, "utf-8");
+	const digest = createHash("sha256").update(content).digest("hex");
+	writeFileSync(
+		join(root, "skills", "manifest.json"),
+		JSON.stringify({ skills: { "rosclaw-embodied": digest } }),
+		"utf-8",
+	);
+	const ok = verifyBundledSkills(join(root, "skills"));
+	assert.deepEqual(ok.verified, ["rosclaw-embodied"]);
+	assert.deepEqual(ok.excluded, []);
+
+	// 篡改后必须排除 + 诊断。
+	writeFileSync(join(skillDir, "SKILL.md"), content + "\ntampered\n", "utf-8");
+	const bad = verifyBundledSkills(join(root, "skills"));
+	assert.deepEqual(bad.verified, []);
+	assert.equal(bad.excluded.length, 1);
+	assert.match(bad.excluded[0].reason, /digest|hash|篡改|digest 不符/i);
+});
+
+test("N2: 上下文信任过滤——出根与超限剔除", () => {
+	const root = mkdtempSync(join(tmpdir(), "n2-ctx-"));
+	const inside = join(root, "CLAUDE.md");
+	writeFileSync(inside, "x".repeat(100), "utf-8");
+	const outside = join(tmpdir(), "outside-CLAUDE.md");
+	writeFileSync(outside, "evil", "utf-8");
+	const result = trustFilterContextFiles(
+		[
+			{ path: inside, content: "x".repeat(100) },
+			{ path: outside, content: "evil" },
+			{ path: join(root, "AGENTS.md"), content: "y".repeat(200 * 1024) },
+		],
+		{ allowedRoots: [root], maxTotalBytes: 64 * 1024 },
+	);
+	assert.deepEqual(result.kept.map((f) => f.path), [inside]);
+	assert.equal(result.diagnostics.length, 2);
+	assert.ok(result.diagnostics.some((d) => d.includes(outside)));
+	assert.ok(result.diagnostics.some((d) => /预算|budget|超/.test(d)));
+});

--- a/packages/rosclaw-agent/test/security.test.ts
+++ b/packages/rosclaw-agent/test/security.test.ts
@@ -34,11 +34,17 @@ test("known commands pass through", () => {
 
 test("resource policy per profile", () => {
 	const robot = resourcePolicy("robot");
-	assert.ok(robot.noExtensions && robot.noSkills && robot.noContextFiles && robot.noThemes);
+	assert.ok(
+		robot.extensions === "off" && robot.skills === "off"
+		&& robot.contextFiles === "off" && !robot.themes,
+	);
 	assert.equal(robot.credentialPolicy, "env-only");
 	assert.equal(robot.allowBash, false);
 	const developer = resourcePolicy("developer");
-	assert.equal(developer.noThemes, false, "developer 允许用户主题");
+	assert.equal(developer.themes, true, "developer 允许用户主题");
+	// PR-N2：developer 的可信上下文/内置签名 Skill 恢复（拆分面）。
+	assert.equal(developer.contextFiles, "trusted-readonly");
+	assert.equal(developer.skills, "bundled-signed");
 	assert.equal(developer.credentialPolicy, "file-0600");
 	const worker = resourcePolicy("worker");
 	assert.equal(worker.allowFileTools, false);

--- a/tests/agentd/test_n2_trusted_context.py
+++ b/tests/agentd/test_n2_trusted_context.py
@@ -1,0 +1,152 @@
+"""PR-N2 PTY 验证：可信上下文与内置 Skill 真实到达模型。
+
+真实链路：workspace 里放 CLAUDE.md（含唯一 marker）→ PTY chat →
+假模型收到的 system/上下文必须含 marker（项目认知恢复）+
+rosclaw-embodied Skill 在可用列表；robot profile 则全不出现。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_entry import find_pi_agent_entry
+from tests.agentd.test_product_journey import PtySession, _chunk, _sse
+
+pytestmark = pytest.mark.skipif(
+    not find_pi_agent_entry(),
+    reason="无 Node/dist（CI 全回归 job 未构建）——诚实 skip",
+)
+
+MARKER = "N2-CTX-MARKER-7f3a9b"
+
+
+class _EchoFake:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    def answer(self, body: dict) -> bytes:
+        self.requests.append(body)
+        if not body.get("stream"):
+            return json.dumps({
+                "id": "c", "object": "chat.completion", "created": 1,
+                "model": "fake-k3",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "pong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 5},
+            }).encode()
+        frames = [
+            _sse(_chunk("已收到。")),
+            _sse(_chunk("", "stop")),
+            b"data: [DONE]\n\n",
+        ]
+        return b"".join(frames)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    fake: _EchoFake
+
+    def log_message(self, *args) -> None:
+        return
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        payload = self.fake.answer(body)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.fake = _EchoFake()
+        handler = type("H", (_Handler,), {"fake": self.fake})
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.server.server_address[1]
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1"
+
+    def close(self) -> None:
+        self.server.shutdown()
+
+
+def _prepare(tmp_path: Path, base_url: str) -> tuple[Path, Path, dict[str, str]]:
+    home = tmp_path / "rh"
+    (home / "run").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "agent:\n  enabled: true\n  default_profile: embodied_default\n"
+        "models:\n  backend: legacy\n  profiles:\n    embodied_default:\n"
+        "      provider: kimi_code\n      model: fake-k3\n"
+        f"      base_url: {base_url}\n"
+        "      api_key_ref: env:FAKE_JOURNEY_KEY\n"
+        "      capabilities: [llm.chat, llm.structured_decision, llm.tool_use]\n",
+        encoding="utf-8",
+    )
+    (home / "agent").mkdir(parents=True, exist_ok=True)
+    (home / "agent" / "settings.json").write_text(
+        json.dumps({"defaultProvider": "journey-fake", "defaultModel": "fake-k3"}),
+        encoding="utf-8",
+    )
+    (home / "agent" / "models.json").write_text(
+        json.dumps({
+            "providers": {
+                "journey-fake": {
+                    "name": "Journey Fake", "baseUrl": base_url,
+                    "api": "openai-completions", "apiKey": "$FAKE_JOURNEY_KEY",
+                    "models": [{"id": "fake-k3", "name": "Fake K3", "contextWindow": 8192, "maxTokens": 4096}],
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+    workdir = tmp_path / "ws"
+    workdir.mkdir()
+    (workdir / ".git").mkdir()  # git root → workspace=workdir（N1 规则）
+    (workdir / "CLAUDE.md").write_text(
+        f"# 项目说明\n\n本项目的唯一标识：{MARKER}\n", encoding="utf-8",
+    )
+    env = dict(
+        os.environ, ROSCLAW_HOME=str(home), TERM="xterm",
+        FAKE_JOURNEY_KEY="sk-fake-journey", ROSCLAW_UI_LOCALE="zh-CN",
+    )
+    return home, workdir, env
+
+
+class TestTrustedContext:
+    def test_context_file_and_bundled_skill_reach_model(self, tmp_path: Path) -> None:
+        fake = _FakeServer()
+        home, workdir, env = _prepare(tmp_path, fake.base_url)
+        session = PtySession(
+            [sys.executable, "-m", "rosclaw.entrypoint", "chat"],
+            env, log_path=tmp_path / "pty-n2.log", cwd=workdir,
+        )
+        try:
+            session.expect(b"ROSClaw Native Agent", timeout=120)
+            session.send("你好\r")
+            session.expect("已收到。".encode(), timeout=180)
+            assert fake.fake.requests, "假模型未收到请求"
+            all_text = json.dumps(fake.fake.requests, ensure_ascii=False)
+            # 项目上下文恢复：CLAUDE.md marker 到达模型。
+            assert MARKER in all_text, (
+                "CLAUDE.md 内容未到达模型（可信上下文未恢复）"
+            )
+            # 内置签名 Skill 在可用技能面。
+            assert "rosclaw-embodied" in all_text, (
+                "内置 Skill 未出现在模型可见面"
+            )
+            session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
+            session.proc.wait(timeout=30)
+        finally:
+            session.stop()
+            fake.close()


### PR DESCRIPTION
## PR-N2

- ResourcePolicy 四通道拆分（contextFiles/skills/promptTemplates/extensions/executables）；developer 恢复 trusted-readonly + bundled-signed，robot/worker 不变
- 内置签名 Skill（manifest sha256 校验，篡改即排除+诊断）
- 上下文信任过滤（信任根 + 64KB 预算，剔除带 path+size 诊断）
- **根因修复**：before_agent_start 每轮用 options.systemPrompt 整体替换 Pi 组装提示词 → 改用 event.systemPrompt（context/skills 此前从未到达模型）

## 验证

- 红→绿：TS 4 红→4/4；PTY 红→绿（CLAUDE.md marker + Skill 实证到达模型）
- TS 137/137；PTY n1/n2/h1 全绿；ruff 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)