### PR TITLE
fix: N0 自审热修——熔断武装链 + /done 诚实 + 402 分类

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -480,6 +480,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			sessionRef: () => options.active.current.sessionId ?? "",
 			backendNativeId: () => options.active.current.sessionId ?? "",
 			cwd: () => options.taskContext.workspaceRoot,
+			bodyId: () => options.active.current.bodyId ?? "",
 			notify: (text, kind) => {
 				latestCtx?.ui.notify(text, kind);
 			},
@@ -501,9 +502,13 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				try {
 					// PR-N0：/done = 用户接受（user_accepted_at）——此后
 					// 新消息开新任务；未接受的 SUCCEEDED 被用户修正重开。
-					await center.call("pi.kernel.accept", {
+					const r = await center.call("pi.kernel.accept", {
 						task_id: inputController.currentTaskId,
 					});
+					if (r.ok === false) {
+						ctx.ui.notify(`不能接受：${String(r.error ?? '')}`, "warning");
+						return;
+					}
 					ctx.ui.notify(
 						`任务已接受（${inputController.currentTaskId.slice(0, 14)}…）`,
 						"info",

--- a/packages/rosclaw-agent/src/native/input-controller.ts
+++ b/packages/rosclaw-agent/src/native/input-controller.ts
@@ -27,6 +27,9 @@ export interface InputControllerDeps {
 	sessionRef: () => string;
 	backendNativeId: () => string;
 	cwd: () => string;
+	/** 当前绑定 body（PR-N0 熔断的执行面：机器人行为任务的受信
+	 *  证据要求由 body_id 驱动——不传则熔断在 chat 路径惰性失效）。 */
+	bodyId?: () => string;
 	notify: (text: string, kind: "info" | "warning" | "error") => void;
 }
 
@@ -50,6 +53,7 @@ export class InputController {
 				message_id: messageId,
 				text,
 				cwd: this.deps.cwd(),
+				body_id: this.deps.bodyId?.() ?? "",
 				force_new: this.forceNewNext,
 			})) as unknown as TaskBindResult & { ok?: boolean };
 			this.forceNewNext = false;

--- a/packages/rosclaw-agent/src/native/model-errors.ts
+++ b/packages/rosclaw-agent/src/native/model-errors.ts
@@ -32,7 +32,7 @@ export function classifyModelError(raw: string): ClassifiedModelError {
 	const text = raw.toLowerCase();
 	// 顺序敏感：quota 在 generic 403/auth 之前。
 	if (
-		/usage limit|quota|billing|access_terminated/.test(text)
+		/usage limit|quota|billing|access_terminated|membership|402/.test(text)
 	) {
 		return {
 			code: "PROVIDER_QUOTA_EXHAUSTED",

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -964,7 +964,15 @@ class PiBridgeServer:
                 # PR-N1：任务 workspace = ActiveTaskContext 的
                 # workspaceRoot（cwd 即工作根——同一事实源）。
                 workspace_root=str(params.get("cwd", "")),
-                body_id=str(params.get("body_id", "")),
+                body_id=(
+                    str(params.get("body_id", ""))
+                    # 首条消息尚无 envelope——回落 mission 绑定 body
+                    # （PR-N0 熔断的执行面必须首条即武装）。
+                    or (service.get_mission(str(params.get("mission_id", "")))
+                        .body_binding.body_id if service.get_mission(
+                            str(params.get("mission_id", ""))
+                        ) else "")
+                ),
                 force_new=bool(params.get("force_new", False)),
             )
             return {"ok": True, **result}

--- a/tests/agentd/test_n0_no_false_success.py
+++ b/tests/agentd/test_n0_no_false_success.py
@@ -234,3 +234,39 @@ class TestNoFalseSuccess:
         assert r2["verification_id"] == r1["verification_id"], (
             "重复验证竟产生新 receipt"
         )
+
+
+class TestFuseArmed:
+    def test_bind_without_body_falls_back_to_mission_body(
+        self, tmp_path: Path
+    ) -> None:
+        """bridge 回落：bind 不带 body_id 时用 mission 绑定 body——
+        熔断在 chat 路径首条消息即武装（不自审前的惰性失效）。"""
+        from tests.agentd.test_pi_tool_bridge import _setup  # noqa: F401
+
+        import asyncio
+
+        async def _run() -> None:
+            service, mission = await _setup(tmp_path)
+            from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+
+            bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+            result = await bridge._dispatch(
+                "user:local:1000", 1, "pi.task.bind",
+                {
+                    "token": service.control_token,
+                    "mission_id": mission.mission_id,
+                    "session_ref": "pi_1", "backend_native_id": "pi_1",
+                    "message_id": "msg_fuse", "text": "画五角星",
+                    "cwd": str(tmp_path),
+                },
+            )
+            assert result.get("ok"), result
+            task = service._task_kernel.get_task(result["task_id"])
+            assert task is not None
+            assert task["body_id"], (
+                "bind 未带 body_id 且未回落 mission body——熔断惰性失效"
+            )
+            await service.close()
+
+        asyncio.run(_run())

--- a/tests/agentd/test_n0_no_false_success.py
+++ b/tests/agentd/test_n0_no_false_success.py
@@ -242,9 +242,9 @@ class TestFuseArmed:
     ) -> None:
         """bridge 回落：bind 不带 body_id 时用 mission 绑定 body——
         熔断在 chat 路径首条消息即武装（不自审前的惰性失效）。"""
-        from tests.agentd.test_pi_tool_bridge import _setup  # noqa: F401
-
         import asyncio
+
+        from tests.agentd.test_pi_tool_bridge import _setup  # noqa: F401
 
         async def _run() -> None:
             service, mission = await _setup(tmp_path)


### PR DESCRIPTION
## 自审发现

1. **熔断惰性失效**：InputController 从不传 body_id → kernel 任务 body_id 恒空 → N0 受信证据规则在 chat 路径从不触发。修复：InputController 接 active bodyId + bridge 回落 mission body；新增桥级武装测试。
2. /done 在桥 ok:false 时仍显示已接受 → 诚实报错。
3. 402 membership → PROVIDER_QUOTA_EXHAUSTED（实测命中）。

## 验证

- 红→绿：武装测试红→绿；N0 9/9；TS 137/137；ruff 全绿。
- 真实 K3 Gate 本次阻塞于 provider 402（key 失效，非代码回归；假模型 PTY 旅程全绿）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)