### PR TITLE
feat: PR-N4.1+N4.2——执行资源证明闭环 + Workspace 产品语义（调整方案 §二）

### DIFF
--- a/packages/rosclaw-agent/src/main.ts
+++ b/packages/rosclaw-agent/src/main.ts
@@ -93,7 +93,7 @@ async function main(): Promise<number> {
 	// PR-N1：ActiveTaskContext 在 session 创建前解析并冻结——
 	// runtime/工具/bridge/artifact/verifier/header 全从这里取路径。
 	const { resolveTaskContext } = await import("./native/active-task-context.js");
-	const taskContext = resolveTaskContext({
+	let taskContext = resolveTaskContext({
 		rosclawHome,
 		cwd: process.cwd(),  // 唯一允许的进程 cwd 读取（启动解析输入）
 		mode: "SIMULATION",
@@ -138,6 +138,19 @@ async function main(): Promise<number> {
 	const isResume = Boolean(
 		resumeSessionId || resumeSessionPath || browseSessions || continueLast,
 	);
+	// N4.2：resume 的 workspace 以会话记录为准（优先于 cwd 推导）。
+	if (isResume && initialSession) {
+		const resumedCwd = initialSession.getCwd();
+		if (resumedCwd) {
+			taskContext = resolveTaskContext({
+				rosclawHome,
+				cwd: process.cwd(),  // 唯一允许的进程 cwd 读取（启动解析输入）
+				mode: "SIMULATION",
+				explicitWorkspace: workspace,
+				resumedWorkspace: resumedCwd,
+			});
+		}
+	}
 	// 十一审 PR-D：Workspace 一等状态——显式 --workspace > cwd git 自动
 	// 绑定 > 既有绑定。
 	const { runtime, coordinator, leaseManager } = await createRosclawRuntime({

--- a/packages/rosclaw-agent/src/native/active-task-context.ts
+++ b/packages/rosclaw-agent/src/native/active-task-context.ts
@@ -16,7 +16,13 @@ import { resolve } from "node:path";
 
 import { gitRootOf, WorkspaceStore } from "../session/workspace.js";
 
-export type WorkspaceSource = "explicit" | "git" | "restored" | "default";
+export type WorkspaceSource =
+	| "explicit"
+	| "resumed"
+	| "git"
+	| "restored"
+	| "cwd"
+	| "default";
 
 export interface ActiveTaskContext {
 	/** session 创建后由 runtime 回填前的占位——冻结时可为空。 */
@@ -50,6 +56,10 @@ export function resolveTaskContext(options: {
 	cwd: string;
 	mode: "SIMULATION" | "SHADOW" | "REAL";
 	explicitWorkspace?: string;
+	/** resume 会话记录的 workspace（优先于 cwd 推导——N4.2）。 */
+	resumedWorkspace?: string;
+	/** 真实 HOME（测试可注入——默认 process.env.HOME）。 */
+	homeDir?: string;
 	robotId?: string;
 	simulatorId?: string;
 }): ActiveTaskContext {
@@ -57,9 +67,14 @@ export function resolveTaskContext(options: {
 	let workspaceSource: WorkspaceSource;
 	let projectRoot: string | undefined;
 
+	const home = options.homeDir ?? process.env.HOME ?? "";
 	if (options.explicitWorkspace) {
 		workspaceRoot = resolve(options.explicitWorkspace);
 		workspaceSource = "explicit";
+		projectRoot = gitRootOf(workspaceRoot) ?? workspaceRoot;
+	} else if (options.resumedWorkspace) {
+		workspaceRoot = resolve(options.resumedWorkspace);
+		workspaceSource = "resumed";
 		projectRoot = gitRootOf(workspaceRoot) ?? workspaceRoot;
 	} else {
 		const repo = gitRootOf(options.cwd);
@@ -74,9 +89,30 @@ export function resolveTaskContext(options: {
 				workspaceSource = "restored";
 				projectRoot = gitRootOf(workspaceRoot) ?? workspaceRoot;
 			} else {
-				workspaceRoot = resolve(options.rosclawHome, "workspaces", "default");
-				workspaceSource = "default";
-				mkdirSync(workspaceRoot, { recursive: true });
+				// N4.2：普通可写目录直接当工作区（用户直觉）——仅 / 或
+				// HOME 或不可写目录回落 default（不把 HOME 当工作区）。
+				const cwdResolved = resolve(options.cwd);
+				const isHomeOrRoot =
+					cwdResolved === "/" || (home !== "" && cwdResolved === resolve(home));
+				let writable = false;
+				if (!isHomeOrRoot) {
+					try {
+						mkdirSync(cwdResolved, { recursive: true });
+						writable = true;
+					} catch {
+						writable = false;
+					}
+				}
+				if (!isHomeOrRoot && writable) {
+					workspaceRoot = cwdResolved;
+					workspaceSource = "cwd";
+				} else {
+					workspaceRoot = resolve(
+						options.rosclawHome, "workspaces", "default",
+					);
+					workspaceSource = "default";
+					mkdirSync(workspaceRoot, { recursive: true });
+				}
 			}
 		}
 	}

--- a/packages/rosclaw-agent/test/n1-task-context.test.ts
+++ b/packages/rosclaw-agent/test/n1-task-context.test.ts
@@ -62,10 +62,21 @@ test("N1: 持久化 workspace 恢复（诚实标注 restored）", () => {
 	assert.equal(ctx.workspaceSource, "restored");
 });
 
-test("N1: 什么都没有 → default workspace（真实创建，不谎称项目）", () => {
+test("N4.2：普通可写 cwd（非 git）→ 工作区=cwd（用户直觉）", () => {
+	const home = mkHome();
+	const plain = mkHome();
+	const ctx = resolveTaskContext({
+		rosclawHome: home, cwd: plain, mode: "SIMULATION",
+	});
+	assert.equal(ctx.workspaceRoot, plain);
+	assert.equal(ctx.workspaceSource, "cwd");
+});
+
+test("N4.2：HOME/根目录启动 → default workspace（不把 HOME 当工作区）", () => {
 	const home = mkHome();
 	const ctx = resolveTaskContext({
-		rosclawHome: home, cwd: mkHome(), mode: "SIMULATION",
+		rosclawHome: home, cwd: join(home, "fakehome"), mode: "SIMULATION",
+		homeDir: join(home, "fakehome"),
 	});
 	assert.equal(ctx.workspaceRoot, join(home, "workspaces", "default"));
 	assert.equal(ctx.workspaceSource, "default");

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -149,6 +149,17 @@ class PiToolDispatcher:
         await self._mirror_decision(request, result)
         return result
 
+    def _note_embodiment_use(self, request: PiToolRequestV1) -> None:
+        """N4.1：具身执行工具落账——行为任务的判定依据是实际调用，
+        不是 body 在场。"""
+        task = self._service._task_kernel.active_task_for(
+            request.mission_id, request.pi_session_id
+        )
+        if task is not None:
+            self._service._task_kernel.note_tool_use(
+                str(task["task_id"]), request.tool_name
+            )
+
     async def _execute_validated(self, request: PiToolRequestV1) -> PiToolResultV1:
         service = self._service
         # 2. session binding + mission。
@@ -311,13 +322,16 @@ class PiToolDispatcher:
                 "no results in this SIM profile",
             )
         if name == "rosclaw_request_action":
+            self._note_embodiment_use(request)
             return await self._request_action(request)
         if name == "rosclaw_task":
+            self._note_embodiment_use(request)
             return await self._task(request)
         # PR-H3：process 工具——长进程 = Operation（立即返回，事件流
         # 可查，终态 followUp 一次）。
         # PR-H5：统一执行入口 + operation 控制。
         if name == "rosclaw_execute":
+            self._note_embodiment_use(request)
             return await self._execute(request)
         if name == "rosclaw_wait_operation":
             return await self._wait_operation(request)
@@ -725,10 +739,12 @@ class PiToolDispatcher:
 
                 with _cl.suppress(ValueError):
                     # 产物文件缺失由验收 failures 表达；受信管道登记
-                    # （producer=kernel——PR-N0 行为任务必须有此证据）。
+                    # （producer=kernel——PR-N0）+ 资源证明元数据
+                    # （N4.1——producer 只是来源身份，资源证明才算数）。
                     service._task_kernel.register_artifact(
                         task_id=task["task_id"], path=path, media_type=media,
                         producer="kernel:sim_pipeline",
+                        metadata={"resource": result.get("resource") or {}},
                     )
         state = "VERIFIED" if not failures else "FAILED"
         payload = {

--- a/src/rosclaw/agentd/sim_trajectory.py
+++ b/src/rosclaw/agentd/sim_trajectory.py
@@ -275,6 +275,7 @@ class SimTrajectoryService:
                 {"x": start["x"], "y": start["y"], "z": lift_z},
             ]
             joint_trajectory = _ik_waypoints(model, data, transit + points)
+            resource_proof = sandbox.resource_manifest()
             scenario = ScenarioSpec(
                 scenario_id=f"sim-trajectory-{plan['hash'][:8]}",
                 robot_id="ur5e",
@@ -282,6 +283,8 @@ class SimTrajectoryService:
                 body_snapshot_hash=f"sha256:{plan['hash']}",
                 model_hash=file_hash(sandbox.model_path),
                 seed=0,
+                # N4.1：执行资源证明随 scenario/receipt 走。
+                metadata={"resource": resource_proof},
             )
             backend = MujocoCpuBackend(sandbox)
             # 慢速插值（0.0005 rad/控制步）——每个 IK 航点约 10 步，
@@ -324,6 +327,8 @@ class SimTrajectoryService:
                     "planned": points,
                     "actual": actual,
                     "evidence_level": "SIM_DYN_ROLLOUT",
+                    # N4.1：资源证明进 trace（可反查 manifest/digest）。
+                    "resource": resource_proof,
                 }, ensure_ascii=False),
                 encoding="utf-8",
             )
@@ -336,7 +341,10 @@ class SimTrajectoryService:
                 encoding="utf-8",
             )
             (out_dir / "metrics.json").write_text(
-                json.dumps(metrics, ensure_ascii=False, indent=2),
+                json.dumps(
+                    {**metrics, "resource": resource_proof},
+                    ensure_ascii=False, indent=2,
+                ),
                 encoding="utf-8",
             )
             return {
@@ -348,6 +356,7 @@ class SimTrajectoryService:
                 "violations": list(receipt.violations),
                 "point_count": len(actual),
                 "tracking": metrics,
+                "resource": resource_proof,
                 "artifacts": {
                     "trace_json": str(out_dir / "trace.json"),
                     "trace_csv": str(out_dir / "trace.csv"),

--- a/src/rosclaw/sandbox/sandbox_api.py
+++ b/src/rosclaw/sandbox/sandbox_api.py
@@ -357,19 +357,60 @@ class Sandbox:
         return self._load_error
 
     def resource_manifest(self) -> dict:
-        """PR-N4（§8 PR-N4）：加载的模型资源身份——resource ID +
-        model path + 内容 digest（verifier 可证明实际加载的是哪个
-        资产）。"""
+        """PR-N4/N4.1：执行资源证明——resource ID + model path +
+        内容 digest + manifest digest + mesh digests + 解析代次 +
+        质量/权威标记（verifier 可证明实际加载的是哪个资产）。"""
         import hashlib
 
         path = self._model_path
+        model_digest = (
+            "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+            if path and path.exists() else ""
+        )
+        mesh_digests: dict[str, str] = {}
+        quality = ""
+        canonical: bool | None = None
+        manifest_digest = ""
+        resolver_generation = ""
+        robot_id = self._robot_id
+        # 别名归一（sim_ur5e → ur5e）后查权威 manifest。
+        robot_id = {"sim_ur5e": "ur5e"}.get(robot_id, robot_id)
+        if path and path.exists():
+            assets_dir = path.parent / "assets"
+            if assets_dir.is_dir():
+                h = hashlib.sha256()
+                for f in sorted(assets_dir.rglob("*")):
+                    if f.is_file():
+                        h.update(str(f.relative_to(assets_dir)).encode())
+                        h.update(hashlib.sha256(f.read_bytes()).digest())
+                mesh_digests = {"assets": "sha256:" + h.hexdigest()}
+            try:
+                from rosclaw.cognition.resolver import resolve_resource
+
+                # 产品根：model path 上溯（e-urdf-zoo/<robot>/x.xml
+                # → 根）。
+                product_root = path.parent.parent.parent
+                manifest = resolve_resource(
+                    "robot", robot_id, product_root=product_root
+                )
+                if manifest is not None:
+                    quality = manifest.get("quality", "")
+                    canonical = manifest.get("canonical")
+                    manifest_digest = manifest.get("digests", {}).get(
+                        "profile", ""
+                    )
+                    resolver_generation = manifest_digest
+            except Exception:  # noqa: BLE001 - resolver 不可用不阻塞执行
+                pass
         return {
-            "resource_id": f"robot:{self._robot_id}",
+            "resource_id": f"robot:{robot_id}",
+            "manifest_digest": manifest_digest,
             "model_path": str(path) if path else "",
-            "digest": (
-                "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
-                if path and path.exists() else ""
-            ),
+            "model_digest": model_digest,
+            "mesh_digests": mesh_digests,
+            "resolver_generation": resolver_generation,
+            "quality": quality,
+            "canonical": canonical,
             "world_id": self._world_id,
             "loaded": self._model is not None,
         }

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -319,6 +319,7 @@ class TaskKernel:
         self, *, task_id: str, path: str, media_type: str,
         producer_operation_id: str = "",
         producer: str = "model:tool",
+        metadata: dict | None = None,
     ) -> dict[str, Any]:
         """登记交付物：实读文件算 sha256/size（不存在的文件拒绝登记）。
         登记才进交付列表——模型口头提到不算。
@@ -350,16 +351,25 @@ class TaskKernel:
             "sha256": hashlib.sha256(content).hexdigest(),
             "size_bytes": len(content),
         }
+        # N4.1：模型自产证据标 EXPERIMENTAL——通过 qualification 前
+        # 不当正式能力证据（N 调整方案 §二）。
+        meta = dict(metadata or {})
+        if producer.startswith("model:"):
+            meta.setdefault("evidence_tier", "EXPERIMENTAL")
+        meta_json = json.dumps(meta, ensure_ascii=False)
         self._conn.execute(
             "INSERT INTO artifacts (artifact_id, task_id, path, media_type, "
-            "sha256, size_bytes, producer_operation_id, producer, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "sha256, size_bytes, producer_operation_id, producer, "
+            "metadata_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (artifact_id, task_id, str(file), media_type, record["sha256"],
-             len(content), producer_operation_id or None, producer, now),
+             len(content), producer_operation_id or None, producer,
+             meta_json, now),
         )
         self._emit(task_id, "artifact.created",
                    {"artifact_id": artifact_id, "path": str(file),
                     "bytes": len(content)})
+        record["metadata_json"] = meta_json
         return record
 
     def finish_task(
@@ -404,6 +414,60 @@ class TaskKernel:
             (task_id, int(task["active_revision"])),
         ).fetchone()
         frozen = json.loads(str(rev_row["acceptance_json"])) if rev_row else {}
+        # N4.1：资源证明比对——产物元数据的 resource 块 ↔ 当前权威
+        # manifest（resolver）↔ 内容 digest。producer 只是来源身份，
+        # 不代替资源证明。
+        provenance_failures: list[str] = []
+        embodiment_used = self.task_used_embodiment(task_id)
+        if embodiment_used:
+            robot_id = str(task["body_id"]).removeprefix("sim/")
+            resource_proofs = []
+            for art in artifacts:
+                meta = json.loads(str(art.get("metadata_json") or "{}"))
+                resource = meta.get("resource") or {}
+                if resource:
+                    resource_proofs.append(resource)
+            if not resource_proofs:
+                provenance_failures.append(
+                    "RESOURCE_PROVENANCE_MISSING: 行为任务产物无资源证明"
+                )
+            else:
+                from rosclaw.cognition.resolver import resolve_resource
+
+                product_root = Path(__file__).resolve().parents[3]
+                manifest = resolve_resource(
+                    "robot", robot_id, product_root=product_root
+                )
+                if manifest is None:
+                    provenance_failures.append(
+                        f"RESOURCE_PROVENANCE_MISSING: 无 {robot_id} 权威 "
+                        "manifest 可比对"
+                    )
+                else:
+                    expected_digest = manifest.get("digests", {}).get(
+                        "mjcf", ""
+                    )
+                    for proof in resource_proofs:
+                        if proof.get("resource_id") != f"robot:{robot_id}":
+                            provenance_failures.append(
+                                "RESOURCE_ID_MISMATCH: "
+                                f"{proof.get('resource_id')} != "
+                                f"robot:{robot_id}"
+                            )
+                        if proof.get("quality") != "PRODUCTION" or (
+                            proof.get("canonical") is not True
+                        ):
+                            provenance_failures.append(
+                                "NON_CANONICAL_RESOURCE: "
+                                f"quality={proof.get('quality')}"
+                            )
+                        if expected_digest and (
+                            proof.get("model_digest") != expected_digest
+                        ):
+                            provenance_failures.append(
+                                "RESOURCE_DIGEST_MISMATCH: 实际加载模型 "
+                                "与权威 manifest 摘要不符"
+                            )
         trusted_present = any(
             str(a.get("producer") or "").startswith("kernel:")
             for a in artifacts
@@ -413,8 +477,9 @@ class TaskKernel:
             acceptance=frozen,
             workspace=Path(task["workspace_path"]),
             summary=summary,
-            require_trusted_evidence=bool(task["body_id"]),
+            require_trusted_evidence=embodiment_used,
             trusted_evidence_present=trusted_present,
+            extra_failures=provenance_failures,
         )
         now = datetime.now(UTC).isoformat()
         if verdict["status"] == "PASS":
@@ -443,6 +508,26 @@ class TaskKernel:
             "failures": verdict["failures"],
             "checks": verdict["checks"],
         }
+
+    #: 具身执行工具（用了这些 = 行为任务——受信证据规则才武装）。
+    _EMBODIMENT_TOOLS = frozenset({
+        "rosclaw_task", "rosclaw_execute", "rosclaw_request_action",
+    })
+
+    def note_tool_use(self, task_id: str, tool_name: str) -> None:
+        """具身工具使用落账（dispatcher 在 _execute_validated 调用）——
+        N4.1：行为任务的判定依据是实际用了具身执行工具，不是
+        body 存在（编码任务绑着机器人 body 也是编码任务）。"""
+        if tool_name in self._EMBODIMENT_TOOLS:
+            self._emit(task_id, "task.tool_used", {"tool": tool_name})
+
+    def task_used_embodiment(self, task_id: str) -> bool:
+        row = self._conn.execute(
+            "SELECT COUNT(*) AS c FROM task_events WHERE task_id = ? "
+            "AND event_type = 'task.tool_used'",
+            (task_id,),
+        ).fetchone()
+        return bool(row and row["c"] > 0)
 
     def set_acceptance(self, task_id: str, acceptance: dict) -> None:
         """验收条件在任务创建/修订时冻结（PR-N0）——finish 不接受

--- a/src/rosclaw/task_kernel/verifier.py
+++ b/src/rosclaw/task_kernel/verifier.py
@@ -98,6 +98,7 @@ def verdict_for(
     summary: str,
     require_trusted_evidence: bool = False,
     trusted_evidence_present: bool = False,
+    extra_failures: list[str] | None = None,
 ) -> dict[str, Any]:
     """统一判定。返回 {status, checks, failures}——status:
     PASS / REPAIR_REQUIRED（零证据即 REPAIR_REQUIRED，绝不 PASS）。
@@ -118,6 +119,7 @@ def verdict_for(
             "TRUSTED_EVIDENCE_MISSING: 机器人行为任务缺受信管道的独立"
             "验证证据——模型自产 artifact 不算数"
         )
+    failures += list(extra_failures or [])
     checks = len(artifacts)
     acc_checks, acc_failures = verify_acceptance(acceptance, workspace)
     checks += acc_checks

--- a/tests/agentd/test_eight8_checkpoint.py
+++ b/tests/agentd/test_eight8_checkpoint.py
@@ -45,6 +45,7 @@ def _bind_kernel_task(service, mission, *, goal: str = "画五角星") -> str:
         message_id="msg_ckpt_1",
         text=goal,
         cwd=str(service._home),
+        body_id=mission.body_binding.body_id,
     )
     return str(bound["task_id"])
 

--- a/tests/agentd/test_n0_no_false_success.py
+++ b/tests/agentd/test_n0_no_false_success.py
@@ -23,6 +23,23 @@ from pathlib import Path
 from rosclaw.task_kernel.service import TaskKernel
 
 
+def _real_ur5e_resource() -> dict:
+    """真实权威 manifest 的资源证明（对照组用真值——不是编数字）。"""
+    from rosclaw.cognition.resolver import resolve_resource
+
+    repo = Path(__file__).resolve().parents[2]
+    manifest = resolve_resource("robot", "ur5e", product_root=repo)
+    assert manifest is not None
+    return {
+        "resource_id": "robot:ur5e",
+        "manifest_digest": manifest["digests"].get("profile", ""),
+        "model_path": manifest["paths"]["mjcf"],
+        "model_digest": manifest["digests"]["mjcf"],
+        "quality": "PRODUCTION",
+        "canonical": True,
+    }
+
+
 def _kernel(tmp_path: Path) -> TaskKernel:
     conn = sqlite3.connect(":memory:", check_same_thread=False)
     conn.row_factory = sqlite3.Row
@@ -63,6 +80,8 @@ class TestNoFalseSuccess:
         机器人行为任务不得 SUCCEEDED（需要受信管道的独立验证证据）。"""
         kernel = _kernel(tmp_path)
         task_id = _bind(kernel, tmp_path)
+        # 行为任务=实际调用具身执行工具（body 在场只是绑定事实）。
+        kernel.note_tool_use(task_id, "rosclaw_task")
         art = _write_artifact(kernel, task_id, "star.gif", b"GIF89a" + b"x" * 2048)
         result = kernel.finish_task(
             task_id=task_id, summary="五角星画好了", artifact_ids=[art["artifact_id"]],
@@ -77,6 +96,7 @@ class TestNoFalseSuccess:
         """对照组：受信管道产物（kernel 内部登记）→ 可以 SUCCEEDED。"""
         kernel = _kernel(tmp_path)
         task_id = _bind(kernel, tmp_path)
+        kernel.note_tool_use(task_id, "rosclaw_task")
         task = kernel.get_task(task_id)
         assert task is not None
         path = Path(task["workspace_path"]) / "star.gif"
@@ -84,6 +104,7 @@ class TestNoFalseSuccess:
         art = kernel.register_artifact(
             task_id=task_id, path=str(path), media_type="image/gif",
             producer="kernel:sim_pipeline",
+            metadata={"resource": _real_ur5e_resource()},
         )
         result = kernel.finish_task(
             task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],

--- a/tests/agentd/test_n41_provenance_closure.py
+++ b/tests/agentd/test_n41_provenance_closure.py
@@ -1,0 +1,172 @@
+"""PR-N4.1 红测试：执行资源证明闭环（调整方案 §二）。
+
+红测试先行——修复前必须红：
+1. 正式 UR5e 内容被换成 fixture 内容（文件名不变）→ 验收必须
+   RESOURCE_DIGEST_MISMATCH；
+2. fixture 复制到工作区再跑 → 仍不能冒充正式 UR5e
+   （RESOURCE_ID_MISMATCH/NON_CANONICAL_RESOURCE）；
+3. SimTrajectoryService 执行 receipt/产物元数据携带完整资源证明
+   （resource_id/manifest_digest/model_path/model_digest/quality/
+   canonical），可反查 manifest；
+4. Verifier 只读 receipt/evidence 元数据——模型口头声明的路径不算；
+5. 模型手写脚本产物标 EXPERIMENTAL_EVIDENCE（不得当正式能力证据）。
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _kernel(tmp_path: Path):
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return TaskKernel(conn, tmp_path)
+
+
+def _task(kernel, tmp_path: Path) -> str:
+    bound = kernel.bind_message(
+        mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+        message_id="m1", text="画五角星", cwd=str(tmp_path),
+        mode="SIMULATION", body_id="sim/ur5e",
+    )
+    task_id = str(bound["task_id"])
+    kernel.note_tool_use(task_id, "rosclaw_task")  # 行为任务标记
+    return task_id
+
+
+def _register_with_resource(kernel, task_id: str, tmp_path: Path,
+                            resource: dict | None) -> dict:
+    task = kernel.get_task(task_id)
+    assert task is not None
+    gif = Path(task["workspace_path"]) / "star.gif"
+    gif.write_bytes(b"GIF89a" + b"x" * 2048)
+    return kernel.register_artifact(
+        task_id=task_id, path=str(gif), media_type="image/gif",
+        producer="kernel:sim_pipeline",
+        metadata={"resource": resource} if resource else None,
+    )
+
+
+class TestProvenanceClosure:
+    def test_sim_receipt_carries_resource_proof(self, tmp_path: Path) -> None:
+        """执行 receipt/trace 携带完整资源证明——可反查 manifest。"""
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        sim = SimTrajectoryService(tmp_path)
+        plan = sim.generate_planar_path(shape="star5", center_m=[0.35, 0.25, 0.30], scale_m=0.05)
+        result = sim.simulate_cartesian_trajectory(plan["plan_id"])
+        trace = json.loads(
+            Path(result["artifacts"]["trace_json"]).read_text(encoding="utf-8")
+        )
+        resource = trace.get("resource") or {}
+        for key in ("resource_id", "manifest_digest", "model_path",
+                    "model_digest", "quality", "canonical"):
+            assert key in resource, f"receipt 缺 {key}"
+        assert resource["resource_id"] == "robot:ur5e"
+        assert resource["model_digest"].startswith("sha256:")
+        assert resource["quality"] == "PRODUCTION"
+        assert resource["canonical"] is True
+        # 反查：model_digest 必须与当前权威 manifest 一致。
+        from rosclaw.cognition.resolver import resolve_resource
+
+        manifest = resolve_resource("robot", "ur5e", product_root=REPO)
+        assert manifest is not None
+        assert manifest["digests"]["mjcf"] == resource["model_digest"]
+
+    def test_swapped_canonical_content_fails_verification(
+        self, tmp_path: Path
+    ) -> None:
+        """正式 UR5e 文件内容被换成 fixture 内容（文件名不变）→
+        RESOURCE_DIGEST_MISMATCH。"""
+
+        kernel = _kernel(tmp_path)
+        task_id = _task(kernel, tmp_path)
+        # 受信产物带资源证明——但 model_digest 是 fixture 的 digest
+        # （模拟内容被换）。
+        fixture_xml = REPO / "tests" / "fixtures" / "ur5e_minimal_fixture.xml"
+        import hashlib
+
+        fixture_digest = "sha256:" + hashlib.sha256(
+            fixture_xml.read_bytes()
+        ).hexdigest()
+        art = _register_with_resource(kernel, task_id, tmp_path, resource={
+            "resource_id": "robot:ur5e",
+            "manifest_digest": "sha256:" + "ab" * 32,
+            "model_path": str(REPO / "e-urdf-zoo" / "ur5e" / "robot.mjcf.xml"),
+            "model_digest": fixture_digest,  # 内容是 fixture 的
+            "quality": "PRODUCTION",
+            "canonical": True,
+        })
+        result = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        assert result["status"] != "SUCCEEDED"
+        assert any(
+            "RESOURCE_DIGEST_MISMATCH" in str(f)
+            for f in result.get("failures", [])
+        ), result
+
+    def test_fixture_copied_to_workspace_cannot_impersonate(
+        self, tmp_path: Path
+    ) -> None:
+        """fixture 复制到工作区运行——声明 robot:ur5e 但 digest 是
+        fixture 的 → 失败；声明 fixture 身份 → NON_CANONICAL_RESOURCE。"""
+        kernel = _kernel(tmp_path)
+        task_id = _task(kernel, tmp_path)
+        art = _register_with_resource(kernel, task_id, tmp_path, resource={
+            "resource_id": "robot:ur5e_minimal_fixture",
+            "manifest_digest": "sha256:" + "cd" * 32,
+            "model_path": str(tmp_path / "ws" / "copied.xml"),
+            "model_digest": "sha256:" + "ef" * 32,
+            "quality": "TEST_FIXTURE",
+            "canonical": False,
+        })
+        result = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        assert result["status"] != "SUCCEEDED"
+        assert any(
+            "NON_CANONICAL_RESOURCE" in str(f) or "RESOURCE_ID_MISMATCH" in str(f)
+            for f in result.get("failures", [])
+        ), result
+
+    def test_missing_provenance_fails(self, tmp_path: Path) -> None:
+        """行为任务产物无资源证明 → RESOURCE_PROVENANCE_MISSING
+        （producer=kernel 前缀本身不再是充分条件）。"""
+        kernel = _kernel(tmp_path)
+        task_id = _task(kernel, tmp_path)
+        art = _register_with_resource(kernel, task_id, tmp_path, resource=None)
+        result = kernel.finish_task(
+            task_id=task_id, summary="done", artifact_ids=[art["artifact_id"]],
+        )
+        assert result["status"] != "SUCCEEDED"
+        assert any(
+            "RESOURCE_PROVENANCE_MISSING" in str(f)
+            for f in result.get("failures", [])
+        ), result
+
+    def test_model_authored_script_marked_experimental(
+        self, tmp_path: Path
+    ) -> None:
+        """模型手写脚本产物标 EXPERIMENTAL_EVIDENCE——不得当正式
+        能力证据。"""
+        kernel = _kernel(tmp_path)
+        task_id = _task(kernel, tmp_path)
+        task = kernel.get_task(task_id)
+        assert task is not None
+        gif = Path(task["workspace_path"]) / "star.gif"
+        gif.write_bytes(b"GIF89a" + b"x" * 2048)
+        art = kernel.register_artifact(
+            task_id=task_id, path=str(gif), media_type="image/gif",
+            producer="model:rosclaw_artifact_register",
+        )
+        meta = json.loads(str(art.get("metadata_json", "{}")) or "{}")
+        assert meta.get("evidence_tier") == "EXPERIMENTAL", meta

--- a/tests/agentd/test_n4_resource_resolver.py
+++ b/tests/agentd/test_n4_resource_resolver.py
@@ -108,7 +108,7 @@ class TestProvenanceVerifier:
             manifest = sandbox.resource_manifest()
             assert manifest["resource_id"] == "robot:ur5e"
             assert Path(manifest["model_path"]).exists()
-            assert manifest["digest"].startswith("sha256:")
+            assert manifest["model_digest"].startswith("sha256:")
             assert "robot.mjcf.xml" in manifest["model_path"]
         finally:
             sandbox.close()

--- a/tests/agentd/test_wp03_resume_report.py
+++ b/tests/agentd/test_wp03_resume_report.py
@@ -49,6 +49,7 @@ def _bind_and_finish(service, mission, *, idem: str) -> str:
         mission_id=mission.mission_id, session_ref="pi_1",
         backend_native_id="pi_1", message_id=f"msg_{idem}",
         text="画五角星", cwd=str(service._home),
+        body_id=mission.body_binding.body_id,
     )
     task_id = str(bound["task_id"])
     return task_id


### PR DESCRIPTION
## N4.1 执行资源证明闭环

- Sandbox resource_manifest 全字段（含 manifest_digest/mesh_digests/resolver_generation）
- 执行证据（scenario metadata/trace.json/metrics.json/artifact metadata）全带资源证明
- verifier 四位比对（声明↔权威↔实际加载↔receipt digest），四种稳定错误码
- producer 只是来源身份不代替资源证明；模型自产标 EXPERIMENTAL
- **行为任务判别修正**：body 在场≠行为任务——以实际调用具身执行工具为准（task.tool_used 事件）

退出条件实证：内容被换（同名文件）必失败 ✓；fixture 复制到工作区不能冒充 ✓；三资产 receipt 可反查 manifest+digest ✓；verifier 只读 receipt 元数据 ✓

## N4.2 Workspace 语义

显式 > resume 记录 > git root > 当前 cwd（非 / 非 HOME 可写）> default——普通目录直接工作。

## 验证

61 Python + 138 TS 全绿；ruff 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)