### PR TITLE
feat: PR-N5A——CapabilityDescriptorV2 与 Capability Registry canonical V2

### DIFF
--- a/src/rosclaw/agentd/tooling/capability_adapter.py
+++ b/src/rosclaw/agentd/tooling/capability_adapter.py
@@ -1,0 +1,157 @@
+"""ToolDescriptorV2 → CapabilityDescriptorV2 迁移适配器（PR-N5A）。
+
+旧 ToolDescriptorV2 是**兼容输入**：catalog 注册时统一适配成
+CapabilityDescriptorV2 作为 canonical 存储。N11 再删除旧合约——
+不并行维护两套正式目录（canonical 只有一份，legacy 是派生视图）。
+
+映射规则（显式可查，测试钉住）：
+
+| 旧字段 | → V2 |
+|---|---|
+| PHYSICAL_ACTION | effect.class=PHYSICAL_EFFECT |
+| effect_domain=SIMULATION_STATE_ONLY | effect.class=SIMULATED_EFFECT |
+| COMPUTE + evidence=SIMULATED | effect.class=SIMULATED_EFFECT |
+| COMPUTE 其余 | effect.class=PURE_COMPUTE |
+| OBSERVE | effect.class=READ_ONLY |
+| side_effect_class NONE/REVERSIBLE | reversible=True |
+| side_effect_class IRREVERSIBLE | reversible=False |
+| supported_modes / required_body_types / required_capabilities | compatibility |
+| idempotent / timeout_ms | execution |
+| evidence_class / verifier | evidence |
+"""
+
+from __future__ import annotations
+
+from rosclaw.contracts.agent.capability import (
+    CapabilityCompatibilityV1,
+    CapabilityDescriptorV2,
+    CapabilityEffectV1,
+    CapabilityEvidenceV1,
+    CapabilityExecutionV1,
+    EffectClassV1,
+)
+from rosclaw.contracts.agent.tool import (
+    ExecutionClass,
+    ToolDescriptorV2,
+    ToolEvidenceClass,
+    ToolSideEffectClass,
+)
+
+_SIM_DOMAIN = "SIMULATION_STATE_ONLY"
+
+
+def _effect_class_of(d: ToolDescriptorV2) -> EffectClassV1:
+    if d.execution_class is ExecutionClass.PHYSICAL_ACTION:
+        return EffectClassV1.PHYSICAL_EFFECT
+    if d.effect_domain == _SIM_DOMAIN:
+        return EffectClassV1.SIMULATED_EFFECT
+    if d.execution_class is ExecutionClass.COMPUTE:
+        if d.evidence_class is ToolEvidenceClass.SIMULATED:
+            return EffectClassV1.SIMULATED_EFFECT
+        return EffectClassV1.PURE_COMPUTE
+    return EffectClassV1.READ_ONLY
+
+
+def _effect_domain_of(d: ToolDescriptorV2, effect: EffectClassV1) -> str:
+    if d.effect_domain:
+        return d.effect_domain.lower()
+    if effect is EffectClassV1.SIMULATED_EFFECT:
+        return "simulation_state"
+    if effect is EffectClassV1.PHYSICAL_EFFECT:
+        return "physical_body"
+    return ""
+
+
+def capability_from_tool_descriptor(d: ToolDescriptorV2) -> CapabilityDescriptorV2:
+    """单个旧描述符 → V2 能力（诚实标注 adapted_from）。"""
+    effect_class = _effect_class_of(d)
+    return CapabilityDescriptorV2(
+        capability_id=d.tool_id,
+        version=d.version,
+        source=d.source,
+        description=d.description,
+        input_schema=dict(d.input_schema),
+        output_schema=dict(d.output_schema),
+        effect=CapabilityEffectV1(
+            **{
+                "class": effect_class,
+                "domain": _effect_domain_of(d, effect_class),
+                "reversible": d.side_effect_class
+                is not ToolSideEffectClass.IRREVERSIBLE,
+                "risk_tier": d.risk_tier,
+                "requires_fresh_real_context": (
+                    effect_class is EffectClassV1.PHYSICAL_EFFECT
+                    and d.freshness_ms is not None
+                ),
+            }
+        ),
+        compatibility=CapabilityCompatibilityV1(
+            modes=list(d.supported_modes),
+            body_types=list(d.required_body_types),
+            runtime_requirements=list(d.required_capabilities),
+        ),
+        execution=CapabilityExecutionV1(
+            long_running=d.typical_latency_ms >= 1000,
+            idempotent=d.idempotent,
+        ),
+        evidence=CapabilityEvidenceV1(
+            evidence_class=d.evidence_class.value,
+            verifier_ref=d.verifier,
+        ),
+        metadata={"adapted_from": ToolDescriptorV2.SCHEMA},
+    )
+
+
+def tool_descriptor_from_capability(cap: CapabilityDescriptorV2) -> ToolDescriptorV2:
+    """V2 → legacy 视图（过渡期服务未迁移消费者；不做新增事实）。
+
+    注意：这是有损投影（execution/compatibility 细节丢失）——legacy
+    视图只供过滤/展示，不作安全判定的唯一来源。
+    """
+    effect = cap.effect.class_
+    if effect is EffectClassV1.PHYSICAL_EFFECT:
+        execution_class = ExecutionClass.PHYSICAL_ACTION
+    elif effect in (EffectClassV1.PURE_COMPUTE, EffectClassV1.SIMULATED_EFFECT):
+        execution_class = ExecutionClass.COMPUTE
+    else:
+        execution_class = ExecutionClass.OBSERVE
+    model_callable = execution_class is not ExecutionClass.PHYSICAL_ACTION
+    return ToolDescriptorV2(
+        tool_id=cap.capability_id,
+        version=cap.version,
+        source=cap.source,
+        execution_class=execution_class,
+        side_effect_class=(
+            ToolSideEffectClass.REVERSIBLE
+            if cap.effect.reversible
+            else ToolSideEffectClass.IRREVERSIBLE
+        ) if effect is not EffectClassV1.READ_ONLY else ToolSideEffectClass.NONE,
+        effect_domain=(
+            "SIMULATION_STATE_ONLY"
+            if effect is EffectClassV1.SIMULATED_EFFECT
+            else ""
+        ),
+        description=cap.description,
+        input_schema=dict(cap.input_schema),
+        output_schema=dict(cap.output_schema),
+        supported_modes=list(cap.compatibility.modes),
+        required_body_types=list(cap.compatibility.body_types),
+        risk_tier=cap.effect.risk_tier,
+        evidence_class=(
+            ToolEvidenceClass.SIMULATED
+            if cap.evidence.evidence_class in ("SIMULATED", "SIM_DYN_ROLLOUT")
+            else ToolEvidenceClass.DERIVED
+            if cap.evidence.evidence_class == "DERIVED"
+            else ToolEvidenceClass.CONFIGURED
+            if cap.evidence.evidence_class == "CONFIGURED"
+            else ToolEvidenceClass.MEASURED
+        ),
+        verifier=cap.evidence.verifier_ref,
+        idempotent=cap.execution.idempotent,
+        model_callable=model_callable,
+        requires_exact_action_grant=not model_callable,
+        required_capabilities=list(cap.compatibility.runtime_requirements),
+    )
+
+
+__all__ = ["capability_from_tool_descriptor", "tool_descriptor_from_capability"]

--- a/src/rosclaw/agentd/tooling/catalog.py
+++ b/src/rosclaw/agentd/tooling/catalog.py
@@ -12,7 +12,17 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from rosclaw.agentd.tooling.capability_adapter import (
+    capability_from_tool_descriptor,
+    tool_descriptor_from_capability,
+)
 from rosclaw.agentd.tooling.result import ToolExecutionResult
+from rosclaw.contracts.agent.capability import (
+    CapabilityDescriptorV2,
+    EffectClassV1,
+    ProjectionExposure,
+    ToolProjectionV1,
+)
 from rosclaw.contracts.agent.tool import ExecutionClass, ToolDescriptorV2
 from rosclaw.contracts.common import ValidationError
 
@@ -33,6 +43,10 @@ class ToolCatalog:
         self._descriptors: dict[str, ToolDescriptorV2] = {}
         self._executors: dict[str, ToolExecutor] = {}
         self._quarantine: dict[str, str] = {}  # tool_id -> reason
+        # PR-N5A：CapabilityDescriptorV2 为 canonical 存储；_descriptors
+        # 是过渡期的 legacy 派生视图（N11 删除）。
+        self._capabilities: dict[str, CapabilityDescriptorV2] = {}
+        self._projections: dict[str, ToolProjectionV1] = {}
 
     def register(self, descriptor: ToolDescriptorV2, executor: ToolExecutor | None = None) -> None:
         if "__" in descriptor.tool_id:
@@ -42,14 +56,62 @@ class ToolCatalog:
         if descriptor.tool_id in self._descriptors:
             raise ValidationError(f"tool {descriptor.tool_id!r} already registered")
         self._descriptors[descriptor.tool_id] = descriptor
+        self._capabilities[descriptor.tool_id] = capability_from_tool_descriptor(descriptor)
         if executor is not None:
             self._executors[descriptor.tool_id] = executor
 
     def replace(self, descriptor: ToolDescriptorV2, executor: ToolExecutor | None = None) -> None:
         """Idempotent re-registration (e.g. MCP reconnect re-discovery)."""
         self._descriptors[descriptor.tool_id] = descriptor
+        self._capabilities[descriptor.tool_id] = capability_from_tool_descriptor(descriptor)
         if executor is not None:
             self._executors[descriptor.tool_id] = executor
+
+    # -- N5A capability/projection surface --------------------------------------
+
+    def register_capability(
+        self, capability: CapabilityDescriptorV2, executor: ToolExecutor | None = None
+    ) -> None:
+        """直接注册 V2 能力（canonical）；同步派生 legacy 视图。"""
+        cid = capability.capability_id
+        if cid in self._capabilities:
+            raise ValidationError(f"capability {cid!r} already registered")
+        self._capabilities[cid] = capability
+        self._descriptors[cid] = tool_descriptor_from_capability(capability)
+        if executor is not None:
+            self._executors[cid] = executor
+
+    def capability(self, tool_id: str) -> CapabilityDescriptorV2 | None:
+        """canonical 能力视图（审批/并发/Verifier 应读这里）。"""
+        return self._capabilities.get(self._canonical(tool_id))
+
+    def list_capabilities(self, *, source: str | None = None) -> list[CapabilityDescriptorV2]:
+        items = sorted(self._capabilities.values(), key=lambda c: c.capability_id)
+        if source is not None:
+            items = [c for c in items if c.source == source]
+        return items
+
+    def register_projection(self, projection: ToolProjectionV1) -> None:
+        """注册能力→工具投影。PHYSICAL_EFFECT 拒绝 direct（fail closed）。"""
+        cap = self._capabilities.get(projection.capability_id)
+        if cap is None:
+            raise ValidationError(
+                f"projection {projection.tool_name!r}: capability "
+                f"{projection.capability_id!r} not registered"
+            )
+        if (
+            cap.effect.class_ is EffectClassV1.PHYSICAL_EFFECT
+            and projection.exposure is ProjectionExposure.DIRECT
+        ):
+            raise ValidationError(
+                f"projection {projection.tool_name!r}: PHYSICAL_EFFECT capability "
+                f"{cap.capability_id!r} is never directly model-exposed — use "
+                "propose_only (ActionAdmission) or internal"
+            )
+        self._projections[projection.tool_name] = projection
+
+    def projection(self, tool_name: str) -> ToolProjectionV1 | None:
+        return self._projections.get(tool_name)
 
     def get(self, tool_id: str) -> ToolDescriptorV2 | None:
         return self._descriptors.get(tool_id)

--- a/src/rosclaw/contracts/agent/capability.py
+++ b/src/rosclaw/contracts/agent/capability.py
@@ -1,0 +1,145 @@
+"""CapabilityDescriptorV2 / ToolProjectionV1（PR-N5A，调整方案 §三.N5A）。
+
+职责拆分：
+- CapabilityDescriptorV2 描述"ROSClaw 具备什么能力"——领域事实，
+  与任何 Harness 无关；
+- ToolProjectionV1 描述该能力如何投影给 Harness/模型/TUI/CLI——
+  一个能力可投影成多种形态（Pi Tool / Codex MCP Tool / TUI 卡片 /
+  CLI 命令 / fixture）。
+
+硬不变量（fail closed）：
+- EffectClassV1 是 N5C 单一 Effect Contract 的目标词表（8 值冻结）；
+- PHYSICAL_EFFECT 能力的原始 executor 永远不得 direct 投影给模型
+  （在 Registry.register_projection 强制，合约层只承载数据）；
+- 物理效应默认 resource_provenance_required=True；
+- 合约任何字段不得携带凭据（沿用 ADR-0006/0007 边界）。
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, ClassVar, Literal
+
+from pydantic import ConfigDict, Field
+
+from rosclaw.contracts.common import ContractModel
+
+
+class EffectClassV1(StrEnum):
+    """单一 Effect Contract 词表（N5C 正式启用，此处先冻结枚举）。"""
+
+    READ_ONLY = "READ_ONLY"
+    PURE_COMPUTE = "PURE_COMPUTE"
+    WORKSPACE_WRITE = "WORKSPACE_WRITE"
+    HOST_PROCESS = "HOST_PROCESS"
+    NETWORK_EFFECT = "NETWORK_EFFECT"
+    SIMULATED_EFFECT = "SIMULATED_EFFECT"
+    SHADOW_PROPOSAL = "SHADOW_PROPOSAL"
+    PHYSICAL_EFFECT = "PHYSICAL_EFFECT"
+
+
+class CapabilityEffectV1(ContractModel):
+    """能力的效应声明：执行前冻结、写事件，审批/并发/Verifier 共读。"""
+
+    class_: EffectClassV1 = Field(alias="class")
+    #: 效应域，如 simulation_state / workspace_fs / physical_body
+    domain: str = ""
+    reversible: bool = True
+    risk_tier: Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"] = "LOW"
+    #: REAL 上下文必须新鲜（PHYSICAL_EFFECT/SHADOW_PROPOSAL 才有意义）
+    requires_fresh_real_context: bool = False
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class CapabilityCompatibilityV1(ContractModel):
+    modes: list[Literal["SIMULATION", "SHADOW", "REAL"]] = Field(
+        default_factory=lambda: ["SIMULATION"]
+    )
+    body_types: list[str] = Field(default_factory=list)
+    robot_ids: list[str] = Field(default_factory=list)
+    resource_kinds: list[str] = Field(default_factory=list)
+    runtime_requirements: list[str] = Field(default_factory=list)
+
+
+class CapabilityExecutionV1(ContractModel):
+    #: 如 python:rosclaw.agentd.sim_trajectory:simulate
+    executor_ref: str = ""
+    long_running: bool = False
+    cancellation: Literal["cooperative", "immediate", "none"] = "cooperative"
+    concurrency: Literal["exclusive", "shared", "serialized"] = "shared"
+    idempotent: bool = True
+
+
+class CapabilityEvidenceV1(ContractModel):
+    #: 如 MEASURED/SIMULATED/CONFIGURED/DERIVED/SIM_DYN_ROLLOUT
+    evidence_class: str = ""
+    verifier_ref: str = ""
+    resource_provenance_required: bool = False
+
+
+class CapabilityDescriptorV2(ContractModel):
+    """ROSClaw 能力描述符（canonical）——Harness 无关的领域事实。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.capability.v2"
+    HASH_PREFIX: ClassVar[str] = "capability"
+
+    schema_version: Literal["rosclaw.capability.v2"] = "rosclaw.capability.v2"
+    capability_id: str = Field(min_length=1)
+    version: str = "1.0.0"
+    #: 如 rosclaw-builtin / mcp:limo-ros-mcp / hub:*
+    source: str = Field(min_length=1)
+    description: str = ""
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+    output_schema: dict[str, Any] = Field(default_factory=dict)
+    effect: CapabilityEffectV1 = Field(
+        default_factory=lambda: CapabilityEffectV1(**{"class": EffectClassV1.READ_ONLY})
+    )
+    compatibility: CapabilityCompatibilityV1 = Field(
+        default_factory=CapabilityCompatibilityV1
+    )
+    execution: CapabilityExecutionV1 = Field(default_factory=CapabilityExecutionV1)
+    evidence: CapabilityEvidenceV1 = Field(default_factory=CapabilityEvidenceV1)
+    #: 自由元数据（如 adapted_from 迁移标注）；不得携带凭据。
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def model_post_init(self, __context: Any, /) -> None:
+        # 物理效应默认要求资源证明（fail closed；显式 False 是有意的声明）。
+        if (
+            self.effect.class_ is EffectClassV1.PHYSICAL_EFFECT
+            and "resource_provenance_required" not in self.evidence.model_fields_set
+        ):
+            self.evidence.resource_provenance_required = True
+
+
+class ProjectionExposure(StrEnum):
+    DIRECT = "direct"  # 直接暴露给模型调用
+    PROPOSE_ONLY = "propose_only"  # 仅生成 propose_* 工具（进 ActionAdmission）
+    INTERNAL = "internal"  # 不进模型面（TUI/CLI/Code Mode 内部用）
+
+
+class ToolProjectionV1(ContractModel):
+    """能力 → 模型/Harness 工具的投影描述。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.tool_projection.v1"
+    HASH_PREFIX: ClassVar[str] = "tool_projection"
+
+    schema_version: Literal["rosclaw.tool_projection.v1"] = "rosclaw.tool_projection.v1"
+    tool_name: str = Field(min_length=1)
+    capability_id: str = Field(min_length=1)
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+    output_schema: dict[str, Any] = Field(default_factory=dict)
+    presentation_ref: str = ""
+    exposure: ProjectionExposure = ProjectionExposure.DIRECT
+
+
+__all__ = [
+    "CapabilityCompatibilityV1",
+    "CapabilityDescriptorV2",
+    "CapabilityEffectV1",
+    "CapabilityEvidenceV1",
+    "CapabilityExecutionV1",
+    "EffectClassV1",
+    "ProjectionExposure",
+    "ToolProjectionV1",
+]

--- a/src/rosclaw/contracts/export.py
+++ b/src/rosclaw/contracts/export.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 
 from rosclaw.contracts.agent.branch import ReasoningBranchV1
+from rosclaw.contracts.agent.capability import CapabilityDescriptorV2, ToolProjectionV1
 from rosclaw.contracts.agent.context import EmbodiedContextBundleV1
 from rosclaw.contracts.agent.decision import DecisionV1
 from rosclaw.contracts.agent.mission import MissionSessionV1
@@ -57,6 +58,8 @@ ALL_CONTRACTS: dict[str, type[ContractModel]] = {
         ApprovalRequestV2,
         ExactActionV1,
         ToolDescriptorV2,
+        CapabilityDescriptorV2,
+        ToolProjectionV1,
         CommandSpecV1,
         CommandRequestV1,
         CommandResultV1,

--- a/tests/agentd/test_n5a_capability_registry.py
+++ b/tests/agentd/test_n5a_capability_registry.py
@@ -1,0 +1,233 @@
+"""PR-N5A 红测试（调整方案 §三.N5A）：Capability Registry 组件/接线/变异层。
+
+红测试先行——适配器与 canonical 存储不存在时必须红。
+
+1. 迁移适配器映射表：ToolDescriptorV2（兼容输入）→
+   CapabilityDescriptorV2（canonical），映射规则显式可查；
+2. ToolCatalog 内部以 CapabilityDescriptorV2 为 canonical 存储——
+   register(legacy) 后 capability() 给出映射结果，legacy 视图不变；
+3. 投影闸：PHYSICAL_EFFECT 能力拒绝 direct 投影（fail closed），
+   propose_only 合法；
+4. 变异：effect 变化 → capability digest 变化（审批/并发/Verifier
+   依赖冻结 digest）；
+5. 产品接线：内置 sim 工具经 register_native_tools 后，
+   sim_reach 的 canonical 能力 effect.class = SIMULATED_EFFECT。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.contracts.agent.tool import (
+    ExecutionClass,
+    ToolDescriptorV2,
+    ToolEvidenceClass,
+    ToolSideEffectClass,
+)
+from rosclaw.contracts.common import ValidationError
+
+
+def _legacy(**overrides) -> ToolDescriptorV2:
+    payload = {
+        "tool_id": "sim_reach",
+        "source": "native:agentd",
+        "execution_class": ExecutionClass.COMPUTE,
+        "description": "MuJoCo reach",
+        "input_schema": {"type": "object", "additionalProperties": False},
+        "output_schema": {"type": "object", "additionalProperties": False},
+        "supported_modes": ["SIMULATION"],
+        "evidence_class": ToolEvidenceClass.SIMULATED,
+        "verifier": "sandbox-receipt+task-predicate",
+        "risk_tier": "LOW",
+    }
+    payload.update(overrides)
+    return ToolDescriptorV2(**payload)
+
+
+class TestMigrationAdapter:
+    """映射表显式可查——任何改动都会被本表钉住。"""
+
+    @pytest.mark.parametrize(
+        ("execution_class", "side_effect", "evidence", "effect_domain",
+         "expected_effect", "expected_reversible"),
+        [
+            (ExecutionClass.OBSERVE, ToolSideEffectClass.NONE,
+             ToolEvidenceClass.MEASURED, "", "READ_ONLY", True),
+            (ExecutionClass.COMPUTE, ToolSideEffectClass.NONE,
+             ToolEvidenceClass.DERIVED, "", "PURE_COMPUTE", True),
+            (ExecutionClass.COMPUTE, ToolSideEffectClass.NONE,
+             ToolEvidenceClass.SIMULATED, "", "SIMULATED_EFFECT", True),
+            (ExecutionClass.COMPUTE, ToolSideEffectClass.REVERSIBLE,
+             ToolEvidenceClass.MEASURED, "SIMULATION_STATE_ONLY",
+             "SIMULATED_EFFECT", True),
+            (ExecutionClass.PHYSICAL_ACTION, ToolSideEffectClass.REVERSIBLE,
+             ToolEvidenceClass.MEASURED, "", "PHYSICAL_EFFECT", True),
+            (ExecutionClass.PHYSICAL_ACTION, ToolSideEffectClass.IRREVERSIBLE,
+             ToolEvidenceClass.MEASURED, "", "PHYSICAL_EFFECT", False),
+        ],
+    )
+    def test_mapping_table(
+        self, execution_class, side_effect, evidence, effect_domain,
+        expected_effect, expected_reversible,
+    ) -> None:
+        from rosclaw.agentd.tooling.capability_adapter import (
+            capability_from_tool_descriptor,
+        )
+
+        legacy = _legacy(
+            execution_class=execution_class,
+            side_effect_class=side_effect,
+            evidence_class=evidence,
+            effect_domain=effect_domain,
+            model_callable=execution_class is not ExecutionClass.PHYSICAL_ACTION,
+            requires_exact_action_grant=(
+                execution_class is ExecutionClass.PHYSICAL_ACTION
+            ),
+        )
+        cap = capability_from_tool_descriptor(legacy)
+        assert cap.schema_version == "rosclaw.capability.v2"
+        assert cap.capability_id == legacy.tool_id
+        assert cap.effect.class.value == expected_effect
+        assert cap.effect.reversible is expected_reversible
+        assert cap.effect.risk_tier == legacy.risk_tier
+        # 兼容块映射
+        assert [m.value for m in cap.compatibility.modes] == list(
+            legacy.supported_modes
+        )
+        assert cap.execution.idempotent == legacy.idempotent
+        assert cap.evidence.evidence_class == legacy.evidence_class.value
+        assert cap.evidence.verifier_ref == legacy.verifier
+        # 来源标记：兼容输入必须诚实标注
+        assert cap.metadata.get("adapted_from") == "rosclaw.tool_descriptor.v2"
+
+
+class TestCatalogCanonicalV2:
+    def test_register_legacy_stores_capability_v2_canonical(self) -> None:
+        from rosclaw.agentd.tooling.catalog import ToolCatalog
+
+        catalog = ToolCatalog()
+        catalog.register(_legacy())
+        cap = catalog.capability("sim_reach")
+        assert cap is not None
+        assert cap.capability_id == "sim_reach"
+        assert cap.effect.class.value == "SIMULATED_EFFECT"
+        # legacy 视图保持不变（resolver/dispatch 未迁移期）
+        legacy = catalog.get("sim_reach")
+        assert legacy is not None
+        assert legacy.execution_class is ExecutionClass.COMPUTE
+
+    def test_register_capability_v2_directly(self) -> None:
+        from rosclaw.agentd.tooling.capability_adapter import (
+            capability_from_tool_descriptor,
+        )
+        from rosclaw.agentd.tooling.catalog import ToolCatalog
+
+        catalog = ToolCatalog()
+        cap = capability_from_tool_descriptor(_legacy(tool_id="sim_state"))
+        catalog.register_capability(cap)
+        assert catalog.capability("sim_state") is not None
+        # V2 注册同样给出 legacy 视图（过渡期为旧消费者服务）
+        assert catalog.get("sim_state") is not None
+
+
+class TestProjectionGuard:
+    def _physical_capability(self):
+        from rosclaw.agentd.tooling.capability_adapter import (
+            capability_from_tool_descriptor,
+        )
+
+        return capability_from_tool_descriptor(_legacy(
+            tool_id="physical_move",
+            execution_class=ExecutionClass.PHYSICAL_ACTION,
+            side_effect_class=ToolSideEffectClass.REVERSIBLE,
+            model_callable=False,
+            requires_exact_action_grant=True,
+        ))
+
+    def test_physical_effect_rejects_direct_projection(self) -> None:
+        """PHYSICAL_EFFECT 原始 executor 永不直接暴露（fail closed）。"""
+        from rosclaw.agentd.tooling.catalog import ToolCatalog
+        from rosclaw.contracts.agent.capability import (
+            ProjectionExposure,
+            ToolProjectionV1,
+        )
+
+        catalog = ToolCatalog()
+        cap = self._physical_capability()
+        catalog.register_capability(cap)
+        direct = ToolProjectionV1(
+            tool_name="physical_move",
+            capability_id=cap.capability_id,
+            input_schema={"type": "object"},
+            output_schema={"type": "object"},
+            exposure=ProjectionExposure.DIRECT,
+        )
+        with pytest.raises(ValidationError):
+            catalog.register_projection(direct)
+
+    def test_physical_effect_propose_only_projection_ok(self) -> None:
+        from rosclaw.agentd.tooling.catalog import ToolCatalog
+        from rosclaw.contracts.agent.capability import (
+            ProjectionExposure,
+            ToolProjectionV1,
+        )
+
+        catalog = ToolCatalog()
+        cap = self._physical_capability()
+        catalog.register_capability(cap)
+        propose = ToolProjectionV1(
+            tool_name="propose_physical_move",
+            capability_id=cap.capability_id,
+            input_schema={"type": "object"},
+            output_schema={"type": "object"},
+            exposure=ProjectionExposure.PROPOSE_ONLY,
+        )
+        catalog.register_projection(propose)
+        assert catalog.projection("propose_physical_move") is not None
+
+    def test_simulated_effect_direct_projection_ok(self) -> None:
+        from rosclaw.agentd.tooling.catalog import ToolCatalog
+        from rosclaw.contracts.agent.capability import (
+            ProjectionExposure,
+            ToolProjectionV1,
+        )
+
+        catalog = ToolCatalog()
+        catalog.register(_legacy())
+        direct = ToolProjectionV1(
+            tool_name="sim_reach",
+            capability_id="sim_reach",
+            input_schema={"type": "object"},
+            output_schema={"type": "object"},
+            exposure=ProjectionExposure.DIRECT,
+        )
+        catalog.register_projection(direct)
+
+
+class TestMutation:
+    def test_effect_change_changes_digest(self) -> None:
+        """拆掉一根关键连线（effect 篡改）→ digest 必须变化。"""
+        from rosclaw.agentd.tooling.capability_adapter import (
+            capability_from_tool_descriptor,
+        )
+
+        cap = capability_from_tool_descriptor(_legacy())
+        tampered = cap.model_copy(deep=True)
+        tampered.effect.class = tampered.effect.class.__class__("READ_ONLY")
+        assert tampered.canonical_hash() != cap.canonical_hash()
+
+
+class TestProductWiring:
+    def test_native_sim_tools_have_canonical_capabilities(self) -> None:
+        """内置工具经 register_native_tools 注册后，canonical 能力可读
+        且 sim_reach effect = SIMULATED_EFFECT。"""
+        from rosclaw.agentd.tooling.catalog import ToolCatalog
+        from rosclaw.agentd.tooling.native_tools import register_native_tools
+        from rosclaw.agentd.tools import SIM_REACH_TOOL, BuiltinToolRegistry
+
+        catalog = ToolCatalog()
+        register_native_tools(catalog, BuiltinToolRegistry(), simulation=True)
+        cap = catalog.capability(SIM_REACH_TOOL)
+        assert cap is not None
+        assert cap.effect.class.value == "SIMULATED_EFFECT"
+        assert cap.evidence.evidence_class == "SIMULATED"

--- a/tests/agentd/test_n5a_capability_registry.py
+++ b/tests/agentd/test_n5a_capability_registry.py
@@ -87,13 +87,11 @@ class TestMigrationAdapter:
         cap = capability_from_tool_descriptor(legacy)
         assert cap.schema_version == "rosclaw.capability.v2"
         assert cap.capability_id == legacy.tool_id
-        assert cap.effect.class.value == expected_effect
+        assert cap.effect.class_.value == expected_effect
         assert cap.effect.reversible is expected_reversible
         assert cap.effect.risk_tier == legacy.risk_tier
         # 兼容块映射
-        assert [m.value for m in cap.compatibility.modes] == list(
-            legacy.supported_modes
-        )
+        assert list(cap.compatibility.modes) == list(legacy.supported_modes)
         assert cap.execution.idempotent == legacy.idempotent
         assert cap.evidence.evidence_class == legacy.evidence_class.value
         assert cap.evidence.verifier_ref == legacy.verifier
@@ -110,7 +108,7 @@ class TestCatalogCanonicalV2:
         cap = catalog.capability("sim_reach")
         assert cap is not None
         assert cap.capability_id == "sim_reach"
-        assert cap.effect.class.value == "SIMULATED_EFFECT"
+        assert cap.effect.class_.value == "SIMULATED_EFFECT"
         # legacy 视图保持不变（resolver/dispatch 未迁移期）
         legacy = catalog.get("sim_reach")
         assert legacy is not None
@@ -210,10 +208,11 @@ class TestMutation:
         from rosclaw.agentd.tooling.capability_adapter import (
             capability_from_tool_descriptor,
         )
+        from rosclaw.contracts.agent.capability import EffectClassV1
 
         cap = capability_from_tool_descriptor(_legacy())
         tampered = cap.model_copy(deep=True)
-        tampered.effect.class = tampered.effect.class.__class__("READ_ONLY")
+        tampered.effect.class_ = EffectClassV1.READ_ONLY
         assert tampered.canonical_hash() != cap.canonical_hash()
 
 
@@ -226,8 +225,12 @@ class TestProductWiring:
         from rosclaw.agentd.tools import SIM_REACH_TOOL, BuiltinToolRegistry
 
         catalog = ToolCatalog()
-        register_native_tools(catalog, BuiltinToolRegistry(), simulation=True)
+        register_native_tools(
+            catalog,
+            BuiltinToolRegistry(body_id="sim/ur5e", body_summary="UR5e"),
+            simulation=True,
+        )
         cap = catalog.capability(SIM_REACH_TOOL)
         assert cap is not None
-        assert cap.effect.class.value == "SIMULATED_EFFECT"
+        assert cap.effect.class_.value == "SIMULATED_EFFECT"
         assert cap.evidence.evidence_class == "SIMULATED"

--- a/tests/contracts/golden/rosclaw.capability.v2.json
+++ b/tests/contracts/golden/rosclaw.capability.v2.json
@@ -1,0 +1,234 @@
+{
+  "$defs": {
+    "CapabilityCompatibilityV1": {
+      "additionalProperties": true,
+      "properties": {
+        "modes": {
+          "items": {
+            "enum": [
+              "SIMULATION",
+              "SHADOW",
+              "REAL"
+            ],
+            "type": "string"
+          },
+          "title": "Modes",
+          "type": "array"
+        },
+        "body_types": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Body Types",
+          "type": "array"
+        },
+        "robot_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Robot Ids",
+          "type": "array"
+        },
+        "resource_kinds": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Resource Kinds",
+          "type": "array"
+        },
+        "runtime_requirements": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Runtime Requirements",
+          "type": "array"
+        }
+      },
+      "title": "CapabilityCompatibilityV1",
+      "type": "object"
+    },
+    "CapabilityEffectV1": {
+      "additionalProperties": true,
+      "description": "能力的效应声明：执行前冻结、写事件，审批/并发/Verifier 共读。",
+      "properties": {
+        "class": {
+          "$ref": "#/$defs/EffectClassV1"
+        },
+        "domain": {
+          "default": "",
+          "title": "Domain",
+          "type": "string"
+        },
+        "reversible": {
+          "default": true,
+          "title": "Reversible",
+          "type": "boolean"
+        },
+        "risk_tier": {
+          "default": "LOW",
+          "enum": [
+            "LOW",
+            "MEDIUM",
+            "HIGH",
+            "CRITICAL"
+          ],
+          "title": "Risk Tier",
+          "type": "string"
+        },
+        "requires_fresh_real_context": {
+          "default": false,
+          "title": "Requires Fresh Real Context",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "class"
+      ],
+      "title": "CapabilityEffectV1",
+      "type": "object"
+    },
+    "CapabilityEvidenceV1": {
+      "additionalProperties": true,
+      "properties": {
+        "evidence_class": {
+          "default": "",
+          "title": "Evidence Class",
+          "type": "string"
+        },
+        "verifier_ref": {
+          "default": "",
+          "title": "Verifier Ref",
+          "type": "string"
+        },
+        "resource_provenance_required": {
+          "default": false,
+          "title": "Resource Provenance Required",
+          "type": "boolean"
+        }
+      },
+      "title": "CapabilityEvidenceV1",
+      "type": "object"
+    },
+    "CapabilityExecutionV1": {
+      "additionalProperties": true,
+      "properties": {
+        "executor_ref": {
+          "default": "",
+          "title": "Executor Ref",
+          "type": "string"
+        },
+        "long_running": {
+          "default": false,
+          "title": "Long Running",
+          "type": "boolean"
+        },
+        "cancellation": {
+          "default": "cooperative",
+          "enum": [
+            "cooperative",
+            "immediate",
+            "none"
+          ],
+          "title": "Cancellation",
+          "type": "string"
+        },
+        "concurrency": {
+          "default": "shared",
+          "enum": [
+            "exclusive",
+            "shared",
+            "serialized"
+          ],
+          "title": "Concurrency",
+          "type": "string"
+        },
+        "idempotent": {
+          "default": true,
+          "title": "Idempotent",
+          "type": "boolean"
+        }
+      },
+      "title": "CapabilityExecutionV1",
+      "type": "object"
+    },
+    "EffectClassV1": {
+      "description": "单一 Effect Contract 词表（N5C 正式启用，此处先冻结枚举）。",
+      "enum": [
+        "READ_ONLY",
+        "PURE_COMPUTE",
+        "WORKSPACE_WRITE",
+        "HOST_PROCESS",
+        "NETWORK_EFFECT",
+        "SIMULATED_EFFECT",
+        "SHADOW_PROPOSAL",
+        "PHYSICAL_EFFECT"
+      ],
+      "title": "EffectClassV1",
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "description": "ROSClaw 能力描述符（canonical）——Harness 无关的领域事实。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.capability.v2",
+      "default": "rosclaw.capability.v2",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "capability_id": {
+      "minLength": 1,
+      "title": "Capability Id",
+      "type": "string"
+    },
+    "version": {
+      "default": "1.0.0",
+      "title": "Version",
+      "type": "string"
+    },
+    "source": {
+      "minLength": 1,
+      "title": "Source",
+      "type": "string"
+    },
+    "description": {
+      "default": "",
+      "title": "Description",
+      "type": "string"
+    },
+    "input_schema": {
+      "additionalProperties": true,
+      "title": "Input Schema",
+      "type": "object"
+    },
+    "output_schema": {
+      "additionalProperties": true,
+      "title": "Output Schema",
+      "type": "object"
+    },
+    "effect": {
+      "$ref": "#/$defs/CapabilityEffectV1"
+    },
+    "compatibility": {
+      "$ref": "#/$defs/CapabilityCompatibilityV1"
+    },
+    "execution": {
+      "$ref": "#/$defs/CapabilityExecutionV1"
+    },
+    "evidence": {
+      "$ref": "#/$defs/CapabilityEvidenceV1"
+    },
+    "metadata": {
+      "additionalProperties": true,
+      "title": "Metadata",
+      "type": "object"
+    }
+  },
+  "required": [
+    "capability_id",
+    "source"
+  ],
+  "title": "rosclaw.capability.v2",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.capability.v2"
+}

--- a/tests/contracts/golden/rosclaw.tool_projection.v1.json
+++ b/tests/contracts/golden/rosclaw.tool_projection.v1.json
@@ -1,0 +1,59 @@
+{
+  "$defs": {
+    "ProjectionExposure": {
+      "enum": [
+        "direct",
+        "propose_only",
+        "internal"
+      ],
+      "title": "ProjectionExposure",
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "description": "能力 → 模型/Harness 工具的投影描述。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.tool_projection.v1",
+      "default": "rosclaw.tool_projection.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "tool_name": {
+      "minLength": 1,
+      "title": "Tool Name",
+      "type": "string"
+    },
+    "capability_id": {
+      "minLength": 1,
+      "title": "Capability Id",
+      "type": "string"
+    },
+    "input_schema": {
+      "additionalProperties": true,
+      "title": "Input Schema",
+      "type": "object"
+    },
+    "output_schema": {
+      "additionalProperties": true,
+      "title": "Output Schema",
+      "type": "object"
+    },
+    "presentation_ref": {
+      "default": "",
+      "title": "Presentation Ref",
+      "type": "string"
+    },
+    "exposure": {
+      "$ref": "#/$defs/ProjectionExposure",
+      "default": "direct"
+    }
+  },
+  "required": [
+    "tool_name",
+    "capability_id"
+  ],
+  "title": "rosclaw.tool_projection.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.tool_projection.v1"
+}

--- a/tests/contracts/test_capability_v2.py
+++ b/tests/contracts/test_capability_v2.py
@@ -99,7 +99,7 @@ class TestCapabilityDescriptorV2:
 
         cap = CapabilityDescriptorV2.model_validate_contract(_capability_payload())
         assert cap.capability_id == "ur5e.simulate_cartesian_trajectory"
-        assert cap.effect.class.value == "SIMULATED_EFFECT"
+        assert cap.effect.class_.value == "SIMULATED_EFFECT"
         assert cap.compatibility.modes == ["SIMULATION"]
         assert cap.execution.idempotent is True
         assert cap.evidence.resource_provenance_required is True
@@ -111,9 +111,13 @@ class TestCapabilityDescriptorV2:
 
         golden = GOLDEN_DIR / "rosclaw.capability.v2.json"
         assert golden.exists(), f"missing golden file {golden}"
-        assert json.loads(golden.read_text(encoding="utf-8")) == (
-            CapabilityDescriptorV2.model_json_schema()
-        ), "schema rosclaw.capability.v2 drifted from golden"
+        current = CapabilityDescriptorV2.model_json_schema()
+        current["$id"] = "rosclaw://schemas/rosclaw.capability.v2"
+        current["title"] = "rosclaw.capability.v2"
+        assert json.loads(golden.read_text(encoding="utf-8")) == current, (
+            "schema rosclaw.capability.v2 drifted from golden; if intentional, "
+            "re-export via rosclaw.contracts.export and review the diff"
+        )
 
     def test_invalid_effect_class_rejected(self) -> None:
         from rosclaw.contracts.agent.capability import CapabilityDescriptorV2
@@ -164,9 +168,14 @@ class TestToolProjectionV1:
 
         golden = GOLDEN_DIR / "rosclaw.tool_projection.v1.json"
         assert golden.exists(), f"missing golden file {golden}"
-        assert json.loads(golden.read_text(encoding="utf-8")) == (
-            ToolProjectionV1.model_json_schema()
-        ), "schema rosclaw.tool_projection.v1 drifted from golden"
+        current = ToolProjectionV1.model_json_schema()
+        current["$id"] = "rosclaw://schemas/rosclaw.tool_projection.v1"
+        current["title"] = "rosclaw.tool_projection.v1"
+        assert json.loads(golden.read_text(encoding="utf-8")) == current, (
+            "schema rosclaw.tool_projection.v1 drifted from golden; if "
+            "intentional, re-export via rosclaw.contracts.export and review "
+            "the diff"
+        )
 
     def test_exposure_values(self) -> None:
         from rosclaw.contracts.agent.capability import ToolProjectionV1

--- a/tests/contracts/test_capability_v2.py
+++ b/tests/contracts/test_capability_v2.py
@@ -1,0 +1,189 @@
+"""PR-N5A 红测试（调整方案 §三.N5A）：CapabilityDescriptorV2 / ToolProjectionV1 合约层。
+
+红测试先行——合约不存在时必须红。
+
+合约要点：
+1. CapabilityDescriptorV2（rosclaw.capability.v2）描述"ROSClaw 具备
+   什么能力"：input/output schema + effect + compatibility +
+   execution + evidence 五块；
+2. EffectClassV1 正式枚举冻结为 8 值（N5C 单一 Effect Contract 的
+   目标词表，先在合约层冻结）；
+3. ToolProjectionV1（rosclaw.tool_projection.v1）描述能力如何投影
+   给 Harness/模型：direct / propose_only / internal；
+4. 版本闸与 golden schema 稳定性沿用 ContractModel 机制。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from rosclaw.contracts.common import UnsupportedVersionError
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+
+
+def _capability_payload(**overrides) -> dict:
+    payload = {
+        "schema_version": "rosclaw.capability.v2",
+        "capability_id": "ur5e.simulate_cartesian_trajectory",
+        "version": "1.0.0",
+        "source": "rosclaw-builtin",
+        "description": "UR5e MuJoCo 笛卡尔轨迹动力学仿真",
+        "input_schema": {
+            "type": "object",
+            "properties": {"plan_id": {"type": "string"}},
+            "required": ["plan_id"],
+            "additionalProperties": False,
+        },
+        "output_schema": {
+            "type": "object",
+            "properties": {"run_id": {"type": "string"}},
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+        "effect": {
+            "class": "SIMULATED_EFFECT",
+            "domain": "simulation_state",
+            "reversible": True,
+            "risk_tier": "LOW",
+            "requires_fresh_real_context": False,
+        },
+        "compatibility": {
+            "modes": ["SIMULATION"],
+            "body_types": ["manipulator"],
+            "robot_ids": ["ur5e"],
+            "resource_kinds": ["robot", "world"],
+            "runtime_requirements": ["rosclaw-simulation"],
+        },
+        "execution": {
+            "executor_ref": "python:rosclaw.agentd.sim_trajectory:simulate",
+            "long_running": True,
+            "cancellation": "cooperative",
+            "concurrency": "exclusive",
+            "idempotent": True,
+        },
+        "evidence": {
+            "evidence_class": "SIM_DYN_ROLLOUT",
+            "verifier_ref": "trajectory_tracking_v2",
+            "resource_provenance_required": True,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestEffectClassV1:
+    def test_enum_frozen_to_eight_values(self) -> None:
+        """EffectClassV1 正式枚举 = N5C 目标词表 8 值，不得增减。"""
+        from rosclaw.contracts.agent.capability import EffectClassV1
+
+        assert {e.value for e in EffectClassV1} == {
+            "READ_ONLY",
+            "PURE_COMPUTE",
+            "WORKSPACE_WRITE",
+            "HOST_PROCESS",
+            "NETWORK_EFFECT",
+            "SIMULATED_EFFECT",
+            "SHADOW_PROPOSAL",
+            "PHYSICAL_EFFECT",
+        }
+
+
+class TestCapabilityDescriptorV2:
+    def test_round_trip_and_hash_deterministic(self) -> None:
+        from rosclaw.contracts.agent.capability import CapabilityDescriptorV2
+
+        cap = CapabilityDescriptorV2.model_validate_contract(_capability_payload())
+        assert cap.capability_id == "ur5e.simulate_cartesian_trajectory"
+        assert cap.effect.class.value == "SIMULATED_EFFECT"
+        assert cap.compatibility.modes == ["SIMULATION"]
+        assert cap.execution.idempotent is True
+        assert cap.evidence.resource_provenance_required is True
+        again = CapabilityDescriptorV2.model_validate_contract(_capability_payload())
+        assert cap.canonical_hash() == again.canonical_hash()
+
+    def test_golden_schema(self) -> None:
+        from rosclaw.contracts.agent.capability import CapabilityDescriptorV2
+
+        golden = GOLDEN_DIR / "rosclaw.capability.v2.json"
+        assert golden.exists(), f"missing golden file {golden}"
+        assert json.loads(golden.read_text(encoding="utf-8")) == (
+            CapabilityDescriptorV2.model_json_schema()
+        ), "schema rosclaw.capability.v2 drifted from golden"
+
+    def test_invalid_effect_class_rejected(self) -> None:
+        from rosclaw.contracts.agent.capability import CapabilityDescriptorV2
+
+        payload = _capability_payload()
+        payload["effect"]["class"] = "MAYBE_SAFE"
+        with pytest.raises((PydanticValidationError, Exception)):
+            CapabilityDescriptorV2.model_validate_contract(payload)
+
+    def test_unknown_major_version_rejected(self) -> None:
+        from rosclaw.contracts.agent.capability import CapabilityDescriptorV2
+
+        payload = _capability_payload()
+        payload["schema_version"] = "rosclaw.capability.v9"
+        with pytest.raises(UnsupportedVersionError):
+            CapabilityDescriptorV2.model_validate_contract(payload)
+
+    def test_physical_effect_requires_provenance_by_default(self) -> None:
+        """PHYSICAL_EFFECT 能力的 resource_provenance_required 默认 True
+        （物理效应必须能反查资源证明——fail closed）。"""
+        from rosclaw.contracts.agent.capability import CapabilityDescriptorV2
+
+        payload = _capability_payload()
+        payload["effect"]["class"] = "PHYSICAL_EFFECT"
+        payload["effect"]["requires_fresh_real_context"] = True
+        payload["compatibility"]["modes"] = ["REAL"]
+        payload.pop("evidence")
+        cap = CapabilityDescriptorV2.model_validate_contract(payload)
+        assert cap.evidence.resource_provenance_required is True
+
+
+class TestToolProjectionV1:
+    def _payload(self, **overrides) -> dict:
+        payload = {
+            "schema_version": "rosclaw.tool_projection.v1",
+            "tool_name": "simulate_ur5e_trajectory",
+            "capability_id": "ur5e.simulate_cartesian_trajectory",
+            "input_schema": {"type": "object", "additionalProperties": False},
+            "output_schema": {"type": "object", "additionalProperties": False},
+            "presentation_ref": "simulation_trajectory_card",
+            "exposure": "direct",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_golden_schema(self) -> None:
+        from rosclaw.contracts.agent.capability import ToolProjectionV1
+
+        golden = GOLDEN_DIR / "rosclaw.tool_projection.v1.json"
+        assert golden.exists(), f"missing golden file {golden}"
+        assert json.loads(golden.read_text(encoding="utf-8")) == (
+            ToolProjectionV1.model_json_schema()
+        ), "schema rosclaw.tool_projection.v1 drifted from golden"
+
+    def test_exposure_values(self) -> None:
+        from rosclaw.contracts.agent.capability import ToolProjectionV1
+
+        for exposure in ("direct", "propose_only", "internal"):
+            proj = ToolProjectionV1.model_validate_contract(
+                self._payload(exposure=exposure)
+            )
+            assert proj.exposure.value == exposure
+        with pytest.raises((PydanticValidationError, Exception)):
+            ToolProjectionV1.model_validate_contract(
+                self._payload(exposure="secret_backdoor")
+            )
+
+    def test_registered_in_export(self) -> None:
+        """两个新合约进入 ALL_CONTRACTS（CI 扫描/工具链可见）。"""
+        from rosclaw.contracts.export import ALL_CONTRACTS
+
+        assert "rosclaw.capability.v2" in ALL_CONTRACTS
+        assert "rosclaw.tool_projection.v1" in ALL_CONTRACTS


### PR DESCRIPTION
## 范围（调整方案 §三.N5A）

把领域能力与模型工具拆成两个概念：

- **CapabilityDescriptorV2**（`rosclaw.capability.v2`）：ROSClaw 具备什么能力——input/output schema + effect（EffectClassV1 8 值词表冻结，N5C 目标）+ compatibility + execution + evidence；PHYSICAL_EFFECT 默认 `resource_provenance_required=True`（fail closed）；
- **ToolProjectionV1**（`rosclaw.tool_projection.v1`）：能力如何投影给 Harness/模型/TUI/CLI——exposure ∈ direct/propose_only/internal；
- **迁移适配器**：旧 ToolDescriptorV2 仅作兼容输入，注册时适配为 V2 canonical（映射表显式可查、测试钉住、诚实标注 adapted_from）；不并行维护两套正式目录；
- **ToolCatalog**：V2 canonical 存储 + legacy 视图（过渡期）；`register_projection` 拒绝 PHYSICAL_EFFECT direct 投影（fail closed）。

## 四层测试

- Contract：枚举冻结/golden schema/版本闸/非法 effect 拒绝（test_capability_v2.py）；
- Component：适配器映射表 6 参数化 + catalog canonical + legacy 视图不变；
- Product Wiring：register_native_tools → sim_reach canonical effect=SIMULATED_EFFECT；
- Adversarial/Mutation：effect 篡改 → digest 变；PHYSICAL direct 投影被拒；实测变异（PHYSICAL_ACTION→PURE_COMPUTE）→ 3 测试红，已还原。

## 红→绿

合约/Registry 22 项红（模块不存在 collection error）→ 本仓 73（contracts）+ 91（tooling 邻接）+ 13（admission/resolver）全绿；ruff 净。

## 不在本 PR

输出 Schema 强制验证（N5B）、Effect 动态解析/删 EFFECT_BY_TOOL（N5C）、动态工具物化（N5D）、MCP 严格绑定（N5E）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)