### PR TITLE
feat: PR-N5E——MCP 严格绑定（显式分类 + QUARANTINED_UNCLASSIFIED）

### DIFF
--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -614,6 +614,20 @@ class PiBridgeServer:
             sim_executor_sources = set(service._sim_executors.keys())
             for descriptor in service._tool_catalog.list():
                 cls = descriptor.execution_class.value
+                # N5E：观测/计算桶也查隔离——被隔离的进 excluded
+                # （与 snapshot 同一事实源），不得显示为可用。
+                if cls in ("OBSERVE", "COMPUTE"):
+                    qreason = service._tool_catalog.quarantine_reason(
+                        descriptor.tool_id
+                    )
+                    if qreason is not None:
+                        excluded.append(
+                            {
+                                "capability_id": descriptor.tool_id,
+                                "reason": qreason.split(":", 1)[0].strip(),
+                            }
+                        )
+                        continue
                 if cls == "OBSERVE":
                     if descriptor.model_callable:
                         # PR-N5C：每条携带 canonical effect_class。

--- a/src/rosclaw/agentd/tooling/catalog.py
+++ b/src/rosclaw/agentd/tooling/catalog.py
@@ -245,6 +245,12 @@ class ToolCatalog:
         if descriptor is None:
             return _blocked("CAPABILITY_UNKNOWN", f"tool {tool_id!r} not in catalog")
         tool_id = descriptor.tool_id
+        # 隔离原因优先于 callable 形态——"为什么不能用"先讲诚实原因。
+        reason = self._quarantine.get(tool_id)
+        if reason is not None:
+            return _blocked(
+                "CAPABILITY_QUARANTINED", f"tool {tool_id!r} quarantined: {reason}"
+            )
         if (
             descriptor.execution_class is ExecutionClass.PHYSICAL_ACTION
             or not descriptor.model_callable
@@ -253,11 +259,6 @@ class ToolCatalog:
                 "TOOL_NOT_CALLABLE",
                 f"tool {tool_id!r} is not directly executable (physical or "
                 "non-model-callable) — flows only through the approval chain",
-            )
-        reason = self._quarantine.get(tool_id)
-        if reason is not None:
-            return _blocked(
-                "CAPABILITY_QUARANTINED", f"tool {tool_id!r} quarantined: {reason}"
             )
         executor = self._executors.get(tool_id)
         if executor is None:

--- a/src/rosclaw/agentd/tooling/mcp_adapter.py
+++ b/src/rosclaw/agentd/tooling/mcp_adapter.py
@@ -169,6 +169,22 @@ class McpServerConfig:
         return env
 
 
+def suggest_classification(tool_name: str, annotations: Any) -> str:
+    """名称/注解启发式建议——仅 developer doctor/inspect 展示用，
+    绝不参与上线分类（PR-N5E）。返回 "" 表示无建议。"""
+    destructive = (
+        bool(getattr(annotations, "destructiveHint", False)) if annotations else False
+    )
+    if destructive:
+        return "PHYSICAL_ACTION"
+    read_only = bool(getattr(annotations, "readOnlyHint", False)) if annotations else False
+    if _ACTION_VERBS.search(tool_name):
+        return "PHYSICAL_ACTION"
+    if read_only:
+        return "OBSERVE"
+    return ""
+
+
 @dataclass
 class DiscoveryReport:
     server: str
@@ -194,7 +210,11 @@ class McpCapabilityAdapter:
 
     # -- classification ---------------------------------------------------------
 
-    def classify(self, tool_name: str, annotations: Any) -> ExecutionClass:
+    def classify(self, tool_name: str, annotations: Any) -> ExecutionClass | None:
+        """PR-N5E 严格绑定：只认安装配置的显式声明列表（绑定 manifest
+        等效物）。未声明 → None（调用方 QUARANTINED_UNCLASSIFIED 隔离，
+        不上线执行）。名称动词/第三方注解启发式不参与上线分类——只在
+        suggest_classification（developer doctor）里给建议。"""
         cfg = self._config
         if tool_name in cfg.action_tools:
             return ExecutionClass.PHYSICAL_ACTION
@@ -202,18 +222,7 @@ class McpCapabilityAdapter:
             return ExecutionClass.COMPUTE
         if tool_name in cfg.observation_tools:
             return ExecutionClass.OBSERVE
-        read_only = bool(getattr(annotations, "readOnlyHint", False)) if annotations else False
-        destructive = (
-            bool(getattr(annotations, "destructiveHint", False)) if annotations else False
-        )
-        if destructive:
-            return ExecutionClass.PHYSICAL_ACTION
-        if read_only and not _ACTION_VERBS.search(tool_name):
-            return ExecutionClass.OBSERVE
-        if _ACTION_VERBS.search(tool_name):
-            return ExecutionClass.PHYSICAL_ACTION
-        # ambiguous → fail closed
-        return ExecutionClass.PHYSICAL_ACTION
+        return None
 
     # -- discovery ---------------------------------------------------------------
 
@@ -255,7 +264,39 @@ class McpCapabilityAdapter:
 
         self._catalog.lift_source_quarantine(self.source)
         for tool in listed.tools:
-            execution_class = self.classify(tool.name, tool.annotations)
+            classified = self.classify(tool.name, tool.annotations)
+            if classified is None:
+                # PR-N5E：含糊工具 → QUARANTINED_UNCLASSIFIED（注册可见、
+                # 不可执行、进 snapshot excluded；原因带启发式建议供
+                # doctor/inspect 展示——建议不上线）。
+                suggestion = suggest_classification(tool.name, tool.annotations)
+                descriptor = ToolDescriptorV2(
+                    tool_id=tool.name,
+                    source=self.source,
+                    execution_class=ExecutionClass.PHYSICAL_ACTION,
+                    side_effect_class=ToolSideEffectClass.REVERSIBLE,
+                    description=tool.description or "",
+                    input_schema=dict(tool.inputSchema or {}),
+                    supported_modes=list(cfg.supported_modes),
+                    required_body_types=list(cfg.required_body_types),
+                    effect_domain="",
+                    timeout_ms=cfg.timeout_ms,
+                    evidence_class=ToolEvidenceClass.MEASURED,
+                    idempotent=False,
+                    model_callable=False,
+                    requires_exact_action_grant=True,
+                )
+                self._catalog.replace(descriptor, self._make_executor(tool.name))
+                self._catalog.quarantine_tool(
+                    tool.name,
+                    "QUARANTINED_UNCLASSIFIED: 未在安装配置显式声明分类"
+                    f"（observation/compute/action 列表）；建议分类: "
+                    f"{suggestion or '未知'}——在 server 配置中显式声明后"
+                    "自动解除隔离",
+                )
+                report.tools.append(descriptor)
+                continue
+            execution_class = classified
             physical = execution_class is ExecutionClass.PHYSICAL_ACTION
             descriptor = ToolDescriptorV2(
                 tool_id=tool.name,

--- a/src/rosclaw/agentd/tooling/snapshot.py
+++ b/src/rosclaw/agentd/tooling/snapshot.py
@@ -54,8 +54,13 @@ def build_capability_snapshot(
         cid = cap.capability_id
         reason = catalog.quarantine_reason(cid)
         if reason is not None:
+            # 已知机器原因码直传（如 QUARANTINED_UNCLASSIFIED），其余
+            # 统一 CAPABILITY_QUARANTINED。
+            code = reason.split(":", 1)[0].strip()
+            if code not in ("QUARANTINED_UNCLASSIFIED",):
+                code = "CAPABILITY_QUARANTINED"
             excluded.append(SnapshotExcludedV1(
-                capability_id=cid, reason="CAPABILITY_QUARANTINED",
+                capability_id=cid, reason=code,
             ))
             continue
         effect = cap.effect.class_

--- a/src/rosclaw/sim/kits/ur5e_sim.json
+++ b/src/rosclaw/sim/kits/ur5e_sim.json
@@ -54,11 +54,13 @@
    "ur5e.move_to_pose",
    "ur5e.stop",
    "ur5e.execute_plan",
-   "ur5e.reset_simulation"
+   "ur5e.reset_simulation",
+   "ur5e.execute_cartesian_path"
   ],
   "compute": [
    "ur5e.plan_cartesian_path",
-   "ur5e.verify_drawing"
+   "ur5e.verify_drawing",
+   "ur5e.render_trace_preview"
   ]
  }
 }

--- a/src/rosclaw/sim/kits/ur5e_sim.json
+++ b/src/rosclaw/sim/kits/ur5e_sim.json
@@ -54,8 +54,7 @@
    "ur5e.move_to_pose",
    "ur5e.stop",
    "ur5e.execute_plan",
-   "ur5e.reset_simulation",
-   "ur5e.execute_cartesian_path"
+   "ur5e.reset_simulation"
   ],
   "compute": [
    "ur5e.plan_cartesian_path",

--- a/tests/agentd/test_n5e_mcp_strict_binding.py
+++ b/tests/agentd/test_n5e_mcp_strict_binding.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 
 class _FakeTool:
     def __init__(self, name: str, *, read_only: bool = False) -> None:

--- a/tests/agentd/test_n5e_mcp_strict_binding.py
+++ b/tests/agentd/test_n5e_mcp_strict_binding.py
@@ -1,0 +1,203 @@
+"""PR-N5E 红测试（调整方案 §三.N5E）：MCP 严格绑定。
+
+红测试先行——严格分类/QUARANTINED_UNCLASSIFIED 不存在时必须红。
+
+1. 生产模式：MCP 工具必须经显式声明分类（安装配置的
+   observation/compute/action 列表 + output_schema + effect domain）；
+   名称/注解启发式不再上线执行；
+2. 含糊工具 → QUARANTINED_UNCLASSIFIED（注册可见、不可执行、
+   进 snapshot excluded）；
+3. 启发式只在 doctor/inspect 给建议（suggest_classification 纯建议，
+   不影响上线分类）；
+4. 第一方 kit（显式声明）不受影响；
+5. discovery / capabilities / snapshot 共享同一 digest 事实源。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _FakeTool:
+    def __init__(self, name: str, *, read_only: bool = False) -> None:
+        self.name = name
+        self.description = f"tool {name}"
+        self.inputSchema = {"type": "object"}
+        self.annotations = (
+            type("A", (), {"readOnlyHint": read_only, "destructiveHint": False})()
+        )
+
+
+class _FakeClient:
+    """持久 client 形态的假 MCP server（跳过 stdio 进程）。"""
+
+    def __init__(self, tool_names: list[str], *, read_only: bool = False) -> None:
+        self._tools = [_FakeTool(n, read_only=read_only) for n in tool_names]
+
+    async def list_tools(self):
+        return self._tools
+
+    async def call_tool(self, name: str, arguments: dict):
+        return {"ok": True, "echo": name}
+
+
+def _adapter(tool_names, *, read_only=False, **cfg_kwargs):
+    from rosclaw.agentd.tooling.catalog import ToolCatalog
+    from rosclaw.agentd.tooling.mcp_adapter import (
+        McpCapabilityAdapter,
+        McpServerConfig,
+    )
+
+    catalog = ToolCatalog()
+    cfg = McpServerConfig(name="ext", command="true", **cfg_kwargs)
+    return McpCapabilityAdapter(
+        cfg, catalog, client=_FakeClient(tool_names, read_only=read_only)
+    ), catalog
+
+
+class TestStrictBinding:
+    async def test_explicitly_declared_tools_classified(self) -> None:
+        """显式声明的工具按列表分类且不隔离。"""
+        adapter, catalog = _adapter(
+            ["ext.get_pose", "ext.plan_path", "ext.move"],
+            observation_tools=("ext.get_pose",),
+            compute_tools=("ext.plan_path",),
+            action_tools=("ext.move",),
+            output_schemas={"ext.plan_path": {
+                "type": "object", "properties": {"ok": {"type": "boolean"}},
+            }},
+        )
+        report = await adapter.discover()
+        assert report.ok
+        from rosclaw.contracts.agent.tool import ExecutionClass
+
+        assert catalog.get("ext.get_pose").execution_class is ExecutionClass.OBSERVE
+        assert catalog.get("ext.plan_path").execution_class is ExecutionClass.COMPUTE
+        assert catalog.get("ext.move").execution_class is ExecutionClass.PHYSICAL_ACTION
+        for tid in ("ext.get_pose", "ext.plan_path", "ext.move"):
+            assert catalog.quarantine_reason(tid) is None
+
+    async def test_undeclared_tool_quarantined_unclassified(self) -> None:
+        """未显式声明的工具 → QUARANTINED_UNCLASSIFIED：注册可见、
+        不可执行、原因诚实。"""
+        adapter, catalog = _adapter(["ext.mystery"], read_only=True)
+        report = await adapter.discover()
+        assert report.ok
+        reason = catalog.quarantine_reason("ext.mystery")
+        assert reason is not None
+        assert "QUARANTINED_UNCLASSIFIED" in reason
+        # 不可执行（execute_v2 BLOCKED）。
+        env = await catalog.execute_v2("c1", "ext.mystery", {})
+        assert env.status.value == "BLOCKED"
+        assert env.error.code == "CAPABILITY_QUARANTINED"
+
+    async def test_name_verb_heuristic_no_longer_classifies(self) -> None:
+        """名称动词启发式不再上线：叫 move_fast 的未声明工具此前会被
+        分成 PHYSICAL_ACTION 上线——现在必须 QUARANTINED_UNCLASSIFIED。"""
+        adapter, catalog = _adapter(["ext.move_fast"])
+        await adapter.discover()
+        reason = catalog.quarantine_reason("ext.move_fast")
+        assert reason is not None and "QUARANTINED_UNCLASSIFIED" in reason
+
+    async def test_annotations_alone_do_not_classify(self) -> None:
+        """第三方自声明注解（readOnlyHint）不是绑定依据——未显式声明
+        的 readOnly 工具同样隔离。"""
+        adapter, catalog = _adapter(["ext.read_thing"], read_only=True)
+        await adapter.discover()
+        assert catalog.quarantine_reason("ext.read_thing") is not None
+
+
+class TestHeuristicIsDoctorOnly:
+    def test_suggest_classification_advisory_only(self) -> None:
+        """启发式仅存于建议函数（developer doctor 用），不参与上线。"""
+        from rosclaw.agentd.tooling.mcp_adapter import suggest_classification
+
+        assert suggest_classification("ext.move_fast", None) == "PHYSICAL_ACTION"
+        assert (
+            suggest_classification(
+                "ext.get_pose",
+                type("A", (), {"readOnlyHint": True, "destructiveHint": False})(),
+            )
+            == "OBSERVE"
+        )
+        assert suggest_classification("ext.mystery", None) == ""
+
+    async def test_suggestion_carried_in_quarantine_reason(self) -> None:
+        """隔离原因里带启发式建议（doctor/inspect 展示），但分类本身
+        不据此上线。"""
+        adapter, catalog = _adapter(["ext.move_fast"])
+        await adapter.discover()
+        reason = catalog.quarantine_reason("ext.move_fast") or ""
+        assert "PHYSICAL_ACTION" in reason  # 建议在案
+        assert "QUARANTINED_UNCLASSIFIED" in reason
+
+
+class TestSharedSnapshotFacts:
+    async def test_quarantined_unclassified_in_snapshot_excluded(
+        self, tmp_path: Path
+    ) -> None:
+        """discovery→catalog→snapshot 同一事实源：隔离工具进 excluded
+        且 digest 覆盖它。"""
+        from rosclaw.agentd.tooling.snapshot import build_capability_snapshot
+
+        adapter, catalog = _adapter(
+            ["ext.get_pose", "ext.mystery"],
+            observation_tools=("ext.get_pose",),
+        )
+        await adapter.discover()
+        snap = build_capability_snapshot(
+            catalog, body_id="sim/ur5e", mode="SIMULATION"
+        )
+        excluded = {e.capability_id: e for e in snap.excluded}
+        assert "ext.mystery" in excluded
+        assert excluded["ext.mystery"].reason == "QUARANTINED_UNCLASSIFIED"
+        assert "ext.get_pose" in {a.capability_id for a in snap.active}
+
+    async def test_first_party_kit_unaffected(self, tmp_path: Path) -> None:
+        """第一方 kit（显式列表+schema 声明）全部正常分类不隔离——
+        产品接线实证。"""
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        await service._ensure_mcp_discovered()
+        for d in service._tool_catalog.list(source="mcp:ur5e-sim"):
+            assert service._tool_catalog.quarantine_reason(d.tool_id) is None, (
+                f"第一方 kit 工具被误隔离: {d.tool_id}"
+            )
+        await service.close()
+
+
+class TestCapabilitiesSnapshotConsistency:
+    async def test_capabilities_and_snapshot_share_excluded(
+        self, tmp_path: Path
+    ) -> None:
+        """pi.capabilities 与 pi.capability.snapshot 的 excluded 一致
+        （同一 digest 事实源）。"""
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        await service._ensure_mcp_discovered()
+        service._tool_catalog.quarantine_tool(
+            "ur5e.plan_cartesian_path", "QUARANTINED_UNCLASSIFIED: 未绑定"
+        )
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        caps = await bridge._dispatch(
+            "user:local:1000", 1, "pi.capabilities",
+            {"token": service.control_token, "mission_id": mission.mission_id},
+        )
+        snap = await bridge._dispatch(
+            "user:local:1000", 1, "pi.capability.snapshot",
+            {"token": service.control_token, "mission_id": mission.mission_id},
+        )
+        cap_excluded = {
+            e["capability_id"] for e in caps.get("excluded") or []
+        }
+        snap_excluded = {
+            e["capability_id"] for e in snap["snapshot"]["excluded"]
+        }
+        assert "ur5e.plan_cartesian_path" in cap_excluded
+        assert "ur5e.plan_cartesian_path" in snap_excluded
+        await service.close()

--- a/tests/agentd/test_n5e_mcp_strict_binding.py
+++ b/tests/agentd/test_n5e_mcp_strict_binding.py
@@ -161,6 +161,12 @@ class TestSharedSnapshotFacts:
         service, mission = await _setup(tmp_path)
         await service._ensure_mcp_discovered()
         for d in service._tool_catalog.list(source="mcp:ur5e-sim"):
+            if d.tool_id == "ur5e.execute_cartesian_path":
+                # deprecated dev 整轨迹层按设计隔离（八审 P0-3 模型不得
+                # 搬运载荷 + N5E 未声明不上线——两契约同时成立）。
+                reason = service._tool_catalog.quarantine_reason(d.tool_id)
+                assert reason is not None and "QUARANTINED_UNCLASSIFIED" in reason
+                continue
             assert service._tool_catalog.quarantine_reason(d.tool_id) is None, (
                 f"第一方 kit 工具被误隔离: {d.tool_id}"
             )

--- a/tests/agentd/test_tooling.py
+++ b/tests/agentd/test_tooling.py
@@ -267,22 +267,36 @@ class TestMcpClassification:
         )
 
     def test_action_verb_is_physical(self) -> None:
+        # PR-N5E：动词启发式不再上线——未显式声明 → None（调用方
+        # QUARANTINED_UNCLASSIFIED）；启发式只在 suggest_classification
+        # 给 doctor 建议。
+        from rosclaw.agentd.tooling.mcp_adapter import suggest_classification
+
         adapter = self._adapter()
-        assert adapter.classify("limo.speaker.play_tone", None) is ExecutionClass.PHYSICAL_ACTION
-        assert adapter.classify("limo.base.move_to", None) is ExecutionClass.PHYSICAL_ACTION
+        assert adapter.classify("limo.speaker.play_tone", None) is None
+        assert adapter.classify("limo.base.move_to", None) is None
+        assert suggest_classification("limo.speaker.play_tone", None) == "PHYSICAL_ACTION"
+        assert suggest_classification("limo.base.move_to", None) == "PHYSICAL_ACTION"
 
     def test_readonly_annotation_is_observe(self) -> None:
         from mcp.types import ToolAnnotations
 
+        from rosclaw.agentd.tooling.mcp_adapter import suggest_classification
+
         adapter = self._adapter()
         ann = ToolAnnotations(readOnlyHint=True)
-        assert adapter.classify("limo.localization.get_pose", ann) is ExecutionClass.OBSERVE
-        # action verb wins over readOnlyHint (suspicious combo → fail closed)
-        assert adapter.classify("limo.arm.set_pose", ann) is ExecutionClass.PHYSICAL_ACTION
+        # N5E：第三方自声明注解不是绑定依据——未显式声明即 None。
+        assert adapter.classify("limo.localization.get_pose", ann) is None
+        assert adapter.classify("limo.arm.set_pose", ann) is None
+        assert suggest_classification("limo.localization.get_pose", ann) == "OBSERVE"
+        assert suggest_classification("limo.arm.set_pose", ann) == "PHYSICAL_ACTION"
 
     def test_ambiguous_fails_closed(self) -> None:
+        # PR-N5E：含糊工具不再默认 PHYSICAL_ACTION 上线——未声明即
+        # None（隔离到 QUARANTINED_UNCLASSIFIED，比"当物理动作上线"
+        # 更诚实：不执行、不展示为可用）。
         adapter = self._adapter()
-        assert adapter.classify("limo.misc.unknown", None) is ExecutionClass.PHYSICAL_ACTION
+        assert adapter.classify("limo.misc.unknown", None) is None
 
     def test_config_overrides(self) -> None:
         adapter = self._adapter(
@@ -294,9 +308,13 @@ class TestMcpClassification:
     def test_destructive_annotation_is_physical(self) -> None:
         from mcp.types import ToolAnnotations
 
+        from rosclaw.agentd.tooling.mcp_adapter import suggest_classification
+
         adapter = self._adapter()
         ann = ToolAnnotations(readOnlyHint=True, destructiveHint=True)
-        assert adapter.classify("x.y", ann) is ExecutionClass.PHYSICAL_ACTION
+        # N5E：注解不参与上线分类；destructive 建议仍为 PHYSICAL_ACTION。
+        assert adapter.classify("x.y", ann) is None
+        assert suggest_classification("x.y", ann) == "PHYSICAL_ACTION"
 
     def test_image_content_is_preserved_with_bounded_metadata(self) -> None:
         from mcp.types import CallToolResult, ImageContent, TextContent
@@ -436,6 +454,10 @@ class TestMcpDiscovery:
                 args=(str(FIXTURE_SERVER),),
                 supported_modes=("SIMULATION", "SHADOW"),
                 required_body_types=("agilex-limo",),
+                # PR-N5E 严格绑定：显式声明分类（生产必需——未声明
+                # 的进 QUARANTINED_UNCLASSIFIED，见下方断言）。
+                observation_tools=("limo.localization.get_pose",),
+                action_tools=("limo.speaker.play_tone",),
             ),
             catalog,
         )
@@ -451,8 +473,10 @@ class TestMcpDiscovery:
         # 退出条件 2：action 不可被模型直接执行。
         assert tone.execution_class is ExecutionClass.PHYSICAL_ACTION
         assert not tone.model_callable and tone.requires_exact_action_grant
-        # 无注解工具 fail closed。
+        # 无声明工具 fail closed：QUARANTINED_UNCLASSIFIED（注册为
+        # 不可调用形态 + 隔离——比"当物理动作上线"更诚实）。
         assert ambiguous.execution_class is ExecutionClass.PHYSICAL_ACTION
+        assert catalog.quarantine_reason("limo.misc.ambiguous") is not None
 
         # observation 通过 catalog 真正执行（真实 MCP stdio 调用）。
         output = await catalog.execute("limo.localization.get_pose", {"frame": "map"})


### PR DESCRIPTION
## 范围（调整方案 §三.N5E）：MCP 严格绑定

生产模式不再按名称动词/第三方注解推测动作类别：

- `mcp_adapter.classify` 只认安装配置显式声明（observation/compute/action 列表）；未声明 → `QUARANTINED_UNCLASSIFIED`（注册可见、不可执行、进 snapshot excluded，原因带启发式建议供 doctor/inspect 展示——建议不上线）；
- 启发式仅存于 `suggest_classification`（doctor-only）；
- execute_v2 隔离原因先于 callable 形态返回；snapshot excluded 直传已知原因码；
- pi.capabilities 观测/计算桶补隔离检查（实证漂移：被隔离的 compute 工具此前仍显示可用）；两读面 excluded 一致；
- **实证根治**：第一方 kit 声明与 server 漂移（12 工具 vs 10 声明）——`render_trace_preview` 显式补入 compute；`execute_cartesian_path`（deprecated dev 整轨迹层）保持不声明即隔离——八审 P0-3（模型不得搬运载荷）与 N5E（未声明不上线）两契约同时成立。

## 四层测试（7 红 → 绿）

- Component：显式声明分类/未声明隔离/动词与注解不再上线/建议在案（6 项）；
- Product Wiring：第一方 kit 全量不隔离 + deprecated 层按设计隔离；
- Consistency：pi.capabilities ↔ snapshot excluded 同源；
- 旧启发式测试改写为新契约（不是删除——改钉 classify None + suggest 建议）；limo fixture 补显式声明（生产对真实 server 的同等要求）。

邻接：test_tooling 36/36 + kit/admission/h5/bridge/eight2/eight3 67+ 全绿；全量回归 608 passed；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)