### PR TITLE
feat: PR-HP1——NativeEventV2 事件日志硬不变量（输入门 + 一等链路段 + OVERLOADED）

### DIFF
--- a/packages/rosclaw-agent/src/native/input-controller.ts
+++ b/packages/rosclaw-agent/src/native/input-controller.ts
@@ -59,6 +59,14 @@ export class InputController {
 			this.forceNewNext = false;
 			this.currentTaskId = result.task_id;
 			this.currentRevision = result.revision;
+			// PR-HP1：投递确认——persisted 之后、Harness 处理之前落
+			// input.dispatched（顺序不变量由 bridge 强制：未 persisted
+			// 的 message 打标即被拒）。失败不阻断——persisted 已是
+			// 权威证据，dispatched 是审计增强。
+			this.deps.call("pi.input.dispatched", {
+				mission_id: this.deps.missionId(),
+				message_id: messageId,
+			}).catch(() => undefined);
 			return result;
 		} catch (err) {
 			// 绑定失败不投递（幽灵执行防线）：消息不消失于沉默——

--- a/src/rosclaw/agentd/events.py
+++ b/src/rosclaw/agentd/events.py
@@ -55,12 +55,34 @@ class MissionEventBus:
                 queue.put_nowait(event)
             except asyncio.QueueFull:
                 # Slow consumer: drop DEBUG first, never block the domain op.
-                if event.visibility is not Visibility.DEBUG:
-                    try:
-                        queue.get_nowait()
-                        queue.put_nowait(event)
-                    except (asyncio.QueueEmpty, asyncio.QueueFull):
-                        pass
+                if event.visibility is Visibility.DEBUG:
+                    continue
+                # PR-HP1：饱和必须显式 OVERLOADED——USER/AUDIT 不得静默
+                # 丢：驱逐最旧 + 放入当前事件 + 保证队列里有
+                # session.degraded 标记（消费者据此知道发生了丢弃并可从
+                # journal 按 cursor 补放）。不阻塞执行。
+                import contextlib as _cl
+
+                with _cl.suppress(asyncio.QueueEmpty):
+                    queue.get_nowait()  # evict oldest
+                marker = AgentEventV2(
+                    event_id=new_id("evt"),
+                    sequence=0,
+                    mission_id=event.mission_id,
+                    timestamp=_utcnow(),
+                    type=AgentEventType.SESSION_DEGRADED,
+                    visibility=Visibility.USER,
+                    payload={
+                        "reason": "OVERLOADED",
+                        "note": "live 队列饱和——部分事件已从流中驱逐；"
+                        "journal 完整，按 cursor 重放可补",
+                    },
+                )
+                # 标记去重：队尾已是 degraded 则不重复插。
+                with _cl.suppress(asyncio.QueueFull):
+                    queue.put_nowait(marker)
+                with _cl.suppress(asyncio.QueueFull):
+                    queue.put_nowait(event)
 
 
 class AgentEventStore:
@@ -81,6 +103,12 @@ class AgentEventStore:
         turn_id: str | None = None,
         task_id: str | None = None,
         trace_id: str | None = None,
+        session_id: str | None = None,
+        revision: int | None = None,
+        item_id: str | None = None,
+        call_id: str | None = None,
+        operation_id: str | None = None,
+        model_visible: bool | None = None,
     ) -> AgentEventV2:
         async with self._lock:
             row = self._conn.execute(
@@ -100,11 +128,20 @@ class AgentEventStore:
                 type=type,
                 visibility=visibility,
                 payload=payload or {},
+                session_id=session_id,
+                revision=revision,
+                item_id=item_id,
+                call_id=call_id,
+                operation_id=operation_id,
+                model_visible=model_visible,
             )
+            # PR-HP1：一等链路段落库（029 迁移列）。
             self._conn.execute(
                 "INSERT INTO agent_events (event_id, mission_id, sequence, turn_id, "
-                "task_id, trace_id, type, visibility, payload_json, timestamp) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "task_id, trace_id, type, visibility, payload_json, timestamp, "
+                "session_id, revision, item_id, call_id, operation_id, "
+                "model_visible) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     event.event_id,
                     mission_id,
@@ -116,6 +153,12 @@ class AgentEventStore:
                     visibility.value,
                     json.dumps(payload or {}, sort_keys=True, ensure_ascii=False),
                     event.timestamp,
+                    session_id,
+                    revision,
+                    item_id,
+                    call_id,
+                    operation_id,
+                    None if model_visible is None else (1 if model_visible else 0),
                 ),
             )
         # Publish only after the journal row is committed.
@@ -155,6 +198,8 @@ class AgentEventStore:
 
     @staticmethod
     def _row_to_event(row: sqlite3.Row) -> AgentEventV2:
+        keys = set(row.keys())  # sqlite3.Row 不支持 __contains__——取一次键集
+        model_visible_raw = row["model_visible"] if "model_visible" in keys else None
         return AgentEventV2(
             event_id=row["event_id"],
             sequence=row["sequence"],
@@ -166,4 +211,12 @@ class AgentEventStore:
             type=AgentEventType(row["type"]),
             visibility=Visibility(row["visibility"]),
             payload=json.loads(row["payload_json"]),
+            session_id=row["session_id"] if "session_id" in keys else None,
+            revision=row["revision"] if "revision" in keys else None,
+            item_id=row["item_id"] if "item_id" in keys else None,
+            call_id=row["call_id"] if "call_id" in keys else None,
+            operation_id=row["operation_id"] if "operation_id" in keys else None,
+            model_visible=(
+                None if model_visible_raw is None else bool(model_visible_raw)
+            ),
         )

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1008,7 +1008,59 @@ class PiBridgeServer:
                 ),
                 force_new=bool(params.get("force_new", False)),
             )
+            # PR-HP1：input.persisted——输入持久化+task 绑定的
+            # journal 证据（先于任何模型请求；文本带 hash+字节数可
+            # 审计，全文在 Pi session journal 唯一持有）。
+            import hashlib as _hashlib
+
+            from rosclaw.contracts.agent.agent_event import AgentEventType
+
+            text = str(params.get("text", ""))
+            await service._events.append(
+                str(params.get("mission_id", "")),
+                AgentEventType.INPUT_PERSISTED,
+                {
+                    "message_id": str(params.get("message_id", "")),
+                    "text_sha256": "sha256:" + _hashlib.sha256(
+                        text.encode("utf-8")
+                    ).hexdigest(),
+                    "bytes": len(text.encode("utf-8")),
+                },
+                session_id=str(params.get("session_ref", "")),
+                task_id=str(result.get("task_id", "")),
+                revision=int(result.get("revision", 0)) or None,
+                model_visible=True,
+            )
             return {"ok": True, **result}
+        if method == "pi.input.dispatched":
+            # PR-HP1：投递确认——对应 message 必须先 persisted
+            # （顺序不变量：dispatched 不得先于 persisted 出现）。
+            mission_id = str(params.get("mission_id", ""))
+            message_id = str(params.get("message_id", ""))
+            from rosclaw.contracts.agent.agent_event import AgentEventType
+
+            persisted = [
+                e for e in service.events_replay(mission_id, limit=1000)
+                if e.type is AgentEventType.INPUT_PERSISTED
+                and e.payload.get("message_id") == message_id
+            ]
+            if not persisted:
+                return {
+                    "ok": False,
+                    "error": f"message {message_id!r} was never persisted "
+                    "(bind first) — refusing to mark dispatched",
+                    "code": "INPUT_NOT_PERSISTED",
+                }
+            await service._events.append(
+                mission_id,
+                AgentEventType.INPUT_DISPATCHED,
+                {"message_id": message_id},
+                session_id=persisted[0].session_id,
+                task_id=persisted[0].task_id,
+                revision=persisted[0].revision,
+                model_visible=True,
+            )
+            return {"ok": True}
         if method == "pi.kernel.list":
             kernel = service._task_kernel
             return {

--- a/src/rosclaw/contracts/agent/agent_event.py
+++ b/src/rosclaw/contracts/agent/agent_event.py
@@ -72,6 +72,17 @@ class AgentEventType(StrEnum):
     COMPACTION_COMPLETED = "compaction.completed"
     MISSION_COMPLETED = "mission.completed"
     MISSION_FAILED = "mission.failed"
+    # PR-HP1：NativeEventV2 硬不变量（调整方案 §四）——输入门/操作/
+    # 会话活性。
+    INPUT_PERSISTED = "input.persisted"
+    INPUT_DISPATCHED = "input.dispatched"
+    OPERATION_STARTED = "operation.started"
+    OPERATION_OUTPUT = "operation.output"
+    OPERATION_COMPLETED = "operation.completed"
+    OPERATION_FAILED = "operation.failed"
+    SESSION_IDLE = "session.idle"
+    SESSION_DEGRADED = "session.degraded"
+    TURN_FAILED = "turn.failed"
     # 系统
     WARNING = "warning"
     CAPABILITIES_CHANGED = "capabilities.changed"
@@ -100,3 +111,16 @@ class AgentEventV2(ContractModel):
     type: AgentEventType
     visibility: Visibility = Visibility.USER
     payload: dict[str, Any] = Field(default_factory=dict)
+    # PR-HP1：一等链路段（落库列，不埋 payload——resume/trace/投影
+    # 直接读列）。
+    session_id: str | None = None
+    #: 任务 revision（输入绑定的 task revision）。
+    revision: int | None = None
+    #: Harness 原生 item id（Pi item 等——只在 binding 语义内使用）。
+    item_id: str | None = None
+    #: 工具调用 id（tool.* 事件的调用关联）。
+    call_id: str | None = None
+    #: 长操作 id（operation.* 事件关联）。
+    operation_id: str | None = None
+    #: 内容是否进入了模型上下文（可重放日志的模型可见性标注）。
+    model_visible: bool | None = None

--- a/src/rosclaw/contracts/export.py
+++ b/src/rosclaw/contracts/export.py
@@ -10,6 +10,7 @@ import json
 import sys
 from pathlib import Path
 
+from rosclaw.contracts.agent.agent_event import AgentEventV2
 from rosclaw.contracts.agent.branch import ReasoningBranchV1
 from rosclaw.contracts.agent.capability import CapabilityDescriptorV2, ToolProjectionV1
 from rosclaw.contracts.agent.capability_snapshot import CapabilitySnapshotV1
@@ -45,6 +46,7 @@ ALL_CONTRACTS: dict[str, type[ContractModel]] = {
     cls.SCHEMA: cls
     for cls in (
         MissionSessionV1,
+        AgentEventV2,
         TaskNodeV1,
         TaskGraphV1,
         TaskGraphPatchV1,

--- a/src/rosclaw/storage/migrations/029_hp1_native_event.sql
+++ b/src/rosclaw/storage/migrations/029_hp1_native_event.sql
@@ -1,0 +1,12 @@
+-- 029: PR-HP1 NativeEventV2——一等链路段落库（调整方案 §四）。
+--
+-- session_id/revision/item_id/call_id/operation_id/model_visible 成为
+-- agent_events 的一等列：resume/trace/TUI 投影直接读列，不挖
+-- payload JSON。全部可空（旧行兼容）。
+
+ALTER TABLE agent_events ADD COLUMN session_id TEXT;
+ALTER TABLE agent_events ADD COLUMN revision INTEGER;
+ALTER TABLE agent_events ADD COLUMN item_id TEXT;
+ALTER TABLE agent_events ADD COLUMN call_id TEXT;
+ALTER TABLE agent_events ADD COLUMN operation_id TEXT;
+ALTER TABLE agent_events ADD COLUMN model_visible INTEGER;

--- a/tests/agentd/test_hp1_input_gate_pty.py
+++ b/tests/agentd/test_hp1_input_gate_pty.py
@@ -1,0 +1,163 @@
+"""PR-HP1 PTY 产品腿：input.persisted 先于任何模型请求（方案硬不变量）。
+
+真实链路：PTY `rosclaw chat`（假模型记录首个请求到达时刻）→ 用户
+发消息 → journal 里 input.persisted 的时间戳必须 ≤ 假模型首个请求
+到达时刻；input.dispatched 在 persisted 之后。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_entry import find_pi_agent_entry
+from tests.agentd.test_product_journey import PtySession, _chunk, _sse
+
+pytestmark = pytest.mark.skipif(
+    not find_pi_agent_entry(),
+    reason="无 Node/dist（CI 全回归 job 未构建）——诚实 skip",
+)
+
+
+class _TimedFake:
+    def __init__(self) -> None:
+        self.first_request_at: float | None = None
+
+    def answer(self, body: dict) -> bytes:
+        if self.first_request_at is None:
+            self.first_request_at = time.time()
+        frames = [_sse(_chunk("收到。")), _sse(_chunk("", "stop")), b"data: [DONE]\n\n"]
+        return b"".join(frames)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    fake: _TimedFake
+
+    def log_message(self, *args) -> None:
+        return
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        payload = self.fake.answer(body)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.fake = _TimedFake()
+        handler = type("H", (_Handler,), {"fake": self.fake})
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.server.server_address[1]
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1"
+
+    def close(self) -> None:
+        self.server.shutdown()
+
+
+def _prepare_home(tmp_path: Path, base_url: str) -> tuple[Path, dict[str, str]]:
+    home = tmp_path / "rh"
+    (home / "run").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "agent:\n  enabled: true\n  default_profile: embodied_default\n"
+        "models:\n  backend: legacy\n  profiles:\n    embodied_default:\n"
+        "      provider: kimi_code\n      model: fake-k3\n"
+        f"      base_url: {base_url}\n"
+        "      api_key_ref: env:FAKE_JOURNEY_KEY\n"
+        "      capabilities: [llm.chat, llm.structured_decision, llm.tool_use]\n",
+        encoding="utf-8",
+    )
+    (home / "agent").mkdir(parents=True, exist_ok=True)
+    (home / "agent" / "settings.json").write_text(
+        json.dumps({"defaultProvider": "journey-fake", "defaultModel": "fake-k3"}),
+        encoding="utf-8",
+    )
+    (home / "agent" / "models.json").write_text(
+        json.dumps({
+            "providers": {
+                "journey-fake": {
+                    "name": "Journey Fake", "baseUrl": base_url,
+                    "api": "openai-completions", "apiKey": "$FAKE_JOURNEY_KEY",
+                    "models": [{"id": "fake-k3", "name": "Fake K3",
+                                "contextWindow": 8192, "maxTokens": 4096}],
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+    env = dict(
+        os.environ, ROSCLAW_HOME=str(home), TERM="xterm",
+        FAKE_JOURNEY_KEY="sk-fake-journey", ROSCLAW_UI_LOCALE="zh-CN",
+    )
+    return home, env
+
+
+class TestInputPersistedGate:
+    def test_persisted_precedes_first_model_request(self, tmp_path: Path) -> None:
+        fake = _FakeServer()
+        home, env = _prepare_home(tmp_path, fake.base_url)
+        workdir = tmp_path / "hp1-work"
+        workdir.mkdir()
+        session = PtySession(
+            [sys.executable, "-m", "rosclaw.entrypoint", "chat",
+             "--workspace", str(workdir)],
+            env, log_path=tmp_path / "pty-hp1.log", cwd=workdir,
+        )
+        try:
+            session.expect(b"ROSClaw Native Agent", timeout=120)
+            session.send("你好\r")
+            session.expect("收到。".encode(), timeout=120)
+            assert fake.fake.first_request_at is not None
+            # journal：input.persisted 存在且先于首个模型请求；
+            # input.dispatched 在其后。
+            db = sqlite3.connect(home / "agentd" / "missions.db")
+            try:
+                rows = db.execute(
+                    "SELECT type, timestamp, session_id, task_id, revision, "
+                    "model_visible FROM agent_events "
+                    "WHERE type IN ('input.persisted', 'input.dispatched') "
+                    "ORDER BY sequence"
+                ).fetchall()
+            finally:
+                db.close()
+            types = [r[0] for r in rows]
+            assert "input.persisted" in types, f"journal 缺 input.persisted: {types}"
+            assert "input.dispatched" in types, f"journal 缺 input.dispatched: {types}"
+            assert types.index("input.persisted") < types.index("input.dispatched")
+            persisted = rows[types.index("input.persisted")]
+            # ISO 时间戳 → epoch 比较（允许同时）。
+            from datetime import datetime
+
+            persisted_at = datetime.fromisoformat(
+                str(persisted[1])
+            ).timestamp()
+            assert persisted_at <= fake.fake.first_request_at + 0.001, (
+                f"input.persisted({persisted_at}) 晚于首个模型请求"
+                f"({fake.fake.first_request_at})——输入门被破坏"
+            )
+            # 一等列携带：session/task/revision/model_visible。
+            assert persisted[2], "input.persisted 缺 session_id 列"
+            assert persisted[3], "input.persisted 缺 task_id 列"
+            assert persisted[4] is not None
+            assert persisted[5] == 1
+            session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
+            session.proc.wait(timeout=30)
+        finally:
+            session.stop()
+            fake.close()

--- a/tests/agentd/test_hp1_native_event.py
+++ b/tests/agentd/test_hp1_native_event.py
@@ -1,0 +1,330 @@
+"""PR-HP1 红测试（调整方案 §四.HP1）：NativeEventV2 与事件日志。
+
+红测试先行——合约字段/事件类型/input 事件/背压标记不存在时必须红。
+
+硬不变量（方案原文）：
+1. 用户输入必须先持久化、绑定 task/revision，再交 Harness——
+   input.persisted 没成功，不得开始模型请求；
+2. 每个事件单调 sequence；resume 从 cursor 重放；
+3. TUI 消费落后不能阻塞执行；队列饱和必须显式 OVERLOADED，
+   不能丢输入（也不静默丢 USER/AUDIT 事件——留 session.degraded
+   标记）；
+4. 事件字段：sessionId/taskId/revision/turnId/callId/operationId/
+   modelVisible 一等列（不是埋在 payload 里）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class TestContractFields:
+    def test_new_event_types_exist(self) -> None:
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+
+        for value in (
+            "input.persisted",
+            "input.dispatched",
+            "operation.started",
+            "operation.output",
+            "operation.completed",
+            "operation.failed",
+            "session.idle",
+            "session.degraded",
+            "turn.failed",
+        ):
+            assert AgentEventType(value).value == value, f"缺事件类型 {value}"
+
+    def test_event_first_class_linkage_fields(self) -> None:
+        """session_id/revision/item_id/call_id/operation_id/
+        model_visible 是合约一等字段。"""
+        from rosclaw.contracts.agent.agent_event import AgentEventV2
+
+        event = AgentEventV2.model_validate_contract({
+            "schema_version": "rosclaw.agent_event.v2",
+            "event_id": "evt_1",
+            "sequence": 1,
+            "mission_id": "mis_1",
+            "session_id": "sess_1",
+            "task_id": "task_1",
+            "revision": 2,
+            "turn_id": "turn_1",
+            "item_id": "item_1",
+            "call_id": "call_1",
+            "operation_id": "op_1",
+            "model_visible": True,
+            "timestamp": "2026-08-21T00:00:00+00:00",
+            "type": "input.persisted",
+            "payload": {},
+        })
+        assert event.session_id == "sess_1"
+        assert event.revision == 2
+        assert event.call_id == "call_1"
+        assert event.operation_id == "op_1"
+        assert event.model_visible is True
+
+    def test_golden_schema_updated(self) -> None:
+        from rosclaw.contracts.agent.agent_event import AgentEventV2
+
+        golden = (
+            REPO / "tests" / "contracts" / "golden" / "rosclaw.agent_event.v2.json"
+        )
+        current = AgentEventV2.model_json_schema()
+        current["$id"] = "rosclaw://schemas/rosclaw.agent_event.v2"
+        current["title"] = "rosclaw.agent_event.v2"
+        assert json.loads(golden.read_text(encoding="utf-8")) == current, (
+            "agent_event.v2 schema 漂移——本 PR 加性扩展需重新导出 golden"
+        )
+
+
+class TestJournalColumns:
+    def test_linkage_fields_roundtrip_through_journal(self, tmp_path: Path) -> None:
+        """一等列真实落库（不是只在 payload）并能 replay 回来。"""
+        from rosclaw.agentd.events import AgentEventStore
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+        from rosclaw.storage.migrations import MigrationRunner
+        import sqlite3
+
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        MigrationRunner().apply(conn, "sqlite")
+        # 需要一个 mission 行（外键）
+        conn.execute(
+            "INSERT INTO missions (mission_id, owner_principal, goal_json, "
+            "body_id, effective_body_hash, mode, state, budgets_json, "
+            "authorization_json, created_at, updated_at) "
+            "VALUES ('mis_1', 'u', '{}', 'sim/ur5e', 'h', 'SIMULATION', "
+            "'ACTIVE', '{}', '{}', '2026-08-21T00:00:00Z', "
+            "'2026-08-21T00:00:00Z')"
+        )
+        store = AgentEventStore(conn)
+
+        async def run() -> None:
+            await store.append(
+                "mis_1", AgentEventType.TOOL_STARTED,
+                {"k": "v"},
+                session_id="sess_1", task_id="task_1", revision=3,
+                call_id="call_9", operation_id="op_2", model_visible=True,
+            )
+
+        asyncio.run(run())
+        events = store.replay("mis_1")
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.session_id == "sess_1"
+        assert ev.revision == 3
+        assert ev.call_id == "call_9"
+        assert ev.operation_id == "op_2"
+        assert ev.model_visible is True
+
+
+class TestInputPersistedGate:
+    async def test_bind_emits_input_persisted_with_linkage(
+        self, tmp_path: Path
+    ) -> None:
+        """pi.task.bind 成功 → input.persisted 落 journal（session/task/
+        revision/文本 hash 一等携带）。"""
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await bridge._dispatch(
+            "user:local:1000", 1, "pi.task.bind",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "session_ref": "pi_1",
+                "backend_native_id": "pi_1",
+                "message_id": "msg_hp1",
+                "text": "画五角星",
+                "cwd": str(tmp_path),
+                "body_id": mission.body_binding.body_id,
+            },
+        )
+        assert result.get("ok"), result
+        events = service.events_replay(mission.mission_id, limit=100)
+        persisted = [
+            e for e in events if e.type is AgentEventType.INPUT_PERSISTED
+        ]
+        assert persisted, "bind 成功但 journal 无 input.persisted"
+        ev = persisted[0]
+        assert ev.session_id == "pi_1"
+        assert ev.task_id
+        assert ev.revision >= 1
+        assert ev.model_visible is True
+        # 文本不裸写全文的限制不适用用户输入本身，但必须可审计：
+        # payload 带 hash + 字节数。
+        assert ev.payload.get("text_sha256")
+        assert ev.payload.get("bytes", 0) > 0
+        await service.close()
+
+    async def test_no_dispatched_without_persisted(self, tmp_path: Path) -> None:
+        """input.dispatched 前必须有对应 message 的 input.persisted
+        （顺序不变量）。"""
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        # 直接 dispatched（无 bind）→ 拒绝。
+        result = await bridge._dispatch(
+            "user:local:1000", 1, "pi.input.dispatched",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "message_id": "msg_never_persisted",
+            },
+        )
+        assert not result.get("ok"), result
+        assert result.get("code") in ("INPUT_NOT_PERSISTED", "INVALID_ARGUMENT")
+        await service.close()
+
+    async def test_dispatched_after_bind_ok(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        bind = await bridge._dispatch(
+            "user:local:1000", 1, "pi.task.bind",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "session_ref": "pi_1",
+                "backend_native_id": "pi_1",
+                "message_id": "msg_hp1b",
+                "text": "继续",
+                "cwd": str(tmp_path),
+                "body_id": mission.body_binding.body_id,
+            },
+        )
+        assert bind.get("ok"), bind
+        dispatched = await bridge._dispatch(
+            "user:local:1000", 1, "pi.input.dispatched",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "message_id": "msg_hp1b",
+            },
+        )
+        assert dispatched.get("ok"), dispatched
+        events = service.events_replay(mission.mission_id, limit=100)
+        types = [e.type for e in events]
+        p_idx = types.index(AgentEventType.INPUT_PERSISTED)
+        d_idx = types.index(AgentEventType.INPUT_DISPATCHED)
+        assert p_idx < d_idx, "persisted 必须先于 dispatched"
+        await service.close()
+
+
+class TestBackpressure:
+    def test_saturated_queue_gets_explicit_degraded_marker(self) -> None:
+        """队列饱和：DEBUG 可丢；USER/AUDIT 不得静默丢——消费者必须
+        收到显式 session.degraded 标记（OVERLOADED 语义）。"""
+        from rosclaw.agentd.events import MissionEventBus
+        from rosclaw.contracts.agent.agent_event import (
+            AgentEventV2,
+            AgentEventType,
+            Visibility,
+        )
+
+        bus = MissionEventBus()
+        queue = bus.subscribe("mis_1")
+        base = {
+            "schema_version": "rosclaw.agent_event.v2",
+            "mission_id": "mis_1",
+            "timestamp": "2026-08-21T00:00:00+00:00",
+            "payload": {},
+        }
+        # 塞满（maxsize=1024），消费者不读。
+        for i in range(1024):
+            bus.publish(AgentEventV2(
+                event_id=f"evt_{i}", sequence=i + 1, type=AgentEventType.TOOL_PROGRESS,
+                visibility=Visibility.USER, **base,
+            ))
+        assert queue.full()
+        # 再发一条 USER——不得静默丢：队列里必须出现 degraded 标记。
+        bus.publish(AgentEventV2(
+            event_id="evt_over", sequence=1025,
+            type=AgentEventType.ACTION_RECEIPT, visibility=Visibility.USER, **base,
+        ))
+        seen_types: list[str] = []
+        while not queue.empty():
+            seen_types.append(queue.get_nowait().type.value)
+        assert "session.degraded" in seen_types, (
+            "饱和时无显式 OVERLOADED 标记——事件被静默丢弃"
+        )
+
+    def test_debug_events_droppable_without_marker(self) -> None:
+        from rosclaw.agentd.events import MissionEventBus
+        from rosclaw.contracts.agent.agent_event import (
+            AgentEventV2,
+            AgentEventType,
+            Visibility,
+        )
+
+        bus = MissionEventBus()
+        queue = bus.subscribe("mis_1")
+        base = {
+            "schema_version": "rosclaw.agent_event.v2",
+            "mission_id": "mis_1",
+            "timestamp": "2026-08-21T00:00:00+00:00",
+            "payload": {},
+        }
+        for i in range(1024):
+            bus.publish(AgentEventV2(
+                event_id=f"evt_{i}", sequence=i + 1, type=AgentEventType.TOOL_PROGRESS,
+                visibility=Visibility.USER, **base,
+            ))
+        bus.publish(AgentEventV2(
+            event_id="evt_dbg", sequence=1025,
+            type=AgentEventType.CONTEXT_USAGE, visibility=Visibility.DEBUG, **base,
+        ))
+        seen = []
+        while not queue.empty():
+            seen.append(queue.get_nowait().event_id)
+        # DEBUG 可丢（设计允许），不强制标记。
+        assert "evt_dbg" not in seen or True  # 记录现状，不阻塞
+
+
+class TestReplayCursor:
+    def test_resume_replay_from_cursor_no_loss_no_dup(self, tmp_path: Path) -> None:
+        """resume 从 cursor 重放：无丢无重（边界 sequence 精确）。"""
+        import sqlite3
+
+        from rosclaw.agentd.events import AgentEventStore
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+        from rosclaw.storage.migrations import MigrationRunner
+
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        MigrationRunner().apply(conn, "sqlite")
+        conn.execute(
+            "INSERT INTO missions (mission_id, owner_principal, goal_json, "
+            "body_id, effective_body_hash, mode, state, budgets_json, "
+            "authorization_json, created_at, updated_at) "
+            "VALUES ('mis_1', 'u', '{}', 'sim/ur5e', 'h', 'SIMULATION', "
+            "'ACTIVE', '{}', '{}', '2026-08-21T00:00:00Z', "
+            "'2026-08-21T00:00:00Z')"
+        )
+        store = AgentEventStore(conn)
+
+        async def run() -> None:
+            for _ in range(10):
+                await store.append("mis_1", AgentEventType.TOOL_PROGRESS)
+
+        asyncio.run(run())
+        # 消费到 7 断了——从 cursor=7 重放必须恰好拿到 8,9,10。
+        tail = store.replay("mis_1", after_sequence=7)
+        assert [e.sequence for e in tail] == [8, 9, 10], tail
+        # 全程单调无洞。
+        all_events = store.replay("mis_1")
+        assert [e.sequence for e in all_events] == list(range(1, 11))

--- a/tests/agentd/test_hp1_native_event.py
+++ b/tests/agentd/test_hp1_native_event.py
@@ -287,11 +287,10 @@ class TestBackpressure:
             event_id="evt_dbg", sequence=1025,
             type=AgentEventType.CONTEXT_USAGE, visibility=Visibility.DEBUG, **base,
         ))
-        seen = []
-        while not queue.empty():
-            seen.append(queue.get_nowait().event_id)
-        # DEBUG 可丢（设计允许），不强制标记。
-        assert "evt_dbg" not in seen or True  # 记录现状，不阻塞
+        # DEBUG 可丢（设计允许）：不驱逐 USER 内容、不加标记、不抛错。
+        head = queue.get_nowait()
+        assert head.event_id == "evt_0", "DEBUG 丢弃不应驱逐既有 USER 事件"
+        assert head.type.value != "session.degraded"
 
 
 class TestReplayCursor:

--- a/tests/agentd/test_hp1_native_event.py
+++ b/tests/agentd/test_hp1_native_event.py
@@ -19,8 +19,6 @@ import asyncio
 import json
 from pathlib import Path
 
-import pytest
-
 REPO = Path(__file__).resolve().parents[2]
 
 
@@ -86,10 +84,11 @@ class TestContractFields:
 class TestJournalColumns:
     def test_linkage_fields_roundtrip_through_journal(self, tmp_path: Path) -> None:
         """一等列真实落库（不是只在 payload）并能 replay 回来。"""
+        import sqlite3
+
         from rosclaw.agentd.events import AgentEventStore
         from rosclaw.contracts.agent.agent_event import AgentEventType
         from rosclaw.storage.migrations import MigrationRunner
-        import sqlite3
 
         conn = sqlite3.connect(":memory:", check_same_thread=False)
         conn.row_factory = sqlite3.Row
@@ -231,8 +230,8 @@ class TestBackpressure:
         收到显式 session.degraded 标记（OVERLOADED 语义）。"""
         from rosclaw.agentd.events import MissionEventBus
         from rosclaw.contracts.agent.agent_event import (
-            AgentEventV2,
             AgentEventType,
+            AgentEventV2,
             Visibility,
         )
 
@@ -266,8 +265,8 @@ class TestBackpressure:
     def test_debug_events_droppable_without_marker(self) -> None:
         from rosclaw.agentd.events import MissionEventBus
         from rosclaw.contracts.agent.agent_event import (
-            AgentEventV2,
             AgentEventType,
+            AgentEventV2,
             Visibility,
         )
 

--- a/tests/contracts/golden/rosclaw.agent_event.v2.json
+++ b/tests/contracts/golden/rosclaw.agent_event.v2.json
@@ -1,0 +1,238 @@
+{
+  "$defs": {
+    "AgentEventType": {
+      "enum": [
+        "agent.started",
+        "agent.settled",
+        "agent.failed",
+        "turn.accepted",
+        "turn.ended",
+        "turn.cancel.requested",
+        "message.started",
+        "message.ended",
+        "mission.state.changed",
+        "mission.renamed",
+        "mission.archived",
+        "context.compilation.started",
+        "context.compilation.completed",
+        "context.usage",
+        "model.selected",
+        "model.request.started",
+        "model.text.delta",
+        "model.retry.scheduled",
+        "model.failover",
+        "model.request.ended",
+        "model.tool_call.proposed",
+        "tool.proposed",
+        "tool.effect_resolved",
+        "tool.started",
+        "tool.progress",
+        "tool.completed",
+        "task_graph.committed",
+        "worker.offered",
+        "worker.claimed",
+        "worker.started",
+        "worker.submitted",
+        "worker.verifying",
+        "worker.accepted",
+        "worker.failed",
+        "worker.expired",
+        "worker.completed",
+        "approval.requested",
+        "approval.decided",
+        "grant.revoked",
+        "grant.consumed",
+        "action.proposed",
+        "action.dispatched",
+        "action.progress",
+        "action.receipt",
+        "receipt.received",
+        "verification.started",
+        "verification.completed",
+        "compaction.started",
+        "compaction.completed",
+        "mission.completed",
+        "mission.failed",
+        "input.persisted",
+        "input.dispatched",
+        "operation.started",
+        "operation.output",
+        "operation.completed",
+        "operation.failed",
+        "session.idle",
+        "session.degraded",
+        "turn.failed",
+        "warning",
+        "capabilities.changed",
+        "config.reloaded",
+        "error"
+      ],
+      "title": "AgentEventType",
+      "type": "string"
+    },
+    "Visibility": {
+      "enum": [
+        "USER",
+        "DEBUG",
+        "AUDIT"
+      ],
+      "title": "Visibility",
+      "type": "string"
+    }
+  },
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.agent_event.v2",
+      "default": "rosclaw.agent_event.v2",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "event_id": {
+      "title": "Event Id",
+      "type": "string"
+    },
+    "sequence": {
+      "default": 0,
+      "title": "Sequence",
+      "type": "integer"
+    },
+    "mission_id": {
+      "title": "Mission Id",
+      "type": "string"
+    },
+    "turn_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Turn Id"
+    },
+    "task_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Task Id"
+    },
+    "trace_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Trace Id"
+    },
+    "timestamp": {
+      "title": "Timestamp",
+      "type": "string"
+    },
+    "type": {
+      "$ref": "#/$defs/AgentEventType"
+    },
+    "visibility": {
+      "$ref": "#/$defs/Visibility",
+      "default": "USER"
+    },
+    "payload": {
+      "additionalProperties": true,
+      "title": "Payload",
+      "type": "object"
+    },
+    "session_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Session Id"
+    },
+    "revision": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Revision"
+    },
+    "item_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Item Id"
+    },
+    "call_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Call Id"
+    },
+    "operation_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Operation Id"
+    },
+    "model_visible": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Model Visible"
+    }
+  },
+  "required": [
+    "event_id",
+    "mission_id",
+    "timestamp",
+    "type"
+  ],
+  "title": "rosclaw.agent_event.v2",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.agent_event.v2"
+}


### PR DESCRIPTION
## 范围（调整方案 §四.HP1）：NativeEventV2 与事件日志

所有模型可见内容进入可重放日志的硬不变量接线：

- **合约**：AgentEventV2 加性扩展 `session_id/revision/item_id/call_id/operation_id/model_visible`（029 迁移落一等列，replay 直接读列不挖 payload）；新事件类型 `input.persisted/dispatched`、`operation.*`、`session.idle/degraded`、`turn.failed`；AgentEventV2 补入 ALL_CONTRACTS + golden（**实证缺口：它此前从未进 golden 集**）；
- **输入门**：`pi.task.bind` 成功 → `input.persisted`（session/task/revision + 文本 hash/字节数）；新 `pi.input.dispatched`——未 persisted 的 message 打标即 `INPUT_NOT_PERSISTED`（bridge 强制顺序不变量）；TS InputController bind 成功后落 dispatched（失败不阻断——persisted 已是权威证据）；
- **背压**：live 队列饱和时 USER/AUDIT 不再静默丢——驱逐最旧 + 显式 `session.degraded`（OVERLOADED）标记进队，journal 完整可按 cursor 补放；DEBUG 仍可丢；
- **PTY 产品腿**：`input.persisted` 时间戳 ≤ 假模型首个请求到达时刻；`dispatched` 在其后；一等列真实携带。

## 四层测试

- Contract：新字段/新事件类型/golden（漂移即红）；
- Component：一等列落库 round-trip + 饱和标记 + DEBUG 可丢；
- Product Wiring：bind→persisted 链路 + dispatched 顺序闸（未 persisted 拒绝）；
- PTY：输入门时序实测。

红→绿：8 红 → 10/10 + 全量 621 passed + TS 120/121；ruff 净。

## 边界（诚实）

`model_visible` 标注的自动填充（镜像链逐事件标注）与 TUI 从事件流投影的收敛属 HP2/N9；本 PR 交付不变量骨架 + 输入门 + 背压。

🤖 Generated with [Claude Code](https://claude.com/claude-code)