### PR TITLE
feat: PR-N7——按副作用管理安全（no-poll 审批 + SIM 域 lease 豁免 + 审批续接）

### DIFF
--- a/src/rosclaw/agentd/pi_bridge/action_admission.py
+++ b/src/rosclaw/agentd/pi_bridge/action_admission.py
@@ -149,6 +149,7 @@ class ActionAdmissionService:
         *,
         caller_pid: int | None = None,
         caller_uid: int | None = None,
+        sim_only_effect: bool = False,
     ) -> ValidatedAdmissionContext:
         """session → mission → writer lease → caller identity → context
         lease → revision → body → mode 全链硬校验（HOTFIX-1：freshness
@@ -170,6 +171,30 @@ class ActionAdmissionService:
         #    P0-5A：lease 记录的 caller_uid 必须与当前调用者一致。
         from rosclaw.agentd.pi_bridge.context_lease import ContextLeaseStore
 
+        if sim_only_effect:
+            # PR-N7（调整方案 §六）：Context Lease 只约束依赖真实身体
+            # 状态的动作——SIM 域（simulation_state）动作豁免真实
+            # context lease（本地 MuJoCo 仿真不要求真实 body freshness；
+            # SIM 任务不再被 REAL lease 阻挡）。身份/写入者/模式校验
+            # 不变（上方 _validate_session_and_caller 已执行）。
+            from rosclaw.agentd.pi_bridge.context import build_embodied_context
+            from rosclaw.agentd.pi_bridge.context_lease import context_hash_of
+
+            current_envelope = build_embodied_context(
+                self._service, ctx.mission_id
+            )
+            snapshot = self._service.snapshot(ctx.mission_id)
+            writer = self._bindings.writer_of(ctx.mission_id)
+            assert writer is not None
+            return ValidatedAdmissionContext(
+                binding_id=binding.binding_id,
+                writer_lease_id=writer.lease_id,
+                context_lease_id="",
+                context_hash=context_hash_of(current_envelope),
+                context_revision=snapshot.context_revision,
+                body_hash=mission.body_binding.effective_body_hash,
+                mode=mission.mode.value,
+            )
         if not ctx.context_lease_id:
             raise ToolBridgeError(
                 "CONTEXT_LEASE_REQUIRED",
@@ -357,12 +382,23 @@ class ActionAdmissionService:
         # 六审 §6.3：发现必须先于 context 校验——capabilities 在
         # context_hash 内，发现会改变 hash。
         await service._ensure_mcp_discovered()
-        validated = self._validate_request_context(
-            request, caller_pid=caller_pid, caller_uid=caller_uid
-        )
         mission = service.get_mission(request.mission_id)
-        assert mission is not None  # _validate_request_context 已保证
+        # PR-N7：lease 豁免判定在验证前——读 canonical 能力效应域
+        # （N5A/N5C 链），不是 legacy 字符串。
         descriptor = service._tool_catalog.get(capability_id)
+        cap = service._tool_catalog.capability(capability_id) if descriptor else None
+        sim_only = bool(
+            descriptor is not None
+            and cap is not None
+            and cap.effect.domain == "simulation_state"
+            and mission is not None
+            and mission.mode.value == "SIMULATION"
+        )
+        validated = self._validate_request_context(
+            request, caller_pid=caller_pid, caller_uid=caller_uid,
+            sim_only_effect=sim_only,
+        )
+        assert mission is not None  # get_mission 已保证（validate 亦有）
         if descriptor is None:
             raise ToolBridgeError(
                 "CAPABILITY_UNKNOWN",

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -833,7 +833,6 @@ class PiToolDispatcher:
         """PNA-5 + NA-FIX-5 + 三审 P0-NA-10：经唯一 ActionAdmissionService——
         完整请求上下文（session/lease/revision/body/mode）硬校验、
         精确 grant、结构化回执、execute TOCTOU 复验。"""
-        import asyncio as _asyncio
 
         from rosclaw.agentd.pi_bridge.action_admission import (
             ActionAdmissionService,
@@ -864,6 +863,38 @@ class PiToolDispatcher:
             context_lease_id=request.context_lease_id,
         )
         admission = ActionAdmissionService(self._service)
+        # PR-N7：审批续接——携带既有 approval_id 的调用直接进入
+        # 执行路径（operator 已决定），不重建卡、不轮询。
+        resume_approval_id = str(args.get("approval_id", "") or "")
+        if resume_approval_id:
+            status = admission.decision_status(resume_approval_id)["status"]
+            if status == "APPROVED":
+                result = await admission.execute(
+                    resume_approval_id, request=ctx,
+                    caller_pid=self._caller_pid, caller_uid=self._caller_uid,
+                )
+                return PiToolResultV1(
+                    request_id=request.request_id,
+                    ok=bool(result.get("executed")),
+                    status=str(result.get("status", "FAILED")),
+                    summary=str(result.get("summary", ""))[:8000],
+                    approval_id=resume_approval_id,
+                    error_code=result.get("error_code"),
+                )
+            if status == "PENDING":
+                return PiToolResultV1(
+                    request_id=request.request_id,
+                    ok=False,
+                    status="WAITING_APPROVAL",
+                    summary=f"审批 {resume_approval_id} 仍待决定——让出回合等待事件",
+                    approval_id=resume_approval_id,
+                    error_code="WAITING_APPROVAL",
+                    retryable=True,
+                )
+            raise ToolBridgeError(
+                "APPROVAL_NOT_FOUND",
+                f"approval {resume_approval_id} 状态 {status}——不可续接执行",
+            )
         card = await admission.propose(
             request=ctx,
             capability_id=capability_id,
@@ -874,20 +905,25 @@ class PiToolDispatcher:
             caller_pid=self._caller_pid,
             caller_uid=self._caller_uid,
         )
-        # 等 operator（决定只能经 operatord 到达）。
-        deadline_sec = 330.0
-        waited = 0.0
-        while waited < deadline_sec:
-            status = admission.decision_status(card["approval_id"])["status"]
-            if status != "PENDING":
-                break
-            await _asyncio.sleep(1.0)
-            waited += 1.0
+        # PR-N7（调整方案 §六）：不再在模型工具里轮询 330 秒——
+        # 创建审批后立即返回 WAITING_APPROVAL + approval_id；operator
+        # 决定事件恢复原 session，模型携带 approval_id 续接执行。
+        # 审批可安全过期，但绝不卡住 Harness 回合。
         status = admission.decision_status(card["approval_id"])["status"]
         if status == "PENDING":
-            raise ToolBridgeError(
-                "APPROVAL_TIMEOUT",
-                "operator 未在期限内决定（默认拒绝语义）——动作未执行",
+            from rosclaw.agentd.tooling.recovery import recovery_for
+
+            return PiToolResultV1(
+                request_id=request.request_id,
+                ok=False,
+                status="WAITING_APPROVAL",
+                summary=(
+                    f"已创建审批 {card['approval_id']}——等待 operator 决定；"
+                    f"{recovery_for('WAITING_APPROVAL') or '让出回合，等待事件恢复'}"
+                ),
+                approval_id=card["approval_id"],
+                error_code="WAITING_APPROVAL",
+                retryable=True,
             )
         if status != "APPROVED":
             return PiToolResultV1(

--- a/tests/agentd/test_n7_effect_safety.py
+++ b/tests/agentd/test_n7_effect_safety.py
@@ -18,8 +18,6 @@ import json
 import time
 from pathlib import Path
 
-import pytest
-
 
 async def _request_action(service, mission, *, idem: str, extra_args=None):
     from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
@@ -88,9 +86,9 @@ class TestLeaseOnlyForRealBodyState:
     ) -> None:
         """REAL 域（physical_body）动作的 lease 要求不变——fail
         closed 不动摇。"""
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
         from rosclaw.agentd.tooling.descriptor import physical_action_descriptor
         from tests.agentd.test_pi_tool_bridge import _request, _setup
-        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
 
         service, mission = await _setup(tmp_path)
         # 注册一个 REAL 域能力（无 SIMULATION_STATE_ONLY 标记）。

--- a/tests/agentd/test_n7_effect_safety.py
+++ b/tests/agentd/test_n7_effect_safety.py
@@ -1,0 +1,156 @@
+"""PR-N7 红测试（调整方案 §六）：按副作用管理安全。
+
+红测试先行——330s 轮询/lease 全域门不存在替代前必须红。
+
+1. `_request_action()` 不再在模型工具中轮询 330 秒：创建审批后立即
+   返回 WAITING_APPROVAL + approval_id；审批可安全过期，但不卡住
+   Harness 回合；
+2. Context Lease 只约束依赖真实身体状态的动作：SIM 域
+   （simulation_state）物理动作不再需要真实 context lease；REAL 域
+   照旧硬要求；
+3. 审批后携带 approval_id 再次调用即执行（审批事件恢复回合后，
+   模型用 approval_id 续接，不重新建卡轮询）。
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+
+async def _request_action(service, mission, *, idem: str, extra_args=None):
+    from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+    from tests.agentd.test_pi_tool_bridge import _request
+
+    return await PiToolDispatcher(service).execute(
+        caller_pid=1,
+        caller_uid=1000,
+        request=_request(
+            "rosclaw_request_action",
+            mission=mission.mission_id,
+            idem=idem,
+            arguments={
+                "capability_id": "ur5e.move_joints",
+                "arguments": {"joints": [0.0, -1.57, 1.57, 0.0, 0.0, 0.0]},
+                "risk_tier": "LOW",
+                **(extra_args or {}),
+            },
+        ),
+    )
+
+
+class TestNoPollingInModelTool:
+    async def test_waiting_approval_returns_immediately(
+        self, tmp_path: Path
+    ) -> None:
+        """SIM ask 策略（用户开了 ask-every-time）：创建审批卡后立即
+        返回 WAITING_APPROVAL——不再轮询 330s 卡死回合。"""
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        # 开 ask-every-time（POLICY_AUTO 关闭 → 需要人工）。
+        safety = service._home / "agent" / "safety.json"
+        safety.parent.mkdir(parents=True, exist_ok=True)
+        safety.write_text(json.dumps({"sim_policy": "ask"}), encoding="utf-8")
+        started = time.monotonic()
+        result = await _request_action(service, mission, idem="n7_1")
+        elapsed = time.monotonic() - started
+        assert elapsed < 10, f"审批等待卡了 {elapsed:.1f}s（330s 轮询未消除）"
+        assert result.status == "WAITING_APPROVAL", result
+        assert result.approval_id, result
+        await service.close()
+
+
+class TestLeaseOnlyForRealBodyState:
+    async def test_sim_domain_action_needs_no_real_context_lease(
+        self, tmp_path: Path
+    ) -> None:
+        """SIM 域（simulation_state）动作不要求真实 context lease——
+        本地 MuJoCo 仿真不要求真实 body freshness。"""
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        # 无 context_lease_id——当前被 CONTEXT_LEASE_REQUIRED 硬拒；
+        # N7：sim-only 效果域豁免（SIM 任务不被 REAL lease 阻挡）。
+        result = await _request_action(service, mission, idem="n7_2")
+        assert result.error_code != "CONTEXT_LEASE_REQUIRED", (
+            f"SIM 域动作仍被真实 context lease 阻挡: {result.error_code}"
+        )
+        # ask 默认关 → POLICY_AUTO 自动执行（SIM 安全动作）。
+        assert result.ok, result
+        await service.close()
+
+    async def test_real_body_domain_still_requires_lease(
+        self, tmp_path: Path
+    ) -> None:
+        """REAL 域（physical_body）动作的 lease 要求不变——fail
+        closed 不动摇。"""
+        from rosclaw.agentd.tooling.descriptor import physical_action_descriptor
+        from tests.agentd.test_pi_tool_bridge import _request, _setup
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+
+        service, mission = await _setup(tmp_path)
+        # 注册一个 REAL 域能力（无 SIMULATION_STATE_ONLY 标记）。
+        service._tool_catalog.register(physical_action_descriptor(
+            "realbody.move",
+            source="mcp:realbody",
+            supported_modes=["SIMULATION", "SHADOW", "REAL"],
+            required_body_types=["sim/ur5e"],
+            input_schema={
+                "type": "object",
+                "properties": {"x": {"type": "number"}},
+                "additionalProperties": False,
+            },
+        ))
+        result = await PiToolDispatcher(service).execute(
+            caller_pid=1, caller_uid=1000,
+            request=_request(
+                "rosclaw_request_action",
+                mission=mission.mission_id,
+                idem="n7_3",
+                arguments={
+                    "capability_id": "realbody.move",
+                    "arguments": {"x": 1.0},
+                    "risk_tier": "LOW",
+                },
+            ),
+        )
+        assert not result.ok
+        assert result.error_code in (
+            "CONTEXT_LEASE_REQUIRED", "CONTEXT_NOT_FRESH",
+        ), result.error_code
+        await service.close()
+
+
+class TestApprovalResume:
+    async def test_reinvoke_with_approval_id_executes(
+        self, tmp_path: Path
+    ) -> None:
+        """审批决定后：模型携带 approval_id 再次调用即执行
+        （审批事件恢复回合的续接路径——不重建卡、不轮询）。"""
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        safety = service._home / "agent" / "safety.json"
+        safety.parent.mkdir(parents=True, exist_ok=True)
+        safety.write_text(json.dumps({"sim_policy": "ask"}), encoding="utf-8")
+        first = await _request_action(service, mission, idem="n7_4a")
+        assert first.status == "WAITING_APPROVAL"
+        approval_id = first.approval_id
+        # operator 批准（broker 决定——与 operatord 同路径）。
+        grant = service._broker.decide(
+            approval_id, principal=mission.owner_principal, approve=True,
+            decided_by="user:local:1000",
+        )
+        assert grant is not None
+        # 模型携带 approval_id 续接执行。
+        second = await _request_action(
+            service, mission, idem="n7_4b",
+            extra_args={"approval_id": approval_id},
+        )
+        assert second.ok, second
+        assert second.status in ("COMPLETED", "EXECUTED"), second
+        await service.close()

--- a/tests/agentd/test_pi_approval.py
+++ b/tests/agentd/test_pi_approval.py
@@ -58,30 +58,47 @@ class TestRequestActionChain:
                     await _decide_pending(service, mission.mission_id, sock, True)
                     return
 
-        approver = asyncio.create_task(operator_approves())
-        try:
-            result = await dispatcher.execute(
-                caller_pid=1,
-                caller_uid=1000,
-                request=_request(
-                    "rosclaw_request_action",
-                    mission=mission.mission_id,
-                    idem="idem_ra_1",
-                    lease=await _issue_lease(service, mission),
-                    arguments={
-                        "capability_id": "sim_ground_truth",
-                        "arguments": {},
-                        "expected_effect": "SIM 探测",
-                        "risk_tier": "LOW",
-                    },
-                )
+        # PR-N7：不再轮询 330s——第一次调用立即 WAITING_APPROVAL +
+        # approval_id；operator 决定后模型携 approval_id 续接执行。
+        result = await dispatcher.execute(
+            caller_pid=1,
+            caller_uid=1000,
+            request=_request(
+                "rosclaw_request_action",
+                mission=mission.mission_id,
+                idem="idem_ra_1",
+                lease=await _issue_lease(service, mission),
+                arguments={
+                    "capability_id": "sim_ground_truth",
+                    "arguments": {},
+                    "expected_effect": "SIM 探测",
+                    "risk_tier": "LOW",
+                },
             )
-        finally:
-            approver.cancel()
+        )
+        assert result.status == "WAITING_APPROVAL"
         assert result.approval_id
+        await _decide_pending(service, mission.mission_id, sock, True)
+        resumed = await dispatcher.execute(
+            caller_pid=1,
+            caller_uid=1000,
+            request=_request(
+                "rosclaw_request_action",
+                mission=mission.mission_id,
+                idem="idem_ra_1b",
+                lease=await _issue_lease(service, mission),
+                arguments={
+                    "capability_id": "sim_ground_truth",
+                    "arguments": {},
+                    "expected_effect": "SIM 探测",
+                    "risk_tier": "LOW",
+                    "approval_id": result.approval_id,
+                },
+            )
+        )
         # SIM executor 结果（接受与否取决于 sim executor 存在性——关键是
         # 链走到了执行而非卡在授权）。
-        assert result.status in {"COMPLETED", "FAILED"}
+        assert resumed.status in {"COMPLETED", "FAILED"}
         await operatord.stop()
         await agent_server.stop()
         await service.close()
@@ -97,25 +114,45 @@ class TestRequestActionChain:
                     await _decide_pending(service, mission.mission_id, sock, False)
                     return
 
-        denier = asyncio.create_task(operator_denies())
-        try:
-            result = await dispatcher.execute(
-                caller_pid=1,
-                caller_uid=1000,
-                request=_request(
-                    "rosclaw_request_action",
-                    mission=mission.mission_id,
-                    idem="idem_ra_2",
-                    lease=await _issue_lease(service, mission),
-                    arguments={"capability_id": "sim_ground_truth", "arguments": {}},
-                )
+        # PR-N7：先立即返回 WAITING_APPROVAL，operator 拒绝后不可执行。
+        result = await dispatcher.execute(
+            caller_pid=1,
+            caller_uid=1000,
+            request=_request(
+                "rosclaw_request_action",
+                mission=mission.mission_id,
+                idem="idem_ra_2",
+                lease=await _issue_lease(service, mission),
+                arguments={"capability_id": "sim_ground_truth", "arguments": {}},
             )
-        finally:
-            denier.cancel()
-        assert not result.ok
-        assert result.status == "DECLINED"
-        assert result.error_code == "OPERATOR_DECLINED"
-        # 没有产生任何 grant。
+        )
+        assert result.status == "WAITING_APPROVAL"
+        await _decide_pending(service, mission.mission_id, sock, False)
+        # 拒绝后携带 approval_id 续接 → 诚实拒绝（不得执行；
+        # dispatcher 把 ToolBridgeError 转成 REJECTED 结果）。
+        rejected = await dispatcher.execute(
+            caller_pid=1,
+            caller_uid=1000,
+            request=_request(
+                "rosclaw_request_action",
+                mission=mission.mission_id,
+                idem="idem_ra_2b",
+                lease=await _issue_lease(service, mission),
+                arguments={
+                    "capability_id": "sim_ground_truth",
+                    "arguments": {},
+                    "approval_id": result.approval_id,
+                },
+            )
+        )
+        assert not rejected.ok
+        assert rejected.error_code == "APPROVAL_NOT_FOUND"
+        # 决定诚实落账（DECLINED）+ 没有产生任何 grant。
+        from rosclaw.agentd.pi_bridge.action_admission import ActionAdmissionService
+
+        assert ActionAdmissionService(service).decision_status(
+            result.approval_id
+        )["status"] in ("DECLINED", "DENIED")
         assert service.list_grants() == []
         await operatord.stop()
         await agent_server.stop()


### PR DESCRIPTION
## 范围（调整方案 §六）：按副作用管理安全，而不是按"是不是机器人任务"

- **消除 330s 轮询**：`_request_action()` 创建审批卡后立即返回 `WAITING_APPROVAL + approval_id`（不卡 Harness 回合）；携带 approval_id 的再次调用直接续接执行（不重建卡、不轮询）；被拒/未知审批续接诚实 `APPROVAL_NOT_FOUND`；审批可安全过期；
- **Context Lease 只约束依赖真实身体状态的动作**：SIM 域（`simulation_state`，读 N5C canonical 效应域而非 legacy 字符串）动作豁免真实 context lease——本地 MuJoCo 仿真不再要求真实 body freshness，SIM 任务不被 REAL lease 阻挡；REAL 域 lease 硬要求不动摇（红测试钉住）；
- **pi_approval 两测试改写为两段式新契约**（WAITING_APPROVAL → 决定 → approval_id 续接）。

## 诚实边界

审批决定事件恢复原 session 的 watcher（TUI followUp）与"Operator Offline 在纯 SIM 下不展示"归 N9 TUI 批次；本 PR 交付 no-poll 契约 + lease 豁免 + 续接路径。

## 验证

红→绿：3 红（轮询仍在/SIM 被 lease 挡/续接不存在）→ 4/4 + pi_approval 9/9 + 邻接（admission/lease/jit/h5/bridge/wp03）46 全绿；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)