### PR TITLE
feat: WP-1——终态一致性：终态后幽灵执行归零（0823 审计 P0-3）

### DIFF
--- a/packages/rosclaw-agent/src/native/operation-watcher.ts
+++ b/packages/rosclaw-agent/src/native/operation-watcher.ts
@@ -73,6 +73,38 @@ export class OperationWatcher {
 			}
 			this.delivered.add(operationId);
 			this.tracked.delete(operationId);
+			// WP-1（0823 审计 P0-3）：终态一致性——owning task 已终态
+			// （或 operation 属旧 revision）时，终态事件只更新账本和
+			// TUI，绝不触发模型回合。规则：Task 终态后、下一条用户
+			// 输入前，模型调用次数恒等于 0。
+			const taskId = String(op.task_id ?? "");
+			let taskTerminal = false;
+			let staleRevision = false;
+			if (taskId) {
+				try {
+					const taskResult = await this.deps.call("pi.kernel.get", {
+						task_id: taskId,
+					});
+					const task = (taskResult.task ?? null) as Record<string, unknown> | null;
+					const taskState = String(task?.state ?? "");
+					taskTerminal = task !== null && taskState !== "RUNNING"
+						&& taskState !== "CREATED" && taskState !== "WAITING_APPROVAL";
+					const opRevision = Number(op.revision ?? 0);
+					const activeRevision = Number(task?.active_revision ?? 0);
+					staleRevision = opRevision > 0 && activeRevision > 0
+						&& opRevision !== activeRevision;
+				} catch {
+					// 查询失败不赌——按终态处理（不触发回合），下周期
+					// 由 delivered 集合保证不重复。
+					taskTerminal = true;
+				}
+			}
+			if (taskTerminal || staleRevision) {
+				sink?.notify?.(
+					`Operation ${state}（任务已${staleRevision ? "换 revision" : "终态"}——已存档，不再打扰）：${operationId.slice(0, 18)}…`,
+				);
+				continue;
+			}
 			// 终态一次性 followUp（compact 结构化结果——同一 session 继续
 			// 验证/修复，不新建 Worker/任务）。
 			const content =

--- a/packages/rosclaw-agent/test/wp1-terminal-watcher.test.ts
+++ b/packages/rosclaw-agent/test/wp1-terminal-watcher.test.ts
@@ -1,0 +1,94 @@
+/** WP-1 红测试（0823 审计 §三.P0-3/§四.WP-1）：终态一致性。
+ *
+ * 红测试先行——修复前必须红：
+ * 1. Operation 终态通知在"owning task 已进入终态"时不得触发模型
+ *    回合（只更新账本+TUI）——当前 OperationWatcher 无条件
+ *    sendMessage(triggerTurn)；
+ * 2. owning task 活跃时 followUp 照常（回归钉住）；
+ * 3. 旧 revision 的迟到终态只能存档——不触发回合。
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+function makeWatcher(opts: {
+	taskState: string;
+	revisionMatch?: boolean;
+	sent: Array<{ content: string; options: unknown }>;
+	notices: string[];
+}) {
+	return import("../src/native/operation-watcher.js").then(({ OperationWatcher }) => {
+		const calls: Array<{ method: string; params: unknown }> = [];
+		const watcher = new OperationWatcher({
+			call: async (method: string, params: unknown) => {
+				calls.push({ method, params });
+				if (method === "pi.op.get") {
+					return {
+						ok: true,
+						operation: {
+							operation_id: "op_1",
+							state: "SUCCEEDED",
+							task_id: "task_1",
+							revision: 1,
+						},
+					};
+				}
+				if (method === "pi.kernel.get") {
+					// owning task 状态（终态 SUCCEEDED 或活跃 RUNNING）。
+					return {
+						ok: true,
+						task: {
+							task_id: "task_1",
+							state: opts.taskState,
+							active_revision: opts.revisionMatch === false ? 2 : 1,
+						},
+					};
+				}
+				return { ok: true };
+			},
+			sink: () => ({
+				isIdle: true,
+				api: {
+					sendMessage: (message: { content: string }, options: unknown) => {
+						opts.sent.push({ content: message.content, options });
+					},
+				},
+				notify: (text: string) => opts.notices.push(text),
+			}),
+		});
+		return watcher;
+	});
+}
+
+test("WP-1: owning task 终态 → operation 终态通知不触发模型回合", async () => {
+	const sent: Array<{ content: string; options: unknown }> = [];
+	const notices: string[] = [];
+	const watcher = await makeWatcher({ taskState: "SUCCEEDED", sent, notices });
+	watcher.track("op_1");
+	await (watcher as unknown as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 0,
+		`task 终态后仍触发模型回合: ${JSON.stringify(sent)}`);
+	// TUI 通知保留（账本/TUI 更新是合法的）。
+	assert.ok(notices.length >= 1);
+});
+
+test("WP-1: owning task 活跃 → operation 终态正常 followUp（回归）", async () => {
+	const sent: Array<{ content: string; options: unknown }> = [];
+	const notices: string[] = [];
+	const watcher = await makeWatcher({ taskState: "RUNNING", sent, notices });
+	watcher.track("op_1");
+	await (watcher as unknown as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 1, "活跃任务的 operation 终态必须照常通知模型");
+});
+
+test("WP-1: 旧 revision 的迟到终态只存档（不触发回合）", async () => {
+	const sent: Array<{ content: string; options: unknown }> = [];
+	const notices: string[] = [];
+	// operation 属 revision 1，task 活跃 revision 已是 2。
+	const watcher = await makeWatcher({
+		taskState: "RUNNING", revisionMatch: false, sent, notices,
+	});
+	watcher.track("op_1");
+	await (watcher as unknown as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 0,
+		"旧 revision 的迟到 operation 结果触发了模型回合");
+});

--- a/src/rosclaw/storage/migrations/031_wp1_operation_revision.sql
+++ b/src/rosclaw/storage/migrations/031_wp1_operation_revision.sql
@@ -1,0 +1,3 @@
+-- 031: WP-1 终态一致性——operations.revision（启动时 task 活跃
+-- revision）。旧 revision 的迟到终态事件只存档，不消费。
+ALTER TABLE operations ADD COLUMN revision INTEGER;

--- a/src/rosclaw/task_kernel/operation_manager.py
+++ b/src/rosclaw/task_kernel/operation_manager.py
@@ -54,12 +54,18 @@ class OperationManager:
         """启动后台进程 operation——立即返回（调用方不死等）。"""
         operation_id = new_id("op")
         now = datetime.now(UTC).isoformat()
+        # WP-1：记录启动时 task 活跃 revision——旧 revision 的迟到
+        # 终态只存档（不触发模型回合）。
+        task_row = self._conn.execute(
+            "SELECT active_revision FROM tasks WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        revision = int(task_row["active_revision"]) if task_row else None
         self._conn.execute(
             "INSERT INTO operations (operation_id, task_id, attempt_id, kind, "
-            "state, resumable, started_at, heartbeat_at) "
-            "VALUES (?, ?, ?, ?, 'RUNNING', ?, ?, ?)",
+            "state, resumable, started_at, heartbeat_at, revision) "
+            "VALUES (?, ?, ?, ?, 'RUNNING', ?, ?, ?, ?)",
             (operation_id, task_id, attempt_id, kind,
-             1 if resumable else 0, now, now),
+             1 if resumable else 0, now, now, revision),
         )
         self._emit(task_id, "operation.started",
                    {"operation_id": operation_id, "kind": kind,

--- a/tests/agentd/test_wp1_terminal_ghost.py
+++ b/tests/agentd/test_wp1_terminal_ghost.py
@@ -1,0 +1,198 @@
+"""WP-1 红测试（0823 审计 §四.WP-1 验收测试）：终态后幽灵执行。
+
+审计验收原文：
+  1. Task 完成后注入延迟 operation 事件。
+  2. 等待一分钟。
+  3. 断言没有任何模型请求、工具调用或新文件。
+
+真实链路：PTY `rosclaw chat`（假模型：process_start 慢操作 → write →
+artifact_register → task_finish → 最终回答）→ task SUCCEEDED 后慢
+operation 才终止 → 断言：最终回答之后模型请求数恒为 0、工作区无
+新文件。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_entry import find_pi_agent_entry
+from tests.agentd.test_product_journey import (
+    PtySession,
+    _chunk,
+    _sse,
+    _tool_call_frames,
+)
+
+pytestmark = pytest.mark.skipif(
+    not find_pi_agent_entry(),
+    reason="无 Node/dist（CI 全回归 job 未构建）——诚实 skip",
+)
+
+
+class _GhostFake:
+    """process_start（慢命令）→ write → artifact_register →
+    task_finish → 最终回答。回答后再来任何请求都是幽灵回合。"""
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+        self.final_answered_at: float | None = None
+
+    def answer(self, body: dict) -> bytes:
+        self.requests.append(body)
+        if not body.get("stream"):
+            return json.dumps({
+                "id": "c", "object": "chat.completion", "created": 1,
+                "model": "fake-k3",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "pong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 5},
+            }).encode()
+        messages = body.get("messages", [])
+        if messages and messages[-1].get("role") == "tool":
+            call_id = str(messages[-1].get("tool_call_id", ""))
+            nxt = {
+                "call_op": ("call_write", "write",
+                            {"path": "note.txt", "content": "wp1\n"}),
+                "call_write": ("call_art", "rosclaw_artifact_register",
+                               {"path": "note.txt"}),
+                "call_art": ("call_fin", "rosclaw_task_finish",
+                             {"summary": "完成"}),
+            }.get(call_id)
+            if nxt is not None:
+                frames = _tool_call_frames(nxt[0], nxt[1], json.dumps(nxt[2]))
+                frames.append(b"data: [DONE]\n\n")
+                return b"".join(frames)
+            self.final_answered_at = time.time()
+            frames = [_sse(_chunk("任务完成。")), _sse(_chunk("", "stop")),
+                      b"data: [DONE]\n\n"]
+            return b"".join(frames)
+        frames = _tool_call_frames(
+            "call_op", "process_start",
+            json.dumps({"command": "sleep 5 && echo wp1-late-marker"}),
+        )
+        frames.append(b"data: [DONE]\n\n")
+        return b"".join(frames)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    fake: _GhostFake
+
+    def log_message(self, *args) -> None:
+        return
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        payload = self.fake.answer(body)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.fake = _GhostFake()
+        handler = type("H", (_Handler,), {"fake": self.fake})
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.server.server_address[1]
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1"
+
+    def close(self) -> None:
+        self.server.shutdown()
+
+
+def _prepare_home(tmp_path: Path, base_url: str) -> tuple[Path, dict[str, str]]:
+    home = tmp_path / "rh"
+    (home / "run").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "agent:\n  enabled: true\n  default_profile: embodied_default\n"
+        "models:\n  backend: legacy\n  profiles:\n    embodied_default:\n"
+        "      provider: kimi_code\n      model: fake-k3\n"
+        f"      base_url: {base_url}\n"
+        "      api_key_ref: env:FAKE_JOURNEY_KEY\n"
+        "      capabilities: [llm.chat, llm.structured_decision, llm.tool_use]\n",
+        encoding="utf-8",
+    )
+    (home / "agent").mkdir(parents=True, exist_ok=True)
+    (home / "agent" / "settings.json").write_text(
+        json.dumps({"defaultProvider": "journey-fake", "defaultModel": "fake-k3"}),
+        encoding="utf-8",
+    )
+    (home / "agent" / "models.json").write_text(
+        json.dumps({
+            "providers": {
+                "journey-fake": {
+                    "name": "Journey Fake", "baseUrl": base_url,
+                    "api": "openai-completions", "apiKey": "$FAKE_JOURNEY_KEY",
+                    "models": [{"id": "fake-k3", "name": "Fake K3",
+                                "contextWindow": 8192, "maxTokens": 4096}],
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+    env = dict(
+        os.environ, ROSCLAW_HOME=str(home), TERM="xterm",
+        FAKE_JOURNEY_KEY="sk-fake-journey", ROSCLAW_UI_LOCALE="zh-CN",
+    )
+    return home, env
+
+
+class TestTerminalGhost:
+    def test_no_model_calls_after_task_terminal(self, tmp_path: Path) -> None:
+        fake = _FakeServer()
+        home, env = _prepare_home(tmp_path, fake.base_url)
+        workdir = tmp_path / "wp1-work"
+        workdir.mkdir()
+        session = PtySession(
+            [sys.executable, "-m", "rosclaw.entrypoint", "chat",
+             "--workspace", str(workdir)],
+            env, log_path=tmp_path / "pty-wp1.log", cwd=workdir,
+        )
+        try:
+            session.expect(b"ROSClaw Native Agent", timeout=120)
+            session.send("写 note.txt 并交付\r")
+            session.expect("任务完成。".encode(), timeout=240)
+            # 任务已终态；慢 operation（5s）随后终止——审计验收：终态
+            # 后模型调用恒为 0。
+            assert fake.fake.final_answered_at is not None
+            answered_count = len(fake.fake.requests)
+            files_before = set(workdir.iterdir())
+            time.sleep(12)  # 慢 operation (5s) 终止 + watcher 周期
+            after_count = len(fake.fake.requests)
+            assert after_count == answered_count, (
+                f"终态后出现 {after_count - answered_count} 次幽灵模型请求"
+                f"（延迟 operation 触发了新回合）"
+            )
+            files_after = set(workdir.iterdir())
+            assert files_after == files_before, (
+                f"终态后工作区出现新文件: {files_after - files_before}"
+            )
+            # 账本：任务 SUCCEEDED；迟到事件只进 task_events 存档。
+            db = sqlite3.connect(home / "agentd" / "missions.db")
+            try:
+                task = db.execute(
+                    "SELECT state FROM tasks ORDER BY created_at DESC LIMIT 1"
+                ).fetchone()
+                assert task and task[0] == "SUCCEEDED", task
+            finally:
+                db.close()
+            session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
+            session.proc.wait(timeout=30)
+        finally:
+            session.stop()
+            fake.close()


### PR DESCRIPTION
## 范围（0823 真实体验审计 P0-3 / WP-1）：Task 终态后幽灵执行归零

审计规则：Task 进入终态后，在收到下一条用户输入前，模型调用次数必须恒等于 0。

- **OperationWatcher**：operation 终态时先查 owning task——task 终态或 operation 属旧 revision → 只更新账本+TUI 通知，绝不 sendMessage/triggerTurn；查询失败按终态处理（不赌）；活跃任务照常 followUp（回归钉住）；
- **operations.revision**（迁移 031）：start 时记录 task 活跃 revision——旧 revision 迟到终态只存档；
- **PTY 审计验收**（方案原文三步骤）：task 完成后注入延迟 operation 事件 → 等待 → 断言零模型请求/零工具调用/零新文件。

## 红→绿证据

PTY 实测红：**终态后 5 次幽灵模型请求**（15 vs 10）→ 修复后 0；TS 单元 3/3（终态抑制/活跃回归/旧 revision 存档）；全量 TS 131/132；PTY h1/h3/h8/n1/nine1/nine2 回归绿；ruff 净。

## 诚实边界

TurnGuard 本就只在有活跃任务时催收尾（kernel.active 返回 null 即退出）——本次未改；普通 bash 在终态后的可用性属"回合不再启动"的推论（回合不启动即无调用）；NO_ACTIVE_TASK 频次收敛与 TaskController 状态机明示化（CREATED→RUNNING→WAITING_OPERATION→VERIFYING→…）在 WP-1 后续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)