### PR TITLE
feat: WP-2——Typed Reference 能力组合（TypedRefV1 + 共享 PlanStore + 引用连通性）

### DIFF
--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -268,12 +268,15 @@ class AgentService:
             if self._daemon_client is not None:
                 break
             from rosclaw.agentd.sim_executor import SimActionChannel
-            from rosclaw.agentd.tooling.persistent_client import PersistentMcpClient
 
             # 观测与 SIM 执行共享同一 server 进程（有状态身体）。
+            from rosclaw.agentd.tooling.mcp_adapter import kit_spawn_env
+            from rosclaw.agentd.tooling.persistent_client import PersistentMcpClient
+
             shared_client = PersistentMcpClient(
                 command=str(sim_server.get("command", "")),
                 args=tuple(str(a) for a in sim_server.get("args", []) or []),
+                env=kit_spawn_env(),
             )
             self._shared_mcp_client = shared_client
             server_name = str(sim_server.get("name", "sim"))
@@ -573,10 +576,15 @@ class AgentService:
             self._mcp_adapters.append(self._make_mcp_adapter(spec, self._tool_catalog))
         if self._daemon_client is None and kit.executor_identity not in self._sim_executors:
             from rosclaw.agentd.sim_executor import SimActionChannel
+
+            # WP-2：持久通道同 spawn_env 规则——ROSCLAW_HOME 必须到达
+            # kit 子进程（否则 PlanStore 退回进程内存）。
+            from rosclaw.agentd.tooling.mcp_adapter import kit_spawn_env
             from rosclaw.agentd.tooling.persistent_client import PersistentMcpClient
 
             shared = PersistentMcpClient(
-                command=str(spec["command"]), args=tuple(spec["args"])
+                command=str(spec["command"]), args=tuple(spec["args"]),
+                env=kit_spawn_env(),
             )
             self._shared_mcp_client = shared
             self._sim_executors[kit.executor_identity] = SimActionChannel(

--- a/src/rosclaw/agentd/sim_trajectory.py
+++ b/src/rosclaw/agentd/sim_trajectory.py
@@ -216,10 +216,21 @@ class SimTrajectoryService:
         }
 
     def _load_plan(self, plan_id: str) -> dict:
+        """WP-2：统一引用——kit envelope 记录（PersistentPlanStore）
+        与 native 原始记录互通；不可解码给诚实错误码。"""
         path = self._plans_dir / f"{plan_id}.json"
         if not path.exists():
-            raise ValueError(f"unknown plan {plan_id!r}")
-        return json.loads(path.read_text(encoding="utf-8"))
+            raise ValueError(f"REF_NOT_FOUND: plan {plan_id!r} 不在共享 PlanStore")
+        record = json.loads(path.read_text(encoding="utf-8"))
+        # kit envelope：{plan_id, digest, trajectory, summary, status}
+        if "trajectory" in record:
+            record = record["trajectory"]
+        if "points" not in record or "hash" not in record:
+            raise ValueError(
+                f"REF_FORMAT_UNKNOWN: plan {plan_id!r} 的记录格式不可解码"
+                "（缺 points/hash）——生产者与消费者的引用格式不兼容"
+            )
+        return record
 
     # --------------------------------------------------------------
     # 2. ur5e.simulate_cartesian_trajectory

--- a/src/rosclaw/agentd/tooling/mcp_adapter.py
+++ b/src/rosclaw/agentd/tooling/mcp_adapter.py
@@ -161,12 +161,28 @@ class McpServerConfig:
             object.__setattr__(self, "output_schemas", {})
 
     def spawn_env(self) -> dict[str, str]:
-        env: dict[str, str] = {}
-        for ref in self.env_refs:
-            value = os.environ.get(ref)
-            if value:  # missing → simply not passed; never logged
-                env[ref] = value
-        return env
+        # WP-2：统一走 kit_spawn_env（默认安全环境 + env_refs +
+        # ROSCLAW_HOME）——ROSCLAW_HOME 是共享存储位置（路径，非凭据），
+        # 不到子进程则第一方 kit 的 PlanStore 退回进程内存（0823 审计
+        # P0-4 根因）。MCP stdio 的 env=None 是"默认最小环境"语义。
+        return kit_spawn_env(self.env_refs)
+
+
+def kit_spawn_env(env_refs: tuple[str, ...] = ()) -> dict[str, str]:
+    """MCP 子进程环境（WP-2）：默认安全环境 + env_refs + ROSCLAW_HOME
+    （共享存储位置——没有它第一方 kit 的 PlanStore 退回进程内存）。
+    spawn_env 与 PersistentMcpClient 共用本函数。"""
+    from mcp.client.stdio import get_default_environment
+
+    env: dict[str, str] = dict(get_default_environment())
+    for ref in env_refs:
+        value = os.environ.get(ref)
+        if value:
+            env[ref] = value
+    home = os.environ.get("ROSCLAW_HOME")
+    if home:
+        env["ROSCLAW_HOME"] = home
+    return env
 
 
 def suggest_classification(tool_name: str, annotations: Any) -> str:

--- a/src/rosclaw/agentd/tooling/snapshot.py
+++ b/src/rosclaw/agentd/tooling/snapshot.py
@@ -87,6 +87,26 @@ def build_capability_snapshot(
             input_schema=dict(cap.input_schema),
             output_schema=dict(cap.output_schema),
         ))
+    # WP-2：引用连通性——消费者 accepts_refs 的每个 kind 必须在
+    # active 里有 produces_refs 生产者；否则 excluded（模型看不到
+    # 天然连不上的工具）。
+    produced_kinds = set()
+    for entry in active:
+        for ref in _capability_produces(catalog, entry.capability_id):
+            produced_kinds.add(ref.get("kind", ""))
+    still_active: list[SnapshotActiveToolV1] = []
+    for entry in active:
+        needs = _capability_accepts(catalog, entry.capability_id)
+        missing = [r.get("kind", "") for r in needs
+                   if r.get("kind", "") not in produced_kinds]
+        if missing:
+            excluded.append(SnapshotExcludedV1(
+                capability_id=entry.capability_id,
+                reason="REF_NOT_CONNECTABLE",
+            ))
+        else:
+            still_active.append(entry)
+    active = still_active
     snap = CapabilitySnapshotV1(
         generation=generation if generation is not None else catalog.generation,
         body_id=body_id,
@@ -102,6 +122,16 @@ def build_capability_snapshot(
         canonical_json(snap.hash_payload()).encode("utf-8")
     ).hexdigest()
     return snap
+
+
+def _capability_accepts(catalog, capability_id: str) -> list[dict]:
+    cap = catalog.capability(capability_id)
+    return list(cap.accepts_refs) if cap is not None else []
+
+
+def _capability_produces(catalog, capability_id: str) -> list[dict]:
+    cap = catalog.capability(capability_id)
+    return list(cap.produces_refs) if cap is not None else []
 
 
 __all__ = ["build_capability_snapshot"]

--- a/src/rosclaw/contracts/agent/capability.py
+++ b/src/rosclaw/contracts/agent/capability.py
@@ -100,6 +100,10 @@ class CapabilityDescriptorV2(ContractModel):
     )
     execution: CapabilityExecutionV1 = Field(default_factory=CapabilityExecutionV1)
     evidence: CapabilityEvidenceV1 = Field(default_factory=CapabilityEvidenceV1)
+    #: WP-2：引用端口——本能力消费/产出哪些 TypedRef kind
+    #: （snapshot 只暴露可实际连接的组合）。
+    accepts_refs: list[dict[str, Any]] = Field(default_factory=list)
+    produces_refs: list[dict[str, Any]] = Field(default_factory=list)
     #: 自由元数据（如 adapted_from 迁移标注）；不得携带凭据。
     metadata: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/rosclaw/contracts/agent/typed_ref.py
+++ b/src/rosclaw/contracts/agent/typed_ref.py
@@ -1,0 +1,39 @@
+"""TypedRefV1（WP-2，0823 审计 §四.WP-2）——能力间统一引用。
+
+模型看到的必须是一张可组合能力图：plan/trace/render/verification
+引用带完整身份与血缘——producer_capability + digest + body/world +
+task/revision + storage_backend。Capability Descriptor 声明
+accepts_refs/produces_refs；Snapshot 只暴露能实际连接的工具组合。
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import Field
+
+from rosclaw.contracts.common import ContractModel
+
+
+class TypedRefV1(ContractModel):
+    """能力产物的类型化引用（plan/trace/render/verification…）。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.typed_ref.v1"
+    HASH_PREFIX: ClassVar[str] = "typed_ref"
+
+    schema_version: Literal["rosclaw.typed_ref.v1"] = "rosclaw.typed_ref.v1"
+    #: plan / trace / render / verification（可扩展）
+    kind: str = Field(min_length=1)
+    #: rosclaw://plan/plan_abc123 等可解析 URI
+    uri: str = Field(min_length=1)
+    producer_capability: str = Field(min_length=1)
+    digest: str = Field(min_length=1)
+    body_id: str = ""
+    world_id: str = ""
+    task_id: str = ""
+    revision: int = 0
+    #: disk:sim/plans / mcp:inprocess / ...
+    storage_backend: str = ""
+
+
+__all__ = ["TypedRefV1"]

--- a/src/rosclaw/contracts/export.py
+++ b/src/rosclaw/contracts/export.py
@@ -30,6 +30,7 @@ from rosclaw.contracts.agent.task_contracts import (
 from rosclaw.contracts.agent.task_graph import TaskGraphPatchV1, TaskGraphV1, TaskNodeV1
 from rosclaw.contracts.agent.tool import ToolDescriptorV2
 from rosclaw.contracts.agent.tool_result import ToolResultEnvelopeV2
+from rosclaw.contracts.agent.typed_ref import TypedRefV1
 from rosclaw.contracts.common import ContractModel
 from rosclaw.contracts.operator.approval import ApprovalRequestV2
 from rosclaw.contracts.operator.exact_action import ExactActionV1
@@ -68,6 +69,7 @@ ALL_CONTRACTS: dict[str, type[ContractModel]] = {
         ToolProjectionV1,
         CapabilitySnapshotV1,
         ToolResultEnvelopeV2,
+        TypedRefV1,
         CommandSpecV1,
         CommandRequestV1,
         CommandResultV1,

--- a/src/rosclaw/sim/plan_store.py
+++ b/src/rosclaw/sim/plan_store.py
@@ -72,10 +72,38 @@ class PersistentPlanStore:
         self._write(record)
         return record
 
-    def get_for_execute(self, plan_id: str) -> dict:
+    def _read_envelope(self, plan_id: str) -> dict | None:
+        """WP-2：envelope/native 原始记录互通——native 原始记录
+        （trajectory 本体）包成 envelope 视图。"""
         record = self._read(plan_id)
         if record is None:
-            raise ValueError(f"unknown plan_id {plan_id!r} (fail closed)")
+            return None
+        if "trajectory" not in record:
+            if "points" not in record or "hash" not in record:
+                return None  # 不可解码——由调用方给 REF_FORMAT_UNKNOWN
+            record = {
+                "plan_id": plan_id,
+                "digest": record["hash"],
+                "trajectory": record,
+                "summary": record.get("summary", ""),
+                "created_at": self._now(),
+                "status": "PLANNED",
+            }
+        return record
+
+    def get_for_execute(self, plan_id: str) -> dict:
+        record = self._read_envelope(plan_id)
+        if record is None:
+            path = self._path(plan_id)
+            if path.exists():
+                raise ValueError(
+                    f"REF_FORMAT_UNKNOWN: plan {plan_id!r} 记录格式不可解码 "
+                    "(fail closed)"
+                )
+            raise ValueError(
+                f"REF_NOT_FOUND: plan_id {plan_id!r} 不在共享 PlanStore "
+                "(fail closed)"
+            )
         if record["status"] != "PLANNED":
             raise ValueError(
                 f"plan {plan_id} already consumed — single-use (fail closed)"

--- a/tests/agentd/test_wp2_typed_refs.py
+++ b/tests/agentd/test_wp2_typed_refs.py
@@ -1,0 +1,176 @@
+"""WP-2 红测试（0823 审计 §三.P0-4/§四.WP-2）：Typed Reference 能力组合。
+
+红测试先行——审计实证：kit plan_cartesian_path 产出的 plan_id 被
+native simulate 报 unknown plan（两套进程/格式互不兼容）。
+
+1. TypedRefV1 合约（uri/kind/producer/digest/body/task/revision/
+   storage_backend）；
+2. 共享 PlanStore：kit 与 native 读写同一磁盘 store（kit 子进程必须
+   拿到 ROSCLAW_HOME——MCP 默认 env 不含它）；
+3. 记录格式互通：kit envelope 记录被 native _load_plan 正确解包，
+   native 产出被 kit 读取；
+4. 消费方诚实报错：不可解码/来源不兼容 → REF_FORMAT_UNKNOWN /
+   REF_PRODUCER_MISMATCH，不再是含糊的 "unknown plan"；
+5. Capability 声明 accepts_refs/produces_refs；snapshot 只暴露可连接
+   组合（消费者无生产者 → excluded REF_NOT_CONNECTABLE）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class TestTypedRefV1:
+    def test_contract_and_golden(self) -> None:
+        from rosclaw.contracts.agent.typed_ref import TypedRefV1
+
+        ref = TypedRefV1.model_validate_contract({
+            "schema_version": "rosclaw.typed_ref.v1",
+            "kind": "plan",
+            "uri": "rosclaw://plan/plan_abc123",
+            "producer_capability": "ur5e.plan_cartesian_path",
+            "digest": "sha256:" + "ab" * 32,
+            "body_id": "sim/ur5e",
+            "world_id": "",
+            "task_id": "task_1",
+            "revision": 1,
+            "storage_backend": "disk:sim/plans",
+        })
+        assert ref.kind == "plan"
+        golden = (
+            REPO / "tests" / "contracts" / "golden" / "rosclaw.typed_ref.v1.json"
+        )
+        current = TypedRefV1.model_json_schema()
+        current["$id"] = "rosclaw://schemas/rosclaw.typed_ref.v1"
+        current["title"] = "rosclaw.typed_ref.v1"
+        assert json.loads(golden.read_text(encoding="utf-8")) == current
+
+
+class TestSharedPlanStore:
+    async def test_kit_plan_consumable_by_native_simulator(self) -> None:
+        """审计事故的直接复现：kit plan → native simulate 必须通。"""
+        with tempfile.TemporaryDirectory() as td:
+            os.environ["ROSCLAW_HOME"] = td
+            from tests.agentd.test_pi_tool_bridge import _setup
+
+            service, mission = await _setup(Path(td))
+            await service._ensure_mcp_discovered()
+            plan_env = await service._tool_catalog.execute_v2(
+                "c1", "ur5e.plan_cartesian_path",
+                {"shape": "star5", "center_x": 0.35, "center_y": 0.25,
+                 "z": 0.3, "outer_radius": 0.08},
+            )
+            assert plan_env.status.value == "SUCCEEDED", plan_env.error
+            plan_id = (plan_env.value or {}).get("plan_id")
+            assert plan_id
+            # 落盘证据：共享 store 必须有这个 plan（kit 子进程看到
+            # ROSCLAW_HOME）。
+            plans_dir = Path(td) / "sim" / "plans"
+            assert (plans_dir / f"{plan_id}.json").exists(), (
+                "kit plan 未落盘到共享 store（子进程缺 ROSCLAW_HOME）"
+            )
+            sim_env = await service._tool_catalog.execute_v2(
+                "c2", "ur5e_simulate_cartesian_trajectory",
+                {"plan_id": plan_id},
+            )
+            assert sim_env.status.value == "SUCCEEDED", sim_env.error
+            await service.close()
+
+    def test_native_plan_readable_by_kit_store(self) -> None:
+        """反向：native SimTrajectoryService 产出的 plan 被 kit 的
+        PersistentPlanStore 正确读取（envelope/raw 互通）。"""
+        with tempfile.TemporaryDirectory() as td:
+            from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+            from rosclaw.sim.plan_store import PersistentPlanStore
+
+            home = Path(td)
+            sim = SimTrajectoryService(home)
+            plan = sim.generate_planar_path(
+                shape="star5", center_m=[0.35, 0.25, 0.30], scale_m=0.05,
+            )
+            store = PersistentPlanStore(home / "sim" / "plans")
+            record = store.get_for_execute(plan["plan_id"])
+            assert record["trajectory"]["points"], record.keys()
+
+    def test_undecodable_ref_honest_error(self) -> None:
+        """不可解码引用 → REF_FORMAT_UNKNOWN（不是 unknown plan）。"""
+        with tempfile.TemporaryDirectory() as td:
+            from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+            home = Path(td)
+            plans = home / "sim" / "plans"
+            plans.mkdir(parents=True)
+            (plans / "plan_garbage.json").write_text(
+                json.dumps({"totally": "foreign"}), encoding="utf-8"
+            )
+            sim = SimTrajectoryService(home)
+            with pytest.raises(ValueError, match="REF_FORMAT_UNKNOWN"):
+                sim.simulate_cartesian_trajectory("plan_garbage")
+
+    def test_missing_ref_honest_not_found(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+            sim = SimTrajectoryService(Path(td))
+            with pytest.raises(ValueError, match="REF_NOT_FOUND"):
+                sim.simulate_cartesian_trajectory("plan_nonexistent")
+
+
+class TestRefConnectivity:
+    def test_capability_declares_ref_ports(self) -> None:
+        """CapabilityDescriptorV2 携带 accepts_refs/produces_refs。"""
+        from rosclaw.contracts.agent.capability import CapabilityDescriptorV2
+
+        cap = CapabilityDescriptorV2.model_validate_contract({
+            "schema_version": "rosclaw.capability.v2",
+            "capability_id": "ur5e_simulate_cartesian_trajectory",
+            "source": "rosclaw-builtin",
+            "input_schema": {"type": "object"},
+            "output_schema": {"type": "object"},
+            "accepts_refs": [{"kind": "plan", "from": "ur5e.plan_cartesian_path"}],
+            "produces_refs": [{"kind": "trace"}],
+        })
+        assert cap.accepts_refs[0]["kind"] == "plan"
+        assert cap.produces_refs[0]["kind"] == "trace"
+
+    def test_snapshot_excludes_unconnectable_consumer(self) -> None:
+        """消费者需要的 ref kind 在 snapshot 中无生产者 → excluded
+        REF_NOT_CONNECTABLE（模型看不到天然连不上的工具）。"""
+        from rosclaw.agentd.tooling.catalog import ToolCatalog
+        from rosclaw.agentd.tooling.snapshot import build_capability_snapshot
+        from rosclaw.contracts.agent.tool import (
+            ExecutionClass,
+            ToolDescriptorV2,
+            ToolEvidenceClass,
+        )
+
+        catalog = ToolCatalog()
+        # 只注册消费者（需要 plan ref），不注册生产者。
+        catalog.register(ToolDescriptorV2(
+            tool_id="sim_needs_plan",
+            source="native:agentd",
+            execution_class=ExecutionClass.COMPUTE,
+            evidence_class=ToolEvidenceClass.SIMULATED,
+            input_schema={"type": "object"},
+            output_schema={"type": "object"},
+        ))
+        # 声明它需要 plan ref（N5A 适配或 V2 直写）。
+        cap = catalog.capability("sim_needs_plan")
+        assert cap is not None
+        cap2 = cap.model_copy(update={
+            "accepts_refs": [{"kind": "plan", "from": ""}],
+        })
+        catalog._capabilities["sim_needs_plan"] = cap2
+        snap = build_capability_snapshot(
+            catalog, body_id="sim/ur5e", mode="SIMULATION"
+        )
+        excluded = {e.capability_id: e for e in snap.excluded}
+        assert "sim_needs_plan" in excluded
+        assert excluded["sim_needs_plan"].reason == "REF_NOT_CONNECTABLE"

--- a/tests/agentd/test_wp2_typed_refs.py
+++ b/tests/agentd/test_wp2_typed_refs.py
@@ -54,10 +54,15 @@ class TestTypedRefV1:
 
 
 class TestSharedPlanStore:
-    async def test_kit_plan_consumable_by_native_simulator(self) -> None:
+    async def test_kit_plan_consumable_by_native_simulator(
+        self, monkeypatch
+    ) -> None:
         """审计事故的直接复现：kit plan → native simulate 必须通。"""
         with tempfile.TemporaryDirectory() as td:
-            os.environ["ROSCLAW_HOME"] = td
+            # monkeypatch：测试结束自动还原——裸 os.environ 赋值会
+            # 泄漏给同进程后续测试（CI 实证：body 测试集体
+            # "Body already linked"）。
+            monkeypatch.setenv("ROSCLAW_HOME", td)
             from tests.agentd.test_pi_tool_bridge import _setup
 
             service, mission = await _setup(Path(td))

--- a/tests/agentd/test_wp2_typed_refs.py
+++ b/tests/agentd/test_wp2_typed_refs.py
@@ -18,7 +18,6 @@ native simulate 报 unknown plan（两套进程/格式互不兼容）。
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 from pathlib import Path
 

--- a/tests/contracts/golden/rosclaw.capability.v2.json
+++ b/tests/contracts/golden/rosclaw.capability.v2.json
@@ -218,6 +218,22 @@
     "evidence": {
       "$ref": "#/$defs/CapabilityEvidenceV1"
     },
+    "accepts_refs": {
+      "items": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Accepts Refs",
+      "type": "array"
+    },
+    "produces_refs": {
+      "items": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Produces Refs",
+      "type": "array"
+    },
     "metadata": {
       "additionalProperties": true,
       "title": "Metadata",

--- a/tests/contracts/golden/rosclaw.typed_ref.v1.json
+++ b/tests/contracts/golden/rosclaw.typed_ref.v1.json
@@ -1,0 +1,66 @@
+{
+  "additionalProperties": true,
+  "description": "能力产物的类型化引用（plan/trace/render/verification…）。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.typed_ref.v1",
+      "default": "rosclaw.typed_ref.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "kind": {
+      "minLength": 1,
+      "title": "Kind",
+      "type": "string"
+    },
+    "uri": {
+      "minLength": 1,
+      "title": "Uri",
+      "type": "string"
+    },
+    "producer_capability": {
+      "minLength": 1,
+      "title": "Producer Capability",
+      "type": "string"
+    },
+    "digest": {
+      "minLength": 1,
+      "title": "Digest",
+      "type": "string"
+    },
+    "body_id": {
+      "default": "",
+      "title": "Body Id",
+      "type": "string"
+    },
+    "world_id": {
+      "default": "",
+      "title": "World Id",
+      "type": "string"
+    },
+    "task_id": {
+      "default": "",
+      "title": "Task Id",
+      "type": "string"
+    },
+    "revision": {
+      "default": 0,
+      "title": "Revision",
+      "type": "integer"
+    },
+    "storage_backend": {
+      "default": "",
+      "title": "Storage Backend",
+      "type": "string"
+    }
+  },
+  "required": [
+    "kind",
+    "uri",
+    "producer_capability",
+    "digest"
+  ],
+  "title": "rosclaw.typed_ref.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.typed_ref.v1"
+}


### PR DESCRIPTION
## 范围（0823 审计 P0-4 / WP-2）：能力之间可组合

审计实证：kit `plan_cartesian_path` 产出的 plan_id 被 native simulate 报 `unknown plan`——名字相似、引用互不兼容。

- **TypedRefV1 合约**（+ golden）：uri/kind/producer_capability/digest/body_id/world_id/task_id/revision/storage_backend；
- **根因修复**：MCP 子进程拿不到 `ROSCLAW_HOME`（stdio `env=None` 是"默认最小环境"语义，不继承父进程）→ kit PlanStore 退回进程内存，plan 对 native 能力不可见。`kit_spawn_env` 统一三处 spawn（adapter spawn_env + 两个 PersistentMcpClient 构造点）；
- **格式互通**：kit envelope ↔ native 原始记录双向解包；诚实错误码 `REF_NOT_FOUND` / `REF_FORMAT_UNKNOWN`（不再含糊 unknown plan）；
- **CapabilityDescriptorV2** 声明 `accepts_refs`/`produces_refs`；snapshot 连通性——消费者的 ref kind 无生产者 → excluded `REF_NOT_CONNECTABLE`（模型看不到天然连不上的工具）；
- **审计事故复现转绿**：kit plan → native simulate 全链路通过 + 落盘证据。

## 验证

红→绿：复现红（unknown plan + 不落盘）→ 7/7 + 邻接 153 + 全量 654 passed；PTY n5d/wp1/h1 绿；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)