### PR TITLE
feat: WP-3——原生离线场景渲染为正式能力（simulation_render_scene）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,11 @@ jobs:
       - name: Install dependencies
         run: uv pip install -e ".[dev]" --system
 
+      # WP-3：OSMesa 软渲染库——CI runner 无 GPU/EGL，MuJoCo 离屏渲染
+      # 后端探测需要 libosmesa6（缺库时渲染测试诚实失败，不跳过）。
+      - name: Install OSMesa (MuJoCo offscreen rendering)
+        run: sudo apt-get update && sudo apt-get install -y libosmesa6
+
       - name: Run full non-deployment suite
         run: pytest -q -m 'not slow and not integration and not deployment'
 

--- a/.github/workflows/data-flywheel-gate.yml
+++ b/.github/workflows/data-flywheel-gate.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Install full data-flywheel extras
         run: uv pip install -e ".[dev,seekdb,embedding,knowledge]" --system
 
+      # WP-3：OSMesa 软渲染库——CI runner 无 GPU/EGL，MuJoCo 离屏渲染
+      # 后端探测需要 libosmesa6（缺库时渲染测试诚实失败，不跳过）。
+      - name: Install OSMesa (MuJoCo offscreen rendering)
+        run: sudo apt-get update && sudo apt-get install -y libosmesa6
+
       - name: Gate A — import / contract
         run: |
           python - <<'PY'

--- a/src/rosclaw/agentd/sim_render.py
+++ b/src/rosclaw/agentd/sim_render.py
@@ -1,0 +1,249 @@
+"""原生离线场景渲染（WP-3，0823 审计 §四.WP-3）。
+
+`simulation.render` 是 ROSClaw 正式能力，不是模型自写脚本：
+
+- canonical MJCF（Sandbox/Resource Resolver 链）；
+- trajectory state replay（rollout 落盘的 trajectory_states.json —
+  动力学真实 qpos，不是命令回放）；
+- 相机预设（follow/free/top）；
+- 渲染后端 EGL→OSMesa→Xvfb 自动探测——**子进程隔离**（本机实证：
+  进程内逐个试会被 glfw 递归初始化崩掉 libc++abi）；
+- RenderReceipt：renderer build digest + input trace digest +
+  backend + camera + frames；
+- 离线：不访问 PyPI/网络。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+#: 探测顺序（经验证的最小到最简）。
+_BACKEND_ORDER = ("egl", "osmesa", "xvfb")
+
+_PROBE_SNIPPET = (
+    "import os,mujoco;"
+    "m=mujoco.MjModel.from_xml_string("
+    "'<mujoco><worldbody><geom type=\"plane\" size=\"2 2 0.1\"/></worldbody></mujoco>');"
+    "d=mujoco.MjData(m);r=mujoco.Renderer(m,64,64);"
+    "r.update_scene(d);r.render();r.close();print('OK')"
+)
+
+
+def probe_render_backend(
+    *, timeout_sec: float = 30.0,
+) -> tuple[str | None, dict[str, str]]:
+    """EGL→OSMesa→Xvfb 子进程隔离探测（进程内探测会崩宿主——
+    本机 glfw 实证）。返回 (backend or None, 每后端明细)。"""
+    detail: dict[str, str] = {}
+    for backend in _BACKEND_ORDER:
+        env = dict(os_environ(), MUJOCO_GL=backend)
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", _PROBE_SNIPPET],
+                env=env, capture_output=True, timeout=timeout_sec,
+            )
+            if proc.returncode == 0 and b"OK" in proc.stdout:
+                detail[backend] = "ok"
+                return backend, detail
+            detail[backend] = (
+                proc.stderr.decode(errors="replace").strip().splitlines() or ["?"]
+            )[-1][:200]
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            detail[backend] = f"{type(exc).__name__}: {exc}"[:200]
+    return None, detail
+
+
+def os_environ() -> dict[str, str]:
+    import os
+
+    return dict(os.environ)
+
+
+def _renderer_build_digest() -> str:
+    import mujoco
+
+    payload = f"mujoco:{mujoco.__version__}|sim_render:v1"
+    return "sha256:" + hashlib.sha256(payload.encode()).hexdigest()
+
+
+def render_scene_trace(
+    home: Path,
+    trace_id: str,
+    *,
+    camera: str = "follow",
+    max_frames: int = 60,
+    width: int = 640,
+    height: int = 360,
+) -> dict[str, Any]:
+    """trace → 场景 GIF（真实 MuJoCo 离屏渲染）+ RenderReceipt。"""
+    home = Path(home)
+    trace_dir = home / "sim" / "traces" / trace_id
+    trace_path = trace_dir / "trace.json"
+    states_path = trace_dir / "trajectory_states.json"
+    if not trace_path.exists() or not states_path.exists():
+        raise ValueError(
+            f"RENDER_INPUT_MISSING: trace {trace_id!r} 缺 trace.json/"
+            "trajectory_states.json"
+        )
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+    states_doc = json.loads(states_path.read_text(encoding="utf-8"))
+    states = states_doc.get("states") or []
+    if not states:
+        raise ValueError(f"RENDER_INPUT_MISSING: {trace_id} 无 trajectory states")
+    # 血缘：states digest 必须与 trace.json 记录一致（篡改即拒）。
+    states_digest = "sha256:" + hashlib.sha256(
+        states_path.read_bytes()
+    ).hexdigest()
+    declared = str(trace.get("states_digest", ""))
+    if declared and declared != states_digest:
+        raise ValueError(
+            f"RENDER_INPUT_DIGEST_MISMATCH: trajectory_states 与 trace 记录"
+            f"不符（{declared[:19]}… != {states_digest[:19]}…）"
+        )
+    backend, probe_detail = probe_render_backend()
+    if backend is None:
+        raise ValueError(
+            "RENDER_BACKEND_UNAVAILABLE: EGL/OSMesa/Xvfb 全部不可用——"
+            + json.dumps(probe_detail, ensure_ascii=False)[:300]
+        )
+    # GL 平台在 mujoco import 时初始化——MUJOCO_GL 必须在子进程首
+    # 次 import 前设定；渲染在子进程执行（GL 崩不跨进程伤宿主）。
+    import os
+
+    env = dict(os.environ, MUJOCO_GL=backend)
+    proc = subprocess.run(
+        [
+            sys.executable, "-m", "rosclaw.agentd.sim_render",
+            str(home), trace_id, camera, str(max_frames),
+            str(width), str(height),
+        ],
+        env=env, capture_output=True, timeout=600,
+    )
+    if proc.returncode != 0:
+        tail = proc.stderr.decode(errors="replace")[-300:]
+        raise ValueError(f"RENDER_FAILED: 子进程渲染失败: {tail}")
+    result = json.loads(proc.stdout.decode())
+    return result
+
+
+def _render_impl(
+    home: Path,
+    trace_id: str,
+    *,
+    camera: str,
+    max_frames: int,
+    width: int,
+    height: int,
+) -> dict[str, Any]:
+    """子进程内真实渲染（MUJOCO_GL 已由父进程设定）。"""
+    backend = os_environ().get("MUJOCO_GL", "")
+    home = Path(home)
+    trace_dir = home / "sim" / "traces" / trace_id
+    trace_path = trace_dir / "trace.json"
+    states_path = trace_dir / "trajectory_states.json"
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+    states = json.loads(states_path.read_text(encoding="utf-8"))["states"]
+    states_digest = "sha256:" + hashlib.sha256(
+        states_path.read_bytes()
+    ).hexdigest()
+    # canonical MJCF（与 rollout 同一资源链）。
+    from rosclaw.sandbox.sandbox_api import Sandbox
+
+    sandbox = Sandbox.create("ur5e", "empty", "mujoco")
+    if not sandbox.has_physics:
+        raise ValueError(f"RENDER_INPUT: canonical 模型不可用: {sandbox.load_error}")
+    import mujoco
+    import numpy as np
+
+    model = sandbox.physics_model
+    data = sandbox.physics_data
+    renderer = mujoco.Renderer(model, height=height, width=width)
+    # 相机预设：follow=跟踪工作区中心；top=俯视；free=固定斜视角。
+    cam = mujoco.MjvCamera()
+    positions = [s["qpos"] for s in states]
+    n = len(positions)
+    step = max(1, n // max_frames)
+    frames_idx = list(range(0, n, step))[: max(2, n // step)]
+    # 工作区取景（eef 路径包围盒中心）。
+    trace_pts = trace.get("actual") or []
+    if trace_pts:
+        cx = sum(p["x"] for p in trace_pts) / len(trace_pts)
+        cy = sum(p["y"] for p in trace_pts) / len(trace_pts)
+        cz = sum(p["z"] for p in trace_pts) / len(trace_pts)
+    else:
+        cx, cy, cz = 0.35, 0.25, 0.30
+    if camera == "top":
+        cam.lookat[:] = [cx, cy, cz]
+        cam.distance = 1.2
+        cam.azimuth = 90.0
+        cam.elevation = -89.0
+    elif camera == "follow":
+        cam.lookat[:] = [cx, cy, cz]
+        cam.distance = 0.9
+        cam.azimuth = 135.0
+        cam.elevation = -25.0
+    else:  # free
+        cam.lookat[:] = [cx, cy, cz]
+        cam.distance = 1.4
+        cam.azimuth = 45.0
+        cam.elevation = -30.0
+    try:
+        from PIL import Image
+
+        images = []
+        for idx in frames_idx:
+            q = positions[idx]
+            data.qpos[: int(model.nu)] = np.array(q[: int(model.nu)])
+            mujoco.mj_forward(model, data)
+            renderer.update_scene(data, camera=cam)
+            images.append(Image.fromarray(renderer.render()))
+        out = trace_dir / f"{trace_id}-scene.gif"
+        images[0].save(
+            out, save_all=True, append_images=images[1:],
+            duration=int(1000 / 12), loop=0,
+        )
+    finally:
+        renderer.close()
+        sandbox.close()
+    receipt = {
+        "schema_version": "rosclaw.render_receipt.v1",
+        "backend": backend,
+        "camera": camera,
+        "renderer_build_digest": _renderer_build_digest(),
+        "input_trace_digest": "sha256:" + hashlib.sha256(
+            trace_path.read_bytes()
+        ).hexdigest(),
+        "states_digest": states_digest,
+        "resource": trace.get("resource") or {},
+    }
+    (trace_dir / "render_receipt.json").write_text(
+        json.dumps(receipt, ensure_ascii=False, indent=1), encoding="utf-8"
+    )
+    return {
+        "ok": True,
+        "artifact": {
+            "path": str(out),
+            "frames": len(images),
+            "format": "gif",
+            "bytes": out.stat().st_size,
+            "evidence_level": "SIM_DYN_ROLLOUT",
+        },
+        "receipt": receipt,
+    }
+
+
+__all__ = ["probe_render_backend", "render_scene_trace"]
+
+
+if __name__ == "__main__":
+
+    _home, _trace, _camera, _maxf, _w, _h = sys.argv[1:7]
+    print(json.dumps(_render_impl(
+        Path(_home), _trace, camera=_camera,
+        max_frames=int(_maxf), width=int(_w), height=int(_h),
+    )))

--- a/src/rosclaw/agentd/sim_trajectory.py
+++ b/src/rosclaw/agentd/sim_trajectory.py
@@ -334,6 +334,11 @@ class SimTrajectoryService:
             (out_dir / "trace.json").write_text(
                 json.dumps({
                     "schema_version": "rosclaw.sim_trace.v1",
+                    # WP-3：states digest 锚点——渲染/验证据此拒绝被
+                    # 篡改的 trajectory_states。
+                    "states_digest": "sha256:" + hashlib.sha256(
+                        states_path.read_bytes()
+                    ).hexdigest(),
                     "plan_hash": plan["hash"],
                     "planned": points,
                     "actual": actual,

--- a/src/rosclaw/agentd/tooling/native_tools.py
+++ b/src/rosclaw/agentd/tooling/native_tools.py
@@ -148,6 +148,7 @@ def register_native_tools(
         # 十四审 PR-14.6：SIM 动力学闭环四能力（COMPUTE——确定性仿真/
         # 渲染/验证，无人工审批；SIMULATION 限定；证据 SIMULATED）。
         from rosclaw.agentd.tools import (
+            SCENE_RENDER_TOOL,
             TRAJ_PLAN_TOOL,
             TRAJ_RENDER_TOOL,
             TRAJ_SIMULATE_TOOL,
@@ -325,6 +326,44 @@ def register_native_tools(
                 reliability=0.99,
                 typical_latency_ms=100,
             ),
+            # WP-3：原生离线场景渲染（真实 MuJoCo 场景 replay——
+            # 不是 2D 折线预览）。
+            ToolDescriptorV2(
+                tool_id=SCENE_RENDER_TOOL,
+                source=NATIVE_SOURCE,
+                execution_class=ExecutionClass.COMPUTE,
+                description=(
+                    "Render a dynamics rollout trace into a real MuJoCo "
+                    "scene GIF (canonical MJCF + trajectory state replay + "
+                    "camera preset + EGL/OSMesa/Xvfb auto-probe). Offline; "
+                    "returns artifact + render receipt (build/input digests)."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "trace_id": {"type": "string"},
+                        "camera": {"type": "string",
+                                   "enum": ["follow", "free", "top"]},
+                    },
+                    "required": ["trace_id"],
+                    "additionalProperties": False,
+                },
+                output_schema={
+                    "type": "object",
+                    "properties": {
+                        "ok": {"type": "boolean", "const": True},
+                        "artifact": {"type": "object"},
+                        "receipt": {"type": "object"},
+                        "evidence_class": {"type": "string", "const": "simulated"},
+                    },
+                    "required": ["ok", "artifact", "receipt", "evidence_class"],
+                    "additionalProperties": False,
+                },
+                supported_modes=["SIMULATION"],
+                evidence_class=ToolEvidenceClass.SIMULATED,
+                reliability=0.95,
+                typical_latency_ms=30000,
+            ),
         ]
     for descriptor in descriptors:
 
@@ -332,3 +371,23 @@ def register_native_tools(
             return await registry.execute(_name, arguments)
 
         catalog.register(descriptor, _exec)
+    # WP-2/WP-3：引用端口声明（canonical capability——snapshot 连通性
+    # 的依据）。simulate 消费 plan 产 trace；scene render 消费 trace
+    # 产 render；plan 产 plan。
+    if simulation:
+        from rosclaw.agentd.tools import TRAJ_PLAN_TOOL as _PLAN
+        from rosclaw.agentd.tools import TRAJ_SIMULATE_TOOL as _SIM
+
+        _ref_ports = {
+            _PLAN: ([], [{"kind": "plan"}]),
+            _SIM: ([{"kind": "plan", "from": _PLAN}], [{"kind": "trace"}]),
+            SCENE_RENDER_TOOL: (
+                [{"kind": "trace", "from": _SIM}], [{"kind": "render"}],
+            ),
+        }
+        for _tid, (_accepts, _produces) in _ref_ports.items():
+            _cap = catalog.capability(_tid)
+            if _cap is not None:
+                catalog._capabilities[_tid] = _cap.model_copy(update={
+                    "accepts_refs": _accepts, "produces_refs": _produces,
+                })

--- a/src/rosclaw/agentd/tools.py
+++ b/src/rosclaw/agentd/tools.py
@@ -22,6 +22,8 @@ TRAJ_PLAN_TOOL = "trajectory_generate_planar_path"
 TRAJ_SIMULATE_TOOL = "ur5e_simulate_cartesian_trajectory"
 TRAJ_RENDER_TOOL = "simulation_render_trace"
 TRAJ_VERIFY_TOOL = "simulation_verify_tracking"
+# WP-3：原生离线场景渲染（真实 MuJoCo 场景 replay，不是 2D 折线）。
+SCENE_RENDER_TOOL = "simulation_render_scene"
 
 _TOOL_SCHEMAS: dict[str, StrictTool] = {
     SIM_STATE_TOOL: StrictTool(
@@ -121,6 +123,25 @@ _TOOL_SCHEMAS: dict[str, StrictTool] = {
             "additionalProperties": False,
         },
     ),
+    SCENE_RENDER_TOOL: StrictTool(
+        name=SCENE_RENDER_TOOL,
+        description=(
+            "Render a dynamics rollout trace into a real MuJoCo scene GIF "
+            "(canonical MJCF + trajectory state replay + camera preset + "
+            "EGL/OSMesa/Xvfb auto-probe). Returns artifact + render receipt "
+            "(renderer build digest + input trace digest). Offline — never "
+            "installs packages at runtime."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "trace_id": {"type": "string"},
+                "camera": {"type": "string", "enum": ["follow", "free", "top"]},
+            },
+            "required": ["trace_id", "camera"],
+            "additionalProperties": False,
+        },
+    ),
     TRAJ_VERIFY_TOOL: StrictTool(
         name=TRAJ_VERIFY_TOOL,
         description=(
@@ -171,6 +192,8 @@ class BuiltinToolRegistry:
             TRAJ_PLAN_TOOL, TRAJ_SIMULATE_TOOL, TRAJ_RENDER_TOOL, TRAJ_VERIFY_TOOL,
         ):
             return await asyncio.to_thread(self._execute_trajectory_tool, name, arguments)
+        if name == SCENE_RENDER_TOOL:
+            return await asyncio.to_thread(self._execute_scene_render, arguments)
         return {
             "evidence_class": "configured",
             "body_id": self._body_id,
@@ -220,6 +243,22 @@ class BuiltinToolRegistry:
                 )
         except (ValueError, KeyError) as exc:
             raise ValidationError(f"{name} 参数错误: {exc}") from exc
+        result["evidence_class"] = "simulated"
+        return result
+
+    def _execute_scene_render(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """WP-3：原生离线场景渲染（canonical MJCF + qpos replay）。"""
+        from pathlib import Path as _Path
+
+        from rosclaw.agentd.sim_render import render_scene_trace
+
+        if self._home is None:
+            raise ValidationError("scene render requires rosclaw home")
+        result = render_scene_trace(
+            _Path(self._home),
+            str(arguments["trace_id"]),
+            camera=str(arguments.get("camera", "follow")),
+        )
         result["evidence_class"] = "simulated"
         return result
 

--- a/src/rosclaw/cognition/inspect_cli.py
+++ b/src/rosclaw/cognition/inspect_cli.py
@@ -71,6 +71,27 @@ def dispatch_inspect_argv(argv: list[str]) -> int | None:
                   f"（{'健康' if info['index']['ok'] and not info['index']['stale'] else '需重建'}）")
         return 0
 
+    if kind == "simulation-render":
+        # WP-3：渲染后端探测诊断（EGL→OSMesa→Xvfb 子进程隔离）。
+        from rosclaw.agentd.sim_render import probe_render_backend
+
+        backend, detail = probe_render_backend()
+        info = {
+            "backend": backend,
+            "probe": detail,
+            "ok": backend is not None,
+        }
+        if json_out:
+            print(json.dumps(info, ensure_ascii=False, indent=2))
+        else:
+            if backend:
+                print(f"渲染后端: {backend}")
+            else:
+                print("渲染后端不可用（EGL/OSMesa/Xvfb 全部失败）:")
+            for name, msg in detail.items():
+                print(f"  {name}: {msg}")
+        return 0 if backend else 1
+
     idx = ensure_index()
     if kind == "robot":
         if not query:

--- a/tests/agentd/test_wp3_scene_render.py
+++ b/tests/agentd/test_wp3_scene_render.py
@@ -1,0 +1,113 @@
+"""WP-3 红测试（0823 审计 §四.WP-3）：MuJoCo 渲染做成 ROSClaw 正式能力。
+
+红测试先行——sim_render 能力不存在时必须红。
+
+1. simulation.render 正式能力：canonical MJCF + trajectory state
+   replay + 相机预设 + GIF 输出 + RenderReceipt（renderer build
+   digest + input trace digest + backend）；
+2. 后端探测子进程隔离（EGL→OSMesa→Xvfb；进程内探测会把宿主搞崩
+   ——本机实证 glfw 递归初始化崩 libc++abi）；
+3. 画面真实非空白（像素方差 > 0——不是全黑帧）；
+4. 输入篡改/缺失诚实失败（RENDER_INPUT_MISSING / digest 不符）；
+5. 能力进 catalog + snapshot（accepts trace ref）。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _make_trace(home: Path) -> dict:
+    """真实 rollout 出一份轨迹（受信管线的既有能力）。"""
+    from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+    sim = SimTrajectoryService(home)
+    plan = sim.generate_planar_path(
+        shape="star5", center_m=[0.35, 0.25, 0.30], scale_m=0.05,
+    )
+    return sim.simulate_cartesian_trajectory(plan["plan_id"])
+
+
+class TestSceneRender:
+    def test_render_produces_real_gif_with_receipt(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.sim_render import render_scene_trace
+
+        run = _make_trace(tmp_path)
+        result = render_scene_trace(tmp_path, run["trace_id"])
+        gif = Path(result["artifact"]["path"])
+        assert gif.exists() and gif.stat().st_size > 10_000
+        assert result["artifact"]["frames"] >= 30
+        receipt = result["receipt"]
+        assert receipt["backend"] in ("egl", "osmesa", "xvfb")
+        assert receipt["renderer_build_digest"].startswith("sha256:")
+        assert receipt["input_trace_digest"].startswith("sha256:")
+        assert receipt["camera"] in ("follow", "free", "top")
+        # 画面真实非空白：帧像素方差 > 0。
+        from PIL import Image
+
+        img = Image.open(gif)
+        frame = img.convert("L")
+        import numpy as np
+
+        assert float(np.asarray(frame).std()) > 1.0, "渲染帧全黑/全白——不是真实场景"
+
+    def test_backend_probe_subprocess_isolated(self, tmp_path: Path) -> None:
+        """探测不得崩宿主进程（本机实证 glfw 进程内递归初始化崩）。"""
+        from rosclaw.agentd.sim_render import probe_render_backend
+
+        backend, detail = probe_render_backend()
+        assert backend in ("egl", "osmesa", "xvfb"), detail
+        assert isinstance(detail, dict) and detail, "探测明细缺失"
+
+    def test_missing_input_honest_failure(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.sim_render import render_scene_trace
+
+        with pytest.raises((ValueError, FileNotFoundError), match="RENDER_INPUT"):
+            render_scene_trace(tmp_path, "trace_nonexistent")
+
+    def test_tampered_states_rejected(self, tmp_path: Path) -> None:
+        """trajectory_states 被换（digest 不符 trace）→ 诚实失败。"""
+        from rosclaw.agentd.sim_render import render_scene_trace
+
+        run = _make_trace(tmp_path)
+        states_path = (
+            tmp_path / "sim" / "traces" / run["trace_id"]
+            / "trajectory_states.json"
+        )
+        states = json.loads(states_path.read_text(encoding="utf-8"))
+        states["states"][10]["qpos"][0] += 5.0  # 篡改一帧
+        states_path.write_text(json.dumps(states), encoding="utf-8")
+        with pytest.raises(ValueError, match="RENDER_INPUT|digest"):
+            render_scene_trace(tmp_path, run["trace_id"])
+
+
+class TestSceneRenderCapability:
+    def test_registered_with_refs_and_schema(self, tmp_path: Path) -> None:
+        """能力入 catalog：output_schema 非空 + accepts trace ref +
+        produces render ref；snapshot 可见。"""
+        from rosclaw.agentd.tooling.catalog import ToolCatalog
+        from rosclaw.agentd.tooling.native_tools import register_native_tools
+        from rosclaw.agentd.tooling.snapshot import build_capability_snapshot
+        from rosclaw.agentd.tools import BuiltinToolRegistry
+
+        catalog = ToolCatalog()
+        register_native_tools(
+            catalog,
+            BuiltinToolRegistry(body_id="sim/ur5e", body_summary="UR5e"),
+            simulation=True,
+        )
+        cap = catalog.capability("simulation_render_scene")
+        assert cap is not None, "simulation_render_scene 未注册"
+        assert cap.output_schema, "output_schema 空"
+        kinds_in = {r.get("kind") for r in cap.accepts_refs}
+        kinds_out = {r.get("kind") for r in cap.produces_refs}
+        assert "trace" in kinds_in
+        assert "render" in kinds_out
+        snap = build_capability_snapshot(
+            catalog, body_id="sim/ur5e", mode="SIMULATION"
+        )
+        active = {a.capability_id for a in snap.active}
+        assert "simulation_render_scene" in active


### PR DESCRIPTION
## 范围（0823 审计 WP-3）：MuJoCo 渲染做成 ROSClaw 正式能力

模型不再花几十次调用研究 Pillow/EGL/OSMesa/Xvfb/MjvGeom/相机：

- **`sim_render.py`**：canonical MJCF（Sandbox/resolver 链）+ trajectory_states qpos replay（动力学真实状态，不是命令回放）+ 相机预设（follow/free/top）+ GIF + **RenderReceipt**（renderer build digest + input trace digest + backend）；
- **后端探测 EGL→OSMesa→Xvfb 子进程隔离**（本机实证：进程内探测被 glfw 递归初始化崩 libc++abi；本机只有 OSMesa 可用）；渲染本体也在子进程（MUJOCO_GL 在 import 时初始化 + GL 崩不跨进程伤宿主）；
- **血缘锚点**：trace.json 新增 states_digest——篡改 states 即拒（RENDER_INPUT_DIGEST_MISMATCH）；缺输入 RENDER_INPUT_MISSING；后端全灭 RENDER_BACKEND_UNAVAILABLE（逐后端明细）；
- **正式能力** `simulation_render_scene`（output_schema + accepts trace / produces render 引用端口）+ BuiltinToolRegistry executor；
- **诊断**：`rosclaw inspect simulation-render`（探测明细）；
- **离线**：不访问 PyPI/网络。

## 验证

红→绿：5 红 → 5/5（真实场景 GIF 非空白像素实证）+ 邻接 42 全绿；PTY n5d/h1 绿；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)