### PR TITLE
feat: WP-7——TUI 收敛：快捷键注册表/JSON 折叠/治理术语隐藏/真实任务命名（0823 审计 WP-7）

### DIFF
--- a/packages/rosclaw-agent/src/extension/commands.ts
+++ b/packages/rosclaw-agent/src/extension/commands.ts
@@ -463,15 +463,17 @@ export function buildCommandHandlers(deps: CommandDeps): Record<string, { descri
 					switchSession?(path: string): Promise<void>;
 					sessionManager: { listAll(dir: string): Promise<unknown[]> };
 				};
-				notify(ctx, "会话列表见 rosclaw sessions；/resume <id|前缀|标题> 切换", "info");
+				notify(ctx, "会话列表见 rosclaw sessions；/switch <id|前缀|标题> 切换", "info");
 			},
 		},
-		resume: {
+		// WP-7：原 /resume 与 Pi 内置命令冲突（启动 [Extension issues]
+		// 实证）——改名 /switch。
+		switch: {
 			description: "恢复会话（id/前缀/标题）",
 			handler: async (args, ctx) => {
 				const query = args.trim();
 				if (!query) {
-					notify(ctx, "用法：/resume <id|前缀|标题>", "warning");
+					notify(ctx, "用法：/switch <id|前缀|标题>", "warning");
 					return;
 				}
 				const c = ctx as unknown as {

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -48,6 +48,9 @@ import { materializeCapabilityTools, type CapabilitySnapshot } from "../tools/ma
 import { MODEL_TOOL_NAMES } from "../tools/surface.js";
 import { fetchEmbodiedContext, renderTrustedContext } from "./context-injection.js";
 import { phaseWorkingMessage } from "./activity.js";
+import { ROSCLAW_SHORTCUTS } from "./shortcuts.js";
+import { AutoNamer } from "../session/auto-name.js";
+import { formatPolicyAutoNotice } from "../ui/tool-display.js";
 
 export interface RosclawExtensionOptions {
 	profile: "developer" | "robot";
@@ -354,7 +357,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			setTimeout(() => {
 				void center.probeOperator(true);
 			}, 800);
-			pi.registerShortcut("shift+ctrl+b", {
+			pi.registerShortcut(ROSCLAW_SHORTCUTS.operatorBootstrap, {
 				description: i18nT("operator.bootstrap_title", locale.effective),
 				handler: async (shortcutCtx) => {
 					await runBootstrap(shortcutCtx as typeof ctx);
@@ -389,16 +392,9 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		pi.on("input", async (event, _ctx) => {
 			const text = String((event as { text?: string }).text ?? "").trim();
 			if (!text || text.startsWith("/")) return { action: "continue" as const };
-			// WP-P0-2：首个有效输入自动命名（确定性截断 ≤30 字，不调
-			// 模型）——退出提示/会话列表展示标题而非内部 ID。
-			try {
-				const sm = options.sessionManager;
-				if (sm && !sm.getSessionName()) {
-					sm.appendSessionInfo(text.slice(0, 30));
-				}
-			} catch {
-				// 命名失败不阻塞输入。
-			}
+			// WP-7：命名权交给 AutoNamer——首个"驱动工具活动"的输入
+			// 才命名（真实任务的确定性信号；闲聊会话不谎报任务名）。
+			autoNamer.noteInput(text);
 			// 九审 §6.1/NINE-2：UserTurn 落账（先落账再进模型）——任务
 			// 因果链（caused_by_turn_id）的来源。落账失败不阻塞输入
 			// （Pi JSONL 仍是消息账本；UserTurn 是任务因果投影）。
@@ -681,7 +677,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				// 桥暂不可用——保留旧内容，下回合再刷。
 			}
 		};
-		pi.registerShortcut("ctrl+t", {
+		pi.registerShortcut(ROSCLAW_SHORTCUTS.taskActivity, {
 			description: "打开/关闭任务活动视图",
 			handler: async (ctx) => {
 				activityWidgetOn = !activityWidgetOn;
@@ -729,14 +725,14 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				});
 			}, { overlay: true });
 		};
-		pi.registerShortcut("f2", {
+		pi.registerShortcut(ROSCLAW_SHORTCUTS.tasksCenter, {
 			description: "打开/关闭任务面板",
 			handler: async (ctx) => {
 				await openTasksCenter(ctx);
 			},
 		});
 		try {
-			pi.registerShortcut("alt+j", {
+			pi.registerShortcut(ROSCLAW_SHORTCUTS.tasksCenterAlt, {
 				description: "任务面板（第二绑定）",
 				handler: async (ctx) => {
 					await openTasksCenter(ctx);
@@ -760,8 +756,10 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			};
 			// 七审 §2.5：POLICY_AUTO——安全 SIM 政策自动授权，只通知不弹卡。
 			if (details.phase === "POLICY_AUTO") {
+				// WP-7：SIM 用户面隐藏 POLICY_AUTO/approval/grant 治理
+				// 术语（审计链在事件账本，用户给可理解的说明）。
 				ctx.ui.notify(
-					`安全仿真自动执行（POLICY_AUTO，approval ${details.approval_id ?? ""}，全链审计）`,
+					formatPolicyAutoNotice({ approvalId: details.approval_id }),
 					"info",
 				);
 				return;
@@ -902,6 +900,17 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		// （可审计事件，不是静态 Working… 也不是思维链）。
 		pi.on("tool_execution_start", async (event, ctx) => {
 			if (!ctx.hasUI) return;
+			// WP-7：首个真实任务命名——工具活动是确定性信号。
+			autoNamer.noteToolActivity();
+			const autoName = autoNamer.name();
+			if (autoName) {
+				try {
+					const sm = options.sessionManager;
+					if (sm && !sm.getSessionName()) sm.appendSessionInfo(autoName);
+				} catch {
+					// 命名失败不阻塞执行。
+				}
+			}
 			ctx.ui.setWorkingMessage(
 				phaseWorkingMessage({
 					currentTool: String(event.toolName ?? ""), operation: null,
@@ -985,6 +994,8 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 
 		// -- 认知事件镜像（PNA-8，规格 §24.2）：hash-only，不双写全文 ----------
 		// NA-FIX-2：mirror 动态读 active（切换后不再写旧 mission）。
+		// WP-7：会话自动命名（见 input/tool_execution_start 接线）。
+		const autoNamer = new AutoNamer();
 		const mirror = new EventMirror(
 			options.rosclawHome,
 			options.active.current.sessionId,

--- a/packages/rosclaw-agent/src/extension/input-guard.ts
+++ b/packages/rosclaw-agent/src/extension/input-guard.ts
@@ -43,6 +43,9 @@ const ROSCLAW_COMMANDS = new Set([
 	"/trace",
 	"/context",
 	"/why",
+	// WP-7：会话面（/switch 原 /resume——与 Pi 内置冲突改名）。
+	"/sessions",
+	"/switch",
 ]);
 
 // Pi 内建（审计 §4 全表）——放行进内建 dispatch。

--- a/packages/rosclaw-agent/src/extension/shortcuts.ts
+++ b/packages/rosclaw-agent/src/extension/shortcuts.ts
@@ -1,0 +1,48 @@
+/** 中央快捷键注册表（WP-7，0823 审计 §四.WP-7）。
+ *
+ * 0823 实测：扩展 ctrl+t 与 Pi 内置冲突被静默跳过——任务活动视图
+ * 根本打不开，用户只看到 [Extension issues]。所有 ROSClaw 快捷键
+ * 在此一处登记；与 Pi 内置保留键的冲突在测试期爆炸，不再等到
+ * 运行时由 Pi loader 报 issue。
+ */
+
+/** ROSClaw 快捷键（唯一事实源——index.ts 只能从这里取键）。 */
+export const ROSCLAW_SHORTCUTS = {
+	/** Task Activity 常驻 widget 开关（原 ctrl+t——Pi 内置，冲突被跳过）。 */
+	taskActivity: "shift+ctrl+t",
+	/** F2 Task Panel。 */
+	tasksCenter: "f2",
+	/** Task Panel 第二绑定。 */
+	tasksCenterAlt: "alt+j",
+	/** Operator 一键初始化。 */
+	operatorBootstrap: "shift+ctrl+b",
+} as const;
+
+/** Pi 内置保留键（从 pi-coding-agent/pi-tui dist 枚举，0823 实证
+ * ctrl+t 在列；Pi 升级新增保留键时本表须同步——冲突测试会红）。 */
+export const PI_RESERVED_SHORTCUTS: ReadonlySet<string> = new Set([
+	"alt+b", "alt+backspace", "alt+d", "alt+delete", "alt+down", "alt+enter",
+	"alt+f", "alt+left", "alt+right", "alt+space", "alt+up", "alt+v", "alt+y",
+	"ctrl+a", "ctrl+b", "ctrl+backspace", "ctrl+c", "ctrl+clear", "ctrl+d",
+	"ctrl+delete", "ctrl+down", "ctrl+e", "ctrl+end", "ctrl+f", "ctrl+g",
+	"ctrl+home", "ctrl+insert", "ctrl+j", "ctrl+k", "ctrl+l", "ctrl+left",
+	"ctrl+n", "ctrl+o", "ctrl+p", "ctrl+r", "ctrl+right", "ctrl+s",
+	"ctrl+space", "ctrl+t", "ctrl+u", "ctrl+up", "ctrl+v", "ctrl+w",
+	"ctrl+x", "ctrl+y", "ctrl+z",
+	"shift+ctrl+d", "shift+ctrl+o", "shift+ctrl+p",
+]);
+
+/** 注册表健康检查：返回冲突列表（空 = 健康）。 */
+export function shortcutConflicts(): string[] {
+	const conflicts: string[] = [];
+	const seen = new Map<string, string>();
+	for (const [name, key] of Object.entries(ROSCLAW_SHORTCUTS)) {
+		if (PI_RESERVED_SHORTCUTS.has(key)) {
+			conflicts.push(`${name}=${key} 与 Pi 内置保留键冲突`);
+		}
+		const prev = seen.get(key);
+		if (prev) conflicts.push(`${name}=${key} 与 ${prev} 重复`);
+		seen.set(key, name);
+	}
+	return conflicts;
+}

--- a/packages/rosclaw-agent/src/session/auto-name.ts
+++ b/packages/rosclaw-agent/src/session/auto-name.ts
@@ -1,0 +1,30 @@
+/** 会话自动命名（WP-7，0823 审计 §四.WP-7）。
+ *
+ * 0823 实测：会话被第一条消息 "hello" 命名——会话列表/退出提示
+ * 展示的是闲聊而非任务。规则：首个**驱动工具活动**的输入用来
+ * 命名（真实任务的确定性信号——工具执行开始）；只闲聊的会话
+ * 不命名（会话列表回退展示首条消息，不谎报任务）。命名后冻结。
+ */
+
+export class AutoNamer {
+	private pending: string | null = null;
+	private named: string | null = null;
+
+	/** 每条自然语言输入登记（命名前最后一条驱动活动的输入胜出）。 */
+	noteInput(text: string): void {
+		if (this.named !== null) return;
+		const trimmed = text.trim();
+		if (trimmed) this.pending = trimmed;
+	}
+
+	/** 工具执行开始 = 当前任务有真实工作（确定性信号，不是内容猜测）。 */
+	noteToolActivity(): void {
+		if (this.named !== null || this.pending === null) return;
+		this.named = this.pending.slice(0, 30);
+	}
+
+	/** 当前应命名的标题（null = 还没到命名时机）。 */
+	name(): string | null {
+		return this.named;
+	}
+}

--- a/packages/rosclaw-agent/src/tools/materialize.ts
+++ b/packages/rosclaw-agent/src/tools/materialize.ts
@@ -16,8 +16,10 @@
  */
 
 import { defineTool } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 
 import type { BridgeToolContext } from "./bridge-tools.js";
+import { displayLabelFor, summarizeToolResultText } from "../ui/tool-display.js";
 
 export interface SnapshotActiveTool {
 	tool_name: string;
@@ -57,7 +59,9 @@ export function materializeCapabilityTools(
 		const digest = snapshot.digest;
 		tools.push(defineTool({
 			name: entry.tool_name,
-			label: entry.tool_name,
+			// WP-7：用户面 label 剥治理前缀（propose_）与双下划线——
+			// 工具 name（模型调用面）不变，只改渲染。
+			label: displayLabelFor(entry.tool_name),
 			description:
 				`${entry.description}（capability: ${capabilityId}；` +
 				`effect: ${entry.effect_class}）`,
@@ -108,6 +112,14 @@ export function materializeCapabilityTools(
 					details: { ok, error_code: result.error_code ?? null },
 					isError: !ok,
 				};
+			},
+			// WP-7：用户面折叠渲染——模型上下文保留完整文本，TUI
+			// 只渲染单行摘要（JSON 不刷屏；REJECTED 明确"未执行"）。
+			renderResult(result: { content?: Array<{ type: string; text?: string }> }) {
+				const text = (result.content ?? [])
+					.map((b) => (b.type === "text" ? String(b.text ?? "") : ""))
+					.join("\n");
+				return new Text(summarizeToolResultText(text), 1, 0);
 			},
 		}));
 	}

--- a/packages/rosclaw-agent/src/ui/tool-display.ts
+++ b/packages/rosclaw-agent/src/ui/tool-display.ts
@@ -1,0 +1,91 @@
+/** 工具结果用户面显示（WP-7，0823 审计 §四.WP-7）。
+ *
+ * 模型面与用户数分离：模型上下文保留完整 envelope/证据文本
+ * （诚实性不降级），TUI 渲染折叠为单行摘要——0823 实测整段
+ * plan/trace JSON 刷屏，propose_/grant 治理术语对用户无意义。
+ */
+
+/** 工具名 → 用户面显示名：剥 propose_ 治理前缀、__ → .。
+ * （工具 name 不变——模型调用面不动；这只管渲染。） */
+export function displayLabelFor(toolName: string): string {
+	let label = toolName;
+	if (label.startsWith("propose_")) label = label.slice("propose_".length);
+	return label.replaceAll("__", ".");
+}
+
+/** envelope/结果文本 → 单行用户摘要（≤160 字符）。 */
+export function summarizeToolResultText(raw: string): string {
+	const text = raw.trim();
+	// REJECTED：明确"未执行"——不得渲染任何完成字样（REJECTED vs
+	// COMPLETED 同源纪律：拒绝就是拒绝）。
+	if (text.startsWith("REJECTED")) {
+		const match = text.match(/^REJECTED\s*\[([^\]]+)\]:?\s*(.*)$/s);
+		if (match) {
+			return `✗ 未执行 [${match[1]}] ${clip(match[2].replaceAll("\n", " "), 110)}`;
+		}
+		return `✗ 未执行 ${clip(text.replaceAll("\n", " "), 120)}`;
+	}
+	// envelope JSON：折叠为状态 + 摘要行。
+	const parsed = tryParseJson(text);
+	if (parsed && typeof parsed === "object") {
+		const env = parsed as Record<string, unknown>;
+		const status = String(env.status ?? "");
+		const cap = String(env.capability_id ?? "");
+		const value = (env.value ?? {}) as Record<string, unknown>;
+		if (status === "SUCCEEDED") {
+			const summary = typeof value.summary === "string" && value.summary
+				? value.summary
+				: scalarDigest(value);
+			return `✓ ${cap}${summary ? ` — ${clip(summary, 110)}` : ""}`;
+		}
+		if (status) {
+			const err = (env.error ?? {}) as Record<string, unknown>;
+			const code = String(err.code ?? "ERROR");
+			const message = String(err.message ?? "").replaceAll("\n", " ");
+			return `✗ ${status} [${code}] ${cap} ${clip(message, 100)}`.trim();
+		}
+	}
+	// 非 JSON（如 SIM 执行器自然语言回执）：去治理术语后截断。
+	return clip(stripGovernanceTerms(text.replaceAll("\n", " ")), 160);
+}
+
+/** SIM auto 用户通知：隐藏 POLICY_AUTO/approval/grant 治理术语
+ * （审计链仍在事件账本——用户面只给可理解的说明）。 */
+export function formatPolicyAutoNotice(_details: { approvalId?: string }): string {
+	return "安全仿真动作已自动放行执行（全程已记录审计，可用 /activity 查看）";
+}
+
+/** 治理术语清洗（用户面）：grant/propose/lease 等机制词汇替换为
+ * 用户可理解的说明；事实部分（final_state/evidence_domain）保留。 */
+function stripGovernanceTerms(text: string): string {
+	return text
+		.replace(/grant 已消费。?/g, "")
+		.replace(/，?\s*grant[_ -]?[a-z0-9]*已?消费/gi, "")
+		.replace(/\s{2,}/g, " ")
+		.trim();
+}
+
+function scalarDigest(value: Record<string, unknown>): string {
+	const parts: string[] = [];
+	for (const [k, v] of Object.entries(value)) {
+		if (parts.length >= 2) break;
+		if (typeof v === "string" && v.length <= 60) parts.push(`${k}=${v}`);
+		else if (typeof v === "number" || typeof v === "boolean") {
+			parts.push(`${k}=${String(v)}`);
+		}
+	}
+	return parts.join(" ");
+}
+
+function clip(text: string, max: number): string {
+	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+function tryParseJson(text: string): unknown {
+	if (!text.startsWith("{")) return undefined;
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/rosclaw-agent/test/n9-productization.test.ts
+++ b/packages/rosclaw-agent/test/n9-productization.test.ts
@@ -2,7 +2,8 @@
  *
  * 红测试先行——以下不存在时必须红：
  * 1. /effort auto|low|medium|high 真实切换 reasoning effort；
- * 2. /sessions 与 /resume 命令存在（TUI 会话面）；
+ * 2. /sessions 与 /switch 命令存在（TUI 会话面；WP-7：/resume 与
+ *    Pi 内置冲突改名 /switch）；
  * 3. 纯 SIM 下不展示 OPERATOR_OFFLINE（SIM 不需要 operator）；
  * 4. Working… 被结构化阶段替代（工具/操作进行中显示当前阶段，
  *    不是静态 Working…）——展示可审计事件，不展示思维链。
@@ -10,7 +11,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-test("N9: /effort 与 /sessions、/resume 命令存在", async () => {
+test("N9: /effort 与 /sessions、/switch 命令存在", async () => {
 	const { buildCommandHandlers } = await import("../src/extension/commands.js");
 	const handlers = buildCommandHandlers({
 		rosclawHome: "/tmp/x",
@@ -21,7 +22,7 @@ test("N9: /effort 与 /sessions、/resume 命令存在", async () => {
 	});
 	assert.ok(handlers.effort, "/effort 缺失");
 	assert.ok(handlers.sessions, "/sessions 缺失");
-	assert.ok(handlers.resume, "/resume 缺失");
+	assert.ok(handlers.switch, "/switch 缺失");
 });
 
 test("N9: /effort 接受 auto|low|medium|high 并真实应用", async () => {

--- a/packages/rosclaw-agent/test/wp7-tui-convergence.test.ts
+++ b/packages/rosclaw-agent/test/wp7-tui-convergence.test.ts
@@ -1,0 +1,166 @@
+/** WP-7 红测试（0823 审计 §四.WP-7）：TUI 收敛。
+ *
+ * 红测试先行——模块/改名不存在时必须红。
+ *
+ * 0823 实测日志证据：
+ * 1. 启动 [Extension issues]：/resume 命令与 ctrl+t 快捷键和 Pi
+ *    内置冲突（快捷键被跳过——任务活动视图根本打不开）；
+ * 2. 工具结果整段 JSON 原文刷屏（plan/trace 全字段）；
+ * 3. propose_ur5e__execute_plan / "grant 已消费" 治理术语在 SIM
+ *    用户界面可见；
+ * 4. 会话被第一条消息 "hello" 命名——应命名自首个真实任务；
+ * 5. REJECTED 与 "完成" 展示必须同源——REJECTED 的调用不得渲染
+ *    出任何"完成"字样。
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("WP-7 中央快捷键注册表", () => {
+	it("注册表存在且无冲突、无重复", async () => {
+		const { ROSCLAW_SHORTCUTS, PI_RESERVED_SHORTCUTS, shortcutConflicts } =
+			await import("../src/extension/shortcuts.js");
+		const keys = Object.values(ROSCLAW_SHORTCUTS);
+		assert.equal(new Set(keys).size, keys.length, "快捷键重复");
+		assert.deepEqual(shortcutConflicts(), [], "与 Pi 内置保留键冲突");
+		for (const key of keys) {
+			assert.ok(!PI_RESERVED_SHORTCUTS.has(key), `${key} 是 Pi 内置保留键`);
+		}
+	});
+
+	it("任务活动视图改用非冲突键（ctrl+t 是 Pi 内置）", async () => {
+		const { ROSCLAW_SHORTCUTS } = await import("../src/extension/shortcuts.js");
+		assert.notEqual(ROSCLAW_SHORTCUTS.taskActivity, "ctrl+t");
+		assert.ok(ROSCLAW_SHORTCUTS.taskActivity.length > 0);
+	});
+});
+
+describe("WP-7 命令不撞 Pi 内置", () => {
+	it("/resume 改名（Pi 内置 /resume 冲突）", async () => {
+		const { buildCommandHandlers } = await import("../src/extension/commands.js");
+		const stub = {
+			rosclawHome: "/tmp/wp7",
+			active: { current: {}, subscribe: () => undefined },
+			center: { call: async () => ({}), statusReport: async () => ({}) },
+			locale: { effective: "zh" },
+			registeredToolNames: () => [],
+		};
+		// @ts-expect-error stub 只覆盖本测试触及的面
+		const handlers = buildCommandHandlers(stub);
+		assert.ok(!("resume" in handlers), "/resume 与 Pi 内置冲突——必须改名");
+		assert.ok("switch" in handlers, "改名后的会话切换命令缺失（/switch）");
+	});
+});
+
+describe("WP-7 工具结果折叠与用户面显示", () => {
+	it("SUCCEEDED envelope → 单行摘要，不刷原始 JSON", async () => {
+		const { summarizeToolResultText } = await import("../src/ui/tool-display.js");
+		const raw = JSON.stringify({
+			status: "SUCCEEDED",
+			capability_id: "ur5e.plan_cartesian_path",
+			value: {
+				ok: true,
+				plan_id: "plan_1da59abd07f44831",
+				summary: "star5：中心 (0.4, 0.0, 0.2)m，51 个插值点，已闭合",
+				point_count: 51,
+				points: Array.from({ length: 51 }, (_, i) => ({ x: i, y: i, z: 0.2 })),
+			},
+		});
+		const out = summarizeToolResultText(raw);
+		assert.ok(out.length < 200, `摘要过长（${out.length} 字符）——仍在刷屏`);
+		assert.ok(out.includes("plan_1da59abd07f44831") || out.includes("已闭合"));
+		assert.ok(!out.includes('"points"'), "原始 JSON 字段泄漏到用户面");
+	});
+
+	it("REJECTED → 明确'未执行'，绝不渲染'完成'", async () => {
+		const { summarizeToolResultText } = await import("../src/ui/tool-display.js");
+		const out = summarizeToolResultText(
+			"REJECTED [DOOM_LOOP]: 同一调用已失败过一次——原样重复不会成功。",
+		);
+		assert.ok(out.includes("未执行"), "REJECTED 未标明未执行");
+		assert.ok(out.includes("DOOM_LOOP"));
+		assert.ok(!/已完成|执行完毕|COMPLETED/.test(out), "REJECTED 渲染出完成字样");
+	});
+
+	it("propose_/双下划线治理术语在用户面显示名中隐藏", async () => {
+		const { displayLabelFor } = await import("../src/ui/tool-display.js");
+		assert.equal(
+			displayLabelFor("propose_ur5e__execute_plan"),
+			"ur5e.execute_plan",
+		);
+		assert.equal(
+			displayLabelFor("ur5e__get_cartesian_trace"),
+			"ur5e.get_cartesian_trace",
+		);
+	});
+
+	it("SIM auto 通知不含 POLICY_AUTO/approval/grant 术语", async () => {
+		const { formatPolicyAutoNotice } = await import("../src/ui/tool-display.js");
+		const out = formatPolicyAutoNotice({ approvalId: "apr_123" });
+		assert.ok(!out.includes("POLICY_AUTO"), "治理术语泄漏");
+		assert.ok(!out.includes("apr_123"), "approval id 泄漏到用户面");
+		assert.ok(!/grant/i.test(out), "grant 术语泄漏");
+		assert.ok(out.includes("仿真"), "缺少用户可理解的说明");
+	});
+});
+
+describe("WP-7 会话命名自首个真实任务", () => {
+	it("问候不命名；首个驱动工具活动的任务消息命名", async () => {
+		const { AutoNamer } = await import("../src/session/auto-name.js");
+		const namer = new AutoNamer();
+		namer.noteInput("hello");
+		assert.equal(namer.name(), null, "无工具活动的闲聊被用来命名");
+		namer.noteInput("帮我用机械臂画一个五角星");
+		assert.equal(namer.name(), null, "任务消息本身还未证明是真实任务");
+		namer.noteToolActivity();
+		assert.equal(namer.name(), "帮我用机械臂画一个五角星");
+	});
+
+	it("命名冻结：后续消息不改名；超长截断", async () => {
+		const { AutoNamer } = await import("../src/session/auto-name.js");
+		const namer = new AutoNamer();
+		namer.noteInput("画五角星");
+		namer.noteToolActivity();
+		assert.equal(namer.name(), "画五角星");
+		namer.noteInput("x".repeat(80));
+		assert.equal(namer.name(), "画五角星", "命名后被后续消息覆盖");
+		const namer2 = new AutoNamer();
+		namer2.noteInput("y".repeat(80));
+		namer2.noteToolActivity();
+		assert.ok((namer2.name() ?? "").length <= 30, "命名未截断到 30 字");
+	});
+});
+
+describe("WP-7 物化工具用户面 label", () => {
+	it("propose_only 工具 label 不带 propose_ 前缀", async () => {
+		const { materializeCapabilityTools } = await import("../src/tools/materialize.js");
+		const snapshot = {
+			schema_version: "rosclaw.capability_snapshot.v1",
+			generation: 1,
+			digest: "sha256:test",
+			body_id: "sim/ur5e",
+			mode: "SIMULATION",
+			active: [{
+				tool_name: "propose_ur5e__execute_plan",
+				capability_id: "ur5e.execute_plan",
+				exposure: "propose_only",
+				effect_class: "SIMULATION_STATE_ONLY",
+				description: "execute plan",
+				input_schema: { type: "object" },
+				output_schema: { type: "object" },
+			}],
+			excluded: [],
+		};
+		const ctx = {
+			center: { call: async () => ({}) },
+			active: { current: {} },
+			rosclawHome: "/tmp/wp7",
+		};
+		// @ts-expect-error stub
+		const tools = materializeCapabilityTools(snapshot, ctx);
+		assert.equal(tools.length, 1);
+		assert.equal(tools[0].name, "propose_ur5e__execute_plan", "工具名（模型调用面）不应改");
+		assert.ok(!String(tools[0].label).includes("propose_"), "label 含治理前缀");
+		assert.ok(!String(tools[0].label).includes("__"), "label 含双下划线");
+	});
+});


### PR DESCRIPTION
## 范围（0823 审计 WP-7）：TUI 收敛——逐项对应实测日志证据

- **启动 [Extension issues] 清零**：中央快捷键注册表
  （`extension/shortcuts.ts`——唯一事实源 + Pi 内置保留键全表 +
  冲突在测试期爆炸而非运行时由 loader 报 issue）；
  `ctrl+t`（Pi 内置，被静默跳过——任务活动视图根本打不开）→
  `shift+ctrl+t`；`/resume`（Pi 内置冲突）→ `/switch`，
  input-guard 同步放行 `/switch`/`/sessions`；
- **JSON 折叠**：`ui/tool-display.ts`——envelope 折叠为单行摘要
  （`✓ capability — summary` / `✗ 未执行 [CODE]`），物化工具经
  `renderResult` 接入；**模型上下文保留完整文本（诚实性不降级）**，
  只改 TUI 渲染；
- **治理术语隐藏**：用户面 label 剥 `propose_` 前缀与双下划线
  （`ur5e.execute_plan`）；POLICY_AUTO 通知不再含 approval id /
  grant 术语（审计链仍在事件账本）；
- **REJECTED 展示同源**：REJECTED 渲染 `✗ 未执行 [CODE]`——
  绝不出现完成字样；
- **会话命名自首个真实任务**：`AutoNamer`——首个驱动工具活动的
  输入才命名（工具执行开始 = 确定性信号，不是内容启发式），
  闲聊会话不谎报任务名；命名后冻结、≤30 字截断。

## 验证

红→绿：TS 红（模块缺失 + ctrl+t//resume 冲突实证）→ 10/10；
TS 全套 141/141（N9 既有断言按改名同步 /switch）；
python PTY/输入回归 11/11（h8 journey / n5d PTY / hp1 input
gate / nine1 input-loss）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)