### PR TITLE
feat: WP-8——项目源码与任务产物隔离：runs 四区布局（0823 审计 WP-8）

### DIFF
--- a/packages/rosclaw-agent/src/extension/context-injection.ts
+++ b/packages/rosclaw-agent/src/extension/context-injection.ts
@@ -23,6 +23,15 @@ export interface EmbodiedContextEnvelope {
 	[key: string]: unknown;
 }
 
+/** WP-8：活跃任务运行目录（pi.context 响应的 active_run）。 */
+export interface ActiveRunInfo {
+	task_id: string;
+	state: string;
+	revision: number;
+	run_dir: string;
+	zones: Record<string, string>;
+}
+
 export interface ContextFetchResult {
 	envelope?: EmbodiedContextEnvelope;
 	stale: boolean;
@@ -30,6 +39,8 @@ export interface ContextFetchResult {
 	/** HOTFIX-1：agentd 签发的 ValidatedContextLease（action 准入凭证）。 */
 	contextLeaseId?: string;
 	contextLeaseExpiresAt?: string;
+	/** WP-8：活跃任务运行目录（无活跃任务时缺省）。 */
+	activeRun?: ActiveRunInfo;
 }
 
 /** 与 Python json.dumps(sort_keys=True, separators=(",", ":")) 逐字节一致。 */
@@ -97,10 +108,12 @@ export async function fetchEmbodiedContext(
 	const leaseExpiresAt = typeof response.context_lease_expires_at === "string"
 		? response.context_lease_expires_at
 		: undefined;
+	const activeRun = response.active_run as ActiveRunInfo | undefined;
 	return {
 		envelope,
 		stale: false,
 		note: "fresh",
+		...(activeRun?.run_dir ? { activeRun } : {}),
 		...(leaseId ? { contextLeaseId: leaseId } : {}),
 		...(leaseExpiresAt ? { contextLeaseExpiresAt: leaseExpiresAt } : {}),
 	};
@@ -124,6 +137,9 @@ export function renderTrustedContext(result: ContextFetchResult): string {
 		`body: ${body.body_id ?? ""} (hash ${String(body.effective_body_hash ?? "").slice(0, 16)})\n` +
 		`body_summary: ${body.summary ?? ""}\n` +
 		`pending_approvals: ${env.pending_approvals.length}\n` +
+		(result.activeRun
+			? `task_run: ${result.activeRun.run_dir}（交付物→outputs/ 证据→evidence/ 草稿→scratch/ 日志→logs/；scratch 不得登记为交付物）\n`
+			: "") +
 		`generated_at: ${env.generated_at}  expires_at: ${env.expires_at}\n` +
 		"规则：以上为本轮唯一权威具身事实；历史消息中的旧状态以此为准。\n" +
 		"</ROSCLAW_TRUSTED_CONTEXT>"

--- a/packages/rosclaw-agent/test/wp8-active-run.test.ts
+++ b/packages/rosclaw-agent/test/wp8-active-run.test.ts
@@ -1,0 +1,56 @@
+/** WP-8 红测试（0823 审计 §四.WP-8）：active_run 进具身上下文。
+ *
+ * 模型每轮必须知道当前任务的运行目录与四区纪律——否则它只会
+ * 把交付物写进项目源码树（0823 实测）。
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { renderTrustedContext, type ContextFetchResult } from "../src/extension/context-injection.js";
+
+function baseResult(): ContextFetchResult {
+	return {
+		stale: false,
+		note: "fresh",
+		envelope: {
+			schema_version: "rosclaw.embodied_context.v1",
+			mission_id: "mis_1",
+			context_revision: 3,
+			generated_at: "2026-08-23T00:00:00Z",
+			expires_at: "2026-08-23T01:00:00Z",
+			hash: "sha256:x",
+			body: { body_id: "sim/ur5e", effective_body_hash: "sha256:y", summary: "UR5e" },
+			safety: { mode: "SIMULATION" },
+			pending_approvals: [],
+		} as never,
+	};
+}
+
+describe("WP-8 active_run 上下文渲染", () => {
+	it("有活跃任务：task_run 行含运行目录与四区纪律", () => {
+		const result = baseResult();
+		result.activeRun = {
+			task_id: "task_1",
+			state: "RUNNING",
+			revision: 2,
+			run_dir: "/home/u/.rosclaw/runs/task_1/r2",
+			zones: {
+				scratch: "/home/u/.rosclaw/runs/task_1/r2/scratch",
+				outputs: "/home/u/.rosclaw/runs/task_1/r2/outputs",
+				evidence: "/home/u/.rosclaw/runs/task_1/r2/evidence",
+				logs: "/home/u/.rosclaw/runs/task_1/r2/logs",
+			},
+		};
+		const out = renderTrustedContext(result);
+		assert.ok(out.includes("/home/u/.rosclaw/runs/task_1/r2"));
+		assert.ok(out.includes("outputs/"), "缺交付区说明");
+		assert.ok(out.includes("scratch"), "缺草稿区说明");
+		assert.ok(out.includes("不得登记"), "缺 scratch 纪律");
+	});
+
+	it("无活跃任务：不渲染 task_run 行", () => {
+		const out = renderTrustedContext(baseResult());
+		assert.ok(!out.includes("task_run"));
+	});
+});

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -735,6 +735,16 @@ class PiBridgeServer:
             response: dict[str, Any] = {"ok": True, "context": envelope.model_dump(mode="json")}
             pi_session_id = str(params.get("pi_session_id", ""))
             if pi_session_id:
+                # WP-8：活跃任务的运行目录随 context 下发——模型每轮
+                # 知道交付物写 outputs/、草稿写 scratch/（项目源码
+                # 不再当任务垃圾场）。观测面信息，不进 envelope hash
+                # （任务流转换 revision 属正常，不触发 context 失效）。
+                with contextlib.suppress(Exception):
+                    active_run = service._task_kernel.active_task_for_session(
+                        mission_id, pi_session_id
+                    )
+                    if active_run is not None:
+                        response["active_run"] = active_run
                 # P0-5A：只有合法 writer（binding + writer lease + peer
                 # PID/UID 与 lease owner 匹配）才能签 action context
                 # lease——观测面（envelope）仍可读，action lease 绝不

--- a/src/rosclaw/task_kernel/run_store.py
+++ b/src/rosclaw/task_kernel/run_store.py
@@ -1,0 +1,46 @@
+"""任务运行目录（WP-8，0823 审计 §四.WP-8）。
+
+项目源码不是任务垃圾场——0823 实测模型把交付 GIF 写进项目源码
+树。每个 task/revision 有确定布局：
+
+~/.rosclaw/runs/<task_id>/r<revision>/{scratch,outputs,evidence,logs}
+
+- scratch：草稿/中间产物（不得登记为交付物）；
+- outputs：交付物（register_artifact 记录 zone）；
+- evidence：证据（receipt/trace 引用）；
+- logs：运行日志。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ZONES = ("scratch", "outputs", "evidence", "logs")
+
+
+def run_dir(home: Path, task_id: str, revision: int) -> Path:
+    return Path(home) / "runs" / task_id / f"r{int(revision)}"
+
+
+def ensure_run(home: Path, task_id: str, revision: int) -> dict[str, object]:
+    """创建（幂等）并返回运行目录描述。"""
+    base = run_dir(home, task_id, revision)
+    zones: dict[str, str] = {}
+    for zone in ZONES:
+        path = base / zone
+        path.mkdir(parents=True, exist_ok=True)
+        zones[zone] = str(path)
+    return {"run_dir": str(base), "zones": zones}
+
+
+def zone_of(home: Path, task_id: str, revision: int, path: Path) -> str:
+    """文件所在的运行区（不在本 task/revision 运行目录内 → ""）。"""
+    base = run_dir(home, task_id, revision)
+    try:
+        rel = path.resolve().relative_to(base.resolve())
+    except ValueError:
+        return ""
+    return rel.parts[0] if rel.parts and rel.parts[0] in ZONES else ""
+
+
+__all__ = ["ZONES", "ensure_run", "run_dir", "zone_of"]

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from rosclaw.contracts.common import new_id
+from rosclaw.task_kernel.run_store import ensure_run, run_dir, zone_of
 
 #: root task 状态机（§9.4）：ACTIVE 子态 + TERMINAL。
 TASK_ACTIVE = frozenset({
@@ -111,6 +112,7 @@ class TaskKernel:
             task_id = str(active["task_id"])
             revision = int(active["active_revision"]) + 1
             now = datetime.now(UTC).isoformat()
+            ensure_run(self._home, task_id, revision)  # WP-8
             self._conn.execute(
                 "INSERT INTO task_revisions (task_id, revision, "
                 "user_message_id, goal_delta, created_at) "
@@ -152,6 +154,7 @@ class TaskKernel:
             active = None
         if active is not None:
             revision = int(active["active_revision"]) + 1
+            ensure_run(self._home, str(active["task_id"]), revision)  # WP-8
             self._conn.execute(
                 "INSERT INTO task_revisions (task_id, revision, "
                 "user_message_id, goal_delta, created_at) "
@@ -187,6 +190,9 @@ class TaskKernel:
         workspace.mkdir(parents=True, exist_ok=True)
         for sub in ("artifacts", "checkpoints", "logs", "snapshots"):
             (self._home / "tasks" / task_id / sub).mkdir(parents=True, exist_ok=True)
+        # WP-8：运行目录四区（scratch/outputs/evidence/logs）——
+        # 项目源码不再当任务垃圾场。
+        ensure_run(self._home, task_id, 1)
         self._conn.execute(
             "INSERT INTO tasks (task_id, mission_id, root_goal, mode, body_id, "
             "workspace_path, state, active_revision, locale, created_at, "
@@ -244,7 +250,42 @@ class TaskKernel:
         row = self._conn.execute(
             "SELECT * FROM tasks WHERE task_id = ?", (task_id,)
         ).fetchone()
-        return dict(row) if row else None
+        if row is None:
+            return None
+        task = dict(row)
+        # WP-8：当前 revision 的运行目录（模型/界面可查）。
+        task["run_dir"] = str(
+            run_dir(self._home, task_id, int(task["active_revision"]))
+        )
+        return task
+
+    def active_task_for_session(
+        self, mission_id: str, session_ref: str
+    ) -> dict | None:
+        """WP-8：session 的活跃 task + 运行目录/四区（pi.context
+        接线——模型每轮知道写哪里）。"""
+        row = self._conn.execute(
+            "SELECT t.* FROM tasks t JOIN task_session_bindings b "
+            "ON b.task_id = t.task_id "
+            "WHERE t.mission_id = ? AND b.session_ref = ? AND b.active = 1 "
+            "AND b.role = 'primary' "
+            "ORDER BY t.created_at DESC LIMIT 1",
+            (mission_id, session_ref),
+        ).fetchone()
+        if row is None:
+            return None
+        task = self.get_task(str(row["task_id"]))
+        assert task is not None
+        run = ensure_run(
+            self._home, str(task["task_id"]), int(task["active_revision"])
+        )
+        return {
+            "task_id": str(task["task_id"]),
+            "state": str(task["state"]),
+            "revision": int(task["active_revision"]),
+            "run_dir": run["run_dir"],
+            "zones": run["zones"],
+        }
 
     def list_tasks(self, mission_id: str = "") -> list[dict]:
         if mission_id:
@@ -341,6 +382,16 @@ class TaskKernel:
                 f"artifact 不存在: {path}（解析根: {workspace}）"
             )
         content = file.read_bytes()
+        # WP-8：运行区纪律——scratch 是草稿区，不得登记为交付物；
+        # outputs/evidence 登记记录 zone（交付/证据可归因）。
+        zone = zone_of(
+            self._home, task_id, int(task["active_revision"]), file
+        )
+        if zone == "scratch":
+            raise ValueError(
+                f"SCRATCH_NOT_DELIVERABLE: {file} 在 scratch 草稿区——"
+                "草稿不是交付物；请把最终交付物写入 outputs/ 再登记"
+            )
         artifact_id = new_id("art")
         now = datetime.now(UTC).isoformat()
         record = {
@@ -354,6 +405,9 @@ class TaskKernel:
         # N4.1：模型自产证据标 EXPERIMENTAL——通过 qualification 前
         # 不当正式能力证据（N 调整方案 §二）。
         meta = dict(metadata or {})
+        if zone:
+            meta["zone"] = zone
+            record["zone"] = zone
         if producer.startswith("model:"):
             meta.setdefault("evidence_tier", "EXPERIMENTAL")
         # WP-4：血缘图——带 render receipt 的交付物在登记时推导并

--- a/tests/agentd/test_wp8_run_isolation.py
+++ b/tests/agentd/test_wp8_run_isolation.py
@@ -1,0 +1,127 @@
+"""WP-8 红测试（0823 审计 §四.WP-8）：项目源码与任务产物隔离。
+
+红测试先行——runs 布局不存在时必须红。
+
+0823 实测：模型把 star_ur5e_sim.gif 写进项目源码目录并登记成交付
+物——项目树成了任务垃圾场。布局：
+
+~/.rosclaw/runs/<task_id>/r<revision>/{scratch,outputs,evidence,logs}
+
+1. 新 task 绑定即建 r1 四区；revision+1 建 r<N> 四区；
+2. task 详情暴露 run_dir（模型/界面可查）；
+3. scratch 区文件不得登记为交付物（SCRATCH_NOT_DELIVERABLE——
+   草稿不是交付）；
+4. outputs/evidence 区登记记录 zone（交付/证据可归因）；
+5. pi.context 响应带 active_run（模型每轮知道写哪里）。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _kernel(home: Path):
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return TaskKernel(conn, home)
+
+
+def _bind(kernel, home: Path, text: str = "画五角星", msg: str = "m1") -> dict:
+    return kernel.bind_message(
+        mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+        message_id=msg, text=text, cwd=str(home),
+    )
+
+
+class TestRunLayout:
+    def test_new_task_creates_run_zones(self, tmp_path: Path) -> None:
+        kernel = _kernel(tmp_path)
+        bound = _bind(kernel, tmp_path)
+        task_id = str(bound["task_id"])
+        run = tmp_path / "runs" / task_id / "r1"
+        for zone in ("scratch", "outputs", "evidence", "logs"):
+            assert (run / zone).is_dir(), f"缺运行区: {run / zone}"
+
+    def test_revision_bump_creates_new_run_dir(self, tmp_path: Path) -> None:
+        kernel = _kernel(tmp_path)
+        bound = _bind(kernel, tmp_path)
+        task_id = str(bound["task_id"])
+        # 同 session 第二条消息 → revision+1。
+        _bind(kernel, tmp_path, text="改大一点儿", msg="m2")
+        assert (tmp_path / "runs" / task_id / "r2" / "outputs").is_dir()
+
+    def test_task_detail_exposes_run_dir(self, tmp_path: Path) -> None:
+        kernel = _kernel(tmp_path)
+        bound = _bind(kernel, tmp_path)
+        task = kernel.get_task(str(bound["task_id"]))
+        assert task is not None
+        run_dir = Path(str(task.get("run_dir", "")))
+        assert run_dir.name == "r1"
+        assert run_dir.parent.name == str(bound["task_id"])
+        assert (run_dir / "outputs").is_dir()
+
+
+class TestArtifactZoneDiscipline:
+    def test_scratch_rejected_as_deliverable(self, tmp_path: Path) -> None:
+        kernel = _kernel(tmp_path)
+        bound = _bind(kernel, tmp_path)
+        task_id = str(bound["task_id"])
+        scratch = tmp_path / "runs" / task_id / "r1" / "scratch"
+        scratch.mkdir(parents=True, exist_ok=True)
+        draft = scratch / "draft.py"
+        draft.write_text("print('draft')", encoding="utf-8")
+        with pytest.raises(ValueError, match="SCRATCH_NOT_DELIVERABLE"):
+            kernel.register_artifact(
+                task_id=task_id, path=str(draft), media_type="text/x-python",
+            )
+
+    def test_outputs_zone_recorded(self, tmp_path: Path) -> None:
+        kernel = _kernel(tmp_path)
+        bound = _bind(kernel, tmp_path)
+        task_id = str(bound["task_id"])
+        outputs = tmp_path / "runs" / task_id / "r1" / "outputs"
+        outputs.mkdir(parents=True, exist_ok=True)
+        gif = outputs / "star.gif"
+        gif.write_bytes(b"GIF89a" + b"\x00" * 64)
+        result = kernel.register_artifact(
+            task_id=task_id, path=str(gif), media_type="image/gif",
+        )
+        artifact = result.get("artifact") or result
+        assert artifact.get("zone") == "outputs", artifact
+
+    def test_evidence_zone_recorded(self, tmp_path: Path) -> None:
+        kernel = _kernel(tmp_path)
+        bound = _bind(kernel, tmp_path)
+        task_id = str(bound["task_id"])
+        evidence = tmp_path / "runs" / task_id / "r1" / "evidence"
+        evidence.mkdir(parents=True, exist_ok=True)
+        receipt = evidence / "receipt.json"
+        receipt.write_text("{}", encoding="utf-8")
+        result = kernel.register_artifact(
+            task_id=task_id, path=str(receipt), media_type="application/json",
+        )
+        artifact = result.get("artifact") or result
+        assert artifact.get("zone") == "evidence", artifact
+
+
+class TestContextCarriesActiveRun:
+    def test_pi_context_response_has_active_run(self, tmp_path: Path) -> None:
+        """pi.context 响应（带 session）必须带 active_run——模型每轮
+        知道当前任务的运行目录与四区。"""
+        kernel = _kernel(tmp_path)
+        bound = _bind(kernel, tmp_path)
+        task_id = str(bound["task_id"])
+        # 直接测内核查询助手（server 接线薄壳）。
+        active = kernel.active_task_for_session("mis_1", "s1")
+        assert active is not None, "缺 active_task_for_session 查询"
+        assert active["task_id"] == task_id
+        assert active["run_dir"].endswith("r1")
+        zones = active.get("zones") or {}
+        assert set(zones) >= {"scratch", "outputs", "evidence", "logs"}


### PR DESCRIPTION
## 范围（0823 审计 WP-8）：项目源码与任务产物隔离

0823 实测：模型把 `star_ur5e_sim.gif` 写进项目源码目录并登记成
交付物——项目树成了任务垃圾场。

- **RunStore**（`task_kernel/run_store.py`）：
  `~/.rosclaw/runs/<task_id>/r<revision>/{scratch,outputs,evidence,logs}`
  确定布局；task 创建与两处 revision+1 路径都建区（幂等）；
- task 详情暴露 `run_dir`；新查询 `active_task_for_session`；
- **register_artifact 运行区纪律**：scratch 区文件拒绝登记
  （`SCRATCH_NOT_DELIVERABLE`——草稿不是交付）；outputs/evidence
  登记记录 zone（交付/证据可归因）；
- **pi.context 响应带 active_run**（观测面，不进 envelope
  hash——任务流转不触发 context 失效）；renderTrustedContext
  渲染 task_run 行——模型每轮知道交付物写 `outputs/`、
  scratch 不得登记为交付物。

## 验证

红→绿：python 7 红 → 7/7；TS 2/2 + 全套 141/141；
kernel/service/context 邻接 67+17 全绿；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)