### PR TITLE
feat: P0-6——Harness Shell 全模式 OS 隔离与敏感路径遮蔽（0823 审计 P0-6）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,10 @@ jobs:
           cache-dependency-path: packages/rosclaw-agent/package-lock.json
       - run: npm ci
         working-directory: packages/rosclaw-agent
+      # P0-6：bubblewrap——OS 隔离实证测试（凭据遮蔽/无网络/越界
+      # 只读）需要真 bwrap；user namespace 在 ubuntu runner 可用。
+      - name: Install bubblewrap (OS isolation proof tests)
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
       - run: npm test
         working-directory: packages/rosclaw-agent
 

--- a/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
+++ b/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
@@ -223,9 +223,10 @@ export async function createRosclawRuntime(
 				...buildWorkspacePackTools({
 					root: cwd,
 					bashLogPath: `${options.rosclawHome}/logs/main-bash.log`,
-					// PR-H6：REAL/SHADOW 模式 bash 必须 bwrap 强隔离
-					// （无 bwrap fail closed）。
+					// P0-6：全模式 bash bwrap 强隔离（敏感路径遮蔽——
+					// 凭据/控制 token/bridge socket 不经 shell 可达）。
 					mode: () => active.current.mode,
+					rosclawHome: options.rosclawHome,
 				}),
 				// PR-H3：process 工具（长 Operation——立即返回 operation_id）。
 				...buildProcessTools({

--- a/packages/rosclaw-agent/src/tools/workspace-pack.ts
+++ b/packages/rosclaw-agent/src/tools/workspace-pack.ts
@@ -71,8 +71,9 @@ function scrubEnv(source: NodeJS.ProcessEnv): Record<string, string> {
 export interface WorkspacePackOptions {
 	/** 项目根（write/edit 的作用域；bash 的 cwd）。 */
 	root: string;
-	/** 当前模式（PR-H6：REAL/SHADOW → bash 必须 bwrap 强隔离；
-	 *  无 bwrap fail closed）。 */
+	/** 当前模式（P0-6：全模式 bash 必须 bwrap 强隔离——无 bwrap
+	 *  REAL/SHADOW fail closed；SIM 仅在操作者显式授权下降级
+	 *  （TOOL_LAYER_ONLY 标记），否则同样 fail closed）。 */
 	mode?: () => string;
 	/** bwrap 路径探测（测试可注入）。 */
 	bwrapPath?: () => string | null;
@@ -80,6 +81,33 @@ export interface WorkspacePackOptions {
 	bashLogPath?: string;
 	/** 显式默认超时（运营配置；默认无定时器）。 */
 	defaultBashTimeoutMs?: number;
+	/** rosclaw home（P0-6：沙箱内遮蔽其 agent/agentd/run——凭据/
+	 *  控制 token/bridge socket 不经 shell 可达，治理不可绕过）。 */
+	rosclawHome?: string;
+	/** 操作者显式授权的无沙箱降级（仅 SIM；bwrap 不可用的主机——
+	 *  等价 ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1）。 */
+	allowUnsandboxedShell?: () => boolean;
+}
+
+/** P0-6：沙箱内必须遮蔽的敏感路径（凭据/控制面/云凭据）。
+ *  无条件遮蔽（不过滤存在性）——--tmpfs 对不存在路径同样成立
+ *  （沙箱内呈现为空目录）：不向外泄漏"哪些路径存在"，会话中
+ *  新建的凭据文件也被覆盖。 */
+export function _sensitiveMasks(homeDir: string, rosclawHome?: string): string[] {
+	const candidates = [
+		`${homeDir}/.ssh`,
+		`${homeDir}/.gnupg`,
+		`${homeDir}/.aws`,
+		`${homeDir}/.config/gh`,
+		...(rosclawHome
+			? [`${rosclawHome}/agent`, `${rosclawHome}/agentd`, `${rosclawHome}/run`]
+			: []),
+	];
+	const args: string[] = [];
+	for (const path of candidates) {
+		args.push("--tmpfs", path);
+	}
+	return args;
 }
 
 export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefinition[] {
@@ -121,20 +149,39 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 				{ defaultTimeoutMs: options.defaultBashTimeoutMs },
 			);
 			const started = Date.now();
-			// PR-H6（§14.5）：REAL/SHADOW 模式的 shell 必须强隔离
-			// （bwrap：宿主只读、workspace 可写、无网络、无 /dev 写、
-			// env 已剥离）——无 bwrap fail closed，绝不裸跑。
+			// P0-6（0823 审计）：全模式 shell 必须 bwrap 强隔离——
+			// SIM auto 下 Harness Shell 裸跑可绕过治理（读凭据/
+			// 控制 token、直调 bridge socket、写项目源码树）。
+			// 无 bwrap：REAL/SHADOW fail closed（H6 不变）；SIM 仅在
+			// 操作者显式授权下降级（TOOL_LAYER_ONLY 诚实标记）。
 			const mode = options.mode?.() ?? "SIMULATION";
-			const sandboxed = mode === "REAL" || mode === "SHADOW";
+			const strict = mode === "REAL" || mode === "SHADOW";
 			// options.bwrapPath 存在即以它为准（测试注入 null =
 			// 强制不可用）；未注入才真实探测。
 			const bwrap = options.bwrapPath
 				? options.bwrapPath()
 				: (_bwrapAvailable() ? "/usr/bin/bwrap" : null);
-			if (sandboxed && !bwrap) {
-				return denied(
-					`${mode} 模式 shell 需要 bwrap 强隔离——本机无 bwrap，fail closed（不裸跑）`,
-				);
+			const sandboxed = bwrap !== null;
+			let degradedMarker = "";
+			if (!sandboxed) {
+				const degradedAllowed = !strict
+					&& (options.allowUnsandboxedShell?.() === true
+						|| process.env.ROSCLAW_ALLOW_UNSANDBOXED_SHELL === "1");
+				if (!degradedAllowed) {
+					return denied(
+						`${mode} 模式 shell 需要 bwrap 强隔离——本机无可用 bwrap`
+						+ "（user namespace 受限），fail closed（不裸跑）。"
+						+ (strict
+							? ""
+							: " SIM 下如确需无沙箱 shell，操作者须显式授权："
+								+ "ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1（结果带 "
+								+ "TOOL_LAYER_ONLY 标记）"),
+					);
+				}
+				degradedMarker =
+					"[TOOL_LAYER_ONLY: 本机无 OS 沙箱（bwrap 不可用）——"
+					+ "操作者显式授权的降级运行，凭据/控制面在 shell 可达"
+					+ "（风险已告知）]\n";
 			}
 			const output = await new Promise<string>((resolvePromise) => {
 				let spawnCmd = "sh";
@@ -143,6 +190,12 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 					spawnCmd = bwrap;
 					spawnArgs = [
 						"--ro-bind", "/", "/",
+						// P0-6：凭据/控制面遮蔽（顺序在 ro-bind 之后、
+						// workspace rw 之前——socket/token/私钥不可读，
+						// 治理链不可经 shell 绕过）。
+						..._sensitiveMasks(
+							process.env.HOME ?? "", options.rosclawHome,
+						),
 						"--bind", root, root, // workspace 可写（其余宿主只读）
 						"--unshare-net",
 						"--dev", "/dev", // 全新 devtmpfs——真设备不可见
@@ -174,7 +227,9 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 					if (timer) clearTimeout(timer);
 					const head = `exit=${code ?? "signal"} wall=${Date.now() - started}ms`
 						+ (timedOut ? " TIMEOUT(explicit)" : "");
-					resolvePromise(`${head}\n${buf.slice(0, MAX_OUTPUT_BYTES)}`);
+					resolvePromise(
+						`${degradedMarker}${head}\n${buf.slice(0, MAX_OUTPUT_BYTES)}`,
+					);
 				});
 				child.on("error", (err) => {
 					if (timer) clearTimeout(timer);

--- a/packages/rosclaw-agent/test/h6-safety.test.ts
+++ b/packages/rosclaw-agent/test/h6-safety.test.ts
@@ -5,7 +5,10 @@
  * 2. REAL/SHADOW 模式 bash 必须 bwrap 强隔离（无 bwrap → fail
  *    closed 诚实拒绝，不裸跑）；
  * 3. bwrap 内：无网络、无 /dev 写、workspace 可写、其余只读；
- * 4. SIM 模式保持现状（不 bwrap——效率优先，env 剥离已在 H1）。
+ * 4. SIM 模式在 H6 曾不沙箱（效率优先）——P0-6（0823 审计）
+ *    起全模式沙箱：SIM 裸跑可绕过治理（读凭据/控制 token、
+ *    直调 bridge socket），无 bwrap 主机 SIM 降级需操作者显式
+ *    授权且带 TOOL_LAYER_ONLY 标记。
  */
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";

--- a/packages/rosclaw-agent/test/p06-os-isolation.test.ts
+++ b/packages/rosclaw-agent/test/p06-os-isolation.test.ts
@@ -1,0 +1,148 @@
+/** P0-6 红测试（0823 审计 §三.P0-6）：Harness Shell OS 隔离实证。
+ *
+ * 红测试先行——全模式 bwrap + 敏感路径遮蔽不存在时必须红。
+ *
+ * 0823 审计：SIM auto 下 Harness Shell 可绕过治理——bash 在宿主
+ * 裸跑（无 bwrap），能读 ~/.rosclaw/agent 凭据与 run/ 控制 token
+ * （可直接调 bridge socket 绕过全部治理链）、能写项目源码树。
+ *
+ * 修复契约（全部实证，不是配置断言）：
+ * 1. 全模式（SIM 同 REAL/SHADOW）bash 必须 bwrap 强隔离——无
+ *    bwrap fail closed，任何模式不裸跑；
+ * 2. 沙箱内敏感路径被遮蔽：~/.ssh/.gnupg/.aws + rosclawHome 的
+ *    agent/agentd/run（凭据/控制 token/socket 不可读——治理链
+ *    不可经 shell 绕过）；
+ * 3. 沙箱内无网络（OS 级 socket 实证，不是 argv 黑名单）；
+ * 4. workspace 可写、其余宿主只读（全模式一致）。
+ */
+
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+async function makeBash(root: string, rosclawHome: string, mode: string, bwrapPath?: () => string | null) {
+	const { buildWorkspacePackTools } = await import("../src/tools/workspace-pack.js");
+	const tools = buildWorkspacePackTools({
+		root,
+		rosclawHome,
+		mode: () => mode,
+		...(bwrapPath ? { bwrapPath } : {}),
+	});
+	const bash = tools.find((t) => t.name === "bash");
+	assert.ok(bash);
+	return bash;
+}
+
+async function run(bash: { execute: Function }, command: string): Promise<{ text: string; isError: boolean }> {
+	const result = await bash.execute(
+		`c${Math.floor(Math.random() * 1e9)}`,
+		{ command },
+		new AbortController().signal,
+		async () => {},
+		{} as never,
+	);
+	return {
+		text: String((result.content[0] as { text: string }).text),
+		isError: (result as { isError?: boolean }).isError === true,
+	};
+}
+
+test("P0-6: SIM 模式无 bwrap → fail closed（任何模式不裸跑）", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "p06-"));
+	const bash = await makeBash(dir, dir, "SIMULATION", () => null);
+	const out = await run(bash, "echo hi");
+	assert.ok(out.isError, "SIM 无 bwrap 裸跑了——治理可绕过");
+	assert.match(out.text, /隔离|bwrap|fail.closed/i);
+});
+
+test("P0-6: SIM 无 bwrap + 显式降级授权 → 运行但带诚实标记", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "p06-"));
+	const { buildWorkspacePackTools } = await import("../src/tools/workspace-pack.js");
+	const tools = buildWorkspacePackTools({
+		root: dir,
+		rosclawHome: dir,
+		mode: () => "SIMULATION",
+		bwrapPath: () => null,
+		// 操作者显式授权降级（等同 ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1）。
+		allowUnsandboxedShell: () => true,
+	});
+	const bash = tools.find((t) => t.name === "bash");
+	assert.ok(bash);
+	const result = await bash.execute(
+		"c1", { command: "echo hi" }, new AbortController().signal,
+		async () => {}, {} as never,
+	);
+	const text = String((result.content[0] as { text: string }).text);
+	assert.match(text, /hi/, "显式授权后降级 shell 应运行");
+	assert.match(text, /TOOL_LAYER_ONLY/, "降级运行必须带无 OS 沙箱标记");
+});
+
+test("P0-6: 敏感路径遮蔽清单覆盖凭据/控制面", async () => {
+	const { _sensitiveMasks } = await import("../src/tools/workspace-pack.js");
+	const masks = _sensitiveMasks("/home/u", "/home/u/.rosclaw");
+	const joined = masks.join(" ");
+	for (const path of [
+		"/home/u/.ssh",
+		"/home/u/.gnupg",
+		"/home/u/.rosclaw/agent",
+		"/home/u/.rosclaw/agentd",
+		"/home/u/.rosclaw/run",
+	]) {
+		assert.ok(joined.includes(path), `遮蔽清单缺 ${path}——治理可经 shell 绕过`);
+	}
+});
+
+test("P0-6: SIM 沙箱实证——凭据/token 不可读、无网络、越界只读", async (t) => {
+	const { _bwrapAvailable } = await import("../src/tools/workspace-pack.js");
+	if (!_bwrapAvailable()) {
+		t.skip("无 bwrap——跳过（CI 装 bubblewrap 后实证）");
+		return;
+	}
+	const root = mkdtempSync(join(tmpdir(), "p06-ws-"));
+	const rosclawHome = mkdtempSync(join(tmpdir(), "p06-home-"));
+	// 伪造凭据/控制 token/socket 目录（与真实布局同名）。
+	mkdirSync(join(rosclawHome, "agent"), { recursive: true });
+	writeFileSync(join(rosclawHome, "agent", "auth.json"), "{\"token\":\"SECRET\"}");
+	mkdirSync(join(rosclawHome, "run"), { recursive: true });
+	writeFileSync(join(rosclawHome, "run", "control.token"), "SECRET");
+	mkdirSync(join(rosclawHome, "agentd"), { recursive: true });
+	const bash = await makeBash(root, rosclawHome, "SIMULATION", () => "/usr/bin/bwrap");
+
+	// 凭据不可读（遮蔽后路径不存在——不是"权限拒绝"）。
+	const cred = await run(bash, `cat ${rosclawHome}/agent/auth.json 2>&1 || echo MASKED`);
+	assert.match(cred.text, /MASKED/, "沙箱内读到了凭据——治理可绕过");
+	const tok = await run(bash, `cat ${rosclawHome}/run/control.token 2>&1 || echo MASKED`);
+	assert.match(tok.text, /MASKED/, "沙箱内读到了控制 token——可冒充 agent 调 bridge");
+
+	// 无网络（OS 级 socket，不是 argv 黑名单）。
+	const net = await run(bash, "python3 -c \"import socket;socket.create_connection(('8.8.8.8',53),2)\" 2>&1 || echo NO_NET");
+	assert.match(net.text, /NO_NET/, "沙箱内有网络——隔离不成立");
+
+	// workspace 可写。
+	const wr = await run(bash, "echo ok > inside.txt && cat inside.txt");
+	assert.match(wr.text, /ok/);
+	assert.ok(readFileSync(join(root, "inside.txt"), "utf-8").startsWith("ok"));
+
+	// 越界只读（rosclawHome 非遮蔽部分也不可写）。
+	const outside = join(rosclawHome, "p06_escape");
+	const esc = await run(bash, `touch ${outside} 2>&1 || echo READONLY`);
+	assert.match(esc.text, /READONLY/, "沙箱内越界可写");
+	assert.ok(!existsSync(outside), "越界文件真的被写了");
+});
+
+test("P0-6: REAL/SHADOW 语义保持（遮蔽同样生效）", async (t) => {
+	const { _bwrapAvailable } = await import("../src/tools/workspace-pack.js");
+	if (!_bwrapAvailable()) {
+		t.skip("无 bwrap——跳过");
+		return;
+	}
+	const root = mkdtempSync(join(tmpdir(), "p06-ws-"));
+	const rosclawHome = mkdtempSync(join(tmpdir(), "p06-home-"));
+	mkdirSync(join(rosclawHome, "agent"), { recursive: true });
+	writeFileSync(join(rosclawHome, "agent", "auth.json"), "SECRET");
+	const bash = await makeBash(root, rosclawHome, "REAL", () => "/usr/bin/bwrap");
+	const cred = await run(bash, `cat ${rosclawHome}/agent/auth.json 2>&1 || echo MASKED`);
+	assert.match(cred.text, /MASKED/);
+});


### PR DESCRIPTION
## 范围（0823 审计 P0-6）：Harness Shell 全模式 OS 隔离

0823 审计：SIM auto 下 Harness Shell 裸跑可绕过治理——bash 在
宿主直接执行，能读 `~/.rosclaw/agent` 凭据与 `run/` 控制 token
（可冒充 agent 直调 bridge socket 绕过全部治理链）、能写项目
源码树。

- **全模式**（SIM 同 REAL/SHADOW）bash 必须 bwrap 强隔离：
  宿主只读 + workspace 可写 + **无网络（OS 级，不是 argv
  黑名单）** + 全新 devtmpfs；
- **敏感路径无条件 `--tmpfs` 遮蔽**：`~/.ssh`/`.gnupg`/`.aws`/
  `.config/gh` + rosclawHome `agent`/`agentd`/`run`——凭据/控制
  token/socket 在沙箱内不存在，治理链不可经 shell 绕过
  （不过滤存在性：不泄漏路径存在信息，会话中新建凭据也覆盖）；
- **无 bwrap**：REAL/SHADOW fail closed（H6 不变）；SIM 同样
  fail closed，仅操作者显式授权（`ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1`）
  可降级运行且结果带 `TOOL_LAYER_ONLY` 诚实标记（风险已告知）；
- CI Node Agent Unit 装 bubblewrap——OS 隔离实证测试在 CI 真跑
  （本机 Jetson userns 受限，实证测试诚实 skip，不假装通过）。

## 验证

红→绿：TS 红（接口/行为缺失）→ 全套 146/146（2 项实证本地
skip——Jetson uid_map Permission denied 实证，CI 装 bubblewrap
后真跑）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)