### PR TITLE
feat: P0-A——Session replay 与 UI 去重：幂等事件账本（0824 总纲 P0-A）

### DIFF
--- a/packages/rosclaw-agent/src/extension/dedup.ts
+++ b/packages/rosclaw-agent/src/extension/dedup.ts
@@ -1,0 +1,18 @@
+/** 稳定 ID 去重（P0-A，0824 总纲 §19.P0-A）。
+ *
+ * 同一逻辑事件（provider retry/断流重连/重放注入）在 UI 只出现
+ * 一次——同一 tool card 只能存在一张。空 id 不去重（无稳定 ID
+ * 的事件不得互相吞掉）。
+ */
+
+export class StableIdDeduper {
+	private readonly seen = new Set<string>();
+
+	/** 首次返回 true；重复 id 返回 false（调用方应抑制渲染/追加）。 */
+	check(id: string): boolean {
+		if (!id) return true;
+		if (this.seen.has(id)) return false;
+		this.seen.add(id);
+		return true;
+	}
+}

--- a/packages/rosclaw-agent/src/extension/event-mirror.ts
+++ b/packages/rosclaw-agent/src/extension/event-mirror.ts
@@ -25,6 +25,9 @@ export function contentHash(text: string): string {
 export class EventMirror {
 	private queue: MirrorEvent[] = [];
 	private flushing = false;
+	// P0-A：provider retry/重连重放对同一 message 重复 push——
+	// 按 (event_type, entryId|content_hash) 去重，只镜像一次。
+	private readonly mirrored = new Set<string>();
 
 	constructor(
 		private readonly rosclawHome: string,
@@ -40,6 +43,10 @@ export class EventMirror {
 	}
 
 	push(eventType: string, options: { entryId?: string; text?: string; model?: string; usage?: Record<string, unknown> } = {}): void {
+		// P0-A：稳定键去重（entryId 优先；无 entryId 用内容 hash）。
+		const dedupKey = `${eventType}:${options.entryId || (options.text !== undefined ? contentHash(options.text) : "")}`;
+		if (dedupKey !== `${eventType}:` && this.mirrored.has(dedupKey)) return;
+		if (dedupKey !== `${eventType}:`) this.mirrored.add(dedupKey);
 		this.queue.push({
 			mirror_id: `mir_${randomUUID().slice(0, 12)}`,
 			pi_session_id: this.piSessionId,

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -49,6 +49,7 @@ import { MODEL_TOOL_NAMES } from "../tools/surface.js";
 import { fetchEmbodiedContext, renderTrustedContext } from "./context-injection.js";
 import { phaseWorkingMessage } from "./activity.js";
 import { ROSCLAW_SHORTCUTS } from "./shortcuts.js";
+import { StableIdDeduper } from "./dedup.js";
 import { AutoNamer } from "../session/auto-name.js";
 import { formatPolicyAutoNotice } from "../ui/tool-display.js";
 
@@ -894,6 +895,9 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					)
 					: undefined,
 		);
+		// P0-A：同一动作的权威结果卡只渲染一张（provider retry/
+		// 事件重放不产生第二张卡）。
+		const actionCardDeduper = new StableIdDeduper();
 		// 每个 outcome 只校验紧随其后的第一段助手叙述；turn 结束清除。
 		let lastOutcome: (ActionResultData & { narrativeSeen?: boolean; conflictClaim?: string }) | null = null;
 		// PR-N9：结构化活动区——工具开始/结束驱动活动区文案
@@ -939,7 +943,12 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				errorCode: details.error_code ? String(details.error_code) : undefined,
 			};
 			lastOutcome = data;
-			pi.appendEntry("rosclaw.action_result", data);
+			// P0-A：稳定 ID（txn/action/approval/call 任一可用）upsert。
+			if (actionCardDeduper.check(
+				data.txnId ?? data.actionId ?? data.approvalId ?? "",
+			)) {
+				pi.appendEntry("rosclaw.action_result", data);
+			}
 		});
 		// 冲突检测：outcome 非 COMPLETED 而助手叙述自称完成 → 可见冲突标记。
 		// pi 事件模型：tool 执行属于"tool_call turn"——turn_end 先于下一轮

--- a/packages/rosclaw-agent/test/p0a-replay-dedup.test.ts
+++ b/packages/rosclaw-agent/test/p0a-replay-dedup.test.ts
@@ -1,0 +1,51 @@
+/** P0-A 红测试（0824 总纲 §19.P0-A）：UI/镜像去重。
+ *
+ * 红测试先行——dedup helper 不存在时必须红。
+ *
+ * 1. EventMirror：provider retry 对同一 message 重复 push → 只镜像
+ *    一次（raw delta 按 message/item 去重）；
+ * 2. action_result 卡：同一 call_id 只 appendEntry 一次（同一 tool
+ *    card 只能存在一张）。
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("P0-A EventMirror 去重", () => {
+	it("同一 entry 重复 push（provider retry）只镜像一次", async () => {
+		const { EventMirror } = await import("../src/extension/event-mirror.js");
+		const batches: Array<Array<Record<string, unknown>>> = [];
+		const mirror = new EventMirror(
+			"/tmp/p0a", "s1", "m1",
+			async (_home, _method, params) => {
+				batches.push((params as { events: Array<Record<string, unknown>> }).events);
+				return { ok: true, stored: 1 };
+			},
+		);
+		mirror.push("message_end", { entryId: "msg_1", text: "hello" });
+		mirror.push("message_end", { entryId: "msg_1", text: "hello" }); // retry 重复
+		mirror.push("message_end", { entryId: "msg_2", text: "world" });
+		await mirror.flush();
+		const all = batches.flat();
+		const msg1 = all.filter((e) => e.pi_entry_id === "msg_1");
+		assert.equal(msg1.length, 1, "provider retry 导致重复镜像");
+		assert.equal(all.length, 2);
+	});
+});
+
+describe("P0-A 稳定 ID upsert", () => {
+	it("同一 call_id 的 action_result 卡只追加一次", async () => {
+		const { StableIdDeduper } = await import("../src/extension/dedup.js");
+		const deduper = new StableIdDeduper();
+		assert.equal(deduper.check("call_1"), true, "首次应通过");
+		assert.equal(deduper.check("call_1"), false, "重复 call 必须抑制（第二张卡）");
+		assert.equal(deduper.check("call_2"), true, "不同 call 不受影响");
+	});
+
+	it("空 id 不去重（无稳定 ID 的事件不得互相吞掉）", async () => {
+		const { StableIdDeduper } = await import("../src/extension/dedup.js");
+		const deduper = new StableIdDeduper();
+		assert.equal(deduper.check(""), true);
+		assert.equal(deduper.check(""), true, "空 id 每次都必须通过");
+	});
+});

--- a/src/rosclaw/agentd/events.py
+++ b/src/rosclaw/agentd/events.py
@@ -109,8 +109,20 @@ class AgentEventStore:
         call_id: str | None = None,
         operation_id: str | None = None,
         model_visible: bool | None = None,
+        event_id: str | None = None,
     ) -> AgentEventV2:
+        """落账一条事件。P0-A：调用方提供稳定 event_id 时幂等——
+        (session_id, event_id) unique；重复注入（provider retry/
+        断流重连/重放）返回既有事件且不重复 publish。"""
         async with self._lock:
+            if event_id is not None and session_id is not None:
+                existing = self._conn.execute(
+                    "SELECT * FROM agent_events WHERE session_id = ? "
+                    "AND event_id = ?",
+                    (session_id, event_id),
+                ).fetchone()
+                if existing is not None:
+                    return self._row_to_event(existing)
             row = self._conn.execute(
                 "SELECT COALESCE(MAX(sequence), 0) + 1 AS next_seq FROM agent_events "
                 "WHERE mission_id = ?",
@@ -118,7 +130,7 @@ class AgentEventStore:
             ).fetchone()
             sequence = int(row["next_seq"])
             event = AgentEventV2(
-                event_id=new_id("evt"),
+                event_id=event_id or new_id("evt"),
                 sequence=sequence,
                 mission_id=mission_id,
                 turn_id=turn_id,

--- a/src/rosclaw/storage/migrations/032_p0a_event_dedup.sql
+++ b/src/rosclaw/storage/migrations/032_p0a_event_dedup.sql
@@ -1,0 +1,7 @@
+-- P0-A（0824 总纲 §19.P0-A）：(session_id, event_id) 幂等去重。
+-- 调用方提供的稳定 event_id（provider retry/断流重连/重放注入的
+-- 同一逻辑事件）只落账一次；mission 级事件（session_id 为 NULL）
+-- 不受约束（它们由 mission 内 sequence 排序）。
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_events_session_event
+    ON agent_events(session_id, event_id)
+    WHERE session_id IS NOT NULL;

--- a/tests/agentd/test_p0a_replay_dedup.py
+++ b/tests/agentd/test_p0a_replay_dedup.py
@@ -16,8 +16,6 @@ import json
 import sqlite3
 from pathlib import Path
 
-import pytest
-
 
 def _store(tmp_path: Path):
     from rosclaw.agentd.events import AgentEventStore

--- a/tests/agentd/test_p0a_replay_dedup.py
+++ b/tests/agentd/test_p0a_replay_dedup.py
@@ -1,0 +1,136 @@
+"""P0-A 红测试（0824 总纲 §19.P0-A）：Session replay 与 UI 去重。
+
+红测试先行——幂等 append / unique index / dedup 不存在时必须红。
+
+验收（文档原文）：
+- 注入 429、断流、重连和重复 event：整段 transcript 不得重复；
+- resume 前后 transcript digest 一致；
+- provider retry 记录 attempt，不重复追加既有事件。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _store(tmp_path: Path):
+    from rosclaw.agentd.events import AgentEventStore
+    from rosclaw.storage.migrations import MigrationRunner
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return AgentEventStore(conn), conn
+
+
+def _digest(events) -> str:
+    canonical = json.dumps(
+        [
+            {
+                "seq": e.sequence, "type": e.type.value,
+                "payload": e.payload, "session_id": e.session_id,
+                "call_id": e.call_id, "item_id": e.item_id,
+            }
+            for e in events
+        ],
+        sort_keys=True, ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+class TestIdempotentAppend:
+    def test_same_event_id_appended_once(self, tmp_path: Path) -> None:
+        """重复 event（provider retry/重连重放）落账一次——
+        (session_id, event_id) unique。"""
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+
+        store, conn = _store(tmp_path)
+        first = asyncio.run(store.append(
+            "mis_1", AgentEventType.TOOL_EFFECT_RESOLVED,
+            {"effect": "sim"}, session_id="s1", call_id="c1",
+            event_id="s1:turn1:c1:effect",
+        ))
+        second = asyncio.run(store.append(
+            "mis_1", AgentEventType.TOOL_EFFECT_RESOLVED,
+            {"effect": "sim"}, session_id="s1", call_id="c1",
+            event_id="s1:turn1:c1:effect",
+        ))
+        assert first.sequence == second.sequence, "重复事件获得了新序号"
+        rows = conn.execute(
+            "SELECT COUNT(*) AS n FROM agent_events WHERE session_id='s1'"
+        ).fetchone()
+        assert int(rows["n"]) == 1, "重复 event 重复落账"
+
+    def test_duplicate_not_republished(self, tmp_path: Path) -> None:
+        """重复 event 不再 publish——live 消费者不得见第二张卡。"""
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+
+        store, _conn = _store(tmp_path)
+        queue = store.bus.subscribe("mis_1")
+        asyncio.run(store.append(
+            "mis_1", AgentEventType.OPERATION_COMPLETED,
+            {"operation_id": "op_1"}, session_id="s1",
+            event_id="s1:op_1:completed",
+        ))
+        asyncio.run(store.append(
+            "mis_1", AgentEventType.OPERATION_COMPLETED,
+            {"operation_id": "op_1"}, session_id="s1",
+            event_id="s1:op_1:completed",
+        ))
+        assert queue.qsize() == 1, f"重复 event 被重复 publish（{queue.qsize()} 张卡）"
+
+    def test_replay_digest_stable_across_duplicate_injection(
+        self, tmp_path: Path
+    ) -> None:
+        """resume 前后 transcript digest 一致——注入重复不改变账本。"""
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+
+        store, _conn = _store(tmp_path)
+        asyncio.run(store.append(
+            "mis_1", AgentEventType.OPERATION_STARTED,
+            {"operation_id": "op_1"}, session_id="s1",
+            event_id="s1:op_1:started",
+        ))
+        before = _digest(store.replay("mis_1"))
+        # 断流重连 → 同一批事件重放注入。
+        for _ in range(3):
+            asyncio.run(store.append(
+                "mis_1", AgentEventType.OPERATION_STARTED,
+                {"operation_id": "op_1"}, session_id="s1",
+                event_id="s1:op_1:started",
+            ))
+        after = _digest(store.replay("mis_1"))
+        assert before == after, "注入重复后 transcript digest 改变"
+
+    def test_unique_index_exists(self, tmp_path: Path) -> None:
+        """migration 提供 (session_id, event_id) unique 兜底。"""
+        _store(tmp_path)
+        conn = sqlite3.connect(":memory:")
+        from rosclaw.storage.migrations import MigrationRunner
+
+        MigrationRunner().apply(conn, "sqlite")
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND sql LIKE '%session_id%event_id%'"
+        ).fetchall()
+        assert rows, "缺 (session_id, event_id) unique index migration"
+
+    def test_caller_event_id_roundtrip(self, tmp_path: Path) -> None:
+        """幂等返回的是同一事件（调用方可安全重试）。"""
+        from rosclaw.contracts.agent.agent_event import AgentEventType
+
+        store, _conn = _store(tmp_path)
+        first = asyncio.run(store.append(
+            "mis_1", AgentEventType.TOOL_EFFECT_RESOLVED,
+            {"a": 1}, session_id="s1", event_id="s1:x",
+        ))
+        second = asyncio.run(store.append(
+            "mis_1", AgentEventType.TOOL_EFFECT_RESOLVED,
+            {"a": 1}, session_id="s1", event_id="s1:x",
+        ))
+        assert first.event_id == second.event_id == "s1:x"


### PR DESCRIPTION
## 范围（0824 总纲 P0-A）：Session replay 与 UI 去重

- **AgentEventStore.append 幂等**：调用方稳定 event_id +
  `(session_id, event_id)` unique（migration 032，部分索引
  `WHERE session_id IS NOT NULL`）——provider retry/断流重连/
  重放注入的同一逻辑事件只落账一次、**不重复 publish**
  （返回既有事件，不分配新序号）；
- **EventMirror 去重**：按 `(event_type, entryId|content_hash)`——
  provider retry 对同一 message 重复 push 只镜像一次；
- **StableIdDeduper**（空 id 不去重——无稳定 ID 的事件不得
  互相吞掉）；action_result 权威卡按 txn/action/approval 稳定
  ID upsert——同一 tool card 只存在一张。

验收对齐（§19.P0-A）：注入重复 event transcript digest 不变；
重复事件不被重复 publish（同一 tool card 一张）；unique index
migration 兜底。

## 验证

红→绿：python 5 红 → 5/5 + events 邻接 32 全绿；TS 红
（模块不存在）→ 全套 149/149；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)