### PR TITLE
feat: P0-C——Conversation/Task 分离与自动 admission（0824 总纲 P0-C）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -411,10 +411,11 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			} catch {
 				// 落账失败不阻塞输入。
 			}
-			// PR-H2（ADR-0012 §9.3）：root task 输入事务——先绑定再
-			// 投递；绑定失败不投递（handled + 通知重发=无幽灵执行）。
-			const bound = await inputController.bind(text);
-			if (!bound) return { action: "handled" as const };
+			// P0-C（0824 总纲 §6.1）：输入先落会话（persist——不立即
+			// 创建 Task；hello/解释/只读查询 tasks=0）。持久化失败不
+			// 投递（handled + 通知重发=无幽灵执行，HP1 语义不变）。
+			const persisted = await inputController.persist(text);
+			if (!persisted) return { action: "handled" as const };
 			return { action: "continue" as const };
 		});
 
@@ -529,7 +530,8 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		pi.registerCommand("done", {
 			description: "接受当前任务（用户验收——之后的新目标是新任务）",
 			handler: async (_args, ctx) => {
-				if (!inputController.currentTaskId) {
+				const doneTaskId = await inputController.activeTaskId();
+				if (!doneTaskId) {
 					ctx.ui.notify("当前没有活跃任务", "warning");
 					return;
 				}
@@ -537,14 +539,14 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					// PR-N0：/done = 用户接受（user_accepted_at）——此后
 					// 新消息开新任务；未接受的 SUCCEEDED 被用户修正重开。
 					const r = await center.call("pi.kernel.accept", {
-						task_id: inputController.currentTaskId,
+						task_id: doneTaskId,
 					});
 					if (r.ok === false) {
 						ctx.ui.notify(`不能接受：${String(r.error ?? '')}`, "warning");
 						return;
 					}
 					ctx.ui.notify(
-						`任务已接受（${inputController.currentTaskId.slice(0, 14)}…）`,
+						`任务已接受（${doneTaskId.slice(0, 14)}…）`,
 						"info",
 					);
 				} catch (err) {
@@ -581,13 +583,14 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		pi.registerCommand("taskinfo", {
 			description: "当前任务详情（root task/revision/workspace/状态）",
 			handler: async (_args, ctx) => {
-				if (!inputController.currentTaskId) {
+				const infoTaskId = await inputController.latestTaskId();
+				if (!infoTaskId) {
 					ctx.ui.notify("当前没有绑定任务", "warning");
 					return;
 				}
 				try {
 					const result = await center.call("pi.kernel.get", {
-						task_id: inputController.currentTaskId,
+						task_id: infoTaskId,
 					});
 					const task = (result.task ?? {}) as Record<string, unknown>;
 					ctx.ui.notify(
@@ -607,9 +610,10 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		// -- PR-H8：Task Activity/Logs/Artifacts（数据全部来自 TaskKernel
 		//    事件流/产物账本，不经 LLM——假进度不可能） --------------------
 		const fetchTaskEvents = async (): Promise<KernelEvent[]> => {
-			if (!inputController.currentTaskId) return [];
+			const taskId = await inputController.latestTaskId();
+			if (!taskId) return [];
 			const result = await center.call("pi.kernel.events", {
-				task_id: inputController.currentTaskId,
+				task_id: taskId,
 				after_seq: 0,
 			});
 			return (result.events ?? []) as KernelEvent[];
@@ -617,7 +621,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		pi.registerCommand("activity", {
 			description: "当前任务活动（阶段时间线——来自任务账本，非模型总结）",
 			handler: async (_args, ctx) => {
-				if (!inputController.currentTaskId) {
+				if (!(await inputController.latestTaskId())) {
 					ctx.ui.notify("当前没有绑定任务", "warning");
 					return;
 				}
@@ -632,7 +636,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		pi.registerCommand("logs", {
 			description: "当前任务后台进程输出（operation 日志尾部）",
 			handler: async (_args, ctx) => {
-				if (!inputController.currentTaskId) {
+				if (!(await inputController.latestTaskId())) {
 					ctx.ui.notify("当前没有绑定任务", "warning");
 					return;
 				}
@@ -647,13 +651,13 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		pi.registerCommand("artifacts", {
 			description: "当前任务交付物列表（登记才算交付）",
 			handler: async (_args, ctx) => {
-				if (!inputController.currentTaskId) {
+				if (!(await inputController.latestTaskId())) {
 					ctx.ui.notify("当前没有绑定任务", "warning");
 					return;
 				}
 				try {
 					const result = await center.call("pi.kernel.artifacts", {
-						task_id: inputController.currentTaskId,
+						task_id: await inputController.latestTaskId(),
 					});
 					const artifacts = (result.artifacts ?? []) as Array<Record<string, unknown>>;
 					ctx.ui.notify(renderArtifactList(artifacts).join("\n"), "info");
@@ -667,7 +671,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		let activityWidgetOn = false;
 		const refreshActivityWidget = async (): Promise<void> => {
 			if (!activityWidgetOn || !latestCtx?.hasUI) return;
-			if (!inputController.currentTaskId) {
+			if (!(await inputController.latestTaskId())) {
 				latestCtx.ui.setWidget("rosclaw-activity", ["（当前没有绑定任务）"]);
 				return;
 			}

--- a/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
+++ b/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
@@ -227,6 +227,18 @@ export async function createRosclawRuntime(
 					// 凭据/控制 token/bridge socket 不经 shell 可达）。
 					mode: () => active.current.mode,
 					rosclawHome: options.rosclawHome,
+					// P0-C：bash/write/edit 执行前的原子 admission
+					// （首个 effectful call 建 task——动机=session
+					// 最新输入）。
+					beforeEffect: async () => {
+						await center.call("pi.task.ensure_effect", {
+							mission_id: active.current.missionId ?? "",
+							session_ref: active.current.sessionId ?? "",
+							backend_native_id: active.current.sessionId ?? "",
+							cwd,
+							mode: active.current.mode ?? "SIMULATION",
+						});
+					},
 				}),
 				// PR-H3：process 工具（长 Operation——立即返回 operation_id）。
 				...buildProcessTools({

--- a/packages/rosclaw-agent/src/native/input-controller.ts
+++ b/packages/rosclaw-agent/src/native/input-controller.ts
@@ -42,40 +42,64 @@ export class InputController {
 
 	constructor(private readonly deps: InputControllerDeps) {}
 
-	/** 输入事务：先落账绑定，再决定是否投递。返回 null = 不投递。 */
-	async bind(text: string): Promise<TaskBindResult | null> {
+	/** P0-C（0824 总纲 §6.1）：输入先落会话（pi.input.persist——
+	 *  不立即创建 Task；persist 失败不投递，HP1 防线语义不变）。
+	 *  返回 null = 不投递。 */
+	async persist(text: string): Promise<{ input_id?: string } | null> {
 		const messageId = `msg_${randomUUID()}`;
 		try {
-			const result = (await this.deps.call("pi.task.bind", {
+			const result = (await this.deps.call("pi.input.persist", {
 				mission_id: this.deps.missionId(),
 				session_ref: this.deps.sessionRef(),
 				backend_native_id: this.deps.backendNativeId(),
 				message_id: messageId,
 				text,
-				cwd: this.deps.cwd(),
-				body_id: this.deps.bodyId?.() ?? "",
 				force_new: this.forceNewNext,
-			})) as unknown as TaskBindResult & { ok?: boolean };
+			})) as unknown as { ok?: boolean; input?: { input_id?: string } };
 			this.forceNewNext = false;
-			this.currentTaskId = result.task_id;
-			this.currentRevision = result.revision;
-			// PR-HP1：投递确认——persisted 之后、Harness 处理之前落
-			// input.dispatched（顺序不变量由 bridge 强制：未 persisted
-			// 的 message 打标即被拒）。失败不阻断——persisted 已是
-			// 权威证据，dispatched 是审计增强。
 			this.deps.call("pi.input.dispatched", {
 				mission_id: this.deps.missionId(),
 				message_id: messageId,
 			}).catch(() => undefined);
-			return result;
+			return result.input ?? {};
 		} catch (err) {
-			// 绑定失败不投递（幽灵执行防线）：消息不消失于沉默——
+			// 持久化失败不投递（幽灵执行防线）：消息不消失于沉默——
 			// 明确通知用户重发。
 			this.deps.notify(
-				`任务绑定失败（消息未发送，请重试）：${(err as Error).message}`.slice(0, 200),
+				`输入持久化失败（消息未发送，请重试）：${(err as Error).message}`.slice(0, 200),
 				"error",
 			);
 			return null;
+		}
+	}
+
+	/** P0-C：活跃 task 来自内核查询（同一事实源）——不再依赖
+	 *  bind 返回值（输入不再逐条建 task）。 */
+	async activeTaskId(): Promise<string> {
+		try {
+			const result = await this.deps.call("pi.kernel.active", {
+				mission_id: this.deps.missionId(),
+				session_ref: this.deps.sessionRef(),
+			});
+			const task = result.task as { task_id?: string } | null | undefined;
+			return String(task?.task_id ?? "");
+		} catch {
+			return "";
+		}
+	}
+
+	/** 最近 task（含刚终态）——/activity /logs /artifacts 的展示
+	 *  目标（终态不抹掉刚完成的任务账本）。 */
+	async latestTaskId(): Promise<string> {
+		try {
+			const result = await this.deps.call("pi.kernel.latest", {
+				mission_id: this.deps.missionId(),
+				session_ref: this.deps.sessionRef(),
+			});
+			const task = result.task as { task_id?: string } | null | undefined;
+			return String(task?.task_id ?? "");
+		} catch {
+			return "";
 		}
 	}
 }

--- a/packages/rosclaw-agent/src/tools/workspace-pack.ts
+++ b/packages/rosclaw-agent/src/tools/workspace-pack.ts
@@ -87,6 +87,10 @@ export interface WorkspacePackOptions {
 	/** 操作者显式授权的无沙箱降级（仅 SIM；bwrap 不可用的主机——
 	 *  等价 ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1）。 */
 	allowUnsandboxedShell?: () => boolean;
+	/** P0-C（0824 总纲 §6.2）：effectful 工具执行前的原子
+	 *  admission（ensure_task_for_effect）——bash/write/edit
+	 *  执行前触发。 */
+	beforeEffect?: () => Promise<void>;
 }
 
 /** P0-6：沙箱内必须遮蔽的敏感路径（凭据/控制面/云凭据）。
@@ -134,6 +138,8 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 		async execute(_id, params, signal) {
 			const command = String(params.command ?? "").trim();
 			if (!command) return denied("empty command");
+			// P0-C：首个 effectful call 的原子 admission。
+			await options.beforeEffect?.();
 			const argv0 = command.split(/\s+/)[0].replace(/^\(.*\)\s*/, "");
 			const base = argv0.split("/").pop() ?? argv0;
 			if (DENIED_COMMAND.has(base)) {
@@ -260,6 +266,8 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 			content: Type.String(),
 		}),
 		async execute(_id, params) {
+			// P0-C：首个 effectful call 的原子 admission。
+			await options.beforeEffect?.();
 			try {
 				const p = resolveInRoot(root, String(params.path));
 				mkdirSync(dirname(p), { recursive: true });
@@ -286,6 +294,8 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 			newText: Type.String(),
 		}),
 		async execute(_id, params) {
+			// P0-C：首个 effectful call 的原子 admission。
+			await options.beforeEffect?.();
 			try {
 				const p = resolveInRoot(root, String(params.path));
 				const text = readFileSync(p, "utf-8");

--- a/packages/rosclaw-agent/test/p0c-input-flow.test.ts
+++ b/packages/rosclaw-agent/test/p0c-input-flow.test.ts
@@ -1,0 +1,96 @@
+/** P0-C 红测试（0824 总纲 §19.P0-C）：TS 输入流与 effect 钩子。
+ *
+ * 红测试先行——persist 路径/ensure 钩子不存在时必须红。
+ *
+ * 1. 输入先 persist（pi.input.persist），不再逐条 bind 建 task；
+ * 2. persist 失败不投递（HP1 输入丢失防线语义不变）；
+ * 3. workspace 工作工具（bash/write/edit）执行前触发
+ *    beforeEffect（首个 effectful call 的原子 admission）；
+ * 4. 活跃 task 查询替代 bind 返回值（/done 等消费的同一事实源）。
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("P0-C 输入流 persist-only", () => {
+	it("输入走 pi.input.persist（不建 task），失败不投递", async () => {
+		const { InputController } = await import("../src/native/input-controller.js");
+		const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+		const controller = new InputController({
+			call: async (method: string, params: Record<string, unknown>) => {
+				calls.push({ method, params });
+				return { ok: true, input: { input_id: "inp_1" } };
+			},
+			missionId: () => "mis_1",
+			sessionRef: () => "s1",
+			backendNativeId: () => "s1",
+			cwd: () => "/tmp",
+			bodyId: () => "sim/ur5e",
+			notify: () => undefined,
+		} as never);
+		const result = await controller.persist("hello");
+		assert.ok(result !== null, "persist 应成功");
+		assert.equal(calls[0]?.method, "pi.input.persist", "仍在 bind 建 task");
+		assert.ok(!calls.some((c) => c.method === "pi.task.bind"),
+			"输入仍在逐条 bind——hello 会建 task");
+	});
+
+	it("persist 失败 → null（不投递）", async () => {
+		const { InputController } = await import("../src/native/input-controller.js");
+		const controller = new InputController({
+			call: async () => {
+				throw new Error("bridge down");
+			},
+			missionId: () => "mis_1",
+			sessionRef: () => "s1",
+			backendNativeId: () => "s1",
+			cwd: () => "/tmp",
+			bodyId: () => "",
+			notify: () => undefined,
+		} as never);
+		assert.equal(await controller.persist("hello"), null);
+	});
+
+	it("activeTaskId 查询 pi.kernel.active（同一事实源）", async () => {
+		const { InputController } = await import("../src/native/input-controller.js");
+		const controller = new InputController({
+			call: async (method: string) => {
+				if (method === "pi.kernel.active") {
+					return { task: { task_id: "task_42" } };
+				}
+				return {};
+			},
+			missionId: () => "mis_1",
+			sessionRef: () => "s1",
+			backendNativeId: () => "s1",
+			cwd: () => "/tmp",
+			bodyId: () => "",
+			notify: () => undefined,
+		} as never);
+		assert.equal(await controller.activeTaskId(), "task_42");
+	});
+});
+
+describe("P0-C workspace effect 钩子", () => {
+	it("bash 执行前触发 beforeEffect", async () => {
+		const { buildWorkspacePackTools } = await import("../src/tools/workspace-pack.js");
+		const { mkdtempSync } = await import("node:fs");
+		const { tmpdir } = await import("node:os");
+		const { join } = await import("node:path");
+		let ensured = 0;
+		const dir = mkdtempSync(join(tmpdir(), "p0c-"));
+		const tools = buildWorkspacePackTools({
+			root: dir,
+			mode: () => "SIMULATION",
+			bwrapPath: () => null,
+			allowUnsandboxedShell: () => true,
+			beforeEffect: async () => {
+				ensured += 1;
+			},
+		});
+		const bash = tools.find((t) => t.name === "bash");
+		await bash?.execute("c1", { command: "echo hi" },
+			new AbortController().signal, async () => {}, {} as never);
+		assert.equal(ensured, 1, "bash 未触发 ensure admission");
+	});
+});

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -322,10 +322,14 @@ def _chat_pi(home: Path, args: argparse.Namespace) -> int:
     from rosclaw.version_diag import (
         assert_installation_coherent,
         collect_diagnostics,
+        is_stamped_install,
     )
 
     try:
-        assert_installation_coherent(collect_diagnostics(home=home))
+        # 只约束带构建戳的安装产物；源码 checkout（无戳）不阻断
+        # ——开发树 python/TS 各自演进是常态。
+        if is_stamped_install():
+            assert_installation_coherent(collect_diagnostics(home=home))
     except SystemExit as exc:
         print(str(exc), file=sys.stderr)
         return 2

--- a/src/rosclaw/agentd/pi_bridge/context_lease.py
+++ b/src/rosclaw/agentd/pi_bridge/context_lease.py
@@ -162,9 +162,10 @@ def context_hash_of(envelope: Any) -> str:
 
     P0-5B：只覆盖稳定的具身事实（body/mode/revision/capabilities/
     task graph）。排除 generated_at/expires_at/hash（时间易变），
-    以及 pending_approvals/receipts/active_actions——它们是动作的
-    *结果*（建卡即在 envelope 里新增 pending），不是使上下文失效
-    的输入变化。
+    以及 pending_approvals/receipts/active_actions/workers——它们是
+    动作的*结果*（建卡/建任务即在 envelope 里新增条目），不是使
+    上下文失效的输入变化（P0-C 实证：首个 effectful call 建 task
+    → workers 新增 → 同回合 admission 误判 CONTEXT_HASH_MISMATCH）。
     """
     from rosclaw.contracts.pi.canonical import canonical_dumps
 
@@ -177,6 +178,7 @@ def context_hash_of(envelope: Any) -> str:
         "pending_approvals",
         "receipts",
         "active_actions",
+        "workers",
     ):
         payload.pop(volatile, None)
     # 八审总纲验证轮实测：turn_in_flight 是回合运行时标志（回合内

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -992,6 +992,54 @@ class PiBridgeServer:
                 stored += 1
             service._store.connection.commit()
             return {"ok": True, "stored": stored}
+        if method == "pi.input.persist":
+            # P0-C（0824 总纲 §6.1）：输入先落会话——不立即创建
+            # Task（问候/解释/只读查询 tasks=0）。持久化失败照样
+            # 阻断投递（HP1 输入丢失防线语义不变）。
+            kernel = service._task_kernel
+            record = kernel.persist_input(
+                mission_id=str(params.get("mission_id", "")),
+                session_ref=str(params.get("session_ref", "")),
+                message_id=str(params.get("message_id", "")),
+                text=str(params.get("text", "")),
+                force_new=bool(params.get("force_new", False)),
+            )
+            import hashlib as _hashlib  # noqa: F401
+
+            from rosclaw.contracts.agent.agent_event import AgentEventType
+
+            text = str(params.get("text", ""))
+            await service._events.append(
+                str(params.get("mission_id", "")),
+                AgentEventType.INPUT_PERSISTED,
+                {
+                    "message_id": str(params.get("message_id", "")),
+                    "text_sha256": _hashlib.sha256(text.encode()).hexdigest(),
+                    "bytes": len(text.encode()),
+                    "task_bound": False,
+                },
+                session_id=str(params.get("session_ref", "")),
+                model_visible=True,
+            )
+            return {"ok": True, "input": record}
+        if method == "pi.task.ensure_effect":
+            # P0-C（0824 总纲 §6.2）：首个 effectful call 的原子
+            # admission——以 session 最新未附着输入为动机建 task/
+            # 新 revision；已附着直接返回（不重复 bump）。
+            kernel = service._task_kernel
+            try:
+                result = kernel.ensure_task_for_effect(
+                    mission_id=str(params.get("mission_id", "")),
+                    session_ref=str(params.get("session_ref", "")),
+                    backend_native_id=str(params.get("backend_native_id", "")),
+                    cwd=str(params.get("cwd", "")),
+                    mode=str(params.get("mode", "SIMULATION")),
+                    body_id=str(params.get("body_id", "")),
+                    explicit_goal=str(params.get("explicit_goal", "")),
+                )
+            except ValueError as exc:
+                return {"ok": False, "error": str(exc), "code": "INPUT_MOTIVATION_MISSING"}
+            return {"ok": True, **result}
         if method == "pi.task.bind":
             # PR-H2（ADR-0012）：输入事务——用户消息先落账+绑定 root
             # task，再投递 Harness（幽灵执行防线的权威端）。
@@ -1101,6 +1149,13 @@ class PiBridgeServer:
             ]
             return {"ok": True, "task": task, "revisions": revisions,
                     "events": events}
+        if method == "pi.kernel.latest":
+            # P0-C：最近 task（含刚终态）——/activity /logs /artifacts。
+            task = service._task_kernel.latest_task_for(
+                str(params.get("mission_id", "")),
+                str(params.get("session_ref", "")),
+            )
+            return {"ok": True, "task": task}
         if method == "pi.kernel.active":
             # PR-H4：TurnGuard 用——当前 session 的活跃 task（无则 null）。
             task = service._task_kernel.active_task_for(

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -277,12 +277,13 @@ class PiToolDispatcher:
         """P0-C（0824 总纲 §6.2）：effectful wire 工具执行前的原子
         admission——缺动机输入诚实拒绝（INPUT_MOTIVATION_MISSING）。"""
         kernel = self._service._task_kernel
+        mission = self._service.get_mission(request.mission_id)
         kernel.ensure_task_for_effect(
             mission_id=request.mission_id,
             session_ref=request.pi_session_id,
             backend_native_id=request.pi_session_id,
             cwd="",
-            mode=request.mode or "SIMULATION",
+            mode=mission.mode.value if mission else "SIMULATION",
         )
 
     async def _dispatch(self, request: PiToolRequestV1) -> PiToolResultV1:

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -273,6 +273,18 @@ class PiToolDispatcher:
         # 5. 分发。
         return await self._dispatch(request)
 
+    def _ensure_task_for_effect(self, request: PiToolRequestV1) -> None:
+        """P0-C（0824 总纲 §6.2）：effectful wire 工具执行前的原子
+        admission——缺动机输入诚实拒绝（INPUT_MOTIVATION_MISSING）。"""
+        kernel = self._service._task_kernel
+        kernel.ensure_task_for_effect(
+            mission_id=request.mission_id,
+            session_ref=request.pi_session_id,
+            backend_native_id=request.pi_session_id,
+            cwd="",
+            mode=request.mode or "SIMULATION",
+        )
+
     async def _dispatch(self, request: PiToolRequestV1) -> PiToolResultV1:
         service = self._service
         name = request.tool_name
@@ -368,6 +380,7 @@ class PiToolDispatcher:
             )
         if name == "rosclaw_request_action":
             self._note_embodiment_use(request)
+            self._ensure_task_for_effect(request)
             return await self._request_action(request)
         if name == "rosclaw_task":
             self._note_embodiment_use(request)
@@ -377,6 +390,7 @@ class PiToolDispatcher:
         # PR-H5：统一执行入口 + operation 控制。
         if name == "rosclaw_execute":
             self._note_embodiment_use(request)
+            self._ensure_task_for_effect(request)
             return await self._execute(request)
         if name == "rosclaw_wait_operation":
             return await self._wait_operation(request)
@@ -390,6 +404,7 @@ class PiToolDispatcher:
         if name == "rosclaw_task_blocked":
             return await self._task_blocked(request)
         if name == "rosclaw_process_start":
+            self._ensure_task_for_effect(request)
             return await self._process_start(request)
         if name == "rosclaw_process_status":
             return await self._process_status(request)

--- a/src/rosclaw/storage/migrations/033_p0c_user_inputs.sql
+++ b/src/rosclaw/storage/migrations/033_p0c_user_inputs.sql
@@ -1,0 +1,16 @@
+-- P0-C（0824 总纲 §6.1/§19.P0-C）：Conversation/Task 分离。
+-- 每条输入先落 user_inputs（不立即创建 Task）；首个 effectful
+-- call 经 ensure_task_for_effect 原子建 task 并回写 task_id。
+CREATE TABLE IF NOT EXISTS user_inputs (
+    input_id TEXT PRIMARY KEY,
+    mission_id TEXT NOT NULL,
+    session_ref TEXT NOT NULL,
+    message_id TEXT NOT NULL UNIQUE,
+    text TEXT NOT NULL,
+    text_digest TEXT NOT NULL,
+    task_id TEXT,
+    delivery_state TEXT NOT NULL DEFAULT 'PERSISTED',
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_user_inputs_session
+    ON user_inputs(mission_id, session_ref, created_at);

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -119,6 +119,9 @@ class TaskKernel:
             ),
             text=explicit_goal or str(row["text"]),
             cwd=cwd, mode=mode, body_id=body_id,
+            # 任务 workspace = 调用方解析的工作根（与 pi.task.bind
+            # 同一语义——不传则回落 home/tasks/<id>/workspace）。
+            workspace_root=cwd,
             # /newtask：该输入被显式要求开新任务。
             force_new=(
                 row is not None and row["delivery_state"] == "FORCE_NEW"

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -46,6 +46,94 @@ class TaskKernel:
     # --------------------------------------------------------------
     # 输入事务（§9.3 Root Task 绑定算法）
     # --------------------------------------------------------------
+    def persist_input(
+        self, *, mission_id: str, session_ref: str, message_id: str,
+        text: str, force_new: bool = False,
+    ) -> dict[str, Any]:
+        """P0-C（0824 总纲 §6.1）：输入先落会话，不立即创建 Task。
+
+        message_id 幂等（重发/重放返回既有 input）；问候/解释/
+        只读查询永远只走这条路——tasks=0 直到首个 effectful call
+        或显式 /goal。"""
+        existing = self._conn.execute(
+            "SELECT * FROM user_inputs WHERE message_id = ?", (message_id,),
+        ).fetchone()
+        if existing is not None:
+            return dict(existing)
+        input_id = new_id("inp")
+        digest = hashlib.sha256(text.encode()).hexdigest()
+        state = "FORCE_NEW" if force_new else "PERSISTED"
+        self._conn.execute(
+            "INSERT INTO user_inputs (input_id, mission_id, session_ref, "
+            "message_id, text, text_digest, delivery_state, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (input_id, mission_id, session_ref, message_id, text,
+             f"sha256:{digest}", state, datetime.now(UTC).isoformat()),
+        )
+        return {
+            "input_id": input_id, "mission_id": mission_id,
+            "session_ref": session_ref, "message_id": message_id,
+            "text": text, "text_digest": f"sha256:{digest}",
+            "task_id": None, "delivery_state": "PERSISTED",
+        }
+
+    def ensure_task_for_effect(
+        self, *, mission_id: str, session_ref: str, backend_native_id: str,
+        cwd: str, mode: str = "SIMULATION", body_id: str = "",
+        explicit_goal: str = "",
+    ) -> dict[str, Any]:
+        """P0-C（0824 总纲 §6.2）：首个 effectful call 的原子 admission。
+
+        以 session 最新未附着输入为动机：未附着 → 建 task/新
+        revision（沿用 bind_message 的全部身份语义）并回写
+        input.task_id；已附着 → 直接返回该 task（同一动机输入的
+        连续 effectful call 不重复 bump revision）。"""
+        row = self._conn.execute(
+            "SELECT * FROM user_inputs WHERE mission_id = ? AND "
+            "session_ref = ? ORDER BY created_at DESC, rowid DESC LIMIT 1",
+            (mission_id, session_ref),
+        ).fetchone()
+        if row is None and not explicit_goal:
+            raise ValueError(
+                "INPUT_MOTIVATION_MISSING: 无持久化输入——effectful "
+                "call 缺少动机输入，不猜目标"
+            )
+        if row is not None and row["task_id"]:
+            task = self.get_task(str(row["task_id"]))
+            if task is not None:
+                return {
+                    "task_id": str(task["task_id"]),
+                    "revision": int(task["active_revision"]),
+                    "created_task": False,
+                    "replayed": False,
+                    "workspace_path": str(task["workspace_path"]),
+                    "state": str(task["state"]),
+                }
+        bound = self.bind_message(
+            mission_id=mission_id,
+            session_ref=session_ref,
+            backend_native_id=backend_native_id,
+            message_id=(
+                str(row["message_id"]) if row is not None
+                else f"goal_{new_id('msg')}"
+            ),
+            text=explicit_goal or str(row["text"]),
+            cwd=cwd, mode=mode, body_id=body_id,
+            # /newtask：该输入被显式要求开新任务。
+            force_new=(
+                row is not None and row["delivery_state"] == "FORCE_NEW"
+            ),
+        )
+        if row is not None:
+            self._conn.execute(
+                "UPDATE user_inputs SET task_id = ? WHERE message_id = ?",
+                (str(bound["task_id"]), str(row["message_id"])),
+            )
+        return bound
+
+    # --------------------------------------------------------------
+    # 输入事务（§9.3 Root Task 绑定算法）
+    # --------------------------------------------------------------
     def bind_message(
         self,
         *,
@@ -329,6 +417,18 @@ class TaskKernel:
         if state in TASK_TERMINAL:
             self._emit(task_id, "task.terminal",
                        {"state": state, "reason": reason[:200]})
+
+    def latest_task_for(self, mission_id: str, session_ref: str) -> dict | None:
+        """P0-C：session 最近 task（含刚终态）——/activity /logs
+        /artifacts 展示最近任务的活动账本（终态不抹掉历史）。"""
+        row = self._conn.execute(
+            "SELECT t.* FROM tasks t JOIN task_session_bindings b "
+            "ON b.task_id = t.task_id "
+            "WHERE t.mission_id = ? AND b.session_ref = ? "
+            "ORDER BY t.created_at DESC LIMIT 1",
+            (mission_id, session_ref),
+        ).fetchone()
+        return dict(row) if row else None
 
     def active_task_for(self, mission_id: str, session_ref: str) -> dict | None:
         row = self._conn.execute(

--- a/src/rosclaw/version_diag.py
+++ b/src/rosclaw/version_diag.py
@@ -180,6 +180,13 @@ def mixed_build_reason(diag: dict[str, Any]) -> str | None:
     )
 
 
+def is_stamped_install() -> bool:
+    """是否带构建戳的安装（CI wheel）。源码 checkout 无戳——
+    chat 门禁只约束安装产物（开发树 python/TS 各自演进是常态，
+    mixed 状态在 version --diagnostic 可见但不阻断）。"""
+    return (_pkg_root() / _STAMP_NAME).exists()
+
+
 def assert_installation_coherent(diag: dict[str, Any]) -> None:
     """chat 启动门禁：混合构建直接阻断（SystemExit）。"""
     reason = mixed_build_reason(diag)
@@ -221,6 +228,7 @@ def cmd_version(*, diagnostic: bool, as_json: bool,
 
 __all__ = [
     "assert_installation_coherent",
+    "is_stamped_install",
     "cmd_version",
     "collect_diagnostics",
     "eurdf_generation",

--- a/tests/agentd/test_hp1_input_gate_pty.py
+++ b/tests/agentd/test_hp1_input_gate_pty.py
@@ -151,11 +151,24 @@ class TestInputPersistedGate:
                 f"input.persisted({persisted_at}) 晚于首个模型请求"
                 f"({fake.fake.first_request_at})——输入门被破坏"
             )
-            # 一等列携带：session/task/revision/model_visible。
+            # 一等列携带：session/model_visible。P0-C（0824 总纲
+            # §6.1）：persist 不再逐条 bind task——input.persisted
+            # 不再携带 task_id（任务在首个 effectful call 才附着，
+            # 可经 user_inputs.task_id 追溯）；纯对话输入（你好）
+            # 必须保持 tasks=0。
             assert persisted[2], "input.persisted 缺 session_id 列"
-            assert persisted[3], "input.persisted 缺 task_id 列"
-            assert persisted[4] is not None
-            assert persisted[5] == 1
+            assert persisted[5] == 1, "input.persisted 缺 model_visible 列"
+            db2 = sqlite3.connect(home / "agentd" / "missions.db")
+            try:
+                task_count = db2.execute(
+                    "SELECT COUNT(*) FROM tasks"
+                ).fetchone()[0]
+            finally:
+                db2.close()
+            assert task_count == 0, (
+                "P0-C 契约破坏：纯对话输入创建了 Task（问候/解释/"
+                "只读查询必须 tasks=0）"
+            )
             session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
             session.proc.wait(timeout=30)
         finally:

--- a/tests/agentd/test_p0c_conversation_task_split.py
+++ b/tests/agentd/test_p0c_conversation_task_split.py
@@ -1,0 +1,164 @@
+"""P0-C 红测试（0824 总纲 §19.P0-C）：Conversation/Task 分离与自动 admission。
+
+红测试先行——persist_input/ensure_task_for_effect 不存在时必须红。
+
+验收（文档原文）：
+- `hello` 后 tasks=0；
+- 提问状态仍 tasks=0；
+- 第一次 SIM action 前 task 已持久化；
+- 输入丢失/重复均不会重复执行。
+
+§6.3 Revision 规则：活跃任务中的 steer/follow-up 同 task 新
+revision；同一输入的多个 effectful call 不重复 bump。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _kernel(home: Path):
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return TaskKernel(conn, home), conn
+
+
+def _task_count(conn) -> int:
+    return int(conn.execute("SELECT COUNT(*) AS n FROM tasks").fetchone()["n"])
+
+
+class TestPersistOnlyInputs:
+    def test_hello_creates_no_task(self, tmp_path: Path) -> None:
+        kernel, conn = _kernel(tmp_path)
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="hello",
+        )
+        assert _task_count(conn) == 0, "问候创建了 Task——职责错位"
+
+    def test_status_query_creates_no_task(self, tmp_path: Path) -> None:
+        kernel, conn = _kernel(tmp_path)
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="现在进度如何？",
+        )
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_2", text="能力列表给我看看",
+        )
+        assert _task_count(conn) == 0
+
+    def test_persist_input_idempotent(self, tmp_path: Path) -> None:
+        """同一 message_id 重复 persist（输入重发/重放）只落一次——
+        输入丢失/重复均不会重复执行。"""
+        kernel, conn = _kernel(tmp_path)
+        first = kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="画五角星",
+        )
+        second = kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="画五角星",
+        )
+        assert first["input_id"] == second["input_id"]
+        rows = conn.execute(
+            "SELECT COUNT(*) AS n FROM user_inputs WHERE message_id='msg_1'"
+        ).fetchone()
+        assert int(rows["n"]) == 1
+
+
+class TestEnsureTaskForEffect:
+    def test_first_effectful_call_creates_task(self, tmp_path: Path) -> None:
+        """首个 effectful call 前 task 已持久化（root_goal 来自动机
+        输入）。"""
+        kernel, conn = _kernel(tmp_path)
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="帮我用机械臂画一个五角星",
+        )
+        result = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path),
+        )
+        assert result["task_id"], "effectful call 未原子建 task"
+        task = kernel.get_task(result["task_id"])
+        assert "五角星" in str(task["root_goal"])
+        assert int(task["active_revision"]) == 1
+
+    def test_effectful_calls_same_input_no_revision_bump(
+        self, tmp_path: Path
+    ) -> None:
+        """同一动机输入的连续 effectful call（plan→simulate→render）
+        共享 task revision——不得每次调用 bump。"""
+        kernel, _conn = _kernel(tmp_path)
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="画五角星",
+        )
+        first = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path),
+        )
+        second = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path),
+        )
+        assert first["task_id"] == second["task_id"]
+        assert first["revision"] == second["revision"] == 1, (
+            "同一输入的 effectful 链被重复 bump revision"
+        )
+
+    def test_new_input_during_active_task_revises(
+        self, tmp_path: Path
+    ) -> None:
+        """活跃任务中的新输入（steer/follow-up）→ 同 task 新 revision。"""
+        kernel, _conn = _kernel(tmp_path)
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="画五角星",
+        )
+        first = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path),
+        )
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_2", text="画大一点",
+        )
+        second = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path),
+        )
+        assert second["task_id"] == first["task_id"]
+        assert second["revision"] == 2
+
+    def test_ensure_without_input_fails_honest(self, tmp_path: Path) -> None:
+        """无任何持久化输入时的 effectful call——诚实拒绝（无动机
+        输入不猜目标）。"""
+        kernel, _conn = _kernel(tmp_path)
+        with pytest.raises(ValueError, match="INPUT"):
+            kernel.ensure_task_for_effect(
+                mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+                cwd=str(tmp_path),
+            )
+
+    def test_explicit_goal_begin(self, tmp_path: Path) -> None:
+        """/goal 提前创建 TaskSpec——不等首个 effectful call。"""
+        kernel, _conn = _kernel(tmp_path)
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="/goal 画一个五角星",
+        )
+        result = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path), explicit_goal="画一个五角星",
+        )
+        task = kernel.get_task(result["task_id"])
+        assert task is not None

--- a/tests/agentd/test_pi_tool_bridge.py
+++ b/tests/agentd/test_pi_tool_bridge.py
@@ -94,6 +94,12 @@ async def _setup(tmp_path: Path):
     bindings.acquire_lease(
         mission_id=mission.mission_id, pi_session_id="pi_1", owner_pid=1, owner_uid=1000
     )
+    # P0-C：effectful admission 的动机输入——与产品流一致（输入
+    # 先 persist，再有工具调用）。
+    service._task_kernel.persist_input(
+        mission_id=mission.mission_id, session_ref="pi_1",
+        message_id="msg_setup", text="tool bridge 测试目标",
+    )
     _register_sim_action_capability(service)
     return service, mission
 


### PR DESCRIPTION
## 范围（0824 总纲 P0-C）：Conversation/Task 分离与自动 admission

0824 判定："每条用户消息都 bind 到 root task" 让 hello/追问/状态
查询和真正目标混在一个 revision 链里。

- **bind_message 拆 persist_input + ensure_task_for_effect**
  （migration 033 `user_inputs`：message_id 幂等 + text_digest +
  task_id 回写 + FORCE_NEW 标记）；hello/解释/只读查询 **tasks=0**——
  首个 effectful call 或显式 /goal 才原子建 task；
- **ensure 语义**：session 最新未附着输入为动机；已附着直接返回
  （同一动机输入的连续 effectful call **不重复 bump revision**）；
  新输入走 bind_message 全部身份语义（steer = 同 task 新
  revision）；无动机输入诚实 `INPUT_MOTIVATION_MISSING`；
- **接线**：`pi.input.persist` + `pi.task.ensure_effect` 端点；
  dispatch 对 rosclaw_execute/rosclaw_request_action/
  rosclaw_process_start 执行前 ensure；workspace bash/write/edit
  经 `beforeEffect` 钩子 ensure；TS 输入流 persist-only
  （失败不投递，HP1 防线不变）；
- `/activity` `/logs` `/artifacts` 改查 `pi.kernel.latest`
  （含刚终态——终态不抹掉刚完成的任务账本）；`/done` 仍查
  active；
- P0-5 混合构建门禁收窄到带戳安装产物（源码 checkout 不阻断
  ——PTY 旅程实证被自家门禁拦下）；
- hp1 契约随总纲更新：persist 不再强制 task_id/revision 列，
  改断言**纯对话 tasks=0**（0824 §6.1 验收原文）。

验收对齐（§19.P0-C）：hello 后 tasks=0 ✓（hp1 PTY 实证）；
状态查询仍 0 ✓；第一次 SIM action 前 task 已持久化 ✓；
输入丢失/重复不重复执行 ✓（message_id 幂等）。

## 验证

红→绿：kernel 8 红 → 8/8；TS 4 红 → 4/4 + 全套 157/157；
PTY 旅程全绿（product / h2 / h8 / wp1 / n5d / nine1 / hp1）；
ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)