### PR TITLE
feat(skill): Skill Runtime 2.0 PR-2——统一 Catalog 与确定性 CapabilityResolver

### DIFF
--- a/src/rosclaw/skill/catalog_service.py
+++ b/src/rosclaw/skill/catalog_service.py
@@ -1,0 +1,126 @@
+"""Unified skill catalog service (Skill Runtime 2.0, doc §9).
+
+One entry point over Builtin / Installed / Official / Workspace sources.
+Search is fully deterministic (doc §6): intent-phrase match, tag match,
+description token overlap, then trust / evidence / installed bonuses —
+no LLM required to find a skill.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+from rosclaw.skill.sources import (
+    BuiltinCatalogSource,
+    CatalogHit,
+    InstalledCatalogSource,
+    OfficialCatalogSource,
+    WorkspaceCatalogSource,
+)
+
+logger = logging.getLogger("rosclaw.skill.catalog_service")
+
+_INTENT_MATCH_SCORE = 100.0
+_VERIFIED_STATUSES = {
+    "official_verified",
+    "host_matrix_verified",
+    "sandbox_validated",
+    "hardware_verified",
+    "field_verified",
+}
+
+
+class SkillCatalogService:
+    """Unified, deterministic search across all skill sources."""
+
+    def __init__(self, sources: list) -> None:
+        self._sources = list(sources)
+
+    @classmethod
+    def default(cls, home: Path | None = None) -> SkillCatalogService:
+        """The standard four-source catalog (doc §9)."""
+        return cls(
+            [
+                InstalledCatalogSource(home),
+                BuiltinCatalogSource(),
+                OfficialCatalogSource(home),
+                WorkspaceCatalogSource(),
+            ]
+        )
+
+    def search(self, query: str, context: dict | None = None, limit: int = 20) -> list[CatalogHit]:
+        """Rank all sources' entries against ``query`` (deterministic, doc §6)."""
+        hits = self._collect()
+        for hit in hits:
+            hit.score = self._score(query, hit)
+        hits = [h for h in hits if h.score > 0]
+        hits.sort(key=lambda h: (-h.score, not h.official, h.name))
+        return hits[:limit]
+
+    def get(self, name: str) -> CatalogHit | None:
+        """Exact-name lookup across all sources (installed overlay applied)."""
+        for hit in self._collect():
+            if hit.name == name:
+                return hit
+        return None
+
+    def _collect(self) -> list[CatalogHit]:
+        """Gather entries from every source; a broken source is skipped.
+
+        Entries with the same name are merged: ``installed``/``official``
+        flags overlay so an installed official skill reads as both.
+        """
+        merged: dict[str, CatalogHit] = {}
+        for source in self._sources:
+            try:
+                entries = source.entries()
+            except Exception as exc:  # noqa: BLE001 — source isolation
+                logger.info("catalog source %s unavailable: %s", source.name, exc)
+                continue
+            for hit in entries:
+                existing = merged.get(hit.name)
+                if existing is None:
+                    merged[hit.name] = hit
+                    continue
+                existing.installed = existing.installed or hit.installed
+                existing.official = existing.official or hit.official
+                if hit.source == "installed":
+                    # Local availability wins as the representative entry,
+                    # but keep official trust/evidence metadata.
+                    hit.official = existing.official
+                    hit.verification_status = hit.verification_status or existing.verification_status
+                    merged[hit.name] = hit
+        return list(merged.values())
+
+    @staticmethod
+    def _score(query: str, hit: CatalogHit) -> float:
+        q = query.lower().strip()
+        score = 0.0
+        # Intent phrase match (multilingual): phrase contained in the query.
+        for phrases in hit.intents.values():
+            if any(p.lower() and p.lower() in q for p in phrases):
+                score += _INTENT_MATCH_SCORE
+                break
+        # Name match (e.g. the user typed the skill name).
+        name_tokens = set(re.findall(r"[a-z0-9]+", hit.name.lower()))
+        q_tokens = set(re.findall(r"[a-z0-9]+", q))
+        if name_tokens and name_tokens <= q_tokens:
+            score += 50.0
+        # Tag match: token hit or CJK substring.
+        matched_tags = [
+            t for t in hit.tags if t.lower() in q_tokens or (t and t.lower() in q)
+        ]
+        score += 10.0 * len(matched_tags)
+        # Description token overlap.
+        desc_tokens = set(re.findall(r"[a-z0-9]+", hit.description.lower()))
+        score += float(len(q_tokens & desc_tokens))
+        # Trust / evidence / local availability bonuses.
+        if hit.official:
+            score += 15.0
+        if hit.verification_status in _VERIFIED_STATUSES:
+            score += 10.0
+        if hit.installed:
+            score += 5.0
+        return score

--- a/src/rosclaw/skill/cli.py
+++ b/src/rosclaw/skill/cli.py
@@ -449,7 +449,15 @@ def cmd_skill_rollback(args: argparse.Namespace) -> int:
 
 
 def cmd_skill_search(args: argparse.Namespace) -> int:
-    """List builtin skills and local skill-hub packages."""
+    """Search the unified catalog, or (no query) list builtin + local skills.
+
+    Skill Runtime 2.0 (doc §10): with a query this searches across
+    builtin/installed/official/workspace sources — the official
+    ``ros-claw/skills`` registry included (fetched once, then cached).
+    """
+    query = getattr(args, "query", None)
+    if query:
+        return _cmd_skill_search_catalog(args, query)
     builtins = list_builtin_skills()
     registry = SkillLocalRegistry()
     local = registry.list_skills()
@@ -462,6 +470,37 @@ def cmd_skill_search(args: argparse.Namespace) -> int:
     print("[ROSClaw] Local skill-hub packages")
     for s in local:
         print(f"  {s.get('name', 'unknown')}")
+    return 0
+
+
+def _cmd_skill_search_catalog(args: argparse.Namespace, query: str) -> int:
+    from rosclaw.skill.catalog_service import SkillCatalogService
+
+    hits = SkillCatalogService.default().search(query)
+    if args.json:
+        print(
+            json.dumps(
+                {"results": [h.to_dict() for h in hits]}, indent=2, ensure_ascii=False
+            )
+        )
+        return 0
+    print(f'[ROSClaw] Skill catalog results for "{query}"')
+    if not hits:
+        print("  (no matching skills)")
+        return 0
+    for h in hits:
+        badges = []
+        if h.official:
+            badges.append("official")
+        if h.installed:
+            badges.append("installed")
+        badge = f"  [{', '.join(badges)}]" if badges else ""
+        version = f"@{h.version}" if h.version else ""
+        print(f"  {h.name}{version}{badge}")
+        if h.description:
+            print(f"      {h.description}")
+        status = h.verification_status or "unverified"
+        print(f"      source={h.source} installed={'yes' if h.installed else 'no'} status={status}")
     return 0
 
 
@@ -526,7 +565,16 @@ def cmd_skill_inspect(args: argparse.Namespace) -> int:
 
 
 def add_skill_hub_parsers(skill_subparsers: Any) -> None:
-    search_parser = skill_subparsers.add_parser("search", help="Search builtin and local skills")
+    search_parser = skill_subparsers.add_parser(
+        "search",
+        help="Search skills across builtin/installed/official/workspace catalogs",
+    )
+    search_parser.add_argument(
+        "query",
+        nargs="?",
+        default=None,
+        help="Intent or keywords (e.g. \"install ros2\"); omit to list builtin+local",
+    )
     search_parser.add_argument("--json", action="store_true", help="Output as JSON")
     search_parser.set_defaults(func=cmd_skill_search)
 

--- a/src/rosclaw/skill/resolver.py
+++ b/src/rosclaw/skill/resolver.py
@@ -1,0 +1,128 @@
+"""Deterministic capability resolver (Skill Runtime 2.0, doc §4/§5/§6).
+
+The agent expresses an intent ("帮我安装 ROS2"); the resolver maps it to a
+capability and a concrete skill implementation — without the agent ever
+guessing a skill name, and without requiring an LLM. Ambiguous rerank by
+a model may be layered on top later; the base path stays deterministic.
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from rosclaw.skill.catalog_service import SkillCatalogService
+from rosclaw.skill.sources import CatalogHit
+
+_INTENT_MATCH_SCORE = 100.0
+
+
+@dataclass
+class CapabilityResolution:
+    """Result of resolving a natural-language intent (doc §5)."""
+
+    capability: str | None
+    selected_skill: str | None
+    confidence: float
+    source: str | None = None
+    installed: bool = False
+    compatible: bool = False
+    reasons: list[str] = field(default_factory=list)
+    candidates: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "capability": self.capability,
+            "selected_skill": self.selected_skill,
+            "confidence": round(self.confidence, 2),
+            "source": self.source,
+            "installed": self.installed,
+            "compatible": self.compatible,
+            "reasons": list(self.reasons),
+            "candidates": self.candidates,
+        }
+
+
+def detect_host_context() -> dict[str, str]:
+    """Best-effort host facts for compatibility checks (doc §34 light)."""
+    os_id, os_version = "", ""
+    try:
+        for line in Path("/etc/os-release").read_text(encoding="utf-8").splitlines():
+            if line.startswith("ID="):
+                os_id = line.split("=", 1)[1].strip().strip('"')
+            elif line.startswith("VERSION_ID="):
+                os_version = line.split("=", 1)[1].strip().strip('"')
+    except OSError:
+        pass
+    machine = platform.machine().lower()
+    arch = {"x86_64": "amd64", "aarch64": "arm64"}.get(machine, machine)
+    return {"os": os_id, "os_version": os_version, "arch": arch}
+
+
+class CapabilityResolver:
+    """intent → capability → skill implementation (deterministic)."""
+
+    def __init__(self, catalog: SkillCatalogService | None = None) -> None:
+        self._catalog = catalog or SkillCatalogService.default()
+
+    def resolve(self, intent: str, context: dict | None = None) -> CapabilityResolution:
+        host = context or detect_host_context()
+        hits = self._catalog.search(intent)
+        candidates = [
+            {"name": h.name, "score": round(h.score, 2), "source": h.source}
+            for h in hits[:5]
+        ]
+        for hit in hits:
+            compatible, compat_reasons = self._check_compatibility(hit, host)
+            if hit.score < _INTENT_MATCH_SCORE:
+                # Below intent match: never auto-select (doc §6 determinism).
+                break
+            if not compatible:
+                continue
+            reasons = ["intent_match", *compat_reasons]
+            if hit.official:
+                reasons.append("official")
+            if hit.verification_status:
+                reasons.append(hit.verification_status)
+            if hit.installed:
+                reasons.append("installed")
+            return CapabilityResolution(
+                capability=hit.capability_id,
+                selected_skill=hit.name,
+                confidence=0.98,
+                source=hit.source,
+                installed=hit.installed,
+                compatible=True,
+                reasons=reasons,
+                candidates=candidates,
+            )
+        # Nothing selectable: report the best-effort confidence honestly.
+        best = hits[0].score if hits else 0.0
+        return CapabilityResolution(
+            capability=None,
+            selected_skill=None,
+            confidence=min(0.89, best / 200.0),
+            compatible=False,
+            reasons=["no_intent_match"] if not hits else ["below_selection_threshold"],
+            candidates=candidates,
+        )
+
+    @staticmethod
+    def _check_compatibility(hit: CatalogHit, host: dict[str, str]) -> tuple[bool, list[str]]:
+        compat = hit.compatibility or {}
+        reasons: list[str] = []
+        os_list = [str(o).lower() for o in compat.get("os", []) or []]
+        if os_list:
+            if host.get("os", "").lower() not in os_list:
+                return False, [f"os_{host.get('os', 'unknown')}_unsupported"]
+            reasons.append(f"{host['os']}_{host.get('os_version', '')}_supported")
+        arch_list = [str(a).lower() for a in compat.get("architectures", []) or []]
+        if arch_list:
+            host_arch = host.get("arch", "").lower()
+            aliases = {host_arch, re.sub(r"^(x86_64)$", "amd64", host_arch)}
+            if not aliases & set(arch_list):
+                return False, [f"arch_{host_arch}_unsupported"]
+            reasons.append(f"{host_arch}_supported")
+        return True, reasons

--- a/src/rosclaw/skill/sources.py
+++ b/src/rosclaw/skill/sources.py
@@ -1,0 +1,312 @@
+"""Skill catalog sources (Skill Runtime 2.0, doc §9/§10).
+
+Four unified sources feed the ``SkillCatalogService``:
+
+- ``BuiltinCatalogSource``   — in-package skills (``rosclaw.skill.builtins``)
+- ``InstalledCatalogSource`` — skills installed into ``$ROSCLAW_HOME/skills``
+- ``OfficialCatalogSource``  — the official ``ros-claw/skills`` registry,
+  fetched once and cached at ``$ROSCLAW_HOME/cache/skills/catalog.json``
+  (offline falls back to the cache)
+- ``WorkspaceCatalogSource`` — project-local ``./skills/*/skill.yaml``
+
+A source that fails (e.g. network down with no cache) is skipped by the
+service — one broken source must never kill the whole catalog.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import urllib.error
+import urllib.request
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from rosclaw.firstboot.workspace import get_rosclaw_home
+
+logger = logging.getLogger("rosclaw.skill.sources")
+
+DEFAULT_OFFICIAL_REGISTRY_URL = (
+    "https://raw.githubusercontent.com/ros-claw/skills/main/registry/skills.json"
+)
+REGISTRY_URL_ENV = "ROSCLAW_SKILLS_REGISTRY_URL"
+_FETCH_TIMEOUT = 15.0
+
+
+class CatalogSourceError(Exception):
+    """A catalog source could not produce entries (and has no cache)."""
+
+
+@dataclass
+class CatalogHit:
+    """One catalog entry, normalized across sources."""
+
+    name: str  # namespaced ("ros-claw/ros_install") or bare builtin name
+    version: str = ""
+    description: str = ""
+    display_name: str = ""
+    source: str = "official"  # builtin | installed | official | workspace
+    official: bool = False
+    installable: bool = False
+    installed: bool = False
+    verification_status: str = ""
+    tags: list[str] = field(default_factory=list)
+    capability_id: str | None = None
+    intents: dict[str, list[str]] = field(default_factory=dict)
+    compatibility: dict[str, Any] = field(default_factory=dict)
+    score: float = 0.0
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "description": self.description,
+            "display_name": self.display_name,
+            "source": self.source,
+            "official": self.official,
+            "installable": self.installable,
+            "installed": self.installed,
+            "verification_status": self.verification_status,
+            "tags": list(self.tags),
+            "capability_id": self.capability_id,
+            "score": round(self.score, 2),
+        }
+
+
+class BuiltinCatalogSource:
+    """In-package builtin skills (always available, T0 trust)."""
+
+    name = "builtin"
+
+    def entries(self) -> list[CatalogHit]:
+        from rosclaw.skill.builtins import list_builtin_skills
+
+        hits = []
+        for info in list_builtin_skills():
+            hits.append(
+                CatalogHit(
+                    name=info["name"],
+                    version=str(info.get("version", "")),
+                    description=str(info.get("description", "")),
+                    display_name=str(info.get("display_name", "")),
+                    source="builtin",
+                    official=True,
+                    installable=False,
+                    installed=True,  # builtins ship with the package
+                    verification_status="builtin",
+                    raw=info,
+                )
+            )
+        return hits
+
+
+class InstalledCatalogSource:
+    """Skills installed into ``$ROSCLAW_HOME/skills`` (lockfile + legacy hub)."""
+
+    name = "installed"
+
+    def __init__(self, home: Path | None = None) -> None:
+        self._home = home
+
+    def _resolve_home(self) -> Path:
+        return self._home or get_rosclaw_home()
+
+    def entries(self) -> list[CatalogHit]:
+        home = self._resolve_home()
+        hits: list[CatalogHit] = []
+        lockfile = home / "skills" / "installed.lock.json"
+        if lockfile.exists():
+            try:
+                data = json.loads(lockfile.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning("installed.lock.json unreadable: %s", exc)
+                data = {}
+            for name, entry in data.items():
+                version = str(entry.get("version", ""))
+                manifest = self._read_manifest(home, name, version)
+                hits.append(
+                    CatalogHit(
+                        name=name,
+                        version=version,
+                        description=manifest.get("description", ""),
+                        source="installed",
+                        official=bool(entry.get("trust", "").startswith("official")),
+                        installable=False,
+                        installed=True,
+                        verification_status=str(entry.get("verification_status", "")),
+                        tags=manifest.get("tags", []),
+                        capability_id=manifest.get("capability_id"),
+                        intents=manifest.get("intents", {}),
+                        compatibility=manifest.get("compatibility", {}),
+                        raw=entry,
+                    )
+                )
+        return hits
+
+    @staticmethod
+    def _read_manifest(home: Path, name: str, version: str) -> dict[str, Any]:
+        """Best-effort manifest read for an installed skill (tolerates v1/v2)."""
+        manifest_path = home / "skills" / name / version / "skill.yaml"
+        if not manifest_path.exists():
+            return {}
+        try:
+            import yaml
+
+            data = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:  # noqa: BLE001 — catalog must stay robust
+            logger.warning("installed manifest unreadable %s: %s", manifest_path, exc)
+            return {}
+        metadata = data.get("metadata", {}) or {}
+        capability = data.get("capability", {}) or {}
+        return {
+            "description": str(metadata.get("description", "")),
+            "tags": list(metadata.get("tags", []) or []),
+            "capability_id": capability.get("id"),
+            "intents": capability.get("intents", {}) or {},
+            "compatibility": data.get("compatibility", {}) or {},
+        }
+
+
+class OfficialCatalogSource:
+    """The official ``ros-claw/skills`` registry with local cache (doc §10).
+
+    First use fetches the registry into ``$ROSCLAW_HOME/cache/skills/
+    catalog.json``; when the network is unavailable the cache is used.
+    Registry signature verification lands with the installer (PR-3, doc §13).
+    """
+
+    name = "official"
+
+    def __init__(
+        self,
+        home: Path | None = None,
+        registry_url: str | None = None,
+        fetch_timeout: float = _FETCH_TIMEOUT,
+    ) -> None:
+        self._home = home
+        self._registry_url = registry_url
+        self._fetch_timeout = fetch_timeout
+
+    def _resolve_home(self) -> Path:
+        return self._home or get_rosclaw_home()
+
+    def _resolve_url(self) -> str:
+        return (
+            self._registry_url
+            or os.environ.get(REGISTRY_URL_ENV)
+            or DEFAULT_OFFICIAL_REGISTRY_URL
+        )
+
+    @property
+    def cache_file(self) -> Path:
+        return self._resolve_home() / "cache" / "skills" / "catalog.json"
+
+    def entries(self) -> list[CatalogHit]:
+        payload = self._load_payload()
+        hits = []
+        for raw in payload.get("skills", []):
+            capability = raw.get("capability", {}) or {}
+            hits.append(
+                CatalogHit(
+                    name=str(raw.get("name", "")),
+                    version=str(raw.get("version", "")),
+                    description=str(raw.get("description", "")).strip(),
+                    display_name=str(raw.get("display_name", "")),
+                    source="official",
+                    official=bool(raw.get("official", False)),
+                    installable=bool(raw.get("installable", False)),
+                    installed=False,  # overlay happens in the service merge
+                    verification_status=str(raw.get("verification_status", "")),
+                    tags=list(raw.get("tags", []) or []),
+                    capability_id=capability.get("id"),
+                    intents=capability.get("intents", {}) or {},
+                    compatibility=raw.get("compatibility", {}) or {},
+                    raw=raw,
+                )
+            )
+        return [h for h in hits if h.name]
+
+    def _load_payload(self) -> dict[str, Any]:
+        url = self._resolve_url()
+        try:
+            text = self._fetch(url)
+        except CatalogSourceError:
+            cache = self.cache_file
+            if cache.exists():
+                logger.info("official registry unreachable; using cache %s", cache)
+                return json.loads(cache.read_text(encoding="utf-8"))
+            raise
+        payload = json.loads(text)
+        self._write_cache(text)
+        return payload
+
+    def _fetch(self, url: str) -> str:
+        try:
+            with urllib.request.urlopen(url, timeout=self._fetch_timeout) as resp:
+                return resp.read().decode("utf-8")
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            raise CatalogSourceError(f"official registry fetch failed: {exc}") from exc
+
+    def _write_cache(self, text: str) -> None:
+        cache = self.cache_file
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write: no half-written cache may be served later.
+        fd, tmp = tempfile.mkstemp(dir=cache.parent, prefix=".catalog-", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(text)
+            os.replace(tmp, cache)
+        except OSError:
+            with suppress(OSError):
+                os.unlink(tmp)
+            raise
+
+
+class WorkspaceCatalogSource:
+    """Project-local skills under ``./skills/*/skill.yaml`` (T4 local_dev)."""
+
+    name = "workspace"
+
+    def __init__(self, workspace_dir: Path | None = None) -> None:
+        self._dir = workspace_dir
+
+    def entries(self) -> list[CatalogHit]:
+        base = self._dir or (Path.cwd() / "skills")
+        if not base.is_dir():
+            return []
+        hits = []
+        for manifest_path in sorted(base.glob("*/skill.yaml")):
+            try:
+                import yaml
+
+                data = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+            except Exception as exc:  # noqa: BLE001 — skip broken manifests
+                logger.warning("workspace manifest unreadable %s: %s", manifest_path, exc)
+                continue
+            metadata = data.get("metadata", {}) or {}
+            capability = data.get("capability", {}) or {}
+            name = metadata.get("name", manifest_path.parent.name)
+            namespace = metadata.get("namespace")
+            hits.append(
+                CatalogHit(
+                    name=f"{namespace}/{name}" if namespace else str(name),
+                    version=str(metadata.get("version", "")),
+                    description=str(metadata.get("description", "")),
+                    source="workspace",
+                    official=False,
+                    installable=False,
+                    installed=True,
+                    verification_status="local_dev",
+                    tags=list(metadata.get("tags", []) or []),
+                    capability_id=capability.get("id"),
+                    intents=capability.get("intents", {}) or {},
+                    compatibility=data.get("compatibility", {}) or {},
+                    raw={"path": str(manifest_path.parent)},
+                )
+            )
+        return hits

--- a/tests/skill/test_official_catalog.py
+++ b/tests/skill/test_official_catalog.py
@@ -1,14 +1,7 @@
-"""PR-1 RED — the official catalog must be a real runtime source (doc §9/§10).
+"""PR-2 GREEN — the official catalog is a real runtime source (doc §9/§10).
 
-Today ``rosclaw skill search`` only lists builtin + local-hub skills, does
-not accept a query argument, and never consults the official
-``ros-claw/skills`` registry — even though that registry marks
-``ros-claw/ros_install`` as ``official`` and ``installable``. Catalog
-existing ≠ runtime knowing the catalog. These tests pin the PR-2 contract
-(Unified Catalog + ``SkillCatalogService``).
-
-xfail is strict: when PR-2 lands and a test passes, the suite fails loudly
-until the mark is removed.
+(Was PR-1 RED: ``skill search`` had no query and never consulted the
+official ``ros-claw/skills`` registry. PR-2 wires the unified catalog.)
 """
 
 from __future__ import annotations
@@ -18,12 +11,7 @@ import json
 
 import pytest
 
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    reason="RED (skill-runtime-2.0 PR-1): official catalog not wired; unmark in PR-2",
-)
-
-from rosclaw.skill.cli import add_skill_hub_parsers, cmd_skill_search  # noqa: E402
+from rosclaw.skill.cli import add_skill_hub_parsers, cmd_skill_search
 
 
 def _search_cli(capsys: pytest.CaptureFixture[str], *argv: str) -> tuple[int, str]:

--- a/tests/skill/test_skill_resolver.py
+++ b/tests/skill/test_skill_resolver.py
@@ -1,22 +1,13 @@
-"""PR-1 RED — deterministic CapabilityResolver (doc §4/§5/§6).
+"""PR-2 GREEN — deterministic CapabilityResolver (doc §4/§5/§6).
 
-The agent must never have to guess a skill name, and resolution must work
-without an LLM: intent → capability → skill implementation, ranked by
-deterministic signals (intent match, compatibility, trust, evidence).
-These tests pin the PR-2 contract.
+The agent never guesses a skill name, and resolution works without an
+LLM: intent → capability → skill implementation, ranked by deterministic
+signals (intent match, compatibility, trust, evidence).
 
-Imports of the not-yet-existing modules live inside test bodies so the
-suite collects cleanly and each test fails RED (xfail strict) until PR-2.
+(Was PR-1 RED; PR-2 implements ``rosclaw.skill.resolver``.)
 """
 
 from __future__ import annotations
-
-import pytest
-
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    reason="RED (skill-runtime-2.0 PR-1): CapabilityResolver missing; unmark in PR-2",
-)
 
 
 def _resolver():


### PR DESCRIPTION
叠在 #431（PR-1 红测试）之上；#431 合并后会自动/手动 retarget 到 main。

## 内容（rosclaw_skill优化.md §44）

- **`sources.py`** — 四源统一 `CatalogHit`：Builtin / Installed / Official / Workspace。官方 `ros-claw/skills` registry 首次拉取缓存到 `$ROSCLAW_HOME/cache/skills/catalog.json`，**离线回退缓存**（§10）；单源故障隔离。
- **`catalog_service.py`** — `SkillCatalogService.default()` 统一搜索；**确定性打分**（§6：intent 短语 + tag + 描述 token + trust/evidence/installed 加成），不依赖 LLM；同名条目跨源合并。
- **`resolver.py`** — `CapabilityResolver`：intent → capability → skill 实现（§4/§5），兼容性对照宿主机 `/etc/os-release` + arch。
- **CLI** — `rosclaw skill search "install ros2"` 真正命中 `ros-claw/ros_install`；无 query 时保持原有 builtin+local 列表行为（既有测试不动）。

## 红→绿

摘除 `test_official_catalog.py` / `test_skill_resolver.py` 共 9 项 `xfail(strict)` —— 全部转绿。

## 验证

```
tests/skill + tests/hostops + tests/mcp：247 passed, 27 xfailed（剩余属 PR-3..6）
ruff: All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)