### PR TITLE
feat(skill): Skill Runtime 2.0 PR-4——SkillLoader 激活桥 + 统一 SkillService

### DIFF
--- a/src/rosclaw/skill/loader.py
+++ b/src/rosclaw/skill/loader.py
@@ -1,0 +1,89 @@
+"""Skill activation: bridge installed packages into the runtime (doc §14).
+
+The two registries keep their distinct responsibilities:
+
+- ``SkillLocalRegistry`` / ``installed.lock.json`` = **InstalledSkillIndex**
+  (persistent, on disk)
+- ``SkillManager.SkillRegistry`` = **ActiveRuntimeRegistry**
+  (in-memory, executable)
+
+``SkillLoader`` is the missing link: at startup it converts installed
+skill packages into runtime entries so a freshly installed official skill
+is visible to the executor — and survives runtime restarts because the
+source of truth is on disk, not in memory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import yaml
+
+from rosclaw.firstboot.workspace import get_rosclaw_home
+from rosclaw.skill_manager.registry import SkillEntry, SkillRegistry
+
+logger = logging.getLogger("rosclaw.skill.loader")
+
+
+class SkillLoader:
+    """Loads installed skills from ``$ROSCLAW_HOME/skills`` into a runtime registry."""
+
+    def __init__(self, home: Path | None, runtime_registry: SkillRegistry) -> None:
+        self._home = Path(home) if home is not None else get_rosclaw_home()
+        self._registry = runtime_registry
+
+    def load_installed(self) -> int:
+        """Register every installed skill not already active. Returns count."""
+        loaded = 0
+        for name, lock_entry in self._read_lockfile().items():
+            if self._registry.get_by_name(name) is not None:
+                continue  # idempotent: already active in this runtime
+            version = str(lock_entry.get("version", ""))
+            manifest = self._read_manifest(name, version)
+            metadata = manifest.get("metadata", {}) or {}
+            execution = manifest.get("execution", {}) or {}
+            capability = manifest.get("capability", {}) or {}
+            entry = SkillEntry(
+                name=name,
+                description=str(metadata.get("description", "")),
+                skill_type="programmed",
+                version=version or "1.0.0",
+                metadata={
+                    "source": "installed",
+                    "trust": lock_entry.get("trust", ""),
+                    "package_digest": lock_entry.get("package_digest", ""),
+                    "install_dir": str(self._home / "skills" / name / version),
+                    "domain": execution.get("domain", ""),
+                    "planner": execution.get("planner", {}) or {},
+                    "verifier": execution.get("verifier", {}) or {},
+                    "capability_id": capability.get("id"),
+                    "permissions": manifest.get("permissions", []) or [],
+                },
+            )
+            self._registry.register(entry)
+            loaded += 1
+            logger.info("activated installed skill %s@%s", name, version)
+        return loaded
+
+    def _read_lockfile(self) -> dict:
+        lockfile = self._home / "skills" / "installed.lock.json"
+        if not lockfile.exists():
+            return {}
+        try:
+            return json.loads(lockfile.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("installed.lock.json unreadable: %s", exc)
+            return {}
+
+    def _read_manifest(self, name: str, version: str) -> dict:
+        manifest_path = self._home / "skills" / name / version / "skill.yaml"
+        if not manifest_path.exists():
+            logger.warning("installed skill %s@%s manifest missing", name, version)
+            return {}
+        try:
+            return yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as exc:
+            logger.warning("installed skill %s manifest invalid: %s", name, exc)
+            return {}

--- a/src/rosclaw/skill/service.py
+++ b/src/rosclaw/skill/service.py
@@ -1,0 +1,85 @@
+"""Unified skill facade (Skill Runtime 2.0, doc §15).
+
+CLI, MCP, the native agent and external harnesses all go through
+``SkillService`` instead of touching ``SkillLocalRegistry`` /
+``SkillManager.SkillRegistry`` / hub clients / builtins directly.
+
+PR-4 scope: discovery + acquisition + activation (search / resolve /
+inspect / ensure_installed / list_active). Execution (plan / invoke /
+verify / rollback) lands with the HostOps plane (PR-5+).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rosclaw.firstboot.workspace import get_rosclaw_home
+from rosclaw.skill.catalog_service import SkillCatalogService
+from rosclaw.skill.installer import InstallReceipt, SkillInstaller
+from rosclaw.skill.loader import SkillLoader
+from rosclaw.skill.resolver import CapabilityResolution, CapabilityResolver
+from rosclaw.skill.sources import CatalogHit
+from rosclaw.skill_manager.registry import SkillRegistry
+
+
+class SkillService:
+    """One facade over catalog, resolver, installer and runtime registry."""
+
+    def __init__(self, home: Path | None = None, runtime_registry: SkillRegistry | None = None) -> None:
+        self._home = Path(home) if home is not None else get_rosclaw_home()
+        self._catalog = SkillCatalogService.default(self._home)
+        self._resolver = CapabilityResolver(self._catalog)
+        self._installer = SkillInstaller(self._home, self._catalog)
+        self._runtime_registry = runtime_registry or SkillRegistry()
+        SkillLoader(self._home, self._runtime_registry).load_installed()
+
+    # Discovery plane -------------------------------------------------
+
+    def search(self, query: str, context: dict | None = None) -> list[CatalogHit]:
+        return self._catalog.search(query, context=context)
+
+    def resolve(self, intent: str, context: dict | None = None) -> CapabilityResolution:
+        return self._resolver.resolve(intent, context=context)
+
+    def inspect(self, ref: str) -> CatalogHit | None:
+        return self._catalog.get(ref)
+
+    # Acquisition plane -------------------------------------------------
+
+    def ensure_installed(self, ref: str) -> InstallReceipt:
+        """doc §28: official (T0/T1) skills may auto-acquire; the rest need
+        an explicit install call from the operator."""
+        if self._installer.lockfile.exists():
+            data = json.loads(self._installer.lockfile.read_text(encoding="utf-8"))
+            if ref in data:
+                entry = data[ref]
+                return InstallReceipt(
+                    name=ref,
+                    version=str(entry.get("version", "")),
+                    package_digest=str(entry.get("package_digest", "")),
+                    install_dir=self._home / "skills" / ref / str(entry.get("version", "")),
+                    trust=str(entry.get("trust", "")),
+                )
+        receipt = self._installer.install(ref)
+        SkillLoader(self._home, self._runtime_registry).load_installed()
+        return receipt
+
+    # Runtime plane -------------------------------------------------
+
+    def list_active(self) -> list[dict]:
+        """Skills active in the runtime registry (what MCP should expose)."""
+        return [
+            {
+                "name": e.name,
+                "version": e.version,
+                "description": e.description,
+                "domain": (e.metadata or {}).get("domain", ""),
+                "trust": (e.metadata or {}).get("trust", ""),
+            }
+            for e in self._runtime_registry.list_skills(return_entries=True)
+        ]
+
+    @property
+    def runtime_registry(self) -> SkillRegistry:
+        return self._runtime_registry

--- a/tests/skill/test_skill_activation.py
+++ b/tests/skill/test_skill_activation.py
@@ -1,31 +1,16 @@
-"""PR-1 RED — installed skills must reach the runtime registry (doc §14).
+"""PR-4 GREEN — installed skills reach the runtime registry (doc §14).
 
-Today there are two disconnected registries: ``SkillLocalRegistry``
-(persistent, ``~/.rosclaw/registry/skills.yaml``) and the runtime
-``SkillManager.SkillRegistry`` (in-memory). Nothing loads an installed
-skill package into the runtime, so a freshly installed official skill is
-invisible to the executor and to MCP. These tests pin the PR-4 contract:
-``SkillLoader`` bridges Installed → ActiveRuntimeRegistry, surviving
-runtime restarts.
-
-Imports of the not-yet-existing modules live inside test bodies so each
-test fails RED (xfail strict) until PR-4.
+(Was PR-1 RED: two disconnected registries, nothing loaded an installed
+skill package into the runtime. PR-4 adds SkillLoader + SkillService.)
 """
 
 from __future__ import annotations
 
-import pytest
-
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    reason="RED (skill-runtime-2.0 PR-1): no activation/loader; unmark in PR-4",
-)
-
-from rosclaw.skill_manager.registry import SkillRegistry  # noqa: E402
+from rosclaw.skill_manager.registry import SkillRegistry
 
 
 def _runtime_skill_names(registry: SkillRegistry) -> set[str]:
-    return {e.name for e in registry.list_skills()}
+    return {e.name for e in registry.list_skills(return_entries=True)}
 
 
 class TestSkillActivation:


### PR DESCRIPTION
叠在 #434（PR-3）之上。

## 内容（rosclaw_skill优化.md §46 / §14 / §15）

两套 Registry 语义落定：

```
SkillLocalRegistry / installed.lock.json  =  InstalledSkillIndex（磁盘、持久）
SkillManager.SkillRegistry                =  ActiveRuntimeRegistry（内存、可执行）
                      ▲
              SkillLoader（本 PR 补上的断链）
```

- **`loader.py`** — `SkillLoader.load_installed()` 把已安装包（含 manifest 的 domain/planner/verifier/capability/permissions）转换为 Runtime `SkillEntry`；幂等；源头在磁盘 ⇒ **runtime 重启后 Skill 仍在**（PR-1 钉的关键验收）。
- **`service.py`** — `SkillService` 统一门面：`search / resolve / inspect / ensure_installed / list_active`；构造即激活；`ensure_installed` 安装后自动激活（§28 官方 T0/T1 自动 acquisition 的底座）。执行面（plan/invoke/verify/rollback）随 PR-5 HostOps 落地。

## 红→绿

`test_skill_activation.py` 4 项 xfail(strict) 摘除，全绿。

## 验证

```
tests/skill + tests/hostops：52 passed, 14 xfailed
ruff: All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)