### PR TITLE
feat(hostops): Skill Runtime 2.0 PR-5——HostOps 平面 + skill run 真实化

### DIFF
--- a/src/rosclaw/hostops/__init__.py
+++ b/src/rosclaw/hostops/__init__.py
@@ -1,0 +1,14 @@
+"""HostOps plane (Skill Runtime 2.0, doc §17-§23).
+
+Host skills never route through the sandboxed harness shell, and never
+gain an unrestricted root shell. The broker accepts **typed operations**
+only (``package.install``, ``repository.enable``, …) and converts them
+into safe argv itself; everything else fails closed.
+"""
+
+from rosclaw.hostops.planner import plan_hash  # noqa: F401
+from rosclaw.hostops.policy import (  # noqa: F401
+    ApprovalMismatchError,
+    HostOpsPolicy,
+    HostOpsPolicyError,
+)

--- a/src/rosclaw/hostops/auth.py
+++ b/src/rosclaw/hostops/auth.py
@@ -1,0 +1,27 @@
+"""Local authorization for privileged host operations (doc §23).
+
+The sudo password never enters the agent context — not the LLM, not MCP,
+not traces, not memory. The agent only ever sees
+``AUTHENTICATION_REQUIRED`` plus an instruction for the operator to run
+on a local TTY. Dashboard/operator auth UX is a follow-up.
+"""
+
+from __future__ import annotations
+
+
+def begin_local_authorization(job_id: str) -> dict:
+    """Start the local-TTY authorization flow for a job.
+
+    Deliberately takes no credential material: authentication happens
+    between the operator and their own machine, outside any agent-visible
+    channel.
+    """
+    return {
+        "status": "AUTHENTICATION_REQUIRED",
+        "job_id": job_id,
+        "channel": "local_tty",
+        "instruction": (
+            f"run `rosclaw host authorize {job_id}` on the host to "
+            f"authenticate with sudo locally"
+        ),
+    }

--- a/src/rosclaw/hostops/executor.py
+++ b/src/rosclaw/hostops/executor.py
@@ -1,0 +1,96 @@
+"""HostOps executor (doc §18/§19/§47).
+
+Accepts validated, approved typed plans and converts each operation into
+safe argv *itself* — the skill never supplies argv. ``shell=True``,
+``bash -c``, ``sudo sh`` and ``curl | bash`` are structurally impossible
+here: there is no shell to inject into.
+
+Real execution requires ``dry_run=False`` *and* an approval bound to the
+plan hash; the default stays a preview so nothing runs by accident.
+"""
+
+from __future__ import annotations
+
+import subprocess  # noqa: S404 — argv-only, shell=False, policy-gated
+
+from rosclaw.hostops.policy import HostOpsPolicy, HostOpsPolicyError
+
+
+class HostOpsExecutor:
+    """Executes typed HostOps plans (preview by default)."""
+
+    def __init__(self, *, dry_run: bool = True, policy: HostOpsPolicy | None = None) -> None:
+        self._dry_run = dry_run
+        self._policy = policy or HostOpsPolicy()
+
+    def execute(self, plan: dict, approval: dict | None = None) -> dict:
+        self._policy.validate_plan(plan)
+        if not self._dry_run:
+            # Mutating the host always requires an approval bound to the
+            # exact plan hash (doc §21); previews are read-only.
+            self._policy.require_approval(plan, approval)
+        results = []
+        for op in plan["operations"]:
+            if self._dry_run:
+                try:
+                    argv: list[str] | None = self._to_argv(op)
+                except HostOpsPolicyError:
+                    argv = None
+                results.append(
+                    {
+                        "type": op["type"],
+                        "argv": argv,
+                        "status": "PREVIEW" if argv else "UNMAPPED",
+                    }
+                )
+                continue
+            argv = self._to_argv(op)  # unmapped ops fail closed here
+            completed = subprocess.run(  # noqa: S603 — shell=False by construction
+                argv, check=False, capture_output=True, text=True, timeout=1800
+            )
+            results.append(
+                {
+                    "type": op["type"],
+                    "argv": argv,
+                    "status": "OK" if completed.returncode == 0 else "FAILED",
+                    "returncode": completed.returncode,
+                }
+            )
+            if completed.returncode != 0:
+                break  # fail fast; recovery belongs to the skill (doc §37)
+        return {
+            "dry_run": self._dry_run,
+            "results": results,
+            "status": "PREVIEW" if self._dry_run else results[-1]["status"],
+        }
+
+    @staticmethod
+    def _to_argv(op: dict) -> list[str]:
+        """Map a typed operation to safe argv owned by the broker."""
+        op_type = op["type"]
+        if op_type == "package.install":
+            return ["apt-get", "install", "-y", *op["packages"]]
+        if op_type == "package.remove":
+            return ["apt-get", "remove", "-y", *op["packages"]]
+        if op_type == "package.install_deb":
+            return ["dpkg", "-i", str(op["artifact"])]
+        if op_type == "repository.enable":
+            return ["add-apt-repository", "-y", str(op["repository"])]
+        if op_type == "systemd.enable":
+            return ["systemctl", "enable", str(op["unit"])]
+        if op_type == "systemd.start":
+            return ["systemctl", "start", str(op["unit"])]
+        if op_type == "systemd.restart":
+            return ["systemctl", "restart", str(op["unit"])]
+        if op_type == "udev.reload":
+            return ["udevadm", "control", "--reload-rules"]
+        if op_type == "user.group_add":
+            return ["usermod", "-aG", str(op["group"]), str(op["user"])]
+        # Operations without a local argv mapping yet (artifact.fetch,
+        # keyring.install, udev.install_rule, file.managed_write,
+        # network.fetch_verified, repository.add/remove/install_package)
+        # fail closed rather than improvising a shell.
+        raise HostOpsPolicyError(
+            f"operation {op_type!r} has no broker argv mapping yet; "
+            f"refusing to improvise one (fail closed, doc §47)"
+        )

--- a/src/rosclaw/hostops/models.py
+++ b/src/rosclaw/hostops/models.py
@@ -1,0 +1,57 @@
+"""HostOps plan models (doc §18/§20).
+
+Plans are JSON-native dicts so they can cross the MCP / CLI / receipt
+boundary without custom codecs. ``ALLOWED_OPERATION_TYPES`` is the
+allowlist the policy enforces — anything outside it fails closed.
+"""
+
+from __future__ import annotations
+
+# Typed host operations (doc §18) plus the artifact/deb operations used by
+# the official ros2-apt-source flow (doc §20/§33).
+ALLOWED_OPERATION_TYPES: frozenset[str] = frozenset(
+    {
+        "package.install",
+        "package.remove",
+        "package.install_deb",
+        "repository.add",
+        "repository.remove",
+        "repository.enable",
+        "repository.install_package",
+        "keyring.install",
+        "systemd.enable",
+        "systemd.start",
+        "systemd.restart",
+        "udev.install_rule",
+        "udev.reload",
+        "user.group_add",
+        "file.managed_write",
+        "network.fetch_verified",
+        "artifact.fetch",
+    }
+)
+
+# Fields that would smuggle arbitrary execution into an otherwise typed op.
+FORBIDDEN_OPERATION_FIELDS: frozenset[str] = frozenset(
+    {"command", "shell", "script", "bash", "sh", "eval", "exec"}
+)
+
+PLAN_DOMAINS: frozenset[str] = frozenset(
+    {"host", "physical", "simulation", "compute", "data", "workflow"}
+)
+
+
+def make_plan(
+    *,
+    skill: str,
+    domain: str,
+    target: dict,
+    operations: list[dict],
+) -> dict:
+    """Assemble a normalized ExecutionPlan dict (doc §20)."""
+    return {
+        "skill": skill,
+        "domain": domain,
+        "target": dict(target),
+        "operations": [dict(op) for op in operations],
+    }

--- a/src/rosclaw/hostops/planner.py
+++ b/src/rosclaw/hostops/planner.py
@@ -1,0 +1,24 @@
+"""Plan hashing (doc §21).
+
+Approval binds to the plan hash: the user approves *this exact plan*, not
+"the agent may sudo". Any change to skill / target / operations changes
+the hash and requires re-approval of the changed plan.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+# Only these fields define what will actually happen on the host.
+_HASH_FIELDS = ("skill", "domain", "target", "operations")
+
+
+def canonical_plan(plan: dict) -> dict:
+    return {k: plan.get(k) for k in _HASH_FIELDS}
+
+
+def plan_hash(plan: dict) -> str:
+    """SHA256 over the canonical plan (skill + target + operations)."""
+    blob = json.dumps(canonical_plan(plan), sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()

--- a/src/rosclaw/hostops/policy.py
+++ b/src/rosclaw/hostops/policy.py
@@ -1,0 +1,113 @@
+"""HostOps policy gate (doc §19/§21/§47).
+
+Default fail closed: unknown operation types are rejected, and no plan may
+contain fields that smuggle arbitrary execution (``command``, ``shell``,
+``bash``, …) — not even on an otherwise-allowed typed op. Argument values
+are validated against injection (no ``--flag`` smuggled as a package name).
+"""
+
+from __future__ import annotations
+
+import re
+
+from rosclaw.hostops.models import (
+    ALLOWED_OPERATION_TYPES,
+    FORBIDDEN_OPERATION_FIELDS,
+)
+from rosclaw.hostops.planner import plan_hash
+
+# Apt package / repository names: no leading dash, no whitespace, no shell
+# metacharacters — the executor must never be an argv-injection vector.
+_SAFE_TOKEN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9+_.:~/-]*$")
+
+
+class HostOpsPolicyError(Exception):
+    """The plan violates HostOps policy and must not execute."""
+
+
+class ApprovalMismatchError(HostOpsPolicyError):
+    """The approval does not match this plan's hash (re-approval needed)."""
+
+
+class HostOpsPolicy:
+    """Validates plans and binds approvals to plan hashes."""
+
+    # ------------------------------------------------------------------
+    # Plan validation (fail closed)
+    # ------------------------------------------------------------------
+
+    def validate_plan(self, plan: dict) -> None:
+        if not isinstance(plan, dict):
+            raise HostOpsPolicyError("plan must be a JSON object")
+        operations = plan.get("operations")
+        if not isinstance(operations, list) or not operations:
+            raise HostOpsPolicyError("plan.operations must be a non-empty list")
+        for index, op in enumerate(operations):
+            self._validate_operation(index, op)
+
+    def _validate_operation(self, index: int, op: object) -> None:
+        where = f"operations[{index}]"
+        if not isinstance(op, dict):
+            raise HostOpsPolicyError(f"{where} must be an object")
+        op_type = op.get("type")
+        if not isinstance(op_type, str) or not op_type:
+            raise HostOpsPolicyError(f"{where} lacks a string 'type'")
+        if op_type not in ALLOWED_OPERATION_TYPES:
+            raise HostOpsPolicyError(
+                f"{where} type {op_type!r} is not in the HostOps allowlist; "
+                f"arbitrary shell execution is never allowed (doc §19)"
+            )
+        smuggled = FORBIDDEN_OPERATION_FIELDS & {k for k, v in op.items() if v}
+        if smuggled:
+            raise HostOpsPolicyError(
+                f"{where} contains forbidden shell field(s) "
+                f"{sorted(smuggled)}; typed operations only (doc §19)"
+            )
+        for key, value in op.items():
+            if key == "type":
+                continue
+            self._validate_value(f"{where}.{key}", value)
+
+    def _validate_value(self, where: str, value: object) -> None:
+        if isinstance(value, str):
+            if not _SAFE_TOKEN.match(value):
+                raise HostOpsPolicyError(
+                    f"{where} value {value!r} is not a safe token "
+                    f"(no flags, whitespace or shell metacharacters)"
+                )
+        elif isinstance(value, list):
+            if not value:
+                raise HostOpsPolicyError(f"{where} must not be an empty list")
+            for item in value:
+                self._validate_value(where, item)
+        elif isinstance(value, (int, float, bool)) or value is None:
+            return
+        else:
+            raise HostOpsPolicyError(
+                f"{where} has unsupported value type {type(value).__name__}"
+            )
+
+    # ------------------------------------------------------------------
+    # Approval binding (doc §21)
+    # ------------------------------------------------------------------
+
+    def approve(self, plan_hash_value: str) -> dict:
+        """Record an operator approval for one exact plan hash."""
+        if not plan_hash_value:
+            raise HostOpsPolicyError("cannot approve an empty plan hash")
+        return {"plan_hash": plan_hash_value, "approved": True}
+
+    def require_approval(self, plan: dict, approval: dict | None) -> None:
+        """Raise unless ``approval`` matches *this* plan (doc §21)."""
+        if not approval or not approval.get("approved"):
+            raise ApprovalMismatchError(
+                "plan has no approval; approve plan_hash "
+                f"{plan_hash(plan)} first"
+            )
+        actual = plan_hash(plan)
+        if approval.get("plan_hash") != actual:
+            raise ApprovalMismatchError(
+                "plan changed after approval "
+                f"(approved {approval.get('plan_hash')}, current {actual}); "
+                f"the changed plan needs a new approval (doc §21)"
+            )

--- a/src/rosclaw/hostops/receipt.py
+++ b/src/rosclaw/hostops/receipt.py
@@ -1,0 +1,41 @@
+"""Execution receipts for HostOps jobs (doc §25).
+
+Receipts are JSON-native and carry the plan hash so an auditor can
+recompute what exactly was approved and executed.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from rosclaw.hostops.planner import plan_hash
+
+
+def new_job_id() -> str:
+    return f"job-{uuid.uuid4().hex[:12]}"
+
+
+def build_receipt(
+    *,
+    job_id: str,
+    plan: dict,
+    environment: dict,
+    intent: str = "",
+    operations_result: dict | None = None,
+    verification: dict | None = None,
+    result: str = "PLANNED",
+) -> dict:
+    """Assemble a uniform execution receipt (doc §25)."""
+    return {
+        "job_id": job_id,
+        "skill": plan.get("skill"),
+        "domain": plan.get("domain"),
+        "intent": intent,
+        "environment": dict(environment),
+        "plan_hash": plan_hash(plan),
+        "operations": (operations_result or {}).get("results", []),
+        "verification": verification or {},
+        "result": result,
+        "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }

--- a/src/rosclaw/skill/cli.py
+++ b/src/rosclaw/skill/cli.py
@@ -549,6 +549,146 @@ def _cmd_skill_install_remote(args: argparse.Namespace, ref: str) -> int:
     return 0
 
 
+def cmd_skill_run(args: argparse.Namespace) -> int:
+    """Run an installed host skill action (doc §16).
+
+    ``--action plan`` loads the skill's planner entrypoint, computes a
+    typed ExecutionPlan from the detected host state, validates it
+    against HostOps policy and prints it (with its plan hash).
+    ``--action install`` requires ``--approve <plan_hash>`` matching the
+    exact plan (doc §21) and then enters the local-TTY authorization
+    flow (doc §23) — the agent never sees credentials.
+    """
+    ref = args.name
+    if "/" not in ref:
+        print(f"[ROSClaw] `skill run` expects a namespaced ref, got: {ref}")
+        return 1
+    try:
+        plan = _build_skill_plan(ref, args)
+    except _SkillRunError as exc:
+        print(f"[ROSClaw] {exc}")
+        return 1
+
+    from rosclaw.hostops.planner import plan_hash
+    from rosclaw.hostops.policy import HostOpsPolicy, HostOpsPolicyError
+
+    policy = HostOpsPolicy()
+    try:
+        policy.validate_plan(plan)
+    except HostOpsPolicyError as exc:
+        print(f"[ROSClaw] Plan rejected by HostOps policy: {exc}")
+        return 1
+    plan["plan_hash"] = plan_hash(plan)
+
+    if args.action == "plan":
+        if args.json:
+            print(json.dumps(plan, indent=2, ensure_ascii=False))
+        else:
+            print(f"[ROSClaw] Execution plan for {plan['skill']}")
+            print(f"  domain: {plan['domain']}  plan_hash: {plan['plan_hash'][:16]}…")
+            for op in plan["operations"]:
+                print(f"  - {op['type']}")
+            print("[ROSClaw] Approve with: rosclaw skill run "
+                  f"{ref} --action install --approve {plan['plan_hash']}")
+        return 0
+
+    # --action install: approval bound to the exact plan hash (doc §21).
+    if not args.approve or args.approve != plan["plan_hash"]:
+        print("[ROSClaw] Execution requires an approval bound to this plan.")
+        print(f"  plan_hash: {plan['plan_hash']}")
+        print(f"  approve with: rosclaw skill run {ref} --action install "
+              f"--approve {plan['plan_hash']}")
+        return 2
+
+    approval = policy.approve(plan["plan_hash"])
+    try:
+        policy.require_approval(plan, approval)
+    except HostOpsPolicyError as exc:
+        print(f"[ROSClaw] {exc}")
+        return 2
+
+    from rosclaw.hostops.auth import begin_local_authorization
+    from rosclaw.hostops.receipt import new_job_id
+
+    auth_request = begin_local_authorization(new_job_id())
+    if args.json:
+        print(json.dumps({**auth_request, "plan": plan}, indent=2, ensure_ascii=False))
+    else:
+        print(f"[ROSClaw] {auth_request['status']}: {auth_request['instruction']}")
+    return 0
+
+
+class _SkillRunError(Exception):
+    pass
+
+
+def _build_skill_plan(ref: str, args: argparse.Namespace) -> dict:
+    """Load the installed skill's planner and produce the ExecutionPlan."""
+    import importlib.util
+
+    import yaml
+
+    from rosclaw.firstboot.workspace import get_rosclaw_home
+    from rosclaw.hostops.models import make_plan
+    from rosclaw.skill.resolver import detect_host_context
+
+    home = get_rosclaw_home()
+    lockfile = home / "skills" / "installed.lock.json"
+    installed = {}
+    if lockfile.exists():
+        try:
+            installed = json.loads(lockfile.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            installed = {}
+    if ref not in installed:
+        raise _SkillRunError(
+            f"skill {ref} is not installed; run `rosclaw skill install {ref}` first"
+        )
+    version = str(installed[ref].get("version", ""))
+    install_dir = home / "skills" / ref / version
+    manifest_path = install_dir / "skill.yaml"
+    if not manifest_path.exists():
+        raise _SkillRunError(f"installed skill {ref}@{version} has no skill.yaml")
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    execution = manifest.get("execution", {}) or {}
+    planner_spec = (execution.get("planner", {}) or {}).get("entrypoint")
+    if not planner_spec:
+        raise _SkillRunError(f"skill {ref} declares no execution.planner entrypoint")
+    module_name, _, func_name = planner_spec.partition(":")
+    if not module_name or not func_name:
+        raise _SkillRunError(f"invalid planner entrypoint {planner_spec!r}")
+    entrypoint_path = install_dir / module_name
+    if not entrypoint_path.exists():
+        raise _SkillRunError(f"planner module {module_name} missing in {install_dir}")
+
+    # Import the skill's planner. Trust basis: the package was digest-pinned
+    # at install time; its *output* is policy-checked before anything runs.
+    spec = importlib.util.spec_from_file_location(f"rosclaw_skill_{ref}", entrypoint_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    planner_fn = getattr(module, func_name, None)
+    if not callable(planner_fn):
+        raise _SkillRunError(f"planner {planner_spec} is not callable")
+
+    context = detect_host_context()
+    skill_args = json.loads(args.args) if getattr(args, "args", None) else {}
+    raw_plan = planner_fn(context, skill_args)
+    if not isinstance(raw_plan, dict) or not isinstance(raw_plan.get("operations"), list):
+        raise _SkillRunError("planner must return a dict with an operations list")
+
+    host_target = {
+        "os": context.get("os", ""),
+        "version": context.get("os_version", ""),
+        "arch": context.get("arch", ""),
+    }
+    return make_plan(
+        skill=raw_plan.get("skill") or f"{ref}@{version}",
+        domain=raw_plan.get("domain") or execution.get("domain", "host"),
+        target=raw_plan.get("target") or host_target,
+        operations=raw_plan["operations"],
+    )
+
+
 def cmd_skill_inspect(args: argparse.Namespace) -> int:
     """Show details for a builtin or local skill."""
     name = args.name
@@ -602,6 +742,29 @@ def add_skill_hub_parsers(skill_subparsers: Any) -> None:
     install_parser.add_argument("name", help="Skill name")
     install_parser.add_argument("--json", action="store_true", help="Output as JSON")
     install_parser.set_defaults(func=cmd_skill_install)
+
+    run_parser = skill_subparsers.add_parser(
+        "run", help="Run an installed skill action (plan/install)"
+    )
+    run_parser.add_argument("name", help="Namespaced skill ref (e.g. ros-claw/ros_install)")
+    run_parser.add_argument(
+        "--action",
+        choices=["plan", "install"],
+        default="plan",
+        help="plan: compute and validate the ExecutionPlan; install: execute it",
+    )
+    run_parser.add_argument(
+        "--approve",
+        default=None,
+        help="Approval token: the plan_hash shown by --action plan",
+    )
+    run_parser.add_argument(
+        "--args",
+        default=None,
+        help="JSON object passed to the skill planner as args",
+    )
+    run_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    run_parser.set_defaults(func=cmd_skill_run)
 
     inspect_parser = skill_subparsers.add_parser("inspect", help="Inspect a skill")
     inspect_parser.add_argument("name", help="Skill name")

--- a/tests/hostops/test_hostops_policy.py
+++ b/tests/hostops/test_hostops_policy.py
@@ -1,24 +1,12 @@
-"""PR-1 RED — HostOps policy: typed operations only, fail closed (doc §17-§23).
+"""PR-5 GREEN — HostOps policy: typed operations only, fail closed (doc §17-§23).
 
-Host skills must not route through the sandboxed harness shell, and must
-never gain an unrestricted root shell. The HostOps broker accepts typed
-operations (``package.install``, ``repository.enable``, …) and rejects
-everything else by default. Approval binds to the plan hash: changing the
-plan requires re-approval. Sudo authentication is a local-TTY affair; the
-password never enters the agent context.
-
-Imports of the not-yet-existing modules live inside test bodies so each
-test fails RED (xfail strict) until PR-5.
+(Was PR-1 RED: no HostOps plane existed. PR-5 implements policy, plan-hash
+approval binding and local-TTY authorization.)
 """
 
 from __future__ import annotations
 
 import pytest
-
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    reason="RED (skill-runtime-2.0 PR-1): HostOps plane missing; unmark in PR-5",
-)
 
 
 def _plan(operations: list[dict]) -> dict:

--- a/tests/skill/test_skill_run.py
+++ b/tests/skill/test_skill_run.py
@@ -1,17 +1,8 @@
-"""PR-1 RED — `rosclaw skill run` must become a real capability (doc §16).
+"""PR-5 GREEN — `rosclaw skill run` is a real capability (doc §16).
 
-The ros_install README already documents ``rosclaw skill run ... --action
-plan|install`` but the CLI has no ``run`` subcommand — specification ahead
-of implementation. These tests pin the contract shared by PR-4 (service),
-PR-5 (HostOps) and PR-7 (golden ros_install):
-
-- ``--action plan`` produces a typed ExecutionPlan (domain=host).
-- Executing without an approval bound to the plan hash must be refused.
-- A skill whose plan contains arbitrary root shell must be rejected by
-  policy before anything executes.
-
-Imports of the not-yet-existing modules live inside test bodies so each
-test fails RED (xfail strict) until PR-4/PR-5.
+(Was PR-1 RED: no ``run`` subcommand existed although the ros_install
+README documented it. PR-4/PR-5 implement plan building, HostOps policy
+gating and plan-hash approval.)
 """
 
 from __future__ import annotations
@@ -21,12 +12,7 @@ import json
 
 import pytest
 
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    reason="RED (skill-runtime-2.0 PR-1): no `skill run`; unmark in PR-4/PR-5",
-)
-
-from rosclaw.skill.cli import add_skill_hub_parsers  # noqa: E402
+from rosclaw.skill.cli import add_skill_hub_parsers
 
 
 def _run_cli(capsys: pytest.CaptureFixture[str], *argv: str) -> tuple[int, str, str]:


### PR DESCRIPTION
叠在 #435（PR-4）之上。这是整个重构的**安全核心**（rosclaw_skill优化.md §47）。

## 设计要点

- **typed ops only（§18/§19）**：`package.install` / `repository.enable` / `systemd.*` / `udev.*` 等白名单；`shell`/`command`/`bash` 字段以任何形式出现即拒；未知 op 类型 **fail closed**。
- **argv 由 broker 生成**：Skill 永远不给 argv，执行器结构上不存在 shell 可注入（无 `shell=True`/`bash -c`/`curl|bash` 的可能）；参数值防注入（禁 `--flag` 伪装成包名）。
- **审批绑定 plan_hash（§21）**：用户批准的是「这个计划」，不是「允许 sudo」；计划变更 → hash 变 → 必须重新审批。
- **sudo 密码不进 Agent 上下文（§23）**：Agent 只见 `AUTHENTICATION_REQUIRED` + 本地 TTY 指令。
- **默认 dry_run 预览**；真实执行必须显式 `dry_run=False` + 匹配审批；无 argv 映射的 op 在真实执行时 fail closed 而非即兴发挥。
- **`skill run` 真实化（§16）**：`--action plan` 产出 typed ExecutionPlan + plan_hash；`--action install` 无匹配 `--approve` 必拒；`sudo bash -c` 恶意计划在执行前被 policy 拒绝。

## 红→绿

`test_hostops_policy.py` + `test_skill_run.py` 共 14 项 xfail(strict) 摘除，全绿。

## 验证

```
68 passed, 3 xfailed（剩余为 PR-6 MCP）
ruff: All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)