### PR TITLE
feat(mcp): Skill Runtime 2.0 PR-6——MCP capability 工具面 + Job 状态机

### DIFF
--- a/.agents/skills/rosclaw/SKILL.md
+++ b/.agents/skills/rosclaw/SKILL.md
@@ -24,6 +24,26 @@ it with a different `rosclaw` found on `PATH`.
   capability- and action-intent-bound permit, and a registered verified REAL
   executor. Refuse direct ROS, DDS, serial, CAN, SDK, or motor commands.
 
+## Capability First (Skill Runtime 2.0)
+
+Before solving a system, robot, environment, device, perception, navigation
+or manipulation task ad-hoc:
+
+1. Call MCP `resolve_capability(intent)` (or
+   `.venv/bin/python -m rosclaw.entrypoint skill search "<intent>"`).
+2. Prefer an applicable verified capability/skill over hand-rolled commands.
+3. Use generic tools only when no capability exists, the capability is
+   incompatible, or it failed after its recovery path.
+
+Never guess skill names: state the goal ("帮我安装 ROS2") and let the
+resolver pick the implementation. Host-domain skills execute only through
+typed HostOps plans with plan-hash approval — never improvise
+`sudo apt install ...` / `curl ... | bash` in a shell. When the sandboxed
+shell refuses a host mutation, treat it as a signal to call
+`resolve_capability` first, not as a prompt to work around the sandbox.
+Sudo authentication is a local-TTY operator step; never ask for, accept, or
+log a sudo password.
+
 ## First Checks
 
 ```bash

--- a/src/rosclaw/agent/tool_catalog.py
+++ b/src/rosclaw/agent/tool_catalog.py
@@ -39,8 +39,21 @@ P0_PRODUCT_TOOLS: tuple[str, ...] = (
     "explain_execution",
 )
 
+# Skill Runtime 2.0 capability tools (doc §26): agents resolve/invoke
+# capabilities without guessing skill names.
+P0_CAPABILITY_TOOLS: tuple[str, ...] = (
+    "resolve_capability",
+    "invoke_capability",
+    "get_skill_job",
+    "cancel_skill_job",
+)
+
 P0_AGENT_MCP_TOOLS: tuple[str, ...] = (
-    P0_CORE_TOOLS + P0_BODY_CONTEXT_TOOLS + P0_CONTROL_PLANE_TOOLS + P0_PRODUCT_TOOLS
+    P0_CORE_TOOLS
+    + P0_BODY_CONTEXT_TOOLS
+    + P0_CONTROL_PLANE_TOOLS
+    + P0_PRODUCT_TOOLS
+    + P0_CAPABILITY_TOOLS
 )
 
 MCP_TOOL_SAFETY_LEVELS: dict[str, str] = {
@@ -81,6 +94,13 @@ MCP_TOOL_SAFETY_LEVELS: dict[str, str] = {
     "rosclaw_know_build_reference_pack": "S0_READ_ONLY",
     "rosclaw_know_open_reference_pack": "S0_READ_ONLY",
     "rosclaw_how_advice": "S0_ADVISORY",
+    # Skill Runtime 2.0 capability tools (doc §26): resolution is read-only;
+    # invoke only ever creates an AWAITING_APPROVAL job — execution needs a
+    # plan-hash approval plus local-TTY authorization (§21/§23).
+    "resolve_capability": "S0_READ_ONLY",
+    "get_skill_job": "S0_READ_ONLY",
+    "invoke_capability": "S3_GUARDED_ACTION",
+    "cancel_skill_job": "S3_GUARDED_ACTION",
 }
 
 

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -8050,13 +8050,9 @@ def main() -> int:
     skill_invoke_parser.add_argument("--trace-id", default=None, help="Trace ID for the invocation")
     skill_invoke_parser.add_argument("--json", action="store_true", help="Output as JSON")
 
-    # `run` is a backward-compatible alias for `invoke`.
-    skill_subparsers.add_parser(
-        "run",
-        parents=[skill_invoke_parser],
-        add_help=False,
-        help="Run a skill (alias for invoke)",
-    )
+    # NOTE: `skill run` is now the Skill Runtime 2.0 planner/executor entry
+    # (registered by add_skill_hub_parsers below); bare-name invocations are
+    # forwarded to cmd_skill_invoke for backward compatibility.
 
     # skill champions subcommand
     skill_champions_parser = skill_subparsers.add_parser(

--- a/src/rosclaw/mcp/tools/__init__.py
+++ b/src/rosclaw/mcp/tools/__init__.py
@@ -549,6 +549,121 @@ async def _fleet_skill_compatibility() -> dict[str, Any]:
     return await _client().fleet_skill_compatibility()
 
 
+# ---------------------------------------------------------------------------
+# Capability tools (Skill Runtime 2.0, doc §26)
+#
+# These deliberately bypass the runtime client: capability resolution must
+# see the *whole skill ecosystem* (catalog), not just the runtime registry.
+# ---------------------------------------------------------------------------
+
+
+def _capability_error(code: str, message: str) -> MCPError:
+    """Error envelope that honest clients can trust-read (UNAVAILABLE)."""
+    return MCPError(
+        code,
+        message,
+        details={"trust_level": "UNAVAILABLE", "usable_for_real_execution": False},
+    )
+
+
+async def _resolve_capability(intent: str) -> dict[str, Any]:
+    """Resolve a natural-language intent to a capability + skill implementation.
+
+    The agent never guesses skill names (doc §27): it states the goal and
+    ROSClaw answers with the capability id, the selected skill, trust and
+    compatibility — deterministically, no LLM required (doc §6).
+    """
+    from rosclaw.skill.resolver import CapabilityResolver
+
+    resolution = await asyncio.to_thread(CapabilityResolver().resolve, intent)
+    return resolution.to_dict()
+
+
+async def _invoke_capability(capability_id: str, args: dict | None = None) -> dict[str, Any]:
+    """Invoke a capability: resolve → auto-acquire (official only) → plan
+    → AWAITING_APPROVAL job (doc §28/§29).
+
+    Host-domain execution never happens here: the job waits for an
+    approval bound to the plan hash (doc §21) and local-TTY authorization
+    (doc §23). Third-party skills are never auto-installed (doc §29).
+    """
+    return await asyncio.to_thread(_invoke_capability_sync, capability_id, args)
+
+
+def _invoke_capability_sync(capability_id: str, args: dict | None) -> dict[str, Any]:
+    from rosclaw.hostops.planner import plan_hash
+    from rosclaw.hostops.policy import HostOpsPolicy, HostOpsPolicyError
+    from rosclaw.skill.jobs import SkillJobStore
+    from rosclaw.skill.service import SkillPlanError, SkillService
+
+    service = SkillService()
+    hit = service.find_by_capability(capability_id)
+    if hit is None:
+        raise _capability_error(
+            "CAPABILITY_NOT_FOUND",
+            f"no skill implements capability {capability_id!r} in any catalog",
+        )
+    if not hit.installed:
+        if not hit.official:
+            # doc §29: third-party skills require an explicit operator install.
+            return {
+                "status": "INSTALL_REQUIRES_OPERATOR",
+                "capability": capability_id,
+                "selected_skill": hit.name,
+                "executed": False,
+                "instruction": f"run `rosclaw skill install {hit.name}` to proceed",
+            }
+        # doc §28: official (T1) skills may auto-acquire.
+        service.ensure_installed(hit.name)
+    try:
+        plan = service.plan(hit.name, args or {})
+        HostOpsPolicy().validate_plan(plan)
+    except (SkillPlanError, HostOpsPolicyError) as exc:
+        raise _capability_error(
+            "PLAN_REJECTED", f"plan for {hit.name} rejected: {exc}"
+        ) from exc
+    job = SkillJobStore().create(
+        skill=hit.name,
+        capability=capability_id,
+        status="AWAITING_APPROVAL",
+        plan_hash=plan_hash(plan),
+        plan=plan,
+    )
+    return {
+        "status": "AWAITING_APPROVAL",
+        "job_id": job["job_id"],
+        "capability": capability_id,
+        "selected_skill": hit.name,
+        "plan_hash": job["plan_hash"],
+        "operations": [op["type"] for op in plan["operations"]],
+        "executed": False,
+        "instruction": (
+            f"approve with `rosclaw skill run {hit.name} --action install "
+            f"--approve {job['plan_hash']}`"
+        ),
+    }
+
+
+async def _get_skill_job(job_id: str) -> dict[str, Any]:
+    """Read a skill job record (doc §24 stable /job semantics)."""
+    from rosclaw.skill.jobs import SkillJobStore
+
+    job = await asyncio.to_thread(SkillJobStore().get, job_id)
+    if job is None:
+        raise _capability_error("JOB_NOT_FOUND", f"skill job {job_id!r} not found")
+    return job
+
+
+async def _cancel_skill_job(job_id: str) -> dict[str, Any]:
+    """Cancel a non-terminal skill job (doc §24/§26)."""
+    from rosclaw.skill.jobs import SkillJobStore
+
+    try:
+        return await asyncio.to_thread(SkillJobStore().cancel, job_id)
+    except KeyError as exc:
+        raise _capability_error("JOB_NOT_FOUND", str(exc)) from exc
+
+
 # Expose wrapped tool functions for FastMCP registration.
 get_robot_state = _tool_wrapper("get_robot_state", _get_robot_state)
 list_skills = _tool_wrapper("list_skills", _list_skills)
@@ -581,6 +696,10 @@ switch_body = _tool_wrapper("switch_body", _switch_body)
 list_body_history = _tool_wrapper("list_body_history", _list_body_history)
 check_skill_compatibility = _tool_wrapper("check_skill_compatibility", _check_skill_compatibility)
 fleet_skill_compatibility = _tool_wrapper("fleet_skill_compatibility", _fleet_skill_compatibility)
+resolve_capability = _tool_wrapper("resolve_capability", _resolve_capability)
+invoke_capability = _tool_wrapper("invoke_capability", _invoke_capability)
+get_skill_job = _tool_wrapper("get_skill_job", _get_skill_job)
+cancel_skill_job = _tool_wrapper("cancel_skill_job", _cancel_skill_job)
 
 P0_TOOLS: list[ToolFunc] = [
     get_robot_state,
@@ -608,6 +727,11 @@ P0_TOOLS: list[ToolFunc] = [
     run_product_demo,
     get_execution_receipt,
     explain_execution,
+    # Skill Runtime 2.0 capability tools (doc §26).
+    resolve_capability,
+    invoke_capability,
+    get_skill_job,
+    cancel_skill_job,
 ]
 
 BODY_TOOLS: list[ToolFunc] = [
@@ -619,12 +743,26 @@ BODY_TOOLS: list[ToolFunc] = [
     fleet_skill_compatibility,
 ]
 
+# Capability tools (Skill Runtime 2.0, doc §26), wrapped like all P0 tools.
+CAPABILITY_TOOLS: list[ToolFunc] = [
+    resolve_capability,
+    invoke_capability,
+    get_skill_job,
+    cancel_skill_job,
+]
+
 __all__ = [
     "P0_TOOLS",
     "BODY_TOOLS",
+    "CAPABILITY_TOOLS",
     "set_client",
     "set_context",
     "ToolFunc",
+    # Capability tools (Skill Runtime 2.0, doc §26).
+    "resolve_capability",
+    "invoke_capability",
+    "get_skill_job",
+    "cancel_skill_job",
     # Expose individual wrapped tools for tests and P2 registration.
     "get_robot_state",
     "list_skills",

--- a/src/rosclaw/skill/cli.py
+++ b/src/rosclaw/skill/cli.py
@@ -561,8 +561,22 @@ def cmd_skill_run(args: argparse.Namespace) -> int:
     """
     ref = args.name
     if "/" not in ref:
-        print(f"[ROSClaw] `skill run` expects a namespaced ref, got: {ref}")
-        return 1
+        # Backward compatibility: `skill run <bare_name> [input]` was an
+        # alias for `skill invoke`. Forward to the legacy handler.
+        import types
+
+        from rosclaw.cli import cmd_skill_invoke
+
+        legacy_args = types.SimpleNamespace(
+            skill_id=ref,
+            input=getattr(args, "input", None) or getattr(args, "args", None) or "{}",
+            body_id=None,
+            output_dir=None,
+            workspace=None,
+            trace_id=None,
+            json=getattr(args, "json", False),
+        )
+        return cmd_skill_invoke(legacy_args)
     try:
         plan = _build_skill_plan(ref, args)
     except _SkillRunError as exc:
@@ -623,70 +637,15 @@ class _SkillRunError(Exception):
 
 
 def _build_skill_plan(ref: str, args: argparse.Namespace) -> dict:
-    """Load the installed skill's planner and produce the ExecutionPlan."""
-    import importlib.util
-
-    import yaml
-
+    """Delegate to the shared SkillService plan builder (doc §15)."""
     from rosclaw.firstboot.workspace import get_rosclaw_home
-    from rosclaw.hostops.models import make_plan
-    from rosclaw.skill.resolver import detect_host_context
+    from rosclaw.skill.service import SkillPlanError, build_skill_plan
 
-    home = get_rosclaw_home()
-    lockfile = home / "skills" / "installed.lock.json"
-    installed = {}
-    if lockfile.exists():
-        try:
-            installed = json.loads(lockfile.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            installed = {}
-    if ref not in installed:
-        raise _SkillRunError(
-            f"skill {ref} is not installed; run `rosclaw skill install {ref}` first"
-        )
-    version = str(installed[ref].get("version", ""))
-    install_dir = home / "skills" / ref / version
-    manifest_path = install_dir / "skill.yaml"
-    if not manifest_path.exists():
-        raise _SkillRunError(f"installed skill {ref}@{version} has no skill.yaml")
-    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
-    execution = manifest.get("execution", {}) or {}
-    planner_spec = (execution.get("planner", {}) or {}).get("entrypoint")
-    if not planner_spec:
-        raise _SkillRunError(f"skill {ref} declares no execution.planner entrypoint")
-    module_name, _, func_name = planner_spec.partition(":")
-    if not module_name or not func_name:
-        raise _SkillRunError(f"invalid planner entrypoint {planner_spec!r}")
-    entrypoint_path = install_dir / module_name
-    if not entrypoint_path.exists():
-        raise _SkillRunError(f"planner module {module_name} missing in {install_dir}")
-
-    # Import the skill's planner. Trust basis: the package was digest-pinned
-    # at install time; its *output* is policy-checked before anything runs.
-    spec = importlib.util.spec_from_file_location(f"rosclaw_skill_{ref}", entrypoint_path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    planner_fn = getattr(module, func_name, None)
-    if not callable(planner_fn):
-        raise _SkillRunError(f"planner {planner_spec} is not callable")
-
-    context = detect_host_context()
     skill_args = json.loads(args.args) if getattr(args, "args", None) else {}
-    raw_plan = planner_fn(context, skill_args)
-    if not isinstance(raw_plan, dict) or not isinstance(raw_plan.get("operations"), list):
-        raise _SkillRunError("planner must return a dict with an operations list")
-
-    host_target = {
-        "os": context.get("os", ""),
-        "version": context.get("os_version", ""),
-        "arch": context.get("arch", ""),
-    }
-    return make_plan(
-        skill=raw_plan.get("skill") or f"{ref}@{version}",
-        domain=raw_plan.get("domain") or execution.get("domain", "host"),
-        target=raw_plan.get("target") or host_target,
-        operations=raw_plan["operations"],
-    )
+    try:
+        return build_skill_plan(get_rosclaw_home(), ref, skill_args)
+    except SkillPlanError as exc:
+        raise _SkillRunError(str(exc)) from exc
 
 
 def cmd_skill_inspect(args: argparse.Namespace) -> int:
@@ -747,6 +706,12 @@ def add_skill_hub_parsers(skill_subparsers: Any) -> None:
         "run", help="Run an installed skill action (plan/install)"
     )
     run_parser.add_argument("name", help="Namespaced skill ref (e.g. ros-claw/ros_install)")
+    run_parser.add_argument(
+        "input",
+        nargs="?",
+        default=None,
+        help="Legacy invoke input JSON (bare skill names only)",
+    )
     run_parser.add_argument(
         "--action",
         choices=["plan", "install"],

--- a/src/rosclaw/skill/jobs.py
+++ b/src/rosclaw/skill/jobs.py
@@ -1,0 +1,133 @@
+"""Skill job store — the unified skill job state machine (doc §24).
+
+Every skill execution, host-domain or otherwise, gets a job record with a
+stable lifecycle:
+
+    RESOLVED → ACQUIRED → VALIDATED → PLANNED → AWAITING_APPROVAL
+    → AUTHORIZED → EXECUTING → VERIFYING → SUCCEEDED
+
+plus FAILED / DEGRADED / CANCELLED / ROLLING_BACK / ROLLED_BACK.
+
+Records persist under ``$ROSCLAW_HOME/skills/jobs/<job_id>.json`` so
+``get_skill_job`` / ``cancel_skill_job`` have stable semantics across
+CLI, MCP and runtime restarts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import time
+from pathlib import Path
+
+from rosclaw.firstboot.workspace import get_rosclaw_home
+from rosclaw.hostops.receipt import new_job_id
+
+JOB_STATES: frozenset[str] = frozenset(
+    {
+        "RESOLVED",
+        "ACQUIRED",
+        "VALIDATED",
+        "PLANNED",
+        "AWAITING_APPROVAL",
+        "AUTHENTICATION_REQUIRED",
+        "AUTHORIZED",
+        "EXECUTING",
+        "VERIFYING",
+        "SUCCEEDED",
+        "FAILED",
+        "DEGRADED",
+        "CANCELLED",
+        "ROLLING_BACK",
+        "ROLLED_BACK",
+    }
+)
+
+TERMINAL_STATES: frozenset[str] = frozenset(
+    {"SUCCEEDED", "FAILED", "CANCELLED", "ROLLED_BACK"}
+)
+
+_JOB_ID_SAFE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$")
+
+
+class SkillJobStore:
+    """Filesystem-backed job records (one JSON file per job)."""
+
+    def __init__(self, home: Path | None = None) -> None:
+        self._home = Path(home) if home is not None else get_rosclaw_home()
+
+    @property
+    def jobs_dir(self) -> Path:
+        return self._home / "skills" / "jobs"
+
+    def create(
+        self,
+        *,
+        skill: str,
+        capability: str | None,
+        status: str,
+        plan_hash: str = "",
+        plan: dict | None = None,
+    ) -> dict:
+        if status not in JOB_STATES:
+            raise ValueError(f"unknown job status {status!r}")
+        job = {
+            "job_id": new_job_id(),
+            "skill": skill,
+            "capability": capability,
+            "status": status,
+            "plan_hash": plan_hash,
+            "plan": plan,
+            "created_at": _now(),
+            "updated_at": _now(),
+        }
+        self._write(job)
+        return job
+
+    def get(self, job_id: str) -> dict | None:
+        path = self._path_for(job_id)
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    def update(self, job_id: str, *, status: str | None = None, **fields) -> dict:
+        job = self.get(job_id)
+        if job is None:
+            raise KeyError(f"job {job_id!r} not found")
+        if status is not None:
+            if status not in JOB_STATES:
+                raise ValueError(f"unknown job status {status!r}")
+            job["status"] = status
+        job.update(fields)
+        job["updated_at"] = _now()
+        self._write(job)
+        return job
+
+    def cancel(self, job_id: str) -> dict:
+        job = self.get(job_id)
+        if job is None:
+            raise KeyError(f"job {job_id!r} not found")
+        if job["status"] in TERMINAL_STATES:
+            return job  # already terminal; cancel is a no-op
+        return self.update(job_id, status="CANCELLED")
+
+    def _path_for(self, job_id: str) -> Path:
+        if not _JOB_ID_SAFE.match(job_id):
+            raise ValueError(f"invalid job id {job_id!r}")
+        return self.jobs_dir / f"{job_id}.json"
+
+    def _write(self, job: dict) -> None:
+        self.jobs_dir.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=self.jobs_dir, prefix=".job-", suffix=".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(job, fh, indent=2, ensure_ascii=False)
+        os.replace(tmp, self.jobs_dir / f"{job['job_id']}.json")
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())

--- a/src/rosclaw/skill/service.py
+++ b/src/rosclaw/skill/service.py
@@ -11,6 +11,7 @@ verify / rollback) lands with the HostOps plane (PR-5+).
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 
@@ -80,6 +81,96 @@ class SkillService:
             for e in self._runtime_registry.list_skills(return_entries=True)
         ]
 
+    # Execution plane -------------------------------------------------
+
+    def find_by_capability(self, capability_id: str) -> CatalogHit | None:
+        """Locate the best skill implementing a capability (installed first)."""
+        installed_hit: CatalogHit | None = None
+        for hit in self._catalog.search(capability_id):
+            if hit.capability_id != capability_id:
+                continue
+            if hit.installed:
+                installed_hit = installed_hit or hit
+            else:
+                return installed_hit or hit
+        return installed_hit
+
+    def plan(self, ref: str, args: dict | None = None) -> dict:
+        """Build the skill's ExecutionPlan from the detected host state.
+
+        The plan is validated against HostOps policy and bound to a plan
+        hash by the caller (CLI ``skill run`` / MCP ``invoke_capability``).
+        """
+        return build_skill_plan(self._home, ref, args or {})
+
     @property
     def runtime_registry(self) -> SkillRegistry:
         return self._runtime_registry
+
+
+class SkillPlanError(Exception):
+    """The skill's plan could not be built or is malformed."""
+
+
+def build_skill_plan(home: Path, ref: str, skill_args: dict) -> dict:
+    """Load an installed skill's planner entrypoint and produce the plan.
+
+    Trust basis: the package was digest-pinned at install time; its
+    *output* is policy-checked by the HostOps gate before anything runs.
+    """
+    import yaml
+
+    from rosclaw.hostops.models import make_plan
+    from rosclaw.skill.resolver import detect_host_context
+
+    lockfile = home / "skills" / "installed.lock.json"
+    installed: dict = {}
+    if lockfile.exists():
+        try:
+            installed = json.loads(lockfile.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            installed = {}
+    if ref not in installed:
+        raise SkillPlanError(
+            f"skill {ref} is not installed; run `rosclaw skill install {ref}` first"
+        )
+    version = str(installed[ref].get("version", ""))
+    install_dir = home / "skills" / ref / version
+    manifest_path = install_dir / "skill.yaml"
+    if not manifest_path.exists():
+        raise SkillPlanError(f"installed skill {ref}@{version} has no skill.yaml")
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    execution = manifest.get("execution", {}) or {}
+    planner_spec = (execution.get("planner", {}) or {}).get("entrypoint")
+    if not planner_spec:
+        raise SkillPlanError(f"skill {ref} declares no execution.planner entrypoint")
+    module_name, _, func_name = planner_spec.partition(":")
+    if not module_name or not func_name:
+        raise SkillPlanError(f"invalid planner entrypoint {planner_spec!r}")
+    entrypoint_path = install_dir / module_name
+    if not entrypoint_path.exists():
+        raise SkillPlanError(f"planner module {module_name} missing in {install_dir}")
+
+    spec = importlib.util.spec_from_file_location(f"rosclaw_skill_{ref}", entrypoint_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    planner_fn = getattr(module, func_name, None)
+    if not callable(planner_fn):
+        raise SkillPlanError(f"planner {planner_spec} is not callable")
+
+    context = detect_host_context()
+    raw_plan = planner_fn(context, skill_args)
+    if not isinstance(raw_plan, dict) or not isinstance(raw_plan.get("operations"), list):
+        raise SkillPlanError("planner must return a dict with an operations list")
+
+    host_target = {
+        "os": context.get("os", ""),
+        "version": context.get("os_version", ""),
+        "arch": context.get("arch", ""),
+    }
+    return make_plan(
+        skill=raw_plan.get("skill") or f"{ref}@{version}",
+        domain=raw_plan.get("domain") or execution.get("domain", "host"),
+        target=raw_plan.get("target") or host_target,
+        operations=raw_plan["operations"],
+    )

--- a/tests/mcp/test_capability_resolver.py
+++ b/tests/mcp/test_capability_resolver.py
@@ -1,39 +1,38 @@
-"""PR-1 RED — MCP must expose capability resolution, not just list_skills (doc §26).
+"""PR-6 GREEN — MCP exposes capability resolution, not just list_skills (doc §26).
 
-Today the MCP surface only has ``list_skills``, and it reads the runtime
-registry — so even an installed official skill is invisible, and an agent
-must *guess* skill names. These tests pin the PR-6 contract:
-``resolve_capability`` / ``invoke_capability`` / ``get_skill_job`` /
-``cancel_skill_job``.
-
-Imports of the not-yet-existing tools live inside test bodies so each
-test fails RED (xfail strict) until PR-6.
+(Was PR-1 RED: MCP only saw the runtime registry and agents had to guess
+skill names. PR-6 adds resolve_capability / invoke_capability /
+get_skill_job / cancel_skill_job, envelope-wrapped like all P0 tools.)
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 
-import pytest
+# Reuse the hermetic skill fixtures (local file:// registry + tmp home).
+from tests.skill.conftest import official_registry, rosclaw_home  # noqa: F401
 
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    reason="RED (skill-runtime-2.0 PR-1): MCP capability tools missing; unmark in PR-6",
-)
+
+def _call(tool, **kwargs) -> dict:
+    """Invoke an envelope-wrapped MCP tool and return the data payload."""
+    envelope = json.loads(asyncio.run(tool(**kwargs)))
+    assert envelope["ok"] is True, envelope
+    return envelope["data"]
 
 
 class TestMcpCapabilityTools:
-    def test_resolve_capability_zh_intent(self, official_registry, rosclaw_home):
+    def test_resolve_capability_zh_intent(self, official_registry, rosclaw_home):  # noqa: F811
         """doc §27: the agent never learns the name `ros_install`."""
         from rosclaw.mcp.tools import resolve_capability
 
-        result = asyncio.run(resolve_capability(intent="帮我安装 ROS2"))
-        assert result["capability"] == "environment.install.ros"
-        assert result["selected_skill"] == "ros-claw/ros_install"
-        assert result["source"] == "official"
-        assert result["compatible"] is True
+        data = _call(resolve_capability, intent="帮我安装 ROS2")
+        assert data["capability"] == "environment.install.ros"
+        assert data["selected_skill"] == "ros-claw/ros_install"
+        assert data["source"] == "official"
+        assert data["compatible"] is True
 
-    def test_capability_tool_surface_is_exposed(self, official_registry, rosclaw_home):
+    def test_capability_tool_surface_is_exposed(self, official_registry, rosclaw_home):  # noqa: F811
         from rosclaw.mcp import tools
 
         for name in (
@@ -45,13 +44,29 @@ class TestMcpCapabilityTools:
             assert callable(getattr(tools, name, None)), f"MCP tool {name} missing"
 
     def test_invoke_capability_requires_approval_for_host_domain(
-        self, official_registry, rosclaw_home
+        self, official_registry, rosclaw_home  # noqa: F811
     ):
         """doc §22/§43: host-domain execution without approval must fail."""
         from rosclaw.mcp.tools import invoke_capability
 
-        result = asyncio.run(
-            invoke_capability(capability_id="environment.install.ros")
-        )
-        assert result.get("status") in {"AWAITING_APPROVAL", "AUTHENTICATION_REQUIRED"}
-        assert result.get("executed") is not True
+        data = _call(invoke_capability, capability_id="environment.install.ros")
+        assert data["status"] in {"AWAITING_APPROVAL", "AUTHENTICATION_REQUIRED"}
+        assert data["executed"] is not True
+
+    def test_skill_job_roundtrip_via_mcp(self, official_registry, rosclaw_home):  # noqa: F811
+        """doc §24: invoke creates a job; get/cancel operate on it (doc §26)."""
+        from rosclaw.mcp.tools import cancel_skill_job, get_skill_job, invoke_capability
+
+        created = _call(invoke_capability, capability_id="environment.install.ros")
+        job_id = created["job_id"]
+
+        fetched = _call(get_skill_job, job_id=job_id)
+        assert fetched["job_id"] == job_id
+        assert fetched["status"] == "AWAITING_APPROVAL"
+
+        cancelled = _call(cancel_skill_job, job_id=job_id)
+        assert cancelled["status"] == "CANCELLED"
+
+        # Terminal jobs are stable: cancelling again is a no-op.
+        again = _call(cancel_skill_job, job_id=job_id)
+        assert again["status"] == "CANCELLED"

--- a/tests/mcp/test_e2e.py
+++ b/tests/mcp/test_e2e.py
@@ -135,10 +135,22 @@ P0_TOOL_CALLS: list[tuple[str, dict[str, Any]]] = [
     ("get_calibration_status", {"component": "head_rgb_camera"}),
     ("get_product_status", {}),
     ("list_product_demos", {}),
+    # Skill Runtime 2.0 capability tools (doc §26). resolve succeeds even
+    # with no catalog match; invoke/get/cancel fail closed with honest
+    # error envelopes (no capable skill / no such job in this workspace).
+    ("resolve_capability", {"intent": "install ROS2"}),
+    ("invoke_capability", {"capability_id": "environment.install.ros"}),
+    ("get_skill_job", {"job_id": "job-e2e-nonexistent"}),
+    ("cancel_skill_job", {"job_id": "job-e2e-nonexistent"}),
 ]
 
 EXPECTED_TOOLS = set(P0_AGENT_MCP_TOOLS)
-EXPECTED_ERROR_TOOLS = {"get_robot_state"}
+EXPECTED_ERROR_TOOLS = {
+    "get_robot_state",
+    "invoke_capability",
+    "get_skill_job",
+    "cancel_skill_job",
+}
 
 
 def _prepare_server_workspace(tmp_path: Path) -> tuple[Path, Path]:


### PR DESCRIPTION
叠在 #436（PR-5）之上。至此 PR-1 的 36 项红测试**全部转绿**。

## 内容（rosclaw_skill优化.md §48）

- **MCP 4 个新工具（§26）**：
  - `resolve_capability(intent)` — Agent 只表达目标（『帮我安装 ROS2』），永不猜 Skill 名（§27）；catalog 全局解析，不限于 runtime registry（§6 断链修复）。
  - `invoke_capability(capability_id)` — 官方 T1 自动 acquisition（§28）；第三方必须显式安装（§29）；host 域**只产出 AWAITING_APPROVAL job + plan_hash**，绝不直接执行（§21/§23）。
  - `get_skill_job` / `cancel_skill_job` — 稳定 /job 语义（§24）。
- **`skill/jobs.py`** — 统一 Job 状态机（RESOLVED→…→SUCCEEDED + FAILED/CANCELLED/…）落盘 `$ROSCLAW_HOME/skills/jobs/`，跨 CLI/MCP/重启一致。
- **`SkillService.plan / find_by_capability`** — plan 构建从 CLI 下沉到统一门面（§15），CLI 与 MCP 共享同一实现。
- **`skill run` 与 legacy invoke 别名冲突**：namespaced ref 走新链路；裸名自动转发 `cmd_skill_invoke`，向后兼容。
- 工具并入 `P0_TOOLS`/`P0_AGENT_MCP_TOOLS`，保持全服务器 envelope 契约（schema_version/trace_id/trust_level UNAVAILABLE 语义）；e2e stdio+http 双通道四工具全演练。
- **SKILL.md** 增加 Capability First 行为规则（§30/§31）：先 resolve_capability，sandbox 拒绝 host 变更时回到 capability 路径而非绕过。

## 红→绿

最后 3 项 xfail(strict) 摘除并扩为 4 项（含 job 全生命周期 roundtrip：invoke→get→cancel→终态幂等）。

## 验证

```
tests/mcp + tests/skill + tests/hostops + agentd 冒烟：289 passed, 0 xfailed
ruff: All checks passed!
```

剩余：PR-7 把 `ros_install` 重写为第一个 Golden Host Skill（typed planner + HostOps + Verifier + Recovery + evidence matrix，ROS 知识全部留在 Skill 侧）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)