### PR TITLE
feat: P0-H——TUI 产品面：命令注册表/三层密度/OSC8 + 深层实证修复（0824 总纲 P0-H）

### DIFF
--- a/packages/rosclaw-agent/src/extension/command-registry.ts
+++ b/packages/rosclaw-agent/src/extension/command-registry.ts
@@ -1,0 +1,34 @@
+/** 命令注册表（P0-H，0824 总纲 §16.4/§19.P0-H）。
+ *
+ * /resume 与 Pi 内置冲突的实证教训（启动 [Extension issues]）——
+ * 命令名与快捷键一样必须注册表化：冲突在测试期爆炸，不在运行时
+ * 由 Pi loader 报 issue。
+ */
+
+/** ROSClaw 扩展命令名（唯一事实源——commands.ts/index.ts 注册的
+ *  命令必须与之一致）。 */
+export const ROSCLAW_COMMAND_NAMES: readonly string[] = [
+	"workspace", "newtask", "done", "tasks", "taskinfo",
+	"activity", "logs", "artifacts",
+	"status", "mission", "body", "tools", "approvals", "revoke",
+	"task", "trace", "context", "why", "sessions", "switch",
+	"language", "operator-init", "safety", "robot", "robots",
+	"capabilities", "tokens", "workers", "delegate", "worker-jobs",
+	"memory", "doctor", "estop", "evidence",
+];
+
+/** Pi 内置命令（审计 §4 全表——与 input-guard.ts 的 PI_BUILTINS
+ *  同源；Pi 升级新增时本表须同步——冲突测试会红）。 */
+export const PI_BUILTIN_COMMANDS: ReadonlySet<string> = new Set([
+	"settings", "model", "scoped-models", "export", "import", "share",
+	"copy", "name", "session", "hotkeys", "fork", "clone", "tree",
+	"trust", "login", "logout", "new", "compact", "resume", "reload",
+	"quit",
+]);
+
+/** 冲突检查：返回冲突命令名列表（空 = 健康）。 */
+export function commandConflicts(): string[] {
+	return ROSCLAW_COMMAND_NAMES.filter((name) =>
+		PI_BUILTIN_COMMANDS.has(name)
+	);
+}

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -51,6 +51,7 @@ import { ROSCLAW_SHORTCUTS } from "./shortcuts.js";
 import { StableIdDeduper } from "./dedup.js";
 import { AutoNamer } from "../session/auto-name.js";
 import { formatPolicyAutoNotice } from "../ui/tool-display.js";
+import { classifyNotice, NotificationLevelFilter } from "../ui/levels.js";
 
 export interface RosclawExtensionOptions {
 	profile: "developer" | "robot";
@@ -155,13 +156,25 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		(center.noteWorkspace?.bind(center) as ((d?: string) => void) | undefined)?.(
 			ctxLabel,
 		);
+		pi.registerCommand("debug", {
+			description: "切换调试信息层（治理/审计机制细节默认隐藏）",
+			handler: async (_args, ctx) => {
+				levelFilter.toggle();
+				ctx.ui.notify(
+					levelFilter.visible("debug")
+						? "调试信息层已开启（approval/grant/lease 等机制细节可见）"
+						: "调试信息层已关闭",
+					"info",
+				);
+			},
+		});
 		pi.registerCommand("workspace", {
 			description: "项目 workspace：/workspace show | use <path> | recent",
 			handler: async (args, ctx) => {
 				const sub = args.trim();
 				if (!sub || sub === "show") {
 					const current = workspaceStore.current;
-					ctx.ui.notify(
+					notifyLeveled(ctx, 
 						current ? `当前 Project：${current}` : "未绑定 Project（从 git 仓库内启动自动绑定，或 /workspace use <path>）",
 						"info",
 					);
@@ -169,7 +182,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				}
 				if (sub === "recent") {
 					const recent = workspaceStore.recent;
-					ctx.ui.notify(
+					notifyLeveled(ctx, 
 						recent.length ? `最近的 workspace：\n${recent.join("\n")}` : "（无最近记录）",
 						"info",
 					);
@@ -182,13 +195,13 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 						(center.noteWorkspace?.bind(center) as ((d?: string) => void) | undefined)?.(
 							workspaceStore.displayName(),
 						);
-						ctx.ui.notify(`已绑定 Project：${bound}`, "info");
+						notifyLeveled(ctx, `已绑定 Project：${bound}`, "info");
 					} catch (err) {
-						ctx.ui.notify(`绑定失败：${(err as Error).message}`, "error");
+						notifyLeveled(ctx, `绑定失败：${(err as Error).message}`, "error");
 					}
 					return;
 				}
-				ctx.ui.notify("用法：/workspace show | use <path> | recent", "warning");
+				notifyLeveled(ctx, "用法：/workspace show | use <path> | recent", "warning");
 			},
 		});
 		pi.on("session_start", async (_event, ctx) => {
@@ -200,7 +213,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				...MODEL_TOOL_NAMES,
 			]);
 			if (options.workspaceAutoBound && workspaceStore.current) {
-				ctx.ui.notify(`已自动绑定 Project：${workspaceStore.current}（/workspace show 查看）`, "info");
+				notifyLeveled(ctx, `已自动绑定 Project：${workspaceStore.current}（/workspace show 查看）`, "info");
 			}
 		});
 		pi.on("session_shutdown", async () => {
@@ -220,7 +233,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 						verdict?: string; lines?: string[];
 					};
 					if (result.ok && report.lines?.length) {
-						ctx.ui.notify(
+						notifyLeveled(ctx, 
 							`已恢复（${report.verdict ?? "?"}）\n${report.lines.join("\n")}`,
 							report.verdict === "RESUMED" ? "info" : "warning",
 						);
@@ -332,9 +345,9 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				// 丢失——helpers 在但未调用，行为测试首跑抓到）：
 				// 空 reason 不渲染悬空冒号；READY 恢复正面清除。
 				if (state === "BROKEN") {
-					ctx.ui.notify(formatKitBrokenHint(kit ?? {}, loc), "warning");
+					notifyLeveled(ctx, formatKitBrokenHint(kit ?? {}, loc), "warning");
 				} else if (state === "READY" && prev === "BROKEN") {
-					ctx.ui.notify(
+					notifyLeveled(ctx, 
 						formatKitRecoveredHint(
 							center.snapshot().body_display ?? "", loc,
 						),
@@ -512,7 +525,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			description: "开始新任务（当前任务保持可恢复）",
 			handler: async (_args, ctx) => {
 				inputController.forceNewNext = true;
-				ctx.ui.notify("下一条消息将开始新任务", "info");
+				notifyLeveled(ctx, "下一条消息将开始新任务", "info");
 			},
 		});
 		pi.registerCommand("done", {
@@ -520,7 +533,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			handler: async (_args, ctx) => {
 				const doneTaskId = await inputController.activeTaskId();
 				if (!doneTaskId) {
-					ctx.ui.notify("当前没有活跃任务", "warning");
+					notifyLeveled(ctx, "当前没有活跃任务", "warning");
 					return;
 				}
 				try {
@@ -530,15 +543,15 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 						task_id: doneTaskId,
 					});
 					if (r.ok === false) {
-						ctx.ui.notify(`不能接受：${String(r.error ?? '')}`, "warning");
+						notifyLeveled(ctx, `不能接受：${String(r.error ?? '')}`, "warning");
 						return;
 					}
-					ctx.ui.notify(
+					notifyLeveled(ctx, 
 						`任务已接受（${doneTaskId.slice(0, 14)}…）`,
 						"info",
 					);
 				} catch (err) {
-					ctx.ui.notify(`操作失败：${(err as Error).message}`, "error");
+					notifyLeveled(ctx, `操作失败：${(err as Error).message}`, "error");
 				}
 			},
 		});
@@ -551,10 +564,10 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					});
 					const tasks = (result.tasks ?? []) as Array<Record<string, unknown>>;
 					if (!tasks.length) {
-						ctx.ui.notify("当前没有任务", "info");
+						notifyLeveled(ctx, "当前没有任务", "info");
 						return;
 					}
-					ctx.ui.notify(
+					notifyLeveled(ctx, 
 						tasks
 							.map(
 								(t) =>
@@ -564,7 +577,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 						"info",
 					);
 				} catch (err) {
-					ctx.ui.notify(`查询失败：${(err as Error).message}`, "error");
+					notifyLeveled(ctx, `查询失败：${(err as Error).message}`, "error");
 				}
 			},
 		});
@@ -573,7 +586,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			handler: async (_args, ctx) => {
 				const infoTaskId = await inputController.latestTaskId();
 				if (!infoTaskId) {
-					ctx.ui.notify("当前没有绑定任务", "warning");
+					notifyLeveled(ctx, "当前没有绑定任务", "warning");
 					return;
 				}
 				try {
@@ -581,7 +594,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 						task_id: infoTaskId,
 					});
 					const task = (result.task ?? {}) as Record<string, unknown>;
-					ctx.ui.notify(
+					notifyLeveled(ctx, 
 						`任务 ${String(task.task_id).slice(0, 14)}…\n` +
 							`状态: ${String(task.state)}\n` +
 							`revision: ${String(task.active_revision)}\n` +
@@ -590,7 +603,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 						"info",
 					);
 				} catch (err) {
-					ctx.ui.notify(`查询失败：${(err as Error).message}`, "error");
+					notifyLeveled(ctx, `查询失败：${(err as Error).message}`, "error");
 				}
 			},
 		});
@@ -610,14 +623,14 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			description: "当前任务活动（阶段时间线——来自任务账本，非模型总结）",
 			handler: async (_args, ctx) => {
 				if (!(await inputController.latestTaskId())) {
-					ctx.ui.notify("当前没有绑定任务", "warning");
+					notifyLeveled(ctx, "当前没有绑定任务", "warning");
 					return;
 				}
 				try {
 					const events = await fetchTaskEvents();
-					ctx.ui.notify(renderTaskActivity(events).join("\n"), "info");
+					notifyLeveled(ctx, renderTaskActivity(events).join("\n"), "info");
 				} catch (err) {
-					ctx.ui.notify(`查询失败：${(err as Error).message}`, "error");
+					notifyLeveled(ctx, `查询失败：${(err as Error).message}`, "error");
 				}
 			},
 		});
@@ -625,14 +638,14 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			description: "当前任务后台进程输出（operation 日志尾部）",
 			handler: async (_args, ctx) => {
 				if (!(await inputController.latestTaskId())) {
-					ctx.ui.notify("当前没有绑定任务", "warning");
+					notifyLeveled(ctx, "当前没有绑定任务", "warning");
 					return;
 				}
 				try {
 					const events = await fetchTaskEvents();
-					ctx.ui.notify(renderOperationLogs(events).join("\n"), "info");
+					notifyLeveled(ctx, renderOperationLogs(events).join("\n"), "info");
 				} catch (err) {
-					ctx.ui.notify(`查询失败：${(err as Error).message}`, "error");
+					notifyLeveled(ctx, `查询失败：${(err as Error).message}`, "error");
 				}
 			},
 		});
@@ -640,7 +653,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			description: "当前任务交付物列表（登记才算交付）",
 			handler: async (_args, ctx) => {
 				if (!(await inputController.latestTaskId())) {
-					ctx.ui.notify("当前没有绑定任务", "warning");
+					notifyLeveled(ctx, "当前没有绑定任务", "warning");
 					return;
 				}
 				try {
@@ -648,9 +661,9 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 						task_id: await inputController.latestTaskId(),
 					});
 					const artifacts = (result.artifacts ?? []) as Array<Record<string, unknown>>;
-					ctx.ui.notify(renderArtifactList(artifacts).join("\n"), "info");
+					notifyLeveled(ctx, renderArtifactList(artifacts).join("\n"), "info");
 				} catch (err) {
-					ctx.ui.notify(`查询失败：${(err as Error).message}`, "error");
+					notifyLeveled(ctx, `查询失败：${(err as Error).message}`, "error");
 				}
 			},
 		});
@@ -694,7 +707,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		};
 		const openTasksCenter = async (ctx: CmdCtx) => {
 			if (!options.active.current.missionId) {
-				ctx.ui.notify("未绑定 Mission——Task Panel 不可用", "warning");
+				notifyLeveled(ctx, "未绑定 Mission——Task Panel 不可用", "warning");
 				return;
 			}
 			const missionId = options.active.current.missionId;
@@ -713,7 +726,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 						const r = await center.call("pi.kernel.artifacts", { task_id: taskId });
 						return (r.artifacts ?? []) as Array<Record<string, unknown>>;
 					},
-					notify: (text, kind) => ctx.ui.notify(text, kind),
+					notify: (text, kind) => notifyLeveled(ctx, text, kind),
 					onClose: () => done(true),
 				});
 			}, { overlay: true });
@@ -751,7 +764,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			if (details.phase === "POLICY_AUTO") {
 				// WP-7：SIM 用户面隐藏 POLICY_AUTO/approval/grant 治理
 				// 术语（审计链在事件账本，用户给可理解的说明）。
-				ctx.ui.notify(
+				notifyLeveled(ctx, 
 					formatPolicyAutoNotice({ approvalId: details.approval_id }),
 					"info",
 				);
@@ -763,7 +776,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			// 明确告知等待态——tool 的 onUpdate partial 文本会被 TUI spinner
 			// 覆盖；spinner 行持续重绘，是执行中唯一稳定可见的通道。
 			ctx.ui.setWorkingMessage(`等待 Operator 决定（approval ${approvalId}）…默认拒绝`);
-			ctx.ui.notify(`等待 Operator 决定（approval ${approvalId}）…默认拒绝`, "info");
+			notifyLeveled(ctx, `等待 Operator 决定（approval ${approvalId}）…默认拒绝`, "info");
 			// P0-NA-14：经 approvals.get 精确拉卡（不扫 list）；拉取失败、
 			// 字段缺失或 display_hash 不一致 → fail-closed，不显示可批准卡。
 			let cardData: Record<string, unknown> | undefined;
@@ -816,7 +829,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				|| (displayHash !== "" && String(cardData.display_hash ?? "") !== displayHash)
 				|| !exactIntegrity
 			) {
-				ctx.ui.notify(
+				notifyLeveled(ctx, 
 					`授权卡不可用（${cardError || "字段缺失或 hash 不一致"}）——` +
 					"动作未执行。为安全起见本卡不可在此批准；请重新发起请求。",
 					"error",
@@ -853,7 +866,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 							approve,
 						},
 					)) as { ok: boolean; error?: string };
-					ctx.ui.notify(
+					notifyLeveled(ctx, 
 						decided.ok
 							? approve
 								? "已批准（等待执行回执）"
@@ -863,7 +876,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					);
 				});
 			} catch (err) {
-				ctx.ui.notify(`授权卡交互失败：${(err as Error).message}`, "error");
+				notifyLeveled(ctx, `授权卡交互失败：${(err as Error).message}`, "error");
 			}
 		});
 
@@ -1027,6 +1040,18 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		// NA-FIX-2：mirror 动态读 active（切换后不再写旧 mission）。
 		// WP-7：会话自动命名（见 input/tool_execution_start 接线）。
 		const autoNamer = new AutoNamer();
+		// P0-H：三层信息密度——debug 层（治理/审计机制细节）默认
+		// 隐藏，/debug 切换；conversation/activity 永远可见。
+		const levelFilter = new NotificationLevelFilter();
+		const notifyLeveled = (
+			ctx: { ui: { notify(t: string, k?: "info" | "warning" | "error"): void } },
+			text: string,
+			kind?: "info" | "warning" | "error",
+		): void => {
+			if (levelFilter.visible(classifyNotice(text))) {
+				ctx.ui.notify(text, kind);
+			}
+		};
 		const mirror = new EventMirror(
 			options.rosclawHome,
 			options.active.current.sessionId,
@@ -1076,16 +1101,16 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			notify: (message, type) => undefined,
 		};
 		pi.on("session_start", async (event, ctx) => {
-			options.coordinator.setNotify((message, type) => ctx.ui.notify(message, type));
-			lifecycle.notify = (message, type) => ctx.ui.notify(message, type);
+			options.coordinator.setNotify((message, type) => notifyLeveled(ctx, message, type));
+			lifecycle.notify = (message, type) => notifyLeveled(ctx, message, type);
 			try {
 				await handleSessionStart(lifecycle, event.reason, sessionIdOf(ctx));
 			} catch (err) {
-				ctx.ui.notify(`session 绑定异常：${(err as Error).message}`, "error");
+				notifyLeveled(ctx, `session 绑定异常：${(err as Error).message}`, "error");
 			}
 		});
 		pi.on("session_before_switch", async (event, ctx) => {
-			lifecycle.notify = (message, type) => ctx.ui.notify(message, type);
+			lifecycle.notify = (message, type) => notifyLeveled(ctx, message, type);
 			// 只读预检：target 文件头可解析——绑定动作在 session_start
 			// （此时 target 已是活动 session，id 无歧义）。
 			const veto = await shouldCancelSwitch(event.targetSessionFile, (file) => {
@@ -1098,19 +1123,19 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				}
 			});
 			if (veto) {
-				ctx.ui.notify(veto, "warning");
+				notifyLeveled(ctx, veto, "warning");
 				return { cancel: true };
 			}
 			return undefined;
 		});
 		pi.on("session_before_tree", async (_event, ctx) => {
-			lifecycle.notify = (message, type) => ctx.ui.notify(message, type);
+			lifecycle.notify = (message, type) => notifyLeveled(ctx, message, type);
 			const veto = await shouldCancelTree({
 				rosclawHome: options.rosclawHome,
 				missionId: options.active.current.missionId,
 			});
 			if (veto) {
-				ctx.ui.notify(veto, "warning");
+				notifyLeveled(ctx, veto, "warning");
 				return { cancel: true };
 			}
 			return undefined;

--- a/packages/rosclaw-agent/src/extension/input-guard.ts
+++ b/packages/rosclaw-agent/src/extension/input-guard.ts
@@ -46,6 +46,8 @@ const ROSCLAW_COMMANDS = new Set([
 	// WP-7：会话面（/switch 原 /resume——与 Pi 内置冲突改名）。
 	"/sessions",
 	"/switch",
+	// P0-H：调试信息层开关。
+	"/debug",
 ]);
 
 // Pi 内建（审计 §4 全表）——放行进内建 dispatch。

--- a/packages/rosclaw-agent/src/native/task-activity.ts
+++ b/packages/rosclaw-agent/src/native/task-activity.ts
@@ -133,10 +133,13 @@ export function renderArtifactList(
 ): string[] {
 	if (!artifacts.length) return ["（当前任务无产物登记）"];
 	return artifacts.map((a) => {
-		const name = String(a.path ?? "").split("/").pop() ?? "";
+		const path = String(a.path ?? "");
+		const name = path.split("/").pop() ?? "";
 		const size = Number(a.size_bytes ?? 0);
 		const sha = String(a.sha256 ?? "").slice(0, 7);
 		const media = String(a.media_type ?? "");
-		return `◆ ${name}  ${size} 字节  sha:${sha}  ${media}`.trimEnd();
+		// P0-H：OSC8 超链接——终端可点击打开交付物。
+		const link = `\x1b]8;;file://${path}\x07${name}\x1b]8;;\x07`;
+		return `◆ ${link}  ${size} 字节  sha:${sha}  ${media}`.trimEnd();
 	});
 }

--- a/packages/rosclaw-agent/src/ui/levels.ts
+++ b/packages/rosclaw-agent/src/ui/levels.ts
@@ -1,0 +1,36 @@
+/** 三层信息密度（P0-H，0824 总纲 §16.1/§19.P0-H）。
+ *
+ * Conversation：用户必须看到的（任务结果、错误、操作确认）——
+ * 永远可见；Activity：任务活动/进度（POLICY_AUTO 自动放行等
+ * 治理事件的用户可读形态）——默认可见；Debug：治理/审计机制
+ * 细节（approval/grant id、lease、内部状态码）——默认隐藏，
+ * 用户切换后可见（内部状态不甩给用户）。
+ */
+
+export type NoticeLevel = "conversation" | "activity" | "debug";
+
+const GOVERNANCE_PATTERN =
+	/\b(approval|grant|lease|permit|capability_snapshot|context_revision)\b|apr_[a-z0-9]+|grt_[a-z0-9]+/i;
+
+/** 通知文本 → 信息层（治理/审计机制细节 = debug）。 */
+export function classifyNotice(text: string): NoticeLevel {
+	if (GOVERNANCE_PATTERN.test(text)) return "debug";
+	if (/^(任务完成|已批准|已拒绝|绑定失败|操作失败|不能接受|查询失败)/.test(text)) {
+		return "conversation";
+	}
+	return "activity";
+}
+
+/** Debug 层开关（默认隐藏；用户切换后可见）。 */
+export class NotificationLevelFilter {
+	private debugVisible = false;
+
+	visible(level: NoticeLevel): boolean {
+		if (level === "debug") return this.debugVisible;
+		return true;
+	}
+
+	toggle(): void {
+		this.debugVisible = !this.debugVisible;
+	}
+}

--- a/packages/rosclaw-agent/test/p0h-product-surface.test.ts
+++ b/packages/rosclaw-agent/test/p0h-product-surface.test.ts
@@ -26,7 +26,7 @@ describe("P0-H 无 engine 痕迹", () => {
 			action_readiness: { state: "ready" },
 			snapshot_seq: 1,
 		} as never;
-		for (const out of [renderHeader(snap, "zh"), renderFooter(snap, "zh")]) {
+		for (const out of [renderHeader(snap, "zh-CN"), renderFooter(snap, "zh-CN")]) {
 			assert.ok(!/pi-coding-agent|Pi SDK|powered by pi/i.test(out),
 				`chrome 含 engine 痕迹: ${out.slice(0, 120)}`);
 		}
@@ -88,7 +88,7 @@ describe("P0-H Working 单行", () => {
 		const { phaseWorkingMessage } = await import("../src/extension/activity.js");
 		for (const msg of [
 			phaseWorkingMessage({ currentTool: "bash", operation: null }),
-			phaseWorkingMessage({ currentTool: "", operation: "op_1" }),
+			phaseWorkingMessage({ currentTool: "", operation: { id: "op_1", label: "op_1" } }),
 		]) {
 			assert.ok(!msg.includes("\n"), `working message 多行: ${msg}`);
 		}

--- a/packages/rosclaw-agent/test/p0h-product-surface.test.ts
+++ b/packages/rosclaw-agent/test/p0h-product-surface.test.ts
@@ -1,0 +1,96 @@
+/** P0-H 红测试（0824 总纲 §19.P0-H）：TUI 产品面。
+ *
+ * 红测试先行——三层信息密度/OSC8/命令冲突注册表不存在时必须红。
+ *
+ * 验收（文档原文）：
+ * - 默认 transcript 中无 raw JSON（WP-7 已钉住）、无 [Extensions]
+ *   （WP-7 快捷键注册表）、无 Pi update/engine 痕迹；
+ * - 同一任务 Working… 占位新增次数为 0（单行就地更新）；
+ * - 用户在 1 秒内能看见当前阶段（阶段化 working message——N9）；
+ * - Worker/Operation 输出可在 Activity 展开（/logs 已钉住）；
+ * - 命令名不与 Pi 内置冲突（/resume 事故的命令侧——快捷键注册表
+ *   已覆盖键位，这里覆盖命令名）；
+ * - artifact 可点击打开（OSC8 超链接）。
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("P0-H 无 engine 痕迹", () => {
+	it("Header/Footer 不含 Pi/engine 品牌字符串", async () => {
+		const { renderHeader, renderFooter } = await import("../src/ui/product-state.js");
+		const snap = {
+			model: "Kimi K3", mode: "SIMULATION", body: "sim/ur5e",
+			context_state: "Fresh", context_revision: 1,
+			lease_state: "valid", operator: "READY",
+			action_readiness: { state: "ready" },
+			snapshot_seq: 1,
+		} as never;
+		for (const out of [renderHeader(snap, "zh"), renderFooter(snap, "zh")]) {
+			assert.ok(!/pi-coding-agent|Pi SDK|powered by pi/i.test(out),
+				`chrome 含 engine 痕迹: ${out.slice(0, 120)}`);
+		}
+	});
+
+	it("命令注册表不与 Pi 内置命令冲突", async () => {
+		const { ROSCLAW_COMMAND_NAMES, PI_BUILTIN_COMMANDS, commandConflicts } =
+			await import("../src/extension/command-registry.js");
+		assert.ok(ROSCLAW_COMMAND_NAMES.length > 0, "命令注册表为空");
+		assert.deepEqual(commandConflicts(), [],
+			`命令名冲突: ${commandConflicts()}`);
+		assert.ok(!ROSCLAW_COMMAND_NAMES.includes("resume"),
+			"/resume 与 Pi 内置冲突（WP-7 实证）——不得复活");
+		assert.ok(PI_BUILTIN_COMMANDS.has("resume"), "Pi 内置表缺 resume");
+	});
+});
+
+describe("P0-H 三层信息密度", () => {
+	it("审计/治理类通知归 Debug 层，默认隐藏；切换后可见", async () => {
+		const { NotificationLevelFilter } = await import("../src/ui/levels.js");
+		const filter = new NotificationLevelFilter();
+		assert.equal(filter.visible("debug"), false, "debug 层默认应隐藏");
+		assert.equal(filter.visible("activity"), true);
+		assert.equal(filter.visible("conversation"), true);
+		filter.toggle();
+		assert.equal(filter.visible("debug"), true, "切换后 debug 层不可见");
+	});
+
+	it("治理类文本分类为 debug（POLICY_AUTO/approval/grant 审计引用）", async () => {
+		const { classifyNotice } = await import("../src/ui/levels.js");
+		assert.equal(classifyNotice("安全仿真动作已自动放行执行（全程已记录审计）"), "activity");
+		assert.equal(classifyNotice("approval apr_123 grant g_456 已消费"), "debug");
+		assert.equal(classifyNotice("任务完成：验收 PASS"), "conversation");
+	});
+});
+
+describe("P0-H artifact 可点击打开", () => {
+	it("artifact 列表渲染 OSC8 超链接", async () => {
+		const { mkdtempSync, writeFileSync } = await import("node:fs");
+		const { tmpdir } = await import("node:os");
+		const { join } = await import("node:path");
+		const dir = mkdtempSync(join(tmpdir(), "p0h-"));
+		const file = join(dir, "star.gif");
+		writeFileSync(file, "GIF89a");
+		const { renderArtifactList } = await import("../src/native/task-activity.js");
+		const lines = renderArtifactList([{
+			artifact_id: "art_1", path: file, media_type: "image/gif",
+			sha256: "ab".repeat(32), size_bytes: 6,
+		} as never]);
+		const joined = lines.join("\n");
+		assert.ok(joined.includes("]8;;"), "缺 OSC8 超链接序列——不可点击");
+		assert.ok(joined.includes(encodeURIComponent("file") + "://" ) || joined.includes("file://"),
+			"缺 file:// 链接目标");
+	});
+});
+
+describe("P0-H Working 单行", () => {
+	it("阶段化 working message 无换行（占位就地更新，新增=0）", async () => {
+		const { phaseWorkingMessage } = await import("../src/extension/activity.js");
+		for (const msg of [
+			phaseWorkingMessage({ currentTool: "bash", operation: null }),
+			phaseWorkingMessage({ currentTool: "", operation: "op_1" }),
+		]) {
+			assert.ok(!msg.includes("\n"), `working message 多行: ${msg}`);
+		}
+	});
+});


### PR DESCRIPTION
## 范围（0824 总纲 P0-H）：TUI 产品面 + 深层实证修复

产品面：
- **命令注册表**（`extension/command-registry.ts`）——/resume 撞
  Pi 内置的事故类命令名冲突改为测试期爆炸（快捷键注册表已覆盖
  键位，这里覆盖命令名）；
- **三层信息密度**（`ui/levels.ts`）——debug 层（approval/grant/
  lease 等治理机制细节）默认隐藏，`/debug` 切换；全部 notify 经
  classifyNotice 路由；内部状态不甩给用户；
- **artifact OSC8 超链接**（终端可点击打开交付物）；
- chrome 无 engine 痕迹 golden 断言；working message 单行
  （占位新增=0）。

深层实证修复（产品旅程抓出，非为绿而改）：
- **跟踪指标只统计接触段**（|z-plane|≤2cm + 路径邻域）——
  approach/lift 过渡采样被 5cm 邻域误纳导致 max error 0.0499
  压在阈值边缘（负载一高就假失败）；实测 0.0196，阈值余量
  2.5×；
- **Pillow/imageio/imageio-ffmpeg 进主依赖**——实证：它们此前
  在 dev extras，离线安装包根本没有 Pillow（0824 用户旅程运行时
  pip install 的根因之一；P0-F 闭包真正闭环）；
- **task.ts 失败面不再空白**（submitted.failures 透出——
  "任务FAILED：" 无可读原因是假失败面）；
- 旅程 env 显式授权降级 shell（P0-6 后 userns 受限主机的
  SIM 旅程）。

验收对齐（§19.P0-H）：默认 transcript 无 raw JSON/无
[Extensions]/无 engine 痕迹 ✓；Working… 占位新增=0 ✓。

## 验证

红→绿：6 红 + 2 对照 → 8/8；TS 159/159；agentd 全套 634
passed（含完整产品 PTY 旅程 VERIFIED）；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)