### PR TITLE
fix: ensure_task body 回落 mission 绑定（N0 熔断——金丝雀实证）

### DIFF
--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1028,13 +1028,20 @@ class PiBridgeServer:
             # 新 revision；已附着直接返回（不重复 bump）。
             kernel = service._task_kernel
             try:
+                # N0 熔断：body_id 缺省回落 mission 绑定（与
+                # pi.task.bind 同语义——执行面必须首条即武装，否则
+                # N4.1 资源证明在空 body 下误判 RESOURCE_PROVENANCE_MISSING）。
+                _mission = service.get_mission(str(params.get("mission_id", "")))
                 result = kernel.ensure_task_for_effect(
                     mission_id=str(params.get("mission_id", "")),
                     session_ref=str(params.get("session_ref", "")),
                     backend_native_id=str(params.get("backend_native_id", "")),
                     cwd=str(params.get("cwd", "")),
                     mode=str(params.get("mode", "SIMULATION")),
-                    body_id=str(params.get("body_id", "")),
+                    body_id=(
+                        str(params.get("body_id", ""))
+                        or (_mission.body_binding.body_id if _mission else "")
+                    ),
                     explicit_goal=str(params.get("explicit_goal", "")),
                 )
             except ValueError as exc:

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -314,6 +314,8 @@ class PiToolDispatcher:
             backend_native_id=request.pi_session_id,
             cwd="",
             mode=mission.mode.value if mission else "SIMULATION",
+            # N0 熔断：body 缺省回落 mission 绑定（执行面首条即武装）。
+            body_id=(mission.body_binding.body_id if mission else ""),
         )
 
     async def _dispatch(self, request: PiToolRequestV1) -> PiToolResultV1:

--- a/src/rosclaw/agentd/tooling/native_tools.py
+++ b/src/rosclaw/agentd/tooling/native_tools.py
@@ -366,6 +366,10 @@ def register_native_tools(
                     "properties": {
                         "ok": {"type": "boolean", "const": True},
                         "artifact": {"type": "object"},
+                        # WP-3 双产物（GIF+MP4）——sim_render 返回 artifacts
+                        # 映射；schema 缺它会把成功渲染误判为
+                        # INVALID_CAPABILITY_OUTPUT。
+                        "artifacts": {"type": "object"},
                         "receipt": {"type": "object"},
                         "evidence_class": {"type": "string", "const": "simulated"},
                     },


### PR DESCRIPTION
## 范围：ensure_task body 回落 mission 绑定（N0 熔断——金丝雀实证）

`ensure_task_for_effect` 两路调用（`pi.task.ensure_effect` 端点 +
dispatch 助手）此前不传 body_id——任务以空 body 创建，N4.1 资源
证明在具身工具实际使用后误判 `RESOURCE_PROVENANCE_MISSING`
（"无  权威 manifest"——robot_id 为空，真实 K3 金丝雀实证）。

与 `pi.task.bind` 同语义：缺省回落
`mission.body_binding.body_id`——执行面必须首条即武装。

## 验证

红→绿：p0c/approval/bridge/h4/n41 邻接 29 全绿；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)