### PR TITLE
fix: deliver 路径补 effectful admission（P0-C 完整化——金丝雀实证）

### DIFF
--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -435,10 +435,15 @@ class PiToolDispatcher:
         # 幂等交付入口（普通文件工具创建的交付物）；capability 产物
         # 自动登记不走模型。
         if name == "rosclaw_deliver":
+            # P0-C：deliver 也是 effectful——首个 effectful call 就是
+            # 交付时先原子 admission（否则裸 NO_ACTIVE_TASK——
+            # 金丝雀实证模型先 deliver 后干活的路径）。
+            self._ensure_task_for_effect(request)
             result = await self._artifact_register(request)
             self._coordinator_consider(request, result)
             return result
         if name == "rosclaw_artifact_register":
+            self._ensure_task_for_effect(request)
             result = await self._artifact_register(request)
             self._coordinator_consider(request, result)
             return result


### PR DESCRIPTION
## 范围：deliver 路径补 effectful admission（P0-C 完整化）

真实 K3 金丝雀实证：模型先 deliver 后干活时裸
`NO_ACTIVE_TASK`——`rosclaw_deliver`/`rosclaw_artifact_register`
是 effectful（workspace 写 + 任务附着）但此前不在 admission
名单里。两路都先 `ensure_task_for_effect`——首个 effectful
call 无论什么入口都原子建 task（P0-C 语义完整化）。

## 验证

红→绿：h4/h8/wp1/p0d 邻接 8 全绿；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)