### PR TITLE
fix: sim 任务管线登记 mp4 交付物（金丝雀实证）

### DIFF
--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -913,6 +913,7 @@ class PiToolDispatcher:
             failures.append(f"rollout 不安全: {result.get('violations')}")
         metrics = verify["metrics"]
         gif_path = str(render["artifact"]["path"])
+        mp4_path = str((render.get("mp4_artifact") or {}).get("path", ""))
         # 产物登记进 kernel 账本（当前会话有活跃任务时——登记才算交付）。
         task = service._task_kernel.active_task_for(
             request.mission_id, request.pi_session_id
@@ -920,8 +921,11 @@ class PiToolDispatcher:
         if task is not None:
             for path, media in (
                 (gif_path, "image/gif"),
+                (mp4_path, "video/mp4"),
                 (str(result["artifacts"]["trace_json"]), "application/json"),
             ):
+                if not path:
+                    continue
                 import contextlib as _cl
 
                 with _cl.suppress(ValueError):


### PR DESCRIPTION
## 范围：sim 任务管线登记 mp4 交付物（金丝雀实证）

`_task` 管线的 artifact 登记列表此前只有 gif+trace_json——2D
预览现在产出 mp4 但不入册（TaskSpec 路径缺 MP4 交付物——
真实 K3 金丝雀 run 实证 kernel:sim_pipeline 只有 gif 登记）。

登记列表加 video/mp4（渲染 mp4_artifact 路径，空则跳过）。

## 验证

红→绿：product journey / h8 PTY 4/4；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)