### PR TITLE
feat: 模型配置与探测单源化——setup/doctor/chat gate 全走 Pi（0824 总纲 §10.1 P1-A1）

### DIFF
--- a/packages/rosclaw-agent/src/harness/pi/pi-probe.ts
+++ b/packages/rosclaw-agent/src/harness/pi/pi-probe.ts
@@ -1,0 +1,198 @@
+/** P1-A1（0824 总纲 §10.1）：模型探测单源——经 Pi ModelRuntime。
+ *
+ * setup/doctor 的 probe 与 chat 走同一引擎、同一配置（agentDir 下
+ * settings.json + models.json + auth.json/env）。不再有第二条
+ * Python HTTP chat probe 栈。
+ *
+ * 探测四步（与 K0 对齐）：auth 配置 → models listing → 短 chat →
+ * 严格 tool call。输出为无 secret 的 JSON 报告（apiKey 的 $ENV
+ * 引用绝不展开打印）。
+ */
+
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
+
+import { createSharedModelRuntime } from "./pi-model-runtime.js";
+
+export interface PiProbeReport {
+	engine: "pi";
+	reachable: boolean;
+	auth_configured: boolean;
+	models_visible: string[];
+	expected_model_present: boolean;
+	chat_ok: boolean;
+	tool_call_ok: boolean;
+	provider?: string;
+	model?: string;
+	error?: string;
+}
+
+interface ProbeOptions {
+	agentDir: string;
+	cwd: string;
+	profile: "developer" | "robot";
+	/** 单步网络超时（chat/tool call）；默认 60s。 */
+	timeoutMs?: number;
+	/** 测试注入：替代真实 ModelRuntime。 */
+	runtime?: ModelRuntime;
+	/** 测试注入：替代 SettingsManager 读取。 */
+	defaults?: { provider?: string; model?: string };
+}
+
+function classifyError(err: unknown): string {
+	const message = err instanceof Error ? err.message : String(err);
+	if (/401|403|unauthorized|forbidden/i.test(message)) return `AUTH_FAILED: ${message}`;
+	if (/402|payment|quota|insufficient/i.test(message)) return `QUOTA_EXHAUSTED: ${message}`;
+	if (/429|rate.?limit/i.test(message)) return `RATE_LIMITED: ${message}`;
+	if (/ECONNREFUSED|ENOTFOUND|ETIMEDOUT|fetch failed|network/i.test(message)) {
+		return `NETWORK_UNREACHABLE: ${message}`;
+	}
+	return `PROBE_FAILED: ${message}`;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error(`${label} timeout after ${ms}ms`)), ms);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+export async function probePiModel(options: ProbeOptions): Promise<PiProbeReport> {
+	const report: PiProbeReport = {
+		engine: "pi",
+		reachable: false,
+		auth_configured: false,
+		models_visible: [],
+		expected_model_present: false,
+		chat_ok: false,
+		tool_call_ok: false,
+	};
+	const timeoutMs = options.timeoutMs ?? 60_000;
+	let defaults = options.defaults;
+	if (!defaults) {
+		const { SettingsManager } = await import("@earendil-works/pi-coding-agent");
+		const settings = SettingsManager.create(options.cwd, options.agentDir);
+		defaults = {
+			provider: settings.getDefaultProvider() ?? undefined,
+			model: settings.getDefaultModel() ?? undefined,
+		};
+	}
+	if (!defaults.provider || !defaults.model) {
+		report.error = "MODEL_NOT_CONFIGURED: settings.json 缺 defaultProvider/defaultModel——运行 rosclaw setup model";
+		return report;
+	}
+	report.provider = defaults.provider;
+	report.model = defaults.model;
+	let runtime = options.runtime;
+	if (!runtime) {
+		try {
+			runtime = await createSharedModelRuntime(options.agentDir, options.profile);
+		} catch (err) {
+			report.error = classifyError(err);
+			return report;
+		}
+	}
+	// 1) auth 配置（models.json $ENV 引用 / auth.json / env——任一命中）。
+	report.auth_configured = runtime.hasConfiguredAuth(defaults.provider);
+	if (!report.auth_configured) {
+		report.error = `AUTH_NOT_CONFIGURED: provider ${defaults.provider} 无可用凭据（env/models.json/auth.json 均无）`;
+		return report;
+	}
+	// 2) models listing（可用性快照=凭据+目录都通）。
+	try {
+		const available = await withTimeout(
+			runtime.getAvailable(defaults.provider), timeoutMs, "models listing",
+		);
+		report.models_visible = available.map((m) => m.id);
+		report.reachable = true;
+	} catch (err) {
+		report.error = classifyError(err);
+		return report;
+	}
+	const model = runtime.getModel(defaults.provider, defaults.model);
+	report.expected_model_present =
+		report.models_visible.length === 0 ||
+		report.models_visible.includes(defaults.model);
+	if (!model) {
+		report.error = `MODEL_UNKNOWN: ${defaults.provider}/${defaults.model} 不在 provider 目录`;
+		report.expected_model_present = false;
+		return report;
+	}
+	// 3) 短 chat。
+	try {
+		const reply = await withTimeout(
+			runtime.completeSimple(model, {
+				messages: [{
+					role: "user",
+					content: "Reply with exactly the two letters: OK",
+					timestamp: 0,
+				}],
+			}),
+			timeoutMs,
+			"chat probe",
+		);
+		// stopReason=error 时 detail 在 errorMessage（如 401）——分类
+		// 透传，不报空泛的 EMPTY。
+		const replyError = (reply as { errorMessage?: string }).errorMessage;
+		if (reply.stopReason === "error" || replyError) {
+			report.error = classifyError(replyError ?? `stopReason=${reply.stopReason}`);
+			return report;
+		}
+		const text = reply.content
+			.filter((b): b is { type: "text"; text: string } => b.type === "text")
+			.map((b) => b.text)
+			.join("");
+		report.chat_ok = text.trim().length > 0;
+		if (!report.chat_ok) {
+			report.error = `CHAT_PROBE_EMPTY: 模型未给出有效回复（stopReason=${reply.stopReason}）`;
+			return report;
+		}
+	} catch (err) {
+		report.error = classifyError(err);
+		return report;
+	}
+	// 4) 严格 tool call。
+	try {
+		const reply = await withTimeout(
+			runtime.completeSimple(model, {
+				systemPrompt: "You must call the report_ok tool exactly once. Do not answer in text.",
+				messages: [{
+					role: "user",
+					content: "Call report_ok with ok=true now.",
+					timestamp: 0,
+				}],
+				tools: [{
+					name: "report_ok",
+					description: "Report probe success.",
+					parameters: {
+						type: "object",
+						properties: { ok: { type: "boolean" } },
+						required: ["ok"],
+					},
+				}],
+			}),
+			timeoutMs,
+			"tool call probe",
+		);
+		const replyError = (reply as { errorMessage?: string }).errorMessage;
+		if (reply.stopReason === "error" || replyError) {
+			report.error = classifyError(replyError ?? `stopReason=${reply.stopReason}`);
+			return report;
+		}
+		report.tool_call_ok = reply.content.some(
+			(b) => b.type === "toolCall" && (b as { name?: string }).name === "report_ok",
+		);
+		if (!report.tool_call_ok) {
+			report.error = "TOOL_CALL_PROBE_FAILED: 模型未发起 report_ok 调用";
+		}
+	} catch (err) {
+		report.error = classifyError(err);
+	}
+	return report;
+}

--- a/packages/rosclaw-agent/src/main.ts
+++ b/packages/rosclaw-agent/src/main.ts
@@ -24,6 +24,7 @@ interface CliArgs {
 	workspace?: string;
 	initialMessage?: string;
 	print: boolean;
+	probe: boolean;
 	missionId?: string;
 	resumeSessionId?: string;
 	resumeSessionPath?: string;
@@ -35,6 +36,7 @@ function parseArgs(argv: string[]): CliArgs {
 	let profile: "developer" | "robot" = "developer";
 	let initialMessage: string | undefined;
 	let print = false;
+	let probe = false;
 	let missionId: string | undefined;
 	let resumeSessionId: string | undefined;
 	let resumeSessionPath: string | undefined;
@@ -53,6 +55,9 @@ function parseArgs(argv: string[]): CliArgs {
 			i += 1;
 		} else if (argv[i] === "--print") {
 			print = true;
+		} else if (argv[i] === "--probe") {
+			// P1-A1：模型探测单源——setup/doctor 经此走 Pi ModelRuntime。
+			probe = true;
 		} else if (argv[i] === "--mission" && argv[i + 1]) {
 			missionId = argv[i + 1];
 			i += 1;
@@ -71,7 +76,7 @@ function parseArgs(argv: string[]): CliArgs {
 		}
 	}
 	return {
-		profile, initialMessage, print, missionId, workspace,
+		profile, initialMessage, print, probe, missionId, workspace,
 		resumeSessionId, resumeSessionPath, browseSessions, continueLast,
 	};
 }
@@ -85,10 +90,24 @@ async function main(): Promise<number> {
 	} = await import("./harness/pi/pi-sessions.js");
 	const { createRosclawRuntime } = await import("./harness/pi/pi-runtime.js");
 	const {
-		profile, initialMessage, print, missionId, workspace,
+		profile, initialMessage, print, probe, missionId, workspace,
 		resumeSessionId, resumeSessionPath, browseSessions, continueLast,
 	} = parseArgs(process.argv.slice(2));
 	const rosclawHome = rosclawHomeEnv;
+	if (probe) {
+		// P1-A1：headless 探测通道——输出单行 JSON（无 secret），
+		// Python onboarding/doctor 解析；不建会话、不进 TUI。
+		const { probePiModel } = await import("./harness/pi/pi-probe.js");
+		const report = await probePiModel({
+			agentDir: `${rosclawHome}/agent`,
+			// 探测只读全局 settings（defaultProvider/Model）——project
+			// settings 无关；probe 不新增进程 cwd 读取（N1 不变量）。
+			cwd: workspace ?? rosclawHome,
+			profile,
+		});
+		console.log(JSON.stringify(report));
+		return report.reachable && report.chat_ok && report.tool_call_ok ? 0 : 1;
+	}
 	// WP-P0-1（总纲 §5.1）：恢复路径全部经 Pi SessionManager 公开
 	// API——不再有手写目录扫描/mtime 排序/文件名拼接（Pi 文件名可含
 	// 时间前缀，拼接 id 是格式漂移风险）。

--- a/packages/rosclaw-agent/test/p1a1-probe.test.ts
+++ b/packages/rosclaw-agent/test/p1a1-probe.test.ts
@@ -1,0 +1,138 @@
+/** P1-A1（0824 总纲 §10.1）：Pi probe 报告契约。
+ *
+ * - 未配置 → MODEL_NOT_CONFIGURED（指向 setup model），不发网络请求；
+ * - auth 缺失 → AUTH_NOT_CONFIGURED；
+ * - 四步全过 → reachable/chat_ok/tool_call_ok 全 true；
+ * - 错误分类稳定（401→AUTH_FAILED、429→RATE_LIMITED）；
+ * - 报告绝不包含 secret 材料。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { probePiModel } from "../src/harness/pi/pi-probe.js";
+
+interface FakeModel {
+	provider: string;
+	id: string;
+}
+
+function fakeRuntime(overrides: {
+	auth?: boolean;
+	available?: FakeModel[];
+	modelsError?: Error;
+	chatReply?: unknown;
+	toolReply?: unknown;
+	chatError?: Error;
+	toolError?: Error;
+}) {
+	const model: FakeModel = { provider: "kimi-code", id: "k3" };
+	return {
+		hasConfiguredAuth: () => overrides.auth ?? true,
+		getAvailable: async () => {
+			if (overrides.modelsError) throw overrides.modelsError;
+			return overrides.available ?? [model];
+		},
+		getModel: () => model,
+		completeSimple: async (_m: unknown, context: { tools?: unknown[] }) => {
+			if (context.tools && context.tools.length > 0) {
+				if (overrides.toolError) throw overrides.toolError;
+				return (
+					overrides.toolReply ?? {
+						stopReason: "toolUse",
+						content: [{ type: "toolCall", name: "report_ok", arguments: { ok: true } }],
+					}
+				);
+			}
+			if (overrides.chatError) throw overrides.chatError;
+			return (
+				overrides.chatReply ?? {
+					stopReason: "stop",
+					content: [{ type: "text", text: "OK" }],
+				}
+			);
+		},
+	} as never;
+}
+
+const BASE = { agentDir: "/tmp/x", cwd: "/tmp/x", profile: "developer" as const };
+const DEFAULTS = { provider: "kimi-code", model: "k3" };
+
+test("未配置 defaultProvider/defaultModel → MODEL_NOT_CONFIGURED", async () => {
+	const report = await probePiModel({ ...BASE, defaults: {} });
+	assert.equal(report.reachable, false);
+	assert.match(report.error ?? "", /MODEL_NOT_CONFIGURED/);
+	assert.match(report.error ?? "", /setup model/);
+});
+
+test("auth 缺失 → AUTH_NOT_CONFIGURED，不做 chat", async () => {
+	const report = await probePiModel({
+		...BASE,
+		defaults: DEFAULTS,
+		runtime: fakeRuntime({ auth: false }),
+	});
+	assert.equal(report.auth_configured, false);
+	assert.match(report.error ?? "", /AUTH_NOT_CONFIGURED/);
+	assert.equal(report.chat_ok, false);
+});
+
+test("四步全过 → 全绿 + provider/model 回显", async () => {
+	const report = await probePiModel({
+		...BASE,
+		defaults: DEFAULTS,
+		runtime: fakeRuntime({}),
+	});
+	assert.equal(report.engine, "pi");
+	assert.equal(report.reachable, true);
+	assert.equal(report.chat_ok, true);
+	assert.equal(report.tool_call_ok, true);
+	assert.equal(report.expected_model_present, true);
+	assert.equal(report.provider, "kimi-code");
+	assert.equal(report.model, "k3");
+	assert.deepEqual(report.models_visible, ["k3"]);
+	assert.equal(report.error, undefined);
+});
+
+test("models listing 401 → AUTH_FAILED 分类", async () => {
+	const report = await probePiModel({
+		...BASE,
+		defaults: DEFAULTS,
+		runtime: fakeRuntime({ modelsError: new Error("HTTP 401 unauthorized") }),
+	});
+	assert.equal(report.reachable, false);
+	assert.match(report.error ?? "", /^AUTH_FAILED/);
+});
+
+test("chat 429 → RATE_LIMITED 分类", async () => {
+	const report = await probePiModel({
+		...BASE,
+		defaults: DEFAULTS,
+		runtime: fakeRuntime({ chatError: new Error("429 rate limit exceeded") }),
+	});
+	assert.equal(report.reachable, true);
+	assert.equal(report.chat_ok, false);
+	assert.match(report.error ?? "", /^RATE_LIMITED/);
+});
+
+test("tool call 缺失 → TOOL_CALL_PROBE_FAILED（诚实失败）", async () => {
+	const report = await probePiModel({
+		...BASE,
+		defaults: DEFAULTS,
+		runtime: fakeRuntime({
+			toolReply: { stopReason: "stop", content: [{ type: "text", text: "ok" }] },
+		}),
+	});
+	assert.equal(report.chat_ok, true);
+	assert.equal(report.tool_call_ok, false);
+	assert.match(report.error ?? "", /TOOL_CALL_PROBE_FAILED/);
+});
+
+test("报告序列化不含 secret 材料", async () => {
+	const report = await probePiModel({
+		...BASE,
+		defaults: DEFAULTS,
+		runtime: fakeRuntime({}),
+	});
+	const text = JSON.stringify(report);
+	assert.ok(!text.includes("sk-"), `报告含 key 材料: ${text}`);
+});

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -253,11 +253,11 @@ def cmd_chat(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    try:
-        if not load_agent_config(home / "config.yaml").profiles:
-            print("未配置模型。先运行 `rosclaw setup model`。", file=sys.stderr)
-            return 2
-    except ValueError:
+    # P1-A1：chat 准入读 Pi 配置单源（agent/settings.json+models.json——
+    # chat 引擎实际消费的那份），不再读 config.yaml 模型段。
+    from rosclaw.agentd.pi_config import pi_model_configured
+
+    if not pi_model_configured(home):
         print("未配置模型。先运行 `rosclaw setup model`。", file=sys.stderr)
         return 2
     return _chat_pi(home, args)

--- a/src/rosclaw/agentd/onboarding.py
+++ b/src/rosclaw/agentd/onboarding.py
@@ -1,9 +1,10 @@
-"""Model onboarding for firstboot / `rosclaw agent init` (PR-NA-041).
+"""Model onboarding for firstboot / `rosclaw setup model`.
 
-Writes credential *references* only, then runs the four firstboot probes
-(connectivity, model listing, short chat, strict tool call) with the same
-endpoint the agent will use. Failure is recorded honestly as
-``MODEL_NOT_READY`` — firstboot may complete, but never with fake success.
+P1-A1（0824 总纲 §10.1）：模型配置与探测**单源**——setup 写
+``~/.rosclaw/agent/{settings,models}.json``（Pi ModelRuntime 实际
+消费的配置），probe 经 Pi engine（``main.js --probe``，与 chat 同一
+ModelRuntime）。不再写 config.yaml 模型段、不再另起 Python HTTP
+chat probe。失败诚实记为 ``MODEL_NOT_READY``——绝不假成功。
 """
 
 from __future__ import annotations
@@ -11,36 +12,38 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from rosclaw.agentd.config import load_agent_config, write_agent_config
-from rosclaw.agentd.models.gateway import (
-    ModelGatewayError,
-    ModelProbeResult,
-    OpenAICompatGateway,
-    key_fingerprint,
-)
-from rosclaw.agentd.models.policy import ModelProfile
+from rosclaw.agentd.models.gateway import ModelProbeResult, key_fingerprint
 from rosclaw.agentd.models.profiles import (
     KIMI_CN_BASE_URL,
     KIMI_CODE_BASE_URL,
     KIMI_CODE_K3_MODEL,
     KIMI_K3_MODEL,
 )
+from rosclaw.agentd.pi_config import (
+    read_pi_model_config,
+    write_pi_model_config,
+)
+from rosclaw.agentd.pi_probe import pi_probe_home
 
 PROVIDER_CHOICES = ("kimi-code", "kimi-api", "openai-compat", "local", "skip")
 
 _TEMPLATES = {
     "kimi-code": {
-        "provider_key": "kimi_code",
         "base_url": KIMI_CODE_BASE_URL,
         "model": KIMI_CODE_K3_MODEL,
+        "model_name": "Kimi K3",
         "api_key_ref": "env:ROSCLAW_KIMI_API_KEY",
+        "context_window": 262144,
+        "max_tokens": 16384,
         "key_hint": "Kimi Coding Plan key (sk-kimi-*) in ROSCLAW_KIMI_API_KEY",
     },
     "kimi-api": {
-        "provider_key": "kimi_cn",
         "base_url": KIMI_CN_BASE_URL,
         "model": KIMI_K3_MODEL,
+        "model_name": "Kimi K3 (open platform)",
         "api_key_ref": "env:MOONSHOT_API_KEY",
+        "context_window": 262144,
+        "max_tokens": 16384,
         "key_hint": "Moonshot open-platform key in MOONSHOT_API_KEY",
     },
 }
@@ -55,7 +58,7 @@ def configure_model(
     api_key_ref: str | None = None,
     reasoning_effort: str = "high",
 ) -> dict:
-    """Write the agent/model config for *choice*. Returns a summary dict."""
+    """Write the Pi model config for *choice*. Returns a summary dict."""
     if choice not in PROVIDER_CHOICES:
         raise ValueError(f"unknown provider choice {choice!r}")
     if choice == "skip":
@@ -63,50 +66,47 @@ def configure_model(
     template = _TEMPLATES.get(
         choice,
         {
-            "provider_key": choice.replace("-", "_"),
             "base_url": base_url or "",
             "model": model or "",
+            "model_name": model or "",
             "api_key_ref": api_key_ref or "",
+            "context_window": 131072,
+            "max_tokens": 8192,
             "key_hint": "custom OpenAI-compatible endpoint",
         },
     )
-    config_path = home / "config.yaml"
-    write_agent_config(
-        config_path,
-        provider_key=template["provider_key"],
+    config = write_pi_model_config(
+        home,
+        provider=choice,
         base_url=base_url or template["base_url"],
         model=model or template["model"],
+        model_name=str(template["model_name"]),
         api_key_ref=api_key_ref or template["api_key_ref"],
-        reasoning_effort=reasoning_effort,
+        context_window=int(template["context_window"]),
+        max_tokens=int(template["max_tokens"]),
     )
+    if reasoning_effort != "high":
+        # thinking level 由 Pi settings 自持（/effort）——setup 不复制。
+        pass
     return {
         "configured": True,
-        "config_path": str(config_path),
-        "provider": template["provider_key"],
-        "base_url": base_url or template["base_url"],
-        "model": model or template["model"],
-        "api_key_ref": api_key_ref or template["api_key_ref"],
+        "config_path": str(home / "agent"),
+        "provider": config.provider,
+        "base_url": config.base_url,
+        "model": config.model,
+        "api_key_ref": config.api_key_ref,
         "key_hint": template["key_hint"],
     }
 
 
-def _profile_from_config(home: Path) -> ModelProfile:
-    config = load_agent_config(home / "config.yaml")
-    return config.to_policy().default
-
-
 async def probe_home(home: Path) -> ModelProbeResult:
-    try:
-        profile = _profile_from_config(home)
-        gateway = OpenAICompatGateway(profile)
-    except Exception as exc:  # noqa: BLE001 - doctor must report, not crash
-        return ModelProbeResult(reachable=False, error=f"config/credential: {exc}")
-    try:
-        return await gateway.probe()
-    except ModelGatewayError as exc:
-        return ModelProbeResult(reachable=False, error=f"{exc.kind}: {exc}")
-    finally:
-        await gateway.close()
+    """经 Pi engine 探测（与 chat 同一 ModelRuntime、同一配置文件）。"""
+    if read_pi_model_config(home) is None:
+        return ModelProbeResult(
+            reachable=False,
+            error="MODEL_NOT_CONFIGURED: 未配置模型——运行 `rosclaw setup model`",
+        )
+    return await pi_probe_home(home)
 
 
 def _component_report() -> dict:
@@ -178,7 +178,11 @@ def _pi_engine_report(home: Path) -> dict:
 
     entry = (
         Path(__file__).resolve().parents[3]
-        / "packages" / "rosclaw-agent" / "dist" / "src" / "main.js"
+        / "packages"
+        / "rosclaw-agent"
+        / "dist"
+        / "src"
+        / "main.js"
     )
     node_ok = False
     for candidate in filter(None, [shutil.which("node"), "/usr/bin/node"]):
@@ -195,9 +199,7 @@ def _pi_engine_report(home: Path) -> dict:
     if dist_present:
         src_dir = entry.parents[2] / "src"
         dist_mtime = entry.stat().st_mtime
-        stale = any(
-            p.stat().st_mtime > dist_mtime for p in src_dir.rglob("*.ts")
-        )
+        stale = any(p.stat().st_mtime > dist_mtime for p in src_dir.rglob("*.ts"))
     settings = home / "agent" / "settings.json"
     credential_file = home / "agent" / "auth.json"
     return {
@@ -211,33 +213,42 @@ def _pi_engine_report(home: Path) -> dict:
         "note": (
             "FAIL: dist 过期（源码新于构建产物）——重新构建发布包，不要手工 npm build"
             if stale
-            else "pi engine ready" if node_ok and dist_present else "pi engine unavailable"
+            else "pi engine ready"
+            if node_ok and dist_present
+            else "pi engine unavailable"
         ),
     }
 
 
 def doctor(home: Path) -> dict:
     """Honest agent readiness report. Never prints raw credentials."""
-    config = load_agent_config(home / "config.yaml")
+    from rosclaw.agentd.config import load_agent_config
+
+    agent_config = load_agent_config(home / "config.yaml")
+    model = read_pi_model_config(home)
     report: dict = {
-        "agent_enabled": config.enabled,
-        "model_backend": config.model_backend,
-        "profiles": [p.name for p in config.profiles],
-        "default_profile": config.default_profile if config.profiles else None,
+        "agent_enabled": agent_config.enabled,
+        "model_backend": "pi",
+        "profiles": [f"{model.provider}/{model.model}"] if model else [],
+        "default_profile": f"{model.provider}/{model.model}" if model else None,
+        "model": (
+            {"provider": model.provider, "model": model.model}
+            if model
+            else {"provider": "", "model": ""}
+        ),
     }
     report["components"] = _component_report()
     report["authorization"] = _authorization_report(home)
-    if not config.profiles:
+    if model is None:
         report["status"] = "MODEL_NOT_READY"
         report["reason"] = "no model profile configured — run `rosclaw setup model`"
         return report
-    profile = config.to_policy().default
     import os
 
     key = ""
-    if profile.api_key_ref.startswith("env:"):
-        key = os.environ.get(profile.api_key_ref[4:], "")
-    report["api_key_ref"] = profile.api_key_ref
+    if model.api_key_ref.startswith("env:"):
+        key = os.environ.get(model.api_key_ref[4:], "")
+    report["api_key_ref"] = model.api_key_ref
     report["api_key_present"] = bool(key)
     if key:
         report["api_key_fingerprint"] = key_fingerprint(key)
@@ -250,7 +261,9 @@ def doctor(home: Path) -> dict:
         "tool_call_ok": probe.tool_call_ok,
         "error": probe.error,
     }
-    ready = bool(probe.reachable and probe.chat_ok and probe.tool_call_ok and key)
+    ready = bool(
+        probe.reachable and probe.chat_ok and probe.tool_call_ok and (key or not model.api_key_ref)
+    )
     report["status"] = "READY" if ready else "MODEL_NOT_READY"
     if not ready and not probe.error:
         report["reason"] = "probe incomplete (see probe fields)"

--- a/src/rosclaw/agentd/pi_config.py
+++ b/src/rosclaw/agentd/pi_config.py
@@ -1,0 +1,158 @@
+"""Pi 模型配置单源（P1-A1，0824 总纲 §10.1）。
+
+``~/.rosclaw/agent/settings.json``（defaultProvider/defaultModel）+
+``~/.rosclaw/agent/models.json``（provider 目录：baseUrl/api/models）
+是 chat（Pi ModelRuntime）实际消费的唯一配置。本模块是 Python 侧
+对该配置的**唯一**读写点——setup/doctor/chat gate/status 全从这里
+取事实，不再另读 config.yaml 模型段。
+
+安全红线：apiKey 只写 ``$ENV_VAR`` 引用（与 Pi models.json 的 env
+间接寻址一致）——原始 key 永远不落盘；``api_key_ref`` 只接受
+``env:VAR`` 形式。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+#: apiKey 的 $ENV 引用形式（Pi models.json 约定）。
+_ENV_REF_RE = re.compile(r"^\$([A-Z][A-Z0-9_]*)$")
+
+
+@dataclass(frozen=True)
+class PiModelConfig:
+    """无 secret 的模型配置视图。"""
+
+    provider: str
+    model: str
+    base_url: str
+    api: str
+    api_key_ref: str  # "env:VAR" 或 ""（local 无 key）
+    context_window: int
+    max_tokens: int
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def read_pi_model_config(home: Path) -> PiModelConfig | None:
+    """读取 chat 实际消费的模型配置；未配置返回 None。"""
+    agent_dir = home / "agent"
+    settings = _read_json(agent_dir / "settings.json")
+    provider = settings.get("defaultProvider")
+    model = settings.get("defaultModel")
+    if not provider or not model:
+        return None
+    providers = _read_json(agent_dir / "models.json").get("providers") or {}
+    entry = providers.get(provider)
+    if not isinstance(entry, dict):
+        return None
+    api_key_ref = ""
+    raw_ref = str(entry.get("apiKey") or "")
+    match = _ENV_REF_RE.match(raw_ref)
+    if match:
+        api_key_ref = f"env:{match.group(1)}"
+    elif raw_ref:
+        # 非 $ENV 形式 = 疑似原始 key 落盘——绝不回显内容，只报事实。
+        api_key_ref = "inline:REDACTED"
+    context_window = 0
+    max_tokens = 0
+    for m in entry.get("models") or []:
+        if isinstance(m, dict) and m.get("id") == model:
+            context_window = int(m.get("contextWindow") or 0)
+            max_tokens = int(m.get("maxTokens") or 0)
+            break
+    return PiModelConfig(
+        provider=str(provider),
+        model=str(model),
+        base_url=str(entry.get("baseUrl") or ""),
+        api=str(entry.get("api") or "openai-completions"),
+        api_key_ref=api_key_ref,
+        context_window=context_window,
+        max_tokens=max_tokens,
+    )
+
+
+def pi_model_configured(home: Path) -> bool:
+    return read_pi_model_config(home) is not None
+
+
+def write_pi_model_config(
+    home: Path,
+    *,
+    provider: str,
+    base_url: str,
+    model: str,
+    api_key_ref: str = "",
+    model_name: str = "",
+    context_window: int = 131072,
+    max_tokens: int = 8192,
+    api: str = "openai-completions",
+) -> PiModelConfig:
+    """合并写入 Pi 配置（幂等、非破坏：保留 settings/models 其他键）。
+
+    ``api_key_ref`` 必须是 ``env:VAR``（或 local 留空）——原始 key
+    材料直接拒绝（安全红线：key 只在环境变量里）。
+    """
+    if api_key_ref:
+        if not api_key_ref.startswith("env:") or not api_key_ref[4:]:
+            raise ValueError("api_key_ref 必须是 env:VAR 引用——原始 key 绝不落盘")
+        api_key_json = f"${api_key_ref[4:]}"
+    else:
+        api_key_json = ""
+    agent_dir = home / "agent"
+    settings = _read_json(agent_dir / "settings.json")
+    settings["defaultProvider"] = provider
+    settings["defaultModel"] = model
+    _write_json(agent_dir / "settings.json", settings)
+
+    models_doc = _read_json(agent_dir / "models.json")
+    providers = models_doc.setdefault("providers", {})
+    entry = providers.get(provider) if isinstance(providers.get(provider), dict) else {}
+    model_entry = {
+        "id": model,
+        "name": model_name or model,
+        "contextWindow": context_window,
+        "maxTokens": max_tokens,
+    }
+    existing = [
+        m for m in (entry.get("models") or []) if isinstance(m, dict) and m.get("id") != model
+    ]
+    entry.update(
+        {
+            "name": entry.get("name") or provider,
+            "baseUrl": base_url,
+            "api": api,
+            "models": [*existing, model_entry],
+        }
+    )
+    if api_key_json:
+        entry["apiKey"] = api_key_json
+    elif "apiKey" not in entry:
+        entry["apiKey"] = ""
+    providers[provider] = entry
+    _write_json(agent_dir / "models.json", models_doc)
+    return PiModelConfig(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        api=api,
+        api_key_ref=api_key_ref,
+        context_window=context_window,
+        max_tokens=max_tokens,
+    )

--- a/src/rosclaw/agentd/pi_probe.py
+++ b/src/rosclaw/agentd/pi_probe.py
@@ -1,0 +1,90 @@
+"""Pi engine 模型探测（P1-A1，0824 总纲 §10.1）。
+
+probe 与 chat 同一引擎：``node <rosclaw-agent>/dist/src/main.js --probe``
+内部走 Pi ModelRuntime（settings.json + models.json + auth.json/env）。
+本模块只做进程编排与无 secret 的结果映射——不另起 HTTP chat 栈。
+
+诚实性：engine 缺失/超时/非零退出/坏 JSON 全部落成显式 error，
+绝不假 GREEN；stderr 回显前做 key 形态脱敏。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from pathlib import Path
+
+from rosclaw.agentd import pi_entry
+from rosclaw.agentd.models.gateway import ModelProbeResult
+
+#: probe 总超时（四步含网络；比单次 chat 超时宽）。
+_PROBE_TIMEOUT_S = 240.0
+
+_SECRET_RE = re.compile(r"sk-[A-Za-z0-9_-]{4,}")
+
+
+def _sanitize(text: str, *, limit: int = 400) -> str:
+    return _SECRET_RE.sub("sk-***", text.strip())[:limit]
+
+
+async def pi_probe_home(home: Path) -> ModelProbeResult:
+    """经 Pi engine 探测 home 的模型配置（settings/models 单源）。"""
+    located = pi_entry.find_pi_agent_entry()
+    if located is None:
+        return ModelProbeResult(
+            reachable=False,
+            error="PI_ENGINE_MISSING: node>=22.19 或 rosclaw-agent dist "
+            "不可用——重新安装或构建发布包",
+        )
+    node, entry = located
+    env = dict(os.environ, ROSCLAW_HOME=str(home))
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            node,
+            str(entry),
+            "--probe",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+    except OSError as exc:
+        return ModelProbeResult(reachable=False, error=f"PI_ENGINE_SPAWN_FAILED: {exc}")
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=_PROBE_TIMEOUT_S)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return ModelProbeResult(
+            reachable=False,
+            error=f"PI_PROBE_TIMEOUT: 超过 {_PROBE_TIMEOUT_S:.0f}s 未收敛",
+        )
+    out = stdout.decode("utf-8", errors="replace").strip()
+    payload: dict | None = None
+    for line in reversed(out.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict) and data.get("engine") == "pi":
+                payload = data
+                break
+    if payload is None:
+        return ModelProbeResult(
+            reachable=False,
+            error=(
+                f"PI_PROBE_FAILED: rc={proc.returncode} 无有效报告——"
+                f"{_sanitize(stderr.decode('utf-8', errors='replace'))}"
+            ),
+        )
+    return ModelProbeResult(
+        reachable=bool(payload.get("reachable")),
+        models_visible=tuple(str(m) for m in payload.get("models_visible") or ()),
+        expected_model_present=bool(payload.get("expected_model_present")),
+        chat_ok=bool(payload.get("chat_ok")),
+        tool_call_ok=bool(payload.get("tool_call_ok")),
+        error=_sanitize(str(payload.get("error") or "")) or None,
+    )

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -1067,17 +1067,18 @@ class AgentService:
         return bool(self._store.mission_meta(mission_id)["archived"])
 
     def status_snapshot(self, mission_id: str | None = None) -> dict:
+        from rosclaw.agentd.pi_config import read_pi_model_config
+
+        model = read_pi_model_config(self._home)
         data: dict = {
             "agent": "rosclaw-agentd",
             "body_id": self._body_id,
             "daemon_connected": self._daemon_client is not None,
             "mcp_servers": [a.source for a in self._mcp_adapters],
             "model_profile": (
-                self._config.to_policy().default.name if self._config.profiles else ""
+                f"{model.provider}/{model.model}" if model else ""
             ),
-            "model": (
-                self._config.to_policy().default.model if self._config.profiles else ""
-            ),
+            "model": model.model if model else "",
             "tools_registered": len(self._tool_catalog.list()),
         }
         if mission_id:
@@ -1428,49 +1429,41 @@ class AgentService:
 
     # ------------------------------------------------------------------
     async def probe(self):
-        """模型探测（PR-H9：不再持有持久 gateway——临时构造、用完
-        即关；配置即真相）。"""
-        from rosclaw.agentd.models.gateway import (
-            ModelGatewayError,
-            ModelProbeResult,
-            OpenAICompatGateway,
-        )
+        """模型探测（P1-A1：经 Pi engine——与 chat 同一 ModelRuntime
+        同一配置；不再有第二条 Python HTTP probe 栈）。"""
+        from rosclaw.agentd.models.gateway import ModelProbeResult
+        from rosclaw.agentd.pi_config import read_pi_model_config
+        from rosclaw.agentd.pi_probe import pi_probe_home
 
-        if not self._config.profiles:
+        if read_pi_model_config(self._home) is None:
             return ModelProbeResult(reachable=False, error="no_profiles")
-        gateway = OpenAICompatGateway(self._config.to_policy().default)
-        try:
-            return await gateway.probe()
-        except ModelGatewayError as exc:
-            return ModelProbeResult(reachable=False, error=f"{exc.kind}: {exc}")
-        finally:
-            await gateway.close()
+        return await pi_probe_home(self._home)
 
     def status(self) -> dict:
-        if not self._config.profiles:
-            return {
-                "agent_enabled": self._config.enabled,
-                "default_mode": self._config.default_mode,
-                "body_id": self._body_id,
-                "daemon_connected": self._daemon_client is not None,
-                "profile": "", "provider": "", "model": "", "base_url": "",
-                "api_key_ref": "",
-                "missions": len(self._store.list_missions()),
-                "maturity": "experimental",
-            }
-        profile = self._config.to_policy().default
-        return {
+        from rosclaw.agentd.pi_config import read_pi_model_config
+
+        model = read_pi_model_config(self._home)
+        base = {
             "agent_enabled": self._config.enabled,
             "default_mode": self._config.default_mode,
             "body_id": self._body_id,
             "daemon_connected": self._daemon_client is not None,
-            "profile": profile.name,
-            "provider": profile.provider,
-            "model": profile.model,
-            "base_url": profile.base_url,
-            "api_key_ref": profile.api_key_ref,
             "missions": len(self._store.list_missions()),
             "maturity": "experimental",
+        }
+        if model is None:
+            return {
+                **base,
+                "profile": "", "provider": "", "model": "", "base_url": "",
+                "api_key_ref": "",
+            }
+        return {
+            **base,
+            "profile": f"{model.provider}/{model.model}",
+            "provider": model.provider,
+            "model": model.model,
+            "base_url": model.base_url,
+            "api_key_ref": model.api_key_ref,
         }
 
     async def estop(self, reason: str, *, principal: str) -> dict:

--- a/tests/agentd/test_p1a1_pi_single_source.py
+++ b/tests/agentd/test_p1a1_pi_single_source.py
@@ -1,0 +1,267 @@
+"""P1-A1 红测试（0824 总纲 §10.1/P1-A）：模型配置与探测单源化。
+
+复现的真实事故：setup 把模型配置写进 ``~/.rosclaw/config.yaml``，
+而 chat 实际消费 ``~/.rosclaw/agent/{settings,models}.json``（Pi
+ModelRuntime）——setup 后 chat 看到的是另一套（可能空的）配置，
+doctor 的 probe 走 Python 自带 HTTP chat 栈（OpenAICompatGateway）
+而不是 Pi ModelRuntime，同一台机器三个"真相"。
+
+本文件断言单一事实源：
+
+1. ``configure_model`` 写 Pi 配置（settings.json defaultProvider/
+   defaultModel + models.json provider 条目），apiKey 只写 ``$ENV``
+   引用——绝不写 config.yaml 模型段、绝不落任何原始 key；
+2. chat 准入门槛读 Pi 配置（不再读 config.yaml profiles）；
+3. ``probe_home``/doctor 的 probe 经 Pi engine（node main.js --probe），
+   不再构造 OpenAICompatGateway；engine 缺失时诚实报错；
+4. doctor 的就绪判定基于 Pi 配置 + Pi probe。
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd import onboarding
+from rosclaw.agentd.onboarding import configure_model, doctor
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class TestConfigureModelSingleSource:
+    def test_writes_pi_settings_and_models(self, tmp_path: Path) -> None:
+        summary = configure_model(tmp_path, "kimi-code")
+        assert summary["configured"] is True
+        settings = _read(tmp_path / "agent" / "settings.json")
+        assert settings["defaultProvider"] == "kimi-code"
+        assert settings["defaultModel"]  # 非空（模板 k3）
+        models = _read(tmp_path / "agent" / "models.json")
+        provider = models["providers"]["kimi-code"]
+        assert provider["baseUrl"] == summary["base_url"]
+        assert provider["api"]  # openai-completions 族
+        # key 只写 $ENV 引用——与生产 home（tests live gate）同构。
+        assert provider["apiKey"] == "$ROSCLAW_KIMI_API_KEY"
+        entry_ids = [m["id"] for m in provider["models"]]
+        assert settings["defaultModel"] in entry_ids
+
+    def test_never_writes_raw_key_or_config_yaml_model_section(self, tmp_path: Path) -> None:
+        configure_model(tmp_path, "kimi-code")
+        for path in (
+            tmp_path / "agent" / "models.json",
+            tmp_path / "agent" / "settings.json",
+        ):
+            text = path.read_text(encoding="utf-8")
+            assert "sk-" not in text, f"{path} 含原始 key 材料"
+        config = tmp_path / "config.yaml"
+        if config.exists():
+            assert "profiles:" not in config.read_text(encoding="utf-8"), (
+                "模型 profiles 仍写进 config.yaml——配置双源"
+            )
+
+    def test_refuses_raw_key_material(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="env:"):
+            configure_model(
+                tmp_path,
+                "openai-compat",
+                base_url="https://example.invalid/v1",
+                model="m",
+                api_key_ref="sk-rawkeymaterial",
+            )
+
+    def test_custom_provider_roundtrip(self, tmp_path: Path) -> None:
+        summary = configure_model(
+            tmp_path,
+            "openai-compat",
+            base_url="https://example.invalid/v1",
+            model="my-model",
+            api_key_ref="env:MY_PROVIDER_KEY",
+        )
+        assert summary["configured"] is True
+        models = _read(tmp_path / "agent" / "models.json")
+        provider = models["providers"]["openai-compat"]
+        assert provider["baseUrl"] == "https://example.invalid/v1"
+        assert provider["apiKey"] == "$MY_PROVIDER_KEY"
+        settings = _read(tmp_path / "agent" / "settings.json")
+        assert settings["defaultModel"] == "my-model"
+
+    def test_preserves_existing_settings_keys(self, tmp_path: Path) -> None:
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "settings.json").write_text(
+            json.dumps({"hideThinkingBlock": True}), encoding="utf-8"
+        )
+        configure_model(tmp_path, "kimi-code")
+        settings = _read(agent_dir / "settings.json")
+        assert settings["hideThinkingBlock"] is True
+        assert settings["defaultProvider"] == "kimi-code"
+
+
+class TestChatGateSingleSource:
+    def test_chat_gate_accepts_pi_config_without_config_yaml(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """chat 准入读 Pi 配置——只有 Pi 文件（无 config.yaml）必须放行。"""
+        from rosclaw.agentd import cli as agentd_cli
+
+        configure_model(tmp_path, "kimi-code")
+        monkeypatch.setattr(agentd_cli, "_chat_pi", lambda home, args: 0)
+        rc = agentd_cli.main(["--home", str(tmp_path), "chat"])
+        assert rc == 0
+
+    def test_chat_gate_rejects_legacy_only_config(
+        self, tmp_path: Path, capsys, monkeypatch
+    ) -> None:
+        """只有 legacy config.yaml（旧事故形态）→ 诚实拒绝并指向 setup。"""
+        from rosclaw.agentd import cli as agentd_cli
+        from rosclaw.agentd.cli import main as agentd_main
+
+        def _forbidden_chat(home, args):  # pragma: no cover - 红期防空转
+            raise AssertionError("legacy-only 配置不应进入 _chat_pi")
+
+        monkeypatch.setattr(agentd_cli, "_chat_pi", _forbidden_chat)
+
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n  enabled: true\n  default_profile: p\n"
+            "models:\n  backend: legacy\n  profiles:\n    p:\n"
+            "      provider: kimi_code\n      model: k3\n"
+            "      base_url: https://api.kimi.com/coding/v1\n"
+            "      api_key_ref: env:ROSCLAW_KIMI_API_KEY\n",
+            encoding="utf-8",
+        )
+        rc = agentd_main(["--home", str(tmp_path), "chat"])
+        assert rc == 2
+        assert "setup model" in capsys.readouterr().err
+
+
+class TestProbeViaPiEngine:
+    def test_onboarding_has_no_legacy_gateway_probe(self) -> None:
+        """结构上根除：onboarding 不再引用 OpenAICompatGateway。"""
+        source = inspect.getsource(onboarding)
+        assert "OpenAICompatGateway" not in source
+
+    def test_probe_home_invokes_pi_engine(self, tmp_path: Path, monkeypatch) -> None:
+        """probe_home 经 node main.js --probe（同一 ModelRuntime）。"""
+        import asyncio
+
+        configure_model(tmp_path, "kimi-code")
+        calls: list[list[str]] = []
+
+        class _FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                payload = json.dumps(
+                    {
+                        "engine": "pi",
+                        "reachable": True,
+                        "auth_configured": True,
+                        "models_visible": ["k3"],
+                        "expected_model_present": True,
+                        "chat_ok": True,
+                        "tool_call_ok": True,
+                        "provider": "kimi-code",
+                        "model": "k3",
+                    }
+                ).encode()
+                return payload, b""
+
+        async def fake_exec(*cmd, **kwargs):
+            calls.append([str(c) for c in cmd])
+            return _FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        result = asyncio.run(onboarding.probe_home(tmp_path))
+        assert result.reachable is True
+        assert result.chat_ok is True and result.tool_call_ok is True
+        assert result.expected_model_present is True
+        assert calls, "probe 未发起子进程"
+        cmdline = " ".join(calls[0])
+        assert "main.js" in cmdline and "--probe" in cmdline
+
+    def test_probe_home_engine_missing_is_honest(self, tmp_path: Path, monkeypatch) -> None:
+        import asyncio
+
+        from rosclaw.agentd import pi_entry
+
+        configure_model(tmp_path, "kimi-code")
+        monkeypatch.setattr(pi_entry, "find_pi_agent_entry", lambda: None)
+        monkeypatch.setattr(onboarding, "_find_pi_agent_entry", lambda: None, raising=False)
+        result = asyncio.run(onboarding.probe_home(tmp_path))
+        assert result.reachable is False
+        assert "PI_ENGINE" in (result.error or "")
+
+    def test_probe_home_failure_payload_honest(self, tmp_path: Path, monkeypatch) -> None:
+        """Pi probe 报告失败（如 401）→ 原样透传，不粉饰。"""
+        import asyncio
+
+        configure_model(tmp_path, "kimi-code")
+
+        class _FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                payload = json.dumps(
+                    {
+                        "engine": "pi",
+                        "reachable": False,
+                        "auth_configured": True,
+                        "models_visible": [],
+                        "expected_model_present": False,
+                        "chat_ok": False,
+                        "tool_call_ok": False,
+                        "error": "AUTH_FAILED: 401",
+                    }
+                ).encode()
+                return payload, b""
+
+        async def fake_exec(*cmd, **kwargs):
+            return _FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        result = asyncio.run(onboarding.probe_home(tmp_path))
+        assert result.reachable is False
+        assert "401" in (result.error or "")
+
+
+class TestDoctorSingleSource:
+    def _write_pi_config(self, home: Path) -> None:
+        configure_model(home, "kimi-code")
+
+    def test_doctor_ready_with_pi_config_and_probe(self, tmp_path: Path, monkeypatch) -> None:
+
+        from rosclaw.agentd.models.gateway import ModelProbeResult
+
+        self._write_pi_config(tmp_path)
+        monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "sk-kimi-doctor-test")
+        monkeypatch.setattr(
+            onboarding,
+            "probe_home",
+            lambda home: _async_result(
+                ModelProbeResult(
+                    reachable=True,
+                    models_visible=("k3",),
+                    expected_model_present=True,
+                    chat_ok=True,
+                    tool_call_ok=True,
+                )
+            ),
+        )
+        report = doctor(tmp_path)
+        assert report["status"] == "READY"
+        assert report["probe"]["chat_ok"] is True
+        assert report["probe"]["tool_call_ok"] is True
+        assert report["api_key_present"] is True
+
+    def test_doctor_not_ready_without_pi_config(self, tmp_path: Path) -> None:
+        report = doctor(tmp_path)
+        assert report["status"] == "MODEL_NOT_READY"
+        assert "setup model" in report["reason"]
+
+
+async def _async_result(value):
+    return value

--- a/tests/agentd/test_p1a1_pi_single_source.py
+++ b/tests/agentd/test_p1a1_pi_single_source.py
@@ -148,7 +148,11 @@ class TestProbeViaPiEngine:
         """probe_home 经 node main.js --probe（同一 ModelRuntime）。"""
         import asyncio
 
+        from rosclaw.agentd import pi_entry
+
         configure_model(tmp_path, "kimi-code")
+        # CI 无已构建 dist——engine 发现打桩（engine-missing 有独立用例）。
+        monkeypatch.setattr(pi_entry, "find_pi_agent_entry", lambda: ("node", "/fake/main.js"))
         calls: list[list[str]] = []
 
         class _FakeProc:
@@ -199,7 +203,10 @@ class TestProbeViaPiEngine:
         """Pi probe 报告失败（如 401）→ 原样透传，不粉饰。"""
         import asyncio
 
+        from rosclaw.agentd import pi_entry
+
         configure_model(tmp_path, "kimi-code")
+        monkeypatch.setattr(pi_entry, "find_pi_agent_entry", lambda: ("node", "/fake/main.js"))
 
         class _FakeProc:
             returncode = 0

--- a/tests/agentd/test_service.py
+++ b/tests/agentd/test_service.py
@@ -12,7 +12,6 @@ import json
 from pathlib import Path
 
 import pytest
-import yaml
 
 from rosclaw.agentd.cli import main as agentd_main
 from rosclaw.agentd.config import load_agent_config
@@ -187,13 +186,20 @@ class TestOnboarding:
         assert config.physical_action_count == 3
 
     def test_configure_writes_key_ref_only(self, tmp_path: Path) -> None:
+        """P1-A1：setup 写 Pi 配置单源——key 只写 $ENV 引用。"""
         summary = configure_model(tmp_path, "kimi-code")
         assert summary["configured"]
-        data = yaml.safe_load((tmp_path / "config.yaml").read_text())
-        profile = data["models"]["profiles"]["embodied_default"]
-        assert profile["api_key_ref"] == "env:ROSCLAW_KIMI_API_KEY"
-        assert "api_key" not in profile
-        assert "sk-" not in (tmp_path / "config.yaml").read_text()
+        models = json.loads(
+            (tmp_path / "agent" / "models.json").read_text(encoding="utf-8")
+        )
+        provider = models["providers"]["kimi-code"]
+        assert provider["apiKey"] == "$ROSCLAW_KIMI_API_KEY"
+        assert summary["api_key_ref"] == "env:ROSCLAW_KIMI_API_KEY"
+        for path in (
+            tmp_path / "agent" / "models.json",
+            tmp_path / "agent" / "settings.json",
+        ):
+            assert "sk-" not in path.read_text(encoding="utf-8")
 
     def test_doctor_not_ready_without_key(self, tmp_path: Path, monkeypatch) -> None:
         configure_model(tmp_path, "kimi-code")


### PR DESCRIPTION
## 真实事故
setup 写 config.yaml，chat 引擎读 agent/{settings,models}.json，doctor probe 走 Python 自带 HTTP chat 栈——同一台机器三个"真相"。

## 红→绿
- 红：tests/agentd/test_p1a1_pi_single_source.py 10 failed（复现双源+legacy probe）
- 绿：13 passed；test_service/test_setup_contract/test_credentials 34 绿；TS 166 绿

## 修改
- TS `pi-probe.ts` + `main.js --probe`：四步探测（auth→models→chat→严格 tool call）走 Pi ModelRuntime，错误分类稳定，单行 JSON 无 secret
- Python `pi_config.py`：Pi 配置唯一读写点（apiKey 只写 $ENV 引用，拒绝原始 key 落盘）
- Python `pi_probe.py`：probe 进程编排 + sk- 脱敏
- onboarding/configure_model/probe_home/doctor、chat gate、service status/probe 全部改读单源；onboarding 不再引用 OpenAICompatGateway

## 验证
- live（真实 K3，key 仅 env）：setup model → doctor READY；输出无真实 key
- fault injection：无 key→AUTH_NOT_CONFIGURED；错 key→AUTH_FAILED 401
- 注：tests/test_firstboot.py 3 个失败在 main(c344059) 本地同样失败（预存本地环境问题，非本 PR 引入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)