### PR TITLE
feat: compaction 后 TaskRefs 锚定——compact 不再丢 task/artifact refs（0824 总纲 P1-A4）

### DIFF
--- a/packages/rosclaw-agent/src/extension/compact-anchor.ts
+++ b/packages/rosclaw-agent/src/extension/compact-anchor.ts
@@ -1,0 +1,98 @@
+/** P1-A4（0824 总纲 P1-A）：/compact 保留 TaskRefs。
+ *
+ * Pi compaction（manual /compact、threshold、overflow）把会话历史压成
+ * 摘要——task_id/root_goal/artifact refs 随被压消息丢失，模型 compact
+ * 后"失忆"。本模块在任何 reason 的 compaction 完成后，从 TaskKernel
+ * 权威账本（pi.kernel.latest + pi.kernel.artifacts——不是模型记忆）
+ * 取最近 task 与产物 refs，经 sendMessage(deliverAs:"nextTurn") 把
+ * TaskRefs 锚定回 LLM 上下文：
+ *
+ * - 锚消息进入会话历史 → 后续 compaction 的 summarizer 也会看到它，
+ *   refs 跨多次 compact 传播；
+ * - 无 task / 拉取失败 → 诚实 no-op（不编造 refs）；
+ * - 同 task+revision 去重（连续 auto-compact 不刷屏）。
+ */
+
+interface KernelTask {
+	task_id?: string;
+	root_goal?: string;
+	state?: string;
+	active_revision?: number;
+}
+
+interface KernelArtifact {
+	artifact_id?: string;
+	path?: string;
+	media_type?: string;
+}
+
+interface BridgeCaller {
+	(method: string, params?: unknown): Promise<{ ok: boolean; task?: unknown; artifacts?: unknown[]; error?: string }>;
+}
+
+interface CompactAnchorDeps {
+	call: BridgeCaller;
+	/** 事件时取值（resume/switch 后绑定可能变化）。 */
+	missionId: () => string;
+	sessionRef: () => string;
+}
+
+interface PiLike {
+	on(event: "session_compact", handler: (event: { reason?: string }) => Promise<void>): void;
+	sendMessage(
+		message: { customType: string; content: string; display: boolean; details?: unknown },
+		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+	): void;
+}
+
+export function buildTaskAnchor(
+	task: KernelTask,
+	artifacts: KernelArtifact[],
+	reason: string,
+): string {
+	const lines = [
+		`[ROSClaw TaskRefs 锚——compaction(${reason}) 后由内核权威账本重建，非模型记忆]`,
+		`task_id: ${task.task_id ?? ""}`,
+		`state: ${task.state ?? ""} (revision ${task.active_revision ?? 0})`,
+		`root_goal: ${task.root_goal ?? ""}`,
+	];
+	if (artifacts.length > 0) {
+		lines.push("artifacts（已登记交付物——引用这些路径，不要凭记忆重造）:");
+		for (const a of artifacts) {
+			lines.push(`- ${a.artifact_id ?? ""} [${a.media_type ?? ""}] ${a.path ?? ""}`);
+		}
+	} else {
+		lines.push("artifacts: （尚无登记产物）");
+	}
+	return lines.join("\n");
+}
+
+export function registerCompactAnchor(pi: PiLike, deps: CompactAnchorDeps): void {
+	let lastKey = "";
+	pi.on("session_compact", async (event) => {
+		const latest = await deps.call("pi.kernel.latest", {
+			mission_id: deps.missionId(),
+			session_ref: deps.sessionRef(),
+		}).catch(() => ({ ok: false }) as never);
+		if (!latest.ok || !latest.task) return; // 无 task/拉取失败——诚实 no-op
+		const task = latest.task as KernelTask;
+		const key = `${task.task_id}:${task.active_revision}`;
+		if (key === lastKey) return; // 同 key 去重
+		const artifactResult = await deps.call("pi.kernel.artifacts", {
+			task_id: task.task_id ?? "",
+		}).catch(() => ({ ok: false }) as never);
+		const artifacts = artifactResult.ok
+			? ((artifactResult.artifacts ?? []) as KernelArtifact[])
+			: [];
+		lastKey = key;
+		pi.sendMessage(
+			{
+				customType: "rosclaw.task_anchor",
+				content: buildTaskAnchor(task, artifacts, String(event.reason ?? "unknown")),
+				display: false,
+				details: { task_id: task.task_id, reason: event.reason },
+			},
+			{ deliverAs: "nextTurn" },
+		);
+	});
+}

--- a/packages/rosclaw-agent/src/extension/compact-anchor.ts
+++ b/packages/rosclaw-agent/src/extension/compact-anchor.ts
@@ -35,6 +35,8 @@ interface CompactAnchorDeps {
 	/** 事件时取值（resume/switch 后绑定可能变化）。 */
 	missionId: () => string;
 	sessionRef: () => string;
+	/** 诊断（诊断先行）：每次决策一行——skip 原因或 anchored。 */
+	log?: (message: string) => void;
 }
 
 interface PiLike {
@@ -74,10 +76,18 @@ export function registerCompactAnchor(pi: PiLike, deps: CompactAnchorDeps): void
 			mission_id: deps.missionId(),
 			session_ref: deps.sessionRef(),
 		}).catch(() => ({ ok: false }) as never);
-		if (!latest.ok || !latest.task) return; // 无 task/拉取失败——诚实 no-op
+		if (!latest.ok || !latest.task) {
+			deps.log?.(
+				`skip: no task (ok=${latest.ok} mission=${deps.missionId()} session=${deps.sessionRef()})`,
+			);
+			return; // 无 task/拉取失败——诚实 no-op
+		}
 		const task = latest.task as KernelTask;
 		const key = `${task.task_id}:${task.active_revision}`;
-		if (key === lastKey) return; // 同 key 去重
+		if (key === lastKey) {
+			deps.log?.(`skip: dup anchor ${key}`);
+			return; // 同 key 去重
+		}
 		const artifactResult = await deps.call("pi.kernel.artifacts", {
 			task_id: task.task_id ?? "",
 		}).catch(() => ({ ok: false }) as never);
@@ -85,6 +95,7 @@ export function registerCompactAnchor(pi: PiLike, deps: CompactAnchorDeps): void
 			? ((artifactResult.artifacts ?? []) as KernelArtifact[])
 			: [];
 		lastKey = key;
+		deps.log?.(`anchored: ${key} artifacts=${artifacts.length}`);
 		pi.sendMessage(
 			{
 				customType: "rosclaw.task_anchor",

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -47,6 +47,7 @@ import { materializeCapabilityTools, type CapabilitySnapshot } from "../tools/ma
 import { MODEL_TOOL_NAMES } from "../tools/surface.js";
 import { fetchEmbodiedContext, renderTrustedContext } from "./context-injection.js";
 import { registerCompactAnchor } from "./compact-anchor.js";
+import { appendFileSync, mkdirSync } from "node:fs";
 import { phaseWorkingMessage } from "./activity.js";
 import { ROSCLAW_SHORTCUTS } from "./shortcuts.js";
 import { StableIdDeduper } from "./dedup.js";
@@ -482,6 +483,18 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				center.call(method, params as Record<string, unknown>) as never,
 			missionId: () => options.active.current.missionId,
 			sessionRef: () => options.active.current.sessionId,
+			log: (message: string) => {
+				// 诊断先行：compact 锚决策日志（小文件，随 logs 轮转）。
+				try {
+					const dir = `${options.rosclawHome}/logs`;
+					mkdirSync(dir, { recursive: true });
+					appendFileSync(
+						`${dir}/compact-anchor.log`,
+						`${new Date().toISOString()} ${message}
+`,
+					);
+				} catch { /* 诊断不阻塞 */ }
+			},
 		} as never);
 
 		// -- 全量 ROSClaw 命令（NA-FIX-6，P0-8：InputGuard 允许的必须真实注册） --

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -46,6 +46,7 @@ import { guardInput } from "./input-guard.js";
 import { materializeCapabilityTools, type CapabilitySnapshot } from "../tools/materialize.js";
 import { MODEL_TOOL_NAMES } from "../tools/surface.js";
 import { fetchEmbodiedContext, renderTrustedContext } from "./context-injection.js";
+import { registerCompactAnchor } from "./compact-anchor.js";
 import { phaseWorkingMessage } from "./activity.js";
 import { ROSCLAW_SHORTCUTS } from "./shortcuts.js";
 import { StableIdDeduper } from "./dedup.js";
@@ -473,6 +474,15 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				},
 			};
 		});
+
+		// P1-A4（0824 总纲）：任何 compaction 完成后从内核权威账本把
+		// TaskRefs 锚回 LLM 上下文——compact 后 task/artifact refs 不丢。
+		registerCompactAnchor(pi as never, {
+			call: (method: string, params: unknown) =>
+				center.call(method, params as Record<string, unknown>) as never,
+			missionId: () => options.active.current.missionId,
+			sessionRef: () => options.active.current.sessionId,
+		} as never);
 
 		// -- 全量 ROSClaw 命令（NA-FIX-6，P0-8：InputGuard 允许的必须真实注册） --
 		for (const [name, spec] of Object.entries(

--- a/packages/rosclaw-agent/test/p1a4-compact-anchor.test.ts
+++ b/packages/rosclaw-agent/test/p1a4-compact-anchor.test.ts
@@ -1,0 +1,159 @@
+/** P1-A4 红测试（0824 总纲 P1-A）：/compact 保留 TaskRefs。
+ *
+ * 复现的真实事故：Pi compaction（manual /compact、threshold、overflow）
+ * 把会话历史压成摘要——task_id/root_goal/artifact refs（TraceRef、
+ * GIF/MP4 路径）随被压掉的消息一起丢失，模型 compact 后"失忆"：
+ * 不知道自己在哪个 task、交付物在哪。
+ *
+ * 断言：任何 reason 的 compaction 完成后，扩展从 TaskKernel 权威账本
+ * （pi.kernel.latest + pi.kernel.artifacts——不是模型记忆）取最近 task
+ * 与产物 refs，经 pi.sendMessage(deliverAs:"nextTurn") 把 TaskRefs 锚
+ * 定回 LLM 上下文；无 task 时不发锚（诚实 no-op）；同 key 锚去重。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	buildTaskAnchor,
+	registerCompactAnchor,
+} from "../src/extension/compact-anchor.js";
+
+const TASK = {
+	task_id: "task_abc123",
+	root_goal: "画五角星并交付 GIF+MP4",
+	state: "ACTIVE",
+	active_revision: 3,
+};
+
+const ARTIFACTS = [
+	{
+		artifact_id: "art_1",
+		path: "/run/traces/trace_1/trace_1-scene.gif",
+		media_type: "image/gif",
+	},
+	{
+		artifact_id: "art_2",
+		path: "/run/traces/trace_1/trace_1-scene.mp4",
+		media_type: "video/mp4",
+	},
+];
+
+function fakePi() {
+	const sent: Array<{ message: unknown; options: unknown }> = [];
+	const handlers = new Map<string, (event: unknown) => Promise<void>>();
+	return {
+		sent,
+		handlers,
+		on(event: string, handler: (event: unknown) => Promise<void>) {
+			handlers.set(event, handler);
+		},
+		sendMessage(message: unknown, options: unknown) {
+			sent.push({ message, options });
+		},
+	};
+}
+
+function fakeCall(task: unknown, artifacts: unknown[]) {
+	const calls: string[] = [];
+	const call = async (method: string, _params?: unknown) => {
+		calls.push(method);
+		if (method === "pi.kernel.latest") return { ok: true, task };
+		if (method === "pi.kernel.artifacts") return { ok: true, artifacts };
+		throw new Error(`unexpected ${method}`);
+	};
+	return { call, calls };
+}
+
+const COMPACT_EVENT = {
+	type: "session_compact",
+	reason: "manual",
+	willRetry: false,
+	compactionEntry: { id: "entry_1" },
+};
+
+test("buildTaskAnchor 含 task/goal/state/revision 与全部产物 refs", () => {
+	const anchor = buildTaskAnchor(TASK, ARTIFACTS, "manual");
+	assert.match(anchor, /task_abc123/);
+	assert.match(anchor, /画五角星并交付 GIF\+MP4/);
+	assert.match(anchor, /ACTIVE/);
+	assert.match(anchor, /rev.*3|revision.*3/);
+	assert.match(anchor, /trace_1-scene\.gif/);
+	assert.match(anchor, /trace_1-scene\.mp4/);
+	assert.match(anchor, /image\/gif/);
+	assert.match(anchor, /video\/mp4/);
+});
+
+test("compaction 后锚定 TaskRefs（deliverAs nextTurn，不触发回合）", async () => {
+	const pi = fakePi();
+	const { call } = fakeCall(TASK, ARTIFACTS);
+	registerCompactAnchor(pi as never, {
+		call: call as never,
+		missionId: () => "m1",
+		sessionRef: () => "s1",
+	});
+	const handler = pi.handlers.get("session_compact");
+	assert.ok(handler, "session_compact 未注册");
+	await handler(COMPACT_EVENT);
+	assert.equal(pi.sent.length, 1);
+	const { message, options } = pi.sent[0] as {
+		message: { customType: string; content: string; display: boolean };
+		options: { triggerTurn?: boolean; deliverAs?: string };
+	};
+	assert.equal(message.customType, "rosclaw.task_anchor");
+	assert.match(message.content, /task_abc123/);
+	assert.match(message.content, /trace_1-scene\.mp4/);
+	assert.equal(options.triggerTurn ?? false, false);
+	assert.equal(options.deliverAs, "nextTurn");
+});
+
+test("无 task → 诚实 no-op（不发空锚）", async () => {
+	const pi = fakePi();
+	const { call } = fakeCall(null, []);
+	registerCompactAnchor(pi as never, {
+		call: call as never,
+		missionId: () => "m1",
+		sessionRef: () => "s1",
+	});
+	await pi.handlers.get("session_compact")!(COMPACT_EVENT);
+	assert.equal(pi.sent.length, 0);
+});
+
+test("同 key 锚去重（task+revision 未变不重复发）", async () => {
+	const pi = fakePi();
+	const { call } = fakeCall(TASK, ARTIFACTS);
+	registerCompactAnchor(pi as never, {
+		call: call as never,
+		missionId: () => "m1",
+		sessionRef: () => "s1",
+	});
+	const handler = pi.handlers.get("session_compact")!;
+	await handler(COMPACT_EVENT);
+	await handler({ ...COMPACT_EVENT, compactionEntry: { id: "entry_2" } });
+	assert.equal(pi.sent.length, 1);
+	// revision 前进 → 新锚。
+	const { call: call2 } = fakeCall({ ...TASK, active_revision: 4 }, ARTIFACTS);
+	const pi2 = fakePi();
+	registerCompactAnchor(pi2 as never, {
+		call: call2 as never,
+		missionId: () => "m1",
+		sessionRef: () => "s1",
+	});
+	await pi2.handlers.get("session_compact")!(COMPACT_EVENT);
+	await pi2.handlers.get("session_compact")!({
+		...COMPACT_EVENT,
+		compactionEntry: { id: "entry_3" },
+	});
+	assert.equal(pi2.sent.length, 1);
+});
+
+test("kernel 拉取失败 → 不发锚（不编造 refs）", async () => {
+	const pi = fakePi();
+	registerCompactAnchor(pi as never, {
+		call: (async () => ({ ok: false, error: "bridge down" })) as never,
+		missionId: () => "m1",
+		sessionRef: () => "s1",
+	});
+	await pi.handlers.get("session_compact")!(COMPACT_EVENT);
+	assert.equal(pi.sent.length, 0);
+});

--- a/tests/agentd/test_p1a4_compact_journey.py
+++ b/tests/agentd/test_p1a4_compact_journey.py
@@ -1,0 +1,302 @@
+"""P1-A4 PTY 旅程（0824 总纲 P1-A）：/compact 后 TaskRefs 不丢。
+
+真实链路：PTY `rosclaw chat` → 假模型完成一条任务（write → deliver）
+→ 用户 /compact（Pi 内置压缩，fake 给出的摘要**故意不含**任何
+task/artifact refs）→ 用户再发一轮 → 断言下一轮请求的消息里出现
+rosclaw.task_anchor 锚（task_id + 产物路径——来自内核权威账本，
+不是模型记忆），且会话 JSONL 落盘该锚。
+
+红测试先行：锚机制实现前，下一轮请求里找不到这些 refs。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_entry import find_pi_agent_entry
+from tests.agentd.test_product_journey import (
+    PtySession,
+    _chunk,
+    _sse,
+    _tool_call_frames,
+)
+
+pytestmark = pytest.mark.skipif(
+    not find_pi_agent_entry(),
+    reason="无 Node/dist（CI 全回归 job 未构建）——诚实 skip",
+)
+
+
+class _CompactJourneyFake:
+    """write → deliver → 最终回答；之后：summary 请求 → 无 refs 摘要；
+    普通回合 → 普通回答。"""
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+        self.task_done = False
+        self.debug: list[str] = []
+
+    @staticmethod
+    def _text_answer(text: str) -> bytes:
+        frames = [_sse(_chunk(text)), _sse(_chunk("", "stop")), b"data: [DONE]\n\n"]
+        return b"".join(frames)
+
+    def answer(self, body: dict) -> bytes:
+        self.requests.append(body)
+        messages = body.get("messages", [])
+        last = messages[-1] if messages else {}
+        self.debug.append(
+            f"tools={bool(body.get('tools'))} "
+            f"last_role={last.get('role')} "
+            f"last_tcid={last.get('tool_call_id', '')} "
+            f"n_msg={len(messages)}"
+        )
+        if not body.get("stream"):
+            return json.dumps(
+                {
+                    "id": "chatcmpl-fake",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "fake-k3",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "pong"},
+                        "finish_reason": "stop",
+                    }],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 5},
+                },
+            ).encode()
+        # trusted context 注入在 typed input 之后也是 user 角色——
+        # 不能只看最后一条；全部 user 文本合并判定。
+        user_texts = []
+        for m in messages:
+            if m.get("role") == "user":
+                content = m.get("content")
+                user_texts.append(
+                    content
+                    if isinstance(content, str)
+                    else json.dumps(content, ensure_ascii=False)
+                )
+        last_user = "\n".join(user_texts)
+        # compaction 摘要请求（generateSummary 不带 tools——正常回合
+        # 都带工具面；trusted context 里可能有 "summary" 字样，不能按
+        # 文本猜）→ 故意不给 refs。
+        if not body.get("tools"):
+            return self._text_answer("摘要：用户让助手生成了一个文件并交付。")
+        if last.get("role") == "tool":
+            call_id = str(last.get("tool_call_id", ""))
+            if call_id == "call_write":
+                frames = _tool_call_frames(
+                    "call_art", "rosclaw_deliver",
+                    json.dumps({"path": "report.txt", "media_type": "text/plain"}),
+                )
+                frames.append(b"data: [DONE]\n\n")
+                return b"".join(frames)
+            self.task_done = True
+            return self._text_answer("任务完成：report.txt 已交付。")
+        # 填充回合 → 长回答（把会话撑过可压缩下限）；尾部标记=
+        # 流结束——expect 它即等回合真正收束。
+        if "填充" in last_user:
+            return self._text_answer(
+                "填充内容：具身智能任务上下文。" * 150 + "==FILLER-END=="
+            )
+        # 首个用户回合 → write；compact 后的用户回合 → 普通回答。
+        if "report" in last_user and not self.task_done:
+            frames = _tool_call_frames(
+                "call_write", "write",
+                json.dumps({"path": "report.txt", "content": "a4-report-body\n"}),
+            )
+            frames.append(b"data: [DONE]\n\n")
+            return b"".join(frames)
+        return self._text_answer("好的，继续。")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    fake: _CompactJourneyFake
+
+    def log_message(self, *args) -> None:
+        return
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        payload = self.fake.answer(body)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.fake = _CompactJourneyFake()
+        handler = type("H", (_Handler,), {"fake": self.fake})
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.server.server_address[1]
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1"
+
+    def close(self) -> None:
+        self.server.shutdown()
+
+
+def _prepare_home(tmp_path: Path, base_url: str) -> tuple[Path, dict[str, str]]:
+    home = tmp_path / "rh"
+    (home / "run").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "agent:\n  enabled: true\n  default_profile: embodied_default\n"
+        "models:\n  backend: legacy\n  profiles:\n    embodied_default:\n"
+        "      provider: kimi_code\n      model: fake-k3\n"
+        f"      base_url: {base_url}\n"
+        "      api_key_ref: env:FAKE_JOURNEY_KEY\n"
+        "      capabilities: [llm.chat, llm.structured_decision, llm.tool_use]\n",
+        encoding="utf-8",
+    )
+    (home / "agent").mkdir(parents=True, exist_ok=True)
+    (home / "agent" / "settings.json").write_text(
+        json.dumps({
+            "defaultProvider": "journey-fake",
+            "defaultModel": "fake-k3",
+            # 旅程确定性：Pi 默认 keepRecentTokens=20000，小会话 /compact
+            # 会被拒（"Nothing to compact"）——旅程内调小，不改产品默认。
+            "compaction": {"keepRecentTokens": 2000},
+        }),
+        encoding="utf-8",
+    )
+    (home / "agent" / "models.json").write_text(
+        json.dumps(
+            {
+                "providers": {
+                    "journey-fake": {
+                        "name": "Journey Fake",
+                        "baseUrl": base_url,
+                        "api": "openai-completions",
+                        "apiKey": "$FAKE_JOURNEY_KEY",
+                        "models": [{
+                            "id": "fake-k3",
+                            "name": "Fake K3",
+                            "contextWindow": 262144,
+                            "maxTokens": 4096,
+                        }],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = dict(
+        os.environ,
+        ROSCLAW_HOME=str(home),
+        TERM="xterm",
+        FAKE_JOURNEY_KEY="sk-fake-journey",
+        ROSCLAW_UI_LOCALE="zh-CN",
+    )
+    return home, env
+
+
+def _wait_summary_request(fake: _CompactJourneyFake, timeout: float = 240.0) -> None:
+    """等 Pi compaction 的摘要请求到达 fake（= /compact 已被处理）。"""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        # compaction 的 generateSummary 调用不带 tools——与正常回合区分。
+        if any(not body.get("tools") for body in fake.requests):
+            return
+        time.sleep(1.0)
+    raise AssertionError("compaction 摘要请求未到达（/compact 未生效）")
+
+
+class TestCompactTaskRefsJourney:
+    def test_compact_then_next_turn_carries_task_anchor(self, tmp_path: Path) -> None:
+        fake = _FakeServer()
+        home, env = _prepare_home(tmp_path, fake.base_url)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        session = PtySession(
+            [sys.executable, "-m", "rosclaw.entrypoint", "chat"],
+            env, log_path=tmp_path / "pty-a4.log", cwd=workspace,
+        )
+        try:
+            session.expect(b"ROSClaw Native Agent", timeout=120)
+            session.send("生成 report.txt 并交付\r")
+            session.expect("任务完成：report.txt 已交付".encode(), timeout=240)
+            # 账本侧先拿到权威 task_id。
+            db_path = home / "agentd" / "missions.db"
+            assert db_path.exists()
+            db = sqlite3.connect(db_path)
+            try:
+                row = db.execute(
+                    "SELECT task_id FROM tasks ORDER BY created_at DESC LIMIT 1"
+                ).fetchone()
+                assert row, "任务未创建"
+                task_id = row[0]
+            finally:
+                db.close()
+
+            # 会话太小 Pi 拒绝压缩（"Nothing to compact"）——先三轮
+            # 填充撑过下限。
+            for i in range(3):
+                session.send(f"第{i}轮填充\r")
+                session.expect(b"==FILLER-END==", timeout=120)
+                time.sleep(1.5)
+
+            # /compact——fake 的摘要故意不含 refs。
+            session.send("/compact\r")
+            _wait_summary_request(fake.fake)
+
+            # compact 后的下一回合：锚必须随上下文到达模型。
+            session.send("继续\r")
+            # convertToLlm 把 custom 消息转为 role=user 的纯内容——请求
+            # 里没有 customType 字面量；锚的判别标记是内容里的
+            # "TaskRefs 锚"（compaction 后工具结果已被摘要替换，task_id
+            # /report.txt 只能来自锚或每轮 trusted context）。
+            deadline = time.monotonic() + 240
+            seen_anchor = ""
+            while time.monotonic() < deadline:
+                last = fake.fake.requests[-1] if fake.fake.requests else {}
+                texts = json.dumps(last.get("messages", []), ensure_ascii=False)
+                if "TaskRefs" in texts:
+                    seen_anchor = texts
+                    break
+                time.sleep(1.0)
+            assert seen_anchor, (
+                "compact 后下一回合上下文无 TaskRefs 锚——"
+                "TaskRefs 已随压缩丢失"
+            )
+            assert task_id in seen_anchor, "锚中缺权威 task_id"
+            assert "report.txt" in seen_anchor, "锚中缺产物 ref"
+
+            # 锚落盘会话历史（后续 compact 的 summarizer 也能看到）。
+            sessions_dir = home / "agent" / "sessions"
+            deadline = time.monotonic() + 60
+            anchored = False
+            while time.monotonic() < deadline:
+                for jsonl in sessions_dir.rglob("*.jsonl"):
+                    if "rosclaw.task_anchor" in jsonl.read_text(
+                        encoding="utf-8", errors="replace"
+                    ):
+                        anchored = True
+                        break
+                if anchored:
+                    break
+                time.sleep(1.0)
+            assert anchored, "锚未落盘会话历史"
+
+            session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
+            session.proc.wait(timeout=30)
+        finally:
+            print("FAKE DEBUG:", *fake.fake.debug[-15:], sep="\n  ")
+            session.stop()
+            fake.close()


### PR DESCRIPTION
## 真实事故
Pi compaction（manual/threshold/overflow）把会话历史压成摘要，task_id/root_goal/artifact refs 随被压消息丢失——模型 compact 后"失忆"。

## 红→绿
- 红：test/p1a4-compact-anchor.test.ts（模块不存在）+ PTY 旅程（compact 后下一回合无 TaskRefs）
- 绿：unit 5 + PTY 旅程 1 + TS 全套 171 全绿

## 机制
session_compact（任何 reason）→ 从 pi.kernel.latest + artifacts **权威账本**（非模型记忆）取 refs → sendMessage(deliverAs:nextTurn) 锚回 LLM 上下文；锚入会话历史 → 后续 compact 的 summarizer 也能看到；无 task/拉取失败诚实 no-op；同 key 去重；决策日志 logs/compact-anchor.log。

## 旅程实证
convertToLlm 把 custom 消息转为 role=user 纯内容（customType 不进请求）；compaction 摘要请求不带 tools；keepRecentTokens 下限拒绝小会话压缩；expect 流尾标记才算回合收束。

🤖 Generated with [Claude Code](https://claude.com/claude-code)