### PR TITLE
feat: operation progress 流式进 TUI——事件流驱动 + 稳定 ID 原位更新（0824 总纲 §12.3 P1-B2）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -133,6 +133,7 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		let latestCtx: LatestCtx | undefined;
 		// PR-H3：OperationWatcher——operation 终态一次性 followUp（同一
 		// session；progress/heartbeat 绝不进模型上下文）。
+		// P1-B2：progress 经 setWidget 按 operation_id 原位更新（单活动区）。
 		const operationWatcher = new OperationWatcher({
 			call: (method, params) => center.call(method, params),
 			sink: () =>
@@ -142,6 +143,10 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 							isIdle: latestCtx.isIdle(),
 							notify: latestCtx.hasUI
 								? (text: string) => latestCtx?.ui.notify(text, "info")
+								: undefined,
+							setWidget: latestCtx.hasUI
+								? (key: string, lines: string[] | undefined) =>
+										latestCtx?.ui.setWidget(key, lines)
 								: undefined,
 						}
 					: undefined,

--- a/packages/rosclaw-agent/src/native/operation-watcher.ts
+++ b/packages/rosclaw-agent/src/native/operation-watcher.ts
@@ -1,9 +1,15 @@
-/** OperationWatcher（PR-H3，总纲 v2 §11.4）——operation 终态一次性
- *  followUp 注入同一 session。
+/** OperationWatcher V2（P1-B2，0824 总纲 §12.3）——operation 事件流
+ *  驱动：progress 流式进 TUI + 终态一次性 followUp。
  *
- * 不是 completion watcher 轮询链：只跟踪模型显式启动的 operation；
- * 终态只触发一次 followUp（紧凑结构化结果），heartbeat/progress 绝不
- * 进模型上下文（零 LLM token 开销——进度展示走 UI 事件流）。
+ * - 每个 tick 只发 pi.kernel.events（task_id + last_seq 增量游标，
+ *   不重不漏）——不再逐 op 轮询 pi.op.get（注册时一次性取 task_id
+ *   除外）；
+ * - operation.output/progress 事件 → sink.setWidget 按 operation_id
+ *   原位更新（单活动区，同 key 覆盖）；终态 → widget 清除；
+ * - progress 绝不进模型上下文（setWidget ≠ sendMessage，零 LLM
+ *   token 开销）；
+ * - 终态一次性 followUp（WP-1 语义不变：owning task 终态/旧
+ *   revision 只存档不触发回合）。
  */
 
 interface SendSink {
@@ -18,23 +24,45 @@ interface SendSink {
 	): void;
 }
 
+interface WatcherSink {
+	api: SendSink;
+	isIdle: boolean;
+	notify?: (text: string) => void;
+	setWidget?: (key: string, lines: string[] | undefined) => void;
+}
+
 interface OperationWatcherDeps {
 	call: (method: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>;
-	sink: () => { api: SendSink; isIdle: boolean; notify?: (text: string) => void } | undefined;
+	sink: () => WatcherSink | undefined;
+}
+
+interface KernelEvent {
+	seq: number;
+	event_type: string;
+	operation_id?: string;
+	payload?: Record<string, unknown>;
 }
 
 const POLL_MS = 2000;
+const TERMINAL_STATES = new Set(["SUCCEEDED", "FAILED", "CANCELLED", "LOST"]);
+const TERMINAL_EVENTS = new Set([
+	"operation.completed", "operation.failed", "operation.cancelled", "operation.lost",
+]);
 
 export class OperationWatcher {
 	private timer: ReturnType<typeof setInterval> | undefined;
-	private readonly tracked = new Map<string, string>(); // operation_id → state(已见终态则删)
+	private readonly tracked = new Map<string, string>(); // operation_id → task_id（注册后解析）
+	private readonly pending = new Set<string>(); // task_id 未解析的 operation
 	private readonly delivered = new Set<string>();
+	private readonly seqByTask = new Map<string, number>();
+	private readonly lastLineByOp = new Map<string, string>();
 
 	constructor(private readonly deps: OperationWatcherDeps) {}
 
 	/** 模型启动 operation 时登记（tool_execution_end: process_start）。 */
 	track(operationId: string): void {
-		if (operationId) this.tracked.set(operationId, "RUNNING");
+		if (!operationId || this.tracked.has(operationId)) return;
+		this.pending.add(operationId);
 	}
 
 	start(): void {
@@ -50,82 +78,140 @@ export class OperationWatcher {
 		this.timer = undefined;
 	}
 
-	private async tick(): Promise<void> {
-		if (!this.tracked.size) return;
-		const sink = this.deps.sink();
-		for (const operationId of [...this.tracked.keys()]) {
-			if (this.delivered.has(operationId)) {
-				this.tracked.delete(operationId);
-				continue;
-			}
-			let op: Record<string, unknown> | undefined;
+	/** 注册解析（每个 op 仅一次）：task_id 是事件流订阅键。 */
+	private async resolvePending(): Promise<void> {
+		for (const operationId of [...this.pending]) {
 			try {
 				const result = await this.deps.call("pi.op.get", {
 					operation_id: operationId,
 				});
-				op = result.operation as Record<string, unknown> | undefined;
+				const op = (result.operation ?? {}) as Record<string, unknown>;
+				const taskId = String(op.task_id ?? "");
+				if (!taskId) continue; // 桥暂不可知——下周期再试（不报假死）
+				this.pending.delete(operationId);
+				this.tracked.set(operationId, taskId);
+				if (TERMINAL_STATES.has(String(op.state ?? ""))) {
+					await this.handleTerminal(operationId, op);
+				}
 			} catch {
-				continue; // 桥暂不可用——下周期再试（不报假死）
+				// 桥暂不可用——下周期再试。
 			}
-			const state = String(op?.state ?? "");
-			if (!op || !(state === "SUCCEEDED" || state === "FAILED" || state === "CANCELLED")) {
-				continue;
+		}
+	}
+
+	private async tick(): Promise<void> {
+		await this.resolvePending();
+		if (!this.tracked.size) return;
+		const sink = this.deps.sink();
+		const taskIds = [...new Set(this.tracked.values())];
+		for (const taskId of taskIds) {
+			let events: KernelEvent[] = [];
+			try {
+				const result = await this.deps.call("pi.kernel.events", {
+					task_id: taskId,
+					last_seq: this.seqByTask.get(taskId) ?? 0,
+				});
+				events = (result.events ?? []) as KernelEvent[];
+			} catch {
+				continue; // 桥暂不可用——下周期从同游标重放（不重不漏）
 			}
-			this.delivered.add(operationId);
-			this.tracked.delete(operationId);
-			// WP-1（0823 审计 P0-3）：终态一致性——owning task 已终态
-			// （或 operation 属旧 revision）时，终态事件只更新账本和
-			// TUI，绝不触发模型回合。规则：Task 终态后、下一条用户
-			// 输入前，模型调用次数恒等于 0。
-			const taskId = String(op.task_id ?? "");
-			let taskTerminal = false;
-			let staleRevision = false;
-			if (taskId) {
-				try {
-					const taskResult = await this.deps.call("pi.kernel.get", {
+			for (const event of events) {
+				this.seqByTask.set(taskId, Math.max(
+					this.seqByTask.get(taskId) ?? 0, Number(event.seq) || 0,
+				));
+				const operationId = String(event.operation_id ?? "");
+				if (!operationId || !this.tracked.has(operationId)) continue;
+				if (event.event_type === "operation.output") {
+					const text = String(event.payload?.text ?? "").trim();
+					if (text) this.upsertWidget(sink, operationId, text);
+				} else if (event.event_type === "operation.progress") {
+					const progress = (event.payload?.progress ?? {}) as Record<string, unknown>;
+					const label = [
+						progress.pct !== undefined ? `${progress.pct}%` : "",
+						String(progress.stage ?? ""),
+					].filter(Boolean).join(" ");
+					if (label) this.upsertWidget(sink, operationId, label);
+				} else if (TERMINAL_EVENTS.has(event.event_type)) {
+					await this.handleTerminal(operationId, {
+						operation_id: operationId,
 						task_id: taskId,
+						state: String(event.payload?.state ?? ""),
 					});
-					const task = (taskResult.task ?? null) as Record<string, unknown> | null;
-					const taskState = String(task?.state ?? "");
-					taskTerminal = task !== null && taskState !== "RUNNING"
-						&& taskState !== "CREATED" && taskState !== "WAITING_APPROVAL";
-					const opRevision = Number(op.revision ?? 0);
-					const activeRevision = Number(task?.active_revision ?? 0);
-					staleRevision = opRevision > 0 && activeRevision > 0
-						&& opRevision !== activeRevision;
-				} catch {
-					// 查询失败不赌——按终态处理（不触发回合），下周期
-					// 由 delivered 集合保证不重复。
-					taskTerminal = true;
 				}
 			}
-			if (taskTerminal || staleRevision) {
-				sink?.notify?.(
-					`Operation ${state}（任务已${staleRevision ? "换 revision" : "终态"}——已存档，不再打扰）：${operationId.slice(0, 18)}…`,
-				);
-				continue;
-			}
-			// 终态一次性 followUp（compact 结构化结果——同一 session 继续
-			// 验证/修复，不新建 Worker/任务）。
-			const content =
-				`后台 Operation ${operationId} 已终止：${state}`
-				+ (op.failure_code ? `（${String(op.failure_code)}）` : "")
-				+ "。用 process_output 查看输出，然后在同一任务里继续（验证/修复/交付）。";
-			if (sink?.api) {
-				sink.api.sendMessage(
-					{
-						customType: "rosclaw.operation.result",
-						content,
-						display: false,
-						details: { operation_id: operationId, state },
-					},
-					// idle 时立即触发回合；忙时 followUp 排队。
-					sink.isIdle
-						? { triggerTurn: true }
-						: { triggerTurn: true, deliverAs: "followUp" },
-				);
-			}
-			sink?.notify?.(`Operation ${state}：${operationId.slice(0, 18)}…`);
 		}
+	}
+
+	private upsertWidget(sink: WatcherSink | undefined, operationId: string, line: string): void {
+		if (!sink?.setWidget) return;
+		this.lastLineByOp.set(operationId, line);
+		sink.setWidget(`op:${operationId}`, [
+			`⠋ Operation ${operationId.slice(0, 18)}… ${line}`,
+		]);
+	}
+
+	private clearWidget(sink: WatcherSink | undefined, operationId: string): void {
+		if (!sink?.setWidget || !this.lastLineByOp.has(operationId)) return;
+		this.lastLineByOp.delete(operationId);
+		sink.setWidget(`op:${operationId}`, undefined);
+	}
+
+	private async handleTerminal(
+		operationId: string, op: Record<string, unknown>,
+	): Promise<void> {
+		if (this.delivered.has(operationId)) return;
+		this.delivered.add(operationId);
+		this.pending.delete(operationId);
+		this.tracked.delete(operationId);
+		const sink = this.deps.sink();
+		this.clearWidget(sink, operationId);
+		const state = String(op.state ?? "");
+		// WP-1（0823 审计 P0-3）：终态一致性——owning task 已终态
+		// （或 operation 属旧 revision）时，终态事件只更新账本和
+		// TUI，绝不触发模型回合。
+		const taskId = String(op.task_id ?? "");
+		let taskTerminal = false;
+		let staleRevision = false;
+		if (taskId) {
+			try {
+				const taskResult = await this.deps.call("pi.kernel.get", {
+					task_id: taskId,
+				});
+				const task = (taskResult.task ?? null) as Record<string, unknown> | null;
+				const taskState = String(task?.state ?? "");
+				taskTerminal = task !== null && taskState !== "RUNNING"
+					&& taskState !== "CREATED" && taskState !== "WAITING_APPROVAL";
+				const opRevision = Number(op.revision ?? 0);
+				const activeRevision = Number(task?.active_revision ?? 0);
+				staleRevision = opRevision > 0 && activeRevision > 0
+					&& opRevision !== activeRevision;
+			} catch {
+				taskTerminal = true; // 查询失败不赌——按终态处理（不触发回合）
+			}
+		}
+		if (taskTerminal || staleRevision) {
+			sink?.notify?.(
+				`Operation ${state}（任务已${staleRevision ? "换 revision" : "终态"}——已存档，不再打扰）：${operationId.slice(0, 18)}…`,
+			);
+			return;
+		}
+		const content =
+			`后台 Operation ${operationId} 已终止：${state}`
+			+ (op.failure_code ? `（${String(op.failure_code)}）` : "")
+			+ "。用 process_output 查看输出，然后在同一任务里继续（验证/修复/交付）。";
+		if (sink?.api) {
+			sink.api.sendMessage(
+				{
+					customType: "rosclaw.operation.result",
+					content,
+					display: false,
+					details: { operation_id: operationId, state },
+				},
+				sink.isIdle
+					? { triggerTurn: true }
+					: { triggerTurn: true, deliverAs: "followUp" },
+			);
+		}
+		sink?.notify?.(`Operation ${state}：${operationId.slice(0, 18)}…`);
 	}
 }

--- a/packages/rosclaw-agent/test/p1b2-progress-widget.test.ts
+++ b/packages/rosclaw-agent/test/p1b2-progress-widget.test.ts
@@ -1,0 +1,161 @@
+/** P1-B2 红测试（0824 总纲 §12.3）：operation progress 流式进 TUI。
+ *
+ * 真实缺口：progress 只有两条路——模型/用户主动 process_output 或
+ * /logs（拉模式），TUI 没有按 operation_id 原位更新的活动区；watcher
+ * 每 2s 对每个 op 发 pi.op.get（N 个 op N 次调用）。
+ *
+ * 断言 V2：
+ * 1. 稳态 tick 只发 pi.kernel.events（task_id + last_seq 增量游标）——
+ *    不再每个 op 一次 pi.op.get（注册时一次性取 task_id 除外）；
+ * 2. operation.output/progress 事件 → sink.setWidget 以 operation_id
+ *    为 key 原位更新（同 key 覆盖，不追加）；
+ * 3. 终态事件 → widget 清除 + 既有 followUp 语义（WP-1 不变）；
+ * 4. progress 绝不进模型上下文（setWidget 不是 sendMessage）。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { OperationWatcher } from "../src/native/operation-watcher.js";
+
+interface WidgetCall { key: string; lines: string[] | undefined }
+
+function harness(opts: {
+	op?: Record<string, unknown>;
+	eventsByTask?: Record<string, Array<Record<string, unknown>>>;
+	task?: Record<string, unknown> | null;
+	idle?: boolean;
+}) {
+	const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+	const widgets: WidgetCall[] = [];
+	const sent: Array<{ message: unknown; options: unknown }> = [];
+	const seqs = new Map<string, number>();
+	const deps = {
+		call: async (method: string, params: Record<string, unknown>) => {
+			calls.push({ method, params });
+			if (method === "pi.op.get") return { operation: opts.op ?? {} };
+			if (method === "pi.kernel.get") return { task: opts.task ?? null };
+			if (method === "pi.kernel.events") {
+				const taskId = String(params.task_id);
+				const since = Number(params.last_seq ?? 0);
+				seqs.set(taskId, since);
+				const events = (opts.eventsByTask?.[taskId] ?? []).filter(
+					(e) => Number(e.seq) > since,
+				);
+				return { events };
+			}
+			throw new Error(`unexpected ${method}`);
+		},
+		sink: () => ({
+			isIdle: opts.idle ?? false,
+			api: {
+				sendMessage(message: unknown, options: unknown) {
+					sent.push({ message, options });
+				},
+			},
+			setWidget(key: string, lines: string[] | undefined) {
+				widgets.push({ key, lines });
+			},
+			notify: () => undefined,
+		}),
+	};
+	return { deps, calls, widgets, sent, seqs };
+}
+
+test("稳态 tick 只发 pi.kernel.events（无逐 op pi.op.get）", async () => {
+	const h = harness({
+		op: { operation_id: "op_aaa", task_id: "task_1", state: "RUNNING" },
+		eventsByTask: { task_1: [] },
+	});
+	const w = new OperationWatcher(h.deps as never);
+	w.track("op_aaa");
+	await (w as never as { tick(): Promise<void> }).tick();
+	const eventCalls = h.calls.filter((c) => c.method === "pi.kernel.events");
+	const getCalls = h.calls.filter((c) => c.method === "pi.op.get");
+	assert.ok(eventCalls.length >= 1, "未走 pi.kernel.events 增量流");
+	assert.equal(getCalls.length <= 1, true, "稳态仍逐 op 轮询");
+	// 第二 tick：events 游标前进（last_seq 带上次位置）。
+	await (w as never as { tick(): Promise<void> }).tick();
+	const second = h.calls.filter((c) => c.method === "pi.kernel.events").pop();
+	assert.ok(Number(second?.params.last_seq ?? 0) >= 0);
+});
+
+test("operation.output 事件 → setWidget 按 operation_id 原位更新", async () => {
+	const h = harness({
+		op: { operation_id: "op_bbb", task_id: "task_1", state: "RUNNING" },
+		eventsByTask: {
+			task_1: [
+				{ seq: 1, event_type: "operation.output", operation_id: "op_bbb", payload: { text: "building 10%\n" } },
+				{ seq: 2, event_type: "operation.output", operation_id: "op_bbb", payload: { text: "building 42%\n" } },
+			],
+		},
+	});
+	const w = new OperationWatcher(h.deps as never);
+	w.track("op_bbb");
+	await (w as never as { tick(): Promise<void> }).tick();
+	const opWidgets = h.widgets.filter((wc) => wc.key.includes("op_bbb"));
+	assert.ok(opWidgets.length >= 1, "无 widget upsert");
+	const last = opWidgets[opWidgets.length - 1];
+	assert.ok(last.lines?.some((l) => l.includes("building 42%")), `widget 未含最新输出: ${JSON.stringify(last.lines)}`);
+	// key 含 operation_id（稳定原位更新——不新增行）。
+	assert.ok(opWidgets.every((wc) => wc.key === opWidgets[0].key), "widget key 不稳定");
+	// progress 不进模型上下文。
+	assert.equal(h.sent.length, 0, "progress 进了模型上下文");
+});
+
+test("operation.progress 事件 → widget 展示结构化进度", async () => {
+	const h = harness({
+		op: { operation_id: "op_ccc", task_id: "task_1", state: "RUNNING" },
+		eventsByTask: {
+			task_1: [
+				{ seq: 3, event_type: "operation.progress", operation_id: "op_ccc", payload: { progress: { pct: 55, stage: "render" } } },
+			],
+		},
+	});
+	const w = new OperationWatcher(h.deps as never);
+	w.track("op_ccc");
+	await (w as never as { tick(): Promise<void> }).tick();
+	const opWidgets = h.widgets.filter((wc) => wc.key.includes("op_ccc"));
+	assert.ok(opWidgets.length >= 1);
+	assert.ok(
+		opWidgets[opWidgets.length - 1].lines?.some((l) => l.includes("55") || l.includes("render")),
+		`widget 未含结构化进度: ${JSON.stringify(opWidgets)}`,
+	);
+});
+
+test("终态事件 → widget 清除 + followUp（WP-1 语义不变）", async () => {
+	const h = harness({
+		// 生产流：注册时 RUNNING，终态经事件流到达。
+		op: { operation_id: "op_ddd", task_id: "task_1", state: "RUNNING", revision: 1 },
+		task: { task_id: "task_1", state: "RUNNING", active_revision: 1 },
+		idle: true,
+		eventsByTask: {
+			task_1: [
+				{ seq: 4, event_type: "operation.output", operation_id: "op_ddd", payload: { text: "final line\n" } },
+				{ seq: 5, event_type: "operation.completed", operation_id: "op_ddd", payload: { state: "SUCCEEDED" } },
+			],
+		},
+	});
+	const w = new OperationWatcher(h.deps as never);
+	w.track("op_ddd");
+	await (w as never as { tick(): Promise<void> }).tick();
+	assert.equal(h.sent.length, 1, "终态未触发 followUp");
+	const cleared = h.widgets.filter((wc) => wc.key.includes("op_ddd") && wc.lines === undefined);
+	assert.ok(cleared.length >= 1, "终态后 widget 未清除");
+});
+
+test("task 已终态 → 不触发模型回合（WP-1），widget 清除", async () => {
+	const h = harness({
+		op: { operation_id: "op_eee", task_id: "task_1", state: "SUCCEEDED", revision: 1 },
+		task: { task_id: "task_1", state: "SUCCEEDED", active_revision: 1 },
+		eventsByTask: {
+			task_1: [
+				{ seq: 6, event_type: "operation.completed", operation_id: "op_eee", payload: { state: "SUCCEEDED" } },
+			],
+		},
+	});
+	const w = new OperationWatcher(h.deps as never);
+	w.track("op_eee");
+	await (w as never as { tick(): Promise<void> }).tick();
+	assert.equal(h.sent.length, 0, "任务终态后仍触发模型回合");
+});

--- a/tests/agentd/test_p1b2_progress_journey.py
+++ b/tests/agentd/test_p1b2_progress_journey.py
@@ -75,7 +75,7 @@ class _ProgressFake:
         frames = _tool_call_frames(
             "call_opstart", "process_start",
             json.dumps({
-                "command": "for i in 1 2 3; do echo progress-step-$i; sleep 1.2; done",
+                "command": "for i in 1 2 3; do echo progress-step-$i; sleep 2.5; done",
             }),
         )
         frames.append(b"data: [DONE]\n\n")

--- a/tests/agentd/test_p1b2_progress_journey.py
+++ b/tests/agentd/test_p1b2_progress_journey.py
@@ -1,0 +1,132 @@
+"""P1-B2 产品旅程（0824 总纲 §12.3）：operation progress 流式进 TUI。
+
+PTY `rosclaw chat` + 假模型：process_start 启动一个分阶段输出的长
+命令（progress-step-1..3，间隔 1.2s）→ 断言 operation **运行期间**
+TUI 已按 operation_id 原位渲染最新输出行（widget——用户不需要
+/logs 或模型轮询）→ 终态 followUp 闭环照旧（WP-1 语义不回归）。
+
+红证据：B2 前 TUI 只有 Working… 占位——运行中看不到任何输出行。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_entry import find_pi_agent_entry
+from tests.agentd.test_h1_native_work import (
+    _FakeServer,
+    _Handler,
+    _prepare_home,
+)
+from tests.agentd.test_product_journey import (
+    PtySession,
+    _chunk,
+    _sse,
+    _tool_call_frames,
+)
+
+pytestmark = pytest.mark.skipif(
+    not find_pi_agent_entry(),
+    reason="无 Node/dist（CI 全回归 job 未构建）——诚实 skip",
+)
+
+
+class _ProgressFake:
+    """process_start（分阶段长命令）→ 首回合结束；终态 followUp → 汇报。"""
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    def answer(self, body: dict) -> bytes:
+        self.requests.append(body)
+        messages = body.get("messages", [])
+
+        def _text(m: dict) -> str:
+            content = m.get("content", "")
+            if isinstance(content, list):
+                return " ".join(
+                    str(b.get("text", "")) for b in content if isinstance(b, dict)
+                )
+            return str(content)
+
+        if not body.get("stream"):
+            return json.dumps({
+                "id": "c", "object": "chat.completion", "created": 1,
+                "model": "fake-k3",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "pong"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 5},
+            }).encode()
+        has_tool_result = bool(messages) and messages[-1].get("role") == "tool"
+        last_text = _text(messages[-1]) if messages else ""
+        if has_tool_result:
+            frames = [_sse(_chunk("已在后台启动 operation，完成会通知。")),
+                      _sse(_chunk("", "stop")), b"data: [DONE]\n\n"]
+            return b"".join(frames)
+        if "已终止" in last_text:
+            frames = [_sse(_chunk("后台 Operation 已完成并汇报。")),
+                      _sse(_chunk("", "stop")), b"data: [DONE]\n\n"]
+            return b"".join(frames)
+        frames = _tool_call_frames(
+            "call_opstart", "process_start",
+            json.dumps({
+                "command": "for i in 1 2 3; do echo progress-step-$i; sleep 1.2; done",
+            }),
+        )
+        frames.append(b"data: [DONE]\n\n")
+        return b"".join(frames)
+
+
+class _ProgressFakeServer(_FakeServer):
+    def __init__(self) -> None:
+        self.fake = _ProgressFake()
+        handler = type("H", (_Handler,), {"fake": self.fake})
+        import threading as _threading
+        from http.server import ThreadingHTTPServer
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.server.server_address[1]
+        _threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+
+class TestOperationProgressWidget:
+    def test_progress_visible_during_run(self, tmp_path: Path) -> None:
+        fake = _ProgressFakeServer()
+        home, env = _prepare_home(tmp_path, fake.base_url)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        session = PtySession(
+            [sys.executable, "-m", "rosclaw.entrypoint", "chat"],
+            env, log_path=tmp_path / "pty-b2.log", cwd=workspace,
+        )
+        try:
+            session.expect(b"ROSClaw Native Agent", timeout=120)
+            session.send("后台跑分阶段命令\r")
+            session.expect("已在后台启动 operation".encode(), timeout=180)
+            # operation 运行期间（~3.6s 总时长内）widget 原位渲染输出
+            # 行——progress-step-1 或 2 必须先于完成通知可见。
+            session.expect(b"progress-step-", timeout=60)
+            seen = bytes(session.output)
+            match = re.search(rb"progress-step-(\d)", seen)
+            assert match, "运行期间未见任何输出行（widget 未渲染）"
+            assert int(match.group(1)) < 3, (
+                "只在完成后才看到输出——不是流式（看到了最后一步才出现）"
+            )
+            # 终态 followUp 闭环不回归。
+            session.expect("后台 Operation 已完成并汇报".encode(), timeout=180)
+            db = sqlite3.connect(home / "agentd" / "missions.db")
+            state = db.execute(
+                "SELECT state FROM operations ORDER BY started_at DESC LIMIT 1"
+            ).fetchone()
+            db.close()
+            assert state and state[0] == "SUCCEEDED", state
+            session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
+            session.proc.wait(timeout=30)
+        finally:
+            session.stop()
+            fake.close()


### PR DESCRIPTION
## 缺口
progress 只有拉模式（process_output//logs）；watcher 每 2s 逐 op pi.op.get。

## 红→绿
- 红：test/p1b2-progress-widget.test.ts 4 failed
- 绿：5 passed + PTY 旅程（运行期间 widget 已渲染 progress-step-N，N<3 证流式）+ TS 全套 176 绿

## 要点
- 稳态 tick 只发 pi.kernel.events（task_id+last_seq 增量游标）；pi.op.get 仅注册解析一次
- operation.output/progress → setWidget 按 operation_id 原位更新；终态 → widget 清除 + followUp（WP-1 语义不变）
- progress 绝不进模型上下文

🤖 Generated with [Claude Code](https://claude.com/claude-code)