### PR TITLE
feat: ROS 2 Action provider adapter——goal 生命周期纳入 Operation 统一契约（0824 总纲 §12 P1-B3）

### DIFF
--- a/src/rosclaw/connectors/ros/action_client.py
+++ b/src/rosclaw/connectors/ros/action_client.py
@@ -1,0 +1,141 @@
+"""ROS 2 Action client over rosbridge（P1-B3，0824 总纲 §12/P1-B）。
+
+不 import rclpy——rosbridge action 协议（send_goal/cancel_goal +
+action_feedback/action_result 推送）。listener 线程收推送，回调经
+调用方提供的 marshaller 投递（OperationManager 用
+loop.call_soon_threadsafe 回事件循环——sqlite 连接不跨线程）。
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from rosclaw.connectors.ros.transport.base import RosTransport
+
+logger = logging.getLogger("rosclaw.connectors.ros.action_client")
+
+#: action_msgs/GoalStatus 状态码。
+STATUS_SUCCEEDED = 4
+STATUS_CANCELED = 5
+STATUS_ABORTED = 6
+
+FeedbackCallback = Callable[[dict], None]
+ResultCallback = Callable[[int, dict], None]
+
+
+class Ros2ActionClient:
+    """rosbridge Action client（单 transport 多 goal 复用）。"""
+
+    def __init__(self, transport: RosTransport) -> None:
+        """单一 transport（rosbridge 语义：feedback/result 回到 goal
+        发起连接——独立 listener 连接收不到推送）。死锁防护在
+        transport 层：receive 空闲超时按有界切片返回（不持锁不死）。"
+        """
+        self._transport = transport
+        self._goals: dict[str, str] = {}  # goal_id → action name
+        self._feedback_cbs: dict[str, FeedbackCallback] = {}
+        self._result_cbs: dict[str, ResultCallback] = {}
+        self._lock = threading.RLock()
+        self._listener: threading.Thread | None = None
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    def send_goal(
+        self,
+        *,
+        action: str,
+        action_type: str,
+        args: dict[str, Any],
+        goal_id: str,
+        on_feedback: FeedbackCallback,
+        on_result: ResultCallback,
+    ) -> None:
+        """发送 goal（异步——feedback/result 经回调推送）。"""
+        with self._lock:
+            self._goals[goal_id] = action
+            self._feedback_cbs[goal_id] = on_feedback
+            self._result_cbs[goal_id] = on_result
+        result = self._transport.send({
+            "op": "send_goal",
+            "action": action,
+            "action_type": action_type,
+            "args": args,
+            "feedback": True,
+            "id": goal_id,
+        })
+        if not result.is_ok:
+            with self._lock:
+                self._goals.pop(goal_id, None)
+                self._feedback_cbs.pop(goal_id, None)
+                self._result_cbs.pop(goal_id, None)
+            raise RuntimeError(f"send_goal failed: {result.error}")
+        self._ensure_listener()
+
+    def cancel_goal(self, goal_id: str) -> None:
+        """请求取消（终态由 action_result(CANCELED) 确认）。"""
+        with self._lock:
+            action = self._goals.get(goal_id, "")
+        self._transport.send({
+            "op": "cancel_goal",
+            "action": action,
+            "id": goal_id,
+        })
+
+    def close(self) -> None:
+        self._closed = True
+        self._transport.close()
+
+    # ------------------------------------------------------------------
+    def _ensure_listener(self) -> None:
+        with self._lock:
+            if self._listener is not None and self._listener.is_alive():
+                return
+            self._listener = threading.Thread(
+                target=self._listen_loop, daemon=True,
+                name="ros2-action-listener",
+            )
+            self._listener.start()
+
+    def _listen_loop(self) -> None:
+        while not self._closed:
+            try:
+                result = self._transport.receive(timeout_sec=1.0)
+            except Exception:  # noqa: BLE001 - listener 不死
+                logger.debug("action listener receive error", exc_info=True)
+                continue
+            if result is None or not getattr(result, "is_ok", False):
+                continue
+            data = result.data or {}
+            op = data.get("op", "")
+            goal_id = str(data.get("id", ""))
+            if op == "action_feedback":
+                with self._lock:
+                    callback = self._feedback_cbs.get(goal_id)
+                if callback is not None:
+                    try:
+                        callback(dict(data.get("values") or {}))
+                    except Exception:  # noqa: BLE001
+                        logger.debug("feedback callback error", exc_info=True)
+            elif op == "action_result":
+                with self._lock:
+                    callback = self._result_cbs.pop(goal_id, None)
+                    self._feedback_cbs.pop(goal_id, None)
+                    self._goals.pop(goal_id, None)
+                if callback is not None:
+                    values = data.get("values") or {}
+                    status = int(values.get("status", 0))
+                    try:
+                        callback(status, dict(values.get("result") or values))
+                    except Exception:  # noqa: BLE001
+                        logger.debug("result callback error", exc_info=True)
+
+
+__all__ = [
+    "Ros2ActionClient",
+    "STATUS_ABORTED",
+    "STATUS_CANCELED",
+    "STATUS_SUCCEEDED",
+]

--- a/src/rosclaw/connectors/ros/transport/rosbridge.py
+++ b/src/rosclaw/connectors/ros/transport/rosbridge.py
@@ -161,7 +161,13 @@ class RosbridgeTransport:
                 self._ws.settimeout(actual_timeout)
                 raw = self._ws.recv()
             except Exception as exc:
-                error = f"Receive failed or timed out after {actual_timeout}s: {exc}"
+                import websocket as _ws_lib
+
+                if isinstance(exc, _ws_lib.WebSocketTimeoutException):
+                    # 推送通道空闲超时——正常（非连接故障，不 invalidate；
+                    # P1-B3 action listener 轮询依赖语义级空闲返回）。
+                    return RosTransportResult(ok=True, data=None, raw=None)
+                error = f"Receive failed after {actual_timeout}s: {exc}"
                 logger.warning(error)
                 self._invalidate()
                 return RosTransportResult(ok=False, error=error, raw=str(exc))

--- a/src/rosclaw/task_kernel/operation_manager.py
+++ b/src/rosclaw/task_kernel/operation_manager.py
@@ -52,6 +52,8 @@ class OperationManager:
         self._conn = conn
         self._procs: dict[str, asyncio.subprocess.Process] = {}
         self._drivers: dict[str, asyncio.Task] = {}
+        # operation_id → (client, goal_id)——ROS 2 Action 操作（P1-B3）。
+        self._actions: dict[str, tuple[object, str]] = {}
 
     # --------------------------------------------------------------
     # 生命周期
@@ -174,7 +176,17 @@ class OperationManager:
         self, operation_id: str, state: str, *, failure_code: str = "",
         result_ref: str = "",
     ) -> None:
-        """终态落账（终态不可逆——CANCELLED/LOST 不被迟到事件覆盖）。"""
+        self._write_terminal(
+            operation_id, state, failure_code=failure_code,
+            result_ref=result_ref,
+        )
+
+    def _write_terminal(
+        self, operation_id: str, state: str, *, failure_code: str = "",
+        result_ref: str = "",
+    ) -> None:
+        """终态落账（终态不可逆——CANCELLED/LOST 不被迟到事件覆盖）。
+        同步核心：Action result 回调（listener 线程）也走这里。"""
         row = self.get(operation_id)
         if row is None or row["state"] in OPERATION_TERMINAL:
             return
@@ -195,6 +207,92 @@ class OperationManager:
                    {"operation_id": operation_id, "state": state,
                     "failure_code": failure_code},
                    operation_id=operation_id)
+
+    # --------------------------------------------------------------
+    # ROS 2 Action provider（P1-B3，0824 总纲 §12/P1-B）
+    # --------------------------------------------------------------
+    async def start_action(
+        self,
+        *,
+        task_id: str,
+        attempt_id: str,
+        action: str,
+        action_type: str,
+        args: dict,
+        client,
+        goal_id: str = "",
+    ) -> dict[str, Any]:
+        """ROS 2 Action → 同一 Operation 契约（QUEUED→ADMITTED→
+        RUNNING；feedback→progress；result→终态）。"""
+        from rosclaw.connectors.ros.action_client import (
+            STATUS_CANCELED,
+            STATUS_SUCCEEDED,
+        )
+
+        operation_id = new_id("op")
+        goal_id = goal_id or new_id("goal")
+        now = _now()
+        task_row = self._conn.execute(
+            "SELECT active_revision FROM tasks WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        revision = int(task_row["active_revision"]) if task_row else None
+        self._conn.execute(
+            "INSERT INTO operations (operation_id, task_id, attempt_id, kind, "
+            "state, resumable, started_at, heartbeat_at, revision, goal_id, "
+            "provider, exitcode_path) "
+            "VALUES (?, ?, ?, ?, 'QUEUED', 0, ?, ?, ?, ?, 'ros2_action', '')",
+            (operation_id, task_id, attempt_id, "action", now, now, revision,
+             goal_id),
+        )
+        self._emit(task_id, "operation.queued",
+                   {"operation_id": operation_id, "goal_id": goal_id,
+                    "provider": "ros2_action", "action": action,
+                    "action_type": action_type},
+                   operation_id=operation_id, attempt_id=attempt_id)
+
+        loop = asyncio.get_running_loop()
+
+        def _marshal(fn):
+            def _wrapped(*cb_args):
+                try:
+                    loop.call_soon_threadsafe(fn, *cb_args)
+                except RuntimeError:
+                    # 事件循环已关（测试相位）——同步执行；连接为
+                    # check_same_thread=False 时安全。生产路径 loop 恒活。
+                    fn(*cb_args)
+
+            return _wrapped
+
+        def _on_feedback(values: dict) -> None:
+            self.report_progress(operation_id, values)
+
+        def _on_result(status: int, values: dict) -> None:
+            result_ref = json.dumps(values, ensure_ascii=False)[:500]
+            if status == STATUS_SUCCEEDED:
+                state, code = "SUCCEEDED", ""
+            elif status == STATUS_CANCELED:
+                state = "CANCELLED"
+                code = str(self.get(operation_id).get("cancel_reason") or "action_canceled")
+            else:
+                state, code = "FAILED", f"action_status_{status}"
+            self._actions.pop(operation_id, None)
+            self._write_terminal(
+                operation_id, state,
+                failure_code=code, result_ref=result_ref,
+            )
+
+        client.send_goal(
+            action=action, action_type=action_type, args=args,
+            goal_id=goal_id,
+            on_feedback=_marshal(_on_feedback),
+            on_result=_marshal(_on_result),
+        )
+        self._actions[operation_id] = (client, goal_id)
+        self._transition(operation_id, "ADMITTED",
+                         event="operation.admitted",
+                         payload={"action": action, "goal_id": goal_id})
+        self._transition(operation_id, "RUNNING", event=None)
+        return self.get(operation_id)
 
     async def wait(self, operation_id: str, *, timeout: float = 60.0) -> dict:
         """等终态（测试/短操作同步点——不是轮询生产路径）。"""
@@ -220,6 +318,17 @@ class OperationManager:
         self._emit(row["task_id"], "operation.canceling",
                    {"operation_id": operation_id, "reason": reason},
                    operation_id=operation_id)
+        action_ref = self._actions.get(operation_id)
+        if action_ref is not None:
+            # ROS 2 Action：cancel_goal 请求——终态由 action_result
+            # (CANCELED) 确认；宽限后服务端无响应也落 CANCELLED
+            # （诚实：请求已发，结局不可考）。
+            client, goal_id = action_ref
+            client.cancel_goal(goal_id)  # type: ignore[attr-defined]
+            self._drivers[operation_id] = asyncio.create_task(
+                self._cancel_grace(operation_id, reason)
+            )
+            return
         proc = self._procs.pop(operation_id, None)
         if proc is not None and proc.returncode is None:
             with contextlib.suppress(ProcessLookupError):
@@ -229,6 +338,15 @@ class OperationManager:
             except TimeoutError:
                 with contextlib.suppress(ProcessLookupError):
                     proc.kill()
+        await self._record_terminal(operation_id, "CANCELLED",
+                                    failure_code=reason)
+
+    async def _cancel_grace(
+        self, operation_id: str, reason: str, grace_s: float = 5.0
+    ) -> None:
+        """Action 取消宽限：action_result 未在宽限内到达也落
+        CANCELLED（账本不再悬空）。"""
+        await asyncio.sleep(grace_s)
         await self._record_terminal(operation_id, "CANCELLED",
                                     failure_code=reason)
 

--- a/tests/agentd/test_p1b3_ros2_action.py
+++ b/tests/agentd/test_p1b3_ros2_action.py
@@ -1,0 +1,202 @@
+"""P1-B3 红测试（0824 总纲 §12/P1-B）：ROS 2 Action provider adapter。
+
+真实缺口：ROS 连接只有同步 request/response——没有 Action client
+（send_goal/feedback/result/cancel），长 Action 无法纳入 Operation
+统一运营层（goal 生命周期/progress/cancel 握手/终态）。
+
+断言（Operation 同一契约的 Action provider）：
+1. send_goal → operation QUEUED→ADMITTED→RUNNING，goal_id 落账；
+2. feedback → operation.progress（progress_json 更新 + 事件）；
+3. result(SUCCEEDED=4) → operation SUCCEEDED + result_ref；
+4. result(ABORTED=6/其他) → FAILED；
+5. cancel → CANCELING → cancel_goal → result(CANCELED=5) → CANCELLED；
+6. 2h 假 Action（持续 feedback、无 result）→ sweep 永不 kill；
+7. 重启：ros2_action provider 无 pid → 诚实 LOST（不可证实）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+from rosclaw.storage.migrations import MigrationRunner
+from rosclaw.task_kernel.operation_manager import (
+    OPERATION_TERMINAL,
+    OperationManager,
+)
+
+
+def _conn(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "missions.db", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return conn
+
+
+def _task(conn: sqlite3.Connection, task_id: str = "task_1") -> None:
+    now = "2026-08-25T00:00:00+00:00"
+    conn.execute(
+        "INSERT INTO tasks (task_id, mission_id, root_goal, mode, body_id, "
+        "state, active_revision, workspace_path, created_at, updated_at) "
+        "VALUES (?, 'm1', 'goal', 'SIMULATION', '', 'ACTIVE', 1, '', ?, ?)",
+        (task_id, now, now),
+    )
+    conn.commit()
+
+
+def _events(conn: sqlite3.Connection, task_id: str = "task_1") -> list[str]:
+    rows = conn.execute(
+        "SELECT event_type FROM task_events WHERE task_id = ? ORDER BY seq",
+        (task_id,),
+    ).fetchall()
+    return [r["event_type"] for r in rows]
+
+
+class FakeActionClient:
+    """协议级假 Action client（与 Ros2ActionClient 同接口）。"""
+
+    def __init__(self) -> None:
+        self.sent_goals: list[dict] = []
+        self.cancelled: list[str] = []
+        self._feedback_cb = None
+        self._result_cb = None
+
+    def send_goal(
+        self, *, action: str, action_type: str, args: dict, goal_id: str,
+        on_feedback, on_result,
+    ) -> None:
+        self.sent_goals.append(
+            {"action": action, "action_type": action_type,
+             "args": args, "goal_id": goal_id}
+        )
+        self._feedback_cb = on_feedback
+        self._result_cb = on_result
+
+    def cancel_goal(self, goal_id: str) -> None:
+        self.cancelled.append(goal_id)
+
+    # -- 测试驱动 --
+    def emit_feedback(self, values: dict) -> None:
+        self._feedback_cb(values)
+
+    def emit_result(self, status: int, values: dict) -> None:
+        self._result_cb(status, values)
+
+
+SUCCEEDED, CANCELED, ABORTED = 4, 5, 6
+
+
+class TestActionOperationLifecycle:
+    def _start(self, conn, client):
+        mgr = OperationManager(None, conn)
+
+        async def run():
+            return await mgr.start_action(
+                task_id="task_1", attempt_id="",
+                action="/fibonacci",
+                action_type="action_tutorials_interfaces/action/Fibonacci",
+                args={"order": 5},
+                client=client,
+            )
+
+        return mgr, asyncio.run(run())
+
+    def test_send_goal_registers_operation(self, tmp_path: Path) -> None:
+        conn = _conn(tmp_path)
+        _task(conn)
+        client = FakeActionClient()
+        mgr, op = self._start(conn, client)
+        assert len(client.sent_goals) == 1
+        goal = client.sent_goals[0]
+        assert goal["action"] == "/fibonacci"
+        assert op["goal_id"] == goal["goal_id"]
+        assert op["provider"] == "ros2_action"
+        assert op["state"] in ("ADMITTED", "RUNNING")
+        types = _events(conn)
+        assert "operation.queued" in types
+        assert "operation.admitted" in types
+
+    def test_feedback_becomes_progress(self, tmp_path: Path) -> None:
+        conn = _conn(tmp_path)
+        _task(conn)
+        client = FakeActionClient()
+        mgr, op = self._start(conn, client)
+        client.emit_feedback({"sequence": [0, 1, 1]})
+        row = mgr.get(op["operation_id"])
+        progress = json.loads(row["progress_json"])
+        assert progress, "feedback 未落成 progress"
+        assert "operation.progress" in _events(conn)
+
+    def test_result_succeeded_completes(self, tmp_path: Path) -> None:
+        conn = _conn(tmp_path)
+        _task(conn)
+        client = FakeActionClient()
+        mgr, op = self._start(conn, client)
+        client.emit_result(SUCCEEDED, {"sequence": [0, 1, 1, 2, 3]})
+        row = mgr.get(op["operation_id"])
+        assert row["state"] == "SUCCEEDED"
+        assert row["result_ref"], "缺 result_ref"
+        assert "operation.completed" in _events(conn)
+
+    def test_result_aborted_fails(self, tmp_path: Path) -> None:
+        conn = _conn(tmp_path)
+        _task(conn)
+        client = FakeActionClient()
+        mgr, op = self._start(conn, client)
+        client.emit_result(ABORTED, {})
+        row = mgr.get(op["operation_id"])
+        assert row["state"] == "FAILED"
+
+    def test_cancel_handshake(self, tmp_path: Path) -> None:
+        conn = _conn(tmp_path)
+        _task(conn)
+        client = FakeActionClient()
+        mgr, op = self._start(conn, client)
+
+        async def cancel():
+            await mgr.cancel(op["operation_id"], reason="user-stop")
+
+        asyncio.run(cancel())
+        assert client.cancelled == [op["goal_id"]], "cancel_goal 未发"
+        # result(CANCELED) 到达 → CANCELLED 终态。
+        client.emit_result(CANCELED, {})
+        row = mgr.get(op["operation_id"])
+        assert row["state"] == "CANCELLED"
+        assert row["cancel_reason"] == "user-stop"
+        types = _events(conn)
+        assert "operation.canceling" in types
+        assert "operation.cancelled" in types
+
+    def test_two_hour_action_never_killed(self, tmp_path: Path) -> None:
+        """验收：持续 feedback 的长 Action——sweep 永不 kill（无默认
+        wall-clock kill）。"""
+        conn = _conn(tmp_path)
+        _task(conn)
+        client = FakeActionClient()
+        mgr, op = self._start(conn, client)
+
+        async def run():
+            for _ in range(5):
+                client.emit_feedback({"sequence": [0, 1]})
+                await mgr.sweep_liveness(stale_after_s=1.0)
+                row = mgr.get(op["operation_id"])
+                assert row["state"] in ("RUNNING", "ADMITTED")
+            return op["operation_id"]
+
+        op_id = asyncio.run(run())
+        assert mgr.get(op_id)["state"] not in OPERATION_TERMINAL
+
+    def test_restart_marks_action_lost_honestly(self, tmp_path: Path) -> None:
+        """ros2_action 无 pid——重启不可证实 → LOST（不假装存活）。"""
+        conn = _conn(tmp_path)
+        _task(conn)
+        client = FakeActionClient()
+        mgr, op = self._start(conn, client)
+        mgr2 = OperationManager(None, conn)
+        report = asyncio.run(mgr2.recover_on_boot())
+        row = mgr2.get(op["operation_id"])
+        assert row["state"] == "LOST"
+        assert report["lost"] >= 1
+        assert "operation.lost" in _events(conn)

--- a/tests/agentd/test_p1b3_ros2_action_live.py
+++ b/tests/agentd/test_p1b3_ros2_action_live.py
@@ -1,0 +1,208 @@
+"""P1-B3 live 旅程（0824 总纲 §12/P1-B）：ROS 2 Action 全链路。
+
+协议级假 rosbridge action server（websockets——忠实 rosbridge action
+协议：send_goal → action_feedback 推送 → action_result；cancel_goal
+→ action_result(CANCELED)）+ 真实 RosbridgeTransport + 真实
+Ros2ActionClient + 真实 OperationManager（SQLite 账本）：
+
+1. goal → QUEUED→ADMITTED→RUNNING；goal_id 落账；
+2. feedback → operation.progress（progress_json + 事件）；
+3. result(SUCCEEDED) → operation SUCCEEDED + result_ref；
+4. 第二个 goal cancel → CANCELING → action_result(CANCELED) →
+   CANCELLED（终态不被迟到事件覆盖）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import websockets
+
+from rosclaw.connectors.ros.action_client import Ros2ActionClient
+from rosclaw.connectors.ros.transport.base import RosbridgeEndpoint
+from rosclaw.connectors.ros.transport.rosbridge import RosbridgeTransport
+from rosclaw.storage.migrations import MigrationRunner
+from rosclaw.task_kernel.operation_manager import OperationManager
+
+SUCCEEDED, CANCELED = 4, 5
+
+
+class FakeRosbridgeActionServer:
+    """协议级假 rosbridge action server（Fibonacci 语义）。"""
+
+    def __init__(self) -> None:
+        self.goals: list[dict] = []
+        self.cancelled: list[str] = []
+        self._loop = asyncio.new_event_loop()
+        self._port = 0
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        deadline = time.monotonic() + 10
+        while not self._port and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._serve())
+
+    async def _serve(self) -> None:
+        running: dict[str, asyncio.Task] = {}
+
+        async def fibonacci(ws, goal_id: str, order: int) -> None:
+            sequence = [0, 1]
+            for _ in range(max(1, min(order, 8))):
+                sequence.append(sequence[-1] + sequence[-2])
+                await ws.send(json.dumps({
+                    "op": "action_feedback", "id": goal_id,
+                    "values": {"sequence": list(sequence)},
+                }))
+                await asyncio.sleep(0.4)
+            await ws.send(json.dumps({
+                "op": "action_result", "id": goal_id,
+                "values": {"status": SUCCEEDED,
+                           "result": {"sequence": sequence}},
+            }))
+
+        async def handler(ws) -> None:
+            # 并发语义（与真 rosbridge 一致）：goal 执行与消息读取并行——
+            # cancel 可在执行中到达。
+            async for raw in ws:
+                msg = json.loads(raw)
+                if msg.get("op") == "send_goal":
+                    self.goals.append(msg)
+                    goal_id = msg["id"]
+                    order = int(msg.get("args", {}).get("order", 3))
+                    running[goal_id] = asyncio.create_task(
+                        fibonacci(ws, goal_id, order)
+                    )
+                elif msg.get("op") == "cancel_goal":
+                    goal_id = str(msg.get("id", ""))
+                    self.cancelled.append(goal_id)
+                    task = running.pop(goal_id, None)
+                    if task is not None:
+                        task.cancel()
+                    await ws.send(json.dumps({
+                        "op": "action_result", "id": goal_id,
+                        "values": {"status": CANCELED, "result": {}},
+                    }))
+
+        self._server = await websockets.serve(handler, "127.0.0.1", 0)
+        self._port = self._server.sockets[0].getsockname()[1]
+        await self._server.wait_closed()
+
+    def close(self) -> None:
+        server = getattr(self, "_server", None)
+        if server is not None:
+            self._loop.call_soon_threadsafe(server.close)
+            deadline = time.monotonic() + 5
+            while self._thread.is_alive() and time.monotonic() < deadline:
+                self._loop.call_soon_threadsafe(self._loop.stop)
+                self._thread.join(timeout=0.5)
+        else:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+
+
+def _wait(predicate, timeout: float = 10.0, label: str = "") -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"timeout waiting: {label}")
+
+
+class TestRos2ActionLiveJourney:
+    def test_full_action_lifecycle(self, tmp_path: Path) -> None:
+        server = FakeRosbridgeActionServer()
+        conn = sqlite3.connect(tmp_path / "missions.db", check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        MigrationRunner().apply(conn, "sqlite")
+        now = "2026-08-25T00:00:00+00:00"
+        conn.execute(
+            "INSERT INTO tasks (task_id, mission_id, root_goal, mode, body_id, "
+            "state, active_revision, workspace_path, created_at, updated_at) "
+            "VALUES ('task_1', 'm1', 'goal', 'SIMULATION', '', 'ACTIVE', 1, "
+            "'', ?, ?)",
+            (now, now),
+        )
+        conn.commit()
+        transport = RosbridgeTransport(
+            RosbridgeEndpoint(host="127.0.0.1", port=server.port)
+        )
+        client = Ros2ActionClient(transport)
+        mgr = OperationManager(None, conn)
+        try:
+            async def run() -> dict:
+                op = await mgr.start_action(
+                    task_id="task_1", attempt_id="",
+                    action="/fibonacci",
+                    action_type="action_tutorials_interfaces/action/Fibonacci",
+                    args={"order": 4},
+                    client=client,
+                )
+                # cancel 链路（第二个 goal）。
+                op2 = await mgr.start_action(
+                    task_id="task_1", attempt_id="",
+                    action="/fibonacci",
+                    action_type="action_tutorials_interfaces/action/Fibonacci",
+                    args={"order": 8},
+                    client=client,
+                )
+                await mgr.cancel(op2["operation_id"], reason="journey-stop")
+                return op
+
+            op = asyncio.run(run())
+            op_id = op["operation_id"]
+
+            _wait(lambda: mgr.get(op_id)["state"] == "SUCCEEDED",
+                  label="goal1 SUCCEEDED")
+            row = mgr.get(op_id)
+            assert row["goal_id"], "缺 goal_id"
+            assert row["provider"] == "ros2_action"
+            assert row["result_ref"], "缺 result_ref"
+            progress = json.loads(row["progress_json"])
+            assert progress.get("sequence"), f"feedback 未落成 progress: {row}"
+
+            rows = conn.execute(
+                "SELECT operation_id, state, cancel_reason FROM operations "
+                "WHERE operation_id != ?",
+                (op_id,),
+            ).fetchall()
+            assert len(rows) == 1
+            _wait(lambda: conn.execute(
+                "SELECT state FROM operations WHERE operation_id = ?",
+                (rows[0]["operation_id"],),
+            ).fetchone()["state"] == "CANCELLED", label="goal2 CANCELLED")
+            final = conn.execute(
+                "SELECT state, cancel_reason FROM operations "
+                "WHERE operation_id = ?",
+                (rows[0]["operation_id"],),
+            ).fetchone()
+            assert final["state"] == "CANCELLED"
+            assert final["cancel_reason"] == "journey-stop"
+            assert server.cancelled, "cancel_goal 未到服务端"
+
+            types = [
+                r["event_type"]
+                for r in conn.execute(
+                    "SELECT event_type FROM task_events ORDER BY seq"
+                ).fetchall()
+            ]
+            for expected in (
+                "operation.queued", "operation.admitted", "operation.progress",
+                "operation.completed", "operation.canceling",
+                "operation.cancelled",
+            ):
+                assert expected in types, f"事件链缺 {expected}"
+        finally:
+            client.close()
+            server.close()


### PR DESCRIPTION
## 缺口
ROS 连接只有同步 request/response——无 Action client，长 Action 无法进 Operation 运营层。

## 红→绿
- 红：tests/agentd/test_p1b3_ros2_action.py 7 failed
- 绿：7 passed + live 旅程（协议级假 rosbridge action server + 真 transport/client/manager）+ operation 全套 23 + connectors 99

## 要点
- Ros2ActionClient（不 import rclpy）：send_goal/cancel_goal + feedback/result 推送
- start_action：QUEUED→ADMITTED→RUNNING；goal_id/provider 落账；feedback→progress；result→终态 + result_ref
- cancel 握手 CANCELING→cancel_goal→CANCELLED；宽限兜底
- 2h 假 Action 不 kill；重启 ros2_action → 诚实 LOST
- 实证修复：receive 空闲超时不 invalidate；feedback 回到 goal 连接（单 transport）；terminal 同步核心

SHADOW 域——不开 REAL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)