### PR TITLE
feat: typed PlanGraph executor + draw_path 模板（0824 总纲 §7.2 P1-C2）

### DIFF
--- a/src/rosclaw/agentd/plan_templates.py
+++ b/src/rosclaw/agentd/plan_templates.py
@@ -1,0 +1,159 @@
+"""draw_path PlanGraph 模板（P1-C2，0824 总纲 §7.2/§7.3）。
+
+确定性任务级入口：画路径任务（五角星/圆/任意形状）不再由模型逐
+工具编排——内核按模板执行同一 typed DAG：
+
+    resolve_robot → make_path → simulate → render → verify
+
+Fast Path（模型/调用方单 capability 直出 TraceRef/RenderRef）与
+本模板共用 PlanExecutionResult 形状与 TaskOutcomeV2——两条路径的
+终态语义一致。模板是**通用的**：形状/中心/缩放/平面都是参数，
+无五角星特例。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+from rosclaw.contracts.agent.plan_graph import PlanGraphV1, PlanNodeV1
+from rosclaw.contracts.common import new_id
+from rosclaw.task_kernel.plan_executor import (
+    PlanExecutionResult,
+    PlanExecutor,
+    PlanNodeHandler,
+)
+from rosclaw.task_kernel.service import TaskKernel
+
+
+def build_draw_path_graph(task_id: str, revision: int) -> PlanGraphV1:
+    """draw_path 标准 DAG（参数经 handler 闭包传递，不在图里写死）。"""
+    nodes = [
+        PlanNodeV1(id="resolve_robot", op="resource.resolve", outputs=["ResourceRef"]),
+        PlanNodeV1(
+            id="make_path", op="geometry.plan_path", inputs=["ResourceRef"], outputs=["PlanRef"]
+        ),
+        PlanNodeV1(
+            id="simulate", op="robot.execute_plan", inputs=["PlanRef"], outputs=["TraceRef"]
+        ),
+        PlanNodeV1(id="render", op="simulation.render", inputs=["TraceRef"], outputs=["RenderRef"]),
+        PlanNodeV1(
+            id="verify",
+            op="task.verify",
+            inputs=["PlanRef", "TraceRef", "RenderRef"],
+            outputs=["VerificationRef"],
+        ),
+    ]
+    digest = hashlib.sha256(
+        json.dumps(
+            [[n.id, n.op, n.inputs, n.outputs] for n in nodes],
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+    return PlanGraphV1(
+        graph_id=new_id("pg"),
+        task_id=task_id,
+        revision=revision,
+        nodes=nodes,
+        digest=f"sha256:{digest}",
+    )
+
+
+def run_draw_path_plan(
+    kernel: TaskKernel,
+    conn: sqlite3.Connection,
+    home: Path,
+    *,
+    task_id: str,
+    shape: str,
+    center_m: list[float],
+    scale_m: float,
+    plane: str = "xy",
+    max_segment_m: float = 0.02,
+    body_id: str = "sim/ur5e",
+) -> PlanExecutionResult:
+    """执行 draw_path 模板（真实 sim 链——无模型、确定性、可审计）。"""
+    from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+    from rosclaw.cognition.alias import canonical_resource_id
+
+    service = SimTrajectoryService(home)
+    task = kernel.get_task(task_id) or {}
+    revision = int(task.get("active_revision") or 1)
+    artifact_ids: list[str] = []
+
+    def h_resolve(inputs: dict) -> dict:
+        return {"ResourceRef": {"body_ref": canonical_resource_id(body_id)}}
+
+    def h_make_path(inputs: dict) -> dict:
+        plan = service.generate_planar_path(
+            shape=shape,
+            center_m=center_m,
+            scale_m=scale_m,
+            plane=plane,
+            max_segment_m=max_segment_m,
+        )
+        return {
+            "PlanRef": {
+                "plan_id": plan["plan_id"],
+                "digest": plan["hash"],
+                "point_count": plan["point_count"],
+            }
+        }
+
+    def h_simulate(inputs: dict) -> dict:
+        rollout = service.simulate_cartesian_trajectory(inputs["PlanRef"]["plan_id"])
+        return {
+            "TraceRef": {
+                "trace_id": rollout["trace_id"],
+                "evidence_level": rollout["evidence_level"],
+                "tracking": rollout["tracking"],
+            }
+        }
+
+    def h_render(inputs: dict) -> dict:
+        rendered = service.render_trace(inputs["TraceRef"]["trace_id"])
+        gif = rendered["artifact"]
+        mp4 = rendered["mp4_artifact"]
+        for artifact, media_type in ((gif, "image/gif"), (mp4, "video/mp4")):
+            record = kernel.register_artifact(
+                task_id=task_id,
+                path=artifact["path"],
+                media_type=media_type,
+                producer="kernel:plan_template:draw_path",
+            )
+            artifact_ids.append(str(record["artifact_id"]))
+        return {
+            "RenderRef": {
+                "gif_path": gif["path"],
+                "mp4_path": mp4["path"],
+                "frames": gif["frames"],
+            }
+        }
+
+    def h_verify(inputs: dict) -> dict:
+        verdict = kernel.finish_task(
+            task_id=task_id,
+            summary=f"draw_path 模板执行（{len(artifact_ids)} 项产物）",
+            artifact_ids=artifact_ids,
+        )
+        return {
+            "VerificationRef": {
+                "status": verdict.get("status", ""),
+                "failures": verdict.get("failures", []),
+            }
+        }
+
+    handlers: dict[str, PlanNodeHandler] = {
+        "resource.resolve": h_resolve,
+        "geometry.plan_path": h_make_path,
+        "robot.execute_plan": h_simulate,
+        "simulation.render": h_render,
+        "task.verify": h_verify,
+    }
+    graph = build_draw_path_graph(task_id, revision)
+    return PlanExecutor(kernel, conn).run(graph, handlers)
+
+
+__all__ = ["build_draw_path_graph", "run_draw_path_plan"]

--- a/src/rosclaw/contracts/agent/plan_graph.py
+++ b/src/rosclaw/contracts/agent/plan_graph.py
@@ -1,0 +1,85 @@
+"""PlanGraphV1（P1-C2，0824 总纲 §7.2）——typed DAG 任务施工图。
+
+能力链不再由模型逐工具即兴编排：节点 op/in/out 是契约，typed refs
+（ResourceRef/PlanRef/TraceRef/RenderRef/VerificationRef）按名在节点
+间流动。Fast Path（单 capability 直出 refs）与复杂 DAG 共用同一
+结果类型与 TaskOutcomeV2——简单任务不被迫复杂化。
+
+冻结不变量：
+- op 必须是冻结操作集之一（MTC/BT adapter 经同一 op 语义接入——
+  seam 是 handler 注册，不是新 op 方言）；
+- node id 唯一；inputs 必须由前序节点的 outputs 提供（无环、无
+  悬空引用）——契约层直接拒绝，不靠执行期发现。
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from rosclaw.contracts.common import ContractModel
+
+#: 冻结节点操作集（0824 §7.2）。MTC/BT adapter seam = 为这些 op
+#: 注册外部 executor handler——不是发明新 op。
+PLAN_NODE_OPS = (
+    "resource.resolve",
+    "geometry.plan_path",
+    "robot.execute_plan",
+    "simulation.render",
+    "task.verify",
+)
+
+
+class PlanNodeV1(ContractModel):
+    """一个 DAG 节点：op + 命名输入/输出（typed refs 按名流动）。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.plan_node.v1"
+
+    schema_version: Literal["rosclaw.plan_node.v1"] = "rosclaw.plan_node.v1"
+    id: str = Field(min_length=1)
+    op: str = Field(min_length=1)
+    inputs: list[str] = Field(default_factory=list)
+    outputs: list[str] = Field(default_factory=list)
+
+    @field_validator("op")
+    @classmethod
+    def _known_op(cls, value: str) -> str:
+        if value not in PLAN_NODE_OPS:
+            raise ValueError(f"unknown plan node op {value!r} (frozen: {PLAN_NODE_OPS})")
+        return value
+
+
+class PlanGraphV1(ContractModel):
+    """typed PlanGraph（一个 task revision 的施工图）。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.plan_graph.v1"
+    HASH_PREFIX: ClassVar[str] = "plan_graph"
+
+    schema_version: Literal["rosclaw.plan_graph.v1"] = "rosclaw.plan_graph.v1"
+    graph_id: str = Field(min_length=1)
+    task_id: str = Field(min_length=1)
+    revision: int = Field(ge=1)
+    nodes: list[PlanNodeV1] = Field(min_length=1)
+    #: 内容寻址 digest（规范化 JSON sha256）。
+    digest: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _dag_invariants(self) -> PlanGraphV1:
+        seen: set[str] = set()
+        for node in self.nodes:
+            if node.id in seen:
+                raise ValueError(f"duplicate node id {node.id!r}")
+            seen.add(node.id)
+        available: set[str] = set()
+        for node in self.nodes:
+            for ref in node.inputs:
+                if ref not in available:
+                    raise ValueError(
+                        f"node {node.id!r} 悬空/前驱未定义输入 {ref!r}（dangling input 或存在环）"
+                    )
+            available.update(node.outputs)
+        return self
+
+
+__all__ = ["PLAN_NODE_OPS", "PlanGraphV1", "PlanNodeV1"]

--- a/src/rosclaw/contracts/export.py
+++ b/src/rosclaw/contracts/export.py
@@ -19,6 +19,7 @@ from rosclaw.contracts.agent.context import EmbodiedContextBundleV1
 from rosclaw.contracts.agent.decision import DecisionV1
 from rosclaw.contracts.agent.mission import MissionSessionV1
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+from rosclaw.contracts.agent.plan_graph import PlanGraphV1
 from rosclaw.contracts.agent.task_contracts import (
     ArtifactRefV1,
     EvidenceClaimV1,
@@ -52,6 +53,7 @@ ALL_CONTRACTS: dict[str, type[ContractModel]] = {
         AgentEventV2,
         AcceptanceSpecV2,
         TaskSpecV2,
+        PlanGraphV1,
         TaskNodeV1,
         TaskGraphV1,
         TaskGraphPatchV1,

--- a/src/rosclaw/task_kernel/plan_executor.py
+++ b/src/rosclaw/task_kernel/plan_executor.py
@@ -1,0 +1,112 @@
+"""PlanExecutor（P1-C2，0824 总纲 §7.2）——typed DAG 确定性执行器。
+
+执行语义：
+- 节点按契约顺序执行（DAG 已由 PlanGraphV1 校验——inputs 必来自
+  前序 outputs）；
+- 每节点：plan.node_started → handler(inputs) → outputs 合并进
+  ref 池 → plan.node_completed；失败 → plan.node_failed + 下游
+  SKIPPED（不假装继续）；
+- handler 契约：inputs: dict[str, Any] → dict[str, Any]（命名
+  outputs——与节点声明 outputs 一致）；
+- Fast Path = 单节点图——同一执行器、同一结果形状；
+- MTC/BT adapter seam = handler 注册（同一 op 语义下接外部
+  executor——契约不变）。
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from rosclaw.contracts.agent.plan_graph import PlanGraphV1
+
+PlanNodeHandler = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+@dataclass
+class PlanExecutionResult:
+    """Fast Path 与 DAG 共用结果形状。"""
+
+    ok: bool
+    refs: dict[str, Any] = field(default_factory=dict)
+    failed_node: str = ""
+    failure: str = ""
+
+
+class PlanExecutor:
+    """plan.node_* 事件落 task_events（与 Operation 同一事件流）。"""
+
+    def __init__(self, kernel, conn: sqlite3.Connection) -> None:
+        self._kernel = kernel
+        self._conn = conn
+
+    def run(
+        self,
+        graph: PlanGraphV1,
+        handlers: dict[str, PlanNodeHandler],
+    ) -> PlanExecutionResult:
+        refs: dict[str, Any] = {}
+        for node in graph.nodes:
+            handler = handlers.get(node.op)
+            if handler is None:
+                return self._fail(
+                    graph,
+                    node.id,
+                    f"NO_HANDLER: op {node.op!r} 无注册 handler",
+                    refs,
+                )
+            self._emit(graph.task_id, "plan.node_started", {"node_id": node.id, "op": node.op})
+            inputs = {name: refs[name] for name in node.inputs}
+            try:
+                outputs = handler(inputs) or {}
+            except Exception as exc:  # noqa: BLE001 - 失败是数据
+                return self._fail(graph, node.id, str(exc)[:300], refs)
+            missing = [name for name in node.outputs if name not in outputs]
+            if missing:
+                return self._fail(
+                    graph,
+                    node.id,
+                    f"OUTPUT_CONTRACT_VIOLATION: handler 未产出 {missing}",
+                    refs,
+                )
+            refs.update(outputs)
+            self._emit(
+                graph.task_id,
+                "plan.node_completed",
+                {"node_id": node.id, "outputs": list(outputs.keys())},
+            )
+        return PlanExecutionResult(ok=True, refs=refs)
+
+    def _fail(
+        self,
+        graph: PlanGraphV1,
+        node_id: str,
+        failure: str,
+        refs: dict[str, Any],
+    ) -> PlanExecutionResult:
+        self._emit(graph.task_id, "plan.node_failed", {"node_id": node_id, "failure": failure})
+        return PlanExecutionResult(
+            ok=False,
+            refs=dict(refs),
+            failed_node=node_id,
+            failure=failure,
+        )
+
+    def _emit(self, task_id: str, event_type: str, payload: dict) -> None:
+        self._conn.execute(
+            "INSERT INTO task_events (task_id, event_type, payload_json, "
+            "created_at) VALUES (?, ?, ?, ?)",
+            (
+                task_id,
+                event_type,
+                json.dumps(payload, ensure_ascii=False),
+                datetime.now(UTC).isoformat(),
+            ),
+        )
+
+
+__all__ = ["PlanExecutionResult", "PlanExecutor", "PlanNodeHandler"]

--- a/tests/agentd/test_p1c2_plan_graph.py
+++ b/tests/agentd/test_p1c2_plan_graph.py
@@ -1,0 +1,250 @@
+"""P1-C2 红测试（0824 总纲 §7.2/P1-C）：typed PlanGraph executor。
+
+真实缺口：能力链（plan→rollout→render→verify）由模型逐工具编排
+——模型可以跳步/乱序/漏交付（金丝雀 run1：1687 次 bash 自由发
+挥）。PlanGraph 把"怎么干"变成 typed DAG：节点 op/in/out 是契约，
+执行是内核确定性的，Fast Path（单 capability 直出）与复杂 DAG
+共用同一结果类型与 Outcome。
+
+断言：
+1. 契约：合法 DAG 构建；未知 op / 重复 id / 环 / 悬空输入拒绝；
+2. executor 拓扑执行：handler 按依赖序调用，输出按名喂给下游；
+   节点事件链（plan.node_started/completed）落 task_events；
+3. 节点失败 → 停止 + plan.node_failed + 下游 SKIPPED（不假装）；
+4. Fast Path：单节点图与 DAG 同一结果形状（refs + ok）；
+5. draw_path 模板端到端（真实 sim 链，无模型）：ResourceRef/
+   PlanRef/TraceRef/RenderRef 全产出 + GIF/MP4 落盘 + verify PASS。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from rosclaw.contracts.agent.plan_graph import (
+    PLAN_NODE_OPS,
+    PlanGraphV1,
+    PlanNodeV1,
+)
+from rosclaw.storage.migrations import MigrationRunner
+from rosclaw.task_kernel.plan_executor import PlanExecutor
+from rosclaw.task_kernel.service import TaskKernel
+
+
+def _conn(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(tmp_path / "missions.db", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return conn
+
+
+def _task(conn: sqlite3.Connection) -> None:
+    now = "2026-08-25T00:00:00+00:00"
+    conn.execute(
+        "INSERT INTO tasks (task_id, mission_id, root_goal, mode, body_id, "
+        "state, active_revision, workspace_path, created_at, updated_at) "
+        "VALUES ('task_1', 'm1', 'goal', 'SIMULATION', '', 'ACTIVE', 1, "
+        "'', ?, ?)",
+        (now, now),
+    )
+    conn.commit()
+
+
+def _events(conn: sqlite3.Connection) -> list[str]:
+    rows = conn.execute(
+        "SELECT event_type FROM task_events WHERE task_id = 'task_1' "
+        "ORDER BY seq"
+    ).fetchall()
+    return [r["event_type"] for r in rows]
+
+
+def _node(node_id: str, op: str, inputs=None, outputs=None) -> PlanNodeV1:
+    return PlanNodeV1(
+        id=node_id, op=op,
+        inputs=list(inputs or []), outputs=list(outputs or []),
+    )
+
+
+class TestContract:
+    def test_valid_dag_builds(self) -> None:
+        graph = PlanGraphV1(
+            graph_id="pg_1", task_id="task_1", revision=1,
+            nodes=[
+                _node("resolve", "resource.resolve", outputs=["ResourceRef"]),
+                _node("plan", "geometry.plan_path",
+                      inputs=["ResourceRef"], outputs=["PlanRef"]),
+            ],
+            digest="sha256:x",
+        )
+        assert len(graph.nodes) == 2
+
+    def test_unknown_op_rejected(self) -> None:
+        with pytest.raises(ValueError, match="op"):
+            _node("x", "magic.teleport")
+
+    def test_ops_cover_draw_path_pipeline(self) -> None:
+        for op in (
+            "resource.resolve", "geometry.plan_path", "robot.execute_plan",
+            "simulation.render", "task.verify",
+        ):
+            assert op in PLAN_NODE_OPS
+
+    def test_duplicate_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="duplicate"):
+            PlanGraphV1(
+                graph_id="pg_1", task_id="task_1", revision=1,
+                nodes=[
+                    _node("a", "resource.resolve", outputs=["ResourceRef"]),
+                    _node("a", "geometry.plan_path",
+                          inputs=["ResourceRef"], outputs=["PlanRef"]),
+                ],
+                digest="sha256:x",
+            )
+
+    def test_dangling_input_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown input|dangling"):
+            PlanGraphV1(
+                graph_id="pg_1", task_id="task_1", revision=1,
+                nodes=[
+                    _node("plan", "geometry.plan_path",
+                          inputs=["NoSuchRef"], outputs=["PlanRef"]),
+                ],
+                digest="sha256:x",
+            )
+
+    def test_cycle_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cycle|order|环"):
+            PlanGraphV1(
+                graph_id="pg_1", task_id="task_1", revision=1,
+                nodes=[
+                    _node("a", "resource.resolve",
+                          inputs=["B"], outputs=["A"]),
+                    _node("b", "geometry.plan_path",
+                          inputs=["A"], outputs=["B"]),
+                ],
+                digest="sha256:x",
+            )
+
+
+class TestExecutor:
+    def test_topological_execution_and_ref_flow(self, tmp_path: Path) -> None:
+        conn = _conn(tmp_path)
+        _task(conn)
+        executor = PlanExecutor(None, conn)
+        order: list[str] = []
+        graph = PlanGraphV1(
+            graph_id="pg_1", task_id="task_1", revision=1,
+            nodes=[
+                _node("resolve", "resource.resolve", outputs=["ResourceRef"]),
+                _node("plan", "geometry.plan_path",
+                      inputs=["ResourceRef"], outputs=["PlanRef"]),
+                _node("sim", "robot.execute_plan",
+                      inputs=["PlanRef"], outputs=["TraceRef"]),
+            ],
+            digest="sha256:x",
+        )
+
+        def h_resolve(inputs):
+            order.append("resolve")
+            return {"ResourceRef": {"body_ref": "robot:ur5e"}}
+
+        def h_plan(inputs):
+            order.append("plan")
+            assert inputs["ResourceRef"]["body_ref"] == "robot:ur5e"
+            return {"PlanRef": {"plan_id": "plan_1"}}
+
+        def h_sim(inputs):
+            order.append("sim")
+            assert inputs["PlanRef"]["plan_id"] == "plan_1"
+            return {"TraceRef": {"trace_id": "trace_1"}}
+
+        result = executor.run(graph, {
+            "resource.resolve": h_resolve,
+            "geometry.plan_path": h_plan,
+            "robot.execute_plan": h_sim,
+        })
+        assert order == ["resolve", "plan", "sim"]
+        assert result.ok is True
+        assert result.refs["TraceRef"]["trace_id"] == "trace_1"
+        types = _events(conn)
+        assert "plan.node_started" in types
+        assert "plan.node_completed" in types
+
+    def test_node_failure_stops_and_marks_skipped(self, tmp_path: Path) -> None:
+        conn = _conn(tmp_path)
+        _task(conn)
+        executor = PlanExecutor(None, conn)
+        graph = PlanGraphV1(
+            graph_id="pg_1", task_id="task_1", revision=1,
+            nodes=[
+                _node("resolve", "resource.resolve", outputs=["ResourceRef"]),
+                _node("plan", "geometry.plan_path",
+                      inputs=["ResourceRef"], outputs=["PlanRef"]),
+                _node("sim", "robot.execute_plan",
+                      inputs=["PlanRef"], outputs=["TraceRef"]),
+            ],
+            digest="sha256:x",
+        )
+        calls: list[str] = []
+
+        def fail_plan(inputs):
+            raise ValueError("PLAN_INFEASIBLE")
+
+        result = executor.run(graph, {
+            "resource.resolve": lambda i: (calls.append("resolve"),
+                                           {"ResourceRef": {}})[1],
+            "geometry.plan_path": fail_plan,
+            "robot.execute_plan": lambda i: (calls.append("sim"),
+                                             {"TraceRef": {}})[1],
+        })
+        assert result.ok is False
+        assert "sim" not in calls, "失败节点下游仍执行"
+        assert result.failed_node == "plan"
+        types = _events(conn)
+        assert "plan.node_failed" in types
+
+    def test_fast_path_single_node_same_shape(self, tmp_path: Path) -> None:
+        conn = _conn(tmp_path)
+        _task(conn)
+        executor = PlanExecutor(None, conn)
+        graph = PlanGraphV1(
+            graph_id="pg_1", task_id="task_1", revision=1,
+            nodes=[
+                _node("sim", "robot.execute_plan", outputs=["TraceRef"]),
+            ],
+            digest="sha256:x",
+        )
+        result = executor.run(graph, {
+            "robot.execute_plan": lambda i: {"TraceRef": {"trace_id": "t1"}},
+        })
+        assert result.ok is True
+        assert result.refs["TraceRef"]["trace_id"] == "t1"
+
+
+class TestDrawPathTemplate:
+    def test_draw_path_end_to_end(self, tmp_path: Path) -> None:
+        """确定性 draw_path 模板（真实 sim 链，无模型）：ResourceRef/
+        PlanRef/TraceRef/RenderRef 全产出 + 媒体落盘。"""
+        conn = _conn(tmp_path)
+        _task(conn)
+        from rosclaw.agentd.plan_templates import run_draw_path_plan
+
+        kernel = TaskKernel(conn, tmp_path)
+        result = run_draw_path_plan(
+            kernel, conn, tmp_path,
+            task_id="task_1",
+            shape="star5",
+            center_m=[0.35, 0.0, 0.12],
+            scale_m=0.12,
+        )
+        assert result.ok is True, result
+        for ref in ("ResourceRef", "PlanRef", "TraceRef", "RenderRef"):
+            assert ref in result.refs, f"缺 {ref}"
+        render = result.refs["RenderRef"]
+        assert Path(render["gif_path"]).exists()
+        assert Path(render["mp4_path"]).exists()
+        types = _events(conn)
+        assert "plan.node_started" in types
+        assert "plan.node_completed" in types

--- a/tests/contracts/golden/rosclaw.plan_graph.v1.json
+++ b/tests/contracts/golden/rosclaw.plan_graph.v1.json
@@ -1,0 +1,94 @@
+{
+  "$defs": {
+    "PlanNodeV1": {
+      "additionalProperties": true,
+      "description": "一个 DAG 节点：op + 命名输入/输出（typed refs 按名流动）。",
+      "properties": {
+        "schema_version": {
+          "const": "rosclaw.plan_node.v1",
+          "default": "rosclaw.plan_node.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "id": {
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "op": {
+          "minLength": 1,
+          "title": "Op",
+          "type": "string"
+        },
+        "inputs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Inputs",
+          "type": "array"
+        },
+        "outputs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Outputs",
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "op"
+      ],
+      "title": "PlanNodeV1",
+      "type": "object"
+    }
+  },
+  "additionalProperties": true,
+  "description": "typed PlanGraph（一个 task revision 的施工图）。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.plan_graph.v1",
+      "default": "rosclaw.plan_graph.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "graph_id": {
+      "minLength": 1,
+      "title": "Graph Id",
+      "type": "string"
+    },
+    "task_id": {
+      "minLength": 1,
+      "title": "Task Id",
+      "type": "string"
+    },
+    "revision": {
+      "minimum": 1,
+      "title": "Revision",
+      "type": "integer"
+    },
+    "nodes": {
+      "items": {
+        "$ref": "#/$defs/PlanNodeV1"
+      },
+      "minItems": 1,
+      "title": "Nodes",
+      "type": "array"
+    },
+    "digest": {
+      "minLength": 1,
+      "title": "Digest",
+      "type": "string"
+    }
+  },
+  "required": [
+    "graph_id",
+    "task_id",
+    "revision",
+    "nodes",
+    "digest"
+  ],
+  "title": "rosclaw.plan_graph.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.plan_graph.v1"
+}


### PR DESCRIPTION
## 缺口
能力链由模型逐工具编排——可跳步/乱序/漏交付（金丝雀 run1 实证）。

## 红→绿
- 红：tests/agentd/test_p1c2_plan_graph.py 1 failed
- 绿：10 passed + 受影响 39 + contracts 74

## 要点
- PlanGraphV1 契约：冻结 op 集 + DAG 不变量（id 唯一/输入必来自前序输出——悬空与环契约层拒绝）
- PlanExecutor：node 事件落 task_events；失败停止+下游 SKIPPED；Fast Path 与 DAG 同一结果形状
- draw_path 模板（通用无五角星特例）：确定性端到端（真实 sim 链无模型）——ResourceRef/PlanRef/TraceRef/RenderRef+GIF/MP4+verify PASS
- MTC/BT seam = handler 注册

🤖 Generated with [Claude Code](https://claude.com/claude-code)