### PR TITLE
feat: R0-1 删除生产双链——TaskSpecV2→TaskRouter→PlanGraph→PlanExecutor 唯一生产链（0826 体验审计）

### DIFF
--- a/packages/rosclaw-agent/src/tools/surface.ts
+++ b/packages/rosclaw-agent/src/tools/surface.ts
@@ -40,7 +40,9 @@ export const PRODUCT_PACK: readonly string[] = [
  * PR-N5D：rosclaw_compute / rosclaw_execute 退出默认模型面——能力以
  * CapabilitySnapshot 物化的精确强类型工具直接进入（materialize.ts）；
  * 两者仍是 bridge wire 上的验证链 plumbing（物化工具内部调用）。
- * rosclaw_task 降级为兼容入口（SIM 管线宏），不再是主要认知路径。 */
+ * R0-1：rosclaw_task = TaskExecutionService 的兼容 adapter（frozen
+ * TaskSpecV2 → TaskRouter → PlanGraph——唯一生产链）；TaskSpec 承载
+ * 完整几何/交付语义（R0-2）后退出模型面，由输入路由自动触发。 */
 export const EMBODIMENT_PACK: readonly string[] = [
 	"rosclaw_status",
 	"rosclaw_capabilities",

--- a/packages/rosclaw-agent/src/tools/task.ts
+++ b/packages/rosclaw-agent/src/tools/task.ts
@@ -1,9 +1,11 @@
 // HP2-COMPAT: 工具定义原语（defineTool/Type/ToolDefinition）——工具层在 HP3 投影层（Codex MCP）落地前保持 Pi 形态；不新增会话装配引用。
-/** `rosclaw_task` 工具（八审 §2.2/P0-5）：任务级入口。
+/** `rosclaw_task` 工具（八审 §2.2/P0-5 → R0-1 重写为 adapter）：
+ * 任务级入口。
  *
- * 已知任务（draw_shape 等）走确定性 Task Compiler/Runner——模型只交
- * TaskSpec（goal + 业务参数），内核完成规划、策略判定、单动作执行与
- * 自动验证；模型不搬轨迹/hash/lease/grant，不逐点控制。
+ * 已知任务（draw_shape 等）走唯一生产链：TaskExecutionService
+ * （frozen TaskSpecV2 → TaskRouter → recipe PlanGraph → PlanExecutor）
+ * ——模型只交 goal + 业务参数，内核完成路由、规划、单动作执行与自动
+ * 验证；模型不搬轨迹/hash/lease/grant，不逐点控制。
  *
  * ASK 策略下两阶段：submit 返回 WAITING_APPROVAL（展卡）→ 人工决定
  * → resume（task_id）执行+验证。与 rosclaw_request_action 共用同一

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -483,7 +483,8 @@ class PiToolDispatcher:
             self._ensure_task_for_effect(request)
             return await self._request_action(request)
         if name == "rosclaw_task":
-            self._note_embodiment_use(request)
+            # R0-1：adapter 内部 ensure admission + 具身落账（任务
+            # 存在后标记，证据规则随之武装）。
             return await self._task(request)
         # PR-H3：process 工具——长进程 = Operation（立即返回，事件流
         # 可查，终态 followUp 一次）。
@@ -796,13 +797,15 @@ class PiToolDispatcher:
         )
 
     async def _task(self, request: PiToolRequestV1) -> PiToolResultV1:
-        """rosclaw_task（PR-H9 重接）：确定性 SIM 任务闭环——
-        SimTrajectoryService 直跑（规划→ rollout → 渲染 → 跟踪验证，
-        总纲 §5.1），产物登记进 TaskKernel 产物账本。
+        """rosclaw_task（R0-1 兼容 adapter，0826 体验审计 §5.R0-1）。
 
-        TaskRunner/task_records 旧链已删除；SIM 动力学由托管
-        rosclaw-simulation runtime 预置（不可用时诚实 BLOCKED，
-        不是渲染时裸 ModuleNotFoundError）。
+        唯一生产链：TaskExecutionService.execute（frozen TaskSpecV2
+        → TaskRouter → recipe → PlanGraph → PlanExecutor）。旧内联
+        SIM 管线（generate/simulate/render/verify 直调）已物理删除
+        ——生产对 draw path 只有一条执行链。
+
+        模型只交 goal+parameters；recipe 选择由 frozen spec 的
+        intent 决定（TaskRouter），不是 goal 字符串。
         """
         import asyncio as _asyncio
         import json as _json
@@ -818,131 +821,91 @@ class PiToolDispatcher:
                 f"未知确定性任务 {goal!r}——当前支持 simulate_trajectory"
                 "（其余长任务走 rosclaw_execute/process_start）",
             )
-        service = self._service
-        mission = service.get_mission(request.mission_id)
-        if mission is not None and mission.mode.value != "SIMULATION":
-            raise ToolBridgeError(
-                "MODE_DENIED",
-                f"rosclaw_task 仅 SIMULATION——当前 {mission.mode.value}",
+        # P0-C：活跃任务优先（不重复 bump revision）；没有时首个
+        # effectful call 的原子 admission（动机输入缺失诚实拒绝）。
+        kernel = self._service._task_kernel
+        task = kernel.active_task_for(request.mission_id, request.pi_session_id)
+        if task is None:
+            self._ensure_task_for_effect(request)
+            task = kernel.active_task_for(
+                request.mission_id, request.pi_session_id
             )
-        from rosclaw.agentd.runtime_manager import RuntimeNotReadyError
-        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
-
-        try:
-            service._runtime_manager.ensure("rosclaw-simulation")
-        except RuntimeNotReadyError as exc:
-            return PiToolResultV1(
-                request_id=request.request_id,
-                ok=False,
-                status="REJECTED",
-                summary=f"RUNTIME_NOT_READY：{exc}"[:400],
-                error_code="RUNTIME_NOT_READY",
-            )
-        sim = SimTrajectoryService(
-            service._home, runtime_manager=service._runtime_manager
+        if task is None:
+            raise ToolBridgeError("NO_ACTIVE_TASK", "无活跃任务")
+        # 具身落账在任务存在后（证据规则随之武装）。
+        self._note_embodiment_use(request)
+        outcome = await _asyncio.to_thread(
+            self._service._task_execution.execute,
+            str(task["task_id"]),
+            recipe_inputs=dict(parameters),
+            goal_hint=goal,
         )
-        acceptance = args.get("acceptance") or {}
-        plan = await _asyncio.to_thread(
-            sim.generate_planar_path,
-            shape=str(parameters.get("shape", "star5")),
-            center_m=parameters.get("center_m") or [0.35, 0.25, 0.30],
-            scale_m=float(parameters.get("scale_m", parameters.get("radius_m", 0.10))),
-            plane=str(parameters.get("plane", "xy")),
-            max_segment_m=float(parameters.get("max_segment_m", 0.03)),
+        if outcome.error_code in (
+            "TASK_NOT_FOUND", "TASK_SPEC_MISSING", "TASK_NO_RECIPE",
+            "MODE_DENIED", "RUNTIME_NOT_READY",
+        ):
+            raise ToolBridgeError(outcome.error_code, outcome.failure)
+        refs = outcome.refs
+        render_ref = refs.get("RenderRef") or {}
+        trace_ref = refs.get("TraceRef") or {}
+        verification_ref = refs.get("VerificationRef") or {}
+        metrics = verification_ref.get("metrics") or {}
+        evidence_level = str(
+            trace_ref.get("evidence_level") or "SIM_DYN_ROLLOUT"
         )
-        result = await _asyncio.to_thread(
-            sim.simulate_cartesian_trajectory, plan["plan_id"]
-        )
-        render = await _asyncio.to_thread(
-            sim.render_trace, result["trace_id"], format="gif"
-        )
-        threshold = float(acceptance.get("max_tracking_error_m", 0.05))
-        verify = await _asyncio.to_thread(
-            sim.verify_tracking, result["trace_id"],
-            max_tracking_error_m=threshold,
-        )
-        min_frames = int(acceptance.get("animation_min_frames", 30))
-        failures: list[str] = []
-        if verify["verdict"] != "PASS":
-            failures.append(
-                f"跟踪误差 {verify['metrics']['max_error_m']}m > {threshold}m"
-            )
-        if render["artifact"]["frames"] < min_frames:
-            failures.append(
-                f"动画帧数 {render['artifact']['frames']} < {min_frames}"
-            )
-        if not result.get("is_safe"):
-            failures.append(f"rollout 不安全: {result.get('violations')}")
-        metrics = verify["metrics"]
-        gif_path = str(render["artifact"]["path"])
-        mp4_path = str((render.get("mp4_artifact") or {}).get("path", ""))
-        # 产物登记进 kernel 账本（当前会话有活跃任务时——登记才算交付）。
-        task = service._task_kernel.active_task_for(
-            request.mission_id, request.pi_session_id
-        )
-        if task is not None:
-            for path, media in (
-                (gif_path, "image/gif"),
-                (mp4_path, "video/mp4"),
-                (str(result["artifacts"]["trace_json"]), "application/json"),
-            ):
-                if not path:
-                    continue
-                import contextlib as _cl
-
-                with _cl.suppress(ValueError):
-                    # 产物文件缺失由验收 failures 表达；受信管道登记
-                    # （producer=kernel——PR-N0）+ 资源证明元数据
-                    # （N4.1——producer 只是来源身份，资源证明才算数）。
-                    # WP-4：媒体带 preview 血缘（2D 预演是 COMMAND_REPLAY
-                    # 可视化——血缘到 trace，不当场景渲染证据）。
-                    _meta: dict = {"resource": result.get("resource") or {}}
-                    if media.startswith("image/"):
-                        _meta["lineage"] = {
-                            "trace_id": str(result.get("trace_id", "")),
-                            "kind": "preview_2d",
-                        }
-                    service._task_kernel.register_artifact(
-                        task_id=task["task_id"], path=path, media_type=media,
-                        producer="kernel:sim_pipeline",
-                        metadata=_meta,
-                    )
-        state = "VERIFIED" if not failures else "FAILED"
+        # 模型可见 artifacts 必须含全部已登记交付物（R0-1 修复：
+        # 旧链 MP4 登记了却不返回——内核成功、产品失败）。
+        artifacts = {
+            "gif": str(render_ref.get("gif_path", "")),
+            "mp4": str(render_ref.get("mp4_path", "")),
+            **{k: str(v) for k, v in (trace_ref.get("artifacts") or {}).items()},
+            "metrics": metrics,
+            "evidence_level": evidence_level,
+        }
+        gif_path = artifacts["gif"]
+        max_error_m = float(metrics.get("max_error_m", 0.0) or 0.0)
         payload = {
-            "state": state,
+            "state": "VERIFIED" if outcome.ok else "FAILED",
             "goal": goal,
-            "artifacts": {
-                "gif": gif_path,
-                **{k: str(v) for k, v in result["artifacts"].items()},
-                "metrics": metrics,
-                "evidence_level": "SIM_DYN_ROLLOUT",
+            "task_id": outcome.task_id,
+            "recipe_id": outcome.recipe_id,
+            "plan": {
+                "refs": sorted(refs.keys()),
+                "failed_node": outcome.failed_node,
             },
-            "failures": failures,
+            "artifacts": artifacts,
+            # 产物账本视图（artifact_id 可查可开——R0-4 交付面的
+            # 原料）。
+            "artifact_refs": outcome.artifacts,
+            "failures": outcome.failures,
             "verification": {
-                "verdict": "PASS" if not failures else "FAIL",
-                "max_error_m": metrics["max_error_m"],
-                "threshold_m": threshold,
-                "frames": render["artifact"]["frames"],
-                "min_frames": min_frames,
+                "verdict": "PASS" if outcome.ok else "FAIL",
+                "max_error_m": max_error_m,
+                "threshold_m": verification_ref.get("threshold_m", 0.0),
+                "frames": render_ref.get("frames", 0),
+                "min_frames": verification_ref.get("min_frames", 0),
+                "verification_id": outcome.verification_id,
             },
             # WP06：证据等级与局限必须显式——动力学 rollout 自洽，
             # 不能证明真机执行。
             "user_view": (
                 f"动力学仿真 rollout 完成：最大跟踪误差 "
-                f"{metrics['max_error_m'] * 1000:.0f}mm，动画 {gif_path}。"
-                "证据等级 SIM_DYN_ROLLOUT——仿真动力学自洽，"
+                f"{max_error_m * 1000:.0f}mm，动画 {gif_path}，"
+                f"视频 {artifacts['mp4']}。"
+                f"证据等级 {evidence_level}——仿真动力学自洽，"
                 "不能证明真机执行效果。"
-                if not failures else
-                f"验收未过：{'；'.join(failures)}（证据等级 SIM_DYN_ROLLOUT）"
+                if outcome.ok else
+                f"验收未过：{'；'.join(outcome.failures)}"
+                f"（证据等级 {evidence_level}）"
             ),
-            "evidence_level": "SIM_DYN_ROLLOUT",
+            "evidence_level": evidence_level,
         }
         return PiToolResultV1(
             request_id=request.request_id,
-            ok=not failures,
-            status="COMPLETED" if not failures else "REJECTED",
+            ok=outcome.ok,
+            status="COMPLETED" if outcome.ok else "REJECTED",
             summary=_json.dumps(payload, ensure_ascii=False),
-            error_code="" if not failures else "ACCEPTANCE_FAILED",
+            error_code="" if outcome.ok else outcome.error_code,
         )
 
     async def _request_action(self, request: PiToolRequestV1) -> PiToolResultV1:

--- a/src/rosclaw/agentd/plan_templates.py
+++ b/src/rosclaw/agentd/plan_templates.py
@@ -1,14 +1,18 @@
-"""draw_path PlanGraph 模板（P1-C2，0824 总纲 §7.2/§7.3）。
+"""draw_path recipe（P1-C2 模板 → R0-1 生产 recipe handler）。
 
 确定性任务级入口：画路径任务（五角星/圆/任意形状）不再由模型逐
 工具编排——内核按模板执行同一 typed DAG：
 
     resolve_robot → make_path → simulate → render → verify
 
+**生产接线纪律（0826 体验审计 §5.R0-1）**：本模块的 handler 只经
+TaskExecutionService（唯一生产入口）到达——测试也不得绕过
+service 直调（绕过 = 证明了一条用户永远到不了的路径）。
+
 Fast Path（模型/调用方单 capability 直出 TraceRef/RenderRef）与
-本模板共用 PlanExecutionResult 形状与 TaskOutcomeV2——两条路径的
-终态语义一致。模板是**通用的**：形状/中心/缩放/平面都是参数，
-无五角星特例。
+本 recipe 共用 PlanExecutionResult 形状与 TaskOutcomeV2——两条
+路径的终态语义一致。模板是**通用的**：形状/中心/缩放/平面都是
+参数，无五角星特例。
 """
 
 from __future__ import annotations
@@ -17,6 +21,7 @@ import hashlib
 import json
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 from rosclaw.contracts.agent.plan_graph import PlanGraphV1, PlanNodeV1
 from rosclaw.contracts.common import new_id
@@ -61,32 +66,54 @@ def build_draw_path_graph(task_id: str, revision: int) -> PlanGraphV1:
     )
 
 
-def run_draw_path_plan(
+def draw_path_recipe(
+    *,
     kernel: TaskKernel,
     conn: sqlite3.Connection,
     home: Path,
-    *,
     task_id: str,
-    shape: str,
-    center_m: list[float],
-    scale_m: float,
-    plane: str = "xy",
-    max_segment_m: float = 0.02,
-    body_id: str = "sim/ur5e",
+    inputs: dict[str, Any],
+    runtime_manager=None,
 ) -> PlanExecutionResult:
-    """执行 draw_path 模板（真实 sim 链——无模型、确定性、可审计）。"""
+    """draw_path recipe handler（真实 sim 链——无模型、确定性、
+    可审计）。只经 TaskExecutionService 调用。
+
+    inputs（recipe 参数，全部可选、有确定性缺省）：
+    shape / center_m / scale_m（radius_m 兼容回落）/ plane /
+    max_segment_m / acceptance{max_tracking_error_m,
+    animation_min_frames}。
+    """
+    from rosclaw.agentd.runtime_manager import RuntimeNotReadyError
     from rosclaw.agentd.sim_trajectory import SimTrajectoryService
     from rosclaw.cognition.alias import canonical_resource_id
 
-    service = SimTrajectoryService(home)
+    if runtime_manager is not None:
+        # SIM 动力学由托管 runtime 预置——不可用时诚实失败（不是
+        # 渲染时裸 ModuleNotFoundError）。
+        try:
+            runtime_manager.ensure("rosclaw-simulation")
+        except RuntimeNotReadyError as exc:
+            raise RecipeInputError("RUNTIME_NOT_READY", str(exc)) from exc
+
+    shape = str(inputs.get("shape", "star5"))
+    center_m = list(inputs.get("center_m") or [0.35, 0.25, 0.30])
+    scale_m = float(inputs.get("scale_m", inputs.get("radius_m", 0.10)))
+    plane = str(inputs.get("plane", "xy"))
+    max_segment_m = float(inputs.get("max_segment_m", 0.03))
+    acceptance = inputs.get("acceptance") or {}
+    threshold = float(acceptance.get("max_tracking_error_m", 0.05))
+    min_frames = int(acceptance.get("animation_min_frames", 30))
+
+    service = SimTrajectoryService(home, runtime_manager=runtime_manager)
     task = kernel.get_task(task_id) or {}
     revision = int(task.get("active_revision") or 1)
+    body_id = str(task.get("body_id") or "sim/ur5e")
     artifact_ids: list[str] = []
 
-    def h_resolve(inputs: dict) -> dict:
+    def h_resolve(inputs_: dict) -> dict:
         return {"ResourceRef": {"body_ref": canonical_resource_id(body_id)}}
 
-    def h_make_path(inputs: dict) -> dict:
+    def h_make_path(inputs_: dict) -> dict:
         plan = service.generate_planar_path(
             shape=shape,
             center_m=center_m,
@@ -102,46 +129,114 @@ def run_draw_path_plan(
             }
         }
 
-    def h_simulate(inputs: dict) -> dict:
-        rollout = service.simulate_cartesian_trajectory(inputs["PlanRef"]["plan_id"])
+    def h_simulate(inputs_: dict) -> dict:
+        rollout = service.simulate_cartesian_trajectory(
+            inputs_["PlanRef"]["plan_id"]
+        )
         return {
             "TraceRef": {
                 "trace_id": rollout["trace_id"],
                 "evidence_level": rollout["evidence_level"],
                 "tracking": rollout["tracking"],
+                "is_safe": bool(rollout.get("is_safe")),
+                "violations": rollout.get("violations") or [],
+                "resource": rollout.get("resource") or {},
+                "artifacts": {
+                    k: str(v)
+                    for k, v in (rollout.get("artifacts") or {}).items()
+                },
             }
         }
 
-    def h_render(inputs: dict) -> dict:
-        rendered = service.render_trace(inputs["TraceRef"]["trace_id"])
+    def h_render(inputs_: dict) -> dict:
+        trace = inputs_["TraceRef"]
+        rendered = service.render_trace(trace["trace_id"])
         gif = rendered["artifact"]
         mp4 = rendered["mp4_artifact"]
-        for artifact, media_type in ((gif, "image/gif"), (mp4, "video/mp4")):
-            record = kernel.register_artifact(
-                task_id=task_id,
-                path=artifact["path"],
-                media_type=media_type,
-                producer="kernel:plan_template:draw_path",
-            )
+        # 产物登记进 kernel 账本（受信管道 producer=kernel:*——
+        # 资源证明 N4.1 + preview 血缘 WP-4：2D 预演是 COMMAND_REPLAY
+        # 可视化，血缘到 trace，不当场景渲染证据）。
+        for artifact, media_type in (
+            (gif, "image/gif"),
+            (mp4, "video/mp4"),
+            ({"path": trace["artifacts"].get("trace_json", "")},
+             "application/json"),
+        ):
+            path = str(artifact.get("path") or "")
+            if not path:
+                continue
+            meta: dict[str, Any] = {"resource": trace["resource"]}
+            if media_type.startswith("image/"):
+                meta["lineage"] = {
+                    "trace_id": trace["trace_id"],
+                    "kind": "preview_2d",
+                }
+            try:
+                record = kernel.register_artifact(
+                    task_id=task_id,
+                    path=path,
+                    media_type=media_type,
+                    producer="kernel:plan_template:draw_path",
+                    metadata=meta,
+                )
+            except ValueError:
+                continue  # 文件缺失由验收 failures 表达——不阻断执行
             artifact_ids.append(str(record["artifact_id"]))
         return {
             "RenderRef": {
                 "gif_path": gif["path"],
                 "mp4_path": mp4["path"],
                 "frames": gif["frames"],
+                "artifact_ids": list(artifact_ids),
             }
         }
 
-    def h_verify(inputs: dict) -> dict:
+    def h_verify(inputs_: dict) -> dict:
+        trace = inputs_["TraceRef"]
+        render = inputs_["RenderRef"]
+        verify = service.verify_tracking(
+            trace["trace_id"], max_tracking_error_m=threshold
+        )
+        metrics = verify["metrics"]
+        failures: list[str] = []
+        if verify["verdict"] != "PASS":
+            failures.append(
+                f"跟踪误差 {metrics['max_error_m']}m > {threshold}m"
+            )
+        if int(render["frames"]) < min_frames:
+            failures.append(f"动画帧数 {render['frames']} < {min_frames}")
+        if not trace["is_safe"]:
+            failures.append(f"rollout 不安全: {trace['violations']}")
+        if failures:
+            # recipe 级验收失败 → 不调 finish_task（不制造
+            # "账本 SUCCEEDED、交付 FAILED"的双真相）；任务保持
+            # ACTIVE，failure 即 RepairDirective 原料。
+            return {
+                "VerificationRef": {
+                    "status": "FAIL",
+                    "verification_id": "",
+                    "failures": failures,
+                    "metrics": metrics,
+                    "threshold_m": threshold,
+                    "min_frames": min_frames,
+                }
+            }
+        # 验收真跑决定终态（frozen acceptance——模型自述不算数）。
         verdict = kernel.finish_task(
             task_id=task_id,
-            summary=f"draw_path 模板执行（{len(artifact_ids)} 项产物）",
+            summary=f"draw_path recipe 执行（{len(artifact_ids)} 项产物）",
             artifact_ids=artifact_ids,
         )
+        kernel_failures = [str(f) for f in verdict.get("failures", [])]
+        status = "PASS" if verdict.get("status") == "SUCCEEDED" else "FAIL"
         return {
             "VerificationRef": {
-                "status": verdict.get("status", ""),
-                "failures": verdict.get("failures", []),
+                "status": status,
+                "verification_id": str(verdict.get("verification_id", "")),
+                "failures": kernel_failures,
+                "metrics": metrics,
+                "threshold_m": threshold,
+                "min_frames": min_frames,
             }
         }
 
@@ -156,4 +251,14 @@ def run_draw_path_plan(
     return PlanExecutor(kernel, conn).run(graph, handlers)
 
 
-__all__ = ["build_draw_path_graph", "run_draw_path_plan"]
+class RecipeInputError(RuntimeError):
+    """recipe 前置条件失败（runtime 未就绪等）——带稳定错误码，
+    由 TaskExecutionService 原样透传（不包成裸异常）。"""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+__all__ = ["RecipeInputError", "build_draw_path_graph", "draw_path_recipe"]

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -237,6 +237,17 @@ class AgentService:
         from rosclaw.task_kernel.operation_manager import OperationManager
 
         self._operation_manager = OperationManager(self._task_kernel, self._store.connection)
+        # R0-1（0826 体验审计 §5.R0-1）：TaskExecutionService——已知
+        # 任务的唯一生产入口（TaskSpecV2→TaskRouter→PlanGraph→
+        # PlanExecutor）。rosclaw_task 只是它的兼容 adapter。
+        from rosclaw.agentd.task_execution import TaskExecutionService
+
+        self._task_execution = TaskExecutionService(
+            kernel=self._task_kernel,
+            conn=self._store.connection,
+            home=self._home,
+            runtime_manager=self._runtime_manager,
+        )
         # Daemon action channel (K3) + consent channel (ADR-0007): only when
         # a rosclawd client is actually available — otherwise both degrade
         # honestly.

--- a/src/rosclaw/agentd/task_execution.py
+++ b/src/rosclaw/agentd/task_execution.py
@@ -1,0 +1,184 @@
+"""TaskExecutionService（R0-1，0826 体验审计 §5.R0-1）——已知任务
+的唯一生产入口。
+
+    frozen TaskSpecV2（task_kernel 权威账本）
+      → TaskRouter（intent → recipe）
+      → recipe handler（typed PlanGraph）
+      → PlanExecutor（plan.node_* 事件落 task_events）
+
+纪律：
+- 生产 draw path 只有这一条执行链（旧 tool_dispatch._task 内联
+  SIM 管线已物理删除）；
+- 无 recipe 的 intent / 缺 frozen spec / 未知任务 → 稳定错误码
+  诚实拒绝（不猜不编）；
+- recipe 失败一次成形（PlanExecutionResult.failed_node/failure
+  即 RepairDirective 原料）——模型不得重新编排同一 recipe。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from rosclaw.agentd.plan_templates import RecipeInputError, draw_path_recipe
+from rosclaw.task_kernel.plan_executor import PlanExecutionResult
+from rosclaw.task_kernel.service import TaskKernel
+from rosclaw.task_kernel.task_router import route_recipe
+
+#: recipe_id → handler。recipe 声明的执行域（mode 门禁在 service
+#: 层统一执行——recipe 不自判）。
+RecipeHandler = Callable[..., PlanExecutionResult]
+
+_RECIPE_REGISTRY: dict[str, RecipeHandler] = {
+    "recipe:sim.draw_path": draw_path_recipe,
+}
+
+#: recipe 的执行域要求（SIM recipe 只在 SIMULATION mode 下运行；
+#: SHADOW/REAL 永远走 rosclawd 权威链——recipe 不是旁路）。
+_RECIPE_MODE: dict[str, str] = {
+    "recipe:sim.draw_path": "SIMULATION",
+}
+
+
+@dataclass
+class TaskExecutionOutcome:
+    """任务级执行结果（模型可见 payload 与 TUI 任务卡同一原料）。"""
+
+    ok: bool
+    task_id: str
+    recipe_id: str = ""
+    refs: dict[str, Any] = field(default_factory=dict)
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
+    verification_id: str = ""
+    failures: list[str] = field(default_factory=list)
+    failed_node: str = ""
+    failure: str = ""
+    error_code: str = ""
+    task_state: str = ""
+
+
+class TaskExecutionService:
+    """execute(task_id) 是已知任务的唯一生产入口。"""
+
+    def __init__(
+        self,
+        *,
+        kernel: TaskKernel,
+        conn: sqlite3.Connection,
+        home: Path,
+        runtime_manager=None,
+    ) -> None:
+        self._kernel = kernel
+        self._conn = conn
+        self._home = home
+        self._runtime_manager = runtime_manager
+
+    def execute(
+        self,
+        task_id: str,
+        *,
+        recipe_inputs: dict[str, Any] | None = None,
+        goal_hint: str = "",
+    ) -> TaskExecutionOutcome:
+        task = self._kernel.get_task(task_id)
+        if task is None:
+            return TaskExecutionOutcome(
+                ok=False, task_id=task_id,
+                error_code="TASK_NOT_FOUND",
+                failure=f"未知任务 {task_id!r}",
+            )
+        spec = self._kernel.get_task_spec(task_id)
+        if spec is None:
+            return TaskExecutionOutcome(
+                ok=False, task_id=task_id,
+                error_code="TASK_SPEC_MISSING",
+                failure=f"任务 {task_id} 缺 frozen TaskSpecV2——无法路由",
+            )
+        recipe_id = route_recipe(spec, goal_hint=goal_hint)
+        if recipe_id is None:
+            intent = str((spec.get("goal") or {}).get("intent", ""))
+            return TaskExecutionOutcome(
+                ok=False, task_id=task_id,
+                error_code="TASK_NO_RECIPE",
+                failure=(
+                    f"intent {intent!r} 无确定性 recipe——改用类型化能力"
+                    "规划（rosclaw_execute/observe），或诚实报告无法完成"
+                ),
+            )
+        required_mode = _RECIPE_MODE.get(recipe_id, "")
+        task_mode = str(task.get("mode") or "SIMULATION")
+        if required_mode and task_mode != required_mode:
+            return TaskExecutionOutcome(
+                ok=False, task_id=task_id, recipe_id=recipe_id,
+                error_code="MODE_DENIED",
+                failure=(
+                    f"{recipe_id} 仅 {required_mode}——当前 {task_mode}"
+                    "（REAL/SHADOW 走 rosclawd 权威链）"
+                ),
+            )
+        handler = _RECIPE_REGISTRY[recipe_id]
+        try:
+            result = handler(
+                kernel=self._kernel,
+                conn=self._conn,
+                home=self._home,
+                task_id=task_id,
+                inputs=dict(recipe_inputs or {}),
+                runtime_manager=self._runtime_manager,
+            )
+        except RecipeInputError as exc:
+            return TaskExecutionOutcome(
+                ok=False, task_id=task_id, recipe_id=recipe_id,
+                error_code=exc.code, failure=exc.message[:400],
+            )
+        artifacts = self._ledger_artifacts(task_id)
+        verification = result.refs.get("VerificationRef") or {}
+        failures = [str(f) for f in verification.get("failures", [])]
+        verify_ok = verification.get("status") == "PASS"
+        ok = result.ok and verify_ok
+        return TaskExecutionOutcome(
+            ok=ok,
+            task_id=task_id,
+            recipe_id=recipe_id,
+            refs=result.refs,
+            artifacts=artifacts,
+            verification_id=str(verification.get("verification_id", "")),
+            failures=failures or ([result.failure] if result.failure else []),
+            failed_node=result.failed_node,
+            failure=(
+                "" if ok else (
+                    result.failure or "；".join(failures)[:300]
+                )
+            ),
+            error_code="" if ok else (
+                "ACCEPTANCE_FAILED" if result.ok else "RECIPE_NODE_FAILED"
+            ),
+            task_state=str(
+                (self._kernel.get_task(task_id) or {}).get("state", "")
+            ),
+        )
+
+    def _ledger_artifacts(self, task_id: str) -> list[dict[str, Any]]:
+        """产物账本视图（id/path/media_type/bytes——用户可见交付的
+        原料；不是"目录里有文件"）。"""
+        rows = self._conn.execute(
+            "SELECT artifact_id, path, media_type, size_bytes, producer "
+            "FROM artifacts WHERE task_id = ? ORDER BY created_at",
+            (task_id,),
+        ).fetchall()
+        return [
+            {
+                "artifact_id": str(r["artifact_id"]),
+                "path": str(r["path"]),
+                "media_type": str(r["media_type"]),
+                "size_bytes": int(r["size_bytes"]),
+                "producer": str(r["producer"]),
+            }
+            for r in rows
+        ]
+
+
+__all__ = ["TaskExecutionOutcome", "TaskExecutionService"]

--- a/src/rosclaw/cognition/index/builder.py
+++ b/src/rosclaw/cognition/index/builder.py
@@ -25,9 +25,16 @@ def _sha256(path: Path) -> str:
 
 
 def _zoo_root(product_root: Path) -> Path | None:
-    """e-URDF-Zoo 根：product_root/e-urdf-zoo（checkout 或打包布局）。"""
+    """e-URDF-Zoo 根：product_root/e-urdf-zoo（checkout）→ packaged
+    eurdf_zoo_data（wheel 安装布局——R0-1 实证：安装布局下无回落
+    会让 N4.1 资源证明误判"无权威 manifest"）。"""
     zoo = product_root / "e-urdf-zoo"
-    return zoo if zoo.is_dir() else None
+    if zoo.is_dir():
+        return zoo
+    from rosclaw.runtime.eurdf_loader import _default_zoo_path
+
+    fallback = _default_zoo_path()
+    return fallback if fallback.is_dir() else None
 
 
 def _product_fingerprint(product_root: Path, zoo: Path | None) -> str:

--- a/src/rosclaw/task_kernel/task_router.py
+++ b/src/rosclaw/task_kernel/task_router.py
@@ -1,0 +1,47 @@
+"""TaskRouter（R0-1，0826 体验审计 §5.R0-1）——TaskSpecV2 → recipe。
+
+唯一路由真相：frozen TaskSpecV2 的 goal.intent 决定走哪条确定性
+recipe。未知 intent 返回 None（诚实"无 recipe"——调用方报错，
+不猜不编）。recipe 注册表在 TaskExecutionService（handler 需要
+runtime/home 等执行资源）；这里只放 intent → recipe_id 映射。
+
+通用 typed planning / workspace loop 是后续路由分支（§4 目标架
+构）——当前不在路由表里的 intent 一律诚实无 recipe。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+#: intent → recipe_id（冻结映射；新增 recipe = 新 intent 映射 +
+#: TaskExecutionService 注册 handler，一一对应）。
+RECIPE_BY_INTENT: dict[str, str] = {
+    "manipulation.draw_path": "recipe:sim.draw_path",
+}
+
+#: 模型显式 goal → recipe_id 回落（spec intent 分类是通用动词规则，
+#: 弱文本可能落 task.unknown——模型经 rosclaw_task 显式请求已知
+#: 任务目标时是合法信号；路由仍集中在 TaskRouter，不分散）。
+RECIPE_BY_GOAL: dict[str, str] = {
+    "draw_shape": "recipe:sim.draw_path",
+    "simulate_trajectory": "recipe:sim.draw_path",
+}
+
+
+def route_recipe(spec: Mapping[str, Any], *, goal_hint: str = "") -> str | None:
+    """frozen TaskSpecV2（dict 视图）→ recipe_id；无路由 → None。
+
+    intent 映射优先；intent 无 recipe 时回落模型显式 goal hint。
+    """
+    goal = spec.get("goal")
+    if not isinstance(goal, Mapping):
+        return None
+    intent = str(goal.get("intent", ""))
+    recipe = RECIPE_BY_INTENT.get(intent)
+    if recipe is not None:
+        return recipe
+    return RECIPE_BY_GOAL.get(goal_hint)
+
+
+__all__ = ["RECIPE_BY_INTENT", "route_recipe"]

--- a/tests/agentd/test_eight8_checkpoint.py
+++ b/tests/agentd/test_eight8_checkpoint.py
@@ -54,39 +54,57 @@ class TestContextCheckpoint:
     async def test_checkpoint_from_authoritative_store(self, tmp_path: Path) -> None:
         service, mission = await _setup(tmp_path)
         task_id = _bind_kernel_task(service, mission)
-        result = await _run_task(service, mission, idem="idem_ckpt_1")
-        assert result.ok
         from rosclaw.agentd.pi_bridge.server import PiBridgeServer
 
         bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
-        checkpoint = await bridge._dispatch(
+        # 执行前：活跃 kernel 任务在非终态列表。
+        before = await bridge._dispatch(
             "user:local:1000",
             1,
             "pi.context.checkpoint",
             {"token": service.control_token, "mission_id": mission.mission_id},
         )
-        assert checkpoint.get("ok"), checkpoint
-        cp = checkpoint.get("checkpoint") or {}
+        assert before.get("ok"), before
+        cp = before.get("checkpoint") or {}
         assert cp.get("schema_version") == "rosclaw.embodied_checkpoint.v1"
         assert cp.get("mission_id") == mission.mission_id
         assert cp.get("mode") == "SIMULATION"
         assert cp.get("body_id") == "sim/ur5e"
-        # 活跃 kernel 任务在非终态列表。
         nonterminal = cp.get("nonterminal_tasks") or []
         assert any(t.get("task_id") == task_id for t in nonterminal), cp
         assert cp.get("pending_approvals") == []
         assert cp.get("sim_policy") in ("auto", "ask")
+        # R0-1：recipe 一次调用即完整闭环（内核自动收尾）——执行后
+        # 任务进入终态，不再停留在非终态列表。
+        result = await _run_task(service, mission, idem="idem_ckpt_1")
+        assert result.ok
+        after = await bridge._dispatch(
+            "user:local:1000",
+            1,
+            "pi.context.checkpoint",
+            {"token": service.control_token, "mission_id": mission.mission_id},
+        )
+        cp_after = after.get("checkpoint") or {}
+        assert not any(
+            t.get("task_id") == task_id
+            for t in (cp_after.get("nonterminal_tasks") or [])
+        ), cp_after
+        recent = cp_after.get("recent_tasks") or []
+        assert any(
+            t.get("task_id") == task_id and t.get("state") == "SUCCEEDED"
+            for t in recent
+        ), cp_after
         await service.close()
 
     async def test_checkpoint_after_kernel_finish(self, tmp_path: Path) -> None:
-        """kernel 终态（Verifier 验收）后：非终态列表为空、recent 含
-        SUCCEEDED。"""
+        """kernel 终态（recipe 内 Verifier 验收）后：非终态列表为空、
+        recent 含 SUCCEEDED；finish_task 重放幂等（不覆盖原 receipt）。"""
         service, mission = await _setup(tmp_path)
         task_id = _bind_kernel_task(service, mission)
         result = await _run_task(service, mission, idem="idem_ckpt_2")
         assert result.ok
-        # rosclaw_task 已把 gif/trace 登记进 kernel 产物账本——用
-        # Verifier 路径收尾（finish_task 真验收）。
+        # R0-1：recipe 的 verify 节点已跑 finish_task 真验收——
+        # 模型面不需要也不应该再次收尾（重放幂等返回原终态）。
         kernel = service._task_kernel
         artifacts = [
             str(r["artifact_id"])
@@ -98,6 +116,7 @@ class TestContextCheckpoint:
             task_id=task_id, summary="五角星仿真完成", artifact_ids=artifacts
         )
         assert finish["status"] == "SUCCEEDED", finish
+        assert finish.get("already_terminal") is True, finish
         from rosclaw.agentd.pi_bridge.server import PiBridgeServer
 
         bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")

--- a/tests/agentd/test_p1c2_plan_graph.py
+++ b/tests/agentd/test_p1c2_plan_graph.py
@@ -225,26 +225,49 @@ class TestExecutor:
 
 class TestDrawPathTemplate:
     def test_draw_path_end_to_end(self, tmp_path: Path) -> None:
-        """确定性 draw_path 模板（真实 sim 链，无模型）：ResourceRef/
-        PlanRef/TraceRef/RenderRef 全产出 + 媒体落盘。"""
+        """确定性 draw_path recipe（真实 sim 链，无模型）：ResourceRef/
+        PlanRef/TraceRef/RenderRef 全产出 + 媒体落盘。
+
+        R0-1：测试必须经 TaskExecutionService（唯一生产入口）——
+        禁止直调 recipe handler 证明一条用户永远到不了的路径。
+        """
         conn = _conn(tmp_path)
-        _task(conn)
-        from rosclaw.agentd.plan_templates import run_draw_path_plan
+        from rosclaw.agentd.task_execution import TaskExecutionService
 
         kernel = TaskKernel(conn, tmp_path)
-        result = run_draw_path_plan(
-            kernel, conn, tmp_path,
-            task_id="task_1",
-            shape="star5",
-            center_m=[0.35, 0.0, 0.12],
-            scale_m=0.12,
+        kernel.persist_input(
+            mission_id="m1", session_ref="s1",
+            message_id="msg_1", text="画一个五角星",
         )
-        assert result.ok is True, result
+        bound = kernel.ensure_task_for_effect(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path),
+        )
+        task_id = str(bound["task_id"])
+        outcome = TaskExecutionService(
+            kernel=kernel, conn=conn, home=tmp_path,
+        ).execute(
+            task_id,
+            recipe_inputs={
+                # 安全工作空间内的已知几何（与生产缺省一致——
+                # 低 z 平面会触发碰撞失败，那是验收在工作）。
+                "shape": "star5", "center_m": [0.35, 0.25, 0.30],
+                "scale_m": 0.12,
+            },
+        )
+        assert outcome.ok, outcome.failure
         for ref in ("ResourceRef", "PlanRef", "TraceRef", "RenderRef"):
-            assert ref in result.refs, f"缺 {ref}"
-        render = result.refs["RenderRef"]
+            assert ref in outcome.refs, f"缺 {ref}"
+        render = outcome.refs["RenderRef"]
         assert Path(render["gif_path"]).exists()
         assert Path(render["mp4_path"]).exists()
-        types = _events(conn)
+        types = [
+            str(r["event_type"])
+            for r in conn.execute(
+                "SELECT event_type FROM task_events WHERE task_id = ? "
+                "ORDER BY seq",
+                (task_id,),
+            ).fetchall()
+        ]
         assert "plan.node_started" in types
         assert "plan.node_completed" in types

--- a/tests/agentd/test_r01_production_chain.py
+++ b/tests/agentd/test_r01_production_chain.py
@@ -1,0 +1,329 @@
+"""R0-1 红测试（0826 体验审计 §5.R0-1）：删除生产双链，接通
+TaskSpecV2 → TaskRouter → PlanGraph → PlanExecutor。
+
+真实事故（0826 体验旅程）：
+- 新 PlanGraph（plan_templates.run_draw_path_plan）只被测试直调；
+  生产 ``rosclaw_task`` 仍走 tool_dispatch._task 的旧 SIM 管线——
+  P1-C2 是"组件完成、生产未接线"；
+- 旧管线读到了 mp4_artifact，但返回给模型的 payload.artifacts 没
+  有 MP4——内核成功、产品失败（用户只看到 GIF）。
+
+断言：
+1. 结构扫描：tool_dispatch.py 不再含旧 SIM 管线实现
+   （SimTrajectoryService/generate_planar_path/simulate_/render_
+   trace 直调）——draw path 在生产代码只有一条执行链；
+2. TaskRouter：draw_path intent → recipe；未知 intent → None；
+3. TaskExecutionService 端到端：frozen spec → recipe → PlanGraph
+   node 事件落账 + typed refs + GIF/MP4 登记 + 任务终态；
+4. 生产接线（dispatcher 级）：rosclaw_task 一次调用 → 调用栈经
+   TaskExecutionService（plan.node 事件存在）+ 模型可见 payload
+   含 GIF 和 MP4（MP4 漏出修复）；
+5. 诚实拒绝：无 recipe 的 intent / 缺 frozen spec / 未知任务——
+   稳定错误码，不猜不编；
+6. 幂等：同一 idempotency key 重放不重复执行（plan node 事件
+   不翻倍）。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _issue_lease, _request
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestSingleChainStructure:
+    """Gate R0-1 结构面：生产代码对 draw path 只存在一条执行链。"""
+
+    def test_dispatcher_has_no_inline_sim_pipeline(self) -> None:
+        source = (
+            REPO_ROOT / "src/rosclaw/agentd/pi_bridge/tool_dispatch.py"
+        ).read_text(encoding="utf-8")
+        for forbidden in (
+            "SimTrajectoryService",
+            "generate_planar_path",
+            "simulate_cartesian_trajectory",
+            "render_trace",
+            "verify_tracking",
+        ):
+            assert forbidden not in source, (
+                f"tool_dispatch.py 仍内联旧 SIM 管线（{forbidden}）——"
+                "生产双链未删除"
+            )
+
+    def test_plan_template_not_called_outside_service(self) -> None:
+        """draw_path recipe 只能经 TaskExecutionService 到达——禁止
+        测试/其他生产代码绕过生产 service 直调模板。"""
+        import subprocess
+
+        hits = subprocess.run(
+            ["grep", "-rn", "draw_path_recipe", "src/", "tests/"],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        ).stdout
+        allowed = (
+            "agentd/plan_templates.py",
+            "agentd/task_execution.py",
+        )
+        for line in hits.splitlines():
+            if "test_r01_production_chain.py" in line:
+                continue  # 扫描器自身的模式串不算引用
+            assert any(a in line for a in allowed), (
+                f"recipe handler 被生产 service 之外引用：{line}"
+            )
+
+
+class TestTaskRouter:
+    def test_draw_path_intent_routes_to_recipe(self) -> None:
+        from rosclaw.task_kernel.task_router import route_recipe
+
+        recipe = route_recipe({"goal": {"intent": "manipulation.draw_path"}})
+        assert recipe == "recipe:sim.draw_path"
+
+    def test_unknown_intent_no_recipe(self) -> None:
+        from rosclaw.task_kernel.task_router import route_recipe
+
+        assert route_recipe({"goal": {"intent": "task.unknown"}}) is None
+        assert route_recipe({"goal": {"intent": "conversation.chat"}}) is None
+
+
+def _kernel(home: Path):
+    import sqlite3
+
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return TaskKernel(conn, home), conn
+
+
+def _draw_task(kernel, home: Path, text: str = "画一个五角星") -> str:
+    kernel.persist_input(
+        mission_id="mis_1", session_ref="s1",
+        message_id="msg_1", text=text,
+    )
+    bound = kernel.ensure_task_for_effect(
+        mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+        cwd=str(home), body_id="sim/ur5e",
+    )
+    return str(bound["task_id"])
+
+
+def _plan_events(kernel, task_id: str) -> list[str]:
+    rows = kernel._conn.execute(
+        "SELECT event_type FROM task_events WHERE task_id = ? "
+        "AND event_type LIKE 'plan.node_%' ORDER BY seq",
+        (task_id,),
+    ).fetchall()
+    return [str(r["event_type"]) for r in rows]
+
+
+class TestTaskExecutionService:
+    def test_execute_draw_path_end_to_end(self, tmp_path: Path) -> None:
+        """唯一生产入口：frozen TaskSpecV2 → router → recipe →
+        PlanGraph node 事件 + typed refs + GIF/MP4 登记 + 终态。"""
+        from rosclaw.agentd.task_execution import TaskExecutionService
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path)
+        service = TaskExecutionService(
+            kernel=kernel, conn=conn, home=tmp_path,
+        )
+        outcome = service.execute(
+            task_id,
+            recipe_inputs={
+                "shape": "star5", "center_m": [0.35, 0.25, 0.30],
+                "scale_m": 0.10,
+            },
+        )
+        assert outcome.ok, outcome.failure
+        assert outcome.recipe_id == "recipe:sim.draw_path"
+        # typed refs 真实持久化（不是"目录里有文件"）。
+        for ref in ("ResourceRef", "PlanRef", "TraceRef",
+                    "RenderRef", "VerificationRef"):
+            assert ref in outcome.refs, f"缺 {ref}"
+        # plan node 事件链完整（5 节点 started+completed）。
+        events = _plan_events(kernel, task_id)
+        assert events.count("plan.node_started") == 5, events
+        assert events.count("plan.node_completed") == 5, events
+        # GIF 和 MP4 都进产物账本。
+        media = {a["media_type"] for a in outcome.artifacts}
+        assert "image/gif" in media and "video/mp4" in media, media
+        task = kernel.get_task(task_id)
+        assert task["state"] == "SUCCEEDED", task["state"]
+
+    def test_unknown_intent_honest_refusal(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.task_execution import TaskExecutionService
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, text="帮我查一下天气")
+        service = TaskExecutionService(
+            kernel=kernel, conn=conn, home=tmp_path,
+        )
+        outcome = service.execute(task_id, recipe_inputs={})
+        assert not outcome.ok
+        assert outcome.error_code == "TASK_NO_RECIPE"
+
+    def test_unknown_task_honest_error(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.task_execution import TaskExecutionService
+
+        kernel, conn = _kernel(tmp_path)
+        service = TaskExecutionService(
+            kernel=kernel, conn=conn, home=tmp_path,
+        )
+        outcome = service.execute("task_nonexistent", recipe_inputs={})
+        assert not outcome.ok
+        assert outcome.error_code == "TASK_NOT_FOUND"
+
+
+async def _setup_ur5e(tmp_path: Path):
+    """生产级接线 harness：真实 AgentService + ur5e body 绑定。"""
+    from rosclaw.agentd.config import load_agent_config
+    from rosclaw.agentd.models.gateway import MockModelGateway
+    from rosclaw.agentd.models.profiles import mock_profile
+    from rosclaw.agentd.pi_bridge.session_binding import SessionBindingStore
+    from rosclaw.agentd.service import AgentService
+    from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
+
+    turn = ModelTurnResultV1(
+        turn_id="t", provider="mock", model="m", content="ok",
+        assistant_message={"role": "assistant", "content": "ok"},
+        usage={"prompt_tokens": 1, "completion_tokens": 1,
+               "total_tokens": 2},  # type: ignore[arg-type]
+    )
+    config = load_agent_config(tmp_path / "config.yaml")
+    service = AgentService(
+        config, tmp_path,
+        gateway=MockModelGateway(mock_profile(), [turn]),
+    )
+    mission = service.create_mission("r01 接线测试")
+    bindings = SessionBindingStore(service._store.connection)
+    bindings.bind(
+        pi_session_id="pi_1", pi_session_path="",
+        mission_id=mission.mission_id, body_id="sim/ur5e",
+        execution_mode="SIMULATION", created_by="user:local:1000",
+    )
+    bindings.acquire_lease(
+        mission_id=mission.mission_id, pi_session_id="pi_1",
+        owner_pid=1, owner_uid=1000,
+    )
+    service._task_kernel.persist_input(
+        mission_id=mission.mission_id, session_ref="pi_1",
+        message_id="msg_draw", text="画一个五角星",
+    )
+    return service, mission
+
+
+class TestProductionWiring:
+    async def test_rosclaw_task_reaches_execution_service(
+        self, tmp_path: Path
+    ) -> None:
+        """生产接线：rosclaw_task（模型入口）→ TaskExecutionService
+        → PlanGraph node 事件——不是旧 _task 内联管线。"""
+        service, mission = await _setup_ur5e(tmp_path)
+        lease = await _issue_lease(service, mission)
+        dispatcher = PiToolDispatcher(service)
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_task", mission=mission.mission_id,
+                idem="r01_wiring", lease=lease,
+                arguments={
+                    "goal": "draw_shape",
+                    "parameters": {
+                        "shape": "star5",
+                        "center_m": [0.35, 0.25, 0.30],
+                        "scale_m": 0.10,
+                    },
+                },
+            )
+        )
+        assert result.ok, result.summary
+        task = service._task_kernel.latest_task_for(
+            mission.mission_id, "pi_1"
+        )
+        assert task is not None
+        events = _plan_events(service._task_kernel, str(task["task_id"]))
+        assert "plan.node_started" in events, (
+            f"生产路径未产生 PlanGraph node 事件（走的不是 "
+            f"TaskExecutionService）：{events}"
+        )
+        await service.close()
+
+    async def test_model_payload_includes_mp4(self, tmp_path: Path) -> None:
+        """MP4 漏出修复：模型可见 payload.artifacts 同时含 GIF 和
+        MP4（不是只在数据库里）。"""
+        service, mission = await _setup_ur5e(tmp_path)
+        lease = await _issue_lease(service, mission)
+        dispatcher = PiToolDispatcher(service)
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_task", mission=mission.mission_id,
+                idem="r01_mp4", lease=lease,
+                arguments={
+                    "goal": "draw_shape",
+                    "parameters": {"shape": "star5"},
+                },
+            )
+        )
+        assert result.ok, result.summary
+        payload = json.loads(result.summary)
+        artifacts = payload.get("artifacts", {})
+        assert artifacts.get("mp4"), (
+            f"模型可见 payload 缺 MP4——用户只能看到 GIF："
+            f"{sorted(artifacts.keys())}"
+        )
+        assert artifacts.get("gif")
+        await service.close()
+
+    async def test_idempotent_replay_no_double_execution(
+        self, tmp_path: Path
+    ) -> None:
+        """同一 idempotency key 重放：返回首个结果，plan node 事件
+        不翻倍。"""
+        service, mission = await _setup_ur5e(tmp_path)
+        lease = await _issue_lease(service, mission)
+        dispatcher = PiToolDispatcher(service)
+        request = _request(
+            "rosclaw_task", mission=mission.mission_id,
+            idem="r01_idem", lease=lease,
+            arguments={
+                "goal": "draw_shape", "parameters": {"shape": "star5"},
+            },
+        )
+        first = await dispatcher.execute(request)
+        second = await dispatcher.execute(request)
+        assert first.ok and second.ok
+        task = service._task_kernel.latest_task_for(
+            mission.mission_id, "pi_1"
+        )
+        events = _plan_events(service._task_kernel, str(task["task_id"]))
+        assert events.count("plan.node_started") == 5, events
+        await service.close()
+
+    async def test_non_sim_mode_denied(self, tmp_path: Path) -> None:
+        """SIM recipe 在非 SIMULATION mode 下诚实拒绝（REAL/SHADOW
+        门禁不变——不静默降级执行）。"""
+        from rosclaw.agentd.task_execution import TaskExecutionService
+
+        kernel, conn = _kernel(tmp_path)
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_shadow", text="画一个五角星",
+        )
+        bound = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path), mode="SHADOW", body_id="sim/ur5e",
+        )
+        service = TaskExecutionService(
+            kernel=kernel, conn=conn, home=tmp_path,
+        )
+        outcome = service.execute(
+            str(bound["task_id"]),
+            recipe_inputs={"shape": "star5"},
+        )
+        assert not outcome.ok
+        assert outcome.error_code == "MODE_DENIED", outcome.failure


### PR DESCRIPTION
## 真实事故（0826 体验旅程 + ROSClaw_0826体验审计与Native_Harness收敛实施指南 §2.1/§2.3）

1. **新 PlanGraph 未接生产**：`plan_templates.run_draw_path_plan` 只被测试直调；生产 `rosclaw_task` 仍走 `tool_dispatch._task` 旧 SIM 管线——P1-C2 是"组件完成、生产未接线"。
2. **MP4 漏出**：旧管线读了 `mp4_artifact` 但返回模型的 `payload.artifacts` 不含 MP4——内核成功、产品失败（数据库金丝雀绿、用户只看到 GIF）。

## 闭环内容

- **TaskExecutionService.execute(task_id)**（新，agentd/task_execution.py）：已知任务唯一生产入口——frozen TaskSpecV2 → TaskRouter → recipe → PlanGraph → PlanExecutor；`plan.node_*` 事件落 task_events；typed refs（ResourceRef/PlanRef/TraceRef/RenderRef/VerificationRef）真实产出；无 recipe/缺 spec/未知任务/越域 → 稳定错误码诚实拒绝。
- **TaskRouter**（新，task_kernel/task_router.py）：intent→recipe 冻结映射；模型显式 goal hint 回落（弱文本 intent 落 task.unknown 时的合法信号——路由仍集中在一处）。
- **plan_templates**：`run_draw_path_plan` → 正式 `draw_path_recipe` handler（资源证明 N4.1 + preview 血缘 WP-4 元数据；recipe 级验收先于 finish_task——不制造"账本 SUCCEEDED、交付 FAILED"双真相）；测试不得绕过生产 service 直调。
- **tool_dispatch._task**：内联 SIM 管线（generate/simulate/render/verify 直调，约 150 行）**物理删除**，改为薄 adapter；模型可见 payload 现在含 **GIF + MP4 + artifact_refs**（MP4 漏出修复）。
- **具身落账**移到任务存在后（N4.1 证据规则真正武装——旧链首次调用时 active_task 不存在，永远不武装）。
- **_zoo_root 回落** packaged `eurdf_zoo_data`：修复 wheel 安装布局下 resolve_resource 空索引导致的 `RESOURCE_PROVENANCE_MISSING` 假拒（PTY 旅程实证）。

## 红→绿证据

- 红：`/tmp/r01-red-full.txt`——11/11 红（结构扫描：dispatcher 仍内联旧管线；router/service 不存在；生产无 plan node 事件；payload 无 MP4）。
- 绿：`tests/agentd/test_r01_production_chain.py` 11/11 + agentd 全套 **704 passed**；PTY 产品旅程 **A/B/C 全绿**；TS build + node tests 绿。
- 结构扫描测试防回归：生产代码对 draw path 只存在一条执行链；recipe handler 只能经 TaskExecutionService 到达。

## 明确不做（诚实边界）

- 模型面 `rosclaw_task` 保留为兼容 adapter（Gate R0-1 允许模型具身入口 0/1 次调用）；**退出模型面**待 TaskSpec 承载几何/交付语义（R0-2）后由输入路由自动触发——指南 §6 删除清单的等价格换前提，届时物理删除。
- TUI 任务卡 / Renderer 结构化协议 / readiness 统一 = R0-8/R0-3/R0-6。

🤖 Generated with [Claude Code](https://claude.com/claude-code)