### PR TITLE
feat: R0-2 TaskSpec 交付与验收语义——任务成功 ≠ 用户请求成功（0826 体验审计）

### DIFF
--- a/src/rosclaw/agentd/plan_templates.py
+++ b/src/rosclaw/agentd/plan_templates.py
@@ -166,7 +166,10 @@ def draw_path_recipe(
             if not path:
                 continue
             meta: dict[str, Any] = {"resource": trace["resource"]}
-            if media_type.startswith("image/"):
+            if media_type.startswith(("image/", "video/")):
+                # gif 与 mp4 都是 2D 轨迹预览（COMMAND_REPLAY 可视
+                # 化）——preview_2d kind；场景视频（scene_3d）是
+                # 另一条渲染链（R0-3），kind 分野是硬边界。
                 meta["lineage"] = {
                     "trace_id": trace["trace_id"],
                     "kind": "preview_2d",

--- a/src/rosclaw/contracts/agent/task_spec.py
+++ b/src/rosclaw/contracts/agent/task_spec.py
@@ -53,7 +53,9 @@ class TaskGoalV2(ContractModel):
 
 
 class TaskSubjectsV2(ContractModel):
-    """作用对象：body_ref（canonical robot:<name>）与 world_ref。"""
+    """作用对象：body_ref（canonical robot:<name>）、tool_ref 与
+    world_ref（R0-2：工具/场景是验收一等事实——"持笔在桌面"必须
+    可声明、可核验，不允许最终回答自由夸大）。"""
 
     SCHEMA: ClassVar[str] = "rosclaw.task_subjects.v2"
 
@@ -61,11 +63,61 @@ class TaskSubjectsV2(ContractModel):
         "rosclaw.task_subjects.v2"
     )
     body_ref: str = ""
+    tool_ref: str = ""
     world_ref: str = ""
 
 
+#: 交付物 kind 冻结分类（R0-2，0826 体验审计 §5.R0-2）。
+DELIVERABLE_KINDS = (
+    "scene_video",
+    "preview_animation",
+    "robot_video",
+    "data_report",
+)
+
+#: 交付物 kind → 产物 kind（lineage.kind 权威）：preview_2d /
+#: scene_3d / robot_video 是不同产物 kind——2D 预览永远不能
+#: 满足 scene_video（0826 审计：GIF 冒充场景视频是假绿）。
+DELIVERABLE_KIND_TO_ARTIFACT_KIND: dict[str, str] = {
+    "scene_video": "scene_3d",
+    "preview_animation": "preview_2d",
+    "robot_video": "robot_video",
+}
+
+
+class TaskDeliverableV2(ContractModel):
+    """交付物声明：kind/media_type/required + 最低质量门槛。
+
+    required=True 的交付物未出现在产物账本（按 kind 匹配）→
+    DELIVERABLE_MISSING——任务成功 ≠ 用户请求成功。
+    """
+
+    SCHEMA: ClassVar[str] = "rosclaw.task_deliverable.v2"
+
+    schema_version: Literal["rosclaw.task_deliverable.v2"] = (
+        "rosclaw.task_deliverable.v2"
+    )
+    kind: str = Field(min_length=1)
+    media_type: str = ""
+    required: bool = False
+    min_frames: int = 0
+    min_resolution: list[int] = Field(default_factory=list)
+
+    @field_validator("kind")
+    @classmethod
+    def _known_kind(cls, value: str) -> str:
+        if value not in DELIVERABLE_KINDS:
+            raise ValueError(
+                f"unknown deliverable kind {value!r} "
+                f"(frozen taxonomy: {DELIVERABLE_KINDS})"
+            )
+        return value
+
+
 class TaskConstraintsV2(ContractModel):
-    """执行约束：mode / frames / allowed_effects。"""
+    """执行约束：mode / frames / allowed_effects + R0-2 接触与
+    工具轴约束（contact_required / tool_axis_aligned_with_plane_
+    normal_deg——语义验收的声明面）。"""
 
     SCHEMA: ClassVar[str] = "rosclaw.task_constraints.v2"
 
@@ -75,6 +127,8 @@ class TaskConstraintsV2(ContractModel):
     mode: str = "SIMULATION"
     frames: list[str] = Field(default_factory=list)
     allowed_effects: list[str] = Field(default_factory=list)
+    contact_required: bool = False
+    tool_axis_aligned_with_plane_normal_deg: float | None = None
 
 
 class TaskPreferencesV2(ContractModel):
@@ -103,14 +157,20 @@ class TaskSpecV2(ContractModel):
     subjects: TaskSubjectsV2 = Field(default_factory=TaskSubjectsV2)
     constraints: TaskConstraintsV2 = Field(default_factory=TaskConstraintsV2)
     preferences: TaskPreferencesV2 = Field(default_factory=TaskPreferencesV2)
+    #: 交付物声明（R0-2）：required 交付物未按 kind 出现在产物
+    #: 账本 → DELIVERABLE_MISSING——任务成功 ≠ 用户请求成功。
+    deliverables: list[TaskDeliverableV2] = Field(default_factory=list)
     #: 冻结验收规格关联（AcceptanceSpecV2.spec_id；未冻结为空——
     #: 诚实空，不编造）。
     acceptance_spec_id: str = ""
 
 
 __all__ = [
+    "DELIVERABLE_KINDS",
+    "DELIVERABLE_KIND_TO_ARTIFACT_KIND",
     "INTENT_TAXONOMY",
     "TaskConstraintsV2",
+    "TaskDeliverableV2",
     "TaskGoalV2",
     "TaskPreferencesV2",
     "TaskSpecV2",

--- a/src/rosclaw/task_kernel/coordinator.py
+++ b/src/rosclaw/task_kernel/coordinator.py
@@ -29,7 +29,7 @@ from rosclaw.contracts.common import new_id
 from rosclaw.task_kernel.service import TaskKernel
 
 #: 媒体/交付类失败前缀（execution 已成功，只 delivery 待修）。
-_DELIVERY_FAILURE_PREFIXES = ("RENDER_", "MEDIA_")
+_DELIVERY_FAILURE_PREFIXES = ("RENDER_", "MEDIA_", "DELIVERABLE_")
 
 #: 目标声明媒体交付物的关键词（通用——不是形状特例：任何要
 #: 视频/GIF/MP4/动画的目标都要求媒体交付证据）。
@@ -103,7 +103,14 @@ class TaskCoordinator:
         # 目标声明媒体交付物（视频/GIF/MP4/动画）但零媒体交付——
         # 执行成功 ≠ 交付成功（0824 金丝雀实证：模型只 rollout 不
         # 渲染就结束，trace 内部件不是用户要的视频）。
-        if _goal_requires_media(str(task.get("root_goal") or "")):
+        # R0-2：spec 冻结 deliverables 时以 spec 为准（finish_task
+        # 已把 DELIVERABLE_MISSING 放进 failures）——启发式只做
+        # 无 spec 任务的回落。
+        spec = self._kernel.get_task_spec(task_id) or {}
+        spec_deliverables = list(spec.get("deliverables") or [])
+        if not spec_deliverables and _goal_requires_media(
+            str(task.get("root_goal") or "")
+        ):
             has_media = any(
                 str(a.get("media_type") or "").startswith(("image/", "video/"))
                 for a in artifacts
@@ -130,17 +137,33 @@ class TaskCoordinator:
             )
             self._store_outcome(task_id, revision, outcome, now)
             return outcome
-        # FAIL：区分 delivery 待修（媒体类）与 verification 失败。
+        # FAIL：区分 delivery 待修（媒体/交付类）与 verification 失败。
         delivery_only = bool(failures) and all(
             f.startswith(_DELIVERY_FAILURE_PREFIXES) for f in failures
         )
         if delivery_only:
+            # R0-2：required deliverables 缺失 = 运动执行 PASS 但
+            # 用户请求未完整满足——verification PARTIAL（不是整体
+            # VERIFIED）；delivery 按已满足 kind 分 MISSING/PARTIAL。
+            deliverable_missing = any(
+                f.startswith("DELIVERABLE_MISSING") for f in failures
+            )
+            delivery = "NEEDS_REPAIR"
+            verification = "FAIL"
+            if deliverable_missing:
+                from rosclaw.task_kernel.deliverables import (
+                    deliverable_verdict,
+                )
+
+                dv = deliverable_verdict(spec_deliverables, artifacts)
+                verification = "PARTIAL"
+                delivery = "PARTIAL" if dv["satisfied"] else "MISSING"
             outcome = self._build_outcome(
                 task, revision, artifacts,
                 lifecycle="ACTIVE",
                 execution="SUCCEEDED",
-                verification="FAIL",
-                delivery="NEEDS_REPAIR",
+                verification=verification,
+                delivery=delivery,
                 created_at=now,
             )
             directive = self._repair_directive(task_id, revision, failures, now)
@@ -192,6 +215,23 @@ class TaskCoordinator:
         ):
             trust = "TRUSTED"
         accepted = bool(task.get("user_accepted_at"))
+        # R0-2：证据等级按产物事实拆分（不是单个 SIM_DYN_ROLLOUT
+        # 覆盖全部）——MOTION_ROLLOUT（资源证明的轨迹）/
+        # SCENE_RENDER（scene_3d kind）/REAL_RECEIPT（REAL 域）。
+        from rosclaw.task_kernel.deliverables import artifact_delivery_kind
+
+        levels: list[str] = []
+        kinds = {artifact_delivery_kind(a) for a in artifacts}
+        has_resource_proof = any(
+            json.loads(str(a.get("metadata_json") or "{}")).get("resource")
+            for a in artifacts
+        )
+        if has_resource_proof:
+            levels.append("MOTION_ROLLOUT")
+        if "scene_3d" in kinds:
+            levels.append("SCENE_RENDER")
+        if str(task.get("mode") or "") == "REAL":
+            levels.append("REAL_RECEIPT")
         return {
             "schema_version": "rosclaw.task_outcome.v2",
             "task_id": str(task["task_id"]),
@@ -204,6 +244,7 @@ class TaskCoordinator:
             "evidence": {
                 "domain": str(task.get("mode") or "SIMULATION"),
                 "trust": trust,
+                "levels": levels,
             },
             "blocked_on": [],
             "created_at": created_at,

--- a/src/rosclaw/task_kernel/deliverables.py
+++ b/src/rosclaw/task_kernel/deliverables.py
@@ -1,0 +1,75 @@
+"""交付物核验（R0-2，0826 体验审计 §5.R0-2）。
+
+任务成功 ≠ 用户请求成功：spec 冻结的 required deliverables 必须
+按 **kind** 出现在产物账本——preview_2d / scene_3d / robot_video
+是不同产物 kind（lineage.kind 权威），2D 预览永远不能冒充场景
+视频（0826 审计：GIF 交付冒充"仿真视频"是假绿）。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from rosclaw.contracts.agent.task_spec import (
+    DELIVERABLE_KIND_TO_ARTIFACT_KIND,
+)
+
+
+def artifact_delivery_kind(artifact: dict[str, Any]) -> str:
+    """产物的交付 kind（lineage.kind 权威；无血缘为 data——
+    不可用于媒体交付断言）。"""
+    meta = artifact.get("metadata_json")
+    if isinstance(meta, str):
+        try:
+            meta = json.loads(meta or "{}")
+        except ValueError:
+            meta = {}
+    if not isinstance(meta, dict):
+        meta = {}
+    lineage = meta.get("lineage") or {}
+    kind = str(lineage.get("kind", "")) if isinstance(lineage, dict) else ""
+    return kind or "data"
+
+
+def deliverable_verdict(
+    deliverables: list[dict[str, Any]],
+    artifacts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """required 交付物按 kind 匹配产物账本。
+
+    返回 {satisfied, missing, partial}：missing = required 但无对应
+    kind 产物的 kind 列表；partial = 有 required 命中但也有缺失。
+    """
+    present_kinds = {artifact_delivery_kind(a) for a in artifacts}
+    satisfied: list[str] = []
+    missing: list[str] = []
+    for item in deliverables:
+        kind = str(item.get("kind", ""))
+        if not kind:
+            continue
+        required = bool(item.get("required"))
+        artifact_kind = DELIVERABLE_KIND_TO_ARTIFACT_KIND.get(kind, kind)
+        media_type = str(item.get("media_type", ""))
+        hit = False
+        if artifact_kind in present_kinds:
+            if not media_type:
+                hit = True
+            else:
+                hit = any(
+                    artifact_delivery_kind(a) == artifact_kind
+                    and str(a.get("media_type", "")) == media_type
+                    for a in artifacts
+                )
+        if hit:
+            satisfied.append(kind)
+        elif required:
+            missing.append(kind)
+    return {
+        "satisfied": satisfied,
+        "missing": missing,
+        "partial": bool(satisfied and missing),
+    }
+
+
+__all__ = ["artifact_delivery_kind", "deliverable_verdict"]

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -791,6 +791,26 @@ class TaskKernel:
                             "该 trace 实际内容不符——renderer 吃的不是这条 trace"
                         )
         provenance_failures += graph_failures
+        # R0-2（0826 体验审计 §5.R0-2）：spec 冻结的 required
+        # deliverables 按 kind 核验全量产物账本——任务成功 ≠ 用户
+        # 请求成功（2D 预览不满足 scene_video——kind 分野是硬边界）。
+        spec = self.get_task_spec(task_id)
+        spec_deliverables = (spec or {}).get("deliverables") or []
+        if spec_deliverables:
+            from rosclaw.task_kernel.deliverables import deliverable_verdict
+
+            ledger = [
+                dict(r)
+                for r in self._conn.execute(
+                    "SELECT * FROM artifacts WHERE task_id = ?", (task_id,),
+                ).fetchall()
+            ]
+            dv = deliverable_verdict(spec_deliverables, ledger)
+            for kind in dv["missing"]:
+                provenance_failures.append(
+                    f"DELIVERABLE_MISSING: required 交付物 {kind} 未在产物"
+                    "账本（按 kind 匹配——2D 预览不满足场景视频）"
+                )
         trusted_present = any(
             str(a.get("producer") or "").startswith("kernel:")
             and not str(a.get("media_type") or "").startswith("image/")

--- a/src/rosclaw/task_kernel/task_spec.py
+++ b/src/rosclaw/task_kernel/task_spec.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from rosclaw.contracts.agent.task_spec import (
     TaskConstraintsV2,
+    TaskDeliverableV2,
     TaskGoalV2,
     TaskPreferencesV2,
     TaskSpecV2,
@@ -29,6 +30,40 @@ _INTENT_MARKERS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("compute.generic", ("计算", "compute", "分析", "误差", "统计")),
 )
 _CHAT_MARKERS = ("你好", "介绍", "hello", "你是谁", "谢谢")
+
+#: R0-2 交付/场景标记（通用词类——与 intent 动词规则同一模式；
+#: 形状/场景特例不进规则）。媒体：视频类 → scene_video（required），
+#: 动画/GIF 类 → preview_animation；工具/场景/接触各一词类。
+_SCENE_VIDEO_MARKERS = ("视频", "video", "mp4", "录像")
+_PREVIEW_MARKERS = ("gif", "动图")
+_TOOL_MARKERS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("tool:pen", ("笔", "pen", "画笔", "马克笔", "marker")),
+)
+_WORLD_MARKERS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("world:tabletop", ("桌面", "桌子", "桌上", "tabletop", "table")),
+)
+_CONTACT_MARKERS = ("接触", "contact", "贴在", "贴着")
+
+
+def _any_marker(text: str, markers: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(m in lowered or m in text for m in markers)
+
+
+def _compile_deliverables(goal_text: str) -> list[TaskDeliverableV2]:
+    """目标文本 → 交付物声明（只声明用户要的——不编造 required）。"""
+    deliverables: list[TaskDeliverableV2] = []
+    if _any_marker(goal_text, _SCENE_VIDEO_MARKERS):
+        deliverables.append(TaskDeliverableV2(
+            kind="scene_video", media_type="video/mp4", required=True,
+            min_frames=30, min_resolution=[640, 360],
+        ))
+    if _any_marker(goal_text, _PREVIEW_MARKERS):
+        deliverables.append(TaskDeliverableV2(
+            kind="preview_animation", media_type="image/gif",
+            required=True, min_frames=30,
+        ))
+    return deliverables
 
 
 def _classify_intent(goal_text: str) -> str:
@@ -61,6 +96,24 @@ def compile_task_spec(
         from rosclaw.cognition.alias import canonical_resource_id
 
         body_ref = canonical_resource_id(body_id)
+    # R0-2：工具/场景/接触声明（通用标记——无形状特例）。
+    tool_ref = ""
+    for ref, markers in _TOOL_MARKERS:
+        if _any_marker(goal_text, markers):
+            tool_ref = ref
+            break
+    if not world_ref:
+        for ref, markers in _WORLD_MARKERS:
+            if _any_marker(goal_text, markers):
+                world_ref = ref
+                break
+    contact_required = _any_marker(goal_text, _CONTACT_MARKERS)
+    # "在桌面/桌上画" = 工具与桌面接触（draw on table 的通用语义）。
+    if world_ref == "world:tabletop" and _classify_intent(goal_text) in (
+        "manipulation.draw_path",
+        "manipulation.reach",
+    ):
+        contact_required = True
     return TaskSpecV2(
         spec_id=new_id("tspec"),
         task_id=task_id,
@@ -69,13 +122,20 @@ def compile_task_spec(
             natural_language=goal_text,
             intent=_classify_intent(goal_text),
         ),
-        subjects=TaskSubjectsV2(body_ref=body_ref, world_ref=world_ref),
+        subjects=TaskSubjectsV2(
+            body_ref=body_ref, tool_ref=tool_ref, world_ref=world_ref
+        ),
         constraints=TaskConstraintsV2(
             mode=mode,
             frames=list(frames or []),
             allowed_effects=list(allowed_effects or []),
+            contact_required=contact_required,
+            tool_axis_aligned_with_plane_normal_deg=(
+                3.0 if tool_ref else None
+            ),
         ),
         preferences=TaskPreferencesV2(language=language, verbosity=verbosity),
+        deliverables=_compile_deliverables(goal_text),
         acceptance_spec_id=acceptance_spec_id,
     )
 

--- a/tests/agentd/test_r02_task_spec_deliverables.py
+++ b/tests/agentd/test_r02_task_spec_deliverables.py
@@ -1,0 +1,271 @@
+"""R0-2 红测试（0826 体验审计 §5.R0-2）：TaskSpec 交付与验收语义。
+
+真实事故（0826 体验旅程）：
+- 用户要"末端持笔、垂直桌面画五角星、做仿真视频"——实际只证明
+  了 UR5e 末端轨迹跟踪 + 2D 预览 GIF；场景渲染器用 empty world，
+  无笔/桌面/接触/场景视频证据，却被整体判 VERIFIED；
+- preview_2d 与 scene_3d 不分 kind——2D GIF 能冒充用户要的
+  scene video。
+
+断言：
+1. 契约：TaskSpecV2 冻结 deliverables（kind/media_type/required/
+   min_frames/min_resolution）+ subjects.tool_ref +
+   constraints.contact_required/tool_axis_aligned——未知 kind 拒绝；
+2. 编译：自然语言目标 → deliverables/tool/world/contact（通用
+   标记——无形状特例）；
+3. 产物 kind 分野：preview_2d / scene_3d / robot_video 是不同
+   kind——2D 预览不能满足 scene_video 交付；
+4. 多维 outcome：运动执行 PASS 但 required scene_video 缺失 →
+   verification PARTIAL + delivery MISSING/PARTIAL，不是整体
+   VERIFIED（账本 SUCCEEDED）；
+5. Gate：3D 渲染缺失（renderer 打坏）→ 任务只能 PARTIAL/
+   NEEDS_REPAIR——最终 payload 不得宣称"任务完整完成"；
+6. 回归：无媒体要求的 draw 任务仍完整 SUCCEEDED。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _issue_lease, _request
+from tests.agentd.test_r01_production_chain import _kernel, _setup_ur5e
+
+
+class TestDeliverableContract:
+    def test_deliverable_fields_frozen(self) -> None:
+        from rosclaw.contracts.agent.task_spec import (
+            TaskDeliverableV2,
+            TaskSpecV2,
+        )
+
+        spec = TaskSpecV2(
+            spec_id="tspec_1", task_id="task_1", revision=1,
+            goal={"natural_language": "画五角星并做仿真视频",
+                  "intent": "manipulation.draw_path"},
+            subjects={"body_ref": "robot:ur5e", "tool_ref": "tool:pen",
+                      "world_ref": "world:tabletop"},
+            constraints={"mode": "SIMULATION", "contact_required": True,
+                         "tool_axis_aligned_with_plane_normal_deg": 3.0},
+            deliverables=[
+                TaskDeliverableV2(
+                    kind="scene_video", media_type="video/mp4",
+                    required=True, min_frames=60,
+                    min_resolution=[640, 360],
+                ),
+                TaskDeliverableV2(
+                    kind="preview_animation", media_type="image/gif",
+                    required=False,
+                ),
+            ],
+        )
+        assert spec.deliverables[0].kind == "scene_video"
+        assert spec.subjects.tool_ref == "tool:pen"
+        assert spec.constraints.contact_required is True
+
+    def test_unknown_deliverable_kind_rejected(self) -> None:
+        from rosclaw.contracts.agent.task_spec import TaskDeliverableV2
+
+        with pytest.raises(ValueError, match="kind|taxonomy|分类"):
+            TaskDeliverableV2(kind="hologram", media_type="video/mp4")
+
+    def test_kinds_are_distinct(self) -> None:
+        """preview_2d / scene_3d / robot_video 必须是不同 artifact
+        kind（2D 预览不能冒充场景视频）。"""
+        from rosclaw.contracts.agent.task_spec import (
+            DELIVERABLE_KIND_TO_ARTIFACT_KIND,
+        )
+
+        kinds = set(DELIVERABLE_KIND_TO_ARTIFACT_KIND.values())
+        assert "preview_2d" in kinds
+        assert "scene_3d" in kinds
+        assert "robot_video" in kinds
+        assert len(kinds) == len(DELIVERABLE_KIND_TO_ARTIFACT_KIND)
+
+
+class TestSpecCompiler:
+    def _compile(self, text: str):
+        from rosclaw.task_kernel.task_spec import compile_task_spec
+
+        return compile_task_spec(
+            task_id="task_1", revision=1, goal_text=text,
+            body_id="sim/ur5e", mode="SIMULATION", acceptance_spec_id="",
+        )
+
+    def test_video_goal_produces_scene_video_deliverable(self) -> None:
+        spec = self._compile("机械臂末端持笔垂直桌面画五角星，并做仿真视频")
+        assert spec.goal.intent == "manipulation.draw_path"
+        scene = [
+            d for d in spec.deliverables
+            if d.kind == "scene_video" and d.required
+        ]
+        assert scene, f"缺 required scene_video：{spec.deliverables}"
+        assert scene[0].media_type == "video/mp4"
+        assert spec.subjects.tool_ref == "tool:pen"
+        assert spec.subjects.world_ref == "world:tabletop"
+        assert spec.constraints.contact_required is True
+
+    def test_plain_draw_no_required_scene(self) -> None:
+        spec = self._compile("画一个五角星")
+        required = [d for d in spec.deliverables if d.required]
+        assert not any(d.kind == "scene_video" for d in required), (
+            f"无视频要求不得编造 required scene_video：{spec.deliverables}"
+        )
+
+
+def _draw_task(kernel, home: Path, text: str) -> str:
+    kernel.persist_input(
+        mission_id="mis_1", session_ref="s1",
+        message_id="msg_1", text=text,
+    )
+    bound = kernel.ensure_task_for_effect(
+        mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+        cwd=str(home), body_id="sim/ur5e",
+    )
+    return str(bound["task_id"])
+
+
+class TestDeliverableVerification:
+    def test_missing_scene_video_not_full_pass(self, tmp_path: Path) -> None:
+        """运动执行成功但 required scene_video 未交付 → 不得整体
+        PASS（finish_task 必须含 DELIVERABLE_MISSING）。"""
+        from rosclaw.agentd.task_execution import TaskExecutionService
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, "画五角星并做仿真视频")
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        outcome = TaskExecutionService(
+            kernel=kernel, conn=conn, home=tmp_path,
+        ).execute(
+            task_id,
+            recipe_inputs={"shape": "star5",
+                           "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+        )
+        # 运动执行成功（refs 全产出）但交付不完整。
+        assert "TraceRef" in outcome.refs
+        assert not outcome.ok, "required scene_video 缺失不得整体 ok"
+        assert any(
+            "DELIVERABLE_MISSING" in f and "scene_video" in f
+            for f in outcome.failures
+        ), outcome.failures
+        task = kernel.get_task(task_id)
+        assert task["state"] != "SUCCEEDED", (
+            f"交付不完整不得 SUCCEEDED：{task['state']}"
+        )
+
+    def test_preview_does_not_satisfy_scene_video(
+        self, tmp_path: Path
+    ) -> None:
+        """2D 预览（preview_2d kind 的 GIF/MP4）不满足 scene_video
+        交付——kind 分野是硬边界。"""
+        from rosclaw.task_kernel.deliverables import deliverable_verdict
+
+        kernel, _conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, "画五角星")
+        f = tmp_path / "preview.gif"
+        f.write_bytes(b"GIF89a" + b"\x00" * 128)
+        kernel.register_artifact(
+            task_id=task_id, path=str(f), media_type="image/gif",
+            producer="kernel:test",
+            metadata={"lineage": {"kind": "preview_2d",
+                                  "trace_id": "t1"}},
+        )
+        artifacts = [
+            dict(r) for r in kernel._conn.execute(
+                "SELECT * FROM artifacts WHERE task_id = ?", (task_id,),
+            ).fetchall()
+        ]
+        verdict = deliverable_verdict(
+            [{"kind": "scene_video", "media_type": "video/mp4",
+              "required": True}],
+            artifacts,
+        )
+        assert verdict["missing"] == ["scene_video"], verdict
+
+
+class TestCoordinatorOutcome:
+    def test_partial_delivery_outcome(self, tmp_path: Path) -> None:
+        """Coordinator：执行成功 + required scene_video 缺失 →
+        execution SUCCEEDED + verification PARTIAL + delivery
+        MISSING/PARTIAL——不是整体 VERIFIED/DELIVERED。"""
+        from rosclaw.agentd.task_execution import TaskExecutionService
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, "画五角星并做仿真视频")
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        TaskExecutionService(
+            kernel=kernel, conn=conn, home=tmp_path,
+        ).execute(
+            task_id,
+            recipe_inputs={"shape": "star5",
+                           "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+        )
+        outcome = TaskCoordinator(kernel).consider(task_id)
+        assert outcome is not None
+        assert outcome["execution"] == "SUCCEEDED"
+        assert outcome["verification"] == "PARTIAL", outcome
+        assert outcome["delivery"] in ("MISSING", "PARTIAL"), outcome
+        assert outcome["lifecycle"] != "COMPLETED", outcome
+
+
+class TestGateRendererBroken:
+    async def test_broken_scene_renderer_honest_partial(
+        self, tmp_path: Path
+    ) -> None:
+        """Gate R0-2：3D 渲染缺失 → 任务只能 PARTIAL/NEEDS_REPAIR；
+        最终 payload 不得宣称任务完整完成。"""
+        service, mission = await _setup_ur5e(tmp_path)
+        # 目标含"仿真视频"——spec 冻结 required scene_video；
+        # 3D 场景渲染链未接通（现状即"renderer 打坏"等价）。
+        kernel = service._task_kernel
+        kernel.persist_input(
+            mission_id=mission.mission_id, session_ref="pi_1",
+            message_id="msg_video",
+            text="画五角星并做仿真视频",
+        )
+        lease = await _issue_lease(service, mission)
+        result = await PiToolDispatcher(service).execute(
+            _request(
+                "rosclaw_task", mission=mission.mission_id,
+                idem="r02_gate", lease=lease,
+                arguments={
+                    "goal": "draw_shape",
+                    "parameters": {"shape": "star5",
+                                   "center_m": [0.35, 0.25, 0.30],
+                                   "scale_m": 0.10},
+                },
+            )
+        )
+        payload = json.loads(result.summary)
+        assert payload["state"] != "VERIFIED", payload
+        assert any(
+            "scene_video" in str(f) for f in payload.get("failures", [])
+        ), payload
+        view = str(payload.get("user_view", ""))
+        assert "完成" not in view or "部分" in view or "未" in view, view
+        task = kernel.latest_task_for(mission.mission_id, "pi_1")
+        assert task["state"] != "SUCCEEDED"
+        await service.close()
+
+    async def test_plain_draw_still_succeeds(self, tmp_path: Path) -> None:
+        """回归：无媒体/场景要求的 draw 任务仍完整 SUCCEEDED。"""
+        service, mission = await _setup_ur5e(tmp_path)
+        lease = await _issue_lease(service, mission)
+        result = await PiToolDispatcher(service).execute(
+            _request(
+                "rosclaw_task", mission=mission.mission_id,
+                idem="r02_plain", lease=lease,
+                arguments={
+                    "goal": "draw_shape",
+                    "parameters": {"shape": "star5"},
+                },
+            )
+        )
+        assert result.ok, result.summary
+        payload = json.loads(result.summary)
+        assert payload["state"] == "VERIFIED", payload
+        await service.close()

--- a/tests/contracts/golden/rosclaw.task_spec.v2.json
+++ b/tests/contracts/golden/rosclaw.task_spec.v2.json
@@ -2,7 +2,7 @@
   "$defs": {
     "TaskConstraintsV2": {
       "additionalProperties": true,
-      "description": "执行约束：mode / frames / allowed_effects。",
+      "description": "执行约束：mode / frames / allowed_effects + R0-2 接触与\n工具轴约束（contact_required / tool_axis_aligned_with_plane_\nnormal_deg——语义验收的声明面）。",
       "properties": {
         "schema_version": {
           "const": "rosclaw.task_constraints.v2",
@@ -28,9 +28,70 @@
           },
           "title": "Allowed Effects",
           "type": "array"
+        },
+        "contact_required": {
+          "default": false,
+          "title": "Contact Required",
+          "type": "boolean"
+        },
+        "tool_axis_aligned_with_plane_normal_deg": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Axis Aligned With Plane Normal Deg"
         }
       },
       "title": "TaskConstraintsV2",
+      "type": "object"
+    },
+    "TaskDeliverableV2": {
+      "additionalProperties": true,
+      "description": "交付物声明：kind/media_type/required + 最低质量门槛。\n\nrequired=True 的交付物未出现在产物账本（按 kind 匹配）→\nDELIVERABLE_MISSING——任务成功 ≠ 用户请求成功。",
+      "properties": {
+        "schema_version": {
+          "const": "rosclaw.task_deliverable.v2",
+          "default": "rosclaw.task_deliverable.v2",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "kind": {
+          "minLength": 1,
+          "title": "Kind",
+          "type": "string"
+        },
+        "media_type": {
+          "default": "",
+          "title": "Media Type",
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "title": "Required",
+          "type": "boolean"
+        },
+        "min_frames": {
+          "default": 0,
+          "title": "Min Frames",
+          "type": "integer"
+        },
+        "min_resolution": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Min Resolution",
+          "type": "array"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "title": "TaskDeliverableV2",
       "type": "object"
     },
     "TaskGoalV2": {
@@ -87,7 +148,7 @@
     },
     "TaskSubjectsV2": {
       "additionalProperties": true,
-      "description": "作用对象：body_ref（canonical robot:<name>）与 world_ref。",
+      "description": "作用对象：body_ref（canonical robot:<name>）、tool_ref 与\nworld_ref（R0-2：工具/场景是验收一等事实——\"持笔在桌面\"必须\n可声明、可核验，不允许最终回答自由夸大）。",
       "properties": {
         "schema_version": {
           "const": "rosclaw.task_subjects.v2",
@@ -98,6 +159,11 @@
         "body_ref": {
           "default": "",
           "title": "Body Ref",
+          "type": "string"
+        },
+        "tool_ref": {
+          "default": "",
+          "title": "Tool Ref",
           "type": "string"
         },
         "world_ref": {
@@ -145,6 +211,13 @@
     },
     "preferences": {
       "$ref": "#/$defs/TaskPreferencesV2"
+    },
+    "deliverables": {
+      "items": {
+        "$ref": "#/$defs/TaskDeliverableV2"
+      },
+      "title": "Deliverables",
+      "type": "array"
     },
     "acceptance_spec_id": {
       "default": "",


### PR DESCRIPTION
## 真实事故（0826 体验旅程 + 实施指南 §2.2/§5.R0-2）

用户要"末端持笔、垂直桌面画五角星、做仿真视频"——实际只证明了 UR5e 末端轨迹跟踪 + 2D 预览 GIF，却被整体判 `VERIFIED`；preview_2d 与 scene_3d 不分 kind，2D GIF 冒充场景视频——典型"内核成功、产品假绿"。

## 闭环内容

- **契约**：`TaskDeliverableV2`（kind/media_type/required/min_frames/min_resolution，kind 冻结分类）+ `subjects.tool_ref` + `constraints.contact_required`/`tool_axis_aligned_with_plane_normal_deg`；golden 重导（仅 task_spec.v2 +75/-2）。
- **编译**：自然语言 → deliverables/tool/world/contact（通用标记——与 intent 动词规则同一模式，无形状特例）；"在桌面画" = 工具-桌面接触声明。
- **kind 分野**：`DELIVERABLE_KIND_TO_ARTIFACT_KIND`——preview_2d / scene_3d / robot_video 是不同产物 kind（lineage.kind 权威），2D 预览**永不**满足 scene_video；recipe 的 gif/mp4 都打 preview_2d 血缘（2D 预览的两种容器）。
- **finish_task**（唯一验收权威）：required deliverables 按 kind 核验全量产物账本——缺失即 `DELIVERABLE_MISSING` → REPAIR_REQUIRED，账本法不 SUCCEEDED。
- **Coordinator**：execution SUCCEEDED + verification **PARTIAL** + delivery MISSING/PARTIAL（不再整体 VERIFIED）；evidence 按产物事实拆分 MOTION_ROLLOUT/SCENE_RENDER/REAL_RECEIPT。

## 红→绿证据

- 红：`/tmp/r02-red.txt`（9 红 + 1 回归绿）。
- 绿：R0-2 测试 10/10；agentd 全套 **714 passed**；PTY 产品旅程 **A/B/C 全绿**。
- **Gate R0-2 实证**：目标含"仿真视频" → 运动执行成功但场景视频未交付 → payload `state != VERIFIED` + `DELIVERABLE_MISSING scene_video` + 账本非 SUCCEEDED（最终回答不得宣称任务完整完成）；无媒体要求的 draw 仍完整 SUCCEEDED（回归护栏）。

## 诚实边界

scene_3d 产物链（3D 场景渲染接线 + 结构化进程协议）在 **R0-3**——本 PR 先把"缺场景视频"说诚实，不假装能产。

🤖 Generated with [Claude Code](https://claude.com/claude-code)