### PR TITLE
feat: R0-3 RendererSupervisor 结构化进程协议 + 内核内一次降级 + 熔断范围修复（0826 体验审计）

### DIFF
--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -158,6 +158,29 @@ def _envelope_result(request: PiToolRequestV1, envelope) -> PiToolResultV1:
     raise ToolBridgeError(code, message[:400], retryable=retryable)
 
 
+#: 熔断指纹的易变参数（R0-3，0826 体验审计 §5.R0-3）：基础设施
+#: 故障的重试熔断按 capability+参数实质判定——换 camera 不绕过
+#: renderer 熔断（事故实证：同一渲染故障换 camera 重试三次）。
+_VOLATILE_FINGERPRINT_KEYS = frozenset({"camera"})
+
+
+def _failure_fingerprint(request: PiToolRequestV1) -> str:
+    def _strip(value: object) -> object:
+        if isinstance(value, dict):
+            return {
+                k: _strip(v)
+                for k, v in value.items()
+                if k not in _VOLATILE_FINGERPRINT_KEYS
+            }
+        if isinstance(value, list):
+            return [_strip(v) for v in value]
+        return value
+
+    return request.tool_name + ":" + json.dumps(
+        _strip(request.arguments), sort_keys=True, ensure_ascii=False
+    )
+
+
 class PiToolDispatcher:
     def __init__(self, service: AgentService) -> None:
         self._service = service
@@ -183,10 +206,9 @@ class PiToolDispatcher:
         # 八审 §4 P0-6：doom-loop 熔断——同一工具同一参数出错后原样
         # 重复直接拒绝（不再消耗模型回合）；成功即重置，不误伤合法
         # 重复观测。进程级指纹（安全语义仍在 fail-closed 链上，熔断
-        # 只是效率护栏）。
-        fingerprint = request.tool_name + ":" + json.dumps(
-            request.arguments, sort_keys=True, ensure_ascii=False
-        )
+        # 只是效率护栏）。R0-3：指纹剔除易变参数（camera 等）——
+        # 基础设施故障换参数不能绕过。
+        fingerprint = _failure_fingerprint(request)
         failures = getattr(self._service, "_tool_fail_fingerprints", None)
         if failures is None:
             failures = self._service._tool_fail_fingerprints = {}

--- a/src/rosclaw/agentd/plan_templates.py
+++ b/src/rosclaw/agentd/plan_templates.py
@@ -33,8 +33,14 @@ from rosclaw.task_kernel.plan_executor import (
 from rosclaw.task_kernel.service import TaskKernel
 
 
-def build_draw_path_graph(task_id: str, revision: int) -> PlanGraphV1:
-    """draw_path 标准 DAG（参数经 handler 闭包传递，不在图里写死）。"""
+def build_draw_path_graph(
+    task_id: str, revision: int, *, include_scene: bool = False
+) -> PlanGraphV1:
+    """draw_path 标准 DAG（参数经 handler 闭包传递，不在图里写死）。
+
+    include_scene（R0-3）：spec 要求 scene_video 时在 2D 渲染后
+    插入场景渲染节点（scene_3d kind——与 preview_2d 硬边界）。
+    """
     nodes = [
         PlanNodeV1(id="resolve_robot", op="resource.resolve", outputs=["ResourceRef"]),
         PlanNodeV1(
@@ -44,13 +50,26 @@ def build_draw_path_graph(task_id: str, revision: int) -> PlanGraphV1:
             id="simulate", op="robot.execute_plan", inputs=["PlanRef"], outputs=["TraceRef"]
         ),
         PlanNodeV1(id="render", op="simulation.render", inputs=["TraceRef"], outputs=["RenderRef"]),
+    ]
+    verify_inputs = ["PlanRef", "TraceRef", "RenderRef"]
+    if include_scene:
+        nodes.append(
+            PlanNodeV1(
+                id="render_scene",
+                op="simulation.render",
+                inputs=["TraceRef"],
+                outputs=["SceneRef"],
+            )
+        )
+        verify_inputs.append("SceneRef")
+    nodes.append(
         PlanNodeV1(
             id="verify",
             op="task.verify",
-            inputs=["PlanRef", "TraceRef", "RenderRef"],
+            inputs=verify_inputs,
             outputs=["VerificationRef"],
-        ),
-    ]
+        )
+    )
     digest = hashlib.sha256(
         json.dumps(
             [[n.id, n.op, n.inputs, n.outputs] for n in nodes],
@@ -109,6 +128,16 @@ def draw_path_recipe(
     revision = int(task.get("active_revision") or 1)
     body_id = str(task.get("body_id") or "sim/ur5e")
     artifact_ids: list[str] = []
+    # R0-3：场景语义来自 frozen spec（world/tool/deliverables）——
+    # spec 要求 scene_video 才跑场景渲染。
+    spec = kernel.get_task_spec(task_id) or {}
+    subjects = spec.get("subjects") or {}
+    scene_world = str(subjects.get("world_ref", "")).removeprefix("world:")
+    scene_tool = str(subjects.get("tool_ref", ""))
+    scene_required = any(
+        d.get("kind") == "scene_video" and d.get("required")
+        for d in (spec.get("deliverables") or [])
+    )
 
     def h_resolve(inputs_: dict) -> dict:
         return {"ResourceRef": {"body_ref": canonical_resource_id(body_id)}}
@@ -194,9 +223,81 @@ def draw_path_recipe(
             }
         }
 
+    def h_scene(inputs_: dict) -> dict:
+        """R0-3：场景渲染节点（spec 要求 scene_video 时入图）。
+
+        world/tool 来自 frozen spec；失败不炸图——SceneRef 记
+        FAILED + 稳定错误码，verify 节点产出 PARTIAL（2D 交付不
+        被场景故障拖死）。
+        """
+        from rosclaw.agentd.sim_render import render_scene_trace
+
+        trace = inputs_["TraceRef"]
+        trace_id = trace["trace_id"]
+        try:
+            result = render_scene_trace(
+                home, trace_id,
+                world_id=scene_world or "empty",
+                tool_ref=scene_tool,
+            )
+        except ValueError as exc:
+            return {
+                "SceneRef": {
+                    "status": "FAILED",
+                    "failure": str(exc)[:300],
+                    "trace_id": trace_id,
+                }
+            }
+        receipt_path = (
+            home / "sim" / "traces" / trace_id / "render_receipt.json"
+        )
+        for key, media_type in (("gif", "image/gif"), ("mp4", "video/mp4")):
+            item = (result.get("artifacts") or {}).get(key) or {}
+            path = str(item.get("path") or "")
+            if not path:
+                continue
+            try:
+                record = kernel.register_artifact(
+                    task_id=task_id,
+                    path=path,
+                    media_type=media_type,
+                    producer="kernel:plan_template:draw_path",
+                    metadata={
+                        "resource": trace["resource"],
+                        "lineage": {
+                            "trace_id": trace_id,
+                            "kind": "scene_3d",
+                            "render_receipt_path": str(receipt_path),
+                        },
+                    },
+                )
+            except ValueError as exc:
+                return {
+                    "SceneRef": {
+                        "status": "FAILED",
+                        "failure": f"SCENE_ARTIFACT_REGISTER: {exc}"[:300],
+                        "trace_id": trace_id,
+                    }
+                }
+            artifact_ids.append(str(record["artifact_id"]))
+        return {
+            "SceneRef": {
+                "status": "OK",
+                "trace_id": trace_id,
+                "receipt": result.get("receipt") or {},
+                "frames": int((result.get("artifact") or {}).get("frames", 0)),
+            }
+        }
+
     def h_verify(inputs_: dict) -> dict:
         trace = inputs_["TraceRef"]
         render = inputs_["RenderRef"]
+        scene = inputs_.get("SceneRef") or {}
+        scene_failure = (
+            str(scene.get("failure", ""))
+            if scene.get("status") == "FAILED"
+            else ""
+        )
         verify = service.verify_tracking(
             trace["trace_id"], max_tracking_error_m=threshold
         )
@@ -218,25 +319,32 @@ def draw_path_recipe(
                 "VerificationRef": {
                     "status": "FAIL",
                     "verification_id": "",
-                    "failures": failures,
+                    "failures": failures + ([scene_failure] if scene_failure else []),
                     "metrics": metrics,
                     "threshold_m": threshold,
                     "min_frames": min_frames,
                 }
             }
-        # 验收真跑决定终态（frozen acceptance——模型自述不算数）。
+        # 验收真跑决定终态（frozen acceptance + R0-2 required
+        # deliverables——场景缺失即 DELIVERABLE_MISSING，不整体 PASS）。
         verdict = kernel.finish_task(
             task_id=task_id,
             summary=f"draw_path recipe 执行（{len(artifact_ids)} 项产物）",
             artifact_ids=artifact_ids,
         )
         kernel_failures = [str(f) for f in verdict.get("failures", [])]
-        status = "PASS" if verdict.get("status") == "SUCCEEDED" else "FAIL"
+        status = (
+            "PASS"
+            if verdict.get("status") == "SUCCEEDED" and not scene_failure
+            else "FAIL"
+        )
         return {
             "VerificationRef": {
                 "status": status,
                 "verification_id": str(verdict.get("verification_id", "")),
-                "failures": kernel_failures,
+                "failures": kernel_failures + (
+                    [scene_failure] if scene_failure else []
+                ),
                 "metrics": metrics,
                 "threshold_m": threshold,
                 "min_frames": min_frames,
@@ -250,7 +358,11 @@ def draw_path_recipe(
         "simulation.render": h_render,
         "task.verify": h_verify,
     }
-    graph = build_draw_path_graph(task_id, revision)
+    graph = build_draw_path_graph(task_id, revision, include_scene=scene_required)
+    if scene_required:
+        # render_scene 与 render 同 op——executor 按节点 id 优先
+        # 分派（同 op 多实例的合法机制）。
+        handlers["render_scene"] = h_scene
     return PlanExecutor(kernel, conn).run(graph, handlers)
 
 

--- a/src/rosclaw/agentd/sim_render.py
+++ b/src/rosclaw/agentd/sim_render.py
@@ -66,25 +66,11 @@ def probe_render_backend(
     本机 glfw 实证；每个后端真实渲染一帧 smoke test）。返回
     (backend or None, 每后端明细)。"""
     detail: dict[str, str] = {}
-    for backend in ("egl", "osmesa"):
-        env = dict(os_environ(), MUJOCO_GL=backend)
-        try:
-            proc = subprocess.run(
-                [sys.executable, "-c", _PROBE_SNIPPET],
-                env=env, capture_output=True, timeout=timeout_sec,
-            )
-            if proc.returncode == 0 and b"OK" in proc.stdout:
-                detail[backend] = "ok"
-                return backend, detail
-            detail[backend] = (
-                proc.stderr.decode(errors="replace").strip().splitlines() or ["?"]
-            )[-1][:200]
-        except (subprocess.TimeoutExpired, OSError) as exc:
-            detail[backend] = f"{type(exc).__name__}: {exc}"[:200]
-    ok, note = _probe_xvfb(timeout_sec=timeout_sec)
-    detail["xvfb"] = note
-    if ok:
-        return "xvfb", detail
+    for backend in _BACKEND_ORDER:
+        ok, note = _probe_backend(backend, timeout_sec=timeout_sec)
+        detail[backend] = note
+        if ok:
+            return backend, detail
     return None, detail
 
 
@@ -109,8 +95,20 @@ def render_scene_trace(
     max_frames: int = 60,
     width: int = 640,
     height: int = 360,
+    world_id: str = "empty",
+    tool_ref: str = "",
 ) -> dict[str, Any]:
-    """trace → 场景 GIF（真实 MuJoCo 离屏渲染）+ RenderReceipt。"""
+    """trace → 场景 GIF+MP4（真实 MuJoCo 离屏渲染）+ RenderReceipt。
+
+    R0-3（0826 体验审计 §5.R0-3）：
+    - 结构化 IPC：子进程写原子 result JSON 文件，stdout/stderr 只
+      作诊断——空输出/噪声/rc=0 无结果都是稳定错误码，绝不向
+      调用方泄漏裸 JSONDecodeError；
+    - 后端降级只在 supervisor 内部执行一次（EGL→OSMesa→Xvfb
+      顺序）——模型只收到最终结果；
+    - world_id/tool_ref 来自 TaskSpec——声明了工具但资产不存在
+      时 TOOL_ASSET_MISSING 诚实失败（不假装持笔）。
+    """
     home = Path(home)
     trace_dir = home / "sim" / "traces" / trace_id
     trace_path = trace_dir / "trace.json"
@@ -135,40 +133,139 @@ def render_scene_trace(
             f"RENDER_INPUT_DIGEST_MISMATCH: trajectory_states 与 trace 记录"
             f"不符（{declared[:19]}… != {states_digest[:19]}…）"
         )
+    if tool_ref:
+        _require_tool_asset(tool_ref)
     backend, probe_detail = probe_render_backend()
     if backend is None:
         raise ValueError(
             "RENDER_BACKEND_UNAVAILABLE: EGL/OSMesa/Xvfb 全部不可用——"
             + json.dumps(probe_detail, ensure_ascii=False)[:300]
         )
-    # GL 平台在 mujoco import 时初始化——MUJOCO_GL 必须在子进程首
-    # 次 import 前设定；渲染在子进程执行（GL 崩不跨进程伤宿主）。
-    import os
+    # supervisor 内部一次降级：首选后端渲染失败 → 下一个后端再试
+    # 一次；之后把最终错误抛出（调用方只见一次有语义的结果）。
+    candidates = [backend, *[b for b in _BACKEND_ORDER if b != backend]]
+    last_error: ValueError | None = None
+    for attempt, candidate in enumerate(candidates[:2]):
+        if attempt > 0:
+            ok, note = _probe_backend(candidate)
+            if not ok:
+                last_error = ValueError(
+                    f"RENDER_BACKEND_UNAVAILABLE: 降级后端 {candidate} "
+                    f"不可用（{note}）"
+                )
+                continue
+        try:
+            return _render_attempt(
+                home, trace_id, candidate,
+                camera=camera, max_frames=max_frames,
+                width=width, height=height,
+                world_id=world_id, tool_ref=tool_ref,
+            )
+        except ValueError as exc:
+            last_error = exc
+    assert last_error is not None
+    raise last_error
 
-    # Xvfb 后端经 xvfb-run 提供虚拟显示 + MUJOCO_GL=glfw（P0-F）。
+
+def _probe_backend(backend: str, *, timeout_sec: float = 30.0) -> tuple[bool, str]:
+    """单后端探测（egl/osmesa 直接；xvfb 经 xvfb-run+glfw）。"""
+    if backend == "xvfb":
+        return _probe_xvfb(timeout_sec=timeout_sec)
+    env = dict(os_environ(), MUJOCO_GL=backend)
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _PROBE_SNIPPET],
+            env=env, capture_output=True, timeout=timeout_sec,
+        )
+        if proc.returncode == 0 and b"OK" in proc.stdout:
+            return True, "ok"
+        return False, (
+            proc.stderr.decode(errors="replace").strip().splitlines() or ["?"]
+        )[-1][:200]
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return False, f"{type(exc).__name__}: {exc}"[:200]
+
+
+def _render_attempt(
+    home: Path,
+    trace_id: str,
+    backend: str,
+    *,
+    camera: str,
+    max_frames: int,
+    width: int,
+    height: int,
+    world_id: str,
+    tool_ref: str,
+) -> dict[str, Any]:
+    """单次渲染尝试（结构化 IPC：原子 result 文件为唯一结果
+    通道——stdout/stderr 只作诊断日志）。"""
+    import os
     import shutil
 
+    result_path = (
+        home / "sim" / "traces" / trace_id / f"{trace_id}-scene-result.json"
+    )
+    result_path.unlink(missing_ok=True)
+    argv = [
+        sys.executable, "-m", "rosclaw.agentd.sim_render",
+        str(home), trace_id, camera, str(max_frames),
+        str(width), str(height),
+        "--world", world_id, "--tool", tool_ref,
+        "--result", str(result_path),
+    ]
     if backend == "xvfb":
         env = dict(os.environ, MUJOCO_GL="glfw")
-        argv = [
-            shutil.which("xvfb-run") or "xvfb-run", "-a",
-            sys.executable, "-m", "rosclaw.agentd.sim_render",
-            str(home), trace_id, camera, str(max_frames),
-            str(width), str(height),
-        ]
+        argv = [shutil.which("xvfb-run") or "xvfb-run", "-a", *argv]
     else:
         env = dict(os.environ, MUJOCO_GL=backend)
-        argv = [
-            sys.executable, "-m", "rosclaw.agentd.sim_render",
-            str(home), trace_id, camera, str(max_frames),
-            str(width), str(height),
-        ]
     proc = subprocess.run(argv, env=env, capture_output=True, timeout=600)
-    if proc.returncode != 0:
-        tail = proc.stderr.decode(errors="replace")[-300:]
-        raise ValueError(f"RENDER_FAILED: 子进程渲染失败: {tail}")
-    result = json.loads(proc.stdout.decode())
+    if not result_path.exists():
+        if proc.returncode != 0:
+            tail = proc.stderr.decode(errors="replace")[-300:]
+            raise ValueError(f"RENDER_FAILED: 子进程渲染失败: {tail}")
+        raise ValueError(
+            "RENDER_RESULT_MISSING: 子进程 rc=0 但未写 result 文件"
+            f"（stdout 尾部: {proc.stdout.decode(errors='replace')[-200:]!r}）"
+        )
+    try:
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        raise ValueError(
+            f"RENDER_RESULT_CORRUPT: result 文件不是合法 JSON（{exc}）"
+        ) from exc
+    if not isinstance(result, dict) or not result.get("ok"):
+        code = str(result.get("error_code", "RENDER_FAILED")) if isinstance(
+            result, dict
+        ) else "RENDER_FAILED"
+        message = (
+            str(result.get("message", "")) if isinstance(result, dict) else ""
+        )
+        raise ValueError(f"{code}: {message}"[:400])
+    missing = [k for k in ("artifact", "artifacts", "receipt")
+               if k not in result]
+    if missing:
+        raise ValueError(
+            f"RENDER_RESULT_INCOMPLETE: result 缺字段 {missing}"
+        )
     return result
+
+
+def _require_tool_asset(tool_ref: str) -> None:
+    """工具资产断言（TOOL_ASSET_MISSING 诚实失败——不假装持笔）。
+
+    资产查找：packaged/repo zoo 的 tools/<name>/ 目录（当前无任何
+    工具资产——声明即失败，等资产包落地后自然解锁）。
+    """
+    from rosclaw.runtime.eurdf_loader import _default_zoo_path
+
+    name = tool_ref.removeprefix("tool:")
+    candidate = _default_zoo_path().parent / "tools" / name
+    if not candidate.is_dir():
+        raise ValueError(
+            f"TOOL_ASSET_MISSING: {tool_ref} 无权威工具资产（查找 "
+            f"{candidate}）——不得假装持笔渲染"
+        )
 
 
 def _render_impl(
@@ -179,6 +276,8 @@ def _render_impl(
     max_frames: int,
     width: int,
     height: int,
+    world_id: str = "empty",
+    tool_ref: str = "",
 ) -> dict[str, Any]:
     """子进程内真实渲染（MUJOCO_GL 已由父进程设定）。"""
     backend = os_environ().get("MUJOCO_GL", "")
@@ -191,10 +290,11 @@ def _render_impl(
     states_digest = "sha256:" + hashlib.sha256(
         states_path.read_bytes()
     ).hexdigest()
-    # canonical MJCF（与 rollout 同一资源链）。
+    # canonical MJCF（与 rollout 同一资源链）；world 来自 TaskSpec
+    # （tabletop/empty——empty 不得冒充桌面场景）。
     from rosclaw.sandbox.sandbox_api import Sandbox
 
-    sandbox = Sandbox.create("ur5e", "empty", "mujoco")
+    sandbox = Sandbox.create("ur5e", world_id, "mujoco")
     if not sandbox.has_physics:
         raise ValueError(f"RENDER_INPUT: canonical 模型不可用: {sandbox.load_error}")
     import mujoco
@@ -262,6 +362,8 @@ def _render_impl(
         "schema_version": "rosclaw.render_receipt.v1",
         "backend": backend,
         "camera": camera,
+        "world_id": world_id,
+        "tool_ref": tool_ref,
         "renderer_build_digest": _renderer_build_digest(),
         "input_trace_digest": "sha256:" + hashlib.sha256(
             trace_path.read_bytes()
@@ -306,9 +408,38 @@ __all__ = ["probe_render_backend", "render_scene_trace"]
 
 
 if __name__ == "__main__":
+    # R0-3 结构化 IPC：结果写原子 result 文件（tmp+replace），
+    # stdout/stderr 只作诊断——父进程不解析 stdout。
+    import argparse
 
-    _home, _trace, _camera, _maxf, _w, _h = sys.argv[1:7]
-    print(json.dumps(_render_impl(
-        Path(_home), _trace, camera=_camera,
-        max_frames=int(_maxf), width=int(_w), height=int(_h),
-    )))
+    _parser = argparse.ArgumentParser()
+    _parser.add_argument("home")
+    _parser.add_argument("trace_id")
+    _parser.add_argument("camera")
+    _parser.add_argument("max_frames", type=int)
+    _parser.add_argument("width", type=int)
+    _parser.add_argument("height", type=int)
+    _parser.add_argument("--world", default="empty")
+    _parser.add_argument("--tool", default="")
+    _parser.add_argument("--result", required=True)
+    _args = _parser.parse_args()
+    _result_path = Path(_args.result)
+    try:
+        _payload: dict = _render_impl(
+            Path(_args.home), _args.trace_id, camera=_args.camera,
+            max_frames=_args.max_frames, width=_args.width,
+            height=_args.height, world_id=_args.world, tool_ref=_args.tool,
+        )
+    except Exception as _exc:  # noqa: BLE001 - 失败也是结构化结果
+        _message = str(_exc)[:300]
+        _code = "RENDER_FAILED"
+        if ":" in _message:
+            _head = _message.split(":", 1)[0]
+            if _head.replace("_", "").isalnum() and _head.isupper():
+                _code, _message = _head, _message.split(":", 1)[1].strip()
+        _payload = {"ok": False, "error_code": _code, "message": _message}
+    _result_path.parent.mkdir(parents=True, exist_ok=True)
+    _tmp = _result_path.with_suffix(".tmp")
+    _tmp.write_text(json.dumps(_payload, ensure_ascii=False), encoding="utf-8")
+    _tmp.replace(_result_path)  # 原子替换——父进程只认完整文件
+    sys.exit(0 if _payload.get("ok") else 1)

--- a/src/rosclaw/task_kernel/plan_executor.py
+++ b/src/rosclaw/task_kernel/plan_executor.py
@@ -51,7 +51,9 @@ class PlanExecutor:
     ) -> PlanExecutionResult:
         refs: dict[str, Any] = {}
         for node in graph.nodes:
-            handler = handlers.get(node.op)
+            # 节点 id 优先于 op——同一 op 可在图中出现多次（如
+            # simulation.render 的 2D 预览与 3D 场景是两个节点）。
+            handler = handlers.get(node.id) or handlers.get(node.op)
             if handler is None:
                 return self._fail(
                     graph,

--- a/tests/agentd/test_r02_task_spec_deliverables.py
+++ b/tests/agentd/test_r02_task_spec_deliverables.py
@@ -131,19 +131,33 @@ def _draw_task(kernel, home: Path, text: str) -> str:
 class TestDeliverableVerification:
     def test_missing_scene_video_not_full_pass(self, tmp_path: Path) -> None:
         """运动执行成功但 required scene_video 未交付 → 不得整体
-        PASS（finish_task 必须含 DELIVERABLE_MISSING）。"""
+        PASS（finish_task 必须含 DELIVERABLE_MISSING）。
+
+        R0-3 后场景链存在——本测试显式注入渲染故障（这正是 Gate
+        R0-2 要求的"把 3D renderer 故意打坏"）。
+        """
+        from rosclaw.agentd import sim_render
         from rosclaw.agentd.task_execution import TaskExecutionService
 
         kernel, conn = _kernel(tmp_path)
         task_id = _draw_task(kernel, tmp_path, "画五角星并做仿真视频")
         kernel.note_tool_use(task_id, "rosclaw_task")
-        outcome = TaskExecutionService(
-            kernel=kernel, conn=conn, home=tmp_path,
-        ).execute(
-            task_id,
-            recipe_inputs={"shape": "star5",
-                           "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
-        )
+        original = sim_render.render_scene_trace
+
+        def broken(*a, **k):
+            raise ValueError("RENDER_BACKEND_UNAVAILABLE: 注入故障")
+
+        sim_render.render_scene_trace = broken  # type: ignore[assignment]
+        try:
+            outcome = TaskExecutionService(
+                kernel=kernel, conn=conn, home=tmp_path,
+            ).execute(
+                task_id,
+                recipe_inputs={"shape": "star5",
+                               "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+            )
+        finally:
+            sim_render.render_scene_trace = original  # type: ignore[assignment]
         # 运动执行成功（refs 全产出）但交付不完整。
         assert "TraceRef" in outcome.refs
         assert not outcome.ok, "required scene_video 缺失不得整体 ok"
@@ -188,22 +202,32 @@ class TestDeliverableVerification:
 
 class TestCoordinatorOutcome:
     def test_partial_delivery_outcome(self, tmp_path: Path) -> None:
-        """Coordinator：执行成功 + required scene_video 缺失 →
-        execution SUCCEEDED + verification PARTIAL + delivery
-        MISSING/PARTIAL——不是整体 VERIFIED/DELIVERED。"""
+        """Coordinator：执行成功 + required scene_video 缺失（注入
+        渲染故障）→ execution SUCCEEDED + verification PARTIAL +
+        delivery MISSING/PARTIAL——不是整体 VERIFIED/DELIVERED。"""
+        from rosclaw.agentd import sim_render
         from rosclaw.agentd.task_execution import TaskExecutionService
         from rosclaw.task_kernel.coordinator import TaskCoordinator
 
         kernel, conn = _kernel(tmp_path)
         task_id = _draw_task(kernel, tmp_path, "画五角星并做仿真视频")
         kernel.note_tool_use(task_id, "rosclaw_task")
-        TaskExecutionService(
-            kernel=kernel, conn=conn, home=tmp_path,
-        ).execute(
-            task_id,
-            recipe_inputs={"shape": "star5",
-                           "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
-        )
+        original = sim_render.render_scene_trace
+
+        def broken(*a, **k):
+            raise ValueError("RENDER_BACKEND_UNAVAILABLE: 注入故障")
+
+        sim_render.render_scene_trace = broken  # type: ignore[assignment]
+        try:
+            TaskExecutionService(
+                kernel=kernel, conn=conn, home=tmp_path,
+            ).execute(
+                task_id,
+                recipe_inputs={"shape": "star5",
+                               "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+            )
+        finally:
+            sim_render.render_scene_trace = original  # type: ignore[assignment]
         outcome = TaskCoordinator(kernel).consider(task_id)
         assert outcome is not None
         assert outcome["execution"] == "SUCCEEDED"
@@ -216,11 +240,20 @@ class TestGateRendererBroken:
     async def test_broken_scene_renderer_honest_partial(
         self, tmp_path: Path
     ) -> None:
-        """Gate R0-2：3D 渲染缺失 → 任务只能 PARTIAL/NEEDS_REPAIR；
-        最终 payload 不得宣称任务完整完成。"""
+        """Gate R0-2：3D renderer 故意打坏 → 任务只能 PARTIAL/
+        NEEDS_REPAIR；最终 payload 不得宣称任务完整完成。"""
         service, mission = await _setup_ur5e(tmp_path)
         # 目标含"仿真视频"——spec 冻结 required scene_video；
-        # 3D 场景渲染链未接通（现状即"renderer 打坏"等价）。
+        # 显式打坏 3D 场景渲染链（R0-3 后链存在，故障必须诚实
+        # 表达为 PARTIAL，不是整体成功也不是整体失败）。
+        from rosclaw.agentd import sim_render
+
+        original = sim_render.render_scene_trace
+
+        def broken(*a, **k):
+            raise ValueError("RENDER_BACKEND_UNAVAILABLE: 注入故障")
+
+        sim_render.render_scene_trace = broken  # type: ignore[assignment]
         kernel = service._task_kernel
         kernel.persist_input(
             mission_id=mission.mission_id, session_ref="pi_1",
@@ -228,18 +261,21 @@ class TestGateRendererBroken:
             text="画五角星并做仿真视频",
         )
         lease = await _issue_lease(service, mission)
-        result = await PiToolDispatcher(service).execute(
-            _request(
-                "rosclaw_task", mission=mission.mission_id,
-                idem="r02_gate", lease=lease,
-                arguments={
-                    "goal": "draw_shape",
-                    "parameters": {"shape": "star5",
-                                   "center_m": [0.35, 0.25, 0.30],
-                                   "scale_m": 0.10},
-                },
+        try:
+            result = await PiToolDispatcher(service).execute(
+                _request(
+                    "rosclaw_task", mission=mission.mission_id,
+                    idem="r02_gate", lease=lease,
+                    arguments={
+                        "goal": "draw_shape",
+                        "parameters": {"shape": "star5",
+                                       "center_m": [0.35, 0.25, 0.30],
+                                       "scale_m": 0.10},
+                    },
+                )
             )
-        )
+        finally:
+            sim_render.render_scene_trace = original  # type: ignore[assignment]
         payload = json.loads(result.summary)
         assert payload["state"] != "VERIFIED", payload
         assert any(

--- a/tests/agentd/test_r03_renderer_supervisor.py
+++ b/tests/agentd/test_r03_renderer_supervisor.py
@@ -1,0 +1,452 @@
+"""R0-3 红测试（0826 体验审计 §5.R0-3）：RendererSupervisor 结构化
+进程协议 + 内核内一次降级 + 熔断范围修复。
+
+真实事故（0826 体验旅程）：
+- sim_render 直接 json.loads(子进程 stdout)——空输出/噪声/rc=0
+  无结果泄漏成裸 JSONDecodeError 给模型；
+- 模型换 camera 参数绕过 doom-loop 指纹，同一基础设施故障被
+  重试三次；
+- scene renderer 用 empty world 且不读 TaskSpec——"桌面/持笔"
+  场景语义缺位（不得假装）。
+
+断言：
+1. 结构化 IPC：子进程写原子 result JSON 文件；stdout/stderr 只
+   作诊断——噪声 stdout 不污染结果；
+2. 稳定错误码：rc=0 无 result → RENDER_RESULT_MISSING（不是
+   JSONDecodeError）；result 坏 → RENDER_RESULT_CORRUPT；缺字
+   段 → RENDER_RESULT_INCOMPLETE；rc!=0 → RENDER_FAILED；
+3. 后端降级内核内一次：首选后端渲染失败 → 自动降级一次；全
+   部失败 → 一条有语义错误（不多次抛给模型）；
+4. 熔断范围：换 camera 不绕过 renderer 失败熔断（指纹不含
+   camera）；
+5. TaskSpec 场景语义：world_ref=tabletop → 场景加载 tabletop；
+   tool_ref=pen 无资产 → TOOL_ASSET_MISSING（不假装持笔）；
+6. recipe 场景节点：spec 要求 scene_video → 场景 GIF+MP4 以
+   scene_3d kind 登记（满足交付）；场景失败 → PARTIAL（2D 交付
+   仍在）；无要求 → 不跑场景渲染；
+7. RenderReceipt 含 world/tool/trace digest。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.agentd.test_r01_production_chain import _kernel
+from tests.agentd.test_r02_task_spec_deliverables import _draw_task
+
+
+def _make_trace(home: Path) -> dict:
+    from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+    sim = SimTrajectoryService(home)
+    plan = sim.generate_planar_path(
+        shape="star5", center_m=[0.35, 0.25, 0.30], scale_m=0.05,
+    )
+    return sim.simulate_cartesian_trajectory(plan["plan_id"])
+
+
+def _fake_run_factory(behaviors):
+    """按 argv 行为表伪造 subprocess.run（结构化协议故障注入）。"""
+    calls: list[list] = []
+
+    class Proc:
+        def __init__(self, rc, out=b"", err=b""):
+            self.returncode = rc
+            self.stdout = out
+            self.stderr = err
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        idx = len(calls) - 1
+        action = behaviors[min(idx, len(behaviors) - 1)]
+        kind = action[0]
+        if kind == "probe_ok":
+            return Proc(0, b"OK")
+        if kind == "probe_fail":
+            return Proc(1, b"", b"no display")
+        if kind == "render_ok":
+            # 结构化协议：写 result 文件（argv 约定含 --result）。
+            result_path = Path(argv[argv.index("--result") + 1])
+            payload = action[1]
+            result_path.parent.mkdir(parents=True, exist_ok=True)
+            result_path.write_text(json.dumps(payload), encoding="utf-8")
+            noise = action[2] if len(action) > 2 else b""
+            return Proc(0, noise, b"")
+        if kind == "render_silent":
+            return Proc(0, b"", b"")  # rc=0 但无 result（事故原型）
+        if kind == "render_corrupt":
+            result_path = Path(argv[argv.index("--result") + 1])
+            result_path.parent.mkdir(parents=True, exist_ok=True)
+            result_path.write_text("{not json", encoding="utf-8")
+            return Proc(0, b"", b"")
+        if kind == "render_rc_fail":
+            return Proc(1, b"", b"GL crashed badly")
+        raise AssertionError(f"unknown fake behavior {action}")
+
+    return fake_run, calls
+
+
+class TestStructuredIPC:
+    def test_empty_stdout_stable_error_not_jsondecode(
+        self, tmp_path: Path
+    ) -> None:
+        """rc=0 但 stdout 空（事故原型）→ RENDER_RESULT_MISSING
+        稳定错误码，绝不泄漏裸 JSONDecodeError。"""
+        from rosclaw.agentd import sim_render
+
+        trace = _make_trace(tmp_path)
+        fake, _calls = _fake_run_factory([
+            ("probe_ok",), ("render_silent",),
+            ("probe_ok",), ("render_silent",),
+            ("probe_ok",), ("render_silent",),
+        ])
+        original = sim_render.subprocess.run
+        sim_render.subprocess.run = fake  # type: ignore[assignment]
+        try:
+            with pytest.raises(ValueError, match="RENDER_RESULT_MISSING"):
+                sim_render.render_scene_trace(
+                    tmp_path, trace["trace_id"],
+                )
+        finally:
+            sim_render.subprocess.run = original  # type: ignore[assignment]
+
+    def test_noisy_stdout_does_not_corrupt_result(
+        self, tmp_path: Path
+    ) -> None:
+        """stdout 带库警告/噪声 → 结果仍从 result 文件读取（不
+        解析 stdout）。"""
+        from rosclaw.agentd import sim_render
+
+        trace = _make_trace(tmp_path)
+        payload = {
+            "ok": True,
+            "artifact": {"path": "/tmp/x.gif", "frames": 60,
+                         "format": "gif", "bytes": 1000},
+            "artifacts": {"gif": {"path": "/tmp/x.gif", "frames": 60},
+                          "mp4": {"path": "/tmp/x.mp4", "frames": 60}},
+            "receipt": {"backend": "egl"},
+        }
+        fake, _calls = _fake_run_factory([
+            ("probe_ok",),
+            ("render_ok", payload, b"WARNING: libGL noise\nOK"),
+        ])
+        original = sim_render.subprocess.run
+        sim_render.subprocess.run = fake  # type: ignore[assignment]
+        try:
+            result = sim_render.render_scene_trace(
+                tmp_path, trace["trace_id"],
+            )
+        finally:
+            sim_render.subprocess.run = original  # type: ignore[assignment]
+        assert result["ok"] is True
+        assert result["artifact"]["frames"] == 60
+
+    def test_corrupt_result_stable_error(self, tmp_path: Path) -> None:
+        from rosclaw.agentd import sim_render
+
+        trace = _make_trace(tmp_path)
+        fake, _calls = _fake_run_factory([
+            ("probe_ok",), ("render_corrupt",),
+            ("probe_ok",), ("render_corrupt",),
+            ("probe_ok",), ("render_corrupt",),
+        ])
+        original = sim_render.subprocess.run
+        sim_render.subprocess.run = fake  # type: ignore[assignment]
+        try:
+            with pytest.raises(ValueError, match="RENDER_RESULT_CORRUPT"):
+                sim_render.render_scene_trace(tmp_path, trace["trace_id"])
+        finally:
+            sim_render.subprocess.run = original  # type: ignore[assignment]
+
+    def test_incomplete_result_stable_error(self, tmp_path: Path) -> None:
+        from rosclaw.agentd import sim_render
+
+        trace = _make_trace(tmp_path)
+        fake, _calls = _fake_run_factory([
+            ("probe_ok",), ("render_ok", {"ok": True}),
+            ("probe_ok",), ("render_ok", {"ok": True}),
+            ("probe_ok",), ("render_ok", {"ok": True}),
+        ])
+        original = sim_render.subprocess.run
+        sim_render.subprocess.run = fake  # type: ignore[assignment]
+        try:
+            with pytest.raises(
+                ValueError, match="RENDER_RESULT_INCOMPLETE"
+            ):
+                sim_render.render_scene_trace(tmp_path, trace["trace_id"])
+        finally:
+            sim_render.subprocess.run = original  # type: ignore[assignment]
+
+    def test_rc_nonzero_render_failed(self, tmp_path: Path) -> None:
+        from rosclaw.agentd import sim_render
+
+        trace = _make_trace(tmp_path)
+        fake, _calls = _fake_run_factory([
+            ("probe_ok",), ("render_rc_fail",),
+            ("probe_ok",), ("render_rc_fail",),
+            ("probe_ok",), ("render_rc_fail",),
+        ])
+        original = sim_render.subprocess.run
+        sim_render.subprocess.run = fake  # type: ignore[assignment]
+        try:
+            with pytest.raises(ValueError, match="RENDER_FAILED"):
+                sim_render.render_scene_trace(tmp_path, trace["trace_id"])
+        finally:
+            sim_render.subprocess.run = original  # type: ignore[assignment]
+
+
+class TestBackendFallbackOnce:
+    def test_fallback_internal_once_then_success(
+        self, tmp_path: Path
+    ) -> None:
+        """首选后端渲染失败 → 内核内降级一次成功——调用方只看到
+        一个成功结果（没有"模型试三次"）。"""
+        from rosclaw.agentd import sim_render
+
+        trace = _make_trace(tmp_path)
+        payload = {
+            "ok": True,
+            "artifact": {"path": "/tmp/x.gif", "frames": 60,
+                         "format": "gif", "bytes": 1000},
+            "artifacts": {"gif": {"path": "/tmp/x.gif", "frames": 60},
+                          "mp4": {"path": "/tmp/x.mp4", "frames": 60}},
+            "receipt": {"backend": "osmesa"},
+        }
+        fake, calls = _fake_run_factory([
+            ("probe_ok",),              # egl probe
+            ("render_silent",),         # egl render 失败（rc=0 无结果）
+            ("probe_ok",),              # osmesa probe
+            ("render_ok", payload),     # osmesa render 成功
+        ])
+        original = sim_render.subprocess.run
+        sim_render.subprocess.run = fake  # type: ignore[assignment]
+        try:
+            result = sim_render.render_scene_trace(
+                tmp_path, trace["trace_id"],
+            )
+        finally:
+            sim_render.subprocess.run = original  # type: ignore[assignment]
+        assert result["ok"] is True
+        renders = [c for c in calls if "--result" in c]
+        assert len(renders) <= 2, f"降级超过一次: {len(renders)}"
+
+    def test_all_backends_fail_single_semantic_error(
+        self, tmp_path: Path
+    ) -> None:
+        """全部后端失败 → 一条有语义错误（RENDER_FAILED/UNAVAILABLE）
+        ——不是三次裸异常。"""
+        from rosclaw.agentd import sim_render
+
+        trace = _make_trace(tmp_path)
+        fake, _calls = _fake_run_factory([
+            ("probe_fail",), ("probe_fail",), ("probe_fail",),
+        ])
+        original = sim_render.subprocess.run
+        sim_render.subprocess.run = fake  # type: ignore[assignment]
+        try:
+            with pytest.raises(
+                ValueError, match="RENDER_BACKEND_UNAVAILABLE|RENDER_FAILED"
+            ):
+                sim_render.render_scene_trace(tmp_path, trace["trace_id"])
+        finally:
+            sim_render.subprocess.run = original  # type: ignore[assignment]
+
+
+class TestSceneContentFromSpec:
+    def test_tabletop_world_loaded(self, tmp_path: Path) -> None:
+        """spec world_ref=world:tabletop → 场景渲染加载 tabletop
+        （不是 empty 冒充桌面）。"""
+        from rosclaw.agentd import sim_render
+
+        created: list[str] = []
+
+        class FakeSandbox:
+            def __init__(self, world: str):
+                self.world = world
+                self.has_physics = True
+                self.load_error = ""
+
+            @classmethod
+            def create(cls, robot, world, engine, publisher=None):
+                created.append(world)
+                return cls(world)
+
+            def close(self):
+                pass
+
+        trace = _make_trace(tmp_path)
+        import contextlib
+
+        import rosclaw.sandbox.sandbox_api as sandbox_api
+
+        original = sandbox_api.Sandbox.create
+        sandbox_api.Sandbox.create = FakeSandbox.create  # type: ignore[assignment]
+        try:
+            # 子进程入口直测：world_id 必须流进 Sandbox.create
+            # （进程边界外 spy 不到子进程）。
+            with contextlib.suppress(Exception):
+                sim_render._render_impl(
+                    tmp_path, trace["trace_id"], camera="follow",
+                    max_frames=4, width=64, height=64,
+                    world_id="tabletop", tool_ref="",
+                )
+        finally:
+            sandbox_api.Sandbox.create = original  # type: ignore[assignment]
+        assert created and created[0] == "tabletop", created
+
+    def test_tool_asset_missing_honest(self, tmp_path: Path) -> None:
+        """spec tool_ref=tool:pen 但无笔资产 → TOOL_ASSET_MISSING
+        （诚实失败，不假装持笔）。"""
+        from rosclaw.agentd import sim_render
+
+        trace = _make_trace(tmp_path)
+        with pytest.raises(ValueError, match="TOOL_ASSET_MISSING"):
+            sim_render.render_scene_trace(
+                tmp_path, trace["trace_id"], tool_ref="tool:pen",
+            )
+
+
+class TestRecipeSceneNode:
+    def test_scene_video_produced_when_required(
+        self, tmp_path: Path
+    ) -> None:
+        """spec 要求 scene_video → recipe 场景节点产出 scene_3d
+        kind 的 GIF+MP4 并满足交付（真实渲染链）。"""
+        from rosclaw.agentd.task_execution import TaskExecutionService
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, "画五角星并做仿真视频")
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        outcome = TaskExecutionService(
+            kernel=kernel, conn=conn, home=tmp_path,
+        ).execute(
+            task_id,
+            recipe_inputs={"shape": "star5",
+                           "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+        )
+        assert outcome.ok, outcome.failures
+        kinds = set()
+        for a in outcome.artifacts:
+            row = kernel._conn.execute(
+                "SELECT metadata_json FROM artifacts WHERE artifact_id = ?",
+                (a["artifact_id"],),
+            ).fetchone()
+            meta = json.loads(str(row["metadata_json"] or "{}"))
+            kinds.add((meta.get("lineage") or {}).get("kind", ""))
+        assert "scene_3d" in kinds, kinds
+        task = kernel.get_task(task_id)
+        assert task["state"] == "SUCCEEDED", task["state"]
+
+    def test_scene_failure_partial_2d_survives(
+        self, tmp_path: Path
+    ) -> None:
+        """场景渲染失败（注入）→ PARTIAL：DELIVERABLE_MISSING
+        scene_video，但 2D 预览交付不受影响（不整体失败）。"""
+        from rosclaw.agentd import sim_render
+        from rosclaw.agentd.task_execution import TaskExecutionService
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, "画五角星并做仿真视频")
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        original = sim_render.render_scene_trace
+
+        def broken(*a, **k):
+            raise ValueError("RENDER_RESULT_MISSING: 注入故障")
+
+        sim_render.render_scene_trace = broken  # type: ignore[assignment]
+        try:
+            outcome = TaskExecutionService(
+                kernel=kernel, conn=conn, home=tmp_path,
+            ).execute(
+                task_id,
+                recipe_inputs={"shape": "star5",
+                               "center_m": [0.35, 0.25, 0.30],
+                               "scale_m": 0.10},
+            )
+        finally:
+            sim_render.render_scene_trace = original  # type: ignore[assignment]
+        assert not outcome.ok
+        assert any(
+            "scene_video" in f for f in outcome.failures
+        ), outcome.failures
+        media = {a["media_type"] for a in outcome.artifacts}
+        assert "image/gif" in media, "2D 预览交付被场景故障拖死"
+
+    def test_no_scene_required_no_scene_render(
+        self, tmp_path: Path
+    ) -> None:
+        """无 scene_video 要求 → 不跑场景渲染（不浪费、不误伤）。"""
+        from rosclaw.agentd import sim_render
+        from rosclaw.agentd.task_execution import TaskExecutionService
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, "画一个五角星")
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        called: list[bool] = []
+        original = sim_render.render_scene_trace
+
+        def spy(*a, **k):
+            called.append(True)
+            return original(*a, **k)
+
+        sim_render.render_scene_trace = spy  # type: ignore[assignment]
+        try:
+            outcome = TaskExecutionService(
+                kernel=kernel, conn=conn, home=tmp_path,
+            ).execute(
+                task_id,
+                recipe_inputs={"shape": "star5",
+                               "center_m": [0.35, 0.25, 0.30],
+                               "scale_m": 0.10},
+            )
+        finally:
+            sim_render.render_scene_trace = original  # type: ignore[assignment]
+        assert outcome.ok, outcome.failures
+        assert not called, "无要求不应跑场景渲染"
+
+
+class TestBreakerScope:
+    async def test_camera_change_does_not_bypass_breaker(
+        self, tmp_path: Path
+    ) -> None:
+        """熔断范围修复：renderer 失败一次后，换 camera 重试同一
+        capability 仍被 DOOM_LOOP 拒绝（指纹不含 camera）。"""
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+        from tests.agentd.test_pi_tool_bridge import (
+            _issue_lease,
+            _request,
+            _setup,
+        )
+
+        service, mission = await _setup(tmp_path)
+        await service._ensure_mcp_discovered()
+        lease = await _issue_lease(service, mission)
+        dispatcher = PiToolDispatcher(service)
+        args_a = {
+            "capability_id": "simulation_render_scene",
+            "arguments": {"trace_id": "trace_nope", "camera": "follow"},
+        }
+        first = await dispatcher.execute(
+            _request(
+                "rosclaw_compute", mission=mission.mission_id,
+                idem="r03_brk_a", lease=lease, arguments=args_a,
+            )
+        )
+        assert not first.ok, "不存在 trace 的渲染必须失败"
+        args_b = {
+            "capability_id": "simulation_render_scene",
+            "arguments": {"trace_id": "trace_nope", "camera": "top"},
+        }
+        second = await dispatcher.execute(
+            _request(
+                "rosclaw_compute", mission=mission.mission_id,
+                idem="r03_brk_b", lease=lease, arguments=args_b,
+            )
+        )
+        assert second.error_code == "DOOM_LOOP", (
+            f"换 camera 绕过了熔断: {second.error_code} {second.summary}"
+        )
+        await service.close()


### PR DESCRIPTION
## 真实事故（0826 体验旅程 + 实施指南 §2.4/§5.R0-3）

- `sim_render` 直接 `json.loads(子进程 stdout)`——空输出/噪声/rc=0 无结果泄漏成裸 `JSONDecodeError` 给模型；
- 模型换 camera 参数绕过 doom-loop 指纹，同一基础设施故障被重试三次；
- scene renderer 用 `empty` world 且不读 TaskSpec——"桌面/持笔"场景语义缺位。

## 闭环内容

- **结构化 IPC**：子进程写原子 result JSON 文件（tmp+replace），stdout/stderr 只作诊断；`rc=0 无 result → RENDER_RESULT_MISSING`、坏 JSON → `RENDER_RESULT_CORRUPT`、缺字段 → `RENDER_RESULT_INCOMPLETE`、rc!=0 → `RENDER_FAILED`——绝无裸 JSONDecodeError 泄漏；
- **后端降级内核内一次**（EGL→OSMesa→Xvfb）——模型只收最终结果，不被要求试后端；
- **熔断指纹剔除易变参数（camera）**——换 camera 不再绕过 renderer 熔断（`capability+参数实质`判定）；
- **场景语义来自 frozen spec**：`world_ref=tabletop` 真实加载 tabletop（不再 empty 冒充）；`tool_ref` 无资产 → `TOOL_ASSET_MISSING` 诚实失败（不假装持笔）；RenderReceipt 增 `world_id`/`tool_ref`；
- **recipe 场景节点**：spec 要求 scene_video 时 DAG 插入 `render_scene`（scene_3d kind + render_receipt 血缘——R0-2 的交付语义第一次能被真正满足）；场景失败 → SceneRef FAILED 不炸图 → verify 产出 PARTIAL（2D 交付不被拖死）；PlanExecutor 按节点 id 优先分派（同 op 多实例合法机制）；
- R0-2 三测试同步演进：场景链存在后"打坏 renderer"改为显式注入（Gate 语义不变——故障 → PARTIAL/NEEDS_REPAIR）。

## 红→绿证据

- 红：`/tmp/r03-red.txt`（9 红）；
- 绿：R0-3 测试 13/13（含真实渲染链 scene_3d 交付 → 任务 SUCCEEDED）；agentd 全套 **727 passed**；PTY 产品旅程 **A/B/C 全绿**；
- **Gate 对齐**：故障注入矩阵（空 stdout/噪声 stdout/坏 JSON/缺字段/rc!=0/全后端不可用）全部一条有语义错误、零模型重试；换 camera 重试被 DOOM_LOOP 拒绝。

## 诚实边界

笔资产当前不存在——`tool:pen` 声明即 `TOOL_ASSET_MISSING`（等资产包落地自然解锁，不假装）。墨迹/接触 overlay 与 verifier 语义在 R0-5。

🤖 Generated with [Claude Code](https://claude.com/claude-code)