### PR TITLE
feat: R0-4 ArtifactRef 用户可达交付面——数据库有文件 ≠ 交付成功（0826 体验审计）

### DIFF
--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -101,6 +101,132 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+# ----------------------------------------------------------------------
+# R0-4（0826 体验审计 §5.R0-4）：artifact 用户可达交付面。
+# ----------------------------------------------------------------------
+
+
+def _artifact_rows(args: argparse.Namespace, artifact_id: str = ""):
+    from rosclaw.agentd.mission.store import MissionStore
+
+    home = _home(args)
+    db_path = home / "agentd" / "missions.db"
+    if not db_path.exists():
+        return None, []
+    store = MissionStore(db_path)
+    conn = store.connection
+    if artifact_id:
+        rows = conn.execute(
+            "SELECT * FROM artifacts WHERE artifact_id = ?", (artifact_id,),
+        ).fetchall()
+    else:
+        task_id = str(getattr(args, "task", "") or "")
+        if task_id:
+            rows = conn.execute(
+                "SELECT * FROM artifacts WHERE task_id = ? "
+                "ORDER BY created_at DESC LIMIT 100",
+                (task_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM artifacts ORDER BY created_at DESC LIMIT 100",
+            ).fetchall()
+    return conn, [dict(r) for r in rows]
+
+
+def _artifact_view(row: dict) -> dict:
+    from rosclaw.task_kernel.deliverables import artifact_delivery_kind
+
+    raw_digest = str(row["sha256"])
+    return {
+        "artifact_id": str(row["artifact_id"]),
+        "task_id": str(row["task_id"]),
+        "kind": artifact_delivery_kind(row),
+        "media_type": str(row["media_type"]),
+        "path": str(row["path"]),
+        "size_bytes": int(row["size_bytes"]),
+        "digest": (
+            raw_digest
+            if raw_digest.startswith("sha256:")
+            else f"sha256:{raw_digest}"
+        ),
+        "open_command": f"rosclaw artifact open {row['artifact_id']}",
+    }
+
+
+def cmd_artifact_list(args: argparse.Namespace) -> int:
+    conn, rows = _artifact_rows(args)
+    if conn is None:
+        print("还没有产物账本（agentd 未初始化）。")
+        return 0
+    views = [_artifact_view(r) for r in rows]
+    if getattr(args, "json", False):
+        print(json.dumps(views, ensure_ascii=False, indent=2))
+        return 0
+    if not views:
+        print("还没有登记的交付物。")
+        return 0
+    for v in views:
+        print(
+            f"  {v['artifact_id']:<28} {v['kind']:<12} {v['media_type']:<16}"
+            f" {v['size_bytes']:>9}B  {v['path']}"
+        )
+    print("\n打开：rosclaw artifact open <id> · 导出：rosclaw artifact export <id> <path>")
+    return 0
+
+
+def cmd_artifact_open(args: argparse.Namespace) -> int:
+    conn, rows = _artifact_rows(args, str(args.artifact_id))
+    if conn is None or not rows:
+        print(f"未知交付物 {args.artifact_id!r}（rosclaw artifact list 可查）")
+        return 2
+    view = _artifact_view(rows[0])
+    path = Path(view["path"])
+    if not path.exists():
+        print(f"交付物文件缺失：{path}（账本登记于 {view['task_id']}）")
+        return 3
+    import shutil
+
+    has_display = bool(
+        os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+    )
+    opener = shutil.which("xdg-open")
+    if has_display and opener:
+        import subprocess
+
+        subprocess.Popen(  # noqa: S603 - 系统 opener，参数无拼接
+            [opener, str(path)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        print(f"已用系统默认程序打开：{path}")
+        return 0
+    # SSH/纯终端：给可复制路径 + 导出提示（OSC 8 链接是有显示时
+    # 的增强，不是依赖）。
+    print(f"{path}")
+    print(f"（无显示环境——导出查看：rosclaw artifact export {view['artifact_id']} <path>）")
+    return 0
+
+
+def cmd_artifact_export(args: argparse.Namespace) -> int:
+    import shutil
+
+    conn, rows = _artifact_rows(args, str(args.artifact_id))
+    if conn is None or not rows:
+        print(f"未知交付物 {args.artifact_id!r}（rosclaw artifact list 可查）")
+        return 2
+    view = _artifact_view(rows[0])
+    src = Path(view["path"])
+    if not src.exists():
+        print(f"交付物文件缺失：{src}（账本登记于 {view['task_id']}）")
+        return 3
+    dest = Path(str(args.dest))
+    if dest.is_dir():
+        dest = dest / src.name
+    shutil.copy2(src, dest)
+    print(f"已导出：{dest}（{view['size_bytes']}B，{view['digest'][:19]}…）")
+    return 0
+
+
 def cmd_learning_list(args: argparse.Namespace) -> int:
     from rosclaw.agentd.learning.pipeline import LearningPipeline
     from rosclaw.agentd.mission import MissionStore
@@ -532,6 +658,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_chat.add_argument("--goal", default=None)
     p_chat.set_defaults(func=cmd_chat)
 
+    p_art = sub.add_parser("artifact", help="交付物查看/打开/导出（R0-4）")
+    art_sub = p_art.add_subparsers(dest="artifact_command", required=True)
+    p_al = art_sub.add_parser("list", help="列出登记的交付物")
+    p_al.add_argument("--task", default="", help="按 task_id 过滤")
+    p_al.add_argument("--json", action="store_true", help="机器可读输出")
+    p_al.set_defaults(func=cmd_artifact_list)
+    p_ao = art_sub.add_parser("open", help="打开交付物（无显示环境给路径）")
+    p_ao.add_argument("artifact_id")
+    p_ao.set_defaults(func=cmd_artifact_open)
+    p_ae = art_sub.add_parser("export", help="导出交付物到指定路径")
+    p_ae.add_argument("artifact_id")
+    p_ae.add_argument("dest")
+    p_ae.set_defaults(func=cmd_artifact_export)
+
     return parser
 
 
@@ -586,6 +726,21 @@ def add_agent_subparsers(subparsers) -> None:
     p_lp.add_argument("--principal", default="user:local:1000")
     p_lp.add_argument("--evaluation-ref", required=True)
     p_lp.set_defaults(func=cmd_learning_promote)
+
+    # R0-4：交付物用户可达面（SSH/纯终端一等）。
+    p_art = subparsers.add_parser("artifact", help="交付物查看/打开/导出")
+    art_sub = p_art.add_subparsers(dest="artifact_command", required=True)
+    p_al = art_sub.add_parser("list", help="列出登记的交付物")
+    p_al.add_argument("--task", default="", help="按 task_id 过滤")
+    p_al.add_argument("--json", action="store_true", help="机器可读输出")
+    p_al.set_defaults(func=cmd_artifact_list)
+    p_ao = art_sub.add_parser("open", help="打开交付物（无显示环境给路径）")
+    p_ao.add_argument("artifact_id")
+    p_ao.set_defaults(func=cmd_artifact_open)
+    p_ae = art_sub.add_parser("export", help="导出交付物到指定路径")
+    p_ae.add_argument("artifact_id")
+    p_ae.add_argument("dest")
+    p_ae.set_defaults(func=cmd_artifact_export)
 
     p_chat = subparsers.add_parser("chat", help="chat with the Native Agent")
     # 十一审 PR-D：rosclaw chat [PATH]——Project workspace 一等状态。

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -80,15 +80,19 @@ _FORMAT_MEDIA = {
 
 def _auto_register_artifacts(
     service, request: PiToolRequestV1, value: object
-) -> None:
+) -> list[dict]:
     """capability 产物自动登记（producer=kernel:capability:<id>，
     幂等——同内容重复登记返回同一 ArtifactRef）。
 
     产物生成即 effectful（0824 总纲 §8.1：可信 capability 产生的
     artifact 必须自动登记）——首次产出时原子 admission（模型不
-    需要也不应该手动 deliver capability 产物）。"""
+    需要也不应该手动 deliver capability 产物）。
+
+    R0-4：返回登记的 ArtifactRef 列表（id/kind/media/digest/
+    open_command）——ToolResult 投影必须带回模型（登记了但模型
+    看不到 = 交付失败）。"""
     if not isinstance(value, dict):
-        return
+        return []
     kernel = service._task_kernel
     mission = service.get_mission(request.mission_id)
     bound = kernel.ensure_task_for_effect(
@@ -101,7 +105,7 @@ def _auto_register_artifacts(
     )
     task = kernel.get_task(str(bound["task_id"]))
     if task is None:
-        return
+        return []
     candidates: list[dict] = []
     for key in _ARTIFACT_SCALAR_KEYS:
         item = value.get(key)
@@ -121,30 +125,55 @@ def _auto_register_artifacts(
     capability_id = str(
         (request.arguments or {}).get("capability_id") or request.tool_name
     )
+    registered: list[dict] = []
     for item in candidates:
         path = str(item["path"])
         fmt = str(item.get("format") or path.rsplit(".", 1)[-1])
         try:
-            kernel.register_artifact(
+            record = kernel.register_artifact(
                 task_id=str(task["task_id"]), path=path,
                 media_type=_FORMAT_MEDIA.get(fmt, "application/octet-stream"),
                 producer=f"kernel:capability:{capability_id}",
             )
         except ValueError:
             continue  # 文件缺失等由验收表达——登记不阻断工具结果
+        registered.append({
+            "artifact_id": str(record["artifact_id"]),
+            "media_type": str(record["media_type"]),
+            "path": str(record["path"]),
+            "size_bytes": int(record["size_bytes"]),
+            "digest": str(record["sha256"]),
+            "open_command": f"rosclaw artifact open {record['artifact_id']}",
+        })
+    return registered
 
 
-def _envelope_result(request: PiToolRequestV1, envelope) -> PiToolResultV1:
+def _envelope_result(
+    request: PiToolRequestV1, envelope, *, auto_refs: list[dict] | None = None
+) -> PiToolResultV1:
     """N5B：canonical envelope → 模型可见投影（status + capability_id +
-    value）；FAILED/BLOCKED 以稳定错误码诚实抛出。"""
+    value）；FAILED/BLOCKED 以稳定错误码诚实抛出。
+
+    R0-4：artifact_refs = 能力声明 refs + 内核自动登记 refs（按
+    artifact_id 去重）——登记了但模型看不到 = 交付失败。"""
     if envelope.status.value == "SUCCEEDED":
         projection = {
             "status": envelope.status.value,
             "capability_id": envelope.capability_id,
             "value": envelope.value,
         }
-        if envelope.artifact_refs:
-            projection["artifact_refs"] = list(envelope.artifact_refs)
+        refs: list[dict] = []
+        seen: set[str] = set()
+        for ref in [*(auto_refs or []), *(envelope.artifact_refs or [])]:
+            if not isinstance(ref, dict):
+                continue
+            key = str(ref.get("artifact_id") or ref.get("path") or "")
+            if key and key in seen:
+                continue
+            seen.add(key)
+            refs.append(ref)
+        if refs:
+            projection["artifact_refs"] = refs
         return PiToolResultV1(
             request_id=request.request_id,
             ok=True,
@@ -451,8 +480,10 @@ class PiToolDispatcher:
             envelope = await service._tool_catalog.execute_v2(
                 request.request_id, capability_id, dict(args.get("arguments", {}))
             )
-            _auto_register_artifacts(service, request, envelope.value)
-            return _envelope_result(request, envelope)
+            auto_refs = _auto_register_artifacts(
+                service, request, envelope.value
+            )
+            return _envelope_result(request, envelope, auto_refs=auto_refs)
         if name == "rosclaw_compute":
             # 七审 §2.2/PR-SEVEN-2.2：COMPUTE 能力免审批调用（纯计算无
             # 物理副作用）——不再被 observe 的 OBSERVE-only 拒绝。
@@ -478,8 +509,10 @@ class PiToolDispatcher:
             envelope = await service._tool_catalog.execute_v2(
                 request.request_id, capability_id, dict(args.get("arguments", {}))
             )
-            _auto_register_artifacts(service, request, envelope.value)
-            return _envelope_result(request, envelope)
+            auto_refs = _auto_register_artifacts(
+                service, request, envelope.value
+            )
+            return _envelope_result(request, envelope, auto_refs=auto_refs)
         if name == "rosclaw_verify":
             receipts = [
                 e.payload

--- a/src/rosclaw/agentd/task_execution.py
+++ b/src/rosclaw/agentd/task_execution.py
@@ -162,23 +162,9 @@ class TaskExecutionService:
         )
 
     def _ledger_artifacts(self, task_id: str) -> list[dict[str, Any]]:
-        """产物账本视图（id/path/media_type/bytes——用户可见交付的
-        原料；不是"目录里有文件"）。"""
-        rows = self._conn.execute(
-            "SELECT artifact_id, path, media_type, size_bytes, producer "
-            "FROM artifacts WHERE task_id = ? ORDER BY created_at",
-            (task_id,),
-        ).fetchall()
-        return [
-            {
-                "artifact_id": str(r["artifact_id"]),
-                "path": str(r["path"]),
-                "media_type": str(r["media_type"]),
-                "size_bytes": int(r["size_bytes"]),
-                "producer": str(r["producer"]),
-            }
-            for r in rows
-        ]
+        """产物账本的用户可见视图（R0-4：id/kind/media/size/
+        digest/open_command——不是"目录里有文件"）。"""
+        return self._kernel.artifact_refs_for(task_id)
 
 
 __all__ = ["TaskExecutionOutcome", "TaskExecutionService"]

--- a/src/rosclaw/task_kernel/coordinator.py
+++ b/src/rosclaw/task_kernel/coordinator.py
@@ -246,6 +246,11 @@ class TaskCoordinator:
                 "trust": trust,
                 "levels": levels,
             },
+            # R0-4：用户可见交付视图（id/kind/media/size/digest/
+            # open_command）——数据库里有文件 ≠ 交付成功。
+            "artifact_refs": self._kernel.artifact_refs_for(
+                str(task["task_id"])
+            ),
             "blocked_on": [],
             "created_at": created_at,
         }

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -931,6 +931,40 @@ class TaskKernel:
             return None
         return json.loads(row["task_spec_json"])
 
+    def artifact_refs_for(self, task_id: str) -> list[dict[str, Any]]:
+        """R0-4（0826 体验审计 §5.R0-4）：用户可见 ArtifactRef 视图
+        ——id/kind/media_type/size/digest/open_command。
+
+        "数据库里有文件"不等于交付成功：交付面（ToolResult/
+        TaskOutcome/CLI）只认这份带 open_command 的视图。
+        """
+        from rosclaw.task_kernel.deliverables import artifact_delivery_kind
+
+        rows = self._conn.execute(
+            "SELECT * FROM artifacts WHERE task_id = ? ORDER BY created_at",
+            (task_id,),
+        ).fetchall()
+        refs: list[dict[str, Any]] = []
+        for row in rows:
+            artifact = dict(row)
+            artifact_id = str(artifact["artifact_id"])
+            raw_digest = str(artifact["sha256"])
+            refs.append({
+                "artifact_id": artifact_id,
+                "kind": artifact_delivery_kind(artifact),
+                "media_type": str(artifact["media_type"]),
+                "path": str(artifact["path"]),
+                "size_bytes": int(artifact["size_bytes"]),
+                "digest": (
+                    raw_digest
+                    if raw_digest.startswith("sha256:")
+                    else f"sha256:{raw_digest}"
+                ),
+                "producer": str(artifact.get("producer") or ""),
+                "open_command": f"rosclaw artifact open {artifact_id}",
+            })
+        return refs
+
     def accept_task(self, task_id: str) -> None:
         """/done：用户接受（PR-N0）——SUCCEEDED 永久关闭；此后新消息
         开新任务，不污染已接受结果。"""

--- a/tests/agentd/test_r04_artifact_delivery.py
+++ b/tests/agentd/test_r04_artifact_delivery.py
@@ -1,0 +1,219 @@
+"""R0-4 红测试（0826 体验审计 §5.R0-4）：ArtifactRef 用户可达交付面。
+
+真实事故（0826 体验旅程）：MP4 生成并登记了，但模型/用户看不到
+——"数据库里有文件"被当成了"交付成功"。
+
+断言：
+1. TaskOutcome 带用户可见 artifact_refs（artifact_id/kind/
+   media_type/size/digest/open_command）——不是只有内部路径；
+2. capability 产物自动登记后，artifact_refs 回进 ToolResult
+   投影（模型看得到登记结果，不再被要求手动 deliver）；
+3. `rosclaw artifact list/open/export` CLI：纯终端/SSH 环境
+   artifact 可达（export 复制文件、open 无 DISPLAY 时给路径
+   不失败）；
+4. Gate：rosclaw_task 成功路径的 payload.artifact_refs 每条都
+   含 artifact_id + open_command（用户最终答案可引用可打开
+   的交付物；数据库有但用户面不可达 = 失败）。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _issue_lease, _request
+from tests.agentd.test_r01_production_chain import _kernel, _setup_ur5e
+from tests.agentd.test_r02_task_spec_deliverables import _draw_task
+
+
+class TestOutcomeArtifactRefs:
+    def test_outcome_includes_user_visible_refs(self, tmp_path: Path) -> None:
+        """Coordinator outcome 必须带 artifact_refs（id/kind/media/
+        size/digest/open_command）——用户可达交付的权威视图。"""
+        from rosclaw.agentd.task_execution import TaskExecutionService
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, "画一个五角星")
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        TaskExecutionService(
+            kernel=kernel, conn=conn, home=tmp_path,
+        ).execute(
+            task_id,
+            recipe_inputs={"shape": "star5",
+                           "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+        )
+        outcome = TaskCoordinator(kernel).consider(task_id)
+        assert outcome is not None
+        refs = outcome.get("artifact_refs")
+        assert refs, f"outcome 缺 artifact_refs：{outcome}"
+        gif = [r for r in refs if r.get("media_type") == "image/gif"]
+        mp4 = [r for r in refs if r.get("media_type") == "video/mp4"]
+        assert gif and mp4, refs
+        for ref in refs:
+            assert ref.get("artifact_id"), ref
+            assert ref.get("kind"), ref
+            assert ref.get("size_bytes", 0) > 0, ref
+            assert ref.get("digest", "").startswith("sha256:"), ref
+            assert ref.get("open_command", "").startswith(
+                "rosclaw artifact open "
+            ), ref
+
+
+class TestCapabilityArtifactRefs:
+    async def test_auto_register_returns_refs_in_projection(
+        self, tmp_path: Path
+    ) -> None:
+        """capability 产物自动登记 → artifact_refs（含 kernel
+        artifact_id）回进 ToolResult 投影——模型不需要也不应该
+        手动 deliver capability 产物。"""
+        service, mission = await _setup_ur5e(tmp_path)
+        await service._ensure_mcp_discovered()
+        lease = await _issue_lease(service, mission)
+        # 真实 trace（render capability 的输入）。
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        sim = SimTrajectoryService(tmp_path)
+        plan = sim.generate_planar_path(
+            shape="star5", center_m=[0.35, 0.25, 0.30], scale_m=0.08,
+        )
+        rollout = sim.simulate_cartesian_trajectory(plan["plan_id"])
+        dispatcher = PiToolDispatcher(service)
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_compute", mission=mission.mission_id,
+                idem="r04_cap", lease=lease,
+                arguments={
+                    "capability_id": "simulation_render_trace",
+                    "arguments": {"trace_id": rollout["trace_id"]},
+                },
+            )
+        )
+        assert result.ok, result.summary
+        projection = json.loads(result.summary)
+        refs = projection.get("artifact_refs") or []
+        assert refs, f"投影缺 artifact_refs：{projection}"
+        assert any(str(r.get("artifact_id", "")).startswith("art_")
+                   for r in refs), refs
+        assert all(r.get("open_command") for r in refs), refs
+        await service.close()
+
+
+class TestArtifactCli:
+    def _register_one(self, tmp_path: Path) -> tuple[str, Path]:
+        """文件账本（CLI 直读 <home>/agentd/missions.db——与生产
+        同一事实源，不是 :memory:）。"""
+        import sqlite3
+
+        from rosclaw.storage.migrations import MigrationRunner
+        from rosclaw.task_kernel.service import TaskKernel
+
+        (tmp_path / "agentd").mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(
+            tmp_path / "agentd" / "missions.db", check_same_thread=False
+        )
+        conn.row_factory = sqlite3.Row
+        MigrationRunner().apply(conn, "sqlite")
+        kernel = TaskKernel(conn, tmp_path)
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="画一个五角星",
+        )
+        bound = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        f = tmp_path / "star.gif"
+        f.write_bytes(b"GIF89a" + b"\x00" * 256)
+        record = kernel.register_artifact(
+            task_id=str(bound["task_id"]), path=str(f),
+            media_type="image/gif", producer="kernel:test",
+        )
+        conn.commit()
+        conn.close()
+        return str(record["artifact_id"]), f
+
+    def test_artifact_list(self, tmp_path: Path, capsys) -> None:
+        artifact_id, f = self._register_one(tmp_path)
+        from rosclaw.agentd.cli import main as agentd_main
+
+        rc = agentd_main([
+            "--home", str(tmp_path), "artifact", "list", "--json",
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        listing = json.loads(out)
+        assert any(
+            a["artifact_id"] == artifact_id and a["path"] == str(f)
+            for a in listing
+        ), listing
+
+    def test_artifact_export_copies_file(self, tmp_path: Path) -> None:
+        artifact_id, f = self._register_one(tmp_path)
+        from rosclaw.agentd.cli import main as agentd_main
+
+        dest = tmp_path / "exported.gif"
+        rc = agentd_main([
+            "--home", str(tmp_path), "artifact", "export",
+            artifact_id, str(dest),
+        ])
+        assert rc == 0
+        assert dest.exists()
+        assert dest.read_bytes() == f.read_bytes()
+
+    def test_artifact_open_headless_prints_path(
+        self, tmp_path: Path, capsys, monkeypatch
+    ) -> None:
+        """SSH/纯终端（无 DISPLAY）→ open 不失败，给出可复制的
+        路径与 export 提示（OSC 8/xdg-open 是有显示时的增强）。"""
+        artifact_id, f = self._register_one(tmp_path)
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        from rosclaw.agentd.cli import main as agentd_main
+
+        rc = agentd_main([
+            "--home", str(tmp_path), "artifact", "open", artifact_id,
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert str(f) in out, out
+
+    def test_artifact_open_unknown_id_honest(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.cli import main as agentd_main
+
+        rc = agentd_main([
+            "--home", str(tmp_path), "artifact", "open", "art_nope",
+        ])
+        assert rc != 0
+
+
+class TestGateUserVisibleDelivery:
+    async def test_payload_refs_openable(self, tmp_path: Path) -> None:
+        """Gate R0-4：成功 payload 的 artifact_refs 每条含
+        artifact_id + open_command——用户最终答案可引用可打开的
+        交付物（DB 有但用户面不可达 = 失败）。"""
+        service, mission = await _setup_ur5e(tmp_path)
+        lease = await _issue_lease(service, mission)
+        result = await PiToolDispatcher(service).execute(
+            _request(
+                "rosclaw_task", mission=mission.mission_id,
+                idem="r04_gate", lease=lease,
+                arguments={
+                    "goal": "draw_shape",
+                    "parameters": {"shape": "star5"},
+                },
+            )
+        )
+        assert result.ok, result.summary
+        payload = json.loads(result.summary)
+        refs = payload.get("artifact_refs") or []
+        assert refs, payload
+        for ref in refs:
+            assert ref.get("artifact_id"), ref
+            assert ref.get("open_command", "").startswith(
+                "rosclaw artifact open "
+            ), ref
+        media = {r.get("media_type") for r in refs}
+        assert "image/gif" in media and "video/mp4" in media, media
+        await service.close()


### PR DESCRIPTION
## 真实事故（0826 体验旅程 + 实施指南 §2.3/§5.R0-4）

MP4 生成并登记了，但模型/用户看不到——"数据库里有文件"被当成"交付成功"（内核成功、产品失败）。

## 闭环内容

- **TaskKernel.artifact_refs_for(task_id)**：用户可见 ArtifactRef 权威视图（artifact_id/kind/media_type/size/digest（canonical `sha256:` 前缀）/open_command）；
- **TaskOutcome 带 artifact_refs**（Coordinator 六维之外的交付面——outcome 与交付物同源）；
- **capability 自动登记 refs 回进 ToolResult 投影**（按 artifact_id 去重——登记了但模型看不到 = 交付失败；模型不再被要求手动 deliver capability 产物）；
- **rosclaw_task payload.artifact_refs** 同一视图（R0-1 的 MP4 修复接上用户可达面）；
- **新 CLI `rosclaw artifact list/open/export`**——SSH/纯终端一等（open 无 DISPLAY 给可复制路径不失败；export 实复制）；同时挂 agentd 与 rosclaw 两个 CLI 面。

## 红→绿证据

- 红：`/tmp/r04-red.txt`（7 红）；
- 绿：R0-4 测试 7/7；agentd 全套 **734 passed**；PTY 产品旅程 **A/B/C 全绿**；
- **Gate R0-4**：成功 payload 的 artifact_refs 每条含 artifact_id + open_command——用户最终答案可引用可打开的交付物；DB 有但用户面不可达 = 失败（测试钉住）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)