### PR TITLE
feat: R0-6 Readiness 单源与启动事务——启动瞬态不再伪装成稳态故障（0826 体验审计）

### DIFF
--- a/packages/rosclaw-agent/src/extension/context-injection.ts
+++ b/packages/rosclaw-agent/src/extension/context-injection.ts
@@ -43,6 +43,41 @@ export interface ContextFetchResult {
 	activeRun?: ActiveRunInfo;
 }
 
+/** R0-6（0826 体验审计 §5.R0-6 item 5）：SIM recipe 前 stale
+ *  context 自动 refresh（一次——不循环烧调用）；REAL 不自动刷新
+ *  （fail closed——内核 admission 裁决，不替它放宽）。 */
+export async function ensureFreshContextForSim(
+	rosclawHome: string,
+	active: {
+		current: {
+			mode: string;
+			missionId?: string;
+			sessionId?: string;
+			contextState: string;
+		};
+		applyEnvelope: (
+			envelope: EmbodiedContextEnvelope,
+			contextLeaseId?: string,
+		) => void;
+	},
+	call: typeof bridgeCall,
+): Promise<void> {
+	const state = active.current;
+	if (state.mode !== "SIMULATION") return; // REAL/SHADOW fail closed
+	if (state.contextState === "FRESH") return;
+	if (!state.missionId) return;
+	const fetched = await fetchEmbodiedContext(
+		rosclawHome,
+		state.missionId,
+		state.sessionId,
+		call,
+	);
+	if (!fetched.stale && fetched.envelope) {
+		active.applyEnvelope(fetched.envelope, fetched.contextLeaseId);
+	}
+}
+
+
 /** 与 Python json.dumps(sort_keys=True, separators=(",", ":")) 逐字节一致。 */
 function canonicalJson(value: unknown): string {
 	if (value === null || value === undefined) return "null";

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -262,6 +262,9 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			// locale）触发同一次 chrome 重绘。
 			center.subscribe(() => refreshChrome());
 			locale.subscribe(() => refreshChrome());
+			// R0-6：启动事务——bridge ping 有限重试（内核行为不耗
+			// token）；完成前 chrome 显示"正在准备"，不是假 Blocked。
+			void center.bootstrap();
 			// 真实探测 operatord——结果回来后经 subscribe 统一重绘
 			// （OFFLINE/READY/UNKNOWN 都是真实返回值，绝不硬编码 ready）。
 			void center.probeOperator();

--- a/packages/rosclaw-agent/src/i18n/catalog.en-US.ts
+++ b/packages/rosclaw-agent/src/i18n/catalog.en-US.ts
@@ -12,6 +12,7 @@ export const CATALOG_EN: Record<CatalogKey, string> = {
 	"chrome.sim_auto": "SIM auto",
 	"chrome.action": "Action",
 	"chrome.unbound": "No Mission bound · /help for commands",
+	"chrome.preparing": "Preparing (connecting kernel)…",
 	"chrome.no_model": "No model selected",
 	"mode.SIMULATION": "Simulation",
 	"mode.SHADOW": "Shadow",

--- a/packages/rosclaw-agent/src/i18n/catalog.zh-CN.ts
+++ b/packages/rosclaw-agent/src/i18n/catalog.zh-CN.ts
@@ -10,6 +10,7 @@ export const CATALOG_ZH = {
 	"chrome.sim_auto": "SIM 自动",
 	"chrome.action": "动作",
 	"chrome.unbound": "未绑定 Mission · /help 查看命令",
+	"chrome.preparing": "正在准备（连接内核）…",
 	"chrome.no_model": "未选模型",
 	"mode.SIMULATION": "仿真",
 	"mode.SHADOW": "影子",

--- a/packages/rosclaw-agent/src/session/state-center.ts
+++ b/packages/rosclaw-agent/src/session/state-center.ts
@@ -29,7 +29,7 @@ export type KernelState = "READY" | "UNREACHABLE";
 export type ContextState = "LOADING" | "FRESH" | "STALE" | "UNAVAILABLE";
 export type LeaseState = "ACTIVE" | "LOST" | "NONE";
 export type OperatorState = "READY" | "OFFLINE" | "UNKNOWN";
-export type ReadinessState = "READY" | "BLOCKED" | "DEGRADED";
+export type ReadinessState = "READY" | "BLOCKED" | "DEGRADED" | "PREPARING";
 
 /** ActionReadinessV1（六审 §3.3）：工具侧硬门 + UI 首要受阻原因。 */
 export interface ActionReadinessV1 {
@@ -92,6 +92,12 @@ type Listener = () => void;
 export class ProductStateCenter {
 	private seq = 0;
 	private kernelState: KernelState = "READY";
+	/** R0-6（0826 体验审计 §5.R0-6）：启动事务——bootstrap 完成前
+	 *  chrome/ready 显示"正在准备"（不是 Kernel Unreachable +
+	 *  Context Stale + Action Blocked 三连假真相）。 */
+	private bootstrapState: "PENDING" | "READY" | "DEGRADED" = "PENDING";
+	private bootstrapPromise: Promise<void> | null = null;
+	private recovering = false;
 	private operatorState: OperatorState = "UNKNOWN";
 	private lastOperatorProbe = 0;
 	private modelDisplay = "";
@@ -171,6 +177,16 @@ export class ProductStateCenter {
 	/** ActionReadinessV1：UI 提前诚实拒绝；内核 admission 仍是最终权威。 */
 	private computeReadiness(): ActionReadinessV1 {
 		const state = this.deps.active.current;
+		// R0-6：启动事务未完成 → PREPARING（不是 Kernel Unreachable +
+		// Context Stale + Action Blocked 三连假真相——启动瞬态不是
+		// 稳态事实）。
+		if (this.bootstrapState === "PENDING") {
+			return {
+				state: "PREPARING",
+				reason_codes: ["BOOTSTRAP"],
+				snapshot_seq: this.seq,
+			};
+		}
 		const codes: string[] = [];
 		if (!state.missionId) codes.push("NO_MISSION");
 		if (this.kernelState !== "READY") codes.push("KERNEL_UNREACHABLE");
@@ -200,6 +216,62 @@ export class ProductStateCenter {
 	async actionReadiness(): Promise<ActionReadinessV1> {
 		await this.probeOperator(true);
 		return this.computeReadiness();
+	}
+
+	/** R0-6：启动事务——bridge ping 有限重试（内核行为，不消耗
+	 *  模型 token）；成功 READY，耗尽诚实 UNREACHABLE（稳态事实
+	 *  才上屏）。幂等：并发/重复调用共享同一事务。 */
+	async bootstrap(): Promise<void> {
+		if (this.bootstrapState === "READY") return;
+		if (this.bootstrapPromise) return this.bootstrapPromise;
+		this.bootstrapPromise = (async () => {
+			const delays = [0, 500, 1500];
+			for (let attempt = 0; attempt < delays.length; attempt += 1) {
+				if (delays[attempt] > 0) {
+					await new Promise((resolve) =>
+						setTimeout(resolve, delays[attempt]),
+					);
+				}
+				try {
+					await this.callFn(this.deps.rosclawHome, "pi.status", {});
+					this.kernelState = "READY";
+					this.bootstrapState = "READY";
+					this.changed();
+					return;
+				} catch {
+					// 下一次重试（启动瞬态——不上屏为稳态）。
+				}
+			}
+			this.kernelState = "UNREACHABLE";
+			this.bootstrapState = "DEGRADED";
+			this.deps.active.markContextStale("kernel unreachable");
+			this.changed();
+		})().finally(() => {
+			this.bootstrapPromise = null;
+		});
+		return this.bootstrapPromise;
+	}
+
+	/** R0-6：运行期瞬态失败后的内核有限重连（不消耗模型
+	 *  token）——成功即 READY 并原位刷新 chrome。 */
+	async recoverKernel(): Promise<void> {
+		if (this.kernelState !== "UNREACHABLE" || this.recovering) return;
+		this.recovering = true;
+		try {
+			for (let attempt = 0; attempt < 2; attempt += 1) {
+				try {
+					await this.callFn(this.deps.rosclawHome, "pi.status", {});
+					this.kernelState = "READY";
+					this.bootstrapState = "READY";
+					this.changed();
+					return;
+				} catch {
+					// 仍不可达——保持诚实 UNREACHABLE。
+				}
+			}
+		} finally {
+			this.recovering = false;
+		}
 	}
 
 	get isSimAutoPolicy(): boolean {
@@ -233,6 +305,9 @@ export class ProductStateCenter {
 				this.deps.active.markContextStale("kernel unreachable");
 			}
 			this.changed();
+			// R0-6：瞬态失败内核有限重连（不消耗模型 token）——
+			// 成功后原位刷新，失败保持诚实 UNREACHABLE。
+			void this.recoverKernel();
 			throw err;
 		}
 	}

--- a/packages/rosclaw-agent/src/tools/task.ts
+++ b/packages/rosclaw-agent/src/tools/task.ts
@@ -14,6 +14,7 @@
 
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool } from "@earendil-works/pi-coding-agent";
+import { ensureFreshContextForSim } from "../extension/context-injection.js";
 import type { BridgeToolContext } from "./bridge-tools.js";
 
 const AWAIT_TIMEOUT_MS = 330_000;
@@ -43,6 +44,13 @@ export function buildTaskTool(ctx: BridgeToolContext) {
 					isError: true,
 				};
 			}
+			// R0-6：SIM stale context 在 recipe 前自动 refresh（REAL
+			// 不刷新——fail closed 由内核 admission 裁决）。
+			await ensureFreshContextForSim(
+				ctx.rosclawHome,
+				ctx.active,
+				(home, method, params2) => ctx.center.call(method, params2),
+			);
 			const callTask = (args: Record<string, unknown>, idemSuffix: string) =>
 				ctx.center.call("pi.tools.execute", {
 					request: {

--- a/packages/rosclaw-agent/src/ui/product-state.ts
+++ b/packages/rosclaw-agent/src/ui/product-state.ts
@@ -69,6 +69,11 @@ export function renderHeader(
 	if (!state.mission_id) {
 		return `${line1}\n${t("chrome.unbound", locale)}`;
 	}
+	// R0-6：启动事务未完成 → "正在准备"（不是 Unreachable/Stale/
+	// Blocked 三连——启动瞬态不是稳态事实）。
+	if (state.action_readiness.state === "PREPARING") {
+		return `${line1}\n${t("chrome.preparing", locale)}`;
+	}
 	const body = state.body_display ?? state.body_id ?? t("state.LOADING", locale);
 	const contextState = t(`state.${state.context_state}` as never, locale);
 	const context =

--- a/packages/rosclaw-agent/test/r06-readiness.test.ts
+++ b/packages/rosclaw-agent/test/r06-readiness.test.ts
@@ -1,0 +1,188 @@
+/** R0-6 红测试（0826 体验审计 §5.R0-6）：Readiness 单源与启动事务。
+ *
+ * 真实事故（0826 体验旅程）：Header 同时显示 Kernel Unreachable +
+ * Context Stale + Action Blocked，同一会话却成功完成 SIM 任务——
+ * 状态系统不可信（启动瞬态被当成稳态真相呈现）。
+ *
+ * 断言：
+ * 1. 启动 barrier：bootstrap 未完成时 readiness 是 PREPARING（不是
+ *    BLOCKED），Header 显示"正在准备"——不显示 Unreachable/
+ *    Stale/Blocked 三连；
+ * 2. bootstrap 成功 → READY；全部重试失败 → 诚实 UNREACHABLE
+ *    （有限重试，不是无限也不是一次定死）；
+ * 3. 运行期瞬态失败 → 内核有限重连（不消耗模型 token）成功后
+ *    恢复 READY；
+ * 4. SIM auto 下 OPERATOR_OFFLINE 不是 blocker（信息提示）；
+ * 5. UI 与 admission 同一 snapshot_seq（一致性钉住）；
+ * 6. SIM stale context 在 recipe 前自动 refresh；REAL 不自动刷新
+ *    （fail closed）。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+async function makeActive(overrides: Record<string, unknown> = {}) {
+	const { ActiveSessionContext } = await import("../src/session/active-context.js");
+	return new ActiveSessionContext({
+		sessionId: "pi_r06",
+		missionId: "mis_1",
+		contextRevision: 3,
+		mode: "SIMULATION",
+		profile: "developer",
+		contextState: "FRESH",
+		leaseState: "ACTIVE",
+		actionsAllowed: true,
+		contextLeaseId: "vcl_1",
+		bodyId: "sim/ur5e",
+		bodyHash: "body_x",
+		...overrides,
+	});
+}
+
+// 通用成功响应（capabilities 必须带 action_capabilities——否则
+// ROBOT_KIT_INCOMPLETE blocker 干扰 readiness 断言）。
+function okPayload(method: string): Record<string, unknown> {
+	if (method === "pi.capabilities") {
+		return { ok: true, action_capabilities: [{ tool_id: "ur5e.move_to_pose" }] };
+	}
+	return { ok: true };
+}
+
+function centerWith(
+	call: (home: string, method: string) => Promise<Record<string, unknown>>,
+	active: unknown,
+) {
+	return import("../src/session/state-center.js").then(
+		({ ProductStateCenter }) =>
+			new ProductStateCenter({
+				rosclawHome: "/tmp/rh-r06",
+				active: active as never,
+				operatorSocket: "/tmp/rh-r06/run/operatord.sock",
+				productVersion: "1.2.0",
+				call: call as never,
+				operatorCallFn: (async () => ({ ok: true })) as never,
+			}),
+	);
+}
+
+test("启动 barrier：bootstrap 未完成 = PREPARING（不是 BLOCKED 三连）", async () => {
+	// 桥调用挂起（启动慢）——bootstrap 期间的 UI/ready 必须是
+	// "正在准备"，不是 Kernel Unreachable + Context Stale +
+	// Action Blocked。
+	const center = await centerWith(
+		() => new Promise(() => undefined),
+		await makeActive(),
+	);
+	const readiness = center.snapshot().action_readiness;
+	assert.equal(
+		readiness.state,
+		"PREPARING",
+		`bootstrap 期应 PREPARING 而非 ${readiness.state}（${readiness.reason_codes}）`,
+	);
+	const { renderHeader } = await import("../src/ui/product-state.js");
+	const header = renderHeader(center.snapshot(), "en-US");
+	assert.match(header, /preparing|Preparing|准备/);
+	assert.ok(!header.includes("Unreachable"), header);
+	assert.ok(!header.includes("Blocked"), header);
+});
+
+test("bootstrap 成功 → READY（一次成功即不再 PREPARING）", async () => {
+	const center = await centerWith(
+		async (_home, method) => okPayload(String(method)),
+		await makeActive(),
+	);
+	await center.bootstrap();
+	const snap = center.snapshot();
+	assert.equal(snap.kernel, "READY");
+	assert.equal(snap.action_readiness.state, "READY");
+});
+
+test("bootstrap 有限重试后诚实 UNREACHABLE（不是一次定死）", async () => {
+	let attempts = 0;
+	const center = await centerWith(
+		async () => {
+			attempts += 1;
+			throw new Error("socket missing");
+		},
+		await makeActive(),
+	);
+	await center.bootstrap();
+	const snap = center.snapshot();
+	assert.equal(snap.kernel, "UNREACHABLE");
+	assert.ok(attempts >= 2, `应有有限重试（实际 ${attempts} 次）`);
+	// 上限 = bootstrap 3 + 失败后 capability 探测 1 + recover 2
+	// （全部内核行为，有界，不消耗模型 token）。
+	assert.ok(attempts <= 8, `重试必须有界（实际 ${attempts} 次）`);
+});
+
+test("运行期瞬态失败 → 内核有限重连恢复（不消耗模型 token）", async () => {
+	let calls = 0;
+	const center = await centerWith(
+		async (_home, method) => {
+			calls += 1;
+			if (calls === 1) throw new Error("transient");
+			return okPayload(String(method));
+		},
+		await makeActive(),
+	);
+	await assert.rejects(center.call("pi.status", {}));
+	// 瞬态失败 → 内核自动有限重连（后台 recoverKernel 已调度，
+	// 第二次调用即成功）——恢复是内核行为，不是模型回合。
+	await center.recoverKernel();
+	assert.ok(calls >= 2, `重连探测未发生（calls=${calls}）`);
+	assert.equal(center.snapshot().kernel, "READY");
+});
+
+test("SIM auto：OPERATOR_OFFLINE 不是 blocker（信息提示即可）", async () => {
+	const center = await centerWith(
+		async (_home, method) => okPayload(String(method)),
+		await makeActive(),
+	);
+	// operator 探测返回失败（offline）。
+	(center as never as { operatorCallFn: unknown });
+	const readiness = center.snapshot().action_readiness;
+	assert.ok(
+		!readiness.reason_codes.includes("OPERATOR_OFFLINE"),
+		`SIM auto 不应被 operator offline 阻塞: ${readiness.reason_codes}`,
+	);
+});
+
+test("UI 与 admission 同一 snapshot_seq", async () => {
+	const center = await centerWith(
+		async (_home, method) => okPayload(String(method)),
+		await makeActive(),
+	);
+	const snap = center.snapshot();
+	assert.equal(snap.action_readiness.snapshot_seq, snap.snapshot_seq);
+});
+
+test("SIM stale context 在 recipe 前自动 refresh；REAL fail closed", async () => {
+	const { ensureFreshContextForSim } = await import(
+		"../src/extension/context-injection.js"
+	);
+	const refreshed: string[] = [];
+	const call = async (_home: string, method: string) => {
+		refreshed.push(method);
+		return { ok: true, context: {} };
+	};
+	const staleSim = await makeActive({
+		contextState: "STALE",
+		mode: "SIMULATION",
+	});
+	await ensureFreshContextForSim("/tmp/rh-r06", staleSim as never, call as never);
+	assert.ok(
+		refreshed.includes("pi.context"),
+		"SIM stale 必须自动 refresh",
+	);
+	const staleReal = await makeActive({
+		contextState: "STALE",
+		mode: "REAL",
+	});
+	refreshed.length = 0;
+	await ensureFreshContextForSim("/tmp/rh-r06", staleReal as never, call as never);
+	assert.equal(
+		refreshed.length,
+		0,
+		"REAL 不得自动 refresh（fail closed 由内核 admission 裁决）",
+	);
+});

--- a/packages/rosclaw-agent/test/state-center.test.ts
+++ b/packages/rosclaw-agent/test/state-center.test.ts
@@ -205,7 +205,7 @@ async function makeCenter(calls: Array<{ method: string }>, activeOverride?: unk
 		if (method === "approvals.list") return { ok: true, approvals: [] };
 		return { ok: true };
 	};
-	return new ProductStateCenter({
+	const center = new ProductStateCenter({
 		rosclawHome: "/tmp/rh-six1",
 		active: active as never,
 		operatorSocket: "/tmp/rh-six1/run/operatord.sock",
@@ -213,4 +213,8 @@ async function makeCenter(calls: Array<{ method: string }>, activeOverride?: unk
 		call: call as never,
 		operatorCallFn: async () => ({ ok: true }),
 	});
+	// R0-6：生产路径 session_start 必跑 bootstrap——测试 center
+	// 同一初始语义（否则 readiness 永远停在 PREPARING）。
+	await center.bootstrap();
+	return center;
 }


### PR DESCRIPTION
同 #469（其 pull_request 事件未触发 ci.yml；dispatch 全绿但合并校验不关联 dispatched check-runs）。

## 闭环
- 启动事务 bootstrap（有限重试不耗 token）；PREPARING 代替 Unreachable/Stale/Blocked 三连假真相；
- 运行期瞬态失败内核有限重连 recoverKernel；SIM auto operator offline 非 blocker；UI 与 admission 同一 snapshot_seq；SIM stale context recipe 前自动 refresh（REAL fail closed）。

## 证据
- R0-6 测试 7/7；TS 全套 183/183；PTY 旅程 A/B/C 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)