### PR TITLE
feat: R0-7 模型配置简化与 readiness 状态格——tool probe 失败不再覆盖 chat 事实（0826 体验审计）

### DIFF
--- a/packages/rosclaw-agent/src/harness/pi/pi-probe.ts
+++ b/packages/rosclaw-agent/src/harness/pi/pi-probe.ts
@@ -32,6 +32,9 @@ interface ProbeOptions {
 	profile: "developer" | "robot";
 	/** 单步网络超时（chat/tool call）；默认 60s。 */
 	timeoutMs?: number;
+	/** R0-7：deep=true 才跑严格 tool call（默认便宜探测——
+	 *  auth/models/chat，setup 不再默认烧两次模型请求）。 */
+	deep?: boolean;
 	/** 测试注入：替代真实 ModelRuntime。 */
 	runtime?: ModelRuntime;
 	/** 测试注入：替代 SettingsManager 读取。 */
@@ -157,7 +160,12 @@ export async function probePiModel(options: ProbeOptions): Promise<PiProbeReport
 		report.error = classifyError(err);
 		return report;
 	}
-	// 4) 严格 tool call。
+	// 4) 严格 tool call——只在 deep 模式执行（R0-7：默认便宜探测
+	// 不烧第二次模型请求；tool readiness 由 deep 探测或 chat 真实
+	// 工具成功证据升级）。
+	if (!options.deep) {
+		return report;
+	}
 	try {
 		const reply = await withTimeout(
 			runtime.completeSimple(model, {

--- a/packages/rosclaw-agent/src/main.ts
+++ b/packages/rosclaw-agent/src/main.ts
@@ -25,6 +25,7 @@ interface CliArgs {
 	initialMessage?: string;
 	print: boolean;
 	probe: boolean;
+	deepProbe: boolean;
 	missionId?: string;
 	resumeSessionId?: string;
 	resumeSessionPath?: string;
@@ -37,6 +38,7 @@ function parseArgs(argv: string[]): CliArgs {
 	let initialMessage: string | undefined;
 	let print = false;
 	let probe = false;
+	let deepProbe = false;
 	let missionId: string | undefined;
 	let resumeSessionId: string | undefined;
 	let resumeSessionPath: string | undefined;
@@ -58,6 +60,10 @@ function parseArgs(argv: string[]): CliArgs {
 		} else if (argv[i] === "--probe") {
 			// P1-A1：模型探测单源——setup/doctor 经此走 Pi ModelRuntime。
 			probe = true;
+		} else if (argv[i] === "--deep") {
+			// R0-7：严格 tool call 探测（doctor --deep 专用——默认
+			// 便宜探测不烧第二次模型请求）。
+			deepProbe = true;
 		} else if (argv[i] === "--mission" && argv[i + 1]) {
 			missionId = argv[i + 1];
 			i += 1;
@@ -76,7 +82,7 @@ function parseArgs(argv: string[]): CliArgs {
 		}
 	}
 	return {
-		profile, initialMessage, print, probe, missionId, workspace,
+		profile, initialMessage, print, probe, deepProbe, missionId, workspace,
 		resumeSessionId, resumeSessionPath, browseSessions, continueLast,
 	};
 }
@@ -90,7 +96,7 @@ async function main(): Promise<number> {
 	} = await import("./harness/pi/pi-sessions.js");
 	const { createRosclawRuntime } = await import("./harness/pi/pi-runtime.js");
 	const {
-		profile, initialMessage, print, probe, missionId, workspace,
+		profile, initialMessage, print, probe, deepProbe, missionId, workspace,
 		resumeSessionId, resumeSessionPath, browseSessions, continueLast,
 	} = parseArgs(process.argv.slice(2));
 	const rosclawHome = rosclawHomeEnv;
@@ -104,9 +110,11 @@ async function main(): Promise<number> {
 			// settings 无关；probe 不新增进程 cwd 读取（N1 不变量）。
 			cwd: workspace ?? rosclawHome,
 			profile,
+			deep: deepProbe,
 		});
 		console.log(JSON.stringify(report));
-		return report.reachable && report.chat_ok && report.tool_call_ok ? 0 : 1;
+		// 便宜探测（默认）以 chat_ok 为收敛；deep 才要求 tool call。
+		return report.reachable && report.chat_ok && (deepProbe ? report.tool_call_ok : true) ? 0 : 1;
 	}
 	// WP-P0-1（总纲 §5.1）：恢复路径全部经 Pi SessionManager 公开
 	// API——不再有手写目录扫描/mtime 排序/文件名拼接（Pi 文件名可含

--- a/packages/rosclaw-agent/test/p1a1-probe.test.ts
+++ b/packages/rosclaw-agent/test/p1a1-probe.test.ts
@@ -76,9 +76,10 @@ test("auth 缺失 → AUTH_NOT_CONFIGURED，不做 chat", async () => {
 	assert.equal(report.chat_ok, false);
 });
 
-test("四步全过 → 全绿 + provider/model 回显", async () => {
+test("四步全过 → 全绿 + provider/model 回显（deep 模式）", async () => {
 	const report = await probePiModel({
 		...BASE,
+		deep: true,
 		defaults: DEFAULTS,
 		runtime: fakeRuntime({}),
 	});
@@ -90,6 +91,27 @@ test("四步全过 → 全绿 + provider/model 回显", async () => {
 	assert.equal(report.provider, "kimi-code");
 	assert.equal(report.model, "k3");
 	assert.deepEqual(report.models_visible, ["k3"]);
+	assert.equal(report.error, undefined);
+});
+
+test("R0-7：默认便宜探测不跑严格 tool call（chat 一次请求）", async () => {
+	let calls = 0;
+	const runtime = fakeRuntime({}) as unknown as {
+		completeSimple: (m: unknown, ctx: { tools?: unknown[] }) => Promise<unknown>;
+	};
+	const orig = runtime.completeSimple;
+	runtime.completeSimple = async (m: unknown, ctx: { tools?: unknown[] }) => {
+		calls += 1;
+		return orig(m, ctx);
+	};
+	const report = await probePiModel({
+		...BASE,
+		defaults: DEFAULTS,
+		runtime: runtime as never,
+	});
+	assert.equal(report.chat_ok, true);
+	assert.equal(calls, 1, `便宜探测竟发起 ${calls} 次模型请求（应为 1 次 chat）`);
+	assert.equal(report.tool_call_ok, false, "便宜探测不判 tool call（未探测≠失败）");
 	assert.equal(report.error, undefined);
 });
 
@@ -114,9 +136,10 @@ test("chat 429 → RATE_LIMITED 分类", async () => {
 	assert.match(report.error ?? "", /^RATE_LIMITED/);
 });
 
-test("tool call 缺失 → TOOL_CALL_PROBE_FAILED（诚实失败）", async () => {
+test("tool call 缺失 → TOOL_CALL_PROBE_FAILED（诚实失败，deep 模式）", async () => {
 	const report = await probePiModel({
 		...BASE,
+		deep: true,
 		defaults: DEFAULTS,
 		runtime: fakeRuntime({
 			toolReply: { stopReason: "stop", content: [{ type: "text", text: "ok" }] },

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -298,9 +298,10 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         report = doctor_runtime(home, topic)
         print(json.dumps(report, ensure_ascii=False, indent=2))
         return 0 if report.get("ready") else 1
-    report = doctor(home)
+    report = doctor(home, deep=bool(getattr(args, "deep", False)))
     print(json.dumps(report, ensure_ascii=False, indent=2))
-    return 0 if report.get("status") == "READY" else 1
+    ok_states = {"TOOL_READY", "CHAT_READY", "DEGRADED"}
+    return 0 if report.get("status") in ok_states else 1
 
 
 def cmd_init(args: argparse.Namespace) -> int:
@@ -323,15 +324,45 @@ def cmd_init(args: argparse.Namespace) -> int:
         model=args.model,
         api_key_ref=args.api_key_ref,
     )
-    print(json.dumps(summary, ensure_ascii=False, indent=2))
     if not summary.get("configured"):
+        print(json.dumps(summary, ensure_ascii=False))
         return 0
-    print("\n运行 doctor 探测（connectivity / models / chat / tool call）…")
+    # R0-7（0826 体验审计 §2.7）：默认便宜探测（auth+models+
+    # chat——严格 tool call 归 `rosclaw agentd doctor --deep`）。
     report = doctor(home)
-    print(json.dumps(report, ensure_ascii=False, indent=2))
-    if report.get("status") != "READY":
+    if getattr(args, "json", False):
+        print(json.dumps(
+            {"configure": summary, "doctor": report},
+            ensure_ascii=False, indent=2,
+        ))
+    else:
+        # 默认 ≤6 行人类摘要（不是一百行 JSON）。
+        status = str(report.get("status", ""))
+        effort = ""
+        try:
+            settings = json.loads(
+                (home / "agent" / "settings.json").read_text(encoding="utf-8")
+            )
+            effort = str(settings.get("defaultThinkingLevel", ""))
+        except (OSError, ValueError):
+            effort = ""
+        print(f"模型已配置：{summary.get('provider')} / {summary.get('model')}")
+        print(f"凭据引用：{summary.get('api_key_ref')}（值只在环境变量）")
+        if effort:
+            print(f"推理强度：{effort}（/effort 可改）")
+        print(f"探测（便宜档）：{status}")
+        if status == "TOOL_READY":
+            print("对话与工具调用均可用。")
+        elif status == "CHAT_READY":
+            print("对话可用；工具调用完整探测：`rosclaw agentd doctor --deep`")
+        elif status == "DEGRADED":
+            print(f"对话可用，工具自检退化——{report.get('reason', '')}")
+        else:
+            print(f"未就绪：{report.get('reason', status)}")
+    ok_states = {"TOOL_READY", "CHAT_READY", "DEGRADED"}
+    if report.get("status") not in ok_states:
         print(
-            "\n模型尚未就绪（MODEL_NOT_READY）。这是诚实状态，不是假成功；"
+            "\n模型尚未通过便宜探测。这是诚实状态，不是假成功；"
             "请检查 key/endpoint 后重试 `rosclaw agent doctor`。",
             file=sys.stderr,
         )
@@ -643,6 +674,11 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help="主题探测：simulation = 托管仿真 runtime（无需模型凭据）",
     )
+    p_doctor.add_argument(
+        "--deep",
+        action="store_true",
+        help="完整探测（严格 tool call——可能产生一次模型请求）",
+    )
     p_doctor.set_defaults(func=cmd_doctor)
 
     p_init = sub.add_parser("init", help="configure model provider + probe")
@@ -650,6 +686,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.add_argument("--base-url", default=None)
     p_init.add_argument("--model", default=None)
     p_init.add_argument("--api-key-ref", default=None)
+    p_init.add_argument("--json", action="store_true", help="完整结构化报告")
     p_init.set_defaults(func=cmd_init)
 
     p_chat = sub.add_parser("chat", help="interactive chat (in-process)")

--- a/src/rosclaw/agentd/onboarding.py
+++ b/src/rosclaw/agentd/onboarding.py
@@ -4,12 +4,19 @@ P1-A1（0824 总纲 §10.1）：模型配置与探测**单源**——setup 写
 ``~/.rosclaw/agent/{settings,models}.json``（Pi ModelRuntime 实际
 消费的配置），probe 经 Pi engine（``main.js --probe``，与 chat 同一
 ModelRuntime）。不再写 config.yaml 模型段、不再另起 Python HTTP
-chat probe。失败诚实记为 ``MODEL_NOT_READY``——绝不假成功。
+chat probe。
+
+R0-7（0826 体验审计 §5.R0-7）：readiness 状态格
+``UNCONFIGURED / AUTH_READY / CHAT_READY / TOOL_READY /
+DEGRADED``——tool probe 失败不覆盖 chat 成功的事实；默认便宜
+探测（无严格 tool call），``doctor --deep`` 完整探测。失败诚实
+分格——绝不假成功。
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 
 from rosclaw.agentd.models.gateway import ModelProbeResult, key_fingerprint
@@ -85,9 +92,11 @@ def configure_model(
         context_window=int(template["context_window"]),
         max_tokens=int(template["max_tokens"]),
     )
-    if reasoning_effort != "high":
-        # thinking level 由 Pi settings 自持（/effort）——setup 不复制。
-        pass
+    if reasoning_effort:
+        # R0-7（0826 体验审计 §2.7/§5.R0-7）：reasoning_effort 真写
+        # Pi settings（defaultThinkingLevel——此前被静默忽略）；保留
+        # 其他 settings 键。
+        _write_thinking_level(home, reasoning_effort)
     return {
         "configured": True,
         "config_path": str(home / "agent"),
@@ -99,14 +108,40 @@ def configure_model(
     }
 
 
-async def probe_home(home: Path) -> ModelProbeResult:
-    """经 Pi engine 探测（与 chat 同一 ModelRuntime、同一配置文件）。"""
+def _write_thinking_level(home: Path, effort: str) -> None:
+    """defaultThinkingLevel 写入 agent/settings.json（保留其他键）。"""
+    allowed = {"auto", "low", "medium", "high", "off"}
+    if effort not in allowed:
+        return
+    settings_path = home / "agent" / "settings.json"
+    settings: dict = {}
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except ValueError:
+            settings = {}
+    if settings.get("defaultThinkingLevel") == effort:
+        return
+    settings["defaultThinkingLevel"] = effort
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        json.dumps(settings, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+async def probe_home(home: Path, *, deep: bool = False) -> ModelProbeResult:
+    """经 Pi engine 探测（与 chat 同一 ModelRuntime、同一配置文件）。
+
+    deep=False：便宜探测（auth + models + chat——默认路径）；
+    deep=True：加严格 tool call（doctor --deep）。
+    """
     if read_pi_model_config(home) is None:
         return ModelProbeResult(
             reachable=False,
             error="MODEL_NOT_CONFIGURED: 未配置模型——运行 `rosclaw setup model`",
         )
-    return await pi_probe_home(home)
+    return await pi_probe_home(home, deep=deep)
 
 
 def _component_report() -> dict:
@@ -218,8 +253,43 @@ def _pi_engine_report(home: Path) -> dict:
     }
 
 
-def doctor(home: Path) -> dict:
-    """Honest agent readiness report. Never prints raw credentials."""
+def _real_tool_success(home: Path) -> bool:
+    """chat 真实工具调用成功（账本证据）——探测失败不覆盖真实
+    成功事实（0826 旅程：setup 报 NOT_READY 后 chat 真实完成了
+    工具调用）。"""
+    db_path = home / "agentd" / "missions.db"
+    if not db_path.exists():
+        return False
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM agent_events "
+                "WHERE type = 'tool.completed' AND json_extract("
+                "payload_json, '$.ok') = 1 AND json_extract("
+                "payload_json, '$.tool_name') IN "
+                "('rosclaw_task', 'rosclaw_execute', 'rosclaw_request_action')",
+            ).fetchone()
+            return bool(row and row[0] > 0)
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
+
+
+def doctor(home: Path, *, deep: bool = False) -> dict:
+    """Honest agent readiness report. Never prints raw credentials.
+
+    R0-7（0826 体验审计 §5.R0-7）：
+    - 默认便宜探测（models listing + chat，无严格 tool call——
+      严格 tool call 是 ``deep=True`` 才跑的完整检查）；
+    - 状态格：UNCONFIGURED / AUTH_READY / CHAT_READY /
+      TOOL_READY / DEGRADED（chat_ok 但 tool probe 失败——对话
+      可用、工具自检退化；tool probe 失败不覆盖 chat 事实）；
+    - chat 真实工具调用成功（账本证据）→ TOOL_READY。
+    """
     from rosclaw.agentd.config import load_agent_config
 
     agent_config = load_agent_config(home / "config.yaml")
@@ -242,7 +312,7 @@ def doctor(home: Path) -> dict:
 
     report["credential_sources"] = credential_source_report(home)
     if model is None:
-        report["status"] = "MODEL_NOT_READY"
+        report["status"] = "UNCONFIGURED"
         report["reason"] = "no model profile configured — run `rosclaw setup model`"
         return report
     import os
@@ -254,22 +324,41 @@ def doctor(home: Path) -> dict:
     report["api_key_present"] = bool(key)
     if key:
         report["api_key_fingerprint"] = key_fingerprint(key)
-    probe = asyncio.run(probe_home(home))
+    probe = asyncio.run(probe_home(home, deep=deep))
     report["probe"] = {
         "reachable": probe.reachable,
         "models_visible": list(probe.models_visible),
         "expected_model_present": probe.expected_model_present,
         "chat_ok": probe.chat_ok,
         "tool_call_ok": probe.tool_call_ok,
+        "deep": deep,
         "error": probe.error,
     }
-    ready = bool(
-        probe.reachable and probe.chat_ok and probe.tool_call_ok and (key or not model.api_key_ref)
-    )
-    report["status"] = "READY" if ready else "MODEL_NOT_READY"
-    if not ready and not probe.error:
-        report["reason"] = "probe incomplete (see probe fields)"
-    elif probe.error:
-        report["reason"] = probe.error
+    # R0-7 状态格（不是二元 READY/NOT_READY——tool probe 失败
+    # 不覆盖 chat 成功的事实）。
+    tool_evidence = _real_tool_success(home)
+    report["tool_evidence"] = tool_evidence
+    if not key and model.api_key_ref:
+        report["status"] = "UNCONFIGURED"
+        report["reason"] = f"api key 未在环境中（{model.api_key_ref}）"
+    elif not probe.reachable:
+        report["status"] = "AUTH_READY"
+        report["reason"] = probe.error or "endpoint 不可达（凭据已配置）"
+    elif probe.chat_ok and (
+        (deep and probe.tool_call_ok) or tool_evidence
+    ):
+        # deep 完整探测通过，或账本有真实工具成功证据。
+        report["status"] = "TOOL_READY"
+    elif probe.chat_ok and deep and not probe.tool_call_ok:
+        report["status"] = "DEGRADED"
+        report["reason"] = (
+            probe.error
+            or "对话可用；工具自检退化（rosclaw doctor --deep 重试）"
+        )
+    elif probe.chat_ok:
+        report["status"] = "CHAT_READY"
+    else:
+        report["status"] = "AUTH_READY"
+        report["reason"] = probe.error or "chat probe 未通过"
     report["pi_engine"] = _pi_engine_report(home)
     return report

--- a/src/rosclaw/agentd/pi_probe.py
+++ b/src/rosclaw/agentd/pi_probe.py
@@ -29,8 +29,12 @@ def _sanitize(text: str, *, limit: int = 400) -> str:
     return _SECRET_RE.sub("sk-***", text.strip())[:limit]
 
 
-async def pi_probe_home(home: Path) -> ModelProbeResult:
-    """经 Pi engine 探测 home 的模型配置（settings/models 单源）。"""
+async def pi_probe_home(home: Path, *, deep: bool = False) -> ModelProbeResult:
+    """经 Pi engine 探测 home 的模型配置（settings/models 单源）。
+
+    deep=False 便宜探测（auth+models+chat）；deep=True 加严格
+    tool call（--deep 传给 TS probe——R0-7 分级探测）。
+    """
     located = pi_entry.find_pi_agent_entry()
     if located is None:
         return ModelProbeResult(
@@ -40,11 +44,12 @@ async def pi_probe_home(home: Path) -> ModelProbeResult:
         )
     node, entry = located
     env = dict(os.environ, ROSCLAW_HOME=str(home))
+    argv = [node, str(entry), "--probe"]
+    if deep:
+        argv.append("--deep")
     try:
         proc = await asyncio.create_subprocess_exec(
-            node,
-            str(entry),
-            "--probe",
+            *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,

--- a/src/rosclaw/setup_cli.py
+++ b/src/rosclaw/setup_cli.py
@@ -40,18 +40,24 @@ def _home() -> Path:
 
 
 def _model_status(home: Path) -> dict:
-    """模型配置状态（复用 agentd onboarding 的探测，不重新实现）。"""
+    """模型配置状态（复用 agentd onboarding 的探测，不重新实现）。
+
+    R0-7 状态格：TOOL_READY/CHAT_READY/DEGRADED 都算"已配置
+    可用"（DEGRADED 是对话可用、工具自检退化——不是
+    NEEDS_SETUP）；UNCONFIGURED/AUTH_READY 才是配置缺口。
+    """
     try:
         from rosclaw.agentd.onboarding import doctor
 
         report = doctor(home)
         model = report.get("model", {})
-        ready = report.get("status") == "READY"
+        status = str(report.get("status", ""))
+        ready = status in {"TOOL_READY", "CHAT_READY", "DEGRADED"}
         return {
             "state": "READY" if ready else "NEEDS_SETUP",
             "provider": model.get("provider", ""),
             "model": model.get("model", ""),
-            "detail": "ready" if ready else str(report.get("status", "unknown")),
+            "detail": status or "unknown",
         }
     except Exception as exc:  # noqa: BLE001 - 状态探测不崩向导
         return {"state": "NEEDS_SETUP", "detail": f"probe failed: {exc}"}

--- a/tests/agentd/test_p1a1_pi_single_source.py
+++ b/tests/agentd/test_p1a1_pi_single_source.py
@@ -248,7 +248,7 @@ class TestDoctorSingleSource:
         monkeypatch.setattr(
             onboarding,
             "probe_home",
-            lambda home: _async_result(
+            lambda home, *, deep=False: _async_result(
                 ModelProbeResult(
                     reachable=True,
                     models_visible=("k3",),
@@ -258,15 +258,17 @@ class TestDoctorSingleSource:
                 )
             ),
         )
-        report = doctor(tmp_path)
-        assert report["status"] == "READY"
+        # R0-7：deep 完整探测全过 → TOOL_READY（状态格）。
+        report = doctor(tmp_path, deep=True)
+        assert report["status"] == "TOOL_READY"
         assert report["probe"]["chat_ok"] is True
         assert report["probe"]["tool_call_ok"] is True
         assert report["api_key_present"] is True
 
     def test_doctor_not_ready_without_pi_config(self, tmp_path: Path) -> None:
         report = doctor(tmp_path)
-        assert report["status"] == "MODEL_NOT_READY"
+        # R0-7 状态格：未配置 = UNCONFIGURED（不是二元 NOT_READY）。
+        assert report["status"] == "UNCONFIGURED"
         assert "setup model" in report["reason"]
 
 

--- a/tests/agentd/test_r07_setup_readiness.py
+++ b/tests/agentd/test_r07_setup_readiness.py
@@ -28,6 +28,15 @@ import json
 from pathlib import Path
 
 
+def _stub_pi_entry(monkeypatch) -> None:
+    """CI 无内置 dist——stub engine 查找（P1-A1 的 CI 教训）。"""
+    from rosclaw.agentd import pi_entry
+
+    monkeypatch.setattr(
+        pi_entry, "find_pi_agent_entry", lambda: ("node", "/fake/main.js")
+    )
+
+
 def _configured_home(tmp_path: Path) -> Path:
     from rosclaw.agentd.onboarding import configure_model
 
@@ -105,6 +114,7 @@ class TestProbeLevels:
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
         monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "sk-test-fake")
+        _stub_pi_entry(monkeypatch)
         from rosclaw.agentd.onboarding import doctor
 
         report = doctor(tmp_path)
@@ -138,6 +148,7 @@ class TestReadinessTaxonomy:
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
         monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "sk-test-fake")
+        _stub_pi_entry(monkeypatch)
         from rosclaw.agentd.onboarding import doctor
 
         return doctor(tmp_path, deep=True)
@@ -219,6 +230,7 @@ class TestReadinessTaxonomy:
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
         monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "sk-test-fake")
+        _stub_pi_entry(monkeypatch)
         from rosclaw.agentd.onboarding import doctor
 
         report = doctor(tmp_path, deep=True)
@@ -254,6 +266,7 @@ class TestSetupOutput:
             return _Proc()
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        _stub_pi_entry(monkeypatch)
         rc = agentd_main([
             "--home", str(tmp_path), "init",
             "--provider", "kimi-code",

--- a/tests/agentd/test_r07_setup_readiness.py
+++ b/tests/agentd/test_r07_setup_readiness.py
@@ -1,0 +1,264 @@
+"""R0-7 红测试（0826 体验审计 §5.R0-7）：模型配置简化与 readiness
+状态格。
+
+真实事故（0826 体验旅程）：
+- `setup model` 报 MODEL_NOT_READY，随后 chat 正常完成工具调用
+  ——tool probe 超时覆盖了 chat 成功的事实；
+- setup 默认跑完整 4 步探测（models+chat+严格 tool call，最长
+  60s 两次模型请求）+ 一百多行 JSON——首次配置过重；
+- configure_model(reasoning_effort="high") 实际忽略该参数——
+  high 从未写入 Pi 设置。
+
+断言：
+1. effort 真写：configure_model 把 defaultThinkingLevel 写入
+   agent/settings.json（保留其他键）；
+2. 分级探测：doctor 默认便宜探测（无严格 tool call），
+   --deep 才跑完整 tool call；
+3. 状态格：UNCONFIGURED/AUTH_READY/CHAT_READY/TOOL_READY/
+   DEGRADED——chat_ok=True + tool_call_ok=False → DEGRADED
+   （不是 MODEL_NOT_READY）；tool probe 失败不覆盖 chat 事实；
+4. 真实工具调用成功 → readiness 升级 TOOL_READY（账本证据
+   优先于探测）；
+5. setup 默认输出 ≤6 行人类摘要；--json 出完整报告。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _configured_home(tmp_path: Path) -> Path:
+    from rosclaw.agentd.onboarding import configure_model
+
+    configure_model(tmp_path, "kimi-code", api_key_ref="env:ROSCLAW_KIMI_API_KEY")
+    return tmp_path
+
+
+class TestEffortWritten:
+    def test_configure_model_writes_thinking_level(
+        self, tmp_path: Path
+    ) -> None:
+        """reasoning_effort="high" 必须真实写入 Pi settings
+        （defaultThinkingLevel）——不再被忽略。"""
+        from rosclaw.agentd.onboarding import configure_model
+
+        configure_model(
+            tmp_path, "kimi-code",
+            api_key_ref="env:ROSCLAW_KIMI_API_KEY", reasoning_effort="high",
+        )
+        settings = json.loads(
+            (tmp_path / "agent" / "settings.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert settings.get("defaultThinkingLevel") == "high", settings
+
+    def test_effort_preserves_other_settings(self, tmp_path: Path) -> None:
+        """写 effort 不得清空其他 settings 键。"""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "settings.json").write_text(
+            json.dumps({"custom_key": "keep-me"}), encoding="utf-8"
+        )
+        from rosclaw.agentd.onboarding import configure_model
+
+        configure_model(
+            tmp_path, "kimi-code",
+            api_key_ref="env:ROSCLAW_KIMI_API_KEY", reasoning_effort="medium",
+        )
+        settings = json.loads(
+            (agent_dir / "settings.json").read_text(encoding="utf-8")
+        )
+        assert settings.get("custom_key") == "keep-me"
+        assert settings.get("defaultThinkingLevel") == "medium"
+
+
+class TestProbeLevels:
+    def test_doctor_default_cheap_probe(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """doctor 默认便宜探测（不调严格 tool-call 步）；--deep 才
+        完整。"""
+        _configured_home(tmp_path)
+        calls: list[list[str]] = []
+
+        class _Proc:
+            def __init__(self, argv):
+                self.argv = argv
+
+            async def communicate(self):
+                return (b'{"engine": "pi", "reachable": true, '
+                        b'"chat_ok": true, "tool_call_ok": true, '
+                        b'"models_visible": ["m"], '
+                        b'"expected_model_present": true}\n', b"")
+
+            @property
+            def returncode(self):
+                return 0
+
+        import asyncio
+
+        async def fake_exec(*argv, **kwargs):
+            calls.append([str(a) for a in argv])
+            return _Proc(argv)
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "sk-test-fake")
+        from rosclaw.agentd.onboarding import doctor
+
+        report = doctor(tmp_path)
+        assert report["status"] in ("CHAT_READY", "TOOL_READY", "DEGRADED")
+        probe_argv = calls[-1] if calls else []
+        assert not any("--deep" in a for a in probe_argv), probe_argv
+
+        report_deep = doctor(tmp_path, deep=True)
+        deep_argv = calls[-1] if calls else []
+        assert any("--deep" in a for a in deep_argv), deep_argv
+        assert report_deep["probe"]["tool_call_ok"] is True
+
+
+class TestReadinessTaxonomy:
+    def _doctor_with_probe(self, tmp_path: Path, monkeypatch, probe_json: dict):
+        _configured_home(tmp_path)
+
+        class _Proc:
+            async def communicate(self):
+                payload = {"engine": "pi", **probe_json}
+                return (json.dumps(payload).encode() + b"\n", b"")
+
+            @property
+            def returncode(self):
+                return 0
+
+        import asyncio
+
+        async def fake_exec(*argv, **kwargs):
+            return _Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "sk-test-fake")
+        from rosclaw.agentd.onboarding import doctor
+
+        return doctor(tmp_path, deep=True)
+
+    def test_chat_ok_tool_fail_is_degraded(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """chat_ok=True 但 tool probe 失败 → DEGRADED（对话可用、
+        工具自检退化）——不是 MODEL_NOT_READY。"""
+        report = self._doctor_with_probe(tmp_path, monkeypatch, {
+            "reachable": True, "chat_ok": True, "tool_call_ok": False,
+            "models_visible": ["m"], "expected_model_present": True,
+            "error": "TOOL_PROBE_TIMEOUT",
+        })
+        assert report["status"] == "DEGRADED", report["status"]
+        assert report["probe"]["chat_ok"] is True
+
+    def test_full_pass_is_tool_ready(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        report = self._doctor_with_probe(tmp_path, monkeypatch, {
+            "reachable": True, "chat_ok": True, "tool_call_ok": True,
+            "models_visible": ["m"], "expected_model_present": True,
+        })
+        assert report["status"] == "TOOL_READY", report["status"]
+
+    def test_unconfigured(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.onboarding import doctor
+
+        report = doctor(tmp_path)
+        assert report["status"] == "UNCONFIGURED", report["status"]
+
+    def test_real_tool_success_upgrades_readiness(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """chat 真实工具调用成功（账本证据）→ TOOL_READY——探测
+        失败不覆盖真实成功事实。"""
+        _configured_home(tmp_path)
+        # 账本里有一条真实成功的具身工具完成记录。
+        import sqlite3
+        from datetime import UTC, datetime
+
+        from rosclaw.storage.migrations import MigrationRunner
+
+        db_path = tmp_path / "agentd" / "missions.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        MigrationRunner().apply(conn, "sqlite")
+        conn.execute(
+            "INSERT INTO agent_events (event_id, mission_id, sequence, "
+            "type, visibility, payload_json, timestamp) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "evt_1", "mis_1", 1, "tool.completed", "USER",
+                json.dumps({"tool_name": "rosclaw_task", "ok": True}),
+                datetime.now(UTC).isoformat(),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        class _Proc:
+            async def communicate(self):
+                return (json.dumps({
+                    "engine": "pi",
+                    "reachable": True, "chat_ok": True,
+                    "tool_call_ok": False, "error": "TOOL_PROBE_TIMEOUT",
+                    "models_visible": [], "expected_model_present": False,
+                }).encode() + b"\n", b"")
+
+            @property
+            def returncode(self):
+                return 0
+
+        import asyncio
+
+        async def fake_exec(*argv, **kwargs):
+            return _Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "sk-test-fake")
+        from rosclaw.agentd.onboarding import doctor
+
+        report = doctor(tmp_path, deep=True)
+        assert report["status"] == "TOOL_READY", report["status"]
+
+
+class TestSetupOutput:
+    def test_cmd_init_default_summary_six_lines(
+        self, tmp_path: Path, capsys, monkeypatch
+    ) -> None:
+        """setup 默认输出 ≤6 行人类摘要（不是一百行 JSON）；
+        --json 才出完整报告。"""
+        from rosclaw.agentd.cli import main as agentd_main
+
+        monkeypatch.setenv("ROSCLAW_KIMI_API_KEY", "sk-test-fake")
+
+        class _Proc:
+            async def communicate(self):
+                return (json.dumps({
+                    "engine": "pi",
+                    "reachable": True, "chat_ok": True,
+                    "tool_call_ok": True, "models_visible": ["m"],
+                    "expected_model_present": True,
+                }).encode() + b"\n", b"")
+
+            @property
+            def returncode(self):
+                return 0
+
+        import asyncio
+
+        async def fake_exec(*argv, **kwargs):
+            return _Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        rc = agentd_main([
+            "--home", str(tmp_path), "init",
+            "--provider", "kimi-code",
+        ])
+        out = capsys.readouterr().out
+        lines = [line for line in out.strip().splitlines() if line.strip()]
+        assert len(lines) <= 8, f"默认输出 {len(lines)} 行（>8）:\n{out}"
+        assert rc == 0, out

--- a/tests/agentd/test_service.py
+++ b/tests/agentd/test_service.py
@@ -205,12 +205,14 @@ class TestOnboarding:
         configure_model(tmp_path, "kimi-code")
         monkeypatch.delenv("ROSCLAW_KIMI_API_KEY", raising=False)
         report = doctor(tmp_path)
-        assert report["status"] == "MODEL_NOT_READY"
+        # R0-7 状态格：配置了但 key 不在环境 = UNCONFIGURED（缺凭据）。
+        assert report["status"] == "UNCONFIGURED"
         assert report["api_key_present"] is False
 
     def test_doctor_no_profiles(self, tmp_path: Path) -> None:
         report = doctor(tmp_path)
-        assert report["status"] == "MODEL_NOT_READY"
+        # R0-7 状态格：未配置 = UNCONFIGURED。
+        assert report["status"] == "UNCONFIGURED"
         assert "setup model" in report["reason"]
 
 


### PR DESCRIPTION
## 真实事故（0826 体验旅程 + 实施指南 §2.7/§5.R0-7）

`setup model` 报 MODEL_NOT_READY，随后 chat 正常完成工具调用（探测超时覆盖了真实可用事实）；setup 默认跑完整 4 步探测 + 一百行 JSON；`reasoning_effort="high"` 被静默忽略。

## 闭环

- **readiness 状态格**：UNCONFIGURED / AUTH_READY / CHAT_READY / TOOL_READY / DEGRADED（chat_ok 但 tool probe 失败 = 对话可用、工具自检退化——不是 NOT_READY）；
- **分级探测**：默认便宜档（auth+models+chat）；严格 tool call 归 `doctor --deep`（标注可能产生一次模型请求）；main.js --probe --deep 单源；
- **真实证据升级**：chat 真实具身工具调用成功（kernel 账本）→ TOOL_READY（探测失败不覆盖真实成功）；
- **reasoning_effort 真写** Pi settings（defaultThinkingLevel，保留其他键）；
- **setup 默认 ≤6 行人类摘要**，--json 出完整报告。

## 红→绿证据

- 红：/tmp/r07-red.txt（8 红）；
- 绿：R0-7 测试 8/8 + P1-A1/service 全绿；TS probe 便宜/深档两路（全套 186/186）；agentd 753 过 + 旅程 A/B/C 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)