### PR TITLE
feat: R0-9 重试预算收回 Harness + 金丝雀真实生产断言重写（0826 体验审计）

### DIFF
--- a/scripts/star_canary.py
+++ b/scripts/star_canary.py
@@ -138,6 +138,48 @@ def run_once(idx: int, base: Path) -> dict:
         if oc.get("verification") != "PASS":
             outcome["failures"].append(f"outcome verification={oc.get('verification')}")
     db.close()
+    # R0-9（§7.4）：生产路径/用户可见交付/行为预算/证据等级/屏幕
+    # 卫生——断言函数抛 AssertionError，失败入 outcome["failures"]。
+    final_outcome = (
+        json.loads(str(outcomes[0]["outcome_json"])) if outcomes else {}
+    )
+    for check in (
+        lambda: assert_production_plan_graph(home),
+        lambda: assert_user_visible_delivery(home, require_scene=True),
+        lambda: assert_model_behavior_budget(home, max_task_calls=1),
+        lambda: assert_evidence_levels(home, require_scene=True),
+        lambda: assert_screen_clean(session.clean),
+        lambda: assert_final_answer_consistent(
+            session.clean.decode("utf-8", errors="replace")[-3000:],
+            final_outcome,
+        ),
+    ):
+        try:
+            check()
+        except AssertionError as exc:
+            outcome["failures"].append(str(exc)[:200])
+    # 指标记录（§7.1：工具调用数、错误数、token/耗时——只报通过率
+    # 不够）。
+    db = sqlite3.connect(db_path)
+    outcome["tool_calls"] = db.execute(
+        "SELECT COUNT(*) FROM task_events WHERE event_type = 'task.tool_used'"
+    ).fetchone()[0]
+    outcome["error_count"] = db.execute(
+        "SELECT COUNT(*) FROM agent_events WHERE type = 'tool.completed' "
+        "AND json_extract(payload_json, '$.ok') = 0"
+    ).fetchone()[0]
+    usage_rows = db.execute(
+        "SELECT usage_json FROM pi_event_mirrors WHERE usage_json != ''"
+    ).fetchall()
+    total_tokens = 0
+    for (usage_json,) in usage_rows:
+        try:
+            usage = json.loads(str(usage_json))
+            total_tokens += int(usage.get("total_tokens") or 0)
+        except (ValueError, TypeError):
+            continue
+    outcome["tokens"] = total_tokens
+    db.close()
     outcome["artifacts"] = paths
     return outcome
 
@@ -159,6 +201,149 @@ def main() -> int:
     report.write_text(json.dumps(results, ensure_ascii=False, indent=1))
     print(f"[canary] {passed}/{RUNS} 通过——报告 {report}")
     return 0 if passed == RUNS else 1
+
+
+# ----------------------------------------------------------------------
+# R0-9（0826 体验审计 §7.4）：金丝雀断言函数——真实生产路径、
+# 用户可见交付、模型行为预算、证据等级、屏幕/最终回答一致性。
+# 每个函数：通过返回 None，失败抛 AssertionError（可单测）。
+# ----------------------------------------------------------------------
+
+_BASE_PLAN_NODES = {
+    "resolve_robot", "make_path", "simulate", "render", "verify",
+}
+
+
+def assert_production_plan_graph(home: Path) -> None:
+    """生产 PlanGraph 证据：plan.node_* 事件存在且覆盖基线五节点
+    （不是"测试直调模板"——真实生产执行才产生这些事件）。"""
+    conn = sqlite3.connect(home / "agentd" / "missions.db")
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT event_type, payload_json FROM task_events "
+        "WHERE event_type LIKE 'plan.node_%'"
+    ).fetchall()
+    conn.close()
+    started = {
+        json.loads(str(r["payload_json"])).get("node_id")
+        for r in rows if r["event_type"] == "plan.node_started"
+    }
+    completed = {
+        json.loads(str(r["payload_json"])).get("node_id")
+        for r in rows if r["event_type"] == "plan.node_completed"
+    }
+    assert started >= _BASE_PLAN_NODES, (
+        f"plan.node_started 缺节点：{_BASE_PLAN_NODES - started}"
+        "——未走生产 PlanGraph"
+    )
+    assert completed >= _BASE_PLAN_NODES, (
+        f"plan.node_completed 缺节点：{_BASE_PLAN_NODES - completed}"
+    )
+
+
+def assert_user_visible_delivery(home: Path, *, require_scene: bool = False) -> None:
+    """用户可见交付：outcome.artifact_refs 含 GIF+MP4，每条带
+    open_command；require_scene 时 MP4 必须是 scene_3d kind
+    （2D 预览不能冒充场景视频）。"""
+    conn = sqlite3.connect(home / "agentd" / "missions.db")
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT outcome_json FROM task_outcomes ORDER BY rowid DESC LIMIT 1"
+    ).fetchone()
+    conn.close()
+    assert row is not None, "task_outcomes 未落库"
+    outcome = json.loads(str(row["outcome_json"]))
+    refs = outcome.get("artifact_refs") or []
+    gif = [r for r in refs if r.get("media_type") == "image/gif"]
+    mp4 = [r for r in refs if r.get("media_type") == "video/mp4"]
+    assert gif, "用户可见 refs 缺 GIF"
+    assert mp4, "用户可见 refs 缺 MP4"
+    for ref in [*gif, *mp4]:
+        assert str(ref.get("open_command", "")).startswith(
+            "rosclaw artifact open "
+        ), f"交付物缺 open_command：{ref}"
+    if require_scene:
+        assert any(r.get("kind") == "scene_3d" for r in mp4), (
+            f"MP4 不是 scene_3d kind（2D 预览冒充场景视频）：{mp4}"
+        )
+
+
+def assert_model_behavior_budget(home: Path, *, max_task_calls: int = 1) -> None:
+    """模型行为预算：具身入口调用 ≤max、bash=0、手工 finish=0
+    （已知 recipe 不允许模型绕链脚本化）。"""
+    conn = sqlite3.connect(home / "agentd" / "missions.db")
+    calls = conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE event_type = 'task.tool_used'"
+    ).fetchone()[0]
+    assert calls <= max_task_calls, f"具身入口调用 {calls} 次 > {max_task_calls}"
+    bash = conn.execute(
+        "SELECT COUNT(*) FROM agent_events WHERE type = 'tool.completed' "
+        "AND json_extract(payload_json, '$.tool_name') = 'bash'"
+    ).fetchone()[0]
+    assert bash == 0, f"模型用 bash 绕过 recipe ×{bash}"
+    finish = conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE payload_json LIKE '%task_finish%'"
+    ).fetchone()[0]
+    assert finish == 0, f"出现手工 task_finish ×{finish}"
+    conn.close()
+
+
+def assert_evidence_levels(home: Path, *, require_scene: bool = False) -> None:
+    """证据等级拆分：GEOMETRY_PLAN/KINEMATIC_TRACKING/DYNAMIC_
+    ROLLOUT（require_scene 加 SCENE_RENDER）——不是单个标签。"""
+    conn = sqlite3.connect(home / "agentd" / "missions.db")
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT outcome_json FROM task_outcomes ORDER BY rowid DESC LIMIT 1"
+    ).fetchone()
+    conn.close()
+    assert row is not None, "task_outcomes 未落库"
+    outcome = json.loads(str(row["outcome_json"]))
+    levels = set((outcome.get("evidence") or {}).get("levels") or [])
+    required = {"GEOMETRY_PLAN", "KINEMATIC_TRACKING", "DYNAMIC_ROLLOUT"}
+    if require_scene:
+        required.add("SCENE_RENDER")
+    assert required <= levels, f"证据等级缺 {required - levels}（{levels}）"
+
+
+_RAW_JSON_KEYS = (b'"artifact_refs"', b'"plan":', b'"verification":')
+_SUCCESS_MARKERS = ("任务完成", "VERIFIED", "✓")
+_FAILURE_MARKERS = ("Unreachable", "Blocked")
+
+
+def assert_screen_clean(screen: bytes) -> None:
+    """屏幕卫生：无 raw JSON 键；无 Unreachable/Blocked 与成功
+    标记并存（readiness 与 effect 结果必须一致）。"""
+    for key in _RAW_JSON_KEYS:
+        assert key not in screen, f"屏幕出现 raw JSON（{key!r}）"
+    text = screen.decode("utf-8", errors="replace")
+    has_success = any(marker in text for marker in _SUCCESS_MARKERS)
+    for marker in _FAILURE_MARKERS:
+        assert not (marker in text and has_success), (
+            f"屏幕同时出现 {marker} 与成功标记——readiness 与 effect 矛盾"
+        )
+
+
+_COMPLETION_CLAIMS = ("已绘制完成，视频已交付", "全部完成", "完整完成")
+_LIMITATION_MARKERS = ("未", "但", "没有", "无法", "限制", "退化", "部分")
+
+
+def assert_final_answer_consistent(answer: str, outcome: dict) -> None:
+    """最终回答与 TaskOutcome 一致：PARTIAL/MISSING 时回答必须带
+    限制说明，不得宣称完整完成。"""
+    verification = str(outcome.get("verification", ""))
+    delivery = str(outcome.get("delivery", ""))
+    partial = verification == "PARTIAL" or delivery in ("MISSING", "PARTIAL")
+    if not partial:
+        return
+    for claim in _COMPLETION_CLAIMS:
+        assert claim not in answer, (
+            f"最终回答与 outcome 不一致：outcome 是 PARTIAL/MISSING，"
+            f"回答却宣称 {claim!r}"
+        )
+    assert any(marker in answer for marker in _LIMITATION_MARKERS), (
+        "最终回答与 outcome 不一致：PARTIAL/MISSING 但回答无限制说明"
+    )
 
 
 if __name__ == "__main__":

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -210,6 +210,51 @@ def _failure_fingerprint(request: PiToolRequestV1) -> str:
     )
 
 
+#: R0-9（0826 体验审计 §5.R0-9）：transient 错误码（可安全重试——
+#: 状态已变化/等待外部事件，不记熔断也不计预算）。
+_TRANSIENT_CODES = frozenset({
+    "CONTEXT_NOT_FRESH",
+    "CONTEXT_HASH_MISMATCH",
+    "NEEDS_REPLAN",
+    "CONTEXT_LEASE_REQUIRED",
+    "CAPABILITY_SNAPSHOT_CHANGED",
+    "WAITING_APPROVAL",
+})
+
+#: 基础设施/配置错误前缀（模型重试预算为 0——重试不会成功，
+#: 修复路径在 recovery_action）。
+_INFRA_PREFIXES = (
+    "RENDER_", "RUNTIME_", "TRANSPORT_", "PI_ENGINE",
+    "WORLD_ASSET_", "TOOL_ASSET_", "RESOURCE_",
+)
+
+
+def _error_envelope_details(code: str) -> dict:
+    """ErrorEnvelope 语义（R0-9）：scope / attempt_budget /
+    recovery_action——基础设施/配置/确定性错误模型重试预算为 0；
+    只有明确 transient 且状态已变化时可重试。"""
+    from rosclaw.agentd.tooling.recovery import recovery_for
+
+    if code in _TRANSIENT_CODES:
+        return {
+            "scope": "transient",
+            "attempt_budget": 1,
+            "retry_after_condition": "状态已变化（context/审批/快照刷新后）",
+            "recovery_action": recovery_for(code),
+        }
+    scope = (
+        "infrastructure"
+        if code.startswith(_INFRA_PREFIXES)
+        else "deterministic"
+    )
+    return {
+        "scope": scope,
+        "attempt_budget": 0,
+        "retry_after_condition": "",
+        "recovery_action": recovery_for(code),
+    }
+
+
 class PiToolDispatcher:
     def __init__(self, service: AgentService) -> None:
         self._service = service
@@ -260,6 +305,7 @@ class PiToolDispatcher:
                 summary=exc.message,
                 error_code=exc.code,
                 retryable=exc.retryable,
+                details=_error_envelope_details(exc.code),
             )
         if result.ok:
             failures.pop(fingerprint, None)

--- a/src/rosclaw/agentd/tooling/catalog.py
+++ b/src/rosclaw/agentd/tooling/catalog.py
@@ -298,9 +298,18 @@ class ToolCatalog:
                 retryable=True,
             )
         except Exception as exc:  # noqa: BLE001 — 诚实 FAILED envelope
-            return _failed(
-                "EXECUTOR_ERROR", f"{type(exc).__name__}: {exc}"[:400],
-            )
+            # R0-9（0826 体验审计 §5.R0-9）：能力实现抛出的带码错误
+            # （"RENDER_INPUT_MISSING: …" 形如 CODE: message）保留
+            # 稳定错误码——基础设施错误不被包成无语义的
+            # EXECUTOR_ERROR（重试预算/恢复动作按码分派）。
+            message = f"{type(exc).__name__}: {exc}"[:400]
+            code = "EXECUTOR_ERROR"
+            import re as _re
+
+            match = _re.match(r"^(?:\w+Error: )?([A-Z][A-Z0-9_]{3,}):\s", str(exc))
+            if match:
+                code = match.group(1)
+            return _failed(code, message)
         # 归一为 canonical value：只接受 dict / ToolExecutionResult /
         # JSON 对象字符串；裸文本不得冒充结构化结果。
         value: Any

--- a/src/rosclaw/agentd/tooling/recovery.py
+++ b/src/rosclaw/agentd/tooling/recovery.py
@@ -27,6 +27,17 @@ RECOVERY_REGISTRY: dict[str, str] = {
     "ACCEPTANCE_FAILED": "按结构化失败项修复同一 revision（不新开任务）",
     "SAFETY_DENIED": "不重复调用——向用户给出原因",
     "WAITING_APPROVAL": "让出回合——等待审批事件恢复，不轮询",
+    # R0-9（0826 体验审计 §5.R0-9）：渲染/资产类基础设施错误——
+    # 模型重试预算为 0（换参数重试不会成功）。
+    "RENDER_INPUT_MISSING": "渲染输入缺失——先完成轨迹 rollout（trace 不存在/无 states），不重试渲染",
+    "RENDER_INPUT_DIGEST_MISMATCH": "trace 被改写——重跑 rollout 生成新 trace，不重试渲染",
+    "RENDER_BACKEND_UNAVAILABLE": "渲染后端不可用（EGL/OSMesa/Xvfb）——安装/修复离屏后端，模型不重试",
+    "RENDER_RESULT_MISSING": "渲染子进程未产出结果——内核已降级一次；检查渲染后端日志，模型不重试",
+    "RENDER_RESULT_CORRUPT": "渲染结果损坏——内核侧故障，模型不重试",
+    "RENDER_RESULT_INCOMPLETE": "渲染结果不完整——内核侧故障，模型不重试",
+    "RENDER_FAILED": "渲染子进程失败——内核已降级一次；检查后端/依赖，模型不重试",
+    "WORLD_ASSET_MISSING": "场景 world 资产不存在——换已支持的 world 或安装资产，模型不重试",
+    "TOOL_ASSET_MISSING": "工具资产不存在——不得假装持笔；安装工具资产或去掉工具声明",
 }
 
 

--- a/tests/agentd/test_r09_retry_canary.py
+++ b/tests/agentd/test_r09_retry_canary.py
@@ -1,0 +1,248 @@
+"""R0-9 红测试（0826 体验审计 §5.R0-9/§7.4）：重试预算收回
+Harness + 金丝雀真实生产断言。
+
+真实事故（0826 体验旅程）：renderer 连续三次裸 JSONDecodeError
+——基础设施故障没有重试预算语义（ErrorEnvelope 无 scope/
+attempt_budget/recovery_action）；金丝雀只查 DB 文件存在，不查
+生产路径/用户可见交付/最终回答一致性。
+
+断言：
+1. ErrorEnvelope 语义：基础设施/配置/确定性错误 → details 带
+   scope + attempt_budget=0 + recovery_action（模型重试预算为
+   0）；transient 且状态变化可重试；
+2. 金丝雀断言函数（合成 home 可测）：
+   a. 生产 PlanGraph——plan.node_* 事件存在且 5 节点完整；
+   b. 用户可见交付——outcome.artifact_refs 含 GIF+MP4 且每条
+      带 open_command；scene_video 要求的 mp4 必须是 scene_3d
+      kind（2D 预览不能冒充）；
+   c. 模型行为预算——具身入口调用 ≤1、bash=0、手工 finish=0；
+   d. 证据等级——outcome.evidence.levels 含 GEOMETRY_PLAN/
+      KINEMATIC_TRACKING/DYNAMIC_ROLLOUT/SCENE_RENDER；
+   e. 屏幕无 raw JSON/无 Unreachable+成功并存；
+   f. 最终回答一致性——outcome PARTIAL 时回答不得宣称完整完成。
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+from tests.agentd.test_pi_tool_bridge import _issue_lease, _request, _setup
+
+
+class TestErrorEnvelopeBudget:
+    async def test_infra_error_zero_budget_with_recovery(
+        self, tmp_path: Path
+    ) -> None:
+        """基础设施错误（RENDER_*）→ details.scope=infrastructure +
+        attempt_budget=0 + recovery_action——模型重试预算为 0。"""
+        service, mission = await _setup(tmp_path)
+        await service._ensure_mcp_discovered()
+        lease = await _issue_lease(service, mission)
+        dispatcher = PiToolDispatcher(service)
+        result = await dispatcher.execute(
+            _request(
+                "rosclaw_compute", mission=mission.mission_id,
+                idem="r09_infra", lease=lease,
+                arguments={
+                    "capability_id": "simulation_render_scene",
+                    "arguments": {"trace_id": "trace_nonexistent"},
+                },
+            )
+        )
+        assert not result.ok
+        details = result.details or {}
+        assert details.get("scope") == "infrastructure", details
+        assert details.get("attempt_budget") == 0, details
+        assert details.get("recovery_action"), details
+        await service.close()
+
+    async def test_transient_context_retryable(self, tmp_path: Path) -> None:
+        """transient 错误码（CONTEXT_* 类）→ scope=transient +
+        attempt_budget=1 + retry_after_condition（可安全重试）。"""
+        from rosclaw.agentd.pi_bridge.tool_dispatch import (
+            _error_envelope_details,
+        )
+
+        details = _error_envelope_details("CONTEXT_NOT_FRESH")
+        assert details["scope"] == "transient"
+        assert details["attempt_budget"] == 1
+        assert details["retry_after_condition"]
+        # 确定性错误预算 0。
+        det = _error_envelope_details("UNKNOWN_CAPABILITY")
+        assert det["attempt_budget"] == 0
+        assert det["scope"] == "deterministic"
+
+
+def _fixture_home(tmp_path: Path) -> Path:
+    """合成金丝雀 home：missions.db（生产路径证据）+ 屏幕文本。"""
+    from rosclaw.storage.migrations import MigrationRunner
+
+    home = tmp_path / "home"
+    (home / "agentd").mkdir(parents=True)
+    conn = sqlite3.connect(home / "agentd" / "missions.db")
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    now = "2026-08-26T00:00:00+00:00"
+    conn.execute(
+        "INSERT INTO tasks (task_id, mission_id, root_goal, mode, body_id, "
+        "state, active_revision, workspace_path, created_at, updated_at) "
+        "VALUES ('task_1', 'm1', '画五角星并做仿真视频', 'SIMULATION', "
+        "'sim/ur5e', 'SUCCEEDED', 1, '', ?, ?)",
+        (now, now),
+    )
+    for seq, (etype, payload) in enumerate([
+        ("plan.node_started", {"node_id": "resolve_robot"}),
+        ("plan.node_completed", {"node_id": "resolve_robot"}),
+        ("plan.node_started", {"node_id": "make_path"}),
+        ("plan.node_completed", {"node_id": "make_path"}),
+        ("plan.node_started", {"node_id": "simulate"}),
+        ("plan.node_completed", {"node_id": "simulate"}),
+        ("plan.node_started", {"node_id": "render"}),
+        ("plan.node_completed", {"node_id": "render"}),
+        ("plan.node_started", {"node_id": "render_scene"}),
+        ("plan.node_completed", {"node_id": "render_scene"}),
+        ("plan.node_started", {"node_id": "verify"}),
+        ("plan.node_completed", {"node_id": "verify"}),
+    ], start=1):
+        conn.execute(
+            "INSERT INTO task_events (task_id, seq, event_type, payload_json, "
+            "created_at) VALUES ('task_1', ?, ?, ?, ?)",
+            (seq, etype, json.dumps(payload), now),
+        )
+    for artifact_id, path, media, kind in (
+        ("art_g", "/h/t1.gif", "image/gif", "preview_2d"),
+        ("art_m", "/h/t1-scene.mp4", "video/mp4", "scene_3d"),
+        ("art_t", "/h/trace.json", "application/json", ""),
+    ):
+        meta = json.dumps(
+            {"lineage": {"kind": kind, "trace_id": "t1"},
+             "evidence": {"levels": ["GEOMETRY_PLAN", "KINEMATIC_TRACKING",
+                                     "DYNAMIC_ROLLOUT"]}}
+            if kind == "" else {"lineage": {"kind": kind, "trace_id": "t1"}}
+        )
+        conn.execute(
+            "INSERT INTO artifacts (artifact_id, task_id, path, media_type, "
+            "sha256, size_bytes, metadata_json, created_at) "
+            "VALUES (?, 'task_1', ?, ?, 'abc', 1000, ?, ?)",
+            (artifact_id, path, media, meta, now),
+        )
+    conn.execute(
+        "INSERT INTO task_outcomes (task_id, revision, outcome_json, created_at) "
+        "VALUES ('task_1', 1, ?, ?)",
+        (
+            json.dumps({
+                "lifecycle": "COMPLETED", "execution": "SUCCEEDED",
+                "verification": "PASS", "delivery": "DELIVERED",
+                "evidence": {"domain": "SIMULATION", "trust": "TRUSTED",
+                             "levels": ["GEOMETRY_PLAN", "KINEMATIC_TRACKING",
+                                        "DYNAMIC_ROLLOUT", "SCENE_RENDER"]},
+                "artifact_refs": [
+                    {"artifact_id": "art_g", "media_type": "image/gif",
+                     "kind": "preview_2d",
+                     "open_command": "rosclaw artifact open art_g"},
+                    {"artifact_id": "art_m", "media_type": "video/mp4",
+                     "kind": "scene_3d",
+                     "open_command": "rosclaw artifact open art_m"},
+                ],
+            }),
+            now,
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return home
+
+
+class TestCanaryAssertions:
+    def test_production_plan_graph_events(self, tmp_path: Path) -> None:
+        from scripts.star_canary import assert_production_plan_graph
+
+        home = _fixture_home(tmp_path)
+        assert_production_plan_graph(home)  # 不抛 = 通过
+
+    def test_plan_graph_missing_fails(self, tmp_path: Path) -> None:
+        from scripts.star_canary import assert_production_plan_graph
+
+        home = _fixture_home(tmp_path)
+        conn = sqlite3.connect(home / "agentd" / "missions.db")
+        conn.execute("DELETE FROM task_events")
+        conn.commit()
+        conn.close()
+        with pytest.raises(AssertionError, match="plan.node"):
+            assert_production_plan_graph(home)
+
+    def test_user_visible_delivery(self, tmp_path: Path) -> None:
+        from scripts.star_canary import assert_user_visible_delivery
+
+        home = _fixture_home(tmp_path)
+        assert_user_visible_delivery(home)
+
+    def test_2d_preview_does_not_satisfy_scene(self, tmp_path: Path) -> None:
+        from scripts.star_canary import assert_user_visible_delivery
+
+        home = _fixture_home(tmp_path)
+        conn = sqlite3.connect(home / "agentd" / "missions.db")
+        conn.execute(
+            "UPDATE task_outcomes SET outcome_json = ?",
+            (json.dumps({
+                "verification": "PASS",
+                "artifact_refs": [
+                    {"artifact_id": "art_g", "media_type": "image/gif",
+                     "kind": "preview_2d",
+                     "open_command": "rosclaw artifact open art_g"},
+                    {"artifact_id": "art_m", "media_type": "video/mp4",
+                     "kind": "preview_2d",
+                     "open_command": "rosclaw artifact open art_m"},
+                ],
+            }),),
+        )
+        conn.commit()
+        conn.close()
+        with pytest.raises(AssertionError, match="scene_3d"):
+            assert_user_visible_delivery(home, require_scene=True)
+
+    def test_model_behavior_budget(self, tmp_path: Path) -> None:
+        from scripts.star_canary import assert_model_behavior_budget
+
+        home = _fixture_home(tmp_path)
+        assert_model_behavior_budget(home, max_task_calls=1)
+
+    def test_evidence_levels(self, tmp_path: Path) -> None:
+        from scripts.star_canary import assert_evidence_levels
+
+        home = _fixture_home(tmp_path)
+        assert_evidence_levels(home)
+
+    def test_screen_clean(self) -> None:
+        from scripts.star_canary import assert_screen_clean
+
+        assert_screen_clean(b"\xe4\xbb\xbb\xe5\x8a\xa1\xe5\xae\x8c\xe6\x88\x90 \xe2\x9c\x93 \xe8\xa7\x84\xe5\x88\x92")
+        with pytest.raises(AssertionError, match="raw JSON"):
+            assert_screen_clean(b'{"artifact_refs": []}')
+        with pytest.raises(AssertionError, match="Unreachable|Blocked"):
+            assert_screen_clean(b"Kernel Unreachable \xe4\xbb\xbb\xe5\x8a\xa1\xe5\xae\x8c\xe6\x88\x90")
+
+    def test_final_answer_consistency(self) -> None:
+        from scripts.star_canary import assert_final_answer_consistent
+
+        # PARTIAL outcome 但回答宣称完整完成 → 拒绝。
+        with pytest.raises(AssertionError, match="一致"):
+            assert_final_answer_consistent(
+                "五角星已绘制完成，视频已交付。",
+                {"verification": "PARTIAL", "delivery": "MISSING"},
+            )
+        # VERIFIED + 完成回答 → 通过。
+        assert_final_answer_consistent(
+            "五角星已绘制完成，几何验证通过。",
+            {"verification": "PASS", "delivery": "DELIVERED"},
+        )
+        # PARTIAL + 诚实回答 → 通过。
+        assert_final_answer_consistent(
+            "运动轨迹已验证，但 3D 场景视频未能生成（渲染后端不可用）。",
+            {"verification": "PARTIAL", "delivery": "MISSING"},
+        )


### PR DESCRIPTION
## 真实事故（0826 体验旅程 + 实施指南 §5.R0-9/§7.4）

renderer 连续三次裸 JSONDecodeError——基础设施故障无重试预算语义；金丝雀只查 DB 文件存在，不查生产路径/用户可见交付/最终回答一致性。

## 闭环

- **ErrorEnvelope 语义**：错误结果 details 带 scope/attempt_budget/retry_after_condition/recovery_action——基础设施/配置/确定性错误模型重试预算 0；transient（CONTEXT_* 等）才可安全重试；
- **能力异常带码透传**（`RENDER_INPUT_MISSING: …` → 稳定错误码，不包成无语义 EXECUTOR_ERROR）；RECOVERY_REGISTRY 补 RENDER_/WORLD_ASSET/TOOL_ASSET 恢复动作；
- **金丝雀断言函数**（可单测）：生产 PlanGraph（plan.node_* 五节点完整）/用户可见交付（GIF+MP4 refs 带 open_command、scene 要求 mp4 必须 scene_3d kind）/模型行为预算（具身入口 ≤1、bash=0、手工 finish=0）/证据等级拆分/屏幕卫生（无 raw JSON、无 Unreachable+成功并存）/最终回答一致性（PARTIAL 不得宣称完整完成）；指标记录 tool_calls/error_count/tokens/elapsed。

## 红→绿证据

- 红：/tmp/r09-red.txt（10 红）；
- 绿：R0-9 测试 10/10；全栈受影响套件 62 过；PTY 旅程 A/B/C 绿（全栈 rebase 后）。

## Gate R0-9 对齐

同类基础设施故障模型可见结果 ≤1 次 + 一条有语义说明——不是三次裸异常 + 两次 shell denied。

🤖 Generated with [Claude Code](https://claude.com/claude-code)