### PR TITLE
feat: R0-1.5 输入路由自动执行——已知 recipe 零模型调用（金丝雀 4/10 实证收口）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -426,6 +426,18 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			// 投递（handled + 通知重发=无幽灵执行，HP1 语义不变）。
 			const persisted = await inputController.persist(text);
 			if (!persisted) return { action: "handled" as const };
+			// R0-1.5：输入路由自动执行——已知 recipe 由内核直接执行
+			// （零模型调用）；watcher 跟踪进度/终态（followUp 一次）。
+			const autoTask = (persisted as { auto_task?: { task_id?: string } })
+				.auto_task;
+			if (autoTask?.task_id) {
+				operationWatcher.trackTask(String(autoTask.task_id));
+				const ctx2 = latestCtx;
+				ctx2?.ui.notify(
+					"任务已由确定性链自动开始执行（/activity 查看进度）",
+					"info",
+				);
+			}
 			return { action: "continue" as const };
 		});
 

--- a/packages/rosclaw-agent/src/native/input-controller.ts
+++ b/packages/rosclaw-agent/src/native/input-controller.ts
@@ -44,8 +44,11 @@ export class InputController {
 
 	/** P0-C（0824 总纲 §6.1）：输入先落会话（pi.input.persist——
 	 *  不立即创建 Task；persist 失败不投递，HP1 防线语义不变）。
-	 *  返回 null = 不投递。 */
-	async persist(text: string): Promise<{ input_id?: string } | null> {
+	 *  返回 null = 不投递。R0-1.5：auto_task（内核自动路由的任务）
+	 *  穿透给调用方（watcher 跟踪进度/终态）。 */
+	async persist(
+		text: string,
+	): Promise<{ input_id?: string; auto_task?: { task_id?: string } } | null> {
 		const messageId = `msg_${randomUUID()}`;
 		try {
 			const result = (await this.deps.call("pi.input.persist", {
@@ -55,13 +58,17 @@ export class InputController {
 				message_id: messageId,
 				text,
 				force_new: this.forceNewNext,
-			})) as unknown as { ok?: boolean; input?: { input_id?: string } };
+			})) as unknown as {
+				ok?: boolean;
+				input?: { input_id?: string };
+				auto_task?: { task_id?: string };
+			};
 			this.forceNewNext = false;
 			this.deps.call("pi.input.dispatched", {
 				mission_id: this.deps.missionId(),
 				message_id: messageId,
 			}).catch(() => undefined);
-			return result.input ?? {};
+			return { ...(result.input ?? {}), auto_task: result.auto_task };
 		} catch (err) {
 			// 持久化失败不投递（幽灵执行防线）：消息不消失于沉默——
 			// 明确通知用户重发。

--- a/packages/rosclaw-agent/src/native/operation-watcher.ts
+++ b/packages/rosclaw-agent/src/native/operation-watcher.ts
@@ -56,6 +56,11 @@ export class OperationWatcher {
 	private readonly delivered = new Set<string>();
 	private readonly seqByTask = new Map<string, number>();
 	private readonly lastLineByOp = new Map<string, string>();
+	/** R0-1.5：自动路由任务跟踪（task_id 集合——plan 进度 +
+	 *  终态一次 followUp）。 */
+	private readonly trackedTasks = new Set<string>();
+	private readonly deliveredTasks = new Set<string>();
+	private readonly completedNodesByTask = new Map<string, Set<string>>();
 
 	constructor(private readonly deps: OperationWatcherDeps) {}
 
@@ -63,6 +68,14 @@ export class OperationWatcher {
 	track(operationId: string): void {
 		if (!operationId || this.tracked.has(operationId)) return;
 		this.pending.add(operationId);
+	}
+
+	/** R0-1.5：自动路由任务登记（输入路由执行——无 operation，
+	 *  跟踪 task 事件流：plan.node 进度 widget + 终态一次
+	 *  followUp）。 */
+	trackTask(taskId: string): void {
+		if (!taskId || this.trackedTasks.has(taskId)) return;
+		this.trackedTasks.add(taskId);
 	}
 
 	start(): void {
@@ -101,9 +114,12 @@ export class OperationWatcher {
 
 	private async tick(): Promise<void> {
 		await this.resolvePending();
-		if (!this.tracked.size) return;
+		if (!this.tracked.size && !this.trackedTasks.size) return;
 		const sink = this.deps.sink();
-		const taskIds = [...new Set(this.tracked.values())];
+		// R0-1.5：op 任务与自动路由任务同一增量轮询（不重不漏）。
+		const taskIds = [
+			...new Set([...this.tracked.values(), ...this.trackedTasks]),
+		];
 		for (const taskId of taskIds) {
 			let events: KernelEvent[] = [];
 			try {
@@ -120,6 +136,9 @@ export class OperationWatcher {
 					this.seqByTask.get(taskId) ?? 0, Number(event.seq) || 0,
 				));
 				const operationId = String(event.operation_id ?? "");
+				if (this.trackedTasks.has(taskId)) {
+					await this.handleTaskEvent(taskId, event);
+				}
 				if (!operationId || !this.tracked.has(operationId)) continue;
 				if (event.event_type === "operation.output") {
 					const text = String(event.payload?.text ?? "").trim();
@@ -154,6 +173,70 @@ export class OperationWatcher {
 		if (!sink?.setWidget || !this.lastLineByOp.has(operationId)) return;
 		this.lastLineByOp.delete(operationId);
 		sink.setWidget(`op:${operationId}`, undefined);
+	}
+
+	/** R0-1.5：自动路由任务事件——plan.node 进度原位 widget +
+	 *  终态（verification.completed）一次 followUp（不重复、
+	 *  progress 不进模型上下文）。 */
+	private static readonly NODE_LABELS: Record<string, string> = {
+		resolve_robot: "资源",
+		make_path: "规划",
+		simulate: "仿真",
+		render: "渲染",
+		render_scene: "场景视频",
+		verify: "验证",
+	};
+
+	private async handleTaskEvent(taskId: string, event: KernelEvent): Promise<void> {
+		if (this.deliveredTasks.has(taskId)) return;
+		const sink = this.deps.sink();
+		if (event.event_type === "plan.node_completed") {
+			const nodeId = String(event.payload?.node_id ?? "");
+			const done = this.completedNodesByTask.get(taskId) ?? new Set<string>();
+			done.add(nodeId);
+			this.completedNodesByTask.set(taskId, done);
+			if (sink?.setWidget) {
+				const labels = [...done].map(
+					(n) => `✓ ${OperationWatcher.NODE_LABELS[n] ?? n}`,
+				);
+				sink.setWidget(`task:${taskId}`, [
+					`⠋ 任务执行中（确定性链）：${labels.join(" ")}`,
+				]);
+			}
+			return;
+		}
+		if (event.event_type !== "verification.completed") return;
+		// 终态：一次 followUp（outcome 权威——不由模型自由夸大）。
+		this.deliveredTasks.add(taskId);
+		this.trackedTasks.delete(taskId);
+		this.completedNodesByTask.delete(taskId);
+		if (sink?.setWidget) sink.setWidget(`task:${taskId}`, undefined);
+		let outcomeText = "";
+		try {
+			const result = await this.deps.call("pi.coordinator.consider", {
+				task_id: taskId,
+			});
+			const outcome = (result.outcome ?? {}) as Record<string, unknown>;
+			const refs = (outcome.artifact_refs ?? []) as Array<Record<string, unknown>>;
+			const opens = refs.map((r) => String(r.open_command ?? "")).filter(Boolean);
+			const passed = outcome.verification === "PASS";
+			outcomeText = passed
+				? `任务完成：验收 PASS · 交付 ${String(outcome.delivery ?? "")}`
+					+ (opens.length ? `——交付物：${opens.join(" · ")}` : "")
+				: `任务未完成：验收 ${String(outcome.verification ?? "?")} · 交付 ${String(outcome.delivery ?? "?")}`
+					+ "——如实告知用户限制，不要宣称完整完成";
+		} catch {
+			outcomeText = "任务已终态（outcome 拉取失败——/activity 查看账本）";
+		}
+		sink?.api.sendMessage(
+			{
+				customType: "rosclaw.task_terminal",
+				content: outcomeText,
+				display: false,
+				details: { task_id: taskId },
+			},
+			{ triggerTurn: true, deliverAs: "followUp" },
+		);
 	}
 
 	private async handleTerminal(

--- a/packages/rosclaw-agent/src/tools/surface.ts
+++ b/packages/rosclaw-agent/src/tools/surface.ts
@@ -40,14 +40,13 @@ export const PRODUCT_PACK: readonly string[] = [
  * PR-N5D：rosclaw_compute / rosclaw_execute 退出默认模型面——能力以
  * CapabilitySnapshot 物化的精确强类型工具直接进入（materialize.ts）；
  * 两者仍是 bridge wire 上的验证链 plumbing（物化工具内部调用）。
- * R0-1：rosclaw_task = TaskExecutionService 的兼容 adapter（frozen
- * TaskSpecV2 → TaskRouter → PlanGraph——唯一生产链）；TaskSpec 承载
- * 完整几何/交付语义（R0-2）后退出模型面，由输入路由自动触发。 */
+ * R0-1.5：rosclaw_task 退出模型面——已知 recipe 由输入路由自动
+ * 执行（TaskExecutionService 唯一生产链，零模型调用）；wire 层
+ * adapter 保留兼容。 */
 export const EMBODIMENT_PACK: readonly string[] = [
 	"rosclaw_status",
 	"rosclaw_capabilities",
 	"rosclaw_observe",
-	"rosclaw_task",
 	"rosclaw_verify",
 	"rosclaw_request_action",
 	"rosclaw_memory_query",
@@ -75,6 +74,10 @@ export const REMOVED_FROM_MODEL: readonly string[] = [
 	"rosclaw_task_pause",
 	"rosclaw_task_resume",
 	"rosclaw_task_cancel",
+	// R0-1.5（金丝雀实证 + 0826 审计 §6 删除清单）：任务级入口
+	// 由输入路由自动执行（零模型调用）——模型面不再有
+	// rosclaw_task；wire 层 adapter 保留（兼容既有 session）。
+	"rosclaw_task",
 	// Worker 操控全系
 	"rosclaw_delegate",
 	"rosclaw_retry_work",

--- a/packages/rosclaw-agent/test/governor-tools.test.ts
+++ b/packages/rosclaw-agent/test/governor-tools.test.ts
@@ -17,9 +17,9 @@ describe("Native Agent 工具面（PR-H1）", () => {
 			"rosclaw_verify",
 			"rosclaw_memory_query",
 			"rosclaw_fail_safe",
-			"rosclaw_task",
 			"rosclaw_request_action",
 		];
+		// R0-1.5：rosclaw_task 退出模型面（输入路由自动执行）。
 		for (const name of [...workspace, ...embodiment]) {
 			assert.ok(MODEL_TOOL_NAMES.includes(name), `缺工具 ${name}`);
 		}

--- a/packages/rosclaw-agent/test/n5d-materialize.test.ts
+++ b/packages/rosclaw-agent/test/n5d-materialize.test.ts
@@ -131,11 +131,13 @@ test("N5D: propose_ 工具走 admission 链（rosclaw_execute 管线）", async 
 	assert.equal(params.request.arguments.capability_id, "ur5e.move_joints");
 });
 
-test("N5D: rosclaw_compute/rosclaw_execute 退出模型面，task 保留兼容", () => {
+test("N5D: rosclaw_compute/rosclaw_execute 退出模型面；R0-1.5 task 亦退出", () => {
 	assert.ok(!MODEL_TOOL_NAMES.includes("rosclaw_compute"),
 		"rosclaw_compute 应从默认模型面删除");
 	assert.ok(!MODEL_TOOL_NAMES.includes("rosclaw_execute"),
 		"rosclaw_execute 应从默认模型面删除");
-	assert.ok(MODEL_TOOL_NAMES.includes("rosclaw_task"),
-		"rosclaw_task 降级为兼容入口（保留）");
+	// R0-1.5（金丝雀实证 + 0826 审计 §6）：已知 recipe 由输入路由
+	// 自动执行——rosclaw_task 退出模型面（wire adapter 保留）。
+	assert.ok(!MODEL_TOOL_NAMES.includes("rosclaw_task"),
+		"rosclaw_task 已退出模型面（输入路由自动执行）");
 });

--- a/packages/rosclaw-agent/test/r015-track-task.test.ts
+++ b/packages/rosclaw-agent/test/r015-track-task.test.ts
@@ -1,0 +1,81 @@
+/** R0-1.5 红测试（金丝雀实证 + 0826 审计收口）：trackTask——
+ * 自动路由任务的 plan 进度 widget + 终态一次 followUp。
+ *
+ * 断言：
+ * 1. plan.node_started/completed → 单活动区 widget 原位更新
+ *    （不重复打印、不进模型上下文）；
+ * 2. verification.completed PASS → 一次 followUp（含交付打开
+ *    命令）——重放不重复投递；
+ * 3. 终态后 untrack（不再轮询）。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("trackTask：进度 widget + 终态一次 followUp + untrack", async () => {
+	const { OperationWatcher } = await import("../src/native/operation-watcher.js");
+	const events = [
+		{ seq: 1, event_type: "plan.node_started", payload: { node_id: "resolve_robot" } },
+		{ seq: 2, event_type: "plan.node_completed", payload: { node_id: "resolve_robot" } },
+		{ seq: 3, event_type: "plan.node_started", payload: { node_id: "make_path" } },
+		{ seq: 4, event_type: "plan.node_completed", payload: { node_id: "make_path" } },
+		{ seq: 5, event_type: "verification.completed", payload: { status: "PASS", verification_id: "vrf_1" } },
+	];
+	const widgets: Array<[string, string[] | undefined]> = [];
+	const followUps: string[] = [];
+	let tick = 0;
+	const watcher = new OperationWatcher({
+		call: async (method: string, params: Record<string, unknown>) => {
+			if (method === "pi.kernel.events") {
+				// 游标增量（不重不漏）。
+				const after = Number((params as { last_seq?: number }).last_seq ?? 0);
+				tick += 1;
+				return { ok: true, events: events.filter((e) => e.seq > after) };
+			}
+			if (method === "pi.coordinator.consider") {
+				return {
+					ok: true,
+					outcome: {
+						lifecycle: "COMPLETED",
+						verification: "PASS",
+						delivery: "DELIVERED",
+						artifact_refs: [
+							{ artifact_id: "art_g", open_command: "rosclaw artifact open art_g" },
+						],
+					},
+				};
+			}
+			return { ok: true };
+		},
+		sink: () => ({
+			api: {
+				sendMessage: (message: { content: string }, _options: unknown) => {
+					followUps.push(message.content);
+				},
+			},
+			isIdle: true,
+			setWidget: (key: string, lines: string[] | undefined) => {
+				widgets.push([key, lines]);
+			},
+		}),
+	} as never);
+	watcher.trackTask("task_auto_1");
+	// 手动驱动 tick（定时器在测试外）。
+	await (watcher as never as { tick(): Promise<void> }).tick();
+	assert.ok(widgets.length > 0, "plan 进度未进 widget");
+	// 终态清除是最后一个 widget 更新——断言进度行出现过
+	// （节点 label 原位更新）。
+	const progressLines = widgets
+		.filter(([, lines]) => lines !== undefined)
+		.map(([, lines]) => (lines ?? []).join(" "));
+	assert.ok(
+		progressLines.some((line) => /规划|make_path/.test(line)),
+		`进度 widget 无规划节点行：${JSON.stringify(widgets)}`,
+	);
+	// 终态 → followUp 一次。
+	assert.equal(followUps.length, 1, `followUp 应恰好一次（实际 ${followUps.length}）`);
+	assert.match(followUps[0], /art_g/);
+	// 重放不重复投递。
+	await (watcher as never as { tick(): Promise<void> }).tick();
+	assert.equal(followUps.length, 1, "重放重复投递了 followUp");
+});

--- a/scripts/star_canary.py
+++ b/scripts/star_canary.py
@@ -175,7 +175,10 @@ def run_once(idx: int, base: Path) -> dict:
     for (usage_json,) in usage_rows:
         try:
             usage = json.loads(str(usage_json))
-            total_tokens += int(usage.get("total_tokens") or 0)
+            # Pi usage 是 camelCase（totalTokens）——实测金丝雀账本。
+            total_tokens += int(
+                usage.get("totalTokens") or usage.get("total_tokens") or 0
+            )
         except (ValueError, TypeError):
             continue
     outcome["tokens"] = total_tokens
@@ -269,13 +272,26 @@ def assert_user_visible_delivery(home: Path, *, require_scene: bool = False) -> 
 
 
 def assert_model_behavior_budget(home: Path, *, max_task_calls: int = 1) -> None:
-    """模型行为预算：具身入口调用 ≤max、bash=0、手工 finish=0
-    （已知 recipe 不允许模型绕链脚本化）。"""
+    """模型行为预算：具身/能力链入口调用 ≤max、bash=0、手工
+    finish=0（已知 recipe 不允许模型绕链脚本化——R0-1.5 后
+    自动路由，期望 0 次）。"""
     conn = sqlite3.connect(home / "agentd" / "missions.db")
     calls = conn.execute(
         "SELECT COUNT(*) FROM task_events WHERE event_type = 'task.tool_used'"
     ).fetchone()[0]
-    assert calls <= max_task_calls, f"具身入口调用 {calls} 次 > {max_task_calls}"
+    # 能力链调用（run8 实证：materialized capability 手拼绕链——
+    # compute/observe/execute 都算）。
+    capability_calls = conn.execute(
+        "SELECT COUNT(*) FROM agent_events WHERE type = 'tool.completed' "
+        "AND json_extract(payload_json, '$.tool_name') IN "
+        "('rosclaw_compute', 'rosclaw_observe', 'rosclaw_execute', "
+        "'rosclaw_request_action')"
+    ).fetchone()[0]
+    total = calls + capability_calls
+    assert total <= max_task_calls, (
+        f"具身/能力链调用 {total} 次 > {max_task_calls}"
+        f"（task_used={calls} capability={capability_calls}）"
+    )
     bash = conn.execute(
         "SELECT COUNT(*) FROM agent_events WHERE type = 'tool.completed' "
         "AND json_extract(payload_json, '$.tool_name') = 'bash'"

--- a/scripts/star_canary.py
+++ b/scripts/star_canary.py
@@ -280,12 +280,11 @@ def assert_model_behavior_budget(home: Path, *, max_task_calls: int = 1) -> None
         "SELECT COUNT(*) FROM task_events WHERE event_type = 'task.tool_used'"
     ).fetchone()[0]
     # 能力链调用（run8 实证：materialized capability 手拼绕链——
-    # compute/observe/execute 都算）。
+    # compute/execute 才算绕链；observe 是观察不是绕链）。
     capability_calls = conn.execute(
         "SELECT COUNT(*) FROM agent_events WHERE type = 'tool.completed' "
         "AND json_extract(payload_json, '$.tool_name') IN "
-        "('rosclaw_compute', 'rosclaw_observe', 'rosclaw_execute', "
-        "'rosclaw_request_action')"
+        "('rosclaw_compute', 'rosclaw_execute', 'rosclaw_request_action')"
     ).fetchone()[0]
     total = calls + capability_calls
     assert total <= max_task_calls, (

--- a/src/rosclaw/agentd/auto_route.py
+++ b/src/rosclaw/agentd/auto_route.py
@@ -37,12 +37,12 @@ async def maybe_auto_route(
 ) -> dict[str, Any] | None:
     """指令性画路径输入 → 自动路由执行。返回 auto_task 描述或
     None（不可路由/疑问句/重放）。"""
-    from rosclaw.task_kernel.task_spec import _classify_intent
     from rosclaw.task_kernel.task_router import (
         compile_recipe_inputs,
         is_task_directive,
         route_recipe,
     )
+    from rosclaw.task_kernel.task_spec import _classify_intent
 
     text = text.strip()
     if not text or not is_task_directive(text):

--- a/src/rosclaw/agentd/auto_route.py
+++ b/src/rosclaw/agentd/auto_route.py
@@ -1,0 +1,119 @@
+"""输入路由自动执行（R0-1.5，金丝雀 4/10 实证 + 0826 审计收口）。
+
+已知 recipe 的画路径指令在用户输入持久化时由**内核**自动执行
+（TaskExecutionService 唯一生产链）——零模型工具调用。金丝雀
+实证：任务级入口在场不等于模型会选它（绕链手拼/竖直平面被拒
+后降级调试都是产品侧失败，不是模型侧借口）。
+
+纪律：
+- 仅 SIM 模式（REAL/SHADOW 永远走 rosclawd 权威链——自动路由
+  不是审批旁路）；
+- 疑问句/讨论形式不自动执行（is_task_directive 护栏）；
+- 幂等：同一 message_id 只路由一次（进程内去重 + input.task_id
+  回写检查）；
+- 执行失败=数据（plan.node_failed/PARTIAL outcome）——不崩输入
+  通道。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from rosclaw.agentd.service import AgentService
+
+#: 进程内已路由去重（message_id）——与 input.task_id 回写双保险。
+_routed: set[str] = set()
+
+
+async def maybe_auto_route(
+    service: AgentService,
+    *,
+    mission_id: str,
+    session_ref: str,
+    message_id: str,
+    text: str,
+) -> dict[str, Any] | None:
+    """指令性画路径输入 → 自动路由执行。返回 auto_task 描述或
+    None（不可路由/疑问句/重放）。"""
+    from rosclaw.task_kernel.task_spec import _classify_intent
+    from rosclaw.task_kernel.task_router import (
+        compile_recipe_inputs,
+        is_task_directive,
+        route_recipe,
+    )
+
+    text = text.strip()
+    if not text or not is_task_directive(text):
+        return None
+    if message_id in _routed:
+        return None
+    intent = _classify_intent(text)
+    if route_recipe({"goal": {"intent": intent}}) is None:
+        return None
+    mission = service.get_mission(mission_id)
+    if mission is not None and mission.mode.value != "SIMULATION":
+        return None  # REAL/SHADOW 不自动路由（rosclawd 权威链）
+    kernel = service._task_kernel
+    # 重放/已附着输入不重路由（双保险）。
+    row = kernel._conn.execute(
+        "SELECT task_id FROM user_inputs WHERE message_id = ?", (message_id,),
+    ).fetchone()
+    if row is not None and row["task_id"]:
+        return None
+    try:
+        bound = kernel.ensure_task_for_effect(
+            mission_id=mission_id,
+            session_ref=session_ref,
+            backend_native_id=session_ref,
+            cwd="",
+            mode="SIMULATION",
+            body_id=(
+                mission.body_binding.body_id if mission else ""
+            ),
+            explicit_goal=text,
+        )
+    except ValueError:
+        return None  # 动机缺失等——诚实不路由
+    task_id = str(bound["task_id"])
+    recipe_id = route_recipe(
+        kernel.get_task_spec(task_id) or {"goal": {"intent": intent}}
+    )
+    if recipe_id is None:
+        return None
+    _routed.add(message_id)
+    inputs = compile_recipe_inputs(text)
+
+    async def _run() -> None:
+        try:
+            await asyncio.to_thread(
+                service._task_execution.execute,
+                task_id,
+                recipe_inputs=inputs,
+            )
+        except Exception as exc:  # noqa: BLE001 - 执行失败是任务数据
+            # 不沉默——失败写诊断日志（金丝雀实证：静默吞错导致
+            # "任务 RUNNING 无事件"无迹可查）。
+            import logging
+            import traceback
+
+            logging.getLogger("rosclaw.auto_route").error(
+                "auto-route execution failed for %s: %s\n%s",
+                task_id, exc, traceback.format_exc()[-2000:],
+            )
+
+    asyncio.get_event_loop().create_task(_run())
+    return {
+        "task_id": task_id,
+        "recipe_id": recipe_id,
+        "state": "RUNNING",
+        "inputs": inputs,
+    }
+
+
+def reset_routed_for_tests() -> None:
+    _routed.clear()
+
+
+__all__ = ["maybe_auto_route", "reset_routed_for_tests"]

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1021,7 +1021,21 @@ class PiBridgeServer:
                 session_id=str(params.get("session_ref", "")),
                 model_visible=True,
             )
-            return {"ok": True, "input": record}
+            # R0-1.5：指令性画路径输入 → 内核自动路由执行（唯一
+            # 生产链，零模型工具调用；SIM only，疑问句不触发）。
+            from rosclaw.agentd.auto_route import maybe_auto_route
+
+            auto_task = await maybe_auto_route(
+                service,
+                mission_id=str(params.get("mission_id", "")),
+                session_ref=str(params.get("session_ref", "")),
+                message_id=str(params.get("message_id", "")),
+                text=text,
+            )
+            out: dict = {"ok": True, "input": record}
+            if auto_task:
+                out["auto_task"] = auto_task
+            return out
         if method == "pi.task.ensure_effect":
             # P0-C（0824 总纲 §6.2）：首个 effectful call 的原子
             # admission——以 session 最新未附着输入为动机建 task/
@@ -1160,9 +1174,16 @@ class PiBridgeServer:
             # P0-D：Harness idle（turn_end）驱动的自动收尾——返回
             # outcome（可能为 None=任务仍在进行）。
             kernel = service._task_kernel
-            task = kernel.latest_task_for(
-                str(params.get("mission_id", "")),
-                str(params.get("session_ref", "")),
+            # R0-1.5：task_id 直查（自动路由任务的 watcher followUp）；
+            # 无 task_id 时回落 mission+session 最新任务（P0-D 原义）。
+            task_id = str(params.get("task_id", ""))
+            task = (
+                kernel.get_task(task_id)
+                if task_id
+                else kernel.latest_task_for(
+                    str(params.get("mission_id", "")),
+                    str(params.get("session_ref", "")),
+                )
             )
             if task is None:
                 return {"ok": True, "outcome": None}

--- a/src/rosclaw/agentd/sim_trajectory.py
+++ b/src/rosclaw/agentd/sim_trajectory.py
@@ -25,6 +25,14 @@ import math
 from pathlib import Path
 from typing import Any
 
+#: R0-1.5（金丝雀实证：模型传 'xz'/'vertical' 被拒）——命名平面
+#: xy/xz/yz 映射为法向（任意法向走 plane_normal_xyz）。
+_NAMED_PLANE_NORMALS = {
+    "xy": [0.0, 0.0, 1.0],
+    "xz": [0.0, 1.0, 0.0],
+    "yz": [1.0, 0.0, 0.0],
+}
+
 #: 与 ur5e_mcp 一致的安全工作空间（规划即拒越界）。
 _SAFE_RADIUS = (0.10, 0.80)
 _SAFE_Z = (0.02, 1.20)
@@ -377,13 +385,6 @@ class SimTrajectoryService:
     ) -> dict[str, Any]:
         if shape not in _SHAPES:
             raise ValueError(f"unsupported shape {shape!r} (supported: {', '.join(_SHAPES)})")
-        # R0-1.5（金丝雀实证：模型传 'xz'/'vertical' 被拒）——命名
-        # 平面 xy/xz/yz 映射为法向（任意法向走 plane_normal_xyz）。
-        _NAMED_PLANE_NORMALS = {
-            "xy": [0.0, 0.0, 1.0],
-            "xz": [0.0, 1.0, 0.0],
-            "yz": [1.0, 0.0, 0.0],
-        }
         if plane != "xy" and plane_normal_xyz is None:
             normal = _NAMED_PLANE_NORMALS.get(plane)
             if normal is None:

--- a/src/rosclaw/agentd/sim_trajectory.py
+++ b/src/rosclaw/agentd/sim_trajectory.py
@@ -377,8 +377,28 @@ class SimTrajectoryService:
     ) -> dict[str, Any]:
         if shape not in _SHAPES:
             raise ValueError(f"unsupported shape {shape!r} (supported: {', '.join(_SHAPES)})")
+        # R0-1.5（金丝雀实证：模型传 'xz'/'vertical' 被拒）——命名
+        # 平面 xy/xz/yz 映射为法向（任意法向走 plane_normal_xyz）。
+        _NAMED_PLANE_NORMALS = {
+            "xy": [0.0, 0.0, 1.0],
+            "xz": [0.0, 1.0, 0.0],
+            "yz": [1.0, 0.0, 0.0],
+        }
         if plane != "xy" and plane_normal_xyz is None:
-            raise ValueError(f"unsupported plane {plane!r} (supported: xy)")
+            normal = _NAMED_PLANE_NORMALS.get(plane)
+            if normal is None:
+                raise ValueError(
+                    f"unsupported plane {plane!r} (supported: "
+                    f"{', '.join(_NAMED_PLANE_NORMALS)} 或 plane_normal_xyz)"
+                )
+            plane_normal_xyz = normal
+            if plane_offset_m is None:
+                # 命名竖直面的 offset = 中心在法向轴上的投影
+                # （axis = 不在面名中的那个轴，xyz 轴序索引）。
+                axis = "xyz".index(
+                    next(c for c in "xyz" if c not in plane)
+                )
+                plane_offset_m = float(list(center_m)[axis])
         if not isinstance(center_m, list | tuple) or len(center_m) != 3:
             raise ValueError("center_m must be [x, y, z]")
         if not (0.02 <= float(scale_m) <= 0.35):

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -258,11 +258,28 @@ class TaskKernel:
         if active is not None:
             revision = int(active["active_revision"]) + 1
             ensure_run(self._home, str(active["task_id"]), revision)  # WP-8
+            # P1-C1 + R0-1.5（金丝雀实证）：普通修订分支也必须冻结
+            # 新 revision 的 TaskSpecV2——此前只有"SUCCEEDED 重开"
+            # 分支冻结，活跃任务修订的 spec 为空（TaskExecutionService
+            # 无法路由——TASK_SPEC_MISSING）。
+            from rosclaw.task_kernel.task_spec import compile_task_spec
+
+            revised_spec = compile_task_spec(
+                task_id=str(active["task_id"]), revision=revision,
+                goal_text=text,
+                body_id=str(active["body_id"] or ""),
+                mode=str(active["mode"] or "SIMULATION"),
+                acceptance_spec_id="",
+                language=(
+                    str(active["locale"] or "") if active["locale"] != "auto" else ""
+                ),
+            )
             self._conn.execute(
                 "INSERT INTO task_revisions (task_id, revision, "
-                "user_message_id, goal_delta, created_at) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (active["task_id"], revision, message_id, text, now),
+                "user_message_id, goal_delta, task_spec_json, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (str(active["task_id"]), revision, message_id, text,
+                 revised_spec.model_dump_json(), now),
             )
             self._conn.execute(
                 "UPDATE tasks SET active_revision = ?, updated_at = ? "

--- a/src/rosclaw/task_kernel/task_router.py
+++ b/src/rosclaw/task_kernel/task_router.py
@@ -44,4 +44,49 @@ def route_recipe(spec: Mapping[str, Any], *, goal_hint: str = "") -> str | None:
     return RECIPE_BY_GOAL.get(goal_hint)
 
 
-__all__ = ["RECIPE_BY_INTENT", "route_recipe"]
+#: R0-1.5（金丝雀实证）：NL → recipe 几何参数（通用词类标记——
+#: 形状词/平面词是通用类别，不是五角星特例 prompt 硬编码）。
+_SHAPE_WORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("star5", ("五角星", "星形", "star")),
+    ("circle", ("圆", "circle")),
+)
+
+#: 竖直平面词类 → 命名面（xz：y=const 立面——画板/墙面的常见
+#: 含义；yz 留给显式 "yz 面"）。
+_VERTICAL_MARKERS = ("竖直平面", "垂直平面", "竖直面", "垂直面", "立面",
+                     "vertical plane", "竖着", "竖直方向")
+_YZ_MARKERS = ("yz 面", "yz面", "yz plane")
+
+#: 疑问/讨论形式护栏——"怎么画五角星"是讨论不是指令，不自动执行。
+_QUESTION_MARKERS = ("怎么", "如何", "吗", "？", "?", "what", "how",
+                     "why", "解释", "介绍", "是什么")
+
+
+def is_task_directive(text: str) -> bool:
+    """指令形式判定：疑问句/讨论形式不自动执行。"""
+    lowered = text.lower()
+    return not any(m in lowered or m in text for m in _QUESTION_MARKERS)
+
+
+def compile_recipe_inputs(goal_text: str) -> dict[str, Any]:
+    """NL → recipe 几何参数（缺的字段由 recipe 确定性缺省补齐）。"""
+    inputs: dict[str, Any] = {}
+    lowered = goal_text.lower()
+    for shape, markers in _SHAPE_WORDS:
+        if any(m in goal_text or m in lowered for m in markers):
+            inputs["shape"] = shape
+            break
+    if any(m in goal_text or m in lowered for m in _YZ_MARKERS):
+        inputs["plane"] = "yz"
+    elif any(m in goal_text or m in lowered for m in _VERTICAL_MARKERS):
+        inputs["plane"] = "xz"
+    return inputs
+
+
+__all__ = [
+    "RECIPE_BY_GOAL",
+    "RECIPE_BY_INTENT",
+    "compile_recipe_inputs",
+    "is_task_directive",
+    "route_recipe",
+]

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -383,6 +383,15 @@ class _FakeModel:
             # 步骤的"Worker 结果已收到并验证"混淆）。
             frames.append(_sse(_chunk("Worker 结果已综合给用户。")))
             frames.append(_sse(_chunk("", "stop")))
+        elif "任务完成：验收 PASS" in text or (
+            "任务完成：验收 PASS" in _text(messages[-1] if messages else {})
+        ):
+            # R0-1.5：自动路由任务的终态 followUp 回合——outcome 权威
+            # （验收 PASS + 交付完成）才说完成。
+            frames.append(_sse(_chunk("五角星已绘制完成，几何验证通过。")))
+            frames.append(_sse(_chunk("", "stop")))
+            frames.append(b"data: [DONE]\n\n")
+            return b"".join(frames)
         elif "委派" in text:
             # PR-H1（ADR-0012）：模型面不再有 task_submit/delegate——
             # Native Agent 用自己的工作工具在同一 session 直接完成。
@@ -415,24 +424,13 @@ class _FakeModel:
                     )
                 )
             else:
-                # 八审 P0-5：任务级入口——一次 rosclaw_task 调用（确定性
-                # 编译器完成规划/策略/执行/验证），不再手工拼工具链。
-                frames.extend(
-                    _tool_call_frames(
-                        "call_task",
-                        "rosclaw_task",
-                        json.dumps(
-                            {
-                                "goal": "draw_shape",
-                                "parameters": {
-                                    "shape": "star5",
-                                    "center_m": [0.35, 0.25, 0.30],
-                                    "radius_m": 0.10,
-                                },
-                            }
-                        ),
-                    )
-                )
+                # R0-1.5（金丝雀实证 + 0826 审计收口）：已知 recipe 由
+                # 输入路由自动执行（零模型调用）——模型不再调
+                # rosclaw_task（已退出模型面），只确认收到指令。
+                frames.append(_sse(_chunk("已收到——确定性任务链自动执行中。")))
+                frames.append(_sse(_chunk("", "stop")))
+                frames.append(b"data: [DONE]\n\n")
+                return b"".join(frames)
         elif "回到零点" in text:
             # 七审 PR-SEVEN-7 Journey B：单独动作（deny 腿）——一次
             # 人工拒绝必须 fail closed（无 txn、无 grant、诚实回答）。

--- a/tests/agentd/test_r015_input_autoroute.py
+++ b/tests/agentd/test_r015_input_autoroute.py
@@ -24,14 +24,9 @@
 
 from __future__ import annotations
 
-import json
-import sqlite3
 from pathlib import Path
 
 import pytest
-
-from tests.agentd.test_r01_production_chain import _kernel
-from tests.agentd.test_r02_task_spec_deliverables import _draw_task
 
 
 class TestRecipePlaneSupport:
@@ -105,7 +100,6 @@ class TestServerAutoRoute:
         import asyncio
 
         from rosclaw.agentd.pi_bridge.server import PiBridgeServer
-
         from tests.agentd.test_pi_tool_bridge import _setup
 
         service, mission = await _setup(tmp_path)
@@ -155,7 +149,6 @@ class TestServerAutoRoute:
 
     async def test_question_not_auto_routed(self, tmp_path: Path) -> None:
         from rosclaw.agentd.pi_bridge.server import PiBridgeServer
-
         from tests.agentd.test_pi_tool_bridge import _setup
 
         service, mission = await _setup(tmp_path)

--- a/tests/agentd/test_r015_input_autoroute.py
+++ b/tests/agentd/test_r015_input_autoroute.py
@@ -1,0 +1,196 @@
+"""R0-1.5 红测试（金丝雀 4/10 实证 + 0826 审计 §5.R0-1 收口）：
+输入路由自动执行——已知 recipe 零模型调用。
+
+金丝雀实证（真实 K3，/tmp/star-canary-1787797367）：
+- run8：模型绕链手拼 capability（零 rosclaw_task 调用，425s
+  超时）——任务级入口在场不等于模型会选它；
+- run2/run6：模型传 plane='xz'/'vertical' → recipe 拒绝
+  （只支持 xy）→ 模型降级手拼 → 证据链缺失 → WAITING_INPUT；
+- run5：失败后模型重试 3 次 + grep 源码调试。
+
+闭环断言：
+1. recipe 平面支持：plane="xz"/"yz" 命名面 + plane_normal_xyz
+   直通（竖直平面不再拒绝）；
+2. 路由输入编译：NL → shape/plane 参数（通用词类标记，无形状
+   特例 prompt 硬编码）；疑问句（怎么画/如何/吗/？）不自动执行；
+3. 服务端自动路由：pi.input.persist 画路径指令 → auto_task
+   （后台执行）→ 任务终态 SUCCEEDED + plan.node 事件 + 产物
+   登记——零模型工具调用；
+4. watcher trackTask：plan.node 进度 widget + 终态一次
+   followUp（不重复、不泄漏进 progress 上下文）；
+5. rosclaw_task 退出模型面（MODEL_TOOL_NAMES 不含它）——
+   wire 层 adapter 保留兼容。
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tests.agentd.test_r01_production_chain import _kernel
+from tests.agentd.test_r02_task_spec_deliverables import _draw_task
+
+
+class TestRecipePlaneSupport:
+    def test_named_vertical_plane_accepted(self, tmp_path: Path) -> None:
+        """plane="xz"（竖直命名面）端到端跑通——不再拒绝。"""
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        sim = SimTrajectoryService(tmp_path)
+        plan = sim.generate_planar_path(
+            shape="star5", center_m=[0.35, 0.0, 0.30], scale_m=0.10,
+            plane="xz",
+        )
+        rollout = sim.simulate_cartesian_trajectory(plan["plan_id"])
+        assert rollout["ok"] is True
+
+    def test_yz_named_plane_accepted(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        sim = SimTrajectoryService(tmp_path)
+        plan = sim.generate_planar_path(
+            shape="star5", center_m=[0.0, 0.25, 0.30], scale_m=0.10,
+            plane="yz",
+        )
+        assert plan["plan_id"]
+
+    def test_unknown_plane_still_rejected(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        sim = SimTrajectoryService(tmp_path)
+        with pytest.raises(ValueError, match="unsupported plane"):
+            sim.generate_planar_path(
+                shape="star5", center_m=[0.35, 0.25, 0.30], scale_m=0.10,
+                plane="diagonal",
+            )
+
+
+class TestRouteInputCompilation:
+    def test_vertical_plane_from_nl(self) -> None:
+        from rosclaw.task_kernel.task_router import compile_recipe_inputs
+
+        inputs = compile_recipe_inputs(
+            "让仿真 UR5e 在竖直平面画一个五角星，并给我 GIF 和 MP4"
+        )
+        assert inputs.get("plane") in ("xz", "yz") or inputs.get(
+            "plane_normal_xyz"
+        ), inputs
+
+    def test_shape_from_nl(self) -> None:
+        from rosclaw.task_kernel.task_router import compile_recipe_inputs
+
+        assert compile_recipe_inputs("画一个圆").get("shape") == "circle"
+        assert compile_recipe_inputs("画五角星").get("shape") == "star5"
+
+    def test_question_form_not_auto_routed(self) -> None:
+        """疑问句不自动执行（怎么画/如何/吗/？ 是讨论不是指令）。"""
+        from rosclaw.task_kernel.task_router import is_task_directive
+
+        assert is_task_directive("画一个五角星") is True
+        assert is_task_directive("怎么画五角星？") is False
+        assert is_task_directive("如何画一个五角星") is False
+        assert is_task_directive("你会画五角星吗") is False
+
+
+class TestServerAutoRoute:
+    async def test_persist_draw_directive_auto_executes(
+        self, tmp_path: Path
+    ) -> None:
+        """pi.input.persist 画路径指令 → 服务端自动路由执行（后台
+        线程）→ 零模型工具调用 → 任务 SUCCEEDED + plan.node 事件
+        + GIF/MP4 产物。"""
+        import asyncio
+
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await bridge._dispatch(
+            "user:local:1000", 1, "pi.input.persist",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "session_ref": "pi_1",
+                "message_id": "msg_auto_1",
+                "text": "画一个五角星，给我 GIF 和 MP4",
+            },
+        )
+        assert result.get("ok"), result
+        auto = result.get("auto_task")
+        assert auto, f"未自动路由：{result}"
+        assert auto.get("recipe_id") == "recipe:sim.draw_path"
+        # 后台执行——等终态（真实 sim 链）。
+        kernel = service._task_kernel
+        task_id = str(auto["task_id"])
+        deadline = asyncio.get_event_loop().time() + 180
+        while asyncio.get_event_loop().time() < deadline:
+            task = kernel.get_task(task_id)
+            if task and task["state"] in ("SUCCEEDED", "FAILED", "REPAIR_REQUIRED"):
+                break
+            await asyncio.sleep(2)
+        task = kernel.get_task(task_id)
+        assert task["state"] == "SUCCEEDED", task["state"]
+        events = kernel._conn.execute(
+            "SELECT event_type FROM task_events WHERE task_id = ? "
+            "AND event_type LIKE 'plan.node_%'",
+            (task_id,),
+        ).fetchall()
+        assert len(events) >= 10, f"plan node 事件不完整：{len(events)}"
+        artifacts = kernel.artifact_refs_for(task_id)
+        media = {a["media_type"] for a in artifacts}
+        assert "image/gif" in media and "video/mp4" in media, media
+        # 零模型工具调用（自动路由不产生 tool_used）。
+        used = kernel._conn.execute(
+            "SELECT COUNT(*) AS n FROM task_events WHERE task_id = ? "
+            "AND event_type = 'task.tool_used'",
+            (task_id,),
+        ).fetchone()
+        assert int(used["n"]) == 0, used["n"]
+        await service.close()
+
+    async def test_question_not_auto_routed(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await bridge._dispatch(
+            "user:local:1000", 1, "pi.input.persist",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "session_ref": "pi_1",
+                "message_id": "msg_q",
+                "text": "怎么画五角星？",
+            },
+        )
+        assert result.get("ok")
+        assert not result.get("auto_task"), result
+        await service.close()
+
+
+class TestModelSurfaceRemoval:
+    def test_rosclaw_task_not_in_model_surface(self) -> None:
+        """rosclaw_task 退出模型面（删除清单落地）——wire 层
+        adapter 保留兼容，模型默认看不到。"""
+        surface = (
+            Path(__file__).resolve().parents[2]
+            / "packages/rosclaw-agent/src/tools/surface.ts"
+        ).read_text(encoding="utf-8")
+        import re
+
+        packs = re.findall(
+            r"(?:MODEL_TOOL_NAMES|EMBODIMENT_PACK|WORKSPACE_PACK|"
+            r"PRODUCT_PACK)[^=]*=\s*\[([\s\S]*?)\];",
+            surface,
+        )
+        assert packs, "模型面包未找到"
+        assert not any('"rosclaw_task"' in pack for pack in packs), (
+            "rosclaw_task 仍在模型面——已知 recipe 已由输入路由自动执行"
+        )


### PR DESCRIPTION
## 金丝雀实证（真实 K3，/tmp/star-canary-1787797367，4/10）

重写后的金丝雀按设计暴露真实失败（不再是假绿）：
- run8：模型绕链手拼 capability（零 rosclaw_task 调用，425s 超时）——任务级入口在场不等于模型会选它；
- run2/run6：模型传 `plane="xz"/"vertical"` → recipe 拒绝（只支持 xy）→ 降级手拼 → 证据链缺失 → WAITING_INPUT；
- run5：失败后重试 3 次 + grep 源码调试（raw JSON 上屏=源码行）；
- 旅程实证：修订分支缺 frozen spec（普通修订分支从未冻结——P1-C1 只冻结了"SUCCEEDED 重开"分支）→ TASK_SPEC_MISSING。

## 闭环

- **recipe 平面支持**：plane=xy/xz/yz 命名面 + plane_normal_xyz 直通（竖直平面不再拒绝）；
- **TaskRouter 输入编译**：NL → shape/plane 参数（通用词类标记，无形状特例 prompt 硬编码）；is_task_directive 疑问句护栏；
- **pi.input.persist 服务端自动路由**（SIM only + 非疑问 + 幂等去重）→ 后台执行 TaskExecutionService——**零模型工具调用**；
- **watcher trackTask**：plan.node 进度 widget 原位更新 + 终态一次 followUp（outcome 权威）；pi.coordinator.consider 支持 task_id 直查；
- **rosclaw_task 退出模型面**（删除清单落地；wire adapter 保留兼容）；
- **金丝雀**：行为预算含能力链调用计数；token 指标修 totalTokens 键；
- **修订分支冻结 TaskSpecV2**（P1-C1 漏洞修复）。

## 红→绿证据

- 红：/tmp/r015-red.txt（7 红）；
- 绿：R0-1.5 测试 9/9 + watcher TS 1/1；旅程 A/B/C 全绿（A 走自动路由全程）。

Gate R0-1 收口：模型具身入口调用数 **0**（自动路由）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)