### PR TITLE
feat: P0-1/2/3 双控制者根治——Input Arbiter 单 Owner + 确定性终态发布（0827 审计）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -30,6 +30,7 @@ import {
 import type { ProductStateCenter } from "../session/state-center.js";
 import { InputController } from "../native/input-controller.js";
 import { OperationWatcher } from "../native/operation-watcher.js";
+import { suppressModelTurn } from "../native/turn-disposition.js";
 import { classifyModelError } from "../native/model-errors.js";
 import {
 	renderArtifactList,
@@ -427,16 +428,37 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			const persisted = await inputController.persist(text);
 			if (!persisted) return { action: "handled" as const };
 			// R0-1.5：输入路由自动执行——已知 recipe 由内核直接执行
-			// （零模型调用）；watcher 跟踪进度/终态（followUp 一次）。
+			// （零模型调用）；watcher 跟踪进度/终态（确定性呈现）。
+			// P0-1/P0-2（0827 审计·双控制者根治）：Input Arbiter——
+			// 一条输入只有一个 Owner。TASK_ROUTER 认领后 suppress 模型
+			// 回合（handled，不再 continue）——同一指令绝不进 Pi Agent。
 			const autoTask = (persisted as { auto_task?: { task_id?: string } })
 				.auto_task;
-			if (autoTask?.task_id) {
-				operationWatcher.trackTask(String(autoTask.task_id));
+			if (suppressModelTurn(persisted)) {
+				if (autoTask?.task_id) {
+					operationWatcher.trackTask(String(autoTask.task_id));
+				}
+				// 指令回声：handled 的输入不进 Pi 会话——确定性链认领的
+				// 指令必须落在 session transcript（HP1 输入丢失防线的
+				// 会话证据 + 用户可见），但绝不触发模型回合。
+				pi.sendMessage(
+					{
+						customType: "rosclaw.user_directive",
+						content: text,
+						display: true,
+						details: {
+							task_id: autoTask?.task_id ?? "",
+							owner: "TASK_ROUTER",
+						},
+					},
+					{ triggerTurn: false },
+				);
 				const ctx2 = latestCtx;
 				ctx2?.ui.notify(
 					"任务已由确定性链自动开始执行（/activity 查看进度）",
 					"info",
 				);
+				return { action: "handled" as const };
 			}
 			return { action: "continue" as const };
 		});

--- a/packages/rosclaw-agent/src/native/input-controller.ts
+++ b/packages/rosclaw-agent/src/native/input-controller.ts
@@ -45,10 +45,21 @@ export class InputController {
 	/** P0-C（0824 总纲 §6.1）：输入先落会话（pi.input.persist——
 	 *  不立即创建 Task；persist 失败不投递，HP1 防线语义不变）。
 	 *  返回 null = 不投递。R0-1.5：auto_task（内核自动路由的任务）
-	 *  穿透给调用方（watcher 跟踪进度/终态）。 */
+	 *  穿透给调用方（watcher 跟踪进度/终态）。P0-1（0827 审计）：
+	 *  turn_disposition（Input Arbiter 权威判定——owner/suppress）
+	 *  穿透给 input hook。 */
 	async persist(
 		text: string,
-	): Promise<{ input_id?: string; auto_task?: { task_id?: string } } | null> {
+	): Promise<{
+		input_id?: string;
+		auto_task?: { task_id?: string; replayed?: boolean };
+		turn_disposition?: {
+			input_id?: string;
+			owner?: string;
+			task_id?: string;
+			suppress_model_turn?: boolean;
+		};
+	} | null> {
 		const messageId = `msg_${randomUUID()}`;
 		try {
 			const result = (await this.deps.call("pi.input.persist", {
@@ -61,14 +72,24 @@ export class InputController {
 			})) as unknown as {
 				ok?: boolean;
 				input?: { input_id?: string };
-				auto_task?: { task_id?: string };
+				auto_task?: { task_id?: string; replayed?: boolean };
+				turn_disposition?: {
+					input_id?: string;
+					owner?: string;
+					task_id?: string;
+					suppress_model_turn?: boolean;
+				};
 			};
 			this.forceNewNext = false;
 			this.deps.call("pi.input.dispatched", {
 				mission_id: this.deps.missionId(),
 				message_id: messageId,
 			}).catch(() => undefined);
-			return { ...(result.input ?? {}), auto_task: result.auto_task };
+			return {
+				...(result.input ?? {}),
+				auto_task: result.auto_task,
+				turn_disposition: result.turn_disposition,
+			};
 		} catch (err) {
 			// 持久化失败不投递（幽灵执行防线）：消息不消失于沉默——
 			// 明确通知用户重发。

--- a/packages/rosclaw-agent/src/native/operation-watcher.ts
+++ b/packages/rosclaw-agent/src/native/operation-watcher.ts
@@ -10,7 +10,13 @@
  *   token 开销）；
  * - 终态一次性 followUp（WP-1 语义不变：owning task 终态/旧
  *   revision 只存档不触发回合）。
+ *
+ * P0-3（0827 审计）：trackTask（输入路由任务）只投影——终态回复由
+ * Coordinator 经 TerminalPresenter 确定性呈现（display:true,
+ * triggerTurn:false），绝不 followUp 唤醒 Agent（双控制者根治）。
  */
+
+import { renderTerminalReply, type TerminalOutcome } from "./terminal-presenter.js";
 
 interface SendSink {
 	sendMessage(
@@ -71,8 +77,9 @@ export class OperationWatcher {
 	}
 
 	/** R0-1.5：自动路由任务登记（输入路由执行——无 operation，
-	 *  跟踪 task 事件流：plan.node 进度 widget + 终态一次
-	 *  followUp）。 */
+	 *  跟踪 task 事件流：plan.node 进度 widget + 终态确定性呈现）。
+	 *  P0-3（0827 审计）：只投影不唤醒——终态回复由 Presenter
+	 *  确定性发布（triggerTurn:false），不再是模型回合。 */
 	trackTask(taskId: string): void {
 		if (!taskId || this.trackedTasks.has(taskId)) return;
 		this.trackedTasks.add(taskId);
@@ -206,7 +213,10 @@ export class OperationWatcher {
 			return;
 		}
 		if (event.event_type !== "verification.completed") return;
-		// 终态：一次 followUp（outcome 权威——不由模型自由夸大）。
+		// P0-3（0827 审计）：Coordinator 是唯一终态发布者——终态回复由
+		// TaskOutcome 确定性生成、display 直接呈现；绝不 followUp 唤醒
+		// Agent（0827 实证：followUp 触发模型回合与确定性链互相矛盾
+		// =双控制者）。trackTask 只投影，不唤醒。
 		this.deliveredTasks.add(taskId);
 		this.trackedTasks.delete(taskId);
 		this.completedNodesByTask.delete(taskId);
@@ -217,14 +227,7 @@ export class OperationWatcher {
 				task_id: taskId,
 			});
 			const outcome = (result.outcome ?? {}) as Record<string, unknown>;
-			const refs = (outcome.artifact_refs ?? []) as Array<Record<string, unknown>>;
-			const opens = refs.map((r) => String(r.open_command ?? "")).filter(Boolean);
-			const passed = outcome.verification === "PASS";
-			outcomeText = passed
-				? `任务完成：验收 PASS · 交付 ${String(outcome.delivery ?? "")}`
-					+ (opens.length ? `——交付物：${opens.join(" · ")}` : "")
-				: `任务未完成：验收 ${String(outcome.verification ?? "?")} · 交付 ${String(outcome.delivery ?? "?")}`
-					+ "——如实告知用户限制，不要宣称完整完成";
+			outcomeText = renderTerminalReply(outcome as TerminalOutcome);
 		} catch {
 			outcomeText = "任务已终态（outcome 拉取失败——/activity 查看账本）";
 		}
@@ -232,10 +235,10 @@ export class OperationWatcher {
 			{
 				customType: "rosclaw.task_terminal",
 				content: outcomeText,
-				display: false,
+				display: true,
 				details: { task_id: taskId },
 			},
-			{ triggerTurn: true, deliverAs: "followUp" },
+			{ triggerTurn: false },
 		);
 	}
 

--- a/packages/rosclaw-agent/src/native/terminal-presenter.ts
+++ b/packages/rosclaw-agent/src/native/terminal-presenter.ts
@@ -1,0 +1,41 @@
+/** TerminalPresenter（0827 体验审计 P0-3）——Coordinator 是唯一终态
+ *  发布者：任务终态的最终回复由 TaskOutcome 确定性生成，不经模型
+ *  回合（0827 实证：模型先说"✅ 任务完成"，watcher 后报"交付
+ *  MISSING"——两个发布者互相矛盾）。
+ *
+ * 输出原则：
+ * - PASS + DELIVERED → 完成 + 交付物打开命令；
+ * - 其余 → 诚实"未完全达成" + 验收/交付状态，绝不出现完成宣称。
+ */
+
+export interface TerminalOutcome {
+	verification?: string;
+	delivery?: string;
+	lifecycle?: string;
+	artifact_refs?: Array<{
+		artifact_id?: string;
+		open_command?: string;
+	}>;
+}
+
+/** 任务终态的最终用户回复（确定性——同一 outcome 永远同一文本）。 */
+export function renderTerminalReply(outcome: TerminalOutcome): string {
+	const verification = String(outcome.verification ?? "UNKNOWN");
+	const delivery = String(outcome.delivery ?? "UNKNOWN");
+	const refs = outcome.artifact_refs ?? [];
+	const opens = refs
+		.map((r) => String(r.open_command ?? ""))
+		.filter(Boolean);
+	const passed = verification === "PASS" && delivery === "DELIVERED";
+	if (passed) {
+		const head = "✅ 任务完成：验收 PASS · 交付 DELIVERED";
+		return opens.length
+			? `${head}\n交付物：${opens.join(" · ")}`
+			: head;
+	}
+	return (
+		`⚠️ 任务未完全达成：验收 ${verification} · 交付 ${delivery}`
+		+ "——如实说明限制，不宣称完整完成（/activity 查看账本）"
+		+ (opens.length ? `\n已产出交付物：${opens.join(" · ")}` : "")
+	);
+}

--- a/packages/rosclaw-agent/src/native/turn-disposition.ts
+++ b/packages/rosclaw-agent/src/native/turn-disposition.ts
@@ -1,0 +1,39 @@
+/** TurnDisposition（0827 体验审计 P0-1/P0-2）——Input Arbiter 的
+ *  Harness 侧判定。
+ *
+ * 一条输入只能有一个 Owner：内核 pi.input.persist 返回权威
+ * turn_disposition；owner=TASK_ROUTER 时 input hook 必须返回
+ * handled（suppress 模型回合）——否则确定性链与 Native Agent
+ * 双控制者竞争，终态互相矛盾（0827 实证事故）。
+ */
+
+export interface TurnDisposition {
+	input_id: string;
+	owner: "TASK_ROUTER" | "PI_CONVERSATION";
+	task_id: string;
+	suppress_model_turn: boolean;
+}
+
+export interface PersistedInput {
+	input_id?: string;
+	auto_task?: { task_id?: string; replayed?: boolean };
+	/** 服务端权威判定（wire 形状——owner 未收窄为联合类型，旧/新
+	 *  daemon 字段倾斜时以 suppress_model_turn/auto_task 为准）。 */
+	turn_disposition?: {
+		input_id?: string;
+		owner?: string;
+		task_id?: string;
+		suppress_model_turn?: boolean;
+	};
+}
+
+/** 模型回合是否被 suppress。disposition 是权威；旧 daemon 无该字段
+ *  时回落 auto_task（版本倾斜期不漏 suppress——双控制者防线不能
+ *  依赖单点字段）。 */
+export function suppressModelTurn(persisted: PersistedInput): boolean {
+	const disposition = persisted.turn_disposition;
+	if (disposition && typeof disposition.suppress_model_turn === "boolean") {
+		return disposition.suppress_model_turn;
+	}
+	return Boolean(persisted.auto_task?.task_id);
+}

--- a/packages/rosclaw-agent/test/p01-single-owner.test.ts
+++ b/packages/rosclaw-agent/test/p01-single-owner.test.ts
@@ -1,0 +1,136 @@
+/** 0827 体验审计 P0-1/2/3 红测试：单 Owner + 单终态发布者。
+ *
+ * 0827 实证事故（双控制者）：自动路由认领输入后模型仍收到同一指令
+ * 并手工执行，终态由"模型回合"和"watcher followUp"两个发布者给出
+ * 相反结论。
+ *
+ * 闭环断言：
+ * 1. TurnDisposition：owner=TASK_ROUTER → suppressModelTurn=true
+ *    （input hook 返回 handled，模型整回合不出现）；
+ * 2. 任务终态由 watcher 以确定性文本直接呈现（display:true,
+ *    triggerTurn:false）——不再 followUp 唤醒 Agent；
+ * 3. 终态文本是 TaskOutcome 的确定性呈现：PASS 带交付打开命令；
+ *    PARTIAL/MISSING 诚实标注限制，不出现完成宣称；
+ * 4. 重放不重复发布。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("TurnDisposition：TASK_ROUTER 认领 → suppress model turn", async () => {
+	const { suppressModelTurn } = await import("../src/native/turn-disposition.js");
+	assert.equal(
+		suppressModelTurn({
+			turn_disposition: {
+				input_id: "in_1",
+				owner: "TASK_ROUTER",
+				task_id: "task_1",
+				suppress_model_turn: true,
+			},
+		}),
+		true,
+	);
+	assert.equal(
+		suppressModelTurn({
+			turn_disposition: {
+				input_id: "in_2",
+				owner: "PI_CONVERSATION",
+				task_id: "",
+				suppress_model_turn: false,
+			},
+		}),
+		false,
+	);
+	assert.equal(suppressModelTurn({}), false);
+	// 旧 daemon 无 disposition 字段时回落 auto_task（版本倾斜期不
+	// 漏 suppress——双控制者防线不能依赖单点字段）。
+	assert.equal(
+		suppressModelTurn({ auto_task: { task_id: "task_9" } }),
+		true,
+	);
+});
+
+test("终态呈现器：PASS 带交付命令；PARTIAL 诚实无完成宣称", async () => {
+	const { renderTerminalReply } = await import(
+		"../src/native/terminal-presenter.js"
+	);
+	const pass = renderTerminalReply({
+		verification: "PASS",
+		delivery: "DELIVERED",
+		artifact_refs: [
+			{ artifact_id: "art_g", open_command: "rosclaw artifact open art_g" },
+			{ artifact_id: "art_m", open_command: "rosclaw artifact open art_m" },
+		],
+	});
+	assert.match(pass, /任务完成/);
+	assert.match(pass, /验收 PASS/);
+	assert.match(pass, /rosclaw artifact open art_g/);
+	assert.match(pass, /rosclaw artifact open art_m/);
+	const partial = renderTerminalReply({
+		verification: "PARTIAL",
+		delivery: "MISSING",
+		artifact_refs: [],
+	});
+	assert.doesNotMatch(partial, /任务完成/);
+	assert.match(partial, /未完全达成|未完成/);
+	assert.match(partial, /PARTIAL/);
+	assert.match(partial, /MISSING/);
+});
+
+test("watcher 终态：确定性呈现一次（display, 无 triggerTurn）+ 重放不重发", async () => {
+	const { OperationWatcher } = await import("../src/native/operation-watcher.js");
+	const events = [
+		{ seq: 1, event_type: "plan.node_completed", payload: { node_id: "make_path" } },
+		{ seq: 2, event_type: "verification.completed", payload: { status: "PASS" } },
+	];
+	const sent: Array<{ content: string; display: boolean; options: Record<string, unknown> }> = [];
+	const watcher = new OperationWatcher({
+		call: async (method: string, params: Record<string, unknown>) => {
+			if (method === "pi.kernel.events") {
+				const after = Number((params as { last_seq?: number }).last_seq ?? 0);
+				return { ok: true, events: events.filter((e) => e.seq > after) };
+			}
+			if (method === "pi.coordinator.consider") {
+				return {
+					ok: true,
+					outcome: {
+						lifecycle: "COMPLETED",
+						verification: "PASS",
+						delivery: "DELIVERED",
+						artifact_refs: [
+							{ artifact_id: "art_g", open_command: "rosclaw artifact open art_g" },
+						],
+					},
+				};
+			}
+			return { ok: true };
+		},
+		sink: () => ({
+			api: {
+				sendMessage: (
+					message: { content: string; display: boolean },
+					options: Record<string, unknown>,
+				) => {
+					sent.push({ content: message.content, display: message.display, options });
+				},
+			},
+			isIdle: true,
+			setWidget: () => undefined,
+		}),
+	} as never);
+	watcher.trackTask("task_p01");
+	await (watcher as never as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 1, `终态呈现应恰好一次（实际 ${sent.length}）`);
+	// P0-3：终态呈现绝不唤醒模型（双控制者根治——Coordinator/
+	// Presenter 是唯一终态发布者）。
+	assert.equal(sent[0].options.triggerTurn ?? false, false,
+		"终态呈现不得触发模型回合（followUp triggerTurn 是双控制者根因）");
+	assert.notEqual(sent[0].options.deliverAs, "followUp",
+		"终态呈现不得以 followUp 注入模型");
+	assert.equal(sent[0].display, true, "终态回复必须用户可见");
+	assert.match(sent[0].content, /任务完成：验收 PASS/);
+	assert.match(sent[0].content, /rosclaw artifact open art_g/);
+	// 重放不重发（不重不漏）。
+	await (watcher as never as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 1, "重放重复发布了终态");
+});

--- a/packages/rosclaw-agent/test/r015-track-task.test.ts
+++ b/packages/rosclaw-agent/test/r015-track-task.test.ts
@@ -1,11 +1,12 @@
 /** R0-1.5 红测试（金丝雀实证 + 0826 审计收口）：trackTask——
- * 自动路由任务的 plan 进度 widget + 终态一次 followUp。
+ * 自动路由任务的 plan 进度 widget + 终态确定性呈现。
  *
  * 断言：
  * 1. plan.node_started/completed → 单活动区 widget 原位更新
  *    （不重复打印、不进模型上下文）；
- * 2. verification.completed PASS → 一次 followUp（含交付打开
- *    命令）——重放不重复投递；
+ * 2. verification.completed PASS → 终态回复确定性呈现一次
+ *    （display:true、triggerTurn:false——0827 P0-3：Coordinator 是
+ *    唯一终态发布者，不 followUp 唤醒 Agent）——重放不重复投递；
  * 3. 终态后 untrack（不再轮询）。
  */
 
@@ -72,8 +73,9 @@ test("trackTask：进度 widget + 终态一次 followUp + untrack", async () => 
 		progressLines.some((line) => /规划|make_path/.test(line)),
 		`进度 widget 无规划节点行：${JSON.stringify(widgets)}`,
 	);
-	// 终态 → followUp 一次。
-	assert.equal(followUps.length, 1, `followUp 应恰好一次（实际 ${followUps.length}）`);
+	// 终态 → 确定性呈现一次（0827 P0-3：display:true +
+	// triggerTurn:false，不唤醒模型）。
+	assert.equal(followUps.length, 1, `终态呈现应恰好一次（实际 ${followUps.length}）`);
 	assert.match(followUps[0], /art_g/);
 	// 重放不重复投递。
 	await (watcher as never as { tick(): Promise<void> }).tick();

--- a/scripts/star_canary.py
+++ b/scripts/star_canary.py
@@ -146,9 +146,10 @@ def run_once(idx: int, base: Path) -> dict:
     for check in (
         lambda: assert_production_plan_graph(home),
         lambda: assert_user_visible_delivery(home, require_scene=True),
-        lambda: assert_model_behavior_budget(home, max_task_calls=1),
+        lambda: assert_model_behavior_budget(home, max_task_calls=0),
         lambda: assert_evidence_levels(home, require_scene=True),
         lambda: assert_screen_clean(session.clean),
+        lambda: assert_single_owner(home, session.clean),
         lambda: assert_final_answer_consistent(
             session.clean.decode("utf-8", errors="replace")[-3000:],
             final_outcome,
@@ -337,6 +338,37 @@ def assert_screen_clean(screen: bytes) -> None:
         assert not (marker in text and has_success), (
             f"屏幕同时出现 {marker} 与成功标记——readiness 与 effect 矛盾"
         )
+
+
+def assert_single_owner(home: Path, screen: bytes) -> None:
+    """0827 审计·已知 recipe Gate：单输入单 Owner + 单终态发布者。
+
+    - 模型 effectful 调用为 0（双控制者时代模型手拼执行 ≈10 次）；
+    - 屏幕恰好 1 条最终回复（"任务完成：验收"——确定性呈现，
+      不再有模型回合的第二个终态）；
+    - 终态后无新模型回合（pi_event_mirrors 的 LLM usage 为 0——
+      suppress_model_turn 后整个窗口无模型调用）。
+    """
+    conn = sqlite3.connect(home / "agentd" / "missions.db")
+    capability_calls = conn.execute(
+        "SELECT COUNT(*) FROM agent_events WHERE type = 'tool.completed' "
+        "AND json_extract(payload_json, '$.tool_name') IN "
+        "('rosclaw_compute', 'rosclaw_execute', 'rosclaw_request_action', "
+        "'rosclaw_deliver')"
+    ).fetchone()[0]
+    llm_turns = conn.execute(
+        "SELECT COUNT(*) FROM pi_event_mirrors WHERE usage_json != ''"
+    ).fetchone()[0]
+    conn.close()
+    assert capability_calls == 0, (
+        f"已知 recipe 竟有 {capability_calls} 次模型具身调用——双控制者未根治"
+    )
+    assert llm_turns == 0, (
+        f"已知 recipe 竟产生 {llm_turns} 次模型回合——suppress_model_turn 未生效"
+    )
+    text = screen.decode("utf-8", errors="replace")
+    replies = text.count("任务完成：验收")
+    assert replies == 1, f"最终回复应恰好 1 条（实际 {replies}）——单终态发布者"
 
 
 _COMPLETION_CLAIMS = ("已绘制完成，视频已交付", "全部完成", "完整完成")

--- a/src/rosclaw/agentd/auto_route.py
+++ b/src/rosclaw/agentd/auto_route.py
@@ -47,7 +47,24 @@ async def maybe_auto_route(
     text = text.strip()
     if not text or not is_task_directive(text):
         return None
+    kernel = service._task_kernel
+    # P0-1/P0-2（0827 审计·双控制者根治）：重放优先——同一
+    # message_id 已认领（进程内去重）或已附着任务（持久层去重，
+    # 覆盖 daemon 重启后的重投递）时，返回同一任务的 auto_task
+    # 描述。若重放返回 None，输入会掉进模型路径=双执行。
     if message_id in _routed:
+        row = kernel._conn.execute(
+            "SELECT task_id FROM user_inputs WHERE message_id = ?",
+            (message_id,),
+        ).fetchone()
+        if row is not None and row["task_id"]:
+            return {
+                "task_id": str(row["task_id"]),
+                "recipe_id": "",
+                "state": "RUNNING",
+                "inputs": {},
+                "replayed": True,
+            }
         return None
     intent = _classify_intent(text)
     if route_recipe({"goal": {"intent": intent}}) is None:
@@ -55,13 +72,19 @@ async def maybe_auto_route(
     mission = service.get_mission(mission_id)
     if mission is not None and mission.mode.value != "SIMULATION":
         return None  # REAL/SHADOW 不自动路由（rosclawd 权威链）
-    kernel = service._task_kernel
-    # 重放/已附着输入不重路由（双保险）。
+    # 重放/已附着输入不重路由（持久层双保险：返回同一任务而不是
+    # None——None 意味着"交给模型"，对重放即双控制者）。
     row = kernel._conn.execute(
         "SELECT task_id FROM user_inputs WHERE message_id = ?", (message_id,),
     ).fetchone()
     if row is not None and row["task_id"]:
-        return None
+        return {
+            "task_id": str(row["task_id"]),
+            "recipe_id": "",
+            "state": "RUNNING",
+            "inputs": {},
+            "replayed": True,
+        }
     try:
         bound = kernel.ensure_task_for_effect(
             mission_id=mission_id,

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1035,6 +1035,19 @@ class PiBridgeServer:
             out: dict = {"ok": True, "input": record}
             if auto_task:
                 out["auto_task"] = auto_task
+            # P0-1（0827 审计·Input Arbiter）：权威 TurnDisposition——
+            # 一条输入只有一个 Owner。TASK_ROUTER 认领后 Harness 必须
+            # suppress 模型回合（否则确定性链与 Native Agent 双控制者
+            # 竞争，终态互相矛盾）。
+            out["turn_disposition"] = {
+                "input_id": str(
+                    record.get("input_id", "")
+                    or params.get("message_id", "")
+                ),
+                "owner": "TASK_ROUTER" if auto_task else "PI_CONVERSATION",
+                "task_id": str(auto_task.get("task_id", "")) if auto_task else "",
+                "suppress_model_turn": bool(auto_task),
+            }
             return out
         if method == "pi.task.ensure_effect":
             # P0-C（0824 总纲 §6.2）：首个 effectful call 的原子

--- a/tests/agentd/test_nine1_input_loss.py
+++ b/tests/agentd/test_nine1_input_loss.py
@@ -83,11 +83,12 @@ class TestInputNeverLost:
                             )
                         if "画一个五角星" in str(content):
                             found_user = True
-                if entry.get("type") == "custom_message" and (
-                    entry.get("customType") == "rosclaw.user_directive"
+                if (
+                    entry.get("type") == "custom_message"
+                    and entry.get("customType") == "rosclaw.user_directive"
+                    and "画一个五角星" in str(entry.get("content", ""))
                 ):
-                    if "画一个五角星" in str(entry.get("content", "")):
-                        found_echo = True
+                    found_echo = True
         # 单 Owner 契约：输入以确定性链回声落在 transcript（绝不能是
         # user message——user message 意味着送进了模型=双控制者）。
         assert found_echo, (

--- a/tests/agentd/test_nine1_input_loss.py
+++ b/tests/agentd/test_nine1_input_loss.py
@@ -1,9 +1,14 @@
 """NINE-1 红测试（九审 §0.1/§25.1）：输入吞噬的最小复现（PTY 级）。
 
 红测试先行——九审实测顺序：hello（正常）→ 自然语言五角星（输入
-消失，后台出现任务结果，模型不知情）。本测试固定：自然语言任务
-输入必须进入 Pi session JSONL 的 user message——TUI、模型消息、
-持久化账本三者一致。
+消失，后台出现任务结果，模型不知情）。
+
+0827 P0-1/2（Input Arbiter）后契约更新：已知 recipe 的指令由
+TASK_ROUTER 认领并 suppress 模型回合——输入绝不作为 user message
+进模型（那是双控制者通道），但必须作为确定性链回声（custom
+message，display:true）落在 session transcript，且内核 user_inputs
+账本持有权威记录。本测试固定：transcript 有回声 + 无 user
+message + 内核账本有记录——三者一致。
 """
 
 from __future__ import annotations
@@ -51,9 +56,13 @@ class TestInputNeverLost:
                     session.stop()
         finally:
             fake.close()
-        # 核心断言：用户输入作为 user message 存在于 session JSONL。
+        # 核心断言：用户输入必须在会话 transcript 可见。0827 P0-1/2
+        # （Input Arbiter）后，已知 recipe 的指令被 TASK_ROUTER 认领并
+        # suppress 模型回合——输入不再是 user message（那是双控制者的
+        # 通道），而是确定性链回声（custom message，display:true）。
         sessions_dir = home / "agent" / "sessions"
-        found = False
+        found_user = False
+        found_echo = False
         for session_file in sessions_dir.glob("*.jsonl"):
             for line in session_file.read_text(
                 encoding="utf-8", errors="replace"
@@ -62,20 +71,30 @@ class TestInputNeverLost:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if entry.get("type") != "message":
-                    continue
-                message = entry.get("message", {})
-                if message.get("role") != "user":
-                    continue
-                content = message.get("content", "")
-                if isinstance(content, list):
-                    content = " ".join(
-                        str(b.get("text", "")) for b in content if isinstance(b, dict)
-                    )
-                if "画一个五角星" in str(content):
-                    found = True
-                    break
-        assert found, (
-            "用户输入'我想用机械臂画一个五角星'未进入 session JSONL——"
-            "P0-INPUT-LOSS（幽灵执行）"
+                if entry.get("type") == "message":
+                    message = entry.get("message", {})
+                    if message.get("role") == "user":
+                        content = message.get("content", "")
+                        if isinstance(content, list):
+                            content = " ".join(
+                                str(b.get("text", ""))
+                                for b in content
+                                if isinstance(b, dict)
+                            )
+                        if "画一个五角星" in str(content):
+                            found_user = True
+                if entry.get("type") == "custom_message" and (
+                    entry.get("customType") == "rosclaw.user_directive"
+                ):
+                    if "画一个五角星" in str(entry.get("content", "")):
+                        found_echo = True
+        # 单 Owner 契约：输入以确定性链回声落在 transcript（绝不能是
+        # user message——user message 意味着送进了模型=双控制者）。
+        assert found_echo, (
+            "用户输入'画一个五角星'的确定性链回声未进入 session JSONL——"
+            "输入在 transcript 不可见（HP1 会话证据缺失）"
+        )
+        assert not found_user, (
+            "已认领输入竟作为 user message 进入会话——模型会再次看到"
+            "同一指令（双控制者回归）"
         )

--- a/tests/agentd/test_p01_input_arbiter.py
+++ b/tests/agentd/test_p01_input_arbiter.py
@@ -1,0 +1,130 @@
+"""0827 体验审计 P0-1/P0-2 红测试：Input Arbiter——一条输入只有一个
+Owner（双控制者根治）。
+
+0827 实证事故：pi.input.persist 自动启动任务后，同一条用户指令仍
+被送给模型——确定性链与 Native Agent 同时接管同一输入，产生两个
+相反的终态（模型宣布"✅ 任务完成"，watcher 随后报"交付 MISSING"）。
+
+闭环断言：
+1. pi.input.persist 响应携带权威 TurnDisposition：
+   已知 recipe → owner=TASK_ROUTER + suppress_model_turn=true +
+   task_id；普通问答 → owner=PI_CONVERSATION + suppress=false；
+2. 重放幂等：同一 message_id 重投递（PTY 重发/网络重试）仍然
+   suppress_model_turn=true 且不创建第二个任务——重放不得掉进
+   模型路径（否则重发即双执行）；
+3. 疑问句永不 suppress（讨论形式走模型）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+async def _persist(bridge, service, mission_id: str, message_id: str, text: str):
+    return await bridge._dispatch(
+        "user:local:1000", 1, "pi.input.persist",
+        {
+            "token": service.control_token,
+            "mission_id": mission_id,
+            "session_ref": "pi_1",
+            "message_id": message_id,
+            "text": text,
+        },
+    )
+
+
+class TestTurnDisposition:
+    async def test_directive_claimed_by_task_router(
+        self, tmp_path: Path
+    ) -> None:
+        """已知 recipe 指令 → disposition owner=TASK_ROUTER，suppress
+        model turn，task_id 与 auto_task 一致。"""
+        from rosclaw.agentd.auto_route import reset_routed_for_tests
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        reset_routed_for_tests()
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await _persist(
+            bridge, service, mission.mission_id, "msg_td_1",
+            "画一个五角星，给我 GIF 和 MP4",
+        )
+        assert result.get("ok"), result
+        disposition = result.get("turn_disposition")
+        assert disposition, f"缺 TurnDisposition：{result}"
+        assert disposition.get("owner") == "TASK_ROUTER", disposition
+        assert disposition.get("suppress_model_turn") is True, disposition
+        auto = result.get("auto_task") or {}
+        assert disposition.get("task_id") == str(auto.get("task_id")), (
+            disposition, auto,
+        )
+        assert disposition.get("input_id"), disposition
+        await service.close()
+
+    async def test_question_owned_by_conversation(
+        self, tmp_path: Path
+    ) -> None:
+        """疑问句 → owner=PI_CONVERSATION，不 suppress（讨论走模型）。"""
+        from rosclaw.agentd.auto_route import reset_routed_for_tests
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        reset_routed_for_tests()
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await _persist(
+            bridge, service, mission.mission_id, "msg_td_q",
+            "怎么画五角星？",
+        )
+        assert result.get("ok"), result
+        disposition = result.get("turn_disposition")
+        assert disposition, f"缺 TurnDisposition：{result}"
+        assert disposition.get("owner") == "PI_CONVERSATION", disposition
+        assert disposition.get("suppress_model_turn") is False, disposition
+        assert not result.get("auto_task"), result
+        await service.close()
+
+    async def test_replay_still_suppressed_no_second_task(
+        self, tmp_path: Path
+    ) -> None:
+        """同一 message_id 重投递：仍 suppress（不能掉进模型路径）
+        且不创建第二个 task。"""
+        from rosclaw.agentd.auto_route import reset_routed_for_tests
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        reset_routed_for_tests()
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        first = await _persist(
+            bridge, service, mission.mission_id, "msg_td_replay",
+            "画一个五角星",
+        )
+        assert first.get("ok"), first
+        first_task = str((first.get("auto_task") or {}).get("task_id"))
+        assert first_task, first
+        # 重放（PTY 重发/投递重试）——同 message_id。
+        second = await _persist(
+            bridge, service, mission.mission_id, "msg_td_replay",
+            "画一个五角星",
+        )
+        assert second.get("ok"), second
+        disposition = second.get("turn_disposition") or {}
+        assert disposition.get("suppress_model_turn") is True, (
+            f"重放掉进模型路径=双执行：{second}"
+        )
+        assert disposition.get("owner") == "TASK_ROUTER", disposition
+        assert str(
+            (second.get("auto_task") or {}).get("task_id")
+        ) == first_task, (first_task, second)
+        kernel = service._task_kernel
+        rows = kernel._conn.execute("SELECT COUNT(*) AS n FROM tasks").fetchone()
+        assert int(rows["n"]) == 1, f"重放创建了第二个任务：{rows['n']}"
+        await service.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -194,7 +194,7 @@ class _FakeModel:
             if tool_call_id == "call_star_action":
                 # Journey B 批准腿：admission COMPLETED → 完成回答。
                 if "COMPLETED" in tool_content:
-                    answer = "五角星已绘制完成，几何验证通过。"
+                    answer = "位姿移动测试完成，结构化回执已确认。"
                 else:
                     answer = f"动作未完成（{tool_content[:80]}）。"
                 frames.append(_sse(_chunk(answer)))
@@ -383,15 +383,6 @@ class _FakeModel:
             # 步骤的"Worker 结果已收到并验证"混淆）。
             frames.append(_sse(_chunk("Worker 结果已综合给用户。")))
             frames.append(_sse(_chunk("", "stop")))
-        elif "任务完成：验收 PASS" in text or (
-            "任务完成：验收 PASS" in _text(messages[-1] if messages else {})
-        ):
-            # R0-1.5：自动路由任务的终态 followUp 回合——outcome 权威
-            # （验收 PASS + 交付完成）才说完成。
-            frames.append(_sse(_chunk("五角星已绘制完成，几何验证通过。")))
-            frames.append(_sse(_chunk("", "stop")))
-            frames.append(b"data: [DONE]\n\n")
-            return b"".join(frames)
         elif "委派" in text:
             # PR-H1（ADR-0012）：模型面不再有 task_submit/delegate——
             # Native Agent 用自己的工作工具在同一 session 直接完成。
@@ -402,35 +393,27 @@ class _FakeModel:
                     json.dumps({"command": "echo 日志要点已归纳"}),
                 )
             )
-        elif "画五角星" in text or "画一个五角星" in text:
-            if getattr(self, "_ask_policy", False):
-                # 七审 Journey B（PR-H9）：ask 策略的人工卡走唯一授权面
-                # rosclaw_request_action（admission）——rosclaw_task 是
-                # 免卡确定性 SIM 闭环，不产生人工卡。
-                frames.extend(
-                    _tool_call_frames(
-                        "call_star_action",
-                        "rosclaw_request_action",
-                        json.dumps(
-                            {
-                                "capability_id": "ur5e.move_to_pose",
-                                "arguments": {
-                                    "x": 0.35, "y": 0.25, "z": 0.40,
-                                },
-                                "expected_effect": "机械臂画五角星",
-                                "risk_tier": "LOW",
-                            }
-                        ),
-                    )
+        elif "位姿移动测试" in text:
+            # Journey B（ask 策略，PR-H9）：人工卡走唯一授权面
+            # rosclaw_request_action（admission）。0827 P0-1 后已知
+            # recipe 由 Input Arbiter 认领（suppress 模型回合）——
+            # 授权卡旅程改用非 recipe 指令保持模型腿可测。
+            frames.extend(
+                _tool_call_frames(
+                    "call_star_action",
+                    "rosclaw_request_action",
+                    json.dumps(
+                        {
+                            "capability_id": "ur5e.move_to_pose",
+                            "arguments": {
+                                "x": 0.35, "y": 0.25, "z": 0.40,
+                            },
+                            "expected_effect": "小幅位姿移动测试",
+                            "risk_tier": "LOW",
+                        }
+                    ),
                 )
-            else:
-                # R0-1.5（金丝雀实证 + 0826 审计收口）：已知 recipe 由
-                # 输入路由自动执行（零模型调用）——模型不再调
-                # rosclaw_task（已退出模型面），只确认收到指令。
-                frames.append(_sse(_chunk("已收到——确定性任务链自动执行中。")))
-                frames.append(_sse(_chunk("", "stop")))
-                frames.append(b"data: [DONE]\n\n")
-                return b"".join(frames)
+            )
         elif "回到零点" in text:
             # 七审 PR-SEVEN-7 Journey B：单独动作（deny 腿）——一次
             # 人工拒绝必须 fail closed（无 txn、无 grant、诚实回答）。
@@ -901,15 +884,18 @@ class TestProductJourney:
             session.expect(b"Operator Ready", timeout=60)
             self._journey_verdicts["operator_bootstrapped_in_tui"] = True
             # -- 批准腿：一次人工卡覆盖整条轨迹 --------------------------
+            # 0827 P0-1：已知 recipe（画五角星）由 Input Arbiter 认领后
+            # suppress 模型回合——授权卡旅程改用非 recipe 指令（位姿
+            # 移动）保持模型腿/人工卡链路真实可测。
             approve_start = len(session.clean)
-            session.send("我想跑一个机械臂仿真，让机械臂画五角星\r")
+            session.send("让机械臂做一次小幅位姿移动测试\r")
             overlay_at = len(session.clean)
             session.expect("ROSCLAW 授权请求".encode(), timeout=240)
             # overlay 聚焦竞态：渲染出现 ≠ 键盘路由就绪——重试发 y
             # 直到任务完成文本出现（decided 后卡片立即关闭，决定行
             # 不一定渲染——不能用它当 marker）。
             session.expect_with_resend(
-                "五角星已绘制完成，几何验证通过".encode(), "y", timeout=240
+                "位姿移动测试完成，结构化回执已确认。".encode(), "y", timeout=240
             )
             segment = session.clean[approve_start:]
             assert b"POLICY_AUTO" not in segment, "ask 策略竟走政策自动授权"
@@ -1607,12 +1593,21 @@ class TestProductJourney:
             #    SIM 自动执行）：能力面 → 初始观测 → POLICY_AUTO（无人工
             #    卡、不按 Y）→ 执行 → 后置观测验证。
             action_start = len(session.clean)
+            model_turns_before = len(fake.fake.requests)
             session.send("我想跑一个机械臂仿真，让机械臂画五角星\r")
-            # 九审 §1.5 + PR-H9：rosclaw_task → SimTrajectoryService
-            # 确定性闭环（SIM 动力学直跑——无 Operator 卡、无 POLICY_AUTO
-            # 卡——默认安全 SIM 自动是产品语义）。
-            # 最终回答必须基于 verifier（不是模型自称画完）。
-            session.expect("五角星已绘制完成，几何验证通过".encode(), timeout=180)
+            # 0827 P0-1/2/3（双控制者根治）：已知 recipe 由 Input
+            # Arbiter 原子认领（TASK_ROUTER）——suppress 模型回合，
+            # 单一 PlanGraph 执行，终态由 Coordinator/Presenter 确定性
+            # 呈现（"任务完成：验收 PASS" 是 TaskOutcome 的呈现，不是
+            # 模型回合的回答）。
+            session.expect("任务完成：验收 PASS".encode(), timeout=180)
+            # 单 Owner 硬证据：整个自动执行窗口零模型请求（双控制者
+            # 时代模型会收到同一指令并手工再执行一遍）。
+            assert len(fake.fake.requests) == model_turns_before, (
+                f"已知 recipe 竟产生 {len(fake.fake.requests) - model_turns_before} "
+                "次模型请求——双控制者未根治"
+            )
+            self._journey_verdicts["auto_route_zero_model_turns"] = True
             action_segment = session.clean[action_start:]
             assert "ROSCLAW 授权请求".encode() not in action_segment, (
                 "默认安全 SIM 竟弹人工审批卡"


### PR DESCRIPTION
0827 体验审计实证事故（双控制者）：auto-route 启动后同一指令仍进 Pi Agent，两执行者产生相反终态。

- P0-1：pi.input.persist 返回权威 TurnDisposition（owner/suppress_model_turn）
- P0-2：TASK_ROUTER 认领后 input hook handled——模型整回合不出现；指令以 custom message 回声进 transcript（HP1 证据）；重投仍 suppress 且返回同一任务
- P0-3：Coordinator/Presenter 唯一终态发布者——watcher 终态不再 followUp 唤醒 Agent，终态回复由 TaskOutcome 确定性生成 display:true 呈现
- 金丝雀收紧 assert_single_owner（0 模型调用/0 LLM 回合/恰好 1 条最终回复）

红→绿：test_p01_input_arbiter.py 3 红→绿、p01-single-owner.test.ts 3 红→绿；agentd 777 passed；旅程 A/B/C 全绿；TS 191/191。