### PR TITLE
feat: P0-4 Kernel 原生产物交付投影——outputs/ 是 ArtifactStore 投影视图（0827 审计）

### DIFF
--- a/packages/rosclaw-agent/src/native/terminal-presenter.ts
+++ b/packages/rosclaw-agent/src/native/terminal-presenter.ts
@@ -12,6 +12,9 @@ export interface TerminalOutcome {
 	verification?: string;
 	delivery?: string;
 	lifecycle?: string;
+	/** P0-4：outputs/ 投影视图状态（DEGRADED = 投影失败但账本
+	 *  交付有效——必须如实告知，不得静默）。 */
+	workspace_projection?: string;
 	artifact_refs?: Array<{
 		artifact_id?: string;
 		open_command?: string;
@@ -27,11 +30,14 @@ export function renderTerminalReply(outcome: TerminalOutcome): string {
 		.map((r) => String(r.open_command ?? ""))
 		.filter(Boolean);
 	const passed = verification === "PASS" && delivery === "DELIVERED";
+	const degraded = outcome.workspace_projection === "DEGRADED"
+		? "\n（工作区投影退化——交付物仍可用上面的 artifact open 命令打开）"
+		: "";
 	if (passed) {
 		const head = "✅ 任务完成：验收 PASS · 交付 DELIVERED";
 		return opens.length
-			? `${head}\n交付物：${opens.join(" · ")}`
-			: head;
+			? `${head}\n交付物：${opens.join(" · ")}${degraded}`
+			: head + degraded;
 	}
 	return (
 		`⚠️ 任务未完全达成：验收 ${verification} · 交付 ${delivery}`

--- a/packages/rosclaw-agent/test/p01-single-owner.test.ts
+++ b/packages/rosclaw-agent/test/p01-single-owner.test.ts
@@ -75,6 +75,17 @@ test("终态呈现器：PASS 带交付命令；PARTIAL 诚实无完成宣称", a
 	assert.match(partial, /未完全达成|未完成/);
 	assert.match(partial, /PARTIAL/);
 	assert.match(partial, /MISSING/);
+	// P0-4：投影退化如实告知（DELIVERED + DEGRADED 不假装正常）。
+	const degraded = renderTerminalReply({
+		verification: "PASS",
+		delivery: "DELIVERED",
+		workspace_projection: "DEGRADED",
+		artifact_refs: [
+			{ artifact_id: "art_g", open_command: "rosclaw artifact open art_g" },
+		],
+	});
+	assert.match(degraded, /任务完成/);
+	assert.match(degraded, /投影退化/);
 });
 
 test("watcher 终态：确定性呈现一次（display, 无 triggerTurn）+ 重放不重发", async () => {

--- a/src/rosclaw/task_kernel/coordinator.py
+++ b/src/rosclaw/task_kernel/coordinator.py
@@ -127,6 +127,13 @@ class TaskCoordinator:
         ) and not failures
         now = datetime.now(UTC).isoformat()
         if passed:
+            # P0-4（0827 审计）：Kernel 原生交付投影——登记产物由内核
+            # 投影到 outputs/ 投影视图（不经模型 Shell、不依赖
+            # bwrap）；投影失败 = DELIVERED + workspace_projection
+            # DEGRADED，绝不翻转成 MISSING（账本/open_command 权威）。
+            from rosclaw.task_kernel.projection import project_deliverables
+
+            projection = project_deliverables(self._kernel, str(task["task_id"]))
             outcome = self._build_outcome(
                 task, revision, artifacts,
                 lifecycle="COMPLETED",
@@ -134,6 +141,7 @@ class TaskCoordinator:
                 verification="PASS",
                 delivery="DELIVERED",
                 created_at=now,
+                workspace_projection=projection,
             )
             self._store_outcome(task_id, revision, outcome, now)
             return outcome
@@ -206,7 +214,7 @@ class TaskCoordinator:
     def _build_outcome(
         self, task: dict, revision: int, artifacts: list[dict], *,
         lifecycle: str, execution: str, verification: str,
-        delivery: str, created_at: str,
+        delivery: str, created_at: str, workspace_projection: str = "",
     ) -> dict[str, Any]:
         trust = "EXPERIMENTAL"
         if any(
@@ -244,6 +252,10 @@ class TaskCoordinator:
             "verification": verification,
             "delivery": delivery,
             "user_acceptance": "ACCEPTED" if accepted else "UNSEEN",
+            # P0-4：outputs/ 是 ArtifactStore 的投影视图——OK/
+            # DEGRADED（投影退化不翻转 delivery；空串=未评估的非
+            # PASS 分支）。
+            "workspace_projection": workspace_projection,
             "evidence": {
                 "domain": str(task.get("mode") or "SIMULATION"),
                 "trust": trust,

--- a/src/rosclaw/task_kernel/projection.py
+++ b/src/rosclaw/task_kernel/projection.py
@@ -1,0 +1,79 @@
+"""交付投影视图（0827 体验审计 P0-4）。
+
+outputs/ 是 ArtifactStore 的**投影视图**，不是第二个交付真相：
+登记产物由内核自动投影到运行 outputs/ 区（hardlink 优先、copy
+兜底）——内核内部文件操作，不经模型 Shell、不依赖 bwrap。
+
+纪律：
+- 投影失败绝不翻转交付判定（DELIVERED + workspace_projection
+  DEGRADED——账本/open_command 仍是权威）；
+- 账本路径不被投影改写（内容寻址的 ArtifactStore 是唯一真相）；
+- 幂等：同 sha256 投影不重复。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rosclaw.task_kernel.run_store import ensure_run, zone_of
+
+if TYPE_CHECKING:
+    from rosclaw.task_kernel.service import TaskKernel
+
+_LOG = logging.getLogger("rosclaw.projection")
+
+
+def project_deliverables(kernel: TaskKernel, task_id: str) -> str:
+    """把任务登记产物投影到运行 outputs/ 区。返回 OK/DEGRADED。"""
+    task = kernel.get_task(task_id)
+    if task is None:
+        return "DEGRADED"
+    revision = int(task["active_revision"])
+    try:
+        run = ensure_run(kernel._home, task_id, revision)
+        outputs = Path(str(run["zones"]["outputs"]))
+        if not outputs.is_dir():
+            raise OSError(f"outputs 区不是目录：{outputs}")
+        degraded = False
+        rows = kernel._conn.execute(
+            "SELECT artifact_id, path, sha256 FROM artifacts "
+            "WHERE task_id = ?",
+            (task_id,),
+        ).fetchall()
+        for row in rows:
+            src = Path(str(row["path"]))
+            if zone_of(kernel._home, task_id, revision, src) == "outputs":
+                continue  # 已在交付区——无需投影
+            if not src.exists():
+                degraded = True
+                _LOG.warning("projection source missing: %s", src)
+                continue
+            target = outputs / src.name
+            if target.exists():
+                if hashlib.sha256(target.read_bytes()).hexdigest() == str(
+                    row["sha256"]
+                ):
+                    continue  # 幂等：同内容已投影
+                target = outputs / f"{row['artifact_id']}_{src.name}"
+            try:
+                os.link(src, target)
+            except OSError:
+                try:
+                    shutil.copy2(src, target)
+                except OSError as exc:
+                    degraded = True
+                    _LOG.warning(
+                        "projection failed: %s → %s: %s", src, target, exc,
+                    )
+        return "DEGRADED" if degraded else "OK"
+    except OSError as exc:
+        _LOG.warning("projection degraded for %s: %s", task_id, exc)
+        return "DEGRADED"
+
+
+__all__ = ["project_deliverables"]

--- a/tests/agentd/test_p04_kernel_delivery.py
+++ b/tests/agentd/test_p04_kernel_delivery.py
@@ -1,0 +1,106 @@
+"""0827 体验审计 P0-4 红测试：Kernel 原生产物交付投影。
+
+0827 实证：Renderer 生成视频 → 模型用 Shell 复制 → bwrap 拒绝 →
+模型手动 deliver → Artifact 登记成功 → Coordinator 又因 outputs
+为空判交付 MISSING（两个交付真相互相矛盾）。
+
+闭环断言：
+1. 登记产物由**内核**自动投影到运行 outputs/ 区（hardlink/copy—
+   —内核内部操作，不经模型 Shell、不依赖 bwrap）；ArtifactStore
+   路径不变（权威仍在账本）；
+2. outcome 带 workspace_projection 字段（OK/DEGRADED）；
+3. 投影失败 → delivery 仍 DELIVERED + workspace_projection
+   DEGRADED（绝不整体 MISSING）；
+4. DEGRADED 时 artifact open_command 仍可用（账本权威不受投影
+   影响）。
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+
+def _run_draw_chain(kernel, conn, tmp_path: Path) -> str:
+    from rosclaw.agentd.task_execution import TaskExecutionService
+    from tests.agentd.test_r02_task_spec_deliverables import _draw_task
+
+    task_id = _draw_task(kernel, tmp_path, "画一个五角星")
+    kernel.note_tool_use(task_id, "rosclaw_task")
+    TaskExecutionService(kernel=kernel, conn=conn, home=tmp_path).execute(
+        task_id,
+        recipe_inputs={"shape": "star5",
+                       "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+    )
+    return task_id
+
+
+class TestKernelDeliveryProjection:
+    def test_artifacts_projected_to_outputs_zone(self, tmp_path: Path) -> None:
+        """生产链跑通后：每个登记产物在 outputs/ 区有同内容投影
+        （hardlink/copy 等价——sha256 一致），账本路径不变。"""
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+        from rosclaw.task_kernel.run_store import run_dir
+        from tests.agentd.test_r01_production_chain import _kernel
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _run_draw_chain(kernel, conn, tmp_path)
+        outcome = TaskCoordinator(kernel).consider(task_id)
+        assert outcome is not None
+        assert outcome.get("delivery") == "DELIVERED", outcome
+        assert outcome.get("workspace_projection") == "OK", outcome
+        outputs = run_dir(tmp_path, task_id, 1) / "outputs"
+        assert outputs.is_dir(), f"outputs 区不存在：{outputs}"
+        rows = conn.execute(
+            "SELECT path, sha256 FROM artifacts WHERE task_id = ?",
+            (task_id,),
+        ).fetchall()
+        media = [r for r in rows if r["path"].endswith((".gif", ".mp4"))]
+        assert media, "生产链应登记 GIF/MP4 产物"
+        for row in media:
+            projected = outputs / Path(str(row["path"])).name
+            assert projected.exists(), (
+                f"产物未投影到 outputs/：{row['path']}"
+            )
+            digest = hashlib.sha256(projected.read_bytes()).hexdigest()
+            assert digest == str(row["sha256"]), (
+                f"投影内容与账本不一致：{projected}"
+            )
+
+    def test_projection_failure_degraded_not_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """投影失败（outputs 区被破坏）→ delivery 仍 DELIVERED +
+        workspace_projection DEGRADED——绝不翻转成 MISSING。"""
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+        from rosclaw.task_kernel.run_store import run_dir
+        from tests.agentd.test_r01_production_chain import _kernel
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _run_draw_chain(kernel, conn, tmp_path)
+        # 破坏 outputs 区：目录替换成普通文件 → mkdir/link 必败。
+        outputs = run_dir(tmp_path, task_id, 1) / "outputs"
+        outputs.mkdir(parents=True, exist_ok=True)
+        import shutil
+
+        shutil.rmtree(outputs)
+        outputs.write_text("sabotaged", encoding="utf-8")
+        outcome = TaskCoordinator(kernel).consider(task_id)
+        assert outcome is not None
+        assert outcome.get("delivery") == "DELIVERED", (
+            f"投影失败竟翻转交付判定：{outcome}"
+        )
+        assert outcome.get("workspace_projection") == "DEGRADED", outcome
+        # 账本权威不受投影影响：artifact_refs 仍可 open。
+        refs = outcome.get("artifact_refs") or []
+        assert refs, "DEGRADED 时 artifact_refs 不应消失"
+        assert all(
+            str(r.get("open_command", "")).startswith("rosclaw artifact open ")
+            for r in refs
+        ), refs
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
0827 实证：Renderer 产物要靠模型 Shell 复制+手动 deliver，bwrap 拒绝后交付判定翻转 MISSING。

- task_kernel/projection.py：登记产物内核自动投影到运行 outputs/ 区（hardlink/copy2，不经模型 Shell、不依赖 bwrap、同 sha256 幂等）
- Coordinator PASS 分支自动投影；outcome 带 workspace_projection（OK/DEGRADED）；投影失败 = DELIVERED + DEGRADED，绝不翻转 MISSING
- TerminalPresenter 如实呈现投影退化

红→绿：test_p04_kernel_delivery.py 2 红→绿（含 outputs 区破坏注入）；TS 191/191。