### PR TITLE
feat: P0-5 语义真实验收 PASS_NEAR_LIMIT + 修订/新任务语义修复（0827 审计）

### DIFF
--- a/packages/rosclaw-agent/src/native/operation-watcher.ts
+++ b/packages/rosclaw-agent/src/native/operation-watcher.ts
@@ -79,9 +79,14 @@ export class OperationWatcher {
 	/** R0-1.5：自动路由任务登记（输入路由执行——无 operation，
 	 *  跟踪 task 事件流：plan.node 进度 widget + 终态确定性呈现）。
 	 *  P0-3（0827 审计）：只投影不唤醒——终态回复由 Presenter
-	 *  确定性发布（triggerTurn:false），不再是模型回合。 */
+	 *  确定性发布（triggerTurn:false），不再是模型回合。
+	 *  修订重跑（"改成画圆形"→ 同 task 新 revision 再执行）必须
+	 *  重新武装终态呈现——deliveredTasks 按执行周期清理（旧事件由
+	 *  seq 游标去重，不靠终态集合挡新一轮）。 */
 	trackTask(taskId: string): void {
-		if (!taskId || this.trackedTasks.has(taskId)) return;
+		if (!taskId) return;
+		this.deliveredTasks.delete(taskId);
+		if (this.trackedTasks.has(taskId)) return;
 		this.trackedTasks.add(taskId);
 	}
 

--- a/packages/rosclaw-agent/src/native/terminal-presenter.ts
+++ b/packages/rosclaw-agent/src/native/terminal-presenter.ts
@@ -29,12 +29,17 @@ export function renderTerminalReply(outcome: TerminalOutcome): string {
 	const opens = refs
 		.map((r) => String(r.open_command ?? ""))
 		.filter(Boolean);
-	const passed = verification === "PASS" && delivery === "DELIVERED";
+	const passed = (verification === "PASS" || verification === "PASS_NEAR_LIMIT")
+		&& delivery === "DELIVERED";
 	const degraded = outcome.workspace_projection === "DEGRADED"
 		? "\n（工作区投影退化——交付物仍可用上面的 artifact open 命令打开）"
 		: "";
 	if (passed) {
-		const head = "✅ 任务完成：验收 PASS · 交付 DELIVERED";
+		// P0-5：PASS_NEAR_LIMIT 如实标注（≥90% 阈值占用不显示普通
+		// PASS——19.86mm/20mm 是"勉强通过"，不是"干净通过"）。
+		const head = verification === "PASS_NEAR_LIMIT"
+			? "✅ 任务完成：验收 PASS_NEAR_LIMIT（误差接近阈值上限，勉强通过） · 交付 DELIVERED"
+			: "✅ 任务完成：验收 PASS · 交付 DELIVERED";
 		return opens.length
 			? `${head}\n交付物：${opens.join(" · ")}${degraded}`
 			: head + degraded;

--- a/packages/rosclaw-agent/test/p01-single-owner.test.ts
+++ b/packages/rosclaw-agent/test/p01-single-owner.test.ts
@@ -153,3 +153,51 @@ test("watcher 终态：确定性呈现一次（display, 无 triggerTurn）+ 重�
 	await (watcher as never as { tick(): Promise<void> }).tick();
 	assert.equal(sent.length, 1, "重放重复发布了终态");
 });
+
+test("watcher 修订重跑：同 task 新 revision 再执行 → 终态再次呈现", async () => {
+	// h2 PTY 实证：deliveredTasks 不清除 → "改成画圆形"（revision 2）
+	// 的 verification.completed 被吞——修订重跑没有终态回复。
+	const { OperationWatcher } = await import("../src/native/operation-watcher.js");
+	const events = [
+		{ seq: 1, event_type: "verification.completed", payload: { status: "PASS" } },
+	];
+	const sent: string[] = [];
+	const watcher = new OperationWatcher({
+		call: async (method: string, params: Record<string, unknown>) => {
+			if (method === "pi.kernel.events") {
+				const after = Number((params as { last_seq?: number }).last_seq ?? 0);
+				return { ok: true, events: events.filter((e) => e.seq > after) };
+			}
+			if (method === "pi.coordinator.consider") {
+				return {
+					ok: true,
+					outcome: {
+						lifecycle: "COMPLETED", verification: "PASS",
+						delivery: "DELIVERED", artifact_refs: [],
+					},
+				};
+			}
+			return { ok: true };
+		},
+		sink: () => ({
+			api: {
+				sendMessage: (message: { content: string }) => {
+					sent.push(message.content);
+				},
+			},
+			isIdle: true,
+			setWidget: () => undefined,
+		}),
+	} as never);
+	watcher.trackTask("task_rev");
+	await (watcher as never as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 1, "首轮终态未呈现");
+	// 修订重跑：再次 trackTask（新执行周期）→ 新终态事件到达后
+	// 必须再次呈现。
+	watcher.trackTask("task_rev");
+	events.push({
+		seq: 2, event_type: "verification.completed", payload: { status: "PASS" },
+	});
+	await (watcher as never as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 2, "修订重跑的终态被吞（deliveredTasks 未按执行周期清理）");
+});

--- a/packages/rosclaw-agent/test/p01-single-owner.test.ts
+++ b/packages/rosclaw-agent/test/p01-single-owner.test.ts
@@ -86,6 +86,14 @@ test("终态呈现器：PASS 带交付命令；PARTIAL 诚实无完成宣称", a
 	});
 	assert.match(degraded, /任务完成/);
 	assert.match(degraded, /投影退化/);
+	// P0-5：PASS_NEAR_LIMIT 诚实标注（接近阈值 ≠ 干净 PASS）。
+	const nearLimit = renderTerminalReply({
+		verification: "PASS_NEAR_LIMIT",
+		delivery: "DELIVERED",
+		artifact_refs: [],
+	});
+	assert.match(nearLimit, /PASS_NEAR_LIMIT/);
+	assert.match(nearLimit, /接近阈值/);
 });
 
 test("watcher 终态：确定性呈现一次（display, 无 triggerTurn）+ 重放不重发", async () => {

--- a/scripts/star_canary.py
+++ b/scripts/star_canary.py
@@ -135,7 +135,8 @@ def run_once(idx: int, base: Path) -> dict:
         outcome["failures"].append("task_outcomes 未落库")
     else:
         oc = json.loads(str(outcomes[0]["outcome_json"]))
-        if oc.get("verification") != "PASS":
+        # P0-5：PASS_NEAR_LIMIT 是合法诚实分级（接近阈值≠失败）。
+        if oc.get("verification") not in ("PASS", "PASS_NEAR_LIMIT"):
             outcome["failures"].append(f"outcome verification={oc.get('verification')}")
     db.close()
     # R0-9（§7.4）：生产路径/用户可见交付/行为预算/证据等级/屏幕

--- a/src/rosclaw/agentd/plan_templates.py
+++ b/src/rosclaw/agentd/plan_templates.py
@@ -336,7 +336,12 @@ def draw_path_recipe(
         )
         metrics = verify["metrics"]
         failures: list[str] = []
-        if verify["verdict"] != "PASS":
+        # P0-5（0827 审计）：误差分级——≥90% 阈值占用是
+        # PASS_NEAR_LIMIT（诚实"接近阈值"），不是普通 PASS。
+        from rosclaw.task_kernel.embodied_verifier import tracking_grade
+
+        grade = tracking_grade(float(metrics["max_error_m"]), threshold)
+        if grade == "FAIL":
             failures.append(
                 f"跟踪误差 {metrics['max_error_m']}m > {threshold}m"
             )
@@ -392,6 +397,8 @@ def draw_path_recipe(
             task_id=task_id,
             summary=f"draw_path recipe 执行（{len(artifact_ids)} 项产物）",
             artifact_ids=artifact_ids,
+            grade=grade,
+            tracking_max_error_m=float(metrics["max_error_m"]),
         )
         kernel_failures = [str(f) for f in verdict.get("failures", [])]
         status = (

--- a/src/rosclaw/task_kernel/coordinator.py
+++ b/src/rosclaw/task_kernel/coordinator.py
@@ -134,11 +134,29 @@ class TaskCoordinator:
             from rosclaw.task_kernel.projection import project_deliverables
 
             projection = project_deliverables(self._kernel, str(task["task_id"]))
+            # P0-5（0827 审计）：验收分级诚实呈现——≥90% 阈值占用的
+            # PASS_NEAR_LIMIT 不显示为普通 PASS（grade 由受信管道随
+            # 验收行持久化，无 grade = 普通 PASS）。
+            grade_row = self._conn.execute(
+                "SELECT checks_json FROM verifications WHERE task_id = ? "
+                "AND status = 'PASS' ORDER BY rowid DESC LIMIT 1",
+                (str(task["task_id"]),),
+            ).fetchone()
+            verification = "PASS"
+            if grade_row is not None:
+                try:
+                    grade = str(
+                        json.loads(str(grade_row["checks_json"])).get("grade", "")
+                    )
+                except ValueError:
+                    grade = ""
+                if grade == "PASS_NEAR_LIMIT":
+                    verification = "PASS_NEAR_LIMIT"
             outcome = self._build_outcome(
                 task, revision, artifacts,
                 lifecycle="COMPLETED",
                 execution="SUCCEEDED",
-                verification="PASS",
+                verification=verification,
                 delivery="DELIVERED",
                 created_at=now,
                 workspace_projection=projection,

--- a/src/rosclaw/task_kernel/embodied_verifier.py
+++ b/src/rosclaw/task_kernel/embodied_verifier.py
@@ -34,6 +34,23 @@ SCALE_FACTOR = 0.05
 #: 工具轴对齐容差（指南 §5.R0-5：tool axis ≤3°）。
 TOOL_AXIS_LIMIT_DEG = 3.0
 
+#: 接近阈值带宽（0827 审计 P0-5）：误差 ≥90% 阈值占用时不得显示
+#: 普通 PASS（19.86mm/20mm=99.3% 显示 PASS 是假成功）。
+NEAR_LIMIT_RATIO = 0.9
+
+
+def tracking_grade(max_error_m: float, threshold_m: float) -> str:
+    """跟踪误差分级：PASS / PASS_NEAR_LIMIT（≥90% 阈值占用）/ FAIL。"""
+    error = float(max_error_m)
+    threshold = float(threshold_m)
+    if error > threshold:
+        return "FAIL"
+    # 浮点边界：90.000...% 也算 near-limit（ε 容差，不放低标准——
+    # 只是不让二进制表示误差吃掉精确边界）。
+    if threshold > 0 and error + 1e-12 >= NEAR_LIMIT_RATIO * threshold:
+        return "PASS_NEAR_LIMIT"
+    return "PASS"
+
 
 def tracking_acceptance(
     scale_m: float, *, robot_floor_m: float = SIM_JACOBIAN_FLOOR_M

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -621,6 +621,7 @@ class TaskKernel:
 
     def finish_task(
         self, *, task_id: str, summary: str, artifact_ids: list[str],
+        grade: str = "", tracking_max_error_m: float | None = None,
     ) -> dict[str, Any]:
         """FinishRequest（§12.1）：验收真跑 → SUCCEEDED / REPAIR_REQUIRED。
         终态幂等（重放不重复验证、不覆盖——返回原 receipt id）。
@@ -629,6 +630,11 @@ class TaskKernel:
         - 验收条件只读任务创建时冻结值（模型收尾不得改规则）；
         - 机器人行为任务（body_id 非空）必须含受信管道证据
           （kernel 内部登记的产物）——模型自产证据不算数。
+
+        P0-5（0827 审计）：grade（PASS / PASS_NEAR_LIMIT——≥90%
+        阈值占用的诚实分级）与 tracking_max_error_m 由调用方（受信
+        管道）申报并随验收行持久化——误差事实留账，Coordinator
+        呈现分级而不是一律 PASS。
         """
         task = self.get_task(task_id)
         if task is None:
@@ -849,20 +855,29 @@ class TaskKernel:
         now = datetime.now(UTC).isoformat()
         if verdict["status"] == "PASS":
             verification_id = new_id("vrf")
+            # P0-5：误差事实与分级随验收行持久化（checks_json 是
+            # 审计面——误差/分级不回填就无从复核"接近阈值"）。
+            checks_payload: dict[str, Any] = {"checks": verdict["checks"]}
+            if grade:
+                checks_payload["grade"] = grade
+            if tracking_max_error_m is not None:
+                checks_payload["tracking_max_error_m"] = float(
+                    tracking_max_error_m
+                )
             self._conn.execute(
                 "INSERT INTO verifications (verification_id, task_id, "
                 "revision, status, checks_json, evidence_json, created_at) "
                 "VALUES (?, ?, ?, 'PASS', ?, ?, ?)",
                 (verification_id, task_id, int(task["active_revision"]),
-                 json.dumps({"checks": verdict["checks"]},
-                            ensure_ascii=False),
+                 json.dumps(checks_payload, ensure_ascii=False),
                  json.dumps({"artifact_ids": artifact_ids},
                             ensure_ascii=False),
                  now),
             )
             self._emit(task_id, "verification.completed",
                        {"verification_id": verification_id, "status": "PASS",
-                        "checks": verdict["checks"]})
+                        "checks": verdict["checks"],
+                        **({"grade": grade} if grade else {})})
             self.transition(task_id, "SUCCEEDED", reason="verification_passed")
             return {"status": "SUCCEEDED", "verification_id": verification_id}
         # REPAIR_REQUIRED：回同一 session（task 保持活跃——修复不新建）。

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -187,6 +187,16 @@ class TaskKernel:
             "ORDER BY t.created_at DESC LIMIT 1",
             (mission_id, session_ref),
         ).fetchone()
+        # /newtask（FORCE_NEW）必须最先判定——先于 SUCCEEDED 重开：
+        # 否则"显式开新任务"被旧任务的重开语义吞掉（h2 旅程实证：
+        # FORCE_NEW 输入落成旧任务 revision 3）。
+        if active is not None and force_new:
+            self._conn.execute(
+                "UPDATE task_session_bindings SET active = 0 "
+                "WHERE task_id = ? AND session_ref = ?",
+                (active["task_id"], session_ref),
+            )
+            active = None
         if (
             active is not None
             and active["state"] in TASK_TERMINAL
@@ -248,13 +258,6 @@ class TaskKernel:
                 "workspace_path": str(active["workspace_path"]),
                 "state": "RUNNING",
             }
-        if active is not None and force_new:
-            self._conn.execute(
-                "UPDATE task_session_bindings SET active = 0 "
-                "WHERE task_id = ? AND session_ref = ?",
-                (active["task_id"], session_ref),
-            )
-            active = None
         if active is not None:
             revision = int(active["active_revision"]) + 1
             ensure_run(self._home, str(active["task_id"]), revision)  # WP-8

--- a/tests/agentd/test_h2_input_txn.py
+++ b/tests/agentd/test_h2_input_txn.py
@@ -43,8 +43,11 @@ class TestInputRootTaskGate:
         )
         try:
             session.expect(b"ROSClaw Native Agent", timeout=120)
+            # 0827 P0-1/2（Input Arbiter）：已知 recipe 指令由
+            # TASK_ROUTER 认领——suppress 模型回合，确定性链执行，
+            # 终态由 Presenter 确定性呈现（不经模型回答）。
             session.send("画一个五角星\r")
-            session.expect("已在同一会话直接完成".encode(), timeout=180)
+            session.expect("任务完成：验收".encode(), timeout=300)
             db = sqlite3.connect(home / "agentd" / "missions.db")
             tasks = db.execute(
                 "SELECT task_id, state, active_revision FROM tasks"
@@ -53,16 +56,25 @@ class TestInputRootTaskGate:
             assert len(tasks) == 1, f"首个目标必须只建一个 root task: {tasks}"
             task_id = tasks[0][0]
             assert tasks[0][2] == 1
-            # 消息可见（不消失）：session JSONL 含用户文本。
-            sessions = list((home / "agent" / "sessions").glob("*.jsonl"))
-            assert sessions, "session JSONL 不存在"
-            blob = sessions[0].read_text(encoding="utf-8", errors="replace")
-            assert "画一个五角星" in blob, "用户消息幽灵消失"
+            # 消息可见（不消失）：屏幕回声 + 内核 user_inputs 权威账本
+            # （0827 P0-1 注：全抑制会话无模型回合——pi 的
+            # SessionManager 在首个 assistant 消息前不落盘，session
+            # JSONL 不存在是 pi 的正常懒惰持久化，不是输入丢失）。
+            assert "画一个五角星" in session.clean.decode(
+                "utf-8", errors="replace"
+            ), "屏幕无指令回声"
+            db = sqlite3.connect(home / "agentd" / "missions.db")
+            input_row = db.execute(
+                "SELECT text FROM user_inputs WHERE text LIKE '%画一个五角星%'"
+            ).fetchone()
+            db.close()
+            assert input_row, "user_inputs 权威账本缺输入（幽灵执行防线）"
 
-            # 追问 → revision 2（同一 task）。
+            # 追问 → revision 2（同一 task，不裂变）；确定性链按新
+            # revision 重跑（圆形）。
             marker = len(session.clean)
             session.send("改成画圆形\r")
-            session.expect("已在同一会话直接完成".encode(), timeout=180,
+            session.expect("任务完成：验收".encode(), timeout=300,
                            after=marker)
             db = sqlite3.connect(home / "agentd" / "missions.db")
             tasks = db.execute(

--- a/tests/agentd/test_p05_semantic_honesty.py
+++ b/tests/agentd/test_p05_semantic_honesty.py
@@ -1,0 +1,119 @@
+"""0827 体验审计 P0-5 红测试：语义真实验收——PASS_NEAR_LIMIT。
+
+0827 实证：最大误差 19.86mm / 阈值 20mm（99.3% 阈值占用）却显示
+普通 PASS——低质量 PASS 是假成功。闭环断言：
+
+1. tracking_grade：≥90% 阈值占用 → PASS_NEAR_LIMIT；<90% → PASS；
+   超阈值 → FAIL；
+2. 生产链端到端：阈值贴近实测误差时 outcome.verification ==
+   "PASS_NEAR_LIMIT"（不是 PASS），verification.completed 事件
+   与 verifications 账本带 grade——三处一致；
+3. 宽松阈值下仍是普通 PASS（不误报）。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class TestTrackingGrade:
+    def test_near_limit_band(self) -> None:
+        from rosclaw.task_kernel.embodied_verifier import tracking_grade
+
+        # 0827 实证数字：19.86mm / 20mm = 99.3% → PASS_NEAR_LIMIT。
+        assert tracking_grade(0.01986, 0.020) == "PASS_NEAR_LIMIT"
+        assert tracking_grade(0.018, 0.020) == "PASS_NEAR_LIMIT"  # 90%
+        assert tracking_grade(0.0179, 0.020) == "PASS"
+        assert tracking_grade(0.010, 0.025) == "PASS"
+        assert tracking_grade(0.0201, 0.020) == "FAIL"
+
+
+def _measure_error(kernel, conn, tmp_path: Path) -> tuple[str, float]:
+    """跑一次生产链，返回 (task_id, 实测 max_error_m)（验收账本
+    checks_json 是误差事实的持久面）。"""
+    from rosclaw.agentd.task_execution import TaskExecutionService
+    from tests.agentd.test_r02_task_spec_deliverables import _draw_task
+
+    task_id = _draw_task(kernel, tmp_path, "画一个五角星")
+    kernel.note_tool_use(task_id, "rosclaw_task")
+    TaskExecutionService(kernel=kernel, conn=conn, home=tmp_path).execute(
+        task_id,
+        recipe_inputs={"shape": "star5",
+                       "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+    )
+    row = conn.execute(
+        "SELECT checks_json FROM verifications WHERE task_id = ? "
+        "AND status = 'PASS' ORDER BY rowid DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    assert row, "PASS 验收行缺失"
+    checks = json.loads(str(row["checks_json"]))
+    return task_id, float(checks["tracking_max_error_m"])
+
+
+class TestNearLimitEndToEnd:
+    def test_tight_threshold_yields_pass_near_limit(
+        self, tmp_path: Path
+    ) -> None:
+        """阈值 = 实测误差的 1.02 倍（>90% 占用）→ outcome
+        verification PASS_NEAR_LIMIT（账本无假 PASS）。"""
+        from rosclaw.agentd.task_execution import TaskExecutionService
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+        from tests.agentd.test_r01_production_chain import _kernel
+
+        kernel, conn = _kernel(tmp_path)
+        _, measured = _measure_error(kernel, conn, tmp_path)
+        assert measured > 0
+        # 第二次任务：验收阈值贴近实测（利用率 ≈98%）。必须不同
+        # session——_draw_task 的固定 mission/session/message 幂等
+        # 键会返回同一（已终态）task。
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s2",
+            message_id="msg_2", text="再画一个五角星（阈值收紧）",
+        )
+        bound = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s2", backend_native_id="s2",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        task_id = str(bound["task_id"])
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        TaskExecutionService(kernel=kernel, conn=conn, home=tmp_path).execute(
+            task_id,
+            recipe_inputs={
+                "shape": "star5",
+                "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10,
+                "acceptance": {"max_tracking_error_m": measured * 1.02},
+            },
+        )
+        outcome = TaskCoordinator(kernel).consider(task_id)
+        assert outcome is not None
+        assert outcome["verification"] == "PASS_NEAR_LIMIT", outcome
+        assert outcome["lifecycle"] == "COMPLETED", outcome
+        row = conn.execute(
+            "SELECT checks_json FROM verifications WHERE task_id = ? "
+            "AND status = 'PASS' ORDER BY rowid DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert row, "PASS 验收行缺失"
+        checks = json.loads(str(row["checks_json"]))
+        assert checks.get("grade") == "PASS_NEAR_LIMIT", checks
+
+    def test_loose_threshold_stays_plain_pass(self, tmp_path: Path) -> None:
+        """默认阈值（利用率 <90%）→ 普通 PASS（不误报 near-limit）。"""
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+        from tests.agentd.test_r01_production_chain import _kernel
+
+        kernel, conn = _kernel(tmp_path)
+        task_id, measured = _measure_error(kernel, conn, tmp_path)
+        outcome = TaskCoordinator(kernel).consider(task_id)
+        assert outcome is not None
+        # 默认阈值 25mm 地板——实测 ~20mm 利用率 <90%。
+        assert measured < 0.9 * 0.025, f"实测误差假设失效：{measured}"
+        assert outcome["verification"] == "PASS", outcome
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
- P0-5：tracking_grade（≥90% 阈值占用 → PASS_NEAR_LIMIT，不显示普通 PASS）；grade+误差随验收行持久化；Coordinator outcome 呈现分级；Presenter 标注勉强通过；金丝雀接受该分级
- h2 旅程实证修复：watcher 修订重跑终态被吞（deliveredTasks 按执行周期清理）；bind_message FORCE_NEW 被 SUCCEEDED 重开吞掉（顺序修正——/newtask 优先）

红→绿：test_p05 3 红→绿；h2 三腿 PTY 全绿；p01 watcher 回归 4/4；TS 193/193。