### PR TITLE
feat: P0-6 PlanRef 跨进程统一 + REF_NOT_FOUND 带码透传（0827 审计）

### DIFF
--- a/src/rosclaw/agentd/plan_ref_conformance.py
+++ b/src/rosclaw/agentd/plan_ref_conformance.py
@@ -1,0 +1,66 @@
+"""PlanRef 跨进程 conformance（0827 体验审计 P0-6）。
+
+启动/快照期探针：生产者（ur5e.plan_cartesian_path 的 PlanStore）
+写一条探针 plan，消费者（SimTrajectoryService._load_plan——生产
+链用的解析器）必须能解析。不可解析 = 生产者/消费者不共享存储
+（home 分裂/内存回落）——工具对必须排除出模型上下文（不兼容
+工具在场 = 模型必然撞 REF_NOT_FOUND 后瞎试）。
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+#: PlanRef 生产者/消费者对（conformance 失败时整对排除——半个链
+#: 在场比不在场更糟）。
+_PLAN_REF_PAIR = (
+    "ur5e.plan_cartesian_path",
+    "ur5e.simulate_cartesian_trajectory",
+)
+
+
+def plan_ref_conformance(home: Path | str) -> list[dict[str, Any]]:
+    """探针：生产者写入 → 消费者解析。返回排除清单（空 = 一致）。"""
+    def _excluded(reason: str) -> list[dict[str, Any]]:
+        return [
+            {
+                "capability_id": cid,
+                "code": "REF_CONFORMANCE_FAILED",
+                "reason": reason,
+            }
+            for cid in _PLAN_REF_PAIR
+        ]
+
+    producer_home = os.environ.get("ROSCLAW_HOME")
+    if not producer_home:
+        return _excluded(
+            "ROSCLAW_HOME 未设置——生产者回落内存 PlanStore，"
+            "跨进程不可解析"
+        )
+    if Path(producer_home).resolve() != Path(home).resolve():
+        return _excluded(
+            f"生产者/消费者 home 分裂：{producer_home} ≠ {home}"
+        )
+    # 探针：真实生产者 store 写入 → 真实消费者解析（不留探针文件）。
+    import rosclaw.sim.ur5e_mcp as ur5e_mcp
+    from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+    store = ur5e_mcp._plan_store()
+    record = store.put(
+        {"hash": "conformance", "points": [], "shape": "probe"},
+        "plan-ref conformance probe",
+    )
+    try:
+        SimTrajectoryService(Path(home))._load_plan(str(record["plan_id"]))
+    except Exception as exc:  # noqa: BLE001 - 不可解析即不一致
+        return _excluded(f"探针 plan 消费者不可解析：{exc}"[:200])
+    finally:
+        path = getattr(store, "_path", None)
+        if callable(path):
+            path(str(record["plan_id"])).unlink(missing_ok=True)
+    return []
+
+
+__all__ = ["plan_ref_conformance"]

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -806,9 +806,31 @@ class AgentService:
 
     def capability_snapshot(self, mission):
         """PR-N5D：当前 registry → 该 mission 的 CapabilitySnapshotV1
-        （body/mode 过滤 + digest）。generation 来自 catalog 代际。"""
+        （body/mode 过滤 + digest）。generation 来自 catalog 代际。
+
+        P0-6（0827 审计）：PlanRef conformance——生产者/消费者不共享
+        存储的工具对在此刻隔离出模型面（不兼容工具在场 = 模型必然
+        撞 REF_NOT_FOUND 后瞎试）。一次性探针，结果缓存。"""
         from rosclaw.agentd.tooling.snapshot import build_capability_snapshot
 
+        if not getattr(self, "_plan_ref_conformance_done", False):
+            self._plan_ref_conformance_done = True
+            try:
+                from rosclaw.agentd.plan_ref_conformance import (
+                    plan_ref_conformance,
+                )
+
+                for exclusion in plan_ref_conformance(self._home):
+                    self._tool_catalog.quarantine_tool(
+                        str(exclusion["capability_id"]),
+                        f"REF_CONFORMANCE_FAILED: {exclusion['reason']}",
+                    )
+            except Exception:  # noqa: BLE001 - 探针自身故障不阻塞快照
+                import logging
+
+                logging.getLogger("rosclaw.conformance").warning(
+                    "plan-ref conformance probe failed", exc_info=True,
+                )
         body_id = mission.body_binding.body_id if mission is not None else ""
         mode = mission.mode.value if mission is not None else "SIMULATION"
         return build_capability_snapshot(self._tool_catalog, body_id=body_id, mode=mode)

--- a/src/rosclaw/agentd/tooling/catalog.py
+++ b/src/rosclaw/agentd/tooling/catalog.py
@@ -41,6 +41,29 @@ class ToolNotCallableError(ValidationError):
     """Raised when code tries to execute a tool the model must never call."""
 
 
+def stable_error_code(exc: Exception) -> str:
+    """异常 → 稳定错误码（R0-9 锚定 + P0-6 白名单搜索）。
+
+    - 锚定："CODE: message"（或 "XxxError: CODE: message"）直取
+      （R0-9 行为：码形前缀即透传，不限注册表——新码不被压扁）；
+    - P0-6（0827 审计）：执行器/MCP 包装前缀（"Error executing
+      tool ...: REF_NOT_FOUND: ..."）让锚定失配——白名单搜索前
+      200 字符，只有注册码透传（散文里的 TODO:/NOTE: 不冒充码）。
+    """
+    import re as _re
+
+    from rosclaw.agentd.tooling.recovery import RECOVERY_REGISTRY
+
+    text = str(exc)
+    match = _re.match(r"^(?:\w+Error: )?([A-Z][A-Z0-9_]{3,}):\s", text)
+    if match:
+        return match.group(1)
+    for candidate in _re.finditer(r"\b([A-Z][A-Z0-9_]{3,}):", text[:200]):
+        if candidate.group(1) in RECOVERY_REGISTRY:
+            return candidate.group(1)
+    return "EXECUTOR_ERROR"
+
+
 class ToolQuarantinedError(ValidationError):
     """Raised when a tool/source is quarantined (health check failed)."""
 
@@ -303,13 +326,7 @@ class ToolCatalog:
             # 稳定错误码——基础设施错误不被包成无语义的
             # EXECUTOR_ERROR（重试预算/恢复动作按码分派）。
             message = f"{type(exc).__name__}: {exc}"[:400]
-            code = "EXECUTOR_ERROR"
-            import re as _re
-
-            match = _re.match(r"^(?:\w+Error: )?([A-Z][A-Z0-9_]{3,}):\s", str(exc))
-            if match:
-                code = match.group(1)
-            return _failed(code, message)
+            return _failed(stable_error_code(exc), message)
         # 归一为 canonical value：只接受 dict / ToolExecutionResult /
         # JSON 对象字符串；裸文本不得冒充结构化结果。
         value: Any

--- a/src/rosclaw/agentd/tooling/recovery.py
+++ b/src/rosclaw/agentd/tooling/recovery.py
@@ -38,6 +38,11 @@ RECOVERY_REGISTRY: dict[str, str] = {
     "RENDER_FAILED": "渲染子进程失败——内核已降级一次；检查后端/依赖，模型不重试",
     "WORLD_ASSET_MISSING": "场景 world 资产不存在——换已支持的 world 或安装资产，模型不重试",
     "TOOL_ASSET_MISSING": "工具资产不存在——不得假装持笔；安装工具资产或去掉工具声明",
+    # P0-6（0827 审计）：引用类稳定码——跨进程引用失败必须带码
+    # 透传（不得包成 EXECUTOR_ERROR 丢语义）。
+    "REF_NOT_FOUND": "引用不在共享 PlanStore——重新规划生成新引用，不重试同一 id",
+    "REF_FORMAT_UNKNOWN": "引用格式不可解码（生产者/消费者 schema 不兼容）——用生产者当前 schema 重新生成",
+    "REF_CONFORMANCE_FAILED": "PlanRef 生产者/消费者不共享存储——工具对已退出模型面，改用别的规划链",
 }
 
 

--- a/src/rosclaw/agentd/tooling/snapshot.py
+++ b/src/rosclaw/agentd/tooling/snapshot.py
@@ -54,10 +54,10 @@ def build_capability_snapshot(
         cid = cap.capability_id
         reason = catalog.quarantine_reason(cid)
         if reason is not None:
-            # 已知机器原因码直传（如 QUARANTINED_UNCLASSIFIED），其余
-            # 统一 CAPABILITY_QUARANTINED。
+            # 已知机器原因码直传（如 QUARANTINED_UNCLASSIFIED /
+            # REF_CONFORMANCE_FAILED），其余统一 CAPABILITY_QUARANTINED。
             code = reason.split(":", 1)[0].strip()
-            if code not in ("QUARANTINED_UNCLASSIFIED",):
+            if code not in ("QUARANTINED_UNCLASSIFIED", "REF_CONFORMANCE_FAILED"):
                 code = "CAPABILITY_QUARANTINED"
             excluded.append(SnapshotExcludedV1(
                 capability_id=cid, reason=code,

--- a/src/rosclaw/sim/ur5e_mcp.py
+++ b/src/rosclaw/sim/ur5e_mcp.py
@@ -117,21 +117,42 @@ class PlanStore:
         self._records.clear()
 
 
-def _make_plan_store():
+def _make_plan_store(home: str | None = None):
     """WP-P0-7：ROSCLAW_HOME 可用 → 落盘 PlanStore（executor 重启
-    不丢 plan、已消费不复活）；否则内存（单测直 import）。"""
+    不丢 plan、已消费不复活）；否则内存（单测直 import 兼容——
+    conformance 会把这种进程的工具对排除出模型面）。"""
     import os as _os
     from pathlib import Path as _Path
 
-    home = _os.environ.get("ROSCLAW_HOME")
-    if home:
+    resolved = home or _os.environ.get("ROSCLAW_HOME")
+    if resolved:
         from rosclaw.sim.plan_store import PersistentPlanStore
 
-        return PersistentPlanStore(_Path(home) / "sim" / "plans")
+        return PersistentPlanStore(_Path(resolved) / "sim" / "plans")
     return PlanStore()
 
 
-_PLAN_STORE = _make_plan_store()
+# P0-6（0827 审计）：import 时解析的模块级单例是 PlanRef 分裂根因
+# ——进程在 ROSCLAW_HOME 设置前 import 就永远拿内存 store（生产者
+# 写内存、消费者读磁盘 → REF_NOT_FOUND）。改为调用时解析（按
+# resolved home 缓存实例）。
+_PLAN_STORES: dict[str, object] = {}
+_FALLBACK_STORE = _make_plan_store("")
+
+
+def _plan_store():
+    """调用时解析共享 PlanStore（ROSCLAW_HOME 后设置也生效）。"""
+    import os as _os
+
+    home = _os.environ.get("ROSCLAW_HOME")
+    if not home:
+        return _FALLBACK_STORE
+    key = home
+    store = _PLAN_STORES.get(key)
+    if store is None:
+        store = _make_plan_store(home)
+        _PLAN_STORES[key] = store
+    return store
 
 
 def _canonical_point(point: dict) -> dict:
@@ -231,7 +252,7 @@ def plan_cartesian_path(
         f"{shape} 五角星：中心 ({center_x}, {center_y}, {z})m，"
         f"外半径 {outer_radius}m，{len(points)} 个插值点，已闭合"
     )
-    record = _PLAN_STORE.put(trajectory, summary)
+    record = _plan_store().put(trajectory, summary)
     result = {
         "ok": True,
         "sim_kind": SIM_KIND,
@@ -254,7 +275,7 @@ def plan_cartesian_path(
     annotations={"readOnlyHint": False, "destructiveHint": False},
 )
 def execute_plan(plan_id: str) -> str:
-    record = _PLAN_STORE.get_for_execute(plan_id)
+    record = _plan_store().get_for_execute(plan_id)
     trajectory = record["trajectory"]
     points = trajectory["points"]
     # 执行前复验（TOCTOU）：canonical hash + 工作空间。
@@ -263,7 +284,7 @@ def execute_plan(plan_id: str) -> str:
         raise ValueError(f"plan {plan_id} payload hash mismatch (fail closed)")
     for point in points:
         _workspace_check(point)
-    _PLAN_STORE.consume(plan_id)
+    _plan_store().consume(plan_id)
     result = json.loads(_execute_trajectory(trajectory))
     result["plan_id"] = plan_id
     result["digest"] = record["digest"]
@@ -490,7 +511,7 @@ def verify_drawing(expected_trajectory_hash: str = "") -> str:
         expected_trajectory_hash = str(last.get("trajectory_hash", ""))
         if not expected_trajectory_hash:
             raise ValueError("no executed plan to verify (fail closed)")
-    record = _PLAN_STORE.by_digest(expected_trajectory_hash)
+    record = _plan_store().by_digest(expected_trajectory_hash)
     if record is None:
         raise ValueError(f"unknown trajectory hash {expected_trajectory_hash[:16]}")
     expected = record["trajectory"]
@@ -546,7 +567,7 @@ def verify_drawing(expected_trajectory_hash: str = "") -> str:
 def reset_simulation() -> str:
     _state["trace"] = []
     _state["plans"] = {}
-    _PLAN_STORE.clear()
+    _plan_store().clear()
     _state["moving"] = False
     return json.dumps(
         {

--- a/tests/agentd/test_p06_planref_unification.py
+++ b/tests/agentd/test_p06_planref_unification.py
@@ -1,0 +1,95 @@
+"""0827 体验审计 P0-6 红测试：PlanRef 跨进程统一 + 带码透传。
+
+0827 实证：ur5e.plan_cartesian_path 产出 plan_28b6... →
+ur5e_simulate_cartesian_trajectory 报 REF_NOT_FOUND——生产者和
+消费者没共享同一个 PlanStore（ur5e_mcp 的 _PLAN_STORE 是 import
+时解析的模块级单例：进程在 ROSCLAW_HOME 设置前 import 就永远拿
+内存 store，或拿到另一个 home）——只是固定 recipe 绕开了问题；
+且 REF_NOT_FOUND 被包装成无语义的 EXECUTOR_ERROR（MCP/执行器
+包装前缀让锚定正则失配）。
+
+闭环断言：
+1. 生产者在调用时解析共享 store（import 后设置 ROSCLAW_HOME 也
+   生效）——产出的 plan_id 消费者 SimTrajectoryService 可解析；
+2. REF_NOT_FOUND/REF_FORMAT_UNKNOWN 等白名单稳定码即使被包装
+   前缀包裹也透传（不得包成 EXECUTOR_ERROR）；
+3. 启动 conformance：生产者探针计划消费者不可解析时，工具对
+   被排除出快照（不兼容工具不进模型上下文）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class TestSharedPlanStoreResolution:
+    def test_producer_store_resolves_at_call_time(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """import 后设置 ROSCLAW_HOME——生产者写入的 plan 必须落在
+        消费者（SimTrajectoryService(home)）可解析的共享目录。"""
+        import json as _json
+
+        import rosclaw.sim.ur5e_mcp as ur5e_mcp
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        monkeypatch.setenv("ROSCLAW_HOME", str(tmp_path))
+        raw = ur5e_mcp.plan_cartesian_path(
+            shape="star5", center_x=0.35, center_y=0.25, z=0.30,
+            outer_radius=0.10,
+        )
+        result = _json.loads(raw)
+        plan_id = result["plan_id"]
+        # 消费者（生产链用的服务）必须能解析——不共享即 REF_NOT_FOUND。
+        consumer = SimTrajectoryService(tmp_path)
+        plan = consumer._load_plan(plan_id)
+        assert plan["points"], plan
+        ur5e_mcp._plan_store().clear()
+
+
+class TestCodedErrorPassthrough:
+    def test_wrapped_ref_not_found_keeps_code(self) -> None:
+        """执行器/MCP 包装前缀（'Error executing tool ...: REF_NOT_FOUND:
+        ...'）不得让稳定码退化成 EXECUTOR_ERROR。"""
+        from rosclaw.agentd.tooling.catalog import stable_error_code
+
+        assert stable_error_code(
+            ValueError("REF_NOT_FOUND: plan 'plan_x' 不在共享 PlanStore")
+        ) == "REF_NOT_FOUND"
+        assert stable_error_code(
+            RuntimeError(
+                "Error executing tool ur5e.simulate_cartesian_trajectory: "
+                "REF_NOT_FOUND: plan_id 'plan_x' 不在共享 PlanStore (fail closed)"
+            )
+        ) == "REF_NOT_FOUND"
+        # 非码散文不冒充稳定码（无 CODE: 前缀 → EXECUTOR_ERROR）。
+        assert stable_error_code(ValueError("plain failure")) == "EXECUTOR_ERROR"
+
+
+class TestPlanRefConformance:
+    def test_conformance_excludes_unresolvable_pair(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """conformance 探针：生产者写的 plan 消费者读不到（home
+        分裂）→ 工具对进排除清单（带机器原因码）；共享时为空。"""
+        from rosclaw.agentd.plan_ref_conformance import (
+            plan_ref_conformance,
+        )
+
+        monkeypatch.setenv("ROSCLAW_HOME", str(tmp_path))
+        # 共享 home → 无排除。
+        assert plan_ref_conformance(tmp_path) == []
+        # 消费者 home 分裂 → 排除生产者+消费者对。
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        excluded = plan_ref_conformance(other)
+        ids = {str(e.get("capability_id")) for e in excluded}
+        assert "ur5e.plan_cartesian_path" in ids, excluded
+        assert "ur5e.simulate_cartesian_trajectory" in ids, excluded
+        assert all(e.get("code") == "REF_CONFORMANCE_FAILED" for e in excluded)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
0827 实证：ur5e.plan_cartesian_path 产出的 plan_id 被 simulate 拒为 REF_NOT_FOUND 且被包成 EXECUTOR_ERROR。

- ur5e_mcp PlanStore 改为调用时解析（import 时单例是分裂根因）
- plan_ref_conformance 快照期探针：生产/消费不共享存储 → 工具对 quarantine 出模型面（REF_CONFORMANCE_FAILED 透传）
- stable_error_code：包装前缀下白名单搜索透传注册码；REF_NOT_FOUND/REF_FORMAT_UNKNOWN 进 RECOVERY_REGISTRY

红→绿：test_p06 3 红→绿；snapshot/capability/bridge 邻近 90 过。