### PR TITLE
feat: P0-7 Provider quota 接入全局重试预算（0827 审计）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -31,7 +31,7 @@ import type { ProductStateCenter } from "../session/state-center.js";
 import { InputController } from "../native/input-controller.js";
 import { OperationWatcher } from "../native/operation-watcher.js";
 import { suppressModelTurn } from "../native/turn-disposition.js";
-import { classifyModelError } from "../native/model-errors.js";
+import { classifyModelError, ProviderErrorGate } from "../native/model-errors.js";
 import {
 	renderArtifactList,
 	renderOperationLogs,
@@ -1028,16 +1028,43 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		// 内消息 finalize 进行中，会话层会丢条目）。
 		const COMPLETION_CLAIM =
 			/(已执行|已完成|已确认|执行完毕|成功执行|successfully executed|has been executed|action completed)/i;
+		// P0-7（0827 审计 §八）：provider 错误经闸门——同一错误码一张
+		// 中文卡（重试的重复 message_end 不重复显示）；原始错误进
+		// /activity 账本；PROVIDER_PAUSED 进 Header/readiness；模型
+		// 切换或下次成功复位（恢复同一 turn，不重建任务）。
+		const providerGate = new ProviderErrorGate();
+		pi.on("model_select", async () => {
+			providerGate.onModelSwitch();
+			center.noteProviderOk();
+			return undefined;
+		});
 		pi.on("message_end", async (event) => {
 			// PR-H7（§8.4）：provider 错误分类——403 配额≠鉴权错误；
 			// 稳定错误码 + 用户可理解说明 + 恢复动作（task 可继续）。
 			const msg = event.message as { role?: string; stopReason?: string; errorMessage?: string };
 			if (msg.role === "assistant" && (msg.stopReason === "error" || msg.errorMessage)) {
-				const classified = classifyModelError(String(msg.errorMessage ?? ""));
-				latestCtx?.ui.notify(
-					`[${classified.code}] ${classified.explanation}——${classified.recovery}`,
-					"error",
-				);
+				const raw = String(msg.errorMessage ?? "");
+				const classified = classifyModelError(raw);
+				let hasActiveTask = false;
+				try {
+					hasActiveTask = Boolean(await inputController.activeTaskId());
+				} catch {
+					hasActiveTask = false;
+				}
+				const verdict = providerGate.onError(classified, {
+					hasActiveTask, raw,
+				});
+				if (verdict.showCard) {
+					latestCtx?.ui.notify(verdict.cardText, "error");
+					center.noteProviderPaused(classified.code);
+				}
+				// 原始错误永远进账本（即使卡片被去重——/activity 可查）。
+				if (verdict.activity) {
+					pi.appendEntry("rosclaw.provider_error", verdict.activity);
+				}
+			} else if (msg.role === "assistant" && !msg.errorMessage) {
+				providerGate.onSuccess();
+				center.noteProviderOk();
 			}
 			if (!lastOutcome || lastOutcome.narrativeSeen) return undefined;
 			const message = event.message as { role?: string; content?: unknown };

--- a/packages/rosclaw-agent/src/native/model-errors.ts
+++ b/packages/rosclaw-agent/src/native/model-errors.ts
@@ -37,7 +37,9 @@ export function classifyModelError(raw: string): ClassifiedModelError {
 		return {
 			code: "PROVIDER_QUOTA_EXHAUSTED",
 			explanation: "模型配额已用完（本计费周期）",
-			recovery: "配额下周期刷新；/model 换可用模型立即继续；任务保持可恢复",
+			// P0-7："任务保持可恢复"由 ProviderErrorGate 按有无 active
+			// task 条件追加——无任务时不得宣称。
+			recovery: "配额下周期刷新；/model 换可用模型立即继续",
 			taskRecoverable: true,
 		};
 	}
@@ -95,4 +97,64 @@ export function classifyModelError(raw: string): ClassifiedModelError {
 		recovery: "查看 /doctor 诊断",
 		taskRecoverable: true,
 	};
+}
+
+/** ProviderErrorGate（0827 审计 P0-7）：provider 错误的展示闸门。
+ *
+ * 0827 实证：同一个 403 配额错误——原始 JSON 显示多次 + 规范化
+ * 错误显示多次 + "Retry failed after 3 attempts"。闸门纪律：
+ * - 同一错误码一张卡（重试产生的重复 message_end 不重复打扰）；
+ * - 卡片含 /model 入口；"任务保持可恢复"只在有 active task 时；
+ * - 原始错误随 activity 负载进账本（默认界面干净，/activity 可查）；
+ * - 模型切换/下次成功复位（恢复同一 turn，不重建任务）。
+ */
+export class ProviderErrorGate {
+	private shown: string | null = null;
+
+	/** 一次 provider 错误（message_end）。返回是否出卡 + 卡文本 +
+	 *  activity 负载。 */
+	onError(
+		classified: ClassifiedModelError,
+		opts: { hasActiveTask: boolean; raw?: string },
+	): {
+		showCard: boolean;
+		cardText: string;
+		activity?: { code: string; raw: string };
+	} {
+		if (this.shown === classified.code) {
+			return { showCard: false, cardText: "" };
+		}
+		this.shown = classified.code;
+		const recoverable = classified.taskRecoverable && opts.hasActiveTask
+			? "；任务保持可恢复"
+			: "";
+		// /model 入口：recovery 未提及时补上（配额类已自带）。
+		const modelEntry = classified.recovery.includes("/model")
+			? ""
+			: "（/model 换模型可立即继续）";
+		return {
+			showCard: true,
+			cardText:
+				`[${classified.code}] ${classified.explanation}——`
+				+ `${classified.recovery}${modelEntry}${recoverable}`,
+			activity: {
+				code: classified.code,
+				raw: String(opts.raw ?? "").slice(0, 1000),
+			},
+		};
+	}
+
+	/** 助手消息成功 → 复位（下次同码错误重新出卡）。 */
+	onSuccess(): void {
+		this.shown = null;
+	}
+
+	/** 模型切换 → 复位（恢复同一 turn，不重建任务）。 */
+	onModelSwitch(): void {
+		this.shown = null;
+	}
+
+	get pausedCode(): string | null {
+		return this.shown;
+	}
 }

--- a/packages/rosclaw-agent/src/session/state-center.ts
+++ b/packages/rosclaw-agent/src/session/state-center.ts
@@ -58,6 +58,9 @@ export interface KernelSnapshotV1 {
 	context_revision: number;
 	lease_state: LeaseState;
 	operator: OperatorState;
+	/** P0-7（0827 审计）：provider 状态——PAUSED = 配额/凭据类确定性
+	 *  错误（一张卡 + /model 入口；不再反复请求）。 */
+	provider?: "OK" | "PAUSED";
 	action_readiness: ActionReadinessV1;
 	/** 十一审 PR-D：当前绑定 workspace（None=无 Project）。 */
 	workspace?: string;
@@ -92,6 +95,9 @@ type Listener = () => void;
 export class ProductStateCenter {
 	private seq = 0;
 	private kernelState: KernelState = "READY";
+	/** P0-7：provider 暂停（配额/凭据类确定性错误——模型切换或
+	 *  下次成功清除）。 */
+	private providerState: "OK" | "PAUSED" = "OK";
 	/** R0-6（0826 体验审计 §5.R0-6）：启动事务——bootstrap 完成前
 	 *  chrome/ready 显示"正在准备"（不是 Kernel Unreachable +
 	 *  Context Stale + Action Blocked 三连假真相）。 */
@@ -169,6 +175,7 @@ export class ProductStateCenter {
 			context_revision: state.contextRevision,
 			lease_state: state.leaseState,
 			operator: this.operatorState,
+			provider: this.providerState,
 			action_readiness: this.computeReadiness(),
 			workspace: this.workspaceDisplay,
 		};
@@ -190,6 +197,9 @@ export class ProductStateCenter {
 		const codes: string[] = [];
 		if (!state.missionId) codes.push("NO_MISSION");
 		if (this.kernelState !== "READY") codes.push("KERNEL_UNREACHABLE");
+		// P0-7：provider 暂停（配额/凭据确定性错误）——模型驱动的
+		// 动作此刻必然失败，readiness 诚实标注。
+		if (this.providerState === "PAUSED") codes.push("PROVIDER_PAUSED");
 		if (state.leaseState !== "ACTIVE") codes.push("NO_WRITER_LEASE");
 		if (state.missionId && state.contextState !== "FRESH") codes.push("CONTEXT_STALE");
 		if (state.missionId && !state.contextLeaseId) codes.push("NO_CONTEXT_LEASE");
@@ -283,6 +293,20 @@ export class ProductStateCenter {
 			this.modelDisplay = display;
 			this.changed();
 		}
+	}
+
+	/** P0-7：provider 确定性错误 → PAUSED（Header/readiness 可见）。 */
+	noteProviderPaused(_code: string): void {
+		if (this.providerState === "PAUSED") return;
+		this.providerState = "PAUSED";
+		this.changed();
+	}
+
+	/** P0-7：模型切换/下次成功 → 恢复（同一 turn 继续，不重建任务）。 */
+	noteProviderOk(): void {
+		if (this.providerState === "OK") return;
+		this.providerState = "OK";
+		this.changed();
 	}
 
 	/** UDS 桥调用包装：失败即原子降级（kernel UNREACHABLE + context

--- a/packages/rosclaw-agent/test/p07-provider-quota.test.ts
+++ b/packages/rosclaw-agent/test/p07-provider-quota.test.ts
@@ -1,0 +1,112 @@
+/** 0827 体验审计 P0-7 红测试：Provider quota 全局重试预算。
+ *
+ * 0827 实证：同一个 Kimi 403 配额错误——原始 JSON 显示多次 +
+ * 规范化错误显示多次 + "Retry failed after 3 attempts"。
+ *
+ * 闭环断言：
+ * 1. ProviderErrorGate：同一错误码只出一张中文错误卡（重试产生
+ *    的重复 message_end 不重复打扰）；卡片含 /model 入口；
+ * 2. "任务保持可恢复"只在有 active task 时出现；
+ * 3. 原始错误进活动账本（onError 返回 activity 负载）；
+ * 4. PROVIDER_PAUSED 状态：state-center snapshot.provider 翻转 +
+ *    readiness reason_codes 带 PROVIDER_PAUSED；模型切换/下次
+ *    成功清除（恢复同一 turn，不重建任务）。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("ProviderErrorGate：一码一卡 + /model 入口 + 条件可恢复", async () => {
+	const { ProviderErrorGate } = await import("../src/native/model-errors.js");
+	const { classifyModelError } = await import("../src/native/model-errors.js");
+	const gate = new ProviderErrorGate();
+	const quota = classifyModelError("403 quota exceeded: insufficient_quota");
+	// 第一次：出卡 + activity 负载（raw 来自 message_end 的原始错误
+	// 文本——与 extension 调用点同契约）。
+	const first = gate.onError(quota, {
+		hasActiveTask: true,
+		raw: "403 quota exceeded: insufficient_quota",
+	});
+	assert.equal(first.showCard, true);
+	assert.match(first.cardText, /PROVIDER_QUOTA_EXHAUSTED/);
+	assert.match(first.cardText, /\/model/);
+	assert.match(first.cardText, /任务保持可恢复/);
+	assert.ok(first.activity, "缺 activity 负载（原始错误要进账本）");
+	assert.match(String(first.activity?.raw), /quota/);
+	// 同码重复（重试的 message_end）→ 不再出卡。
+	const dup = gate.onError(quota, { hasActiveTask: true });
+	assert.equal(dup.showCard, false, "同一错误码重复出卡");
+	// 无 active task → 不说"任务保持可恢复"。
+	const gate2 = new ProviderErrorGate();
+	const noTask = gate2.onError(quota, { hasActiveTask: false });
+	assert.equal(noTask.showCard, true);
+	assert.doesNotMatch(noTask.cardText, /任务保持可恢复/);
+	// 不同错误码 → 新卡。
+	const other = gate.onError(
+		classifyModelError("401 invalid api key"), { hasActiveTask: false },
+	);
+	assert.equal(other.showCard, true);
+	// 模型切换/成功 → 闸门复位（恢复同一 turn）。
+	gate.onModelSwitch();
+	const afterSwitch = gate.onError(quota, { hasActiveTask: false });
+	assert.equal(afterSwitch.showCard, true, "换模型后同码应重新出卡");
+	gate.onModelSwitch();
+	const gate3 = new ProviderErrorGate();
+	gate3.onError(quota, { hasActiveTask: false });
+	gate3.onSuccess();
+	const afterSuccess = gate3.onError(quota, { hasActiveTask: false });
+	assert.equal(afterSuccess.showCard, true, "成功后同码应重新出卡");
+});
+
+test("state-center：PROVIDER_PAUSED 进出快照与 readiness", async () => {
+	const { ProductStateCenter } = await import("../src/session/state-center.js");
+	const { ActiveSessionContext } = await import("../src/session/active-context.js");
+	const active = new ActiveSessionContext({
+		sessionId: "pi_test",
+		missionId: "mis_1",
+		contextRevision: 3,
+		mode: "SIMULATION",
+		profile: "developer",
+		contextState: "FRESH",
+		leaseState: "ACTIVE",
+		actionsAllowed: true,
+		contextLeaseId: "vcl_1",
+		bodyId: "sim/ur5e",
+		bodyHash: "body_x",
+	});
+	const center = new ProductStateCenter({
+		rosclawHome: "/tmp/p07",
+		active,
+		operatorSocket: "/tmp/p07/run/operatord.sock",
+		productVersion: "0.0.0-test",
+		call: (async (_home: string, method: string) => {
+			if (method === "pi.status") {
+				return {
+					ok: true,
+					agentd: "READY",
+					authorization_profile: "dev",
+					mission: {
+						mission_id: "mis_1",
+						state: "ACTIVE",
+						mode: "SIMULATION",
+						body_id: "sim/ur5e",
+					},
+				};
+			}
+			if (method === "approvals.list") return { ok: true, approvals: [] };
+			return { ok: true };
+		}) as never,
+		operatorCallFn: async () => ({ ok: true }) as never,
+	});
+	await center.bootstrap();
+	assert.equal(center.snapshot().provider ?? "OK", "OK");
+	center.noteProviderPaused("PROVIDER_QUOTA_EXHAUSTED");
+	assert.equal(center.snapshot().provider, "PAUSED");
+	const readiness = center.snapshot().action_readiness;
+	assert.ok(
+		readiness.reason_codes.includes("PROVIDER_PAUSED"),
+		`readiness 缺 PROVIDER_PAUSED：${readiness.reason_codes}`,
+	);
+	center.noteProviderOk();
+	assert.equal(center.snapshot().provider, "OK");
+});

--- a/src/rosclaw/agentd/onboarding.py
+++ b/src/rosclaw/agentd/onboarding.py
@@ -97,6 +97,10 @@ def configure_model(
         # Pi settings（defaultThinkingLevel——此前被静默忽略）；保留
         # 其他 settings 键。
         _write_thinking_level(home, reasoning_effort)
+        # P0-7（0827 审计 §八）：Provider 重试预算进 Pi settings——
+        # 配额类确定性错误命中 Pi NON_RETRYABLE 词表时零重试；其余
+        # 瞬态错误最多 1 次自动重试（默认 3 次会把确定性 403 烧 4 次）。
+        _write_retry_budget(home)
     return {
         "configured": True,
         "config_path": str(home / "agent"),
@@ -123,6 +127,30 @@ def _write_thinking_level(home: Path, effort: str) -> None:
     if settings.get("defaultThinkingLevel") == effort:
         return
     settings["defaultThinkingLevel"] = effort
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        json.dumps(settings, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_retry_budget(home: Path) -> None:
+    """retry.maxRetries=1 写入 agent/settings.json（保留其他键，
+    幂等）——P0-7：确定性 provider 错误不得被自动重试烧配额。"""
+    settings_path = home / "agent" / "settings.json"
+    settings: dict = {}
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        except ValueError:
+            settings = {}
+    retry = settings.get("retry")
+    if not isinstance(retry, dict):
+        retry = {}
+    if retry.get("maxRetries") == 1:
+        return
+    retry["maxRetries"] = 1
+    settings["retry"] = retry
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(
         json.dumps(settings, ensure_ascii=False, indent=2) + "\n",

--- a/tests/agentd/test_p07_provider_retry_budget.py
+++ b/tests/agentd/test_p07_provider_retry_budget.py
@@ -1,0 +1,47 @@
+"""0827 体验审计 P0-7 红测试（Python 侧）：Pi 重试预算写入。
+
+0827 实证：Kimi 403 配额错误被 Pi 自动重试 3 次（默认
+retry.maxRetries=3）——确定性错误重复烧配额。setup 必须把重试
+预算写进 Pi settings（maxRetries=1：瞬态一次；配额类措辞命中 Pi
+NON_RETRYABLE 词表时零重试）。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class TestRetryBudgetWritten:
+    def test_setup_writes_retry_budget(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.onboarding import _write_retry_budget
+
+        _write_retry_budget(tmp_path)
+        settings = json.loads(
+            (tmp_path / "agent" / "settings.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert settings.get("retry", {}).get("maxRetries") == 1, settings
+
+    def test_preserves_other_keys_and_idempotent(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.onboarding import _write_retry_budget
+
+        settings_path = tmp_path / "agent" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text(
+            json.dumps({"defaultThinkingLevel": "high", "retry": {"baseDelayMs": 1500}}),
+            encoding="utf-8",
+        )
+        _write_retry_budget(tmp_path)
+        _write_retry_budget(tmp_path)  # 幂等
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert settings["defaultThinkingLevel"] == "high", settings
+        assert settings["retry"]["maxRetries"] == 1, settings
+        assert settings["retry"]["baseDelayMs"] == 1500, settings
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
0827 实证：同一 Kimi 403 配额错误被显示多次 + 重试 3 次。

- ProviderErrorGate：一码一卡（重试重复 message_end 不重复打扰）；/model 入口；任务保持可恢复只在有 active task 时；原始错误进 /activity
- PROVIDER_PAUSED 进 state-center snapshot + readiness reason_codes；模型切换/成功复位
- onboarding 写 retry.maxRetries=1

诚实边界：pi 无 per-error retry veto——命中 retryable 词表的配额错误 capped 在 2 次请求（已知限制）。

红→绿：p07 TS 2 红→绿 + py 2 红→绿；TS 193/193。