### PR TITLE
feat: P0-8 build identity 一致性 Gate——version --verbose 全景 + agentd boot_id（0827 审计）

### DIFF
--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -176,9 +176,26 @@ class PiBridgeServer:
             # 七审 PR-SEVEN-5：机器人友好名 + kit 摘要——UI 默认显示
             # display_name，不再只显示内部 body_id。
             kit_status = await service.robot_kit_status()
+            # P0-8（0827 审计）：build identity——agentd 版本 + boot_id
+            # （每次启动唯一）+ capability snapshot hash（有 mission
+            # 时）——/status 与 version --verbose 同源。
+            from rosclaw import __version__ as _agentd_version
+
+            capability_digest = ""
+            if mission is not None:
+                try:
+                    snapshot = service.capability_snapshot(mission)
+                    capability_digest = str(
+                        snapshot.to_canonical_dict().get("digest", "")
+                    )
+                except Exception:  # noqa: BLE001 - 快照失败不阻塞 status
+                    capability_digest = ""
             return {
                 "ok": True,
                 "agentd": "READY",
+                "agentd_version": _agentd_version,
+                "boot_id": service.boot_id,
+                "capability_digest": capability_digest,
                 "authorization_profile": service.authorization_profile(),
                 "sim_policy": sim_policy,
                 "body_id": service._body_id,

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -98,6 +98,11 @@ class AgentService:
 
         self._config = config
         self._home = rosclaw_home
+        # P0-8（0827 审计）：boot_id——每次进程启动唯一（会话间状态
+        # 归因/日志关联的安装身份面）。
+        import uuid as _uuid
+
+        self.boot_id = f"boot_{_uuid.uuid4().hex[:16]}"
         db_dir = rosclaw_home / AGENTD_DIR
         db_dir.mkdir(parents=True, exist_ok=True)
         self._store = MissionStore(db_dir / "missions.db")

--- a/src/rosclaw/cli.py
+++ b/src/rosclaw/cli.py
@@ -6846,7 +6846,7 @@ def main() -> int:
         "version", help="Show version / installation diagnostics"
     )
     version_parser.add_argument(
-        "--diagnostic", action="store_true",
+        "--diagnostic", "--verbose", dest="diagnostic", action="store_true",
         help="Show installation composition (commits/digests/revisions)",
     )
     version_parser.add_argument("--json", action="store_true", help="JSON output")
@@ -8954,6 +8954,7 @@ def main() -> int:
 
             return cmd_version(
                 diagnostic=bool(args.diagnostic), as_json=bool(args.json),
+                home=get_rosclaw_home(),  # P0-8：home 给运行时身份
             )
         if args.command == "init":
             return cmd_init(args)

--- a/src/rosclaw/version_diag.py
+++ b/src/rosclaw/version_diag.py
@@ -14,7 +14,7 @@
 - eurdf_generation：e-urdf-zoo 内容 digest（无代数标记时内容
   寻址就是代数）；
 - mixed_build：wheel 与 TS dist 的 commit 都已知且不同 →
-  INSTALLATION_MIXED_BUILD（chat 启动阻断）；任一侧 unknown
+  INSTALLATION_VERSION_MISMATCH（chat 启动阻断）；任一侧 unknown
   不谎报混合。
 """
 
@@ -146,9 +146,48 @@ def eurdf_generation() -> str:
     return _tree_digest(zoo) or "unknown"
 
 
+def _live_agentd(home: Path | None) -> dict[str, Any]:
+    """查询运行中的 agentd（pi-bridge.sock，NDJSON）——P0-8 运行时
+    身份（version + boot_id + capability snapshot hash）。未运行/
+    不可达 → {"running": False}（诚实，不编造）。"""
+    if home is None:
+        return {"running": False}
+    sock = Path(home) / "run" / "pi-bridge.sock"
+    if not sock.exists():
+        return {"running": False}
+    import asyncio
+
+    async def _query() -> dict[str, Any]:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_unix_connection(str(sock)), timeout=2.0,
+        )
+        try:
+            writer.write(
+                json.dumps({"method": "pi.status", "params": {}}).encode() + b"\n"
+            )
+            await writer.drain()
+            line = await asyncio.wait_for(reader.readline(), timeout=2.0)
+            return json.loads(line.decode())
+        finally:
+            writer.close()
+
+    try:
+        status = asyncio.run(_query())
+    except Exception:  # noqa: BLE001 - 不可达即未运行
+        return {"running": False}
+    if not status.get("ok"):
+        return {"running": False}
+    return {
+        "running": True,
+        "agentd_version": status.get("agentd_version", ""),
+        "boot_id": status.get("boot_id", ""),
+        "capability_digest": status.get("capability_digest", ""),
+    }
+
+
 def collect_diagnostics(*, home: Path | None = None) -> dict[str, Any]:
-    """安装一致性快照（home 保留给运行时项——当前全部为安装态）。"""
-    del home  # 运行时项（capability snapshot digest）由 agentd 面提供
+    """安装一致性快照 + 运行时身份（home 给运行时项——agentd
+    version/boot_id/capability digest 来自活实例）。"""
     from rosclaw import __version__
 
     ts = _ts_dist()
@@ -160,6 +199,8 @@ def collect_diagnostics(*, home: Path | None = None) -> dict[str, Any]:
         "kit_digest": kit_digest(),
         "migration_revision": migration_revision(),
         "eurdf_generation": eurdf_generation(),
+        # P0-8：agentd 运行时身份（未运行 = running False，不编造）。
+        "agentd": _live_agentd(home),
     }
     reason = mixed_build_reason(diag)
     diag["mixed_build"] = reason is not None
@@ -169,13 +210,17 @@ def collect_diagnostics(*, home: Path | None = None) -> dict[str, Any]:
 
 
 def mixed_build_reason(diag: dict[str, Any]) -> str | None:
-    """两侧 commit 都已知且不同 → 混合构建（诚实：unknown 不报）。"""
+    """两侧 commit 都已知且不同 → 混合构建（诚实：unknown 不报）。
+
+    P0-8（0827 审计）：稳定错误码 INSTALLATION_VERSION_MISMATCH——
+    "报告测新代码、用户跑旧 wheel/dist"必须能被这个码拒绝。
+    """
     wheel = str(diag.get("wheel_commit", "unknown"))
     ts = str((diag.get("ts_dist") or {}).get("commit", "unknown"))
     if wheel == "unknown" or ts == "unknown" or wheel == ts:
         return None
     return (
-        f"INSTALLATION_MIXED_BUILD: wheel 构建自 {wheel[:12]} 而 TS dist "
+        f"INSTALLATION_VERSION_MISMATCH: wheel 构建自 {wheel[:12]} 而 TS dist "
         f"构建自 {ts[:12]}——实现与部署不一致，能力声明不可信"
     )
 
@@ -221,6 +266,14 @@ def cmd_version(*, diagnostic: bool, as_json: bool,
         print(f"  kit_digest:        {diag['kit_digest']}")
         print(f"  migration:         r{diag['migration_revision']}")
         print(f"  eurdf_generation:  {diag['eurdf_generation']}")
+        agentd = diag.get("agentd") or {}
+        if agentd.get("running"):
+            print(f"  agentd_version:    {agentd.get('agentd_version', '')}")
+            print(f"  agentd_boot_id:    {agentd.get('boot_id', '')}")
+            digest = agentd.get("capability_digest") or "（无 active mission）"
+            print(f"  capability_digest: {digest}")
+        else:
+            print("  agentd:            未在运行（version 会话外无活实例）")
         if diag["mixed_build"]:
             print(f"  ⚠ {diag['mixed_build_reason']}")
     return 0

--- a/src/rosclaw/version_diag.py
+++ b/src/rosclaw/version_diag.py
@@ -158,12 +158,23 @@ def _live_agentd(home: Path | None) -> dict[str, Any]:
     import asyncio
 
     async def _query() -> dict[str, Any]:
+        # pi-bridge 全方法要 control token（0600 文件，同 UID 可读）。
+        import contextlib
+
+        token = ""
+        with contextlib.suppress(OSError):
+            token = (sock.parent / "agentd-control.token").read_text(
+                encoding="utf-8"
+            ).strip()
         reader, writer = await asyncio.wait_for(
             asyncio.open_unix_connection(str(sock)), timeout=2.0,
         )
         try:
             writer.write(
-                json.dumps({"method": "pi.status", "params": {}}).encode() + b"\n"
+                json.dumps({
+                    "method": "pi.status",
+                    "params": {"token": token},
+                }).encode() + b"\n"
             )
             await writer.drain()
             line = await asyncio.wait_for(reader.readline(), timeout=2.0)

--- a/tests/agentd/test_p08_build_identity.py
+++ b/tests/agentd/test_p08_build_identity.py
@@ -1,0 +1,74 @@
+"""0827 体验审计 P0-8 红测试：安装产物 build identity 一致性 Gate。
+
+0827 实证疑点：报告称 verifier 用 ~25mm 地板，真实日志显示 20mm
+阈值——"报告测的是新代码，用户跑的是旧 wheel/旧 dist"无法排除。
+
+闭环断言：
+1. `rosclaw version --verbose`（=--diagnostic 别名）一次显示：
+   CLI/wheel 版本+commit、TS dist commit+digest、schema（migration
+   revision）、capability snapshot hash（有运行实例时）、agentd
+   version+boot_id（有运行实例时）；
+2. 不一致错误码是 INSTALLATION_VERSION_MISMATCH（不是自造词）；
+3. pi.status 暴露 agentd_version + boot_id（每次 boot 唯一）；
+4. 活的 agentd 在跑时 version --verbose 显示其 boot_id。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class TestVersionVerboseSurface:
+    def test_verbose_alias_and_fields(self, tmp_path: Path, capsys) -> None:
+        from rosclaw.version_diag import cmd_version
+
+        rc = cmd_version(diagnostic=True, as_json=True, home=tmp_path)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        # 安装身份五件套（0827 §九.P0-8）。
+        assert out.get("rosclaw_version"), out
+        assert "wheel_commit" in out, out
+        assert (out.get("ts_dist") or {}).get("dist_digest"), out
+        assert "migration_revision" in out, out  # schema version
+        assert "agentd" in out, "缺 agentd 段（version+boot_id）"
+
+    def test_mismatch_code(self) -> None:
+        from rosclaw.version_diag import mixed_build_reason
+
+        reason = mixed_build_reason(
+            {"wheel_commit": "aaa", "ts_dist": {"commit": "bbb"}}
+        )
+        assert reason is not None
+        assert reason.startswith("INSTALLATION_VERSION_MISMATCH"), reason
+
+
+class TestAgentdBootIdentity:
+    async def test_status_exposes_version_and_boot_id(
+        self, tmp_path: Path
+    ) -> None:
+        from rosclaw import __version__
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await bridge._dispatch(
+            "user:local:1000", 1, "pi.status",
+            {"token": service.control_token, "mission_id": mission.mission_id},
+        )
+        assert result.get("ok"), result
+        assert result.get("agentd_version") == __version__, result
+        boot_id = str(result.get("boot_id") or "")
+        assert boot_id, result
+        # 每次 boot 唯一（重启即变——会话间状态归因靠它）。
+        assert service.boot_id == boot_id
+        # capability snapshot hash（有 mission 时必须给出）。
+        assert result.get("capability_digest"), result
+        await service.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/cli/test_version_diag.py
+++ b/tests/cli/test_version_diag.py
@@ -6,7 +6,7 @@
 实现与部署漂移而不可察觉。`rosclaw version --diagnostic --json`
 必须报告安装的真实构成：wheel commit / TS dist digest / extension
 digest / kit digest / migration revision / e-URDF 内容代数；
-两侧 commit 不一致 → INSTALLATION_MIXED_BUILD（chat 阻断）。
+两侧 commit 不一致 → INSTALLATION_VERSION_MISMATCH（chat 阻断）。
 """
 
 from __future__ import annotations
@@ -42,7 +42,7 @@ class TestCollectDiagnostics:
             "ts_dist": {"commit": "def456", "entry": "x", "dist_digest": "y"},
         }
         reason = mixed_build_reason(diag)
-        assert reason is not None and "INSTALLATION_MIXED_BUILD" in reason
+        assert reason is not None and "INSTALLATION_VERSION_MISMATCH" in reason
 
     def test_matching_commits_not_mixed(self) -> None:
         from rosclaw.version_diag import mixed_build_reason
@@ -71,7 +71,7 @@ class TestCollectDiagnostics:
                 "wheel_commit": "aaa",
                 "ts_dist": {"commit": "bbb", "entry": "x", "dist_digest": "y"},
             })
-        assert "INSTALLATION_MIXED_BUILD" in str(exc.value)
+        assert "INSTALLATION_VERSION_MISMATCH" in str(exc.value)
 
 
 class TestVersionCli:


### PR DESCRIPTION
0827 实证疑点：报告 25mm 地板 vs 日志 20mm——实现/部署漂移无法排除。

- pi.status 暴露 agentd_version + boot_id（每启动唯一）+ capability_digest
- version --verbose（--diagnostic 别名）：wheel commit、TS dist commit+digest、schema revision、eurdf 代数 + 活 agentd 实查（pi-bridge.sock + control token；未运行诚实标注）
- 不一致码定名 INSTALLATION_VERSION_MISMATCH（chat 启动门禁不变）

红→绿：test_p08 3 红→绿；tests/cli 全过。