### PR TITLE
fix: 终态呈现三补漏——空闲门控 + task.terminal 权威 + render 原子写（0827 真实 K3 复验实证）

### DIFF
--- a/packages/rosclaw-agent/src/native/operation-watcher.ts
+++ b/packages/rosclaw-agent/src/native/operation-watcher.ts
@@ -67,6 +67,9 @@ export class OperationWatcher {
 	private readonly trackedTasks = new Set<string>();
 	private readonly deliveredTasks = new Set<string>();
 	private readonly completedNodesByTask = new Map<string, Set<string>>();
+	/** 空闲门控挂起：终态事件已到但 Agent 流式中——延迟到空闲呈现
+	 *  （seq 游标已前进，靠本集合重试，不是重放事件）。 */
+	private readonly pendingTerminalTasks = new Set<string>();
 
 	constructor(private readonly deps: OperationWatcherDeps) {}
 
@@ -126,7 +129,8 @@ export class OperationWatcher {
 
 	private async tick(): Promise<void> {
 		await this.resolvePending();
-		if (!this.tracked.size && !this.trackedTasks.size) return;
+		if (!this.tracked.size && !this.trackedTasks.size
+			&& !this.pendingTerminalTasks.size) return;
 		const sink = this.deps.sink();
 		// R0-1.5：op 任务与自动路由任务同一增量轮询（不重不漏）。
 		const taskIds = [
@@ -170,6 +174,11 @@ export class OperationWatcher {
 					});
 				}
 			}
+		}
+		// 空闲门控挂起 drain：流式中延迟的终态在空闲后独立呈现
+		// （seq 游标已前进——靠 pending 集合重试，不是重放事件）。
+		for (const taskId of [...this.pendingTerminalTasks]) {
+			await this.presentTerminal(taskId);
 		}
 	}
 
@@ -218,10 +227,30 @@ export class OperationWatcher {
 			return;
 		}
 		if (event.event_type !== "verification.completed") return;
-		// P0-3（0827 审计）：Coordinator 是唯一终态发布者——终态回复由
-		// TaskOutcome 确定性生成、display 直接呈现；绝不 followUp 唤醒
-		// Agent（0827 实证：followUp 触发模型回合与确定性链互相矛盾
-		// =双控制者）。trackTask 只投影，不唤醒。
+		// 空闲门控（0827 真实 K3 复验实证）：Agent 还在流式回答时，
+		// pi 会把 triggerTurn:false 的 custom message steer 进正在运行
+		// 的回合——终态回复消失在流里且违反"终态后零模型回合"。
+		// 不空闲 → 挂起（pendingTerminalTasks），空闲后由 tick 呈现。
+		const sinkNow = this.deps.sink();
+		if (sinkNow && !sinkNow.isIdle) {
+			this.pendingTerminalTasks.add(taskId);
+			return;
+		}
+		await this.presentTerminal(taskId);
+	}
+
+	/** P0-3（0827 审计）：Coordinator 是唯一终态发布者——终态回复由
+	 *  TaskOutcome 确定性生成、display 直接呈现；绝不 followUp 唤醒
+	 *  Agent（0827 实证：followUp 触发模型回合与确定性链互相矛盾
+	 *  =双控制者）。trackTask 只投影，不唤醒。 */
+	private async presentTerminal(taskId: string): Promise<void> {
+		if (this.deliveredTasks.has(taskId)) return;
+		const sink = this.deps.sink();
+		if (sink && !sink.isIdle) {
+			this.pendingTerminalTasks.add(taskId);
+			return;
+		}
+		this.pendingTerminalTasks.delete(taskId);
 		this.deliveredTasks.add(taskId);
 		this.trackedTasks.delete(taskId);
 		this.completedNodesByTask.delete(taskId);

--- a/packages/rosclaw-agent/src/native/operation-watcher.ts
+++ b/packages/rosclaw-agent/src/native/operation-watcher.ts
@@ -226,11 +226,16 @@ export class OperationWatcher {
 			}
 			return;
 		}
-		if (event.event_type !== "verification.completed") return;
-		// 空闲门控（0827 真实 K3 复验实证）：Agent 还在流式回答时，
-		// pi 会把 triggerTurn:false 的 custom message steer 进正在运行
-		// 的回合——终态回复消失在流里且违反"终态后零模型回合"。
-		// 不空闲 → 挂起（pendingTerminalTasks），空闲后由 tick 呈现。
+		if (event.event_type !== "task.terminal") return;
+		// 0827 真实 K3 复验实证：verification.completed 会在中间态
+		// （REPAIR_REQUIRED/FAIL）触发——把它当终态呈现 = 把瞬态失败
+		// 钉成用户可见终态并毒化 deliveredTasks（链恢复 PASS 后回复
+		// 缺席，内核 SUCCEEDED 与屏幕 FAIL 矛盾——正是 0827 审计的
+		// 双真相）。终态发布只认 task.terminal（内核权威终态）。
+		// 空闲门控：Agent 还在流式回答时，pi 会把 triggerTurn:false 的
+		// custom message steer 进正在运行的回合——终态回复消失在流
+		// 里且违反"终态后零模型回合"。不空闲 → 挂起
+		// （pendingTerminalTasks），空闲后由 tick 呈现。
 		const sinkNow = this.deps.sink();
 		if (sinkNow && !sinkNow.isIdle) {
 			this.pendingTerminalTasks.add(taskId);

--- a/packages/rosclaw-agent/test/p01-single-owner.test.ts
+++ b/packages/rosclaw-agent/test/p01-single-owner.test.ts
@@ -100,7 +100,7 @@ test("watcher 终态：确定性呈现一次（display, 无 triggerTurn）+ 重�
 	const { OperationWatcher } = await import("../src/native/operation-watcher.js");
 	const events = [
 		{ seq: 1, event_type: "plan.node_completed", payload: { node_id: "make_path" } },
-		{ seq: 2, event_type: "verification.completed", payload: { status: "PASS" } },
+		{ seq: 2, event_type: "task.terminal", payload: { status: "PASS" } },
 	];
 	const sent: Array<{ content: string; display: boolean; options: Record<string, unknown> }> = [];
 	const watcher = new OperationWatcher({
@@ -159,7 +159,7 @@ test("watcher 修订重跑：同 task 新 revision 再执行 → 终态再次呈
 	// 的 verification.completed 被吞——修订重跑没有终态回复。
 	const { OperationWatcher } = await import("../src/native/operation-watcher.js");
 	const events = [
-		{ seq: 1, event_type: "verification.completed", payload: { status: "PASS" } },
+		{ seq: 1, event_type: "task.terminal", payload: { status: "PASS" } },
 	];
 	const sent: string[] = [];
 	const watcher = new OperationWatcher({
@@ -196,7 +196,7 @@ test("watcher 修订重跑：同 task 新 revision 再执行 → 终态再次呈
 	// 必须再次呈现。
 	watcher.trackTask("task_rev");
 	events.push({
-		seq: 2, event_type: "verification.completed", payload: { status: "PASS" },
+		seq: 2, event_type: "task.terminal", payload: { status: "PASS" },
 	});
 	await (watcher as never as { tick(): Promise<void> }).tick();
 	assert.equal(sent.length, 2, "修订重跑的终态被吞（deliveredTasks 未按执行周期清理）");

--- a/packages/rosclaw-agent/test/p03-idle-gate.test.ts
+++ b/packages/rosclaw-agent/test/p03-idle-gate.test.ts
@@ -1,0 +1,58 @@
+/** P0-3 补漏红测试（0827 真实 K3 复验实证）：终态呈现空闲门控。
+ *
+ * 实证：腿2（疑问句→真实模型回答）还在流式输出时，确定性链修订
+ * 重跑已终态——watcher 此刻 sendMessage(triggerTurn:false) 被 pi
+ * steer 进正在运行的回合：终态回复从屏幕消失（内核 SUCCEEDED 但
+ * 用户看不到），且违背"终态后零模型回合"。
+ *
+ * 闭环断言：Agent 流式中 → 不发布、不标 delivered、保持 tracked；
+ * 空闲后下个 tick 独立呈现（display:true triggerTurn:false）。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("终态呈现空闲门控：流式中延迟，空闲后呈现", async () => {
+	const { OperationWatcher } = await import("../src/native/operation-watcher.js");
+	const events = [
+		{ seq: 1, event_type: "verification.completed", payload: { status: "PASS" } },
+	];
+	const sent: string[] = [];
+	let idle = false;
+	const watcher = new OperationWatcher({
+		call: async (method: string, params: Record<string, unknown>) => {
+			if (method === "pi.kernel.events") {
+				const after = Number((params as { last_seq?: number }).last_seq ?? 0);
+				return { ok: true, events: events.filter((e) => e.seq > after) };
+			}
+			if (method === "pi.coordinator.consider") {
+				return {
+					ok: true,
+					outcome: {
+						lifecycle: "COMPLETED", verification: "PASS",
+						delivery: "DELIVERED", artifact_refs: [],
+					},
+				};
+			}
+			return { ok: true };
+		},
+		sink: () => ({
+			api: {
+				sendMessage: (message: { content: string }) => {
+					sent.push(message.content);
+				},
+			},
+			isIdle: idle,
+			setWidget: () => undefined,
+		}),
+	} as never);
+	watcher.trackTask("task_gate");
+	// 流式中：终态事件到达但不发布（不能被 steer 吞掉）。
+	await (watcher as never as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 0, "流式中竟发布终态（会被 steer 吞掉）");
+	// 空闲后：下个 tick 独立呈现。
+	idle = true;
+	await (watcher as never as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 1, "空闲后终态未呈现");
+	assert.match(sent[0], /任务完成/);
+});

--- a/packages/rosclaw-agent/test/p03-idle-gate.test.ts
+++ b/packages/rosclaw-agent/test/p03-idle-gate.test.ts
@@ -15,7 +15,7 @@ import test from "node:test";
 test("终态呈现空闲门控：流式中延迟，空闲后呈现", async () => {
 	const { OperationWatcher } = await import("../src/native/operation-watcher.js");
 	const events = [
-		{ seq: 1, event_type: "verification.completed", payload: { status: "PASS" } },
+		{ seq: 1, event_type: "task.terminal", payload: { status: "PASS" } },
 	];
 	const sent: string[] = [];
 	let idle = false;
@@ -55,4 +55,48 @@ test("终态呈现空闲门控：流式中延迟，空闲后呈现", async () =>
 	await (watcher as never as { tick(): Promise<void> }).tick();
 	assert.equal(sent.length, 1, "空闲后终态未呈现");
 	assert.match(sent[0], /任务完成/);
+});
+
+test("中间态 verification.completed(FAIL) 不呈现；task.terminal 才发布", async () => {
+	// 0827 真实 K3 复验实证：修订重跑中 verify_artifacts 抓到瞬态
+	// 空文件（同 trace 目录原位重写）→ REPAIR_REQUIRED 的
+	// verification.completed 被当成终态呈现——屏幕 FAIL 与内核
+	// SUCCEEDED 矛盾（双真相回归）。只有 task.terminal 是发布点。
+	const { OperationWatcher } = await import("../src/native/operation-watcher.js");
+	const events = [
+		{ seq: 1, event_type: "verification.completed", payload: { status: "FAIL" } },
+		{ seq: 2, event_type: "task.terminal", payload: { state: "SUCCEEDED" } },
+	];
+	const sent: string[] = [];
+	const watcher = new OperationWatcher({
+		call: async (method: string, params: Record<string, unknown>) => {
+			if (method === "pi.kernel.events") {
+				const after = Number((params as { last_seq?: number }).last_seq ?? 0);
+				return { ok: true, events: events.filter((e) => e.seq > after) };
+			}
+			if (method === "pi.coordinator.consider") {
+				return {
+					ok: true,
+					outcome: {
+						lifecycle: "COMPLETED", verification: "PASS",
+						delivery: "DELIVERED", artifact_refs: [],
+					},
+				};
+			}
+			return { ok: true };
+		},
+		sink: () => ({
+			api: {
+				sendMessage: (message: { content: string }) => {
+					sent.push(message.content);
+				},
+			},
+			isIdle: true,
+			setWidget: () => undefined,
+		}),
+	} as never);
+	watcher.trackTask("task_midstate");
+	await (watcher as never as { tick(): Promise<void> }).tick();
+	assert.equal(sent.length, 1, `应只在 task.terminal 呈现一次（实际 ${sent.length}）`);
+	assert.match(sent[0], /任务完成/, `中间态 FAIL 竟被呈现：${sent[0]}`);
 });

--- a/packages/rosclaw-agent/test/r015-track-task.test.ts
+++ b/packages/rosclaw-agent/test/r015-track-task.test.ts
@@ -20,7 +20,7 @@ test("trackTask：进度 widget + 终态一次 followUp + untrack", async () => 
 		{ seq: 2, event_type: "plan.node_completed", payload: { node_id: "resolve_robot" } },
 		{ seq: 3, event_type: "plan.node_started", payload: { node_id: "make_path" } },
 		{ seq: 4, event_type: "plan.node_completed", payload: { node_id: "make_path" } },
-		{ seq: 5, event_type: "verification.completed", payload: { status: "PASS", verification_id: "vrf_1" } },
+		{ seq: 5, event_type: "task.terminal", payload: { status: "PASS", verification_id: "vrf_1" } },
 	];
 	const widgets: Array<[string, string[] | undefined]> = [];
 	const followUps: string[] = [];

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -461,6 +461,12 @@ def _chat_pi(home: Path, args: argparse.Namespace) -> int:
         return 2
     node, entry = runtime
     config = load_agent_config(home / "config.yaml")
+    # P0-7（0827 审计·真实 K3 复验实证）：retry 预算只在 setup 写
+    # 不够——手工/legacy 配置的家目录绕过 setup（pi 默认 3 次重试
+    # 把确定性 403 烧 4 次）。chat 启动幂等补齐（保留其他键）。
+    from rosclaw.agentd.onboarding import _write_retry_budget
+
+    _write_retry_budget(home)
     # 十审 W0：诊断路由必须先于 AgentService 构造（启动 warning 就在那里）。
     _route_internal_diagnostics_to_log(home, debug=bool(getattr(args, "debug", False)))
     service = AgentService(config, home)

--- a/src/rosclaw/agentd/sim_trajectory.py
+++ b/src/rosclaw/agentd/sim_trajectory.py
@@ -890,13 +890,20 @@ class SimTrajectoryService:
             draw.ellipse((ex - 5, ey - 5, ex + 5, ey + 5), outline=(200, 30, 30), width=2)
             images.append(img)
         out = out_dir / f"{trace_id}.gif"
+        # 原子写（0827 真实 K3 复验实证）：同内容修订重跑同 trace_id
+        # 目录——原位写 GIF 的截断窗口被 verify_artifacts 抓成
+        # "artifact 为空"瞬态 FAIL。先写临时文件再 os.replace。
+        import os as _os
+
+        tmp_out = out_dir / f".{trace_id}.gif.tmp"
         images[0].save(
-            out,
+            tmp_out,
             save_all=True,
             append_images=images[1:],
             duration=int(1000 / max(fps, 1)),
             loop=0,
         )
+        _os.replace(tmp_out, out)
         # P0-F 闭包（金丝雀实证）：2D 预览与场景渲染同样产出
         # MP4——两条渲染路径都覆盖完整视频格式集（用户要 MP4 时
         # 选哪条都有交付物，同一 TraceRef）。
@@ -904,7 +911,9 @@ class SimTrajectoryService:
         import numpy as _np
 
         mp4 = out_dir / f"{trace_id}.mp4"
-        iio.imwrite(mp4, [_np.asarray(img) for img in images], fps=max(fps, 1))
+        tmp_mp4 = out_dir / f".{trace_id}.mp4.tmp"
+        iio.imwrite(tmp_mp4, [_np.asarray(img) for img in images], fps=max(fps, 1))
+        _os.replace(tmp_mp4, mp4)
         return {
             "ok": True,
             "artifact": {

--- a/src/rosclaw/agentd/sim_trajectory.py
+++ b/src/rosclaw/agentd/sim_trajectory.py
@@ -895,9 +895,10 @@ class SimTrajectoryService:
         # "artifact 为空"瞬态 FAIL。先写临时文件再 os.replace。
         import os as _os
 
-        tmp_out = out_dir / f".{trace_id}.gif.tmp"
+        tmp_out = out_dir / f".{trace_id}.gif.tmp.gif"
         images[0].save(
             tmp_out,
+            format="GIF",
             save_all=True,
             append_images=images[1:],
             duration=int(1000 / max(fps, 1)),
@@ -911,7 +912,7 @@ class SimTrajectoryService:
         import numpy as _np
 
         mp4 = out_dir / f"{trace_id}.mp4"
-        tmp_mp4 = out_dir / f".{trace_id}.mp4.tmp"
+        tmp_mp4 = out_dir / f".{trace_id}.mp4.tmp.mp4"
         iio.imwrite(tmp_mp4, [_np.asarray(img) for img in images], fps=max(fps, 1))
         _os.replace(tmp_mp4, mp4)
         return {


### PR DESCRIPTION
真实 K3 复验（画→疑问句→修订追问链）抓到 #477 残留的三处双真相/呈现缺陷：

1. **空闲门控**：Agent 流式回答时 watcher 的 triggerTurn:false custom message 被 pi steer 进运行中回合——终态回复消失在流里。不空闲则挂起 pendingTerminalTasks，空闲后独立呈现。
2. **终态只认 task.terminal**：verification.completed 在中间态（REPAIR_REQUIRED/FAIL）也触发——瞬态失败被钉成用户可见终态并毒化 deliveredTasks（链恢复 PASS 后回复缺席；屏幕 FAIL vs 内核 SUCCEEDED=0827 双真相回归）。
3. **render 原子写**：同内容修订重跑同 trace_id 目录，原位写 GIF/MP4 的截断窗口被 verify_artifacts 抓成 artifact 为空瞬态 FAIL——改 tmp+os.replace（临时名保留真实扩展名，ffmpeg/PIL 按扩展名选格式实证）。

另：chat 启动幂等补齐 retry.maxRetries=1（手工/legacy 家目录绕过 setup 的缺口——复验实证 pi 默认 3 次重试烧确定性 403）。

复验（真实 K3 + 真实 403 配额耗尽）：腿1 画→1 task/0 模型调用/1 终态回复；腿2 疑问句→配额分类卡恰 1 张、未执行；腿3 修订→rev 2 SUCCEEDED 且终态回复呈现。旅程 A/B/C+h2 4/4；金丝雀 3/3。