### PR TITLE
fix: 0827 对抗复核三补漏——断链不沉默 + 启动恢复中断链 + agentd 导出 ROSCLAW_HOME

### DIFF
--- a/src/rosclaw/agentd/auto_route.py
+++ b/src/rosclaw/agentd/auto_route.py
@@ -110,11 +110,24 @@ async def maybe_auto_route(
 
     async def _run() -> None:
         try:
-            await asyncio.to_thread(
+            outcome = await asyncio.to_thread(
                 service._task_execution.execute,
                 task_id,
                 recipe_inputs=inputs,
             )
+            # 0827 复核实证：断链不能沉默——execute 失败（node_failed/
+            # 验收失败）时任务停在 RUNNING、无 task.terminal，用户
+            # 永远等不到回复。无模型可修复的路径（suppress 了模型
+            # 回合）必须诚实终态：FAILED + task.terminal——watcher
+            # 由此呈现失败回复（用户可追问开新 revision）。
+            if not outcome.ok:
+                kernel.transition(
+                    task_id, "FAILED",
+                    reason=(
+                        f"{outcome.error_code or 'EXECUTION_FAILED'}: "
+                        f"{(outcome.failure or ';'.join(outcome.failures))[:200]}"
+                    ),
+                )
         except Exception as exc:  # noqa: BLE001 - 执行失败是任务数据
             # 不沉默——失败写诊断日志（金丝雀实证：静默吞错导致
             # "任务 RUNNING 无事件"无迹可查）。
@@ -125,6 +138,16 @@ async def maybe_auto_route(
                 "auto-route execution failed for %s: %s\n%s",
                 task_id, exc, traceback.format_exc()[-2000:],
             )
+            # 同上：异常断链也到 FAILED 终态（不沉默）。
+            try:
+                kernel.transition(
+                    task_id, "FAILED",
+                    reason=f"EXECUTION_EXCEPTION: {exc}"[:220],
+                )
+            except Exception:  # noqa: BLE001 - 终态迁移失败只记日志
+                logging.getLogger("rosclaw.auto_route").exception(
+                    "FAILED transition failed for %s", task_id,
+                )
 
     asyncio.get_event_loop().create_task(_run())
     return {

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -378,9 +378,39 @@ def _ensure_home_env(home: Path) -> None:
     os.environ.setdefault("ROSCLAW_HOME", str(home))
 
 
+def _ensure_home_env(home: Path) -> str | None:
+    """agentd 进程导出 ROSCLAW_HOME（0827 复核实证）：此前只传给
+    子进程——agentd 自身没有时，ur5e_mcp 的 PlanStore 回落内存
+    （PlanRef 生产/消费分裂）或 conformance 把工具对误杀出模型面。
+
+    返回之前的值（None = 此前未设置）——调用方在退出时恢复
+    （cmd_chat 是库函数也是进程入口：进程 env 不得永久改写，否则
+    同进程后续调用方/测试的 get_rosclaw_home 被劫持——p1a1 测试
+    实证：泄漏的 ROSCLAW_HOME 让 35 个 body 测试 split-brain）。"""
+    previous = os.environ.get("ROSCLAW_HOME")
+    if previous is None:
+        os.environ["ROSCLAW_HOME"] = str(home)
+    return previous
+
+
+def _restore_home_env(previous: str | None) -> None:
+    """_ensure_home_env 的配对恢复（进程 env 不永久改写）。"""
+    if previous is None:
+        os.environ.pop("ROSCLAW_HOME", None)
+    else:
+        os.environ["ROSCLAW_HOME"] = previous
+
+
 def cmd_chat(args: argparse.Namespace) -> int:
     home = _home(args)
-    _ensure_home_env(home)
+    previous_home_env = _ensure_home_env(home)
+    try:
+        return _cmd_chat_impl(args, home)
+    finally:
+        _restore_home_env(previous_home_env)
+
+
+def _cmd_chat_impl(args: argparse.Namespace, home: Path) -> int:
     # PR-H9：legacy 引擎（Python AgentLoop console）已删除——Native
     # Agent（Harness Backend 主会话）是唯一引擎（ADR-0012）。
     if getattr(args, "legacy", False) or (getattr(args, "engine", None) not in (None, "pi")):

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -370,8 +370,17 @@ def cmd_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def _ensure_home_env(home: Path) -> None:
+    """agentd 进程导出 ROSCLAW_HOME（0827 复核实证）：此前只传给
+    子进程——agentd 自身没有时，ur5e_mcp 的 PlanStore 回落内存
+    （PlanRef 生产/消费分裂）或 conformance 把工具对误杀出模型面。
+    setdefault：显式 export 的值优先。"""
+    os.environ.setdefault("ROSCLAW_HOME", str(home))
+
+
 def cmd_chat(args: argparse.Namespace) -> int:
     home = _home(args)
+    _ensure_home_env(home)
     # PR-H9：legacy 引擎（Python AgentLoop console）已删除——Native
     # Agent（Harness Backend 主会话）是唯一引擎（ADR-0012）。
     if getattr(args, "legacy", False) or (getattr(args, "engine", None) not in (None, "pi")):

--- a/src/rosclaw/agentd/service.py
+++ b/src/rosclaw/agentd/service.py
@@ -1446,7 +1446,61 @@ class AgentService:
         self._pi_bridge = PiBridgeServer(self, path)
         await self._pi_bridge.start()
         await self._ensure_operation_maintenance()
+        await self.resume_interrupted_executions()
         return path
+
+    async def resume_interrupted_executions(self) -> list[str]:
+        """0827 复核实证（§十 故障注入 Gate）：rollout 与 render 之间
+        agentd 重启——auto_route 的后台协程死掉，确定性链任务停在
+        RUNNING 无人重新驱动。启动时扫描"RUNNING + 有 plan.node 事件
+        + 最新事件不是 task.terminal"的任务重新执行（同一 task、同一
+        revision——重跑即恢复，幂等每进程一次）。
+
+        失败处理与 auto_route 同一纪律：重驱动失败 → FAILED 终态
+        （不沉默）。返回被重新驱动的 task_id 列表。"""
+        if getattr(self, "_resume_interrupted_done", False):
+            return []
+        self._resume_interrupted_done = True
+        rows = self._store.connection.execute(
+            "SELECT t.task_id, "
+            "  (SELECT e2.event_type FROM task_events e2 "
+            "   WHERE e2.task_id = t.task_id ORDER BY e2.seq DESC LIMIT 1"
+            "  ) AS last_event "
+            "FROM tasks t "
+            "WHERE t.state = 'RUNNING' AND EXISTS ("
+            "  SELECT 1 FROM task_events e WHERE e.task_id = t.task_id "
+            "  AND e.event_type LIKE 'plan.node_%'"
+            ")"
+        ).fetchall()
+        resumed: list[str] = []
+        for row in rows:
+            if str(row["last_event"] or "") == "task.terminal":
+                continue  # 旧 revision 的终态事件——不是中断现场
+            task_id = str(row["task_id"])
+            resumed.append(task_id)
+
+            async def _redrive(tid: str = task_id) -> None:
+                outcome = await asyncio.to_thread(
+                    self._task_execution.execute, tid,
+                )
+                if not outcome.ok:
+                    import logging
+
+                    try:
+                        self._task_kernel.transition(
+                            tid, "FAILED",
+                            reason=(
+                                f"{outcome.error_code or 'EXECUTION_FAILED'}: "
+                                f"{(outcome.failure or '')[:200]}"
+                            ),
+                        )
+                    except Exception:  # noqa: BLE001 - 迁移失败只记日志
+                        logging.getLogger("rosclaw.resume").exception(
+                            "FAILED transition failed for %s", tid,
+                        )
+
+            asyncio.get_event_loop().create_task(_redrive())
+        return resumed
 
     async def _ensure_operation_maintenance(self) -> None:
         """P1-B1（0824 总纲 §12）：operation 维护循环——启动时

--- a/tests/agentd/test_p09_audit_recheck.py
+++ b/tests/agentd/test_p09_audit_recheck.py
@@ -1,0 +1,165 @@
+"""0827 复核（对抗自审）红测试：断链不沉默 + 重启恢复 + HOME 导出。
+
+复核发现的三处真实缺陷（文档 §十 故障注入 Gate 的未实证项）：
+1. 断链沉默：确定性链失败（渲染坏掉）→ execute() ok=False，任务
+   停在 RUNNING 无 task.terminal——watcher 无呈现点，用户永远
+   等不到回复（进度 widget 永久空转）。
+2. 重启不恢复：rollout 与 render 之间 agentd 重启 → auto_route
+   后台协程死掉，任务停在 RUNNING 无人重新驱动（Gate 明确要求
+   "恢复同一 task/revision"）。
+3. ROSCLAW_HOME 未在 agentd 进程导出 → PlanRef 生产/消费分裂
+   （或 conformance 误杀工具对）——cli chat 必须 setdefault 导出。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+
+async def _persist(bridge, service, mission_id: str, message_id: str, text: str):
+    return await bridge._dispatch(
+        "user:local:1000", 1, "pi.input.persist",
+        {
+            "token": service.control_token,
+            "mission_id": mission_id,
+            "session_ref": "pi_1",
+            "message_id": message_id,
+            "text": text,
+        },
+    )
+
+
+class TestBrokenChainNotSilent:
+    async def test_failed_chain_transitions_terminal(
+        self, tmp_path: Path
+    ) -> None:
+        """渲染链打坏 → 自动路由执行失败 → 任务必须到 FAILED 终态
+        （task.terminal 事件存在——watcher 才能呈现诚实失败）。"""
+        from rosclaw.agentd import sim_render
+        from rosclaw.agentd.auto_route import reset_routed_for_tests
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        reset_routed_for_tests()
+        service, mission = await _setup(tmp_path)
+        # 打坏场景渲染（spec 要求 scene_video → render_scene 节点失败）。
+        original = sim_render.render_scene_trace
+
+        def broken(*a, **k):
+            raise ValueError("RENDER_BACKEND_UNAVAILABLE: 注入故障")
+
+        sim_render.render_scene_trace = broken  # type: ignore[assignment]
+        try:
+            bridge = PiBridgeServer(
+                service, tmp_path / "run" / "pi-bridge.sock"
+            )
+            result = await _persist(
+                bridge, service, mission.mission_id, "msg_broken",
+                "画一个五角星，给我仿真视频",
+            )
+            assert result.get("auto_task"), result
+            task_id = str(result["auto_task"]["task_id"])
+            kernel = service._task_kernel
+            deadline = asyncio.get_event_loop().time() + 180
+            while asyncio.get_event_loop().time() < deadline:
+                task = kernel.get_task(task_id)
+                if task and task["state"] in ("SUCCEEDED", "FAILED", "REPAIR_REQUIRED"):
+                    break
+                await asyncio.sleep(2)
+            task = kernel.get_task(task_id)
+            assert task["state"] == "FAILED", (
+                f"断链必须到 FAILED 终态（不能 RUNNING 沉默空转）：{task['state']}"
+            )
+            terminal = kernel._conn.execute(
+                "SELECT COUNT(*) AS n FROM task_events WHERE task_id = ? "
+                "AND event_type = 'task.terminal'",
+                (task_id,),
+            ).fetchone()
+            assert int(terminal["n"]) == 1, "缺 task.terminal 事件"
+        finally:
+            sim_render.render_scene_trace = original  # type: ignore[assignment]
+            await service.close()
+
+
+class TestResumeInterruptedExecution:
+    async def test_startup_redrives_interrupted_chain(
+        self, tmp_path: Path
+    ) -> None:
+        """模拟崩溃现场（RUNNING + plan.node 事件 + 无 task.terminal）
+        → 服务启动恢复钩子重新驱动 → 同一 task/revision 到终态。"""
+        from rosclaw.agentd.auto_route import reset_routed_for_tests
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        reset_routed_for_tests()
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await _persist(
+            bridge, service, mission.mission_id, "msg_resume",
+            "画一个五角星",
+        )
+        assert result.get("auto_task"), result
+        task_id = str(result["auto_task"]["task_id"])
+        kernel = service._task_kernel
+        # 等首轮执行完（SUCCEEDED），然后**伪造崩溃现场**：把任务
+        # 状态拨回 RUNNING（等价于 rollout/render 之间进程被杀）。
+        deadline = asyncio.get_event_loop().time() + 180
+        while asyncio.get_event_loop().time() < deadline:
+            task = kernel.get_task(task_id)
+            if task and task["state"] == "SUCCEEDED":
+                break
+            await asyncio.sleep(2)
+        assert kernel.get_task(task_id)["state"] == "SUCCEEDED"
+        revision_before = int(kernel.get_task(task_id)["active_revision"])
+        kernel._conn.execute(
+            "UPDATE tasks SET state = 'RUNNING' WHERE task_id = ?",
+            (task_id,),
+        )
+        kernel._conn.commit()
+        # 中途崩溃的真实事件形态：最后一条事件是 plan.node_*（不是
+        # task.terminal——旧终态事件不算中断现场）。
+        kernel._emit(task_id, "plan.node_started",
+                     {"node_id": "render", "op": "simulation.render"})
+        kernel._conn.commit()
+        # 调用启动恢复钩子——必须把中断的链重新驱动到终态（同一
+        # task、同一 revision）。
+        resumed = await service.resume_interrupted_executions()
+        assert task_id in resumed, f"中断任务未被恢复驱动：{resumed}"
+        deadline = asyncio.get_event_loop().time() + 180
+        while asyncio.get_event_loop().time() < deadline:
+            task = kernel.get_task(task_id)
+            if task and task["state"] in ("SUCCEEDED", "FAILED"):
+                break
+            await asyncio.sleep(2)
+        task = kernel.get_task(task_id)
+        assert task["state"] == "SUCCEEDED", task["state"]
+        assert int(task["active_revision"]) == revision_before, (
+            f"恢复不得新建 revision：{task['active_revision']} ≠ {revision_before}"
+        )
+        await service.close()
+
+
+class TestHomeEnvExported:
+    def test_chat_bootstrap_exports_rosclaw_home(self, tmp_path: Path) -> None:
+        """agentd 进程必须导出 ROSCLAW_HOME（否则 PlanRef 生产/消费
+        分裂或 conformance 误杀工具对——用户不会手工 export）。"""
+        import os
+
+        from rosclaw.agentd.cli import _ensure_home_env
+
+        old = os.environ.pop("ROSCLAW_HOME", None)
+        try:
+            _ensure_home_env(tmp_path)
+            assert os.environ.get("ROSCLAW_HOME") == str(tmp_path)
+        finally:
+            if old is not None:
+                os.environ["ROSCLAW_HOME"] = old
+            else:
+                os.environ.pop("ROSCLAW_HOME", None)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
文档 §十 故障注入 Gate 的未实证项，对抗自审实证后修复：

1. **断链沉默**：确定性链失败 → execute() ok=False、任务停 RUNNING、无 task.terminal——用户永远等不到回复。auto_route/启动恢复统一：执行失败 → FAILED 终态（watcher 呈现诚实失败，用户可追问开新 revision）。
2. **重启不恢复**：rollout 与 render 之间重启 → 后台协程死掉无人重新驱动。start_pi_bridge 扫描"RUNNING + plan.node 事件 + 最新事件非 task.terminal"的中断任务重新执行（同一 task/revision）。
3. **ROSCLAW_HOME 未在 agentd 导出**（只给子进程）→ ur5e_mcp PlanStore 回落内存（PlanRef 分裂）或 conformance 误杀工具对。cli chat setdefault 导出。

红→绿：test_p09_audit_recheck.py 3 红→绿；agentd 全套 796 过 0 败；旅程 A/B/C+h2 4/4。