### PR TITLE
feat(continual): add generic bounded growth contracts

### DIFF
--- a/src/rosclaw/continual/__init__.py
+++ b/src/rosclaw/continual/__init__.py
@@ -1,5 +1,12 @@
 """Versioned continual-learning substrate for ROSClaw simulation."""
 
+from rosclaw.continual.champion_registry import (
+    CanonicalChampionRegistry,
+    ChampionClaimAudit,
+    ChampionRecordKind,
+    ChampionRegistryRecord,
+    PromotionAuthority,
+)
 from rosclaw.continual.contracts import (
     ControlSegment,
     CostVector,
@@ -17,6 +24,53 @@ from rosclaw.continual.experience import (
     ExperienceRecord,
     ReplayMix,
 )
+from rosclaw.continual.failure_curriculum import (
+    CapabilityBin,
+    CapabilityFrontierScheduler,
+    CurriculumMixture,
+    CurriculumSource,
+    DreamPerturbation,
+    FailureConditionedDream,
+    PerturbationDistribution,
+)
+from rosclaw.continual.individual_scope import (
+    FrozenPartner,
+    FrozenPartnerSet,
+    IndividualGrowthScope,
+    IndividualPromotionEvidence,
+)
+from rosclaw.continual.learner_backend import (
+    LearnerBackendContract,
+    LearnerCapability,
+    LearnerRunEvidence,
+    LearnerRunStatus,
+)
+from rosclaw.continual.plasticity_lease import (
+    AgentPolicyBinding,
+    AgentUpdateMode,
+    PlasticityLease,
+    PlasticityLeaseAudit,
+    audit_plasticity_lease,
+)
+from rosclaw.continual.reproducibility import (
+    THREAD_ENVIRONMENT_KEYS,
+    NumericalEnvironmentCheck,
+    NumericalRuntimeContract,
+)
+from rosclaw.continual.residual_adaptation import (
+    ParameterIsolationEvidence,
+    ResidualAdaptationContract,
+    load_residual_adaptation_contract,
+    write_residual_adaptation_contract,
+)
+from rosclaw.continual.safety_profiles import (
+    GrowthSafetyDecision,
+    GrowthSafetyObservation,
+    GrowthSafetyProfile,
+    GrowthSafetyUse,
+    evaluate_growth_safety,
+    validate_profile_pair,
+)
 from rosclaw.continual.serde import experience_batch_from_dict, experience_batch_to_dict
 from rosclaw.continual.stability import (
     ContinualCandidateEvidence,
@@ -27,18 +81,69 @@ from rosclaw.continual.stability import (
     StabilityPlasticityGate,
     TaskRetention,
 )
+from rosclaw.continual.successor_state import (
+    SkillSuccessorState,
+    SuccessorMetricSpec,
+    SuccessorStateEvaluation,
+    SuccessorStateGrowthObjective,
+    SuccessorStateSample,
+    SuccessorStateTracker,
+)
+from rosclaw.continual.teacher_manifold import (
+    TeacherManifoldDecision,
+    TeacherManifoldGateContract,
+    TeacherManifoldMetric,
+)
+from rosclaw.continual.teacher_prior import (
+    ConditionalTeacherPriorContract,
+    ConditionalTeacherQuery,
+)
 from rosclaw.continual.weight_update import ResidualWeightSlot, WeightSlotReceipt, WeightSlotState
 
 __all__ = [
+    "AgentPolicyBinding",
+    "AgentUpdateMode",
+    "CanonicalChampionRegistry",
+    "CapabilityBin",
+    "CapabilityFrontierScheduler",
+    "ChampionClaimAudit",
+    "ChampionRecordKind",
+    "ChampionRegistryRecord",
     "ControlSegment",
     "CostVector",
+    "CurriculumMixture",
+    "CurriculumSource",
+    "DreamPerturbation",
     "ExperiencePartition",
     "ExperienceUse",
+    "FailureConditionedDream",
+    "FrozenPartner",
+    "FrozenPartnerSet",
+    "IndividualGrowthScope",
+    "IndividualPromotionEvidence",
+    "LearnerBackendContract",
+    "LearnerCapability",
+    "LearnerRunEvidence",
+    "LearnerRunStatus",
+    "GrowthSafetyDecision",
+    "GrowthSafetyObservation",
+    "GrowthSafetyProfile",
+    "GrowthSafetyUse",
+    "NumericalEnvironmentCheck",
+    "NumericalRuntimeContract",
+    "ParameterIsolationEvidence",
     "PolicyVersion",
+    "PerturbationDistribution",
+    "PromotionAuthority",
     "RewardVector",
     "SkillPhase",
     "VersionedTrajectory",
     "ContinualCandidateEvidence",
+    "ConditionalTeacherPriorContract",
+    "ConditionalTeacherQuery",
+    "TeacherManifoldDecision",
+    "TeacherManifoldGateContract",
+    "TeacherManifoldMetric",
     "ContinualDecision",
     "ContinualExperienceStore",
     "ContinualGateReport",
@@ -46,13 +151,28 @@ __all__ = [
     "ExperienceBufferConfig",
     "ExperienceRecord",
     "PlasticityEvidence",
+    "PlasticityLease",
+    "PlasticityLeaseAudit",
     "ReplayMix",
+    "ResidualAdaptationContract",
+    "load_residual_adaptation_contract",
+    "write_residual_adaptation_contract",
     "ResidualWeightSlot",
     "SelfCoreEvidence",
+    "SkillSuccessorState",
     "StabilityPlasticityGate",
     "TaskRetention",
+    "THREAD_ENVIRONMENT_KEYS",
     "WeightSlotReceipt",
     "WeightSlotState",
+    "SuccessorMetricSpec",
+    "SuccessorStateEvaluation",
+    "SuccessorStateGrowthObjective",
+    "SuccessorStateSample",
+    "SuccessorStateTracker",
+    "audit_plasticity_lease",
+    "evaluate_growth_safety",
     "experience_batch_from_dict",
     "experience_batch_to_dict",
+    "validate_profile_pair",
 ]

--- a/src/rosclaw/continual/__init__.py
+++ b/src/rosclaw/continual/__init__.py
@@ -5,6 +5,9 @@ from rosclaw.continual.champion_registry import (
     ChampionClaimAudit,
     ChampionRecordKind,
     ChampionRegistryRecord,
+    DominanceMetricRole,
+    PairedDominanceEvidence,
+    PairedDominanceMetric,
     PromotionAuthority,
 )
 from rosclaw.continual.contracts import (
@@ -109,6 +112,7 @@ __all__ = [
     "ChampionClaimAudit",
     "ChampionRecordKind",
     "ChampionRegistryRecord",
+    "DominanceMetricRole",
     "ControlSegment",
     "CostVector",
     "CurriculumMixture",
@@ -152,6 +156,8 @@ __all__ = [
     "ExperienceRecord",
     "PlasticityEvidence",
     "PlasticityLease",
+    "PairedDominanceEvidence",
+    "PairedDominanceMetric",
     "PlasticityLeaseAudit",
     "ReplayMix",
     "ResidualAdaptationContract",

--- a/src/rosclaw/continual/champion_registry.py
+++ b/src/rosclaw/continual/champion_registry.py
@@ -1,0 +1,282 @@
+"""Canonical, replayable champion lineage for continual learners.
+
+Promotion evidence is not sufficient on its own: a valid paired exam can still
+compare against a stale or previously rejected parent.  This registry makes the
+active track head part of the promotion authority and fails closed when lineage
+does not match it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+
+
+def _require_hash(label: str, value: str | None) -> None:
+    if value is None or not _SHA256.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+def _require_identifier(label: str, value: str) -> None:
+    if not _IDENTIFIER.fullmatch(value):
+        raise ValueError(f"{label} is not a valid stable identifier")
+
+
+class PromotionAuthority(StrEnum):
+    """Evidence authority allowed to create each type of lineage record."""
+
+    BASELINE_STRICT_EXAM = "baseline_strict_exam"
+    PAIRED_DOMINANCE = "paired_dominance"
+    SEALED_SPECIALIST_EXAM = "sealed_specialist_exam"
+
+
+class ChampionRecordKind(StrEnum):
+    """How a record affects its track's active champion."""
+
+    GLOBAL_BASELINE = "global_baseline"
+    TRACK_REPLACEMENT = "track_replacement"
+    SPECIALIST_BASELINE = "specialist_baseline"
+    CANDIDATE_ARCHIVED = "candidate_archived"
+
+
+@dataclass(frozen=True)
+class ChampionRegistryRecord:
+    """One immutable result in a champion track.
+
+    ``parent_record_hash`` binds the decision to the exact registry head while
+    ``parent_artifact_hash`` binds the external paired evaluation.  A specialist
+    baseline may retain ``source_parent_artifact_hash`` as training provenance,
+    but that ancestry does not give it authority to replace another track.
+    """
+
+    agent_id: str
+    track_id: str
+    artifact_hash: str
+    evidence_hash: str
+    scenario_suite_hash: str
+    authority: PromotionAuthority
+    kind: ChampionRecordKind
+    evidence_valid: bool
+    promotion_passed: bool
+    generation: int
+    parent_record_hash: str | None = None
+    parent_artifact_hash: str | None = None
+    source_parent_artifact_hash: str | None = None
+    sim_only: bool = True
+    schema_version: str = "rosclaw.continual.champion_registry_record.v1"
+
+    def __post_init__(self) -> None:
+        _require_identifier("agent_id", self.agent_id)
+        _require_identifier("track_id", self.track_id)
+        for label, value in (
+            ("artifact_hash", self.artifact_hash),
+            ("evidence_hash", self.evidence_hash),
+            ("scenario_suite_hash", self.scenario_suite_hash),
+        ):
+            _require_hash(label, value)
+        if self.generation < 0:
+            raise ValueError("generation must be non-negative")
+        optional_hashes: tuple[tuple[str, str | None], ...] = (
+            ("parent_record_hash", self.parent_record_hash),
+            ("parent_artifact_hash", self.parent_artifact_hash),
+            ("source_parent_artifact_hash", self.source_parent_artifact_hash),
+        )
+        for optional_label, optional_value in optional_hashes:
+            if optional_value is not None:
+                _require_hash(optional_label, optional_value)
+        if not self.sim_only:
+            raise ValueError(
+                "continual champion records are SIM_ONLY until a separate real-body gate"
+            )
+        if self.kind is ChampionRecordKind.GLOBAL_BASELINE:
+            self._require_baseline(PromotionAuthority.BASELINE_STRICT_EXAM)
+        elif self.kind is ChampionRecordKind.SPECIALIST_BASELINE:
+            self._require_baseline(PromotionAuthority.SEALED_SPECIALIST_EXAM)
+        elif self.kind is ChampionRecordKind.TRACK_REPLACEMENT:
+            self._require_child(promoted=True)
+        else:
+            self._require_child(promoted=False)
+
+    def _require_baseline(self, authority: PromotionAuthority) -> None:
+        if self.authority is not authority:
+            raise ValueError("baseline record uses the wrong promotion authority")
+        if self.parent_record_hash is not None or self.parent_artifact_hash is not None:
+            raise ValueError("baseline record cannot claim a registry parent")
+        if self.generation != 0:
+            raise ValueError("baseline record generation must be zero")
+        if not self.evidence_valid or not self.promotion_passed:
+            raise ValueError("baseline record requires valid, passing evidence")
+
+    def _require_child(self, *, promoted: bool) -> None:
+        if self.authority is not PromotionAuthority.PAIRED_DOMINANCE:
+            raise ValueError("child record requires paired-dominance authority")
+        _require_hash("parent_record_hash", self.parent_record_hash)
+        _require_hash("parent_artifact_hash", self.parent_artifact_hash)
+        if self.generation <= 0:
+            raise ValueError("child record generation must be positive")
+        if promoted and (not self.evidence_valid or not self.promotion_passed):
+            raise ValueError("replacement requires valid, passing evidence")
+        if not promoted and self.promotion_passed:
+            raise ValueError("archived candidate cannot carry a passing promotion decision")
+
+    @property
+    def record_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "agent_id": self.agent_id,
+            "track_id": self.track_id,
+            "artifact_hash": self.artifact_hash,
+            "evidence_hash": self.evidence_hash,
+            "scenario_suite_hash": self.scenario_suite_hash,
+            "authority": self.authority.value,
+            "kind": self.kind.value,
+            "evidence_valid": self.evidence_valid,
+            "promotion_passed": self.promotion_passed,
+            "generation": self.generation,
+            "parent_record_hash": self.parent_record_hash,
+            "parent_artifact_hash": self.parent_artifact_hash,
+            "source_parent_artifact_hash": self.source_parent_artifact_hash,
+            "sim_only": self.sim_only,
+        }
+
+
+@dataclass(frozen=True)
+class ChampionClaimAudit:
+    """Fail-closed comparison of a claimed parent and the active track head."""
+
+    track_id: str
+    claimed_parent_artifact_hash: str
+    active_record_hash: str | None
+    active_artifact_hash: str | None
+    valid: bool
+    reasons: tuple[str, ...]
+    schema_version: str = "rosclaw.continual.champion_claim_audit.v1"
+
+    @property
+    def audit_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "track_id": self.track_id,
+            "claimed_parent_artifact_hash": self.claimed_parent_artifact_hash,
+            "active_record_hash": self.active_record_hash,
+            "active_artifact_hash": self.active_artifact_hash,
+            "valid": self.valid,
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalChampionRegistry:
+    """Append-only lineage whose active heads are reproduced from its records."""
+
+    records: tuple[ChampionRegistryRecord, ...] = ()
+    schema_version: str = "rosclaw.continual.canonical_champion_registry.v1"
+
+    def __post_init__(self) -> None:
+        self._replay()
+
+    @property
+    def registry_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def append(self, record: ChampionRegistryRecord) -> CanonicalChampionRegistry:
+        if any(existing.record_hash == record.record_hash for existing in self.records):
+            raise ValueError("champion record is already registered")
+        return CanonicalChampionRegistry(records=(*self.records, record))
+
+    def active_head(self, track_id: str) -> ChampionRegistryRecord | None:
+        _require_identifier("track_id", track_id)
+        return self._replay().get(track_id)
+
+    def audit_parent_claim(
+        self,
+        *,
+        track_id: str,
+        claimed_parent_artifact_hash: str,
+    ) -> ChampionClaimAudit:
+        _require_identifier("track_id", track_id)
+        _require_hash("claimed_parent_artifact_hash", claimed_parent_artifact_hash)
+        active = self.active_head(track_id)
+        reasons: list[str] = []
+        if active is None:
+            reasons.append("track_has_no_active_head")
+        elif active.artifact_hash != claimed_parent_artifact_hash:
+            reasons.append("parent_not_active_track_head")
+        return ChampionClaimAudit(
+            track_id=track_id,
+            claimed_parent_artifact_hash=claimed_parent_artifact_hash,
+            active_record_hash=None if active is None else active.record_hash,
+            active_artifact_hash=None if active is None else active.artifact_hash,
+            valid=not reasons,
+            reasons=tuple(reasons),
+        )
+
+    def _replay(self) -> dict[str, ChampionRegistryRecord]:
+        heads: dict[str, ChampionRegistryRecord] = {}
+        record_hashes: set[str] = set()
+        artifact_keys: set[tuple[str, str]] = set()
+        for record in self.records:
+            if record.record_hash in record_hashes:
+                raise ValueError("duplicate champion record hash")
+            artifact_key = (record.track_id, record.artifact_hash)
+            if artifact_key in artifact_keys:
+                raise ValueError("artifact is already recorded on this track")
+            record_hashes.add(record.record_hash)
+            artifact_keys.add(artifact_key)
+            active = heads.get(record.track_id)
+            if record.kind in (
+                ChampionRecordKind.GLOBAL_BASELINE,
+                ChampionRecordKind.SPECIALIST_BASELINE,
+            ):
+                if active is not None:
+                    raise ValueError("track already has a baseline")
+                heads[record.track_id] = record
+                continue
+            if active is None:
+                raise ValueError("child record has no active track head")
+            if record.parent_record_hash != active.record_hash:
+                raise ValueError("parent record is not the active track head")
+            if record.parent_artifact_hash != active.artifact_hash:
+                raise ValueError("parent artifact is not the active track head")
+            if record.generation != active.generation + 1:
+                raise ValueError("child generation does not follow the active track head")
+            if record.kind is ChampionRecordKind.TRACK_REPLACEMENT:
+                heads[record.track_id] = record
+        return heads
+
+    def to_dict(self) -> dict[str, Any]:
+        heads = self._replay()
+        return {
+            "schema_version": self.schema_version,
+            "records": [record.to_dict() for record in self.records],
+            "active_heads": {
+                track_id: {
+                    "record_hash": record.record_hash,
+                    "artifact_hash": record.artifact_hash,
+                    "generation": record.generation,
+                }
+                for track_id, record in sorted(heads.items())
+            },
+        }
+
+
+__all__ = [
+    "CanonicalChampionRegistry",
+    "ChampionClaimAudit",
+    "ChampionRecordKind",
+    "ChampionRegistryRecord",
+    "PromotionAuthority",
+]

--- a/src/rosclaw/continual/champion_registry.py
+++ b/src/rosclaw/continual/champion_registry.py
@@ -8,6 +8,7 @@ does not match it.
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
 from enum import StrEnum
@@ -44,6 +45,126 @@ class ChampionRecordKind(StrEnum):
     TRACK_REPLACEMENT = "track_replacement"
     SPECIALIST_BASELINE = "specialist_baseline"
     CANDIDATE_ARCHIVED = "candidate_archived"
+
+
+class DominanceMetricRole(StrEnum):
+    """Whether a paired metric must improve or merely remain safe."""
+
+    OBJECTIVE = "objective"
+    GUARDRAIL = "guardrail"
+
+
+@dataclass(frozen=True)
+class PairedDominanceMetric:
+    """One same-suite challenger comparison with explicit direction and tolerance."""
+
+    metric_id: str
+    incumbent_value: float
+    challenger_value: float
+    higher_is_better: bool
+    role: DominanceMetricRole
+    minimum_improvement: float = 0.0
+    maximum_regression: float = 0.0
+    schema_version: str = "rosclaw.continual.paired_dominance_metric.v1"
+
+    def __post_init__(self) -> None:
+        _require_identifier("metric_id", self.metric_id)
+        if not isinstance(self.higher_is_better, bool) or not isinstance(
+            self.role, DominanceMetricRole
+        ):
+            raise ValueError("paired-dominance metric direction or role is invalid")
+        values = (
+            self.incumbent_value,
+            self.challenger_value,
+            self.minimum_improvement,
+            self.maximum_regression,
+        )
+        if any(not math.isfinite(value) for value in values):
+            raise ValueError("paired-dominance metric values must be finite")
+        if self.minimum_improvement < 0.0 or self.maximum_regression < 0.0:
+            raise ValueError("paired-dominance tolerances must be non-negative")
+        if self.role is DominanceMetricRole.OBJECTIVE:
+            if self.minimum_improvement <= 0.0 or self.maximum_regression != 0.0:
+                raise ValueError("objective metric requires a positive minimum improvement")
+        elif self.minimum_improvement != 0.0:
+            raise ValueError("guardrail metric cannot require objective improvement")
+
+    @property
+    def signed_improvement(self) -> float:
+        delta = self.challenger_value - self.incumbent_value
+        return delta if self.higher_is_better else -delta
+
+    @property
+    def passed(self) -> bool:
+        if self.role is DominanceMetricRole.OBJECTIVE:
+            return self.signed_improvement >= self.minimum_improvement
+        return self.signed_improvement >= -self.maximum_regression
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "metric_id": self.metric_id,
+            "incumbent_value": self.incumbent_value,
+            "challenger_value": self.challenger_value,
+            "higher_is_better": self.higher_is_better,
+            "role": self.role.value,
+            "minimum_improvement": self.minimum_improvement,
+            "maximum_regression": self.maximum_regression,
+            "signed_improvement": self.signed_improvement,
+            "passed": self.passed,
+        }
+
+
+@dataclass(frozen=True)
+class PairedDominanceEvidence:
+    """Domain-neutral proof that a challenger improves a frozen champion suite."""
+
+    incumbent_artifact_hash: str
+    challenger_artifact_hash: str
+    scenario_suite_hash: str
+    metrics: tuple[PairedDominanceMetric, ...]
+    evidence_domain: str = "SIM"
+    schema_version: str = "rosclaw.continual.paired_dominance_evidence.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("incumbent_artifact_hash", self.incumbent_artifact_hash),
+            ("challenger_artifact_hash", self.challenger_artifact_hash),
+            ("scenario_suite_hash", self.scenario_suite_hash),
+        ):
+            _require_hash(label, value)
+        if not isinstance(self.metrics, tuple) or any(
+            not isinstance(metric, PairedDominanceMetric) for metric in self.metrics
+        ):
+            raise ValueError("paired-dominance metrics must be an immutable typed tuple")
+        metric_ids = tuple(metric.metric_id for metric in self.metrics)
+        if (
+            self.incumbent_artifact_hash == self.challenger_artifact_hash
+            or not self.metrics
+            or len(metric_ids) != len(set(metric_ids))
+            or not any(metric.role is DominanceMetricRole.OBJECTIVE for metric in self.metrics)
+            or self.evidence_domain != "SIM"
+        ):
+            raise ValueError("paired-dominance evidence is invalid")
+
+    @property
+    def promotion_passed(self) -> bool:
+        return all(metric.passed for metric in self.metrics)
+
+    @property
+    def evidence_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "incumbent_artifact_hash": self.incumbent_artifact_hash,
+            "challenger_artifact_hash": self.challenger_artifact_hash,
+            "scenario_suite_hash": self.scenario_suite_hash,
+            "metrics": [metric.to_dict() for metric in self.metrics],
+            "promotion_passed": self.promotion_passed,
+            "evidence_domain": self.evidence_domain,
+        }
 
 
 @dataclass(frozen=True)
@@ -278,5 +399,8 @@ __all__ = [
     "ChampionClaimAudit",
     "ChampionRecordKind",
     "ChampionRegistryRecord",
+    "DominanceMetricRole",
+    "PairedDominanceEvidence",
+    "PairedDominanceMetric",
     "PromotionAuthority",
 ]

--- a/src/rosclaw/continual/failure_curriculum.py
+++ b/src/rosclaw/continual/failure_curriculum.py
@@ -1,0 +1,259 @@
+"""Failure-conditioned Dream and capability-frontier curriculum contracts."""
+
+from __future__ import annotations
+
+import math
+import random
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class CurriculumSource(StrEnum):
+    CAPABILITY_FRONTIER = "CAPABILITY_FRONTIER"
+    RECENT_FAILURE = "RECENT_FAILURE"
+    HISTORICAL_ANCHOR = "HISTORICAL_ANCHOR"
+    NIGHTMARE = "NIGHTMARE"
+    SOCIAL_TEACHER = "SOCIAL_TEACHER"
+
+
+class PerturbationDistribution(StrEnum):
+    UNIFORM = "UNIFORM"
+    NORMAL_CLIPPED = "NORMAL_CLIPPED"
+
+
+@dataclass(frozen=True)
+class CurriculumMixture:
+    capability_frontier: float = 0.40
+    recent_failure: float = 0.25
+    historical_anchor: float = 0.15
+    nightmare: float = 0.10
+    social_teacher: float = 0.10
+    schema_version: str = "rosclaw.continual.curriculum_mixture.v1"
+
+    def __post_init__(self) -> None:
+        values = tuple(self.as_mapping().values())
+        if any(not math.isfinite(value) or value < 0.0 for value in values) or not math.isclose(
+            sum(values),
+            1.0,
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise ValueError("curriculum mixture must be finite, non-negative, and sum to one")
+
+    def as_mapping(self) -> MappingProxyType[CurriculumSource, float]:
+        return MappingProxyType(
+            {
+                CurriculumSource.CAPABILITY_FRONTIER: self.capability_frontier,
+                CurriculumSource.RECENT_FAILURE: self.recent_failure,
+                CurriculumSource.HISTORICAL_ANCHOR: self.historical_anchor,
+                CurriculumSource.NIGHTMARE: self.nightmare,
+                CurriculumSource.SOCIAL_TEACHER: self.social_teacher,
+            }
+        )
+
+    def allocate(self, batch_size: int) -> MappingProxyType[CurriculumSource, int]:
+        if batch_size <= 0 or batch_size > 1_000_000:
+            raise ValueError("curriculum batch size is invalid")
+        weights = self.as_mapping()
+        raw = {source: batch_size * weight for source, weight in weights.items()}
+        counts = {source: math.floor(value) for source, value in raw.items()}
+        remainder = batch_size - sum(counts.values())
+        order = sorted(
+            weights,
+            key=lambda source: (raw[source] - counts[source], weights[source], source.value),
+            reverse=True,
+        )
+        for source in order[:remainder]:
+            counts[source] += 1
+        return MappingProxyType(counts)
+
+
+@dataclass(frozen=True)
+class DreamPerturbation:
+    name: str
+    minimum_delta: float
+    maximum_delta: float
+    distribution: PerturbationDistribution = PerturbationDistribution.UNIFORM
+
+    def __post_init__(self) -> None:
+        if (
+            not _IDENTIFIER.fullmatch(self.name)
+            or not math.isfinite(self.minimum_delta)
+            or not math.isfinite(self.maximum_delta)
+            or self.minimum_delta > self.maximum_delta
+            or self.minimum_delta == self.maximum_delta
+        ):
+            raise ValueError("dream perturbation is invalid")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "minimum_delta": self.minimum_delta,
+            "maximum_delta": self.maximum_delta,
+            "distribution": self.distribution.value,
+        }
+
+
+@dataclass(frozen=True)
+class FailureConditionedDream:
+    failure_code: str
+    source_snapshot_hash: str
+    body_hash: str
+    scenario_hash: str
+    perturbations: tuple[DreamPerturbation, ...]
+    maximum_variants: int
+    training_use_only: bool = True
+    activation_ceiling: str = "SIM_ONLY"
+    hardware_authorized: bool = False
+    schema_version: str = "rosclaw.continual.failure_conditioned_dream.v1"
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.failure_code):
+            raise ValueError("failure code must be a normalized identifier")
+        if any(
+            not _SHA256.fullmatch(value)
+            for value in (self.source_snapshot_hash, self.body_hash, self.scenario_hash)
+        ):
+            raise ValueError("failure-conditioned dream identities must be content hashes")
+        names = tuple(item.name for item in self.perturbations)
+        if (
+            not self.perturbations
+            or len(names) != len(set(names))
+            or not 1 <= self.maximum_variants <= 100_000
+            or not self.training_use_only
+            or self.activation_ceiling != "SIM_ONLY"
+            or self.hardware_authorized
+        ):
+            raise ValueError("failure-conditioned dream contract is invalid")
+
+    @property
+    def contract_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "failure_code": self.failure_code,
+            "source_snapshot_hash": self.source_snapshot_hash,
+            "body_hash": self.body_hash,
+            "scenario_hash": self.scenario_hash,
+            "perturbations": [item.to_dict() for item in self.perturbations],
+            "maximum_variants": self.maximum_variants,
+            "training_use_only": self.training_use_only,
+            "activation_ceiling": self.activation_ceiling,
+            "hardware_authorized": self.hardware_authorized,
+        }
+
+    def sample(self, *, count: int, seed: int) -> tuple[dict[str, float], ...]:
+        if count <= 0 or count > self.maximum_variants or seed < 0:
+            raise ValueError("failure-conditioned dream sampling request is invalid")
+        generator = random.Random(seed)
+        rows = []
+        for _ in range(count):
+            row = {}
+            for item in self.perturbations:
+                if item.distribution is PerturbationDistribution.UNIFORM:
+                    value = generator.uniform(item.minimum_delta, item.maximum_delta)
+                else:
+                    midpoint = 0.5 * (item.minimum_delta + item.maximum_delta)
+                    sigma = (item.maximum_delta - item.minimum_delta) / 6.0
+                    value = min(
+                        item.maximum_delta,
+                        max(item.minimum_delta, generator.gauss(midpoint, sigma)),
+                    )
+                row[item.name] = value
+            rows.append(row)
+        return tuple(rows)
+
+
+@dataclass(frozen=True)
+class CapabilityBin:
+    bin_id: str
+    difficulty: float
+    successes: int
+    attempts: int
+
+    def __post_init__(self) -> None:
+        if (
+            not _IDENTIFIER.fullmatch(self.bin_id)
+            or not math.isfinite(self.difficulty)
+            or not 0.0 <= self.difficulty <= 1.0
+            or self.successes < 0
+            or self.attempts < 0
+            or self.successes > self.attempts
+        ):
+            raise ValueError("capability bin is invalid")
+
+    @property
+    def success_rate(self) -> float | None:
+        return None if self.attempts == 0 else self.successes / self.attempts
+
+
+class CapabilityFrontierScheduler:
+    """Prioritize measured 30--70% success regions without starving anchors."""
+
+    def __init__(
+        self,
+        *,
+        lower_success: float = 0.30,
+        upper_success: float = 0.70,
+        minimum_probability: float = 0.02,
+        minimum_attempts: int = 16,
+        temperature: float = 0.15,
+    ) -> None:
+        values = (lower_success, upper_success, minimum_probability, temperature)
+        if (
+            any(not math.isfinite(value) for value in values)
+            or not 0.0 <= lower_success < upper_success <= 1.0
+            or not 0.0 < minimum_probability < 1.0
+            or minimum_attempts <= 0
+            or temperature <= 0.0
+        ):
+            raise ValueError("capability-frontier scheduler config is invalid")
+        self.lower_success = lower_success
+        self.upper_success = upper_success
+        self.minimum_probability = minimum_probability
+        self.minimum_attempts = minimum_attempts
+        self.temperature = temperature
+
+    def probabilities(
+        self,
+        bins: tuple[CapabilityBin, ...],
+    ) -> MappingProxyType[str, float]:
+        if not bins or len({item.bin_id for item in bins}) != len(bins):
+            raise ValueError("capability frontier requires unique bins")
+        scores: dict[str, float] = {}
+        for item in bins:
+            rate = item.success_rate
+            if rate is None:
+                frontier_score = 0.25
+            elif self.lower_success <= rate <= self.upper_success:
+                frontier_score = 1.0
+            else:
+                distance = min(abs(rate - self.lower_success), abs(rate - self.upper_success))
+                frontier_score = math.exp(-distance / self.temperature)
+            confidence = min(1.0, item.attempts / self.minimum_attempts)
+            scores[item.bin_id] = self.minimum_probability + frontier_score * (
+                0.25 + 0.75 * confidence
+            )
+        total = sum(scores.values())
+        return MappingProxyType({key: value / total for key, value in sorted(scores.items())})
+
+
+__all__ = [
+    "CapabilityBin",
+    "CapabilityFrontierScheduler",
+    "CurriculumMixture",
+    "CurriculumSource",
+    "DreamPerturbation",
+    "FailureConditionedDream",
+    "PerturbationDistribution",
+]

--- a/src/rosclaw/continual/individual_scope.py
+++ b/src/rosclaw/continual/individual_scope.py
@@ -1,0 +1,298 @@
+"""Agent-isolated Parent/Candidate/Champion lifecycle contracts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from typing import Any
+
+from rosclaw.continual.contracts import PolicyVersion
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+
+
+def _require_hash(label: str, value: str) -> None:
+    if not _SHA256.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+def _require_identifier(label: str, value: str) -> None:
+    if not _IDENTIFIER.fullmatch(value):
+        raise ValueError(f"{label} is not a valid stable identifier")
+
+
+@dataclass(frozen=True)
+class FrozenPartner:
+    """One immutable collaborator/opponent used for counterfactual evaluation."""
+
+    agent_id: str
+    champion_policy_hash: str
+    body_hash: str
+    foundation_policy_hash: str
+    capability_profile_hash: str
+
+    def __post_init__(self) -> None:
+        _require_identifier("agent_id", self.agent_id)
+        for label, value in (
+            ("champion_policy_hash", self.champion_policy_hash),
+            ("body_hash", self.body_hash),
+            ("foundation_policy_hash", self.foundation_policy_hash),
+            ("capability_profile_hash", self.capability_profile_hash),
+        ):
+            _require_hash(label, value)
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "agent_id": self.agent_id,
+            "champion_policy_hash": self.champion_policy_hash,
+            "body_hash": self.body_hash,
+            "foundation_policy_hash": self.foundation_policy_hash,
+            "capability_profile_hash": self.capability_profile_hash,
+        }
+
+
+@dataclass(frozen=True)
+class FrozenPartnerSet:
+    """Content-addressed roster around one focal learner."""
+
+    focal_agent_id: str
+    partners: tuple[FrozenPartner, ...]
+    numerical_contract_hash: str
+    scenario_contract_hash: str
+    schema_version: str = "rosclaw.continual.frozen_partner_set.v1"
+
+    def __post_init__(self) -> None:
+        _require_identifier("focal_agent_id", self.focal_agent_id)
+        _require_hash("numerical_contract_hash", self.numerical_contract_hash)
+        _require_hash("scenario_contract_hash", self.scenario_contract_hash)
+        partner_ids = tuple(partner.agent_id for partner in self.partners)
+        if self.focal_agent_id in partner_ids:
+            raise ValueError("focal agent cannot appear in its frozen partner set")
+        if len(partner_ids) != len(set(partner_ids)):
+            raise ValueError("frozen partner identifiers must be unique")
+
+    @property
+    def snapshot_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "focal_agent_id": self.focal_agent_id,
+            "partners": [partner.to_dict() for partner in self.partners],
+            "numerical_contract_hash": self.numerical_contract_hash,
+            "scenario_contract_hash": self.scenario_contract_hash,
+        }
+
+
+@dataclass(frozen=True)
+class IndividualPromotionEvidence:
+    """Identity-bound evidence required to promote one agent only."""
+
+    agent_id: str
+    parent_policy_hash: str
+    candidate_policy_hash: str
+    frozen_partner_snapshot_hash: str
+    matched_seed_commitment_hash: str
+    gate_report_hash: str
+    personal_memory_namespace: str
+    retention_passed: bool
+    safety_passed: bool
+    team_compatibility_passed: bool
+    schema_version: str = "rosclaw.continual.individual_promotion_evidence.v1"
+
+    def __post_init__(self) -> None:
+        _require_identifier("agent_id", self.agent_id)
+        _require_identifier("personal_memory_namespace", self.personal_memory_namespace)
+        for label, value in (
+            ("parent_policy_hash", self.parent_policy_hash),
+            ("candidate_policy_hash", self.candidate_policy_hash),
+            ("frozen_partner_snapshot_hash", self.frozen_partner_snapshot_hash),
+            ("matched_seed_commitment_hash", self.matched_seed_commitment_hash),
+            ("gate_report_hash", self.gate_report_hash),
+        ):
+            _require_hash(label, value)
+
+    @property
+    def passed(self) -> bool:
+        return self.retention_passed and self.safety_passed and self.team_compatibility_passed
+
+    @property
+    def evidence_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "agent_id": self.agent_id,
+            "parent_policy_hash": self.parent_policy_hash,
+            "candidate_policy_hash": self.candidate_policy_hash,
+            "frozen_partner_snapshot_hash": self.frozen_partner_snapshot_hash,
+            "matched_seed_commitment_hash": self.matched_seed_commitment_hash,
+            "gate_report_hash": self.gate_report_hash,
+            "personal_memory_namespace": self.personal_memory_namespace,
+            "retention_passed": self.retention_passed,
+            "safety_passed": self.safety_passed,
+            "team_compatibility_passed": self.team_compatibility_passed,
+            "passed": self.passed,
+        }
+
+
+@dataclass(frozen=True)
+class IndividualGrowthScope:
+    """Immutable growth state whose candidate can affect exactly one agent."""
+
+    agent_id: str
+    body_hash: str
+    body_state_hash: str
+    foundation_policy_hash: str
+    personal_adapter_hash: str
+    role_policy_hash: str
+    residual_policy_hash: str
+    capability_profile_hash: str
+    career_lineage_hash: str
+    personal_memory_namespace: str
+    failure_memory_namespace: str
+    parent_policy: PolicyVersion
+    champion_policy: PolicyVersion
+    candidate_policy: PolicyVersion | None = None
+    candidate_partner_snapshot_hash: str | None = None
+    generation: int = 0
+    last_promotion_evidence_hash: str | None = None
+    schema_version: str = "rosclaw.continual.individual_growth_scope.v1"
+
+    def __post_init__(self) -> None:
+        _require_identifier("agent_id", self.agent_id)
+        _require_identifier("personal_memory_namespace", self.personal_memory_namespace)
+        _require_identifier("failure_memory_namespace", self.failure_memory_namespace)
+        for label, value in (
+            ("body_hash", self.body_hash),
+            ("body_state_hash", self.body_state_hash),
+            ("foundation_policy_hash", self.foundation_policy_hash),
+            ("personal_adapter_hash", self.personal_adapter_hash),
+            ("role_policy_hash", self.role_policy_hash),
+            ("residual_policy_hash", self.residual_policy_hash),
+            ("capability_profile_hash", self.capability_profile_hash),
+            ("career_lineage_hash", self.career_lineage_hash),
+        ):
+            _require_hash(label, value)
+        if self.generation < 0:
+            raise ValueError("generation must be non-negative")
+        if self.parent_policy.version_hash != self.champion_policy.version_hash:
+            raise ValueError("parent and champion must identify the current deployed policy")
+        for policy in (self.parent_policy, self.champion_policy):
+            if policy.body_hash != self.body_hash:
+                raise ValueError("scope body does not match parent/champion policy")
+        if (self.candidate_policy is None) != (self.candidate_partner_snapshot_hash is None):
+            raise ValueError("candidate and frozen partner snapshot must be staged together")
+        if self.candidate_policy is not None:
+            self._validate_candidate(self.candidate_policy)
+            _require_hash(
+                "candidate_partner_snapshot_hash",
+                self.candidate_partner_snapshot_hash or "",
+            )
+        if self.last_promotion_evidence_hash is not None:
+            _require_hash("last_promotion_evidence_hash", self.last_promotion_evidence_hash)
+
+    @property
+    def scope_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def stage_candidate(
+        self,
+        candidate: PolicyVersion,
+        *,
+        partners: FrozenPartnerSet,
+    ) -> IndividualGrowthScope:
+        if self.candidate_policy is not None:
+            raise ValueError("a candidate is already staged")
+        if partners.focal_agent_id != self.agent_id:
+            raise ValueError("partner snapshot belongs to another focal agent")
+        self._validate_candidate(candidate)
+        return replace(
+            self,
+            candidate_policy=candidate,
+            candidate_partner_snapshot_hash=partners.snapshot_hash,
+        )
+
+    def reject_candidate(self) -> IndividualGrowthScope:
+        """Discard only the focal agent's staged candidate."""
+
+        return replace(
+            self,
+            candidate_policy=None,
+            candidate_partner_snapshot_hash=None,
+        )
+
+    def promote_candidate(
+        self,
+        evidence: IndividualPromotionEvidence,
+    ) -> IndividualGrowthScope:
+        candidate = self.candidate_policy
+        if candidate is None or self.candidate_partner_snapshot_hash is None:
+            raise ValueError("no candidate is staged")
+        if evidence.agent_id != self.agent_id:
+            raise ValueError("promotion evidence belongs to another agent")
+        if evidence.personal_memory_namespace != self.personal_memory_namespace:
+            raise ValueError("promotion evidence is bound to another memory namespace")
+        if evidence.parent_policy_hash != self.champion_policy.version_hash:
+            raise ValueError("promotion evidence parent does not match the champion")
+        if evidence.candidate_policy_hash != candidate.version_hash:
+            raise ValueError("promotion evidence candidate does not match the staged policy")
+        if evidence.frozen_partner_snapshot_hash != self.candidate_partner_snapshot_hash:
+            raise ValueError("promotion evidence used a different partner snapshot")
+        if not evidence.passed:
+            raise ValueError("candidate failed an individual promotion gate")
+        return replace(
+            self,
+            parent_policy=candidate,
+            champion_policy=candidate,
+            candidate_policy=None,
+            candidate_partner_snapshot_hash=None,
+            generation=self.generation + 1,
+            last_promotion_evidence_hash=evidence.evidence_hash,
+        )
+
+    def _validate_candidate(self, candidate: PolicyVersion) -> None:
+        if candidate.parent_version_hash != self.champion_policy.version_hash:
+            raise ValueError("candidate parent does not match the focal champion")
+        if candidate.body_hash != self.body_hash:
+            raise ValueError("candidate body does not match the individual scope")
+        if candidate.controller_snapshot_hash != self.champion_policy.controller_snapshot_hash:
+            raise ValueError("candidate controller snapshot changed inside an individual scope")
+        if candidate.safety_kernel_hash != self.champion_policy.safety_kernel_hash:
+            raise ValueError("candidate safety kernel changed inside an individual scope")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "agent_id": self.agent_id,
+            "body_hash": self.body_hash,
+            "body_state_hash": self.body_state_hash,
+            "foundation_policy_hash": self.foundation_policy_hash,
+            "personal_adapter_hash": self.personal_adapter_hash,
+            "role_policy_hash": self.role_policy_hash,
+            "residual_policy_hash": self.residual_policy_hash,
+            "capability_profile_hash": self.capability_profile_hash,
+            "career_lineage_hash": self.career_lineage_hash,
+            "personal_memory_namespace": self.personal_memory_namespace,
+            "failure_memory_namespace": self.failure_memory_namespace,
+            "parent_policy": self.parent_policy.to_dict(),
+            "champion_policy": self.champion_policy.to_dict(),
+            "candidate_policy": (
+                None if self.candidate_policy is None else self.candidate_policy.to_dict()
+            ),
+            "candidate_partner_snapshot_hash": self.candidate_partner_snapshot_hash,
+            "generation": self.generation,
+            "last_promotion_evidence_hash": self.last_promotion_evidence_hash,
+        }
+
+
+__all__ = [
+    "FrozenPartner",
+    "FrozenPartnerSet",
+    "IndividualGrowthScope",
+    "IndividualPromotionEvidence",
+]

--- a/src/rosclaw/continual/learner_backend.py
+++ b/src/rosclaw/continual/learner_backend.py
@@ -1,0 +1,183 @@
+"""Backend-neutral contracts for external continual-learning engines."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+_COMMIT = re.compile(r"^[0-9a-f]{7,64}$")
+
+
+class LearnerCapability(StrEnum):
+    MOTION_TRACKING = "motion_tracking"
+    ADVERSARIAL_MOTION_PRIOR = "adversarial_motion_prior"
+    SPECIALIST_TRAINING = "specialist_training"
+    GENERALIST_DISTILLATION = "generalist_distillation"
+    PERSONAL_ADAPTER = "personal_adapter"
+    MULTI_GPU = "multi_gpu"
+    SIM2SIM = "sim2sim"
+
+
+class LearnerRunStatus(StrEnum):
+    PLANNED = "planned"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class LearnerBackendContract:
+    """Pinned capabilities and trust boundary of one learner implementation."""
+
+    backend_id: str
+    backend_version: str
+    source_url: str
+    source_commit: str
+    license_id: str
+    capabilities: tuple[LearnerCapability, ...]
+    supported_body_ids: tuple[str, ...]
+    training_available: bool
+    inference_available: bool
+    external_environment: bool = True
+    hardware_execution_allowed: bool = False
+    sim_only: bool = True
+    schema_version: str = "rosclaw.continual.learner_backend.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("backend_id", self.backend_id),
+            ("backend_version", self.backend_version),
+            ("license_id", self.license_id),
+        ):
+            if not _IDENTIFIER.fullmatch(value):
+                raise ValueError(f"{label} is not a normalized identifier")
+        if not self.source_url.startswith("https://"):
+            raise ValueError("source_url must use https")
+        if not _COMMIT.fullmatch(self.source_commit):
+            raise ValueError("source_commit must be a pinned hexadecimal commit")
+        if not self.capabilities or len(set(self.capabilities)) != len(self.capabilities):
+            raise ValueError("capabilities must be non-empty and unique")
+        if (
+            not self.supported_body_ids
+            or len(set(self.supported_body_ids)) != len(self.supported_body_ids)
+            or any(not _IDENTIFIER.fullmatch(item) for item in self.supported_body_ids)
+        ):
+            raise ValueError("supported_body_ids must be non-empty unique identifiers")
+        if not self.training_available and not self.inference_available:
+            raise ValueError("backend must expose training or inference")
+        if not self.external_environment:
+            raise ValueError("learner backends must remain outside the control-plane environment")
+        if self.hardware_execution_allowed or not self.sim_only:
+            raise ValueError("learner backend contracts are SIM_ONLY and cannot execute hardware")
+
+    @property
+    def contract_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "backend_id": self.backend_id,
+            "backend_version": self.backend_version,
+            "source_url": self.source_url,
+            "source_commit": self.source_commit,
+            "license_id": self.license_id,
+            "capabilities": sorted(item.value for item in self.capabilities),
+            "supported_body_ids": sorted(self.supported_body_ids),
+            "training_available": self.training_available,
+            "inference_available": self.inference_available,
+            "external_environment": self.external_environment,
+            "hardware_execution_allowed": self.hardware_execution_allowed,
+            "sim_only": self.sim_only,
+        }
+
+
+@dataclass(frozen=True)
+class LearnerRunEvidence:
+    """Content-addressed receipt for a backend run; never executes the backend."""
+
+    run_id: str
+    backend_contract_hash: str
+    body_hash: str
+    dataset_manifest_hash: str
+    config_hash: str
+    seed_commitment_hash: str
+    physics_backend: str
+    device_ids: tuple[int, ...]
+    world_steps: int
+    sample_count: int
+    status: LearnerRunStatus
+    candidate_artifact_hash: str | None = None
+    sim_only: bool = True
+    schema_version: str = "rosclaw.continual.learner_run_evidence.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (("run_id", self.run_id), ("physics_backend", self.physics_backend)):
+            if not _IDENTIFIER.fullmatch(value):
+                raise ValueError(f"{label} is not a normalized identifier")
+        for label, value in (
+            ("backend_contract_hash", self.backend_contract_hash),
+            ("body_hash", self.body_hash),
+            ("dataset_manifest_hash", self.dataset_manifest_hash),
+            ("config_hash", self.config_hash),
+            ("seed_commitment_hash", self.seed_commitment_hash),
+        ):
+            if not _SHA256.fullmatch(value):
+                raise ValueError(f"{label} must be a sha256: content hash")
+        if self.candidate_artifact_hash is not None and not _SHA256.fullmatch(
+            self.candidate_artifact_hash
+        ):
+            raise ValueError("candidate_artifact_hash must be a sha256: content hash")
+        if len(set(self.device_ids)) != len(self.device_ids) or any(
+            device < 0 for device in self.device_ids
+        ):
+            raise ValueError("device_ids must contain unique non-negative integers")
+        if self.world_steps < 0 or self.sample_count < 0:
+            raise ValueError("run counts must be non-negative")
+        if self.status is LearnerRunStatus.COMPLETED:
+            if (
+                self.candidate_artifact_hash is None
+                or self.world_steps == 0
+                or self.sample_count == 0
+            ):
+                raise ValueError("completed run requires samples, steps, and a candidate artifact")
+        elif self.candidate_artifact_hash is not None:
+            raise ValueError("only a completed run can publish a candidate artifact")
+        if not self.sim_only:
+            raise ValueError("learner run evidence is SIM_ONLY until a separate real-body gate")
+
+    @property
+    def evidence_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "backend_contract_hash": self.backend_contract_hash,
+            "body_hash": self.body_hash,
+            "dataset_manifest_hash": self.dataset_manifest_hash,
+            "config_hash": self.config_hash,
+            "seed_commitment_hash": self.seed_commitment_hash,
+            "physics_backend": self.physics_backend,
+            "device_ids": list(self.device_ids),
+            "world_steps": self.world_steps,
+            "sample_count": self.sample_count,
+            "status": self.status.value,
+            "candidate_artifact_hash": self.candidate_artifact_hash,
+            "sim_only": self.sim_only,
+        }
+
+
+__all__ = [
+    "LearnerBackendContract",
+    "LearnerCapability",
+    "LearnerRunEvidence",
+    "LearnerRunStatus",
+]

--- a/src/rosclaw/continual/plasticity_lease.py
+++ b/src/rosclaw/continual/plasticity_lease.py
@@ -1,0 +1,179 @@
+"""Single-focal plasticity leases for multi-agent continual learning."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class AgentUpdateMode(StrEnum):
+    PLASTIC = "PLASTIC"
+    FROZEN = "FROZEN"
+
+
+@dataclass(frozen=True)
+class AgentPolicyBinding:
+    agent_id: str
+    policy_hash: str
+    mode: AgentUpdateMode
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.agent_id) or not _SHA256.fullmatch(self.policy_hash):
+            raise ValueError("agent policy binding is invalid")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "agent_id": self.agent_id,
+            "policy_hash": self.policy_hash,
+            "mode": self.mode.value,
+        }
+
+
+@dataclass(frozen=True)
+class PlasticityLease:
+    """Grant candidate updates to exactly one focal agent for a bounded run."""
+
+    lease_id: str
+    bindings: tuple[AgentPolicyBinding, ...]
+    dataset_manifest_hash: str
+    scenario_contract_hash: str
+    maximum_optimizer_steps: int
+    activation_ceiling: str = "SIM_ONLY"
+    hardware_authorized: bool = False
+    schema_version: str = "rosclaw.continual.plasticity_lease.v1"
+
+    def __post_init__(self) -> None:
+        ids = tuple(binding.agent_id for binding in self.bindings)
+        plastic = tuple(
+            binding.agent_id for binding in self.bindings if binding.mode is AgentUpdateMode.PLASTIC
+        )
+        if (
+            not _IDENTIFIER.fullmatch(self.lease_id)
+            or len(self.bindings) < 2
+            or len(ids) != len(set(ids))
+            or len(plastic) != 1
+            or any(
+                not _SHA256.fullmatch(value)
+                for value in (self.dataset_manifest_hash, self.scenario_contract_hash)
+            )
+            or not 1 <= self.maximum_optimizer_steps <= 100_000_000
+            or self.activation_ceiling != "SIM_ONLY"
+            or self.hardware_authorized
+        ):
+            raise ValueError("plasticity lease is invalid")
+
+    @property
+    def focal_agent_id(self) -> str:
+        return next(
+            binding.agent_id for binding in self.bindings if binding.mode is AgentUpdateMode.PLASTIC
+        )
+
+    @property
+    def lease_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "lease_id": self.lease_id,
+            "bindings": [binding.to_dict() for binding in self.bindings],
+            "dataset_manifest_hash": self.dataset_manifest_hash,
+            "scenario_contract_hash": self.scenario_contract_hash,
+            "maximum_optimizer_steps": self.maximum_optimizer_steps,
+            "activation_ceiling": self.activation_ceiling,
+            "hardware_authorized": self.hardware_authorized,
+        }
+
+
+@dataclass(frozen=True)
+class PlasticityLeaseAudit:
+    lease_hash: str
+    optimizer_steps: int
+    changed_agent_ids: tuple[str, ...]
+    passed: bool
+    reasons: tuple[str, ...]
+    before_policy_hashes: Mapping[str, str]
+    after_policy_hashes: Mapping[str, str]
+    schema_version: str = "rosclaw.continual.plasticity_lease_audit.v1"
+
+    def __post_init__(self) -> None:
+        if not _SHA256.fullmatch(self.lease_hash) or self.optimizer_steps < 0:
+            raise ValueError("plasticity lease audit identity is invalid")
+        before = _policy_hash_mapping(self.before_policy_hashes)
+        after = _policy_hash_mapping(self.after_policy_hashes)
+        if set(before) != set(after):
+            raise ValueError("plasticity audit before/after rosters differ")
+        object.__setattr__(self, "before_policy_hashes", MappingProxyType(before))
+        object.__setattr__(self, "after_policy_hashes", MappingProxyType(after))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "lease_hash": self.lease_hash,
+            "optimizer_steps": self.optimizer_steps,
+            "changed_agent_ids": list(self.changed_agent_ids),
+            "passed": self.passed,
+            "reasons": list(self.reasons),
+            "before_policy_hashes": dict(self.before_policy_hashes),
+            "after_policy_hashes": dict(self.after_policy_hashes),
+        }
+
+
+def audit_plasticity_lease(
+    *,
+    lease: PlasticityLease,
+    optimizer_steps: int,
+    before_policy_hashes: Mapping[str, str],
+    after_policy_hashes: Mapping[str, str],
+) -> PlasticityLeaseAudit:
+    before = _policy_hash_mapping(before_policy_hashes)
+    after = _policy_hash_mapping(after_policy_hashes)
+    expected = {binding.agent_id for binding in lease.bindings}
+    if set(before) != expected or set(after) != expected:
+        raise ValueError("plasticity audit roster does not match its lease")
+    changed = tuple(
+        sorted(agent_id for agent_id in expected if before[agent_id] != after[agent_id])
+    )
+    reasons = []
+    if optimizer_steps < 0 or optimizer_steps > lease.maximum_optimizer_steps:
+        reasons.append("OPTIMIZER_STEP_BUDGET_EXCEEDED")
+    unexpected = tuple(agent_id for agent_id in changed if agent_id != lease.focal_agent_id)
+    if unexpected:
+        reasons.append("FROZEN_AGENT_CHANGED:" + ",".join(unexpected))
+    return PlasticityLeaseAudit(
+        lease_hash=lease.lease_hash,
+        optimizer_steps=optimizer_steps,
+        changed_agent_ids=changed,
+        passed=not reasons,
+        reasons=tuple(reasons),
+        before_policy_hashes=before,
+        after_policy_hashes=after,
+    )
+
+
+def _policy_hash_mapping(values: Mapping[str, str]) -> dict[str, str]:
+    normalized = {str(agent_id): str(policy_hash) for agent_id, policy_hash in values.items()}
+    if any(
+        not _IDENTIFIER.fullmatch(agent_id) or not _SHA256.fullmatch(policy_hash)
+        for agent_id, policy_hash in normalized.items()
+    ):
+        raise ValueError("policy hash mapping is invalid")
+    return dict(sorted(normalized.items()))
+
+
+__all__ = [
+    "AgentPolicyBinding",
+    "AgentUpdateMode",
+    "PlasticityLease",
+    "PlasticityLeaseAudit",
+    "audit_plasticity_lease",
+]

--- a/src/rosclaw/continual/reproducibility.py
+++ b/src/rosclaw/continual/reproducibility.py
@@ -1,0 +1,183 @@
+"""Fail-closed numerical-runtime contracts for reproducible learning evidence.
+
+The contract is intentionally independent of any simulator.  It can be bound
+to MuJoCo, ONNX Runtime, a learner subprocess, or another numerical workload.
+It does not mutate the current process: callers either validate the current
+environment or use :meth:`NumericalRuntimeContract.subprocess_environment`
+before importing a numerical backend in a child process.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+THREAD_ENVIRONMENT_KEYS = (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "BLIS_NUM_THREADS",
+)
+
+
+@dataclass(frozen=True)
+class NumericalEnvironmentCheck:
+    """Result of checking a process environment against a pinned contract."""
+
+    expected: Mapping[str, str]
+    observed: Mapping[str, str | None]
+    mismatches: tuple[str, ...]
+    schema_version: str = "rosclaw.continual.numerical_environment_check.v1"
+
+    def __post_init__(self) -> None:
+        expected = MappingProxyType(dict(sorted(self.expected.items())))
+        observed = MappingProxyType(dict(sorted(self.observed.items())))
+        if set(expected) != set(observed):
+            raise ValueError("expected and observed environment keys must match")
+        object.__setattr__(self, "expected", expected)
+        object.__setattr__(self, "observed", observed)
+
+    @property
+    def passed(self) -> bool:
+        return not self.mismatches
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "passed": self.passed,
+            "expected": dict(self.expected),
+            "observed": dict(self.observed),
+            "mismatches": list(self.mismatches),
+        }
+
+
+@dataclass(frozen=True)
+class NumericalRuntimeContract:
+    """Pinned thread, floating-point, seed, and ONNX execution settings."""
+
+    thread_counts: Mapping[str, int]
+    random_seed: int
+    onnx_execution_providers: tuple[str, ...] = ("CPUExecutionProvider",)
+    onnx_intra_op_threads: int = 1
+    onnx_inter_op_threads: int = 1
+    onnx_execution_mode: str = "ORT_SEQUENTIAL"
+    floating_point_mode: str = "IEEE754_STRICT"
+    deterministic_compute: bool = True
+    allow_tf32: bool = False
+    schema_version: str = "rosclaw.continual.numerical_runtime_contract.v1"
+
+    def __post_init__(self) -> None:
+        normalized = {str(key): int(value) for key, value in self.thread_counts.items()}
+        if set(normalized) != set(THREAD_ENVIRONMENT_KEYS):
+            raise ValueError("thread_counts must pin every supported BLAS/OpenMP environment key")
+        if any(value <= 0 for value in normalized.values()):
+            raise ValueError("thread counts must be positive")
+        if not 0 <= self.random_seed < 2**63:
+            raise ValueError("random_seed must be in [0, 2**63)")
+        if (
+            not self.onnx_execution_providers
+            or len(set(self.onnx_execution_providers)) != len(self.onnx_execution_providers)
+            or any(not provider.strip() for provider in self.onnx_execution_providers)
+        ):
+            raise ValueError("ONNX execution providers must be non-empty and unique")
+        if self.onnx_intra_op_threads <= 0 or self.onnx_inter_op_threads <= 0:
+            raise ValueError("ONNX thread counts must be positive")
+        if self.onnx_execution_mode not in {"ORT_SEQUENTIAL", "ORT_PARALLEL"}:
+            raise ValueError("unsupported ONNX execution mode")
+        if self.floating_point_mode not in {"IEEE754_STRICT", "BACKEND_DETERMINISTIC"}:
+            raise ValueError("unsupported floating-point mode")
+        object.__setattr__(
+            self, "thread_counts", MappingProxyType(dict(sorted(normalized.items())))
+        )
+
+    @classmethod
+    def single_threaded_cpu(cls, *, random_seed: int) -> NumericalRuntimeContract:
+        """Return the strict CPU evidence profile used by promotion gates."""
+
+        return cls(
+            thread_counts=dict.fromkeys(THREAD_ENVIRONMENT_KEYS, 1),
+            random_seed=random_seed,
+        )
+
+    @property
+    def contract_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    @property
+    def required_environment(self) -> Mapping[str, str]:
+        values = {key: str(value) for key, value in self.thread_counts.items()}
+        values.update(
+            {
+                "PYTHONHASHSEED": str(self.random_seed),
+                "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+            }
+        )
+        return MappingProxyType(dict(sorted(values.items())))
+
+    def verify_environment(
+        self,
+        environment: Mapping[str, str] | None = None,
+    ) -> NumericalEnvironmentCheck:
+        """Fail closed on missing as well as mismatched numerical settings."""
+
+        source = os.environ if environment is None else environment
+        expected = self.required_environment
+        observed = {key: source.get(key) for key in expected}
+        mismatches = tuple(
+            key for key, expected_value in expected.items() if observed[key] != expected_value
+        )
+        return NumericalEnvironmentCheck(
+            expected=expected,
+            observed=observed,
+            mismatches=mismatches,
+        )
+
+    def subprocess_environment(
+        self,
+        base: Mapping[str, str] | None = None,
+    ) -> dict[str, str]:
+        """Build an environment that must be applied before backend imports."""
+
+        result = dict(os.environ if base is None else base)
+        result.update(self.required_environment)
+        return result
+
+    def onnx_session_settings(self) -> dict[str, Any]:
+        """Return import-free settings for a caller-created ONNX session."""
+
+        return {
+            "providers": list(self.onnx_execution_providers),
+            "intra_op_num_threads": self.onnx_intra_op_threads,
+            "inter_op_num_threads": self.onnx_inter_op_threads,
+            "execution_mode": self.onnx_execution_mode,
+            "deterministic_compute": self.deterministic_compute,
+            "allow_tf32": self.allow_tf32,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "thread_counts": dict(self.thread_counts),
+            "random_seed": self.random_seed,
+            "onnx_execution_providers": list(self.onnx_execution_providers),
+            "onnx_intra_op_threads": self.onnx_intra_op_threads,
+            "onnx_inter_op_threads": self.onnx_inter_op_threads,
+            "onnx_execution_mode": self.onnx_execution_mode,
+            "floating_point_mode": self.floating_point_mode,
+            "deterministic_compute": self.deterministic_compute,
+            "allow_tf32": self.allow_tf32,
+        }
+
+
+__all__ = [
+    "NumericalEnvironmentCheck",
+    "NumericalRuntimeContract",
+    "THREAD_ENVIRONMENT_KEYS",
+]

--- a/src/rosclaw/continual/residual_adaptation.py
+++ b/src/rosclaw/continual/residual_adaptation.py
@@ -1,0 +1,228 @@
+"""Backend-neutral contracts for stability-preserving residual adaptation."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+
+
+def _require_hash(label: str, value: str) -> None:
+    if not _SHA256.fullmatch(value):
+        raise ValueError(f"{label} must be a sha256: content hash")
+
+
+def _require_selectors(label: str, values: tuple[str, ...]) -> None:
+    if (
+        not values
+        or len(set(values)) != len(values)
+        or any(not value.strip() or "\n" in value for value in values)
+    ):
+        raise ValueError(f"{label} must contain unique non-empty selectors")
+
+
+@dataclass(frozen=True)
+class ResidualAdaptationContract:
+    """Seal what can learn while a proven parent remains immutable."""
+
+    run_id: str
+    backend_contract_hash: str
+    parent_artifact_hash: str
+    body_hash: str
+    rehearsal_dataset_hash: str
+    acquisition_dataset_hash: str
+    frozen_parameter_selectors: tuple[str, ...]
+    trainable_parameter_selectors: tuple[str, ...]
+    device_ids: tuple[int, ...]
+    maximum_world_steps: int
+    policy_learning_rate: float
+    rehearsal_fraction: float
+    acquisition_fraction: float
+    maximum_residual_output_rms: float
+    maximum_frozen_parameter_drift: float = 0.0
+    sim_only: bool = True
+    hardware_execution_allowed: bool = False
+    schema_version: str = "rosclaw.continual.residual_adaptation_contract.v1"
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.run_id):
+            raise ValueError("run_id is not a normalized identifier")
+        for label, value in (
+            ("backend_contract_hash", self.backend_contract_hash),
+            ("parent_artifact_hash", self.parent_artifact_hash),
+            ("body_hash", self.body_hash),
+            ("rehearsal_dataset_hash", self.rehearsal_dataset_hash),
+            ("acquisition_dataset_hash", self.acquisition_dataset_hash),
+        ):
+            _require_hash(label, value)
+        _require_selectors("frozen_parameter_selectors", self.frozen_parameter_selectors)
+        _require_selectors("trainable_parameter_selectors", self.trainable_parameter_selectors)
+        overlap = set(self.frozen_parameter_selectors) & set(self.trainable_parameter_selectors)
+        if overlap:
+            raise ValueError("frozen and trainable parameter selectors must be disjoint")
+        if (
+            not self.device_ids
+            or len(set(self.device_ids)) != len(self.device_ids)
+            or any(device < 0 for device in self.device_ids)
+        ):
+            raise ValueError("device_ids must be unique non-negative identifiers")
+        if self.maximum_world_steps <= 0:
+            raise ValueError("maximum_world_steps must be positive")
+        for label, numeric_value in (
+            ("policy_learning_rate", self.policy_learning_rate),
+            ("maximum_residual_output_rms", self.maximum_residual_output_rms),
+        ):
+            if not math.isfinite(numeric_value) or numeric_value <= 0.0:
+                raise ValueError(f"{label} must be finite and positive")
+        if (
+            not 0.0 < self.rehearsal_fraction < 1.0
+            or not 0.0 < self.acquisition_fraction < 1.0
+            or not math.isclose(
+                self.rehearsal_fraction + self.acquisition_fraction,
+                1.0,
+                abs_tol=1e-12,
+            )
+        ):
+            raise ValueError("rehearsal and acquisition fractions must be positive and sum to one")
+        if (
+            not math.isfinite(self.maximum_frozen_parameter_drift)
+            or self.maximum_frozen_parameter_drift < 0.0
+        ):
+            raise ValueError("maximum_frozen_parameter_drift must be finite and non-negative")
+        if not self.sim_only or self.hardware_execution_allowed:
+            raise ValueError("residual adaptation contracts are SIM_ONLY")
+
+    @property
+    def contract_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["frozen_parameter_selectors"] = sorted(self.frozen_parameter_selectors)
+        value["trainable_parameter_selectors"] = sorted(self.trainable_parameter_selectors)
+        value["device_ids"] = list(self.device_ids)
+        return value
+
+
+@dataclass(frozen=True)
+class ParameterIsolationEvidence:
+    """Post-training proof that only the contracted residual scope changed."""
+
+    adaptation_contract_hash: str
+    parent_artifact_hash: str
+    candidate_artifact_hash: str
+    frozen_base_hash_before: str
+    frozen_base_hash_after: str
+    matched_exam_hash: str
+    examined_frozen_parameter_count: int
+    examined_trainable_parameter_count: int
+    candidate_world_steps: int
+    maximum_frozen_parameter_drift: float
+    residual_output_rms: float
+    retention_passed: bool
+    acquisition_passed: bool
+    critical_safety_regressions: int
+    sim_only: bool = True
+    schema_version: str = "rosclaw.continual.parameter_isolation_evidence.v1"
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("adaptation_contract_hash", self.adaptation_contract_hash),
+            ("parent_artifact_hash", self.parent_artifact_hash),
+            ("candidate_artifact_hash", self.candidate_artifact_hash),
+            ("frozen_base_hash_before", self.frozen_base_hash_before),
+            ("frozen_base_hash_after", self.frozen_base_hash_after),
+            ("matched_exam_hash", self.matched_exam_hash),
+        ):
+            _require_hash(label, value)
+        if self.parent_artifact_hash == self.candidate_artifact_hash:
+            raise ValueError("residual candidate must be a new artifact")
+        if min(self.examined_frozen_parameter_count, self.examined_trainable_parameter_count) <= 0:
+            raise ValueError("parameter-isolation evidence must inspect both scopes")
+        if self.candidate_world_steps <= 0:
+            raise ValueError("candidate_world_steps must be positive")
+        if self.critical_safety_regressions < 0:
+            raise ValueError("critical_safety_regressions must be non-negative")
+        for label, numeric_value in (
+            ("maximum_frozen_parameter_drift", self.maximum_frozen_parameter_drift),
+            ("residual_output_rms", self.residual_output_rms),
+        ):
+            if not math.isfinite(numeric_value) or numeric_value < 0.0:
+                raise ValueError(f"{label} must be finite and non-negative")
+        if not self.sim_only:
+            raise ValueError("parameter-isolation evidence is SIM_ONLY")
+
+    def passes(self, contract: ResidualAdaptationContract) -> bool:
+        """Fail closed unless identity, isolation, safety, and both suites pass."""
+
+        return bool(
+            self.adaptation_contract_hash == contract.contract_hash
+            and self.parent_artifact_hash == contract.parent_artifact_hash
+            and self.frozen_base_hash_before == self.frozen_base_hash_after
+            and self.maximum_frozen_parameter_drift <= contract.maximum_frozen_parameter_drift
+            and self.residual_output_rms <= contract.maximum_residual_output_rms
+            and self.candidate_world_steps <= contract.maximum_world_steps
+            and self.retention_passed
+            and self.acquisition_passed
+            and self.critical_safety_regressions == 0
+        )
+
+    @property
+    def evidence_hash(self) -> str:
+        return canonical_hash(asdict(self))
+
+
+def write_residual_adaptation_contract(
+    contract: ResidualAdaptationContract, output_path: Path
+) -> dict[str, Any]:
+    """Atomically seal a new residual-learning contract before evaluation."""
+
+    output = output_path.expanduser().resolve()
+    if output.suffix != ".json" or output.exists():
+        raise ValueError("residual adaptation contract requires a new JSON output")
+    payload = contract.to_dict()
+    payload["contract_hash"] = contract.contract_hash
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, output)
+    return payload
+
+
+def load_residual_adaptation_contract(path: Path) -> ResidualAdaptationContract:
+    """Load and verify a previously sealed residual-learning contract."""
+
+    payload = json.loads(path.expanduser().resolve().read_text(encoding="utf-8"))
+    expected = set(ResidualAdaptationContract.__dataclass_fields__) | {"contract_hash"}
+    if not isinstance(payload, dict) or set(payload) != expected:
+        raise ValueError("residual adaptation contract fields are incomplete")
+    expected_hash = payload.pop("contract_hash")
+    for key in (
+        "frozen_parameter_selectors",
+        "trainable_parameter_selectors",
+        "device_ids",
+    ):
+        if not isinstance(payload[key], list):
+            raise ValueError("residual adaptation contract tuple field must be a list")
+        payload[key] = tuple(payload[key])
+    contract = ResidualAdaptationContract(**payload)
+    if expected_hash != contract.contract_hash:
+        raise ValueError("residual adaptation contract hash does not match its contents")
+    return contract
+
+
+__all__ = [
+    "ParameterIsolationEvidence",
+    "ResidualAdaptationContract",
+    "load_residual_adaptation_contract",
+    "write_residual_adaptation_contract",
+]

--- a/src/rosclaw/continual/safety_profiles.py
+++ b/src/rosclaw/continual/safety_profiles.py
@@ -1,0 +1,258 @@
+"""Separate simulation exploration permission from promotion evidence.
+
+Exploration may admit declared contact-rich behavior to discover a skill, but
+it never grants activation authority.  Promotion remains fail-closed and may
+use a strictly tighter envelope.  Non-finite state, prohibited contacts and
+unrealistic actuator commands are hard failures in both modes.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+
+
+class GrowthSafetyUse(StrEnum):
+    EXPLORATION_SIM = "EXPLORATION_SIM"
+    PROMOTION_SIM = "PROMOTION_SIM"
+
+
+@dataclass(frozen=True)
+class GrowthSafetyProfile:
+    profile_id: str
+    use: GrowthSafetyUse
+    maximum_joint_limit_excess_rad: float
+    maximum_normalized_actuator_command: float
+    maximum_head_impact_speed_mps: float
+    maximum_root_angular_speed_rad_s: float
+    maximum_self_penetration_m: float
+    always_allowed_contacts: tuple[str, ...]
+    hard_fail_contacts: tuple[str, ...]
+    phase_contact_permissions: Mapping[str, tuple[str, ...]]
+    activation_ceiling: str = "SIM_ONLY"
+    hardware_authorized: bool = False
+    schema_version: str = "rosclaw.continual.growth_safety_profile.v1"
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.profile_id):
+            raise ValueError("growth safety profile id is invalid")
+        thresholds = (
+            self.maximum_joint_limit_excess_rad,
+            self.maximum_normalized_actuator_command,
+            self.maximum_head_impact_speed_mps,
+            self.maximum_root_angular_speed_rad_s,
+            self.maximum_self_penetration_m,
+        )
+        if (
+            any(not math.isfinite(value) or value < 0.0 for value in thresholds)
+            or self.maximum_normalized_actuator_command <= 0.0
+            or self.activation_ceiling != "SIM_ONLY"
+            or self.hardware_authorized
+        ):
+            raise ValueError("growth safety thresholds or authority are invalid")
+        allowed = _identifiers(self.always_allowed_contacts, label="always allowed contacts")
+        hard = _identifiers(self.hard_fail_contacts, label="hard-fail contacts")
+        if set(allowed) & set(hard):
+            raise ValueError("a contact cannot be both allowed and hard-fail")
+        permissions: dict[str, tuple[str, ...]] = {}
+        for raw_phase, raw_contacts in self.phase_contact_permissions.items():
+            phase = str(raw_phase)
+            if not _IDENTIFIER.fullmatch(phase):
+                raise ValueError("growth safety phase is invalid")
+            contacts = _identifiers(raw_contacts, label="phase contacts")
+            if set(contacts) & set(hard):
+                raise ValueError("phase permissions cannot override hard-fail contacts")
+            permissions[phase] = contacts
+        if not permissions:
+            raise ValueError("growth safety profile requires phase permissions")
+        object.__setattr__(self, "always_allowed_contacts", allowed)
+        object.__setattr__(self, "hard_fail_contacts", hard)
+        object.__setattr__(
+            self,
+            "phase_contact_permissions",
+            MappingProxyType(dict(sorted(permissions.items()))),
+        )
+
+    @property
+    def profile_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "profile_id": self.profile_id,
+            "use": self.use.value,
+            "maximum_joint_limit_excess_rad": self.maximum_joint_limit_excess_rad,
+            "maximum_normalized_actuator_command": self.maximum_normalized_actuator_command,
+            "maximum_head_impact_speed_mps": self.maximum_head_impact_speed_mps,
+            "maximum_root_angular_speed_rad_s": self.maximum_root_angular_speed_rad_s,
+            "maximum_self_penetration_m": self.maximum_self_penetration_m,
+            "always_allowed_contacts": list(self.always_allowed_contacts),
+            "hard_fail_contacts": list(self.hard_fail_contacts),
+            "phase_contact_permissions": {
+                phase: list(contacts) for phase, contacts in self.phase_contact_permissions.items()
+            },
+            "activation_ceiling": self.activation_ceiling,
+            "hardware_authorized": self.hardware_authorized,
+        }
+
+
+@dataclass(frozen=True)
+class GrowthSafetyObservation:
+    phase: str
+    finite_state: bool
+    joint_limit_excess_rad: float
+    normalized_actuator_command: float
+    head_impact_speed_mps: float
+    root_angular_speed_rad_s: float
+    self_penetration_m: float
+    contacts: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.phase) or not isinstance(self.finite_state, bool):
+            raise ValueError("growth safety observation identity is invalid")
+        values = (
+            self.joint_limit_excess_rad,
+            self.normalized_actuator_command,
+            self.head_impact_speed_mps,
+            self.root_angular_speed_rad_s,
+            self.self_penetration_m,
+        )
+        if any(not math.isfinite(value) or value < 0.0 for value in values):
+            raise ValueError("growth safety observation must contain finite non-negative values")
+        contacts = _identifiers(self.contacts, label="observed contacts")
+        object.__setattr__(self, "contacts", contacts)
+
+
+@dataclass(frozen=True)
+class GrowthSafetyDecision:
+    profile_hash: str
+    passed: bool
+    promotion_eligible: bool
+    hard_failure: bool
+    reasons: tuple[str, ...]
+    schema_version: str = "rosclaw.continual.growth_safety_decision.v1"
+
+
+def evaluate_growth_safety(
+    profile: GrowthSafetyProfile,
+    observation: GrowthSafetyObservation,
+) -> GrowthSafetyDecision:
+    reasons: list[str] = []
+    if not observation.finite_state:
+        reasons.append("NON_FINITE_STATE")
+    thresholds = (
+        (
+            observation.joint_limit_excess_rad,
+            profile.maximum_joint_limit_excess_rad,
+            "JOINT_LIMIT_EXCESS",
+        ),
+        (
+            observation.normalized_actuator_command,
+            profile.maximum_normalized_actuator_command,
+            "ACTUATOR_COMMAND_EXCESS",
+        ),
+        (
+            observation.head_impact_speed_mps,
+            profile.maximum_head_impact_speed_mps,
+            "HEAD_IMPACT_EXCESS",
+        ),
+        (
+            observation.root_angular_speed_rad_s,
+            profile.maximum_root_angular_speed_rad_s,
+            "ROOT_ANGULAR_SPEED_EXCESS",
+        ),
+        (
+            observation.self_penetration_m,
+            profile.maximum_self_penetration_m,
+            "SELF_PENETRATION_EXCESS",
+        ),
+    )
+    reasons.extend(label for value, maximum, label in thresholds if value > maximum)
+    hard_contacts = set(observation.contacts) & set(profile.hard_fail_contacts)
+    if hard_contacts:
+        reasons.append("HARD_CONTACT:" + ",".join(sorted(hard_contacts)))
+    permitted = set(profile.always_allowed_contacts)
+    permitted.update(profile.phase_contact_permissions.get(observation.phase, ()))
+    undeclared = set(observation.contacts) - permitted - set(profile.hard_fail_contacts)
+    if undeclared:
+        reasons.append("UNDECLARED_CONTACT:" + ",".join(sorted(undeclared)))
+    passed = not reasons
+    return GrowthSafetyDecision(
+        profile_hash=profile.profile_hash,
+        passed=passed,
+        promotion_eligible=bool(passed and profile.use is GrowthSafetyUse.PROMOTION_SIM),
+        hard_failure=not passed,
+        reasons=tuple(reasons),
+    )
+
+
+def validate_profile_pair(
+    exploration: GrowthSafetyProfile,
+    promotion: GrowthSafetyProfile,
+) -> None:
+    """Require promotion to be at least as strict as exploration."""
+
+    if (
+        exploration.use is not GrowthSafetyUse.EXPLORATION_SIM
+        or promotion.use is not GrowthSafetyUse.PROMOTION_SIM
+    ):
+        raise ValueError("growth safety pair has incorrect uses")
+    exploration_thresholds = (
+        exploration.maximum_joint_limit_excess_rad,
+        exploration.maximum_normalized_actuator_command,
+        exploration.maximum_head_impact_speed_mps,
+        exploration.maximum_root_angular_speed_rad_s,
+        exploration.maximum_self_penetration_m,
+    )
+    promotion_thresholds = (
+        promotion.maximum_joint_limit_excess_rad,
+        promotion.maximum_normalized_actuator_command,
+        promotion.maximum_head_impact_speed_mps,
+        promotion.maximum_root_angular_speed_rad_s,
+        promotion.maximum_self_penetration_m,
+    )
+    if any(
+        promotion_value > exploration_value
+        for exploration_value, promotion_value in zip(
+            exploration_thresholds,
+            promotion_thresholds,
+            strict=True,
+        )
+    ):
+        raise ValueError("promotion safety thresholds cannot be looser than exploration")
+    for phase, contacts in promotion.phase_contact_permissions.items():
+        if not set(contacts).issubset(exploration.phase_contact_permissions.get(phase, ())):
+            raise ValueError("promotion phase contacts must be a subset of exploration")
+    if not set(promotion.always_allowed_contacts).issubset(exploration.always_allowed_contacts):
+        raise ValueError("promotion always-allowed contacts must be a subset of exploration")
+    if not set(exploration.hard_fail_contacts).issubset(promotion.hard_fail_contacts):
+        raise ValueError("promotion cannot remove exploration hard-fail contacts")
+
+
+def _identifiers(values: tuple[str, ...], *, label: str) -> tuple[str, ...]:
+    normalized = tuple(str(value) for value in values)
+    if len(normalized) != len(set(normalized)) or any(
+        not _IDENTIFIER.fullmatch(value) for value in normalized
+    ):
+        raise ValueError(f"{label} must be unique normalized identifiers")
+    return normalized
+
+
+__all__ = [
+    "GrowthSafetyDecision",
+    "GrowthSafetyObservation",
+    "GrowthSafetyProfile",
+    "GrowthSafetyUse",
+    "evaluate_growth_safety",
+    "validate_profile_pair",
+]

--- a/src/rosclaw/continual/successor_state.py
+++ b/src/rosclaw/continual/successor_state.py
@@ -1,0 +1,286 @@
+"""Task-independent successor-state contracts for composable physical skills.
+
+A skill is not complete merely because its local event succeeded.  Its final
+physical state must remain inside the declared entry envelope of the next
+skill for a continuous hold window.  These contracts make that boundary
+content-addressed and machine-testable without putting task vocabulary in the
+ROSClaw core.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class SuccessorMetricSpec:
+    """One observable interval required by a successor skill."""
+
+    name: str
+    minimum: float | None = None
+    maximum: float | None = None
+    critical: bool = True
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.name):
+            raise ValueError("successor metric name must be a normalized identifier")
+        if self.minimum is None and self.maximum is None:
+            raise ValueError("successor metric requires at least one bound")
+        bounds = tuple(value for value in (self.minimum, self.maximum) if value is not None)
+        if any(not math.isfinite(value) for value in bounds):
+            raise ValueError("successor metric bounds must be finite")
+        if self.minimum is not None and self.maximum is not None and self.minimum > self.maximum:
+            raise ValueError("successor metric minimum cannot exceed maximum")
+
+    def accepts(self, value: float) -> bool:
+        return bool(
+            math.isfinite(value)
+            and (self.minimum is None or value >= self.minimum)
+            and (self.maximum is None or value <= self.maximum)
+        )
+
+    def margin(self, value: float) -> float:
+        if not math.isfinite(value):
+            return float("-inf")
+        margins = []
+        if self.minimum is not None:
+            margins.append(value - self.minimum)
+        if self.maximum is not None:
+            margins.append(self.maximum - value)
+        return min(margins)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "minimum": self.minimum,
+            "maximum": self.maximum,
+            "critical": self.critical,
+        }
+
+
+@dataclass(frozen=True)
+class SkillSuccessorState:
+    """Immutable entry envelope connecting two physical skills."""
+
+    contract_id: str
+    source_skill_id: str
+    successor_skill_id: str
+    source_policy_hash: str
+    successor_policy_hash: str
+    body_hash: str
+    metrics: tuple[SuccessorMetricSpec, ...]
+    hold_steps: int
+    maximum_transition_steps: int
+    control_period_s: float
+    evidence_domain: str = "SIM"
+    schema_version: str = "rosclaw.continual.skill_successor_state.v1"
+
+    def __post_init__(self) -> None:
+        for value in (self.contract_id, self.source_skill_id, self.successor_skill_id):
+            if not _IDENTIFIER.fullmatch(value):
+                raise ValueError("successor-state identifiers must be normalized")
+        for value in (self.source_policy_hash, self.successor_policy_hash, self.body_hash):
+            if not _SHA256.fullmatch(value):
+                raise ValueError("successor-state identities must be sha256 content hashes")
+        names = tuple(metric.name for metric in self.metrics)
+        if not self.metrics or len(names) != len(set(names)):
+            raise ValueError("successor-state metrics must be non-empty and unique")
+        if (
+            self.hold_steps <= 0
+            or self.maximum_transition_steps < self.hold_steps
+            or not math.isfinite(self.control_period_s)
+            or not 0.001 <= self.control_period_s <= 1.0
+            or self.evidence_domain != "SIM"
+        ):
+            raise ValueError("successor-state timing or evidence domain is invalid")
+
+    @property
+    def contract_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "contract_id": self.contract_id,
+            "source_skill_id": self.source_skill_id,
+            "successor_skill_id": self.successor_skill_id,
+            "source_policy_hash": self.source_policy_hash,
+            "successor_policy_hash": self.successor_policy_hash,
+            "body_hash": self.body_hash,
+            "metrics": [metric.to_dict() for metric in self.metrics],
+            "hold_steps": self.hold_steps,
+            "maximum_transition_steps": self.maximum_transition_steps,
+            "control_period_s": self.control_period_s,
+            "evidence_domain": self.evidence_domain,
+        }
+
+
+@dataclass(frozen=True)
+class SuccessorStateSample:
+    step: int
+    values: Mapping[str, float]
+
+    def __post_init__(self) -> None:
+        normalized = {str(name): float(value) for name, value in self.values.items()}
+        if (
+            self.step < 0
+            or not normalized
+            or any(
+                not _IDENTIFIER.fullmatch(name) or not math.isfinite(value)
+                for name, value in normalized.items()
+            )
+        ):
+            raise ValueError("successor-state sample must be finite and normalized")
+        object.__setattr__(self, "values", MappingProxyType(normalized))
+
+
+@dataclass(frozen=True)
+class SuccessorStateEvaluation:
+    contract_hash: str
+    achieved: bool
+    timed_out: bool
+    consecutive_hold_steps: int
+    entry_step: int | None
+    achieved_step: int | None
+    transition_time_s: float | None
+    failed_metrics: tuple[str, ...]
+    metric_margins: Mapping[str, float]
+    schema_version: str = "rosclaw.continual.successor_state_evaluation.v1"
+
+    def __post_init__(self) -> None:
+        if not _SHA256.fullmatch(self.contract_hash):
+            raise ValueError("successor evaluation requires a contract hash")
+        margins = {str(name): float(value) for name, value in self.metric_margins.items()}
+        if any(
+            not _IDENTIFIER.fullmatch(name) or math.isnan(value) for name, value in margins.items()
+        ):
+            raise ValueError("successor evaluation margins are invalid")
+        object.__setattr__(self, "metric_margins", MappingProxyType(margins))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "contract_hash": self.contract_hash,
+            "achieved": self.achieved,
+            "timed_out": self.timed_out,
+            "consecutive_hold_steps": self.consecutive_hold_steps,
+            "entry_step": self.entry_step,
+            "achieved_step": self.achieved_step,
+            "transition_time_s": self.transition_time_s,
+            "failed_metrics": list(self.failed_metrics),
+            "metric_margins": dict(self.metric_margins),
+        }
+
+
+class SuccessorStateTracker:
+    """Causal continuous-hold evaluator for one successor-state contract."""
+
+    def __init__(self, contract: SkillSuccessorState) -> None:
+        self.contract = contract
+        self._start_step: int | None = None
+        self._last_step: int | None = None
+        self._hold = 0
+        self._entry_step: int | None = None
+        self._achieved_step: int | None = None
+
+    def update(self, sample: SuccessorStateSample) -> SuccessorStateEvaluation:
+        expected_names = tuple(metric.name for metric in self.contract.metrics)
+        if tuple(sample.values) != expected_names:
+            raise ValueError("successor sample order must match the frozen contract")
+        if self._last_step is not None and sample.step != self._last_step + 1:
+            raise ValueError("successor samples must be contiguous")
+        if self._start_step is None:
+            self._start_step = sample.step
+        self._last_step = sample.step
+
+        margins = {
+            metric.name: metric.margin(sample.values[metric.name])
+            for metric in self.contract.metrics
+        }
+        failed = tuple(
+            metric.name
+            for metric in self.contract.metrics
+            if not metric.accepts(sample.values[metric.name])
+        )
+        if not failed and self._achieved_step is None:
+            self._hold += 1
+            if self._hold == 1:
+                self._entry_step = sample.step
+            if self._hold >= self.contract.hold_steps:
+                self._achieved_step = sample.step
+        elif self._achieved_step is None:
+            self._hold = 0
+            self._entry_step = None
+
+        assert self._start_step is not None
+        elapsed_steps = sample.step - self._start_step + 1
+        timed_out = bool(
+            self._achieved_step is None and elapsed_steps >= self.contract.maximum_transition_steps
+        )
+        transition_time_s = (
+            None
+            if self._achieved_step is None
+            else (self._achieved_step - self._start_step + 1) * self.contract.control_period_s
+        )
+        return SuccessorStateEvaluation(
+            contract_hash=self.contract.contract_hash,
+            achieved=self._achieved_step is not None,
+            timed_out=timed_out,
+            consecutive_hold_steps=self._hold,
+            entry_step=self._entry_step,
+            achieved_step=self._achieved_step,
+            transition_time_s=transition_time_s,
+            failed_metrics=failed,
+            metric_margins=margins,
+        )
+
+
+@dataclass(frozen=True)
+class SuccessorStateGrowthObjective:
+    """Makes the next skill's value explicit in the current skill objective."""
+
+    task_weight: float = 1.0
+    successor_value_weight: float = 0.25
+    transition_cost_weight: float = 1.0
+    schema_version: str = "rosclaw.continual.successor_state_growth_objective.v1"
+
+    def __post_init__(self) -> None:
+        values = (self.task_weight, self.successor_value_weight, self.transition_cost_weight)
+        if any(not math.isfinite(value) or value < 0.0 for value in values) or not any(values):
+            raise ValueError("successor-state objective weights must be finite and non-negative")
+
+    def score(
+        self,
+        *,
+        task_return: float,
+        successor_value: float,
+        transition_cost: float = 0.0,
+    ) -> float:
+        values = (task_return, successor_value, transition_cost)
+        if any(not math.isfinite(value) for value in values) or transition_cost < 0.0:
+            raise ValueError("successor-state objective inputs are invalid")
+        return (
+            self.task_weight * task_return
+            + self.successor_value_weight * successor_value
+            - self.transition_cost_weight * transition_cost
+        )
+
+
+__all__ = [
+    "SkillSuccessorState",
+    "SuccessorMetricSpec",
+    "SuccessorStateEvaluation",
+    "SuccessorStateGrowthObjective",
+    "SuccessorStateSample",
+    "SuccessorStateTracker",
+]

--- a/src/rosclaw/continual/teacher_manifold.py
+++ b/src/rosclaw/continual/teacher_manifold.py
@@ -1,0 +1,174 @@
+"""Generic stability-plasticity gates around immutable teacher manifolds."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+
+
+@dataclass(frozen=True)
+class TeacherManifoldMetric:
+    """One normalized deployable signal used to measure teacher novelty."""
+
+    name: str
+    scale: float
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.name):
+            raise ValueError("teacher-manifold metric name must be a normalized identifier")
+        if (
+            not math.isfinite(self.scale)
+            or self.scale <= 0.0
+            or not math.isfinite(self.weight)
+            or self.weight <= 0.0
+        ):
+            raise ValueError("teacher-manifold metric scale and weight must be finite and positive")
+
+
+@dataclass(frozen=True)
+class TeacherManifoldDecision:
+    """Content-bound continuous permission for a residual learner."""
+
+    gate_contract_hash: str
+    normalized_distance: float
+    plasticity_fraction: float
+    inside_retention_core: bool
+    fully_plastic: bool
+    schema_version: str = "rosclaw.continual.teacher_manifold_decision.v1"
+
+    def __post_init__(self) -> None:
+        if not _SHA256.fullmatch(self.gate_contract_hash):
+            raise ValueError("teacher-manifold decision requires a gate contract hash")
+        if not math.isfinite(self.normalized_distance) or self.normalized_distance < 0.0:
+            raise ValueError("teacher-manifold distance must be finite and non-negative")
+        if (
+            not math.isfinite(self.plasticity_fraction)
+            or not 0.0 <= self.plasticity_fraction <= 1.0
+        ):
+            raise ValueError("teacher-manifold plasticity fraction must be in [0, 1]")
+        if self.inside_retention_core != (self.plasticity_fraction == 0.0):
+            raise ValueError("teacher-manifold retention-core decision is inconsistent")
+        if self.fully_plastic != (self.plasticity_fraction == 1.0):
+            raise ValueError("teacher-manifold full-plasticity decision is inconsistent")
+
+    @property
+    def decision_hash(self) -> str:
+        return canonical_hash(asdict(self))
+
+
+@dataclass(frozen=True)
+class TeacherManifoldGateContract:
+    """Seal how novelty opens learning without rewriting a known teacher.
+
+    The caller supplies deployable scalar signals for the current and reference
+    states.  The contract computes a weighted normalized RMS distance and maps
+    it continuously to a plasticity fraction.  It grants training permission
+    only; it never promotes or executes a policy.
+    """
+
+    gate_id: str
+    teacher_artifact_hash: str
+    body_hash: str
+    metrics: tuple[TeacherManifoldMetric, ...]
+    retention_core_radius: float
+    full_plasticity_radius: float
+    activation_ceiling: str = "SIM_ONLY"
+    hardware_execution_allowed: bool = False
+    promotion_authority: str = "NONE"
+    schema_version: str = "rosclaw.continual.teacher_manifold_gate.v1"
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.gate_id):
+            raise ValueError("teacher-manifold gate id must be a normalized identifier")
+        for label, value in (
+            ("teacher_artifact_hash", self.teacher_artifact_hash),
+            ("body_hash", self.body_hash),
+        ):
+            if not _SHA256.fullmatch(value):
+                raise ValueError(f"{label} must be a sha256 content hash")
+        names = tuple(metric.name for metric in self.metrics)
+        if not self.metrics or len(names) != len(set(names)):
+            raise ValueError("teacher-manifold metrics must be non-empty and unique")
+        if (
+            not math.isfinite(self.retention_core_radius)
+            or not math.isfinite(self.full_plasticity_radius)
+            or not 0.0 <= self.retention_core_radius < self.full_plasticity_radius
+        ):
+            raise ValueError("teacher-manifold radii must be finite and ordered")
+        if (
+            self.activation_ceiling != "SIM_ONLY"
+            or self.hardware_execution_allowed
+            or self.promotion_authority != "NONE"
+        ):
+            raise ValueError("teacher-manifold gates grant SIM_ONLY training permission only")
+
+    @property
+    def contract_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def evaluate(
+        self,
+        current: Mapping[str, float],
+        reference: Mapping[str, float],
+    ) -> TeacherManifoldDecision:
+        """Fail closed on missing/non-finite signals and return bounded permission."""
+
+        expected = {metric.name for metric in self.metrics}
+        if set(current) != expected or set(reference) != expected:
+            raise ValueError("teacher-manifold observations must match contracted metrics exactly")
+        squared_distance = 0.0
+        total_weight = 0.0
+        for metric in self.metrics:
+            current_value = float(current[metric.name])
+            reference_value = float(reference[metric.name])
+            if not math.isfinite(current_value) or not math.isfinite(reference_value):
+                raise ValueError("teacher-manifold observations must be finite")
+            delta = (current_value - reference_value) / metric.scale
+            squared_distance += metric.weight * delta * delta
+            total_weight += metric.weight
+        distance = math.sqrt(squared_distance / total_weight)
+        fraction = min(
+            1.0,
+            max(
+                0.0,
+                (distance - self.retention_core_radius)
+                / (self.full_plasticity_radius - self.retention_core_radius),
+            ),
+        )
+        return TeacherManifoldDecision(
+            gate_contract_hash=self.contract_hash,
+            normalized_distance=distance,
+            plasticity_fraction=fraction,
+            inside_retention_core=fraction == 0.0,
+            fully_plastic=fraction == 1.0,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "gate_id": self.gate_id,
+            "teacher_artifact_hash": self.teacher_artifact_hash,
+            "body_hash": self.body_hash,
+            "metrics": [asdict(metric) for metric in self.metrics],
+            "retention_core_radius": self.retention_core_radius,
+            "full_plasticity_radius": self.full_plasticity_radius,
+            "activation_ceiling": self.activation_ceiling,
+            "hardware_execution_allowed": self.hardware_execution_allowed,
+            "promotion_authority": self.promotion_authority,
+        }
+
+
+__all__ = [
+    "TeacherManifoldDecision",
+    "TeacherManifoldGateContract",
+    "TeacherManifoldMetric",
+]

--- a/src/rosclaw/continual/teacher_prior.py
+++ b/src/rosclaw/continual/teacher_prior.py
@@ -1,0 +1,134 @@
+"""Generic train-only contracts for condition-selectable teacher priors."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from rosclaw.feedback.contracts import canonical_hash
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IDENTIFIER = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$")
+
+
+@dataclass(frozen=True)
+class ConditionalTeacherQuery:
+    """One fully specified teacher selection bound to an immutable prior."""
+
+    prior_contract_hash: str
+    condition_values: Mapping[str, str]
+    schema_version: str = "rosclaw.continual.conditional_teacher_query.v1"
+
+    def __post_init__(self) -> None:
+        if not _SHA256.fullmatch(self.prior_contract_hash):
+            raise ValueError("teacher query requires a prior contract hash")
+        values = {str(key): str(value) for key, value in self.condition_values.items()}
+        if not values or any(
+            not _IDENTIFIER.fullmatch(key) or not _IDENTIFIER.fullmatch(value)
+            for key, value in values.items()
+        ):
+            raise ValueError("teacher query conditions must be normalized identifiers")
+        object.__setattr__(self, "condition_values", MappingProxyType(dict(sorted(values.items()))))
+
+    @property
+    def query_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "prior_contract_hash": self.prior_contract_hash,
+            "condition_values": dict(self.condition_values),
+        }
+
+
+@dataclass(frozen=True)
+class ConditionalTeacherPriorContract:
+    """A teacher that is selected by task/condition rather than fixed phase."""
+
+    prior_id: str
+    artifact_hash: str
+    body_hash: str
+    observation_names: tuple[str, ...]
+    output_names: tuple[str, ...]
+    condition_vocabulary: Mapping[str, tuple[str, ...]]
+    training_use_only: bool = True
+    deployed_actor_depends_on_teacher: bool = False
+    schema_version: str = "rosclaw.continual.conditional_teacher_prior.v1"
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.prior_id):
+            raise ValueError("teacher prior id must be a normalized identifier")
+        for label, value in (("artifact_hash", self.artifact_hash), ("body_hash", self.body_hash)):
+            if not _SHA256.fullmatch(value):
+                raise ValueError(f"{label} must be a sha256 content hash")
+        for label, names in (
+            ("observation_names", self.observation_names),
+            ("output_names", self.output_names),
+        ):
+            if (
+                not names
+                or len(names) != len(set(names))
+                or any(not _IDENTIFIER.fullmatch(name) for name in names)
+            ):
+                raise ValueError(f"{label} must contain unique normalized names")
+        vocabulary: dict[str, tuple[str, ...]] = {}
+        for raw_key, raw_values in self.condition_vocabulary.items():
+            key = str(raw_key)
+            values = tuple(str(value) for value in raw_values)
+            if (
+                not _IDENTIFIER.fullmatch(key)
+                or not values
+                or len(values) != len(set(values))
+                or any(not _IDENTIFIER.fullmatch(value) for value in values)
+            ):
+                raise ValueError("teacher condition vocabulary is invalid")
+            vocabulary[key] = values
+        if not vocabulary:
+            raise ValueError("conditional teacher requires at least one condition")
+        if not self.training_use_only or self.deployed_actor_depends_on_teacher:
+            raise ValueError("teacher priors must remain train-only deployment aids")
+        object.__setattr__(
+            self,
+            "condition_vocabulary",
+            MappingProxyType(dict(sorted(vocabulary.items()))),
+        )
+
+    @property
+    def contract_hash(self) -> str:
+        return canonical_hash(self.to_dict())
+
+    def query(self, condition_values: Mapping[str, str]) -> ConditionalTeacherQuery:
+        values = {str(key): str(value) for key, value in condition_values.items()}
+        if set(values) != set(self.condition_vocabulary):
+            raise ValueError("teacher query must set every condition exactly once")
+        invalid = tuple(
+            key for key, value in values.items() if value not in self.condition_vocabulary[key]
+        )
+        if invalid:
+            raise ValueError("teacher query uses values outside the frozen vocabulary")
+        return ConditionalTeacherQuery(
+            prior_contract_hash=self.contract_hash,
+            condition_values=values,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "prior_id": self.prior_id,
+            "artifact_hash": self.artifact_hash,
+            "body_hash": self.body_hash,
+            "observation_names": list(self.observation_names),
+            "output_names": list(self.output_names),
+            "condition_vocabulary": {
+                key: list(values) for key, values in self.condition_vocabulary.items()
+            },
+            "training_use_only": self.training_use_only,
+            "deployed_actor_depends_on_teacher": self.deployed_actor_depends_on_teacher,
+        }
+
+
+__all__ = ["ConditionalTeacherPriorContract", "ConditionalTeacherQuery"]

--- a/tests/agentd/test_p1b3_ros2_action_live.py
+++ b/tests/agentd/test_p1b3_ros2_action_live.py
@@ -103,10 +103,10 @@ class FakeRosbridgeActionServer:
         server = getattr(self, "_server", None)
         if server is not None:
             self._loop.call_soon_threadsafe(server.close)
-            deadline = time.monotonic() + 5
-            while self._thread.is_alive() and time.monotonic() < deadline:
+            self._thread.join(timeout=5)
+            if self._thread.is_alive():
                 self._loop.call_soon_threadsafe(self._loop.stop)
-                self._thread.join(timeout=0.5)
+                self._thread.join(timeout=1)
         else:
             self._loop.call_soon_threadsafe(self._loop.stop)
 
@@ -158,6 +158,16 @@ class TestRos2ActionLiveJourney:
                     client=client,
                 )
                 await mgr.cancel(op2["operation_id"], reason="journey-stop")
+                # Keep the request loop alive until the listener callback or
+                # bounded cancel grace commits the terminal state.  Closing
+                # asyncio.run immediately after cancel races a valid callback
+                # against loop shutdown under full-suite load.
+                deadline = asyncio.get_running_loop().time() + 10.0
+                while (
+                    mgr.get(op2["operation_id"])["state"] != "CANCELLED"
+                    and asyncio.get_running_loop().time() < deadline
+                ):
+                    await asyncio.sleep(0.05)
                 return op
 
             op = asyncio.run(run())

--- a/tests/continual/test_champion_registry.py
+++ b/tests/continual/test_champion_registry.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from rosclaw.continual.champion_registry import (
+    CanonicalChampionRegistry,
+    ChampionRecordKind,
+    ChampionRegistryRecord,
+    PromotionAuthority,
+)
+from tests.continual.helpers import digest
+
+
+def _baseline(*, track_id: str = "global") -> ChampionRegistryRecord:
+    return ChampionRegistryRecord(
+        agent_id="agent.goalkeeper",
+        track_id=track_id,
+        artifact_hash=digest(f"{track_id}:baseline"),
+        evidence_hash=digest(f"{track_id}:evidence"),
+        scenario_suite_hash=digest("suite"),
+        authority=(
+            PromotionAuthority.BASELINE_STRICT_EXAM
+            if track_id == "global"
+            else PromotionAuthority.SEALED_SPECIALIST_EXAM
+        ),
+        kind=(
+            ChampionRecordKind.GLOBAL_BASELINE
+            if track_id == "global"
+            else ChampionRecordKind.SPECIALIST_BASELINE
+        ),
+        evidence_valid=True,
+        promotion_passed=True,
+        generation=0,
+    )
+
+
+def _child(parent: ChampionRegistryRecord, *, promoted: bool) -> ChampionRegistryRecord:
+    return ChampionRegistryRecord(
+        agent_id=parent.agent_id,
+        track_id=parent.track_id,
+        artifact_hash=digest(f"candidate:{promoted}"),
+        evidence_hash=digest(f"candidate-evidence:{promoted}"),
+        scenario_suite_hash=parent.scenario_suite_hash,
+        authority=PromotionAuthority.PAIRED_DOMINANCE,
+        kind=(
+            ChampionRecordKind.TRACK_REPLACEMENT
+            if promoted
+            else ChampionRecordKind.CANDIDATE_ARCHIVED
+        ),
+        evidence_valid=True,
+        promotion_passed=promoted,
+        generation=parent.generation + 1,
+        parent_record_hash=parent.record_hash,
+        parent_artifact_hash=parent.artifact_hash,
+    )
+
+
+def test_archived_candidate_does_not_move_the_active_head() -> None:
+    baseline = _baseline()
+    archive = _child(baseline, promoted=False)
+    registry = CanonicalChampionRegistry().append(baseline).append(archive)
+
+    assert registry.active_head("global") == baseline
+    assert registry.audit_parent_claim(
+        track_id="global", claimed_parent_artifact_hash=baseline.artifact_hash
+    ).valid
+
+
+def test_stale_rejected_parent_cannot_spawn_a_new_global_candidate() -> None:
+    baseline = _baseline()
+    archive = _child(baseline, promoted=False)
+    registry = CanonicalChampionRegistry((baseline, archive))
+    stale_child = replace(
+        _child(archive, promoted=True),
+        artifact_hash=digest("stale-descendant"),
+        generation=archive.generation + 1,
+    )
+
+    audit = registry.audit_parent_claim(
+        track_id="global", claimed_parent_artifact_hash=archive.artifact_hash
+    )
+    assert not audit.valid
+    assert audit.reasons == ("parent_not_active_track_head",)
+    with pytest.raises(ValueError, match="active track head"):
+        registry.append(stale_child)
+
+
+def test_valid_replacement_advances_track_and_specialist_is_isolated() -> None:
+    baseline = _baseline()
+    replacement = _child(baseline, promoted=True)
+    specialist = replace(
+        _baseline(track_id="goalkeeper.arm.elite"),
+        source_parent_artifact_hash=baseline.artifact_hash,
+    )
+    registry = CanonicalChampionRegistry().append(baseline).append(replacement).append(specialist)
+
+    assert registry.active_head("global") == replacement
+    assert registry.active_head("goalkeeper.arm.elite") == specialist
+    assert registry.registry_hash.startswith("sha256:")
+
+
+def test_registry_rejects_unqualified_baseline_and_duplicate_artifact() -> None:
+    with pytest.raises(ValueError, match="valid, passing"):
+        replace(_baseline(), promotion_passed=False)
+    baseline = _baseline()
+    with pytest.raises(ValueError, match="already recorded"):
+        CanonicalChampionRegistry((baseline, replace(baseline, evidence_hash=digest("other"))))

--- a/tests/continual/test_champion_registry.py
+++ b/tests/continual/test_champion_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import Any, cast
 
 import pytest
 
@@ -8,6 +9,9 @@ from rosclaw.continual.champion_registry import (
     CanonicalChampionRegistry,
     ChampionRecordKind,
     ChampionRegistryRecord,
+    DominanceMetricRole,
+    PairedDominanceEvidence,
+    PairedDominanceMetric,
     PromotionAuthority,
 )
 from tests.continual.helpers import digest
@@ -107,3 +111,79 @@ def test_registry_rejects_unqualified_baseline_and_duplicate_artifact() -> None:
     baseline = _baseline()
     with pytest.raises(ValueError, match="already recorded"):
         CanonicalChampionRegistry((baseline, replace(baseline, evidence_hash=digest("other"))))
+
+
+def _dominance(*, acquisition: float, retention: float) -> PairedDominanceEvidence:
+    return PairedDominanceEvidence(
+        incumbent_artifact_hash=digest("incumbent"),
+        challenger_artifact_hash=digest(f"challenger:{acquisition}:{retention}"),
+        scenario_suite_hash=digest("paired-suite"),
+        metrics=(
+            PairedDominanceMetric(
+                metric_id="acquisition_success_count",
+                incumbent_value=27.0,
+                challenger_value=acquisition,
+                higher_is_better=True,
+                role=DominanceMetricRole.OBJECTIVE,
+                minimum_improvement=1.0,
+            ),
+            PairedDominanceMetric(
+                metric_id="retention_success_count",
+                incumbent_value=94.0,
+                challenger_value=retention,
+                higher_is_better=True,
+                role=DominanceMetricRole.GUARDRAIL,
+                maximum_regression=1.0,
+            ),
+        ),
+    )
+
+
+def test_paired_dominance_requires_growth_without_forgetting() -> None:
+    tied = _dominance(acquisition=27.0, retention=94.0)
+    improved = _dominance(acquisition=29.0, retention=93.0)
+    forgetting = _dominance(acquisition=30.0, retention=92.0)
+
+    assert not tied.promotion_passed
+    assert improved.promotion_passed
+    assert not forgetting.promotion_passed
+    assert improved.evidence_hash.startswith("sha256:")
+
+
+def test_paired_dominance_rejects_invalid_objective_and_duplicate_metric() -> None:
+    with pytest.raises(ValueError, match="positive minimum"):
+        PairedDominanceMetric(
+            metric_id="acquisition",
+            incumbent_value=1.0,
+            challenger_value=1.0,
+            higher_is_better=True,
+            role=DominanceMetricRole.OBJECTIVE,
+        )
+    metric = _dominance(acquisition=29.0, retention=94.0).metrics[0]
+    with pytest.raises(ValueError, match="invalid"):
+        PairedDominanceEvidence(
+            incumbent_artifact_hash=digest("incumbent"),
+            challenger_artifact_hash=digest("challenger"),
+            scenario_suite_hash=digest("suite"),
+            metrics=(metric, metric),
+        )
+
+
+def test_paired_dominance_rejects_runtime_type_coercion() -> None:
+    with pytest.raises(ValueError, match="direction or role"):
+        PairedDominanceMetric(
+            metric_id="acquisition",
+            incumbent_value=1.0,
+            challenger_value=2.0,
+            higher_is_better=cast(Any, 1),
+            role=DominanceMetricRole.OBJECTIVE,
+            minimum_improvement=1.0,
+        )
+    metric = _dominance(acquisition=29.0, retention=94.0).metrics[0]
+    with pytest.raises(ValueError, match="immutable typed tuple"):
+        PairedDominanceEvidence(
+            incumbent_artifact_hash=digest("incumbent"),
+            challenger_artifact_hash=digest("challenger"),
+            scenario_suite_hash=digest("suite"),
+            metrics=cast(Any, [metric]),
+        )

--- a/tests/continual/test_failure_curriculum.py
+++ b/tests/continual/test_failure_curriculum.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.continual.failure_curriculum import (
+    CapabilityBin,
+    CapabilityFrontierScheduler,
+    CurriculumMixture,
+    CurriculumSource,
+    DreamPerturbation,
+    FailureConditionedDream,
+    PerturbationDistribution,
+)
+from tests.continual.helpers import digest
+
+
+def test_curriculum_mix_allocates_exact_batch_without_rounding_loss() -> None:
+    allocation = CurriculumMixture().allocate(17)
+
+    assert sum(allocation.values()) == 17
+    assert allocation[CurriculumSource.CAPABILITY_FRONTIER] >= 6
+    assert allocation[CurriculumSource.RECENT_FAILURE] >= 4
+
+
+def test_failure_conditioned_dream_is_deterministic_and_sim_only() -> None:
+    contract = FailureConditionedDream(
+        failure_code="goalkeeper.getup_failure",
+        source_snapshot_hash=digest("snapshot"),
+        body_hash=digest("body"),
+        scenario_hash=digest("scene"),
+        perturbations=(
+            DreamPerturbation("root_momentum", -0.2, 0.2),
+            DreamPerturbation(
+                "friction",
+                -0.1,
+                0.1,
+                PerturbationDistribution.NORMAL_CLIPPED,
+            ),
+        ),
+        maximum_variants=32,
+    )
+
+    assert contract.sample(count=4, seed=7) == contract.sample(count=4, seed=7)
+    assert contract.training_use_only
+    assert contract.activation_ceiling == "SIM_ONLY"
+    with pytest.raises(ValueError, match="sampling"):
+        contract.sample(count=33, seed=7)
+
+
+def test_capability_frontier_prioritizes_the_learning_edge() -> None:
+    probabilities = CapabilityFrontierScheduler().probabilities(
+        (
+            CapabilityBin("mastered", difficulty=0.2, successes=99, attempts=100),
+            CapabilityBin("frontier", difficulty=0.6, successes=50, attempts=100),
+            CapabilityBin("impossible", difficulty=1.0, successes=0, attempts=100),
+        )
+    )
+
+    assert probabilities["frontier"] > probabilities["mastered"]
+    assert probabilities["frontier"] > probabilities["impossible"]
+    assert sum(probabilities.values()) == pytest.approx(1.0)

--- a/tests/continual/test_individual_scope.py
+++ b/tests/continual/test_individual_scope.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from rosclaw.continual.individual_scope import (
+    FrozenPartner,
+    FrozenPartnerSet,
+    IndividualGrowthScope,
+    IndividualPromotionEvidence,
+)
+from tests.continual.helpers import digest, policy
+
+
+def _scope(agent_id: str = "agent.goalkeeper") -> IndividualGrowthScope:
+    champion, _ = policy(0)
+    return IndividualGrowthScope(
+        agent_id=agent_id,
+        body_hash=champion.body_hash,
+        body_state_hash=digest(f"body-state:{agent_id}"),
+        foundation_policy_hash=digest("foundation"),
+        personal_adapter_hash=digest(f"adapter:{agent_id}"),
+        role_policy_hash=digest(f"role:{agent_id}"),
+        residual_policy_hash=digest(f"residual:{agent_id}"),
+        capability_profile_hash=digest(f"capability:{agent_id}"),
+        career_lineage_hash=digest(f"career:{agent_id}"),
+        personal_memory_namespace=f"memory.{agent_id}",
+        failure_memory_namespace=f"failure.{agent_id}",
+        parent_policy=champion,
+        champion_policy=champion,
+    )
+
+
+def _partners(scope: IndividualGrowthScope) -> FrozenPartnerSet:
+    return FrozenPartnerSet(
+        focal_agent_id=scope.agent_id,
+        partners=(
+            FrozenPartner(
+                agent_id="agent.finisher",
+                champion_policy_hash=digest("finisher"),
+                body_hash=digest("finisher-body"),
+                foundation_policy_hash=scope.foundation_policy_hash,
+                capability_profile_hash=digest("finisher-capability"),
+            ),
+        ),
+        numerical_contract_hash=digest("numerical"),
+        scenario_contract_hash=digest("scenario"),
+    )
+
+
+def test_individual_candidate_is_bound_to_focal_agent_and_frozen_partners() -> None:
+    scope = _scope()
+    candidate, _ = policy(1, parent=scope.champion_policy)
+    partners = _partners(scope)
+
+    staged = scope.stage_candidate(candidate, partners=partners)
+
+    assert staged.candidate_policy == candidate
+    assert staged.candidate_partner_snapshot_hash == partners.snapshot_hash
+    with pytest.raises(ValueError, match="another focal agent"):
+        scope.stage_candidate(
+            candidate,
+            partners=replace(partners, focal_agent_id="agent.playmaker"),
+        )
+
+
+def test_promotion_updates_only_the_individual_scope() -> None:
+    scope = _scope()
+    teammate = _scope("agent.playmaker")
+    candidate, _ = policy(1, parent=scope.champion_policy)
+    staged = scope.stage_candidate(candidate, partners=_partners(scope))
+    evidence = IndividualPromotionEvidence(
+        agent_id=scope.agent_id,
+        parent_policy_hash=scope.champion_policy.version_hash,
+        candidate_policy_hash=candidate.version_hash,
+        frozen_partner_snapshot_hash=staged.candidate_partner_snapshot_hash or "",
+        matched_seed_commitment_hash=digest("seeds"),
+        gate_report_hash=digest("gate"),
+        personal_memory_namespace=scope.personal_memory_namespace,
+        retention_passed=True,
+        safety_passed=True,
+        team_compatibility_passed=True,
+    )
+
+    promoted = staged.promote_candidate(evidence)
+
+    assert promoted.generation == 1
+    assert promoted.champion_policy == candidate
+    assert promoted.candidate_policy is None
+    assert teammate.generation == 0
+    assert teammate.champion_policy.version_hash != promoted.champion_policy.version_hash
+
+
+def test_failed_or_cross_agent_evidence_cannot_promote() -> None:
+    scope = _scope()
+    candidate, _ = policy(1, parent=scope.champion_policy)
+    staged = scope.stage_candidate(candidate, partners=_partners(scope))
+    evidence = IndividualPromotionEvidence(
+        agent_id=scope.agent_id,
+        parent_policy_hash=scope.champion_policy.version_hash,
+        candidate_policy_hash=candidate.version_hash,
+        frozen_partner_snapshot_hash=staged.candidate_partner_snapshot_hash or "",
+        matched_seed_commitment_hash=digest("seeds"),
+        gate_report_hash=digest("gate"),
+        personal_memory_namespace=scope.personal_memory_namespace,
+        retention_passed=True,
+        safety_passed=False,
+        team_compatibility_passed=True,
+    )
+
+    with pytest.raises(ValueError, match="failed"):
+        staged.promote_candidate(evidence)
+    with pytest.raises(ValueError, match="another agent"):
+        staged.promote_candidate(replace(evidence, agent_id="agent.finisher"))

--- a/tests/continual/test_learner_backend.py
+++ b/tests/continual/test_learner_backend.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from rosclaw.continual.learner_backend import (
+    LearnerBackendContract,
+    LearnerCapability,
+    LearnerRunEvidence,
+    LearnerRunStatus,
+)
+from tests.continual.helpers import digest
+
+
+def _backend() -> LearnerBackendContract:
+    return LearnerBackendContract(
+        backend_id="protomotions3",
+        backend_version="3.0",
+        source_url="https://github.com/NVlabs/ProtoMotions",
+        source_commit="a" * 40,
+        license_id="Apache-2.0",
+        capabilities=(
+            LearnerCapability.MOTION_TRACKING,
+            LearnerCapability.MULTI_GPU,
+        ),
+        supported_body_ids=("unitree.g1.29dof",),
+        training_available=True,
+        inference_available=True,
+    )
+
+
+def test_backend_contract_is_hashed_and_sim_only() -> None:
+    backend = _backend()
+
+    assert backend.contract_hash.startswith("sha256:")
+    assert backend.to_dict()["capabilities"] == ["motion_tracking", "multi_gpu"]
+    with pytest.raises(ValueError, match="SIM_ONLY"):
+        replace(backend, hardware_execution_allowed=True)
+
+
+def test_completed_run_requires_bound_candidate_and_nonzero_work() -> None:
+    backend = _backend()
+    run = LearnerRunEvidence(
+        run_id="s33.foundation.smoke",
+        backend_contract_hash=backend.contract_hash,
+        body_hash=digest("g1-body"),
+        dataset_manifest_hash=digest("motion-atlas"),
+        config_hash=digest("config"),
+        seed_commitment_hash=digest("seeds"),
+        physics_backend="mujoco",
+        device_ids=(0, 1, 2, 3),
+        world_steps=4096,
+        sample_count=1024,
+        status=LearnerRunStatus.COMPLETED,
+        candidate_artifact_hash=digest("candidate"),
+    )
+
+    assert run.evidence_hash.startswith("sha256:")
+    assert run.to_dict()["device_ids"] == [0, 1, 2, 3]
+    with pytest.raises(ValueError, match="requires samples"):
+        replace(run, world_steps=0)
+
+
+def test_noncompleted_run_cannot_publish_candidate() -> None:
+    with pytest.raises(ValueError, match="only a completed run"):
+        LearnerRunEvidence(
+            run_id="s33.failed",
+            backend_contract_hash=digest("backend"),
+            body_hash=digest("body"),
+            dataset_manifest_hash=digest("dataset"),
+            config_hash=digest("config"),
+            seed_commitment_hash=digest("seed"),
+            physics_backend="mujoco",
+            device_ids=(),
+            world_steps=0,
+            sample_count=0,
+            status=LearnerRunStatus.FAILED,
+            candidate_artifact_hash=digest("untrusted"),
+        )

--- a/tests/continual/test_plasticity_lease.py
+++ b/tests/continual/test_plasticity_lease.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.continual import (
+    AgentPolicyBinding,
+    AgentUpdateMode,
+    PlasticityLease,
+    audit_plasticity_lease,
+)
+
+_A = "sha256:" + "a" * 64
+_B = "sha256:" + "b" * 64
+_C = "sha256:" + "c" * 64
+
+
+def _lease() -> PlasticityLease:
+    return PlasticityLease(
+        lease_id="three-player-cycle-7",
+        bindings=(
+            AgentPolicyBinding("passer", _A, AgentUpdateMode.FROZEN),
+            AgentPolicyBinding("finisher", _B, AgentUpdateMode.PLASTIC),
+            AgentPolicyBinding("goalkeeper", _C, AgentUpdateMode.FROZEN),
+        ),
+        dataset_manifest_hash=_A,
+        scenario_contract_hash=_B,
+        maximum_optimizer_steps=500,
+    )
+
+
+def test_lease_requires_exactly_one_plastic_agent() -> None:
+    with pytest.raises(ValueError, match="plasticity lease"):
+        PlasticityLease(
+            lease_id="bad",
+            bindings=(
+                AgentPolicyBinding("passer", _A, AgentUpdateMode.PLASTIC),
+                AgentPolicyBinding("finisher", _B, AgentUpdateMode.PLASTIC),
+            ),
+            dataset_manifest_hash=_A,
+            scenario_contract_hash=_B,
+            maximum_optimizer_steps=1,
+        )
+
+
+def test_only_focal_agent_may_change_inside_lease() -> None:
+    lease = _lease()
+    before = {"passer": _A, "finisher": _B, "goalkeeper": _C}
+    after = {**before, "finisher": _C}
+    audit = audit_plasticity_lease(
+        lease=lease,
+        optimizer_steps=400,
+        before_policy_hashes=before,
+        after_policy_hashes=after,
+    )
+    assert audit.passed
+    assert audit.changed_agent_ids == ("finisher",)
+
+
+def test_frozen_partner_drift_and_step_overrun_fail_closed() -> None:
+    lease = _lease()
+    before = {"passer": _A, "finisher": _B, "goalkeeper": _C}
+    after = {**before, "passer": _B}
+    audit = audit_plasticity_lease(
+        lease=lease,
+        optimizer_steps=501,
+        before_policy_hashes=before,
+        after_policy_hashes=after,
+    )
+    assert not audit.passed
+    assert audit.reasons == (
+        "OPTIMIZER_STEP_BUDGET_EXCEEDED",
+        "FROZEN_AGENT_CHANGED:passer",
+    )

--- a/tests/continual/test_reproducibility.py
+++ b/tests/continual/test_reproducibility.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from rosclaw.continual.reproducibility import NumericalRuntimeContract
+
+
+def test_single_threaded_contract_fails_closed_on_missing_environment() -> None:
+    contract = NumericalRuntimeContract.single_threaded_cpu(random_seed=17)
+
+    report = contract.verify_environment({})
+
+    assert not report.passed
+    assert "OMP_NUM_THREADS" in report.mismatches
+    assert "PYTHONHASHSEED" in report.mismatches
+
+
+def test_subprocess_environment_satisfies_the_exact_contract() -> None:
+    contract = NumericalRuntimeContract.single_threaded_cpu(random_seed=17)
+
+    environment = contract.subprocess_environment({"PATH": "/bin"})
+    report = contract.verify_environment(environment)
+
+    assert report.passed
+    assert environment["OPENBLAS_NUM_THREADS"] == "1"
+    assert environment["CUBLAS_WORKSPACE_CONFIG"] == ":4096:8"
+    assert environment["PATH"] == "/bin"
+
+
+def test_runtime_hash_binds_seed_and_onnx_settings() -> None:
+    first = NumericalRuntimeContract.single_threaded_cpu(random_seed=17)
+    second = NumericalRuntimeContract.single_threaded_cpu(random_seed=18)
+
+    assert first.contract_hash != second.contract_hash
+    assert first.onnx_session_settings()["providers"] == ["CPUExecutionProvider"]
+    assert first.onnx_session_settings()["execution_mode"] == "ORT_SEQUENTIAL"

--- a/tests/continual/test_residual_adaptation.py
+++ b/tests/continual/test_residual_adaptation.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from rosclaw.continual.residual_adaptation import (
+    ParameterIsolationEvidence,
+    ResidualAdaptationContract,
+    load_residual_adaptation_contract,
+    write_residual_adaptation_contract,
+)
+from tests.continual.helpers import digest
+
+
+def _contract() -> ResidualAdaptationContract:
+    return ResidualAdaptationContract(
+        run_id="adapter.run-1",
+        backend_contract_hash=digest("backend"),
+        parent_artifact_hash=digest("parent"),
+        body_hash=digest("body"),
+        rehearsal_dataset_hash=digest("rehearsal"),
+        acquisition_dataset_hash=digest("acquisition"),
+        frozen_parameter_selectors=("policy.hidden_*",),
+        trainable_parameter_selectors=("policy.adapter_*",),
+        device_ids=(0, 1, 2, 3),
+        maximum_world_steps=5_000_000,
+        policy_learning_rate=3e-5,
+        rehearsal_fraction=0.6,
+        acquisition_fraction=0.4,
+        maximum_residual_output_rms=0.05,
+    )
+
+
+def _evidence(contract: ResidualAdaptationContract) -> ParameterIsolationEvidence:
+    return ParameterIsolationEvidence(
+        adaptation_contract_hash=contract.contract_hash,
+        parent_artifact_hash=contract.parent_artifact_hash,
+        candidate_artifact_hash=digest("candidate"),
+        frozen_base_hash_before=digest("frozen"),
+        frozen_base_hash_after=digest("frozen"),
+        matched_exam_hash=digest("exam"),
+        examined_frozen_parameter_count=10,
+        examined_trainable_parameter_count=10,
+        candidate_world_steps=4_000_000,
+        maximum_frozen_parameter_drift=0.0,
+        residual_output_rms=0.02,
+        retention_passed=True,
+        acquisition_passed=True,
+        critical_safety_regressions=0,
+    )
+
+
+def test_residual_contract_binds_rehearsal_and_trainable_scope() -> None:
+    contract = _contract()
+
+    assert contract.contract_hash.startswith("sha256:")
+    assert _evidence(contract).passes(contract)
+    with pytest.raises(ValueError, match="disjoint"):
+        replace(contract, trainable_parameter_selectors=("policy.hidden_*",))
+
+
+def test_parameter_isolation_rejects_forgetting_or_base_mutation() -> None:
+    contract = _contract()
+    evidence = _evidence(contract)
+
+    assert not replace(evidence, retention_passed=False).passes(contract)
+    assert not replace(evidence, frozen_base_hash_after=digest("mutated")).passes(contract)
+    assert not replace(evidence, critical_safety_regressions=1).passes(contract)
+
+
+def test_parameter_isolation_rejects_excessive_residual_churn() -> None:
+    contract = _contract()
+    evidence = replace(_evidence(contract), residual_output_rms=0.051)
+
+    assert not evidence.passes(contract)
+
+
+def test_parameter_isolation_rejects_training_beyond_sealed_budget() -> None:
+    contract = _contract()
+    evidence = replace(_evidence(contract), candidate_world_steps=5_000_001)
+
+    assert not evidence.passes(contract)
+
+
+def test_contract_writer_is_atomic_and_refuses_overwrite(tmp_path: Path) -> None:
+    contract = _contract()
+    output = tmp_path / "contract.json"
+
+    payload = write_residual_adaptation_contract(contract, output)
+
+    assert payload["contract_hash"] == contract.contract_hash
+    assert load_residual_adaptation_contract(output) == contract
+    assert output.read_text(encoding="utf-8").endswith("\n")
+    with pytest.raises(ValueError, match="new JSON"):
+        write_residual_adaptation_contract(contract, output)

--- a/tests/continual/test_safety_profiles.py
+++ b/tests/continual/test_safety_profiles.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from rosclaw.continual.safety_profiles import (
+    GrowthSafetyObservation,
+    GrowthSafetyProfile,
+    GrowthSafetyUse,
+    evaluate_growth_safety,
+    validate_profile_pair,
+)
+
+
+def _profile(use: GrowthSafetyUse) -> GrowthSafetyProfile:
+    exploration = use is GrowthSafetyUse.EXPLORATION_SIM
+    return GrowthSafetyProfile(
+        profile_id="g1.controlled-fall." + use.value.lower(),
+        use=use,
+        maximum_joint_limit_excess_rad=0.08 if exploration else 0.02,
+        maximum_normalized_actuator_command=1.20 if exploration else 1.0,
+        maximum_head_impact_speed_mps=0.20 if exploration else 0.10,
+        maximum_root_angular_speed_rad_s=8.0 if exploration else 3.5,
+        maximum_self_penetration_m=0.01 if exploration else 0.002,
+        always_allowed_contacts=("left_foot", "right_foot"),
+        hard_fail_contacts=("head", "neck"),
+        phase_contact_permissions={
+            "ready": (),
+            "landing": ("hand", "forearm", "lateral_thigh", "side_torso")
+            if exploration
+            else ("hand", "forearm", "lateral_thigh"),
+        },
+    )
+
+
+def _observation() -> GrowthSafetyObservation:
+    return GrowthSafetyObservation(
+        phase="landing",
+        finite_state=True,
+        joint_limit_excess_rad=0.0,
+        normalized_actuator_command=0.9,
+        head_impact_speed_mps=0.0,
+        root_angular_speed_rad_s=3.0,
+        self_penetration_m=0.0,
+        contacts=("forearm", "lateral_thigh"),
+    )
+
+
+def test_exploration_can_pass_without_becoming_promotion_evidence() -> None:
+    decision = evaluate_growth_safety(_profile(GrowthSafetyUse.EXPLORATION_SIM), _observation())
+
+    assert decision.passed
+    assert not decision.promotion_eligible
+
+
+def test_promotion_is_tighter_and_can_be_eligible() -> None:
+    exploration = _profile(GrowthSafetyUse.EXPLORATION_SIM)
+    promotion = _profile(GrowthSafetyUse.PROMOTION_SIM)
+    validate_profile_pair(exploration, promotion)
+
+    decision = evaluate_growth_safety(promotion, _observation())
+
+    assert decision.passed
+    assert decision.promotion_eligible
+
+
+def test_head_contact_and_non_finite_state_fail_in_exploration() -> None:
+    profile = _profile(GrowthSafetyUse.EXPLORATION_SIM)
+
+    head = evaluate_growth_safety(profile, replace(_observation(), contacts=("head",)))
+    non_finite = evaluate_growth_safety(profile, replace(_observation(), finite_state=False))
+
+    assert head.hard_failure and "HARD_CONTACT:head" in head.reasons
+    assert non_finite.hard_failure and "NON_FINITE_STATE" in non_finite.reasons
+
+
+def test_promotion_pair_rejects_a_looser_threshold() -> None:
+    exploration = _profile(GrowthSafetyUse.EXPLORATION_SIM)
+    promotion = replace(
+        _profile(GrowthSafetyUse.PROMOTION_SIM),
+        maximum_root_angular_speed_rad_s=9.0,
+    )
+
+    with pytest.raises(ValueError, match="looser"):
+        validate_profile_pair(exploration, promotion)

--- a/tests/continual/test_successor_state.py
+++ b/tests/continual/test_successor_state.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.continual.successor_state import (
+    SkillSuccessorState,
+    SuccessorMetricSpec,
+    SuccessorStateGrowthObjective,
+    SuccessorStateSample,
+    SuccessorStateTracker,
+)
+from tests.continual.helpers import digest
+
+
+def _contract(*, hold_steps: int = 3, maximum_steps: int = 6) -> SkillSuccessorState:
+    return SkillSuccessorState(
+        contract_id="recovery.to.locomotion-ready",
+        source_skill_id="recovery",
+        successor_skill_id="locomotion",
+        source_policy_hash=digest("recovery"),
+        successor_policy_hash=digest("locomotion"),
+        body_hash=digest("body"),
+        metrics=(
+            SuccessorMetricSpec("pelvis_height_m", minimum=0.70),
+            SuccessorMetricSpec("root_angular_speed_rad_s", maximum=0.50),
+        ),
+        hold_steps=hold_steps,
+        maximum_transition_steps=maximum_steps,
+        control_period_s=0.02,
+    )
+
+
+def _sample(step: int, *, height: float, angular: float) -> SuccessorStateSample:
+    return SuccessorStateSample(
+        step=step,
+        values={"pelvis_height_m": height, "root_angular_speed_rad_s": angular},
+    )
+
+
+def test_successor_requires_a_contiguous_hold_window() -> None:
+    tracker = SuccessorStateTracker(_contract())
+
+    assert not tracker.update(_sample(10, height=0.72, angular=0.2)).achieved
+    reset = tracker.update(_sample(11, height=0.60, angular=0.2))
+    assert reset.consecutive_hold_steps == 0
+    tracker.update(_sample(12, height=0.72, angular=0.2))
+    tracker.update(_sample(13, height=0.73, angular=0.3))
+    passed = tracker.update(_sample(14, height=0.74, angular=0.4))
+
+    assert passed.achieved
+    assert passed.entry_step == 12
+    assert passed.achieved_step == 14
+    assert passed.transition_time_s == pytest.approx(0.10)
+
+
+def test_successor_times_out_without_fabricating_success() -> None:
+    tracker = SuccessorStateTracker(_contract(hold_steps=2, maximum_steps=3))
+
+    tracker.update(_sample(0, height=0.5, angular=1.0))
+    tracker.update(_sample(1, height=0.5, angular=1.0))
+    report = tracker.update(_sample(2, height=0.5, angular=1.0))
+
+    assert report.timed_out
+    assert not report.achieved
+    assert set(report.failed_metrics) == {"pelvis_height_m", "root_angular_speed_rad_s"}
+
+
+def test_successor_rejects_non_finite_or_wrong_order_samples() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        SuccessorStateSample(step=0, values={"pelvis_height_m": float("nan")})
+
+    tracker = SuccessorStateTracker(_contract())
+    with pytest.raises(ValueError, match="order"):
+        tracker.update(
+            SuccessorStateSample(
+                step=0,
+                values={"root_angular_speed_rad_s": 0.1, "pelvis_height_m": 0.8},
+            )
+        )
+
+
+def test_successor_growth_objective_values_the_next_skill() -> None:
+    objective = SuccessorStateGrowthObjective(successor_value_weight=0.4)
+
+    poor_handoff = objective.score(task_return=1.0, successor_value=0.0, transition_cost=0.2)
+    good_handoff = objective.score(task_return=1.0, successor_value=0.9, transition_cost=0.1)
+
+    assert good_handoff > poor_handoff

--- a/tests/continual/test_teacher_manifold.py
+++ b/tests/continual/test_teacher_manifold.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from rosclaw.continual.teacher_manifold import (
+    TeacherManifoldGateContract,
+    TeacherManifoldMetric,
+)
+from tests.continual.helpers import digest
+
+
+def _gate() -> TeacherManifoldGateContract:
+    return TeacherManifoldGateContract(
+        gate_id="whole_body.recovery.teacher.v1",
+        teacher_artifact_hash=digest("teacher-memory"),
+        body_hash=digest("body"),
+        metrics=(
+            TeacherManifoldMetric("pelvis_height", scale=0.10),
+            TeacherManifoldMetric("body_speed", scale=1.0),
+        ),
+        retention_core_radius=0.10,
+        full_plasticity_radius=0.30,
+    )
+
+
+def test_teacher_manifold_gate_freezes_known_states_and_opens_smoothly() -> None:
+    gate = _gate()
+    reference = {"pelvis_height": 0.75, "body_speed": 0.0}
+
+    known = gate.evaluate(reference, reference)
+    transition = gate.evaluate(
+        {"pelvis_height": 0.75 + 0.2 * math.sqrt(2.0) * 0.10, "body_speed": 0.0},
+        reference,
+    )
+    novel = gate.evaluate({"pelvis_height": 0.85, "body_speed": 1.0}, reference)
+
+    assert known.inside_retention_core is True
+    assert known.plasticity_fraction == 0.0
+    assert transition.normalized_distance == pytest.approx(0.2)
+    assert transition.plasticity_fraction == pytest.approx(0.5)
+    assert novel.fully_plastic is True
+    assert novel.decision_hash.startswith("sha256:")
+
+
+def test_teacher_manifold_gate_fails_closed_on_observation_drift() -> None:
+    gate = _gate()
+    reference = {"pelvis_height": 0.75, "body_speed": 0.0}
+
+    with pytest.raises(ValueError, match="exactly"):
+        gate.evaluate({"pelvis_height": 0.75}, reference)
+    with pytest.raises(ValueError, match="finite"):
+        gate.evaluate({"pelvis_height": float("nan"), "body_speed": 0.0}, reference)
+
+
+def test_teacher_manifold_gate_has_no_hardware_or_promotion_authority() -> None:
+    with pytest.raises(ValueError, match="SIM_ONLY"):
+        TeacherManifoldGateContract(
+            gate_id="unsafe.gate",
+            teacher_artifact_hash=digest("teacher-memory"),
+            body_hash=digest("body"),
+            metrics=(TeacherManifoldMetric("state", scale=1.0),),
+            retention_core_radius=0.1,
+            full_plasticity_radius=0.3,
+            hardware_execution_allowed=True,
+        )

--- a/tests/continual/test_teacher_prior.py
+++ b/tests/continual/test_teacher_prior.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from rosclaw.continual.teacher_prior import ConditionalTeacherPriorContract
+from tests.continual.helpers import digest
+
+
+def _contract() -> ConditionalTeacherPriorContract:
+    return ConditionalTeacherPriorContract(
+        prior_id="humanoid.motion.teacher.v2",
+        artifact_hash=digest("teacher"),
+        body_hash=digest("body"),
+        observation_names=("gravity", "joint_position"),
+        output_names=("target_position", "target_velocity"),
+        condition_vocabulary={
+            "task": ("ready", "save", "recovery"),
+            "region": ("upper_left", "upper_right"),
+        },
+    )
+
+
+def test_conditional_teacher_query_is_complete_and_content_addressed() -> None:
+    contract = _contract()
+
+    query = contract.query({"task": "save", "region": "upper_left"})
+
+    assert query.prior_contract_hash == contract.contract_hash
+    assert query.condition_values == {"region": "upper_left", "task": "save"}
+    assert query.query_hash.startswith("sha256:")
+
+
+def test_teacher_query_fails_closed_on_average_or_missing_condition() -> None:
+    contract = _contract()
+
+    with pytest.raises(ValueError, match="every condition"):
+        contract.query({"task": "save"})
+    with pytest.raises(ValueError, match="frozen vocabulary"):
+        contract.query({"task": "save", "region": "average"})
+
+
+def test_teacher_cannot_become_a_deployed_actor_dependency() -> None:
+    with pytest.raises(ValueError, match="train-only"):
+        ConditionalTeacherPriorContract(
+            prior_id="unsafe.teacher",
+            artifact_hash=digest("teacher"),
+            body_hash=digest("body"),
+            observation_names=("state",),
+            output_names=("action",),
+            condition_vocabulary={"task": ("save",)},
+            deployed_actor_depends_on_teacher=True,
+        )


### PR DESCRIPTION
## Summary
- add domain-neutral failure curricula, successor-state, teacher-prior/manifold, residual-adaptation, plasticity-lease, individual-scope, learner-backend, safety, and reproducibility contracts
- add a generic champion registry plus content-bound paired-dominance evidence: objectives must improve, guardrails may regress only within an explicit bound, and ties cannot claim growth
- harden the live ROS2 action lifecycle test against cancel-callback versus event-loop shutdown races
- keep all learning authority SIM_ONLY with no promotion or hardware authority

## Validation
- Continual + Practice + live ROS2: 268 passed, 9 skipped
- paired-dominance + live ROS2 targeted: 8 passed
- Python 3.11 live ROS2 lifecycle repeated 10 times without failure
- targeted Ruff, format, mypy, and compileall passed
- GitHub CI rerun is in progress on the latest head

## Scope
Extracted from the S117 humanoid recovery experiment, but the Core APIs contain no G1 or soccer-specific fields.