### PR TITLE
feat: 0901-P0-1 artifact CLI 进 rosclaw 入口——open/path/show/export 真实可达

### DIFF
--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -207,6 +207,45 @@ def cmd_artifact_open(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_artifact_show(args: argparse.Namespace) -> int:
+    """0901 P0-1：类型/大小/摘要/任务/血缘详情。"""
+    conn, rows = _artifact_rows(args, str(args.artifact_id))
+    if conn is None or not rows:
+        print(f"未知交付物 {args.artifact_id!r}（rosclaw artifact list 可查）")
+        return 2
+    view = _artifact_view(rows[0])
+    meta = rows[0].get("metadata_json")
+    lineage = {}
+    if isinstance(meta, str):
+        import contextlib
+
+        with contextlib.suppress(ValueError):
+            lineage = (json.loads(meta) or {}).get("lineage") or {}
+    if getattr(args, "json", False):
+        print(json.dumps({**view, "lineage": lineage}, ensure_ascii=False, indent=2))
+        return 0
+    print(f"artifact:  {view['artifact_id']}")
+    print(f"kind:      {view['kind']}")
+    print(f"media:     {view['media_type']}")
+    print(f"size:      {view['size_bytes']}B")
+    print(f"digest:    {view['digest']}")
+    print(f"task:      {view['task_id']}")
+    print(f"path:      {view['path']}")
+    if lineage:
+        print(f"lineage:   {json.dumps(lineage, ensure_ascii=False)[:200]}")
+    return 0
+
+
+def cmd_artifact_path(args: argparse.Namespace) -> int:
+    """0901 P0-1：只输出绝对路径（SSH/脚本一等）。"""
+    conn, rows = _artifact_rows(args, str(args.artifact_id))
+    if conn is None or not rows:
+        print(f"未知交付物 {args.artifact_id!r}", file=sys.stderr)
+        return 2
+    print(_artifact_view(rows[0])["path"])
+    return 0
+
+
 def cmd_artifact_export(args: argparse.Namespace) -> int:
     import shutil
 
@@ -222,9 +261,49 @@ def cmd_artifact_export(args: argparse.Namespace) -> int:
     dest = Path(str(args.dest))
     if dest.is_dir():
         dest = dest / src.name
+    dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dest)
     print(f"已导出：{dest}（{view['size_bytes']}B，{view['digest'][:19]}…）")
     return 0
+
+
+def dispatch_artifact_argv(argv: list[str]) -> int | None:
+    """0901 P0-1：`rosclaw artifact ...` 入口快路径（entrypoint
+    dispatch 链调用）。
+
+    实证事故：artifact list/open/export 只注册在 rosclaw-agentd
+    子命令树里，用户面 `rosclaw artifact open <id>` 落到 legacy
+    parser 打顶层帮助——TerminalPresenter 给用户的 open_command
+    不可达。这里把 artifact 一族直接挂进 `rosclaw` 入口（与
+    rosclaw-agentd 同一组 handler——不复制实现）。"""
+    if not argv or argv[0] != "artifact":
+        return None
+    parser = argparse.ArgumentParser(
+        prog="rosclaw artifact",
+        description="交付物查看/打开/导出",
+    )
+    sub = parser.add_subparsers(dest="artifact_command", required=True)
+    p_list = sub.add_parser("list", help="列出登记的交付物")
+    p_list.add_argument("--task", default="", help="按 task_id 过滤")
+    p_list.add_argument("--json", action="store_true", help="机器可读输出")
+    p_list.set_defaults(func=cmd_artifact_list)
+    p_show = sub.add_parser("show", help="交付物详情（类型/大小/任务/血缘）")
+    p_show.add_argument("artifact_id")
+    p_show.add_argument("--json", action="store_true", help="机器可读输出")
+    p_show.set_defaults(func=cmd_artifact_show)
+    p_path = sub.add_parser("path", help="只输出绝对路径（SSH/脚本可用）")
+    p_path.add_argument("artifact_id")
+    p_path.set_defaults(func=cmd_artifact_path)
+    p_open = sub.add_parser("open", help="打开交付物（无显示环境给路径）")
+    p_open.add_argument("artifact_id")
+    p_open.set_defaults(func=cmd_artifact_open)
+    p_export = sub.add_parser("export", help="导出交付物到指定路径")
+    p_export.add_argument("artifact_id")
+    p_export.add_argument("dest")
+    p_export.set_defaults(func=cmd_artifact_export)
+    args = parser.parse_args(argv[1:])
+    # --home 由 _home(args) 统一解析（env ROSCLAW_HOME 回落）。
+    return args.func(args)
 
 
 def cmd_learning_list(args: argparse.Namespace) -> int:

--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -30,6 +30,15 @@ def main() -> int:
     if result is not None:
         return result
 
+    # 0901 P0-1：artifact 交付面挂进 `rosclaw` 入口（实证事故：
+    # TerminalPresenter 给的 `rosclaw artifact open <id>` 此前落到
+    # legacy parser 打顶层帮助——dispatch 链缺失，不是版本漂移）。
+    from rosclaw.agentd.cli import dispatch_artifact_argv
+
+    result = dispatch_artifact_argv(sys.argv[1:])
+    if result is not None:
+        return result
+
     # P0-CLI-01：统一 setup 向导（model/body/operator/worker/integration）
     # 先于 legacy parser——legacy 的 setup 只有 lerobot，契约失真。
     from rosclaw.setup_cli import dispatch_setup_argv

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1632,6 +1632,24 @@ class TestProductJourney:
             # 6b. 对抗场景（P0-4F 场景 D）：模型谎称完成——系统必须
             #    以结构化状态为准，不采信模型自述。
             self._assert_adversarial_model_ignored(session, home)
+            # 0901 P0-1（硬 Gate B）：安装产物的 `rosclaw artifact` 一族
+            # 真实可达——list 不回落顶层帮助、path 给绝对路径（0901
+            # 实证：open_command 给了 `rosclaw artifact open` 但入口
+            # 没有 dispatch——承诺无实现）。
+            import subprocess as _subp
+
+            art_list = _subp.run(
+                [str(rosclaw), "artifact", "list"], env=env,
+                capture_output=True, text=True, timeout=60,
+            )
+            assert art_list.returncode == 0, art_list.stderr
+            assert "usage: rosclaw" not in art_list.stdout, (
+                f"安装产物的 artifact list 回落顶层帮助：{art_list.stdout[:300]}"
+            )
+            assert ".mp4" in art_list.stdout or ".gif" in art_list.stdout, (
+                f"交付物未列出：{art_list.stdout[:300]}"
+            )
+            self._journey_verdicts["artifact_cli_reachable_in_install"] = True
             # 7. /compact（HOTFIX-5：真断言——compact 完成、上下文与
             #    receipt 保留、summary 可用——不是只发命令后 sleep）。
             #    先把 session 推过 keepRecentTokens 阈值（~20K tokens），

--- a/tests/cli/test_artifact_entry.py
+++ b/tests/cli/test_artifact_entry.py
@@ -1,0 +1,111 @@
+"""0901 体验探讨 P0-1 红测试：artifact CLI 必须经 `rosclaw` 入口可达。
+
+0901 实证：`rosclaw artifact open art_xxx` 打顶层帮助——artifact
+list/open/export 只在 rosclaw-agentd 可达，entrypoint dispatch 链
+没有 artifact 分支。R0-4 的测试只测 handler 函数（假绿），从没在
+`rosclaw` 入口跑过 subprocess。
+
+硬 Gate B（文档 §十二）：真实入口 subprocess 下——
+- `rosclaw artifact list` 不打顶层帮助（不回落 legacy parser）；
+- `rosclaw artifact path <id>` 输出绝对路径（SSH/脚本可用）；
+- `rosclaw artifact open <id>` 不打帮助（无显示环境打路径）；
+- `rosclaw artifact export <id> <dest>` 复制且 sha256 一致；
+- `rosclaw artifact show <id>` 显示类型/大小/任务/血缘。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _make_artifact(home: Path) -> tuple[str, Path, str]:
+    """在 tmp home 建一个真实 artifact（落盘账本——CLI subprocess
+    读的是 home/agentd/missions.db）。"""
+    import sqlite3
+
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    db_path = home / "agentd" / "missions.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    kernel = TaskKernel(conn, home)
+    kernel.persist_input(
+        mission_id="mis_1", session_ref="s1",
+        message_id="msg_1", text="画一个五角星",
+    )
+    bound = kernel.ensure_task_for_effect(
+        mission_id="mis_1", session_ref="s1", backend_native_id="s1",
+        cwd=str(home), body_id="sim/ur5e",
+    )
+    task_id = str(bound["task_id"])
+    payload = home / "demo.bin"
+    payload.write_bytes(b"rosclaw-0901-artifact-payload" * 8)
+    record = kernel.register_artifact(
+        task_id=task_id, path=str(payload), media_type="application/octet-stream",
+        producer="kernel:test",
+    )
+    conn.commit()
+    conn.close()
+    digest = hashlib.sha256(payload.read_bytes()).hexdigest()
+    return str(record["artifact_id"]), payload, digest
+
+
+def _run(home: Path, *argv: str) -> subprocess.CompletedProcess:
+    import os
+
+    return subprocess.run(
+        [sys.executable, "-m", "rosclaw.entrypoint", *argv],
+        capture_output=True, text=True, timeout=60,
+        env={**os.environ, "ROSCLAW_HOME": str(home)},
+    )
+
+
+class TestArtifactCliReachable:
+    def test_list_not_top_level_help(self, tmp_path: Path) -> None:
+        _make_artifact(tmp_path)
+        result = _run(tmp_path, "artifact", "list")
+        assert "usage: rosclaw" not in result.stdout, (
+            f"artifact list 回落到顶层帮助（dispatch 缺失）：{result.stdout[:200]}"
+        )
+        assert "demo.bin" in result.stdout, result.stdout
+
+    def test_path_prints_absolute_path(self, tmp_path: Path) -> None:
+        artifact_id, payload, _ = _make_artifact(tmp_path)
+        result = _run(tmp_path, "artifact", "path", artifact_id)
+        assert result.returncode == 0, result.stderr
+        assert str(payload) in result.stdout, result.stdout
+
+    def test_open_never_prints_help(self, tmp_path: Path) -> None:
+        artifact_id, payload, _ = _make_artifact(tmp_path)
+        result = _run(tmp_path, "artifact", "open", artifact_id)
+        assert "usage: rosclaw" not in result.stdout, result.stdout[:200]
+        # 无显示环境：打路径（SSH 一等）。
+        assert str(payload) in result.stdout, result.stdout
+
+    def test_export_digest_consistent(self, tmp_path: Path) -> None:
+        artifact_id, _payload, digest = _make_artifact(tmp_path)
+        dest = tmp_path / "export" / "out.bin"
+        result = _run(tmp_path, "artifact", "export", artifact_id, str(dest))
+        assert result.returncode == 0, result.stderr
+        assert dest.exists()
+        assert hashlib.sha256(dest.read_bytes()).hexdigest() == digest
+
+    def test_show_details(self, tmp_path: Path) -> None:
+        artifact_id, payload, digest = _make_artifact(tmp_path)
+        result = _run(tmp_path, "artifact", "show", artifact_id)
+        assert result.returncode == 0, result.stderr
+        assert artifact_id in result.stdout
+        assert f"sha256:{digest}" in result.stdout, result.stdout
+        assert str(payload) in result.stdout
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
0901 实证：rosclaw artifact open 打顶层帮助（dispatch 缺失，非版本漂移）。

- entrypoint 接入 dispatch_artifact_argv（与 rosclaw-agentd 同 handler）
- 新增 show/path 子命令；export 自动建目录
- 硬 Gate B：subprocess 真实入口 5 命令测试 + 安装产物旅程断言

红→绿：test_artifact_entry.py 5 红→绿；旅程 A 绿。