### PR TITLE
feat: 0901-P0-2 artifact 生成即投影 outputs/——登记即交付视图更新

### DIFF
--- a/src/rosclaw/task_kernel/projection.py
+++ b/src/rosclaw/task_kernel/projection.py
@@ -47,8 +47,11 @@ def project_deliverables(kernel: TaskKernel, task_id: str) -> str:
         ).fetchall()
         for row in rows:
             src = Path(str(row["path"]))
-            if zone_of(kernel._home, task_id, revision, src) == "outputs":
+            zone = zone_of(kernel._home, task_id, revision, src)
+            if zone == "outputs":
                 continue  # 已在交付区——无需投影
+            if zone == "evidence":
+                continue  # 证据区（verify_*.json）不进交付视图
             if not src.exists():
                 degraded = True
                 _LOG.warning("projection source missing: %s", src)

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -620,6 +620,19 @@ class TaskKernel:
                    {"artifact_id": artifact_id, "path": str(file),
                     "bytes": len(content)})
         record["metadata_json"] = meta_json
+        # 0901 P0-2：登记即投影——outputs/ 是即时投影视图（不等
+        # coordinator PASS；PARTIAL/FAIL 任务的已产出交付物也必须
+        # 可打开）。投影失败绝不阻断登记（投影是视图不是真相）。
+        from rosclaw.task_kernel.projection import project_deliverables
+
+        try:
+            project_deliverables(self, task_id)
+        except Exception:  # noqa: BLE001 - 投影是视图，失败不阻断登记
+            import logging
+
+            logging.getLogger("rosclaw.projection").warning(
+                "project-on-register failed for %s", task_id, exc_info=True,
+            )
         return record
 
     def finish_task(

--- a/tests/agentd/test_a0901_p02_project_on_register.py
+++ b/tests/agentd/test_a0901_p02_project_on_register.py
@@ -1,0 +1,103 @@
+"""0901 体验探讨 P0-2 红测试：artifact 生成即投影（不等 PASS）。
+
+0901 实证：任务 FAIL+PARTIAL 时 Presenter 给了 3 个 Artifact ID，
+但 Agent 查 outputs/ 目录是空的——P0-4 的投影只在 Coordinator
+PASS 分支执行。正确逻辑（文档 §三）：每个有效 artifact 一生成立即
+投影到任务 outputs/，最终 Outcome 只判 FULL/PARTIAL。
+
+闭环断言：
+1. register_artifact 成功即投影——不调 coordinator、不过 PASS，
+   outputs/ 就有同内容文件；
+2. 投影失败不翻转登记（登记成功 + 投影 DEGRADED 日志，不抛错）；
+3. coordinator 的 PASS 分支投影保留为兜底（幂等——已投影不重复）。
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+
+def _kernel_on_disk(home: Path):
+    import sqlite3
+
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return TaskKernel(conn, home), conn
+
+
+class TestProjectOnRegister:
+    def test_register_projects_immediately(self, tmp_path: Path) -> None:
+        """登记即投影：不等 coordinator PASS。"""
+        from rosclaw.task_kernel.run_store import run_dir
+
+        kernel, _conn = _kernel_on_disk(tmp_path)
+        kernel.persist_input(
+            mission_id="m1", session_ref="s1",
+            message_id="msg_1", text="画一个五角星",
+        )
+        bound = kernel.ensure_task_for_effect(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        task_id = str(bound["task_id"])
+        payload = tmp_path / "traces" / "t1"
+        payload.mkdir(parents=True)
+        gif = payload / "scene.gif"
+        gif.write_bytes(b"GIF89a" + b"\x00" * 100)
+        record = kernel.register_artifact(
+            task_id=task_id, path=str(gif), media_type="image/gif",
+            producer="kernel:test",
+        )
+        assert record.get("artifact_id")
+        projected = (
+            run_dir(tmp_path, task_id, 1) / "outputs" / gif.name
+        )
+        assert projected.exists(), (
+            f"登记后 outputs/ 无投影（0901 实证：PARTIAL 任务 outputs 空）："
+            f"{projected}"
+        )
+        assert hashlib.sha256(projected.read_bytes()).hexdigest() == hashlib.sha256(
+            gif.read_bytes()
+        ).hexdigest()
+
+    def test_projection_failure_does_not_break_registration(
+        self, tmp_path: Path
+    ) -> None:
+        """投影失败（outputs 区被破坏）→ 登记仍成功（投影是视图，
+        不是交付真相）。"""
+        from rosclaw.task_kernel.run_store import run_dir
+
+        kernel, _conn = _kernel_on_disk(tmp_path)
+        kernel.persist_input(
+            mission_id="m1", session_ref="s1",
+            message_id="msg_1", text="画一个五角星",
+        )
+        bound = kernel.ensure_task_for_effect(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        task_id = str(bound["task_id"])
+        # 破坏 outputs 区（先删目录再占位为普通文件）。
+        import shutil as _shutil
+
+        outputs_parent = run_dir(tmp_path, task_id, 1)
+        _shutil.rmtree(outputs_parent / "outputs", ignore_errors=True)
+        (outputs_parent / "outputs").write_text("sabotaged", encoding="utf-8")
+        payload = tmp_path / "x.bin"
+        payload.write_bytes(b"x" * 16)
+        record = kernel.register_artifact(
+            task_id=task_id, path=str(payload), media_type="application/octet-stream",
+            producer="kernel:test",
+        )
+        assert record.get("artifact_id"), "投影失败竟阻断登记"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 0901 体验审计 P0-2：artifact 生成即投影 outputs/（不等 PASS）

### 问题（0901 体验实证）
用户在任务跑完后去 outputs/ 找产物——空。原因：project_deliverables 只在终态 PASS 路径调用；任务还在跑/未达标时产物已登记进 ArtifactStore，但投影视图不更新——产物去哪了。

### 修复
- task_kernel/service.py register_artifact：登记+事件发出后立即 project_deliverables(task_id)（try/except——投影失败绝不阻塞登记）。
- task_kernel/projection.py：evidence zone 不投影（证据是审计面，不是交付面）。

### 红→绿证据
tests/agentd/test_a0901_p02_project_on_register.py（2 tests）：登记即投影；outputs/ 被破坏时登记仍成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)