### PR TITLE
feat: 0901-P0-3 只读任务/交付物能力——追问不再靠猜名字

### DIFF
--- a/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
+++ b/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
@@ -39,6 +39,7 @@ import { buildCapabilitiesTool } from "../../tools/capabilities.js";
 import { buildInspectTool } from "../../tools/inspect.js";
 
 import { buildTaskTool } from "../../tools/task.js";
+import { buildReadOnlyTaskTools } from "../../tools/task-read.js";
 import { buildStatusTool } from "../../tools/status.js";
 
 export interface RosclawRuntimeOptions {
@@ -275,6 +276,13 @@ export async function createRosclawRuntime(
 				// PR-EIGHT-5：任务级入口（确定性编译器——模型只交
 				// TaskSpec，不搬载荷、不逐点控制）。
 				buildTaskTool({
+					rosclawHome: options.rosclawHome,
+					active,
+					center,
+				}),
+				// 0901 P0-3：只读任务/交付物面（解释/查看已有结果——
+				// 认识确定性链刚做的事，不重跑）。
+				...buildReadOnlyTaskTools({
 					rosclawHome: options.rosclawHome,
 					active,
 					center,

--- a/packages/rosclaw-agent/src/tools/effects.generated.json
+++ b/packages/rosclaw-agent/src/tools/effects.generated.json
@@ -1,5 +1,7 @@
 {
+  "rosclaw_artifact_list": "READ_ONLY",
   "rosclaw_artifact_register": "WORKSPACE_WRITE",
+  "rosclaw_artifact_resolve": "READ_ONLY",
   "rosclaw_capabilities": "READ_ONLY",
   "rosclaw_compute": "DYNAMIC",
   "rosclaw_deliver": "WORKSPACE_WRITE",
@@ -18,5 +20,6 @@
   "rosclaw_task": "SIMULATED_EFFECT",
   "rosclaw_task_blocked": "WORKSPACE_WRITE",
   "rosclaw_task_finish": "WORKSPACE_WRITE",
+  "rosclaw_task_inspect": "READ_ONLY",
   "rosclaw_verify": "READ_ONLY"
 }

--- a/packages/rosclaw-agent/src/tools/surface.ts
+++ b/packages/rosclaw-agent/src/tools/surface.ts
@@ -55,6 +55,12 @@ export const EMBODIMENT_PACK: readonly string[] = [
 	// operation 停止（P0-D：轮询式 wait_operation 退出模型面——
 	// Operation 事件流驱动，模型不轮询）
 	"rosclaw_stop_operation",
+	// 0901 P0-3：只读任务/交付物面——解释/查看不再靠猜名字
+	// （task.list_artifacts/artifact.open 漂移实证撞
+	// EFFECT_UNRESOLVABLE 后重跑任务）。
+	"rosclaw_task_inspect",
+	"rosclaw_artifact_list",
+	"rosclaw_artifact_resolve",
 ];
 
 /** 模型可见工具（唯一真相源）。 */

--- a/packages/rosclaw-agent/src/tools/task-read.ts
+++ b/packages/rosclaw-agent/src/tools/task-read.ts
@@ -1,0 +1,106 @@
+// HP2-COMPAT: 工具定义原语（defineTool/Type/ToolDefinition）——工具层在 HP3 投影层（Codex MCP）落地前保持 Pi 形态；不新增会话装配引用。
+/** 只读任务/交付物工具（0901 体验探讨 P0-3）。
+ *
+ * 0901 实证：用户问"你这是啥？"——模型没有只读能力，猜
+ * task.list_artifacts/artifact.open 撞 EFFECT_UNRESOLVABLE，
+ * 降级 Shell 被 bwrap 拒，最后把任务重跑一遍制造第二套
+ * trace/artifact。这三个工具让 Native Agent 认识确定性链刚做的事：
+ *
+ * - rosclaw_task_inspect：最近任务 + TaskOutcome（验收/交付/交付物）；
+ * - rosclaw_artifact_list：最近任务的交付物（含绝对路径）；
+ * - rosclaw_artifact_resolve：artifact_id → path/kind/size/digest。
+ *
+ * 全部只读——不产生新 task/trace/artifact。
+ */
+
+import { Type } from "@earendil-works/pi-ai";
+import { defineTool } from "@earendil-works/pi-coding-agent";
+import type { BridgeToolContext } from "./bridge-tools.js";
+
+function text(value: unknown): string {
+	return JSON.stringify(value, null, 1);
+}
+
+export function buildReadOnlyTaskTools(ctx: BridgeToolContext) {
+	const taskInspect = defineTool({
+		name: "rosclaw_task_inspect",
+		label: "ROSClaw Task Inspect",
+		description:
+			"Read the latest task and its outcome (state, verification, " +
+			"delivery, artifact refs with absolute paths). Read-only — use " +
+			"this to explain what just happened instead of re-running anything.",
+		parameters: Type.Object({}),
+		async execute() {
+			const state = ctx.active.current;
+			const call = (m: string, p: Record<string, unknown>) =>
+				ctx.center.call(m, p);
+			const latest = await call("pi.kernel.latest", {
+				mission_id: state.missionId ?? "",
+				session_ref: state.sessionId ?? "",
+			});
+			const task = (latest.task ?? null) as Record<string, unknown> | null;
+			if (!task) {
+				return {
+					content: [{ type: "text" as const, text: "当前会话还没有任务。" }],
+					details: { ok: true, task_id: "" },
+				};
+			}
+			const considered = await call("pi.coordinator.consider", {
+				task_id: task.task_id,
+			});
+			const outcome = (considered.outcome ?? null) as Record<string, unknown> | null;
+			return {
+				content: [{ type: "text" as const, text: text({ task, outcome }) }],
+				details: { ok: true, task_id: String(task.task_id ?? "") },
+			};
+		},
+	});
+
+	const artifactList = defineTool({
+		name: "rosclaw_artifact_list",
+		label: "ROSClaw Artifact List",
+		description:
+			"List deliverables of the latest task (artifact id, kind, media " +
+			"type, size, absolute path, open command). Read-only.",
+		parameters: Type.Object({
+			task_id: Type.Optional(Type.String({ description: "task id（缺省=最近任务）" })),
+		}),
+		async execute(_id, params) {
+			const state = ctx.active.current;
+			const result = await ctx.center.call("pi.artifact.list", {
+				mission_id: state.missionId ?? "",
+				session_ref: state.sessionId ?? "",
+				task_id: String(params.task_id ?? ""),
+			});
+			return {
+				content: [{ type: "text" as const, text: text(result) }],
+				details: { ok: true },
+			};
+		},
+	});
+
+	const artifactResolve = defineTool({
+		name: "rosclaw_artifact_resolve",
+		label: "ROSClaw Artifact Resolve",
+		description:
+			"Resolve an artifact id to its absolute path, kind, size and " +
+			"digest. Read-only — use before pointing the user at a file.",
+		parameters: Type.Object({
+			artifact_id: Type.String({ description: "artifact id（art_...）" }),
+		}),
+		async execute(_id, params) {
+			const state = ctx.active.current;
+			const result = await ctx.center.call("pi.artifact.resolve", {
+				mission_id: state.missionId ?? "",
+				artifact_id: String(params.artifact_id),
+			});
+			return {
+				content: [{ type: "text" as const, text: text(result) }],
+				details: { ok: Boolean(result.ok) },
+				isError: !result.ok,
+			};
+		},
+	});
+
+	return [taskInspect, artifactList, artifactResolve];
+}

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1235,6 +1235,69 @@ class PiBridgeServer:
                 str(params.get("session_ref", "")),
             )
             return {"ok": True, "task": task}
+        # 0901 P0-3：只读交付物面——解释/查看不再靠模型猜名字
+        # （task.list_artifacts/artifact.open 漂移实证）。
+        if method == "pi.artifact.list":
+            # task_id 缺省=该 session 最近任务（含刚终态）；session 无
+            # 绑定时回落 mission 最近任务（session 轮换不丢交付面）。
+            kernel = service._task_kernel
+            task_id = str(params.get("task_id", ""))
+            if not task_id:
+                latest = kernel.latest_task_for(
+                    str(params.get("mission_id", "")),
+                    str(params.get("session_ref", "")),
+                )
+                task_id = str(latest["task_id"]) if latest else ""
+            if not task_id:
+                row = kernel._conn.execute(
+                    "SELECT task_id FROM tasks WHERE mission_id = ? "
+                    "ORDER BY created_at DESC LIMIT 1",
+                    (str(params.get("mission_id", "")),),
+                ).fetchone()
+                task_id = str(row["task_id"]) if row else ""
+            if not task_id:
+                return {"ok": True, "artifacts": []}
+            return {
+                "ok": True,
+                "task_id": task_id,
+                "artifacts": kernel.artifact_refs_for(task_id),
+            }
+        if method == "pi.artifact.resolve":
+            artifact_id = str(params.get("artifact_id", ""))
+            conn = service._task_kernel._conn
+            row = conn.execute(
+                "SELECT * FROM artifacts WHERE artifact_id = ?",
+                (artifact_id,),
+            ).fetchone()
+            if row is None:
+                return {
+                    "ok": False,
+                    "error": f"未知交付物 {artifact_id!r}",
+                    "code": "REF_NOT_FOUND",
+                }
+            from rosclaw.task_kernel.deliverables import (
+                artifact_delivery_kind,
+            )
+
+            record = dict(row)
+            raw_digest = str(record["sha256"])
+            return {
+                "ok": True,
+                "artifact": {
+                    "artifact_id": artifact_id,
+                    "task_id": str(record["task_id"]),
+                    "kind": artifact_delivery_kind(record),
+                    "media_type": str(record["media_type"]),
+                    "path": str(record["path"]),
+                    "size_bytes": int(record["size_bytes"]),
+                    "digest": (
+                        raw_digest
+                        if raw_digest.startswith("sha256:")
+                        else f"sha256:{raw_digest}"
+                    ),
+                    "open_command": f"rosclaw artifact open {artifact_id}",
+                },
+            }
         if method == "pi.kernel.accept":
             # PR-N0：/done 用户接受（与系统验收 accepted_at 区分）。
             try:

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -229,18 +229,21 @@ _INFRA_PREFIXES = (
 )
 
 
-def _error_envelope_details(code: str) -> dict:
+def _error_envelope_details(code: str, *, tool_name: str = "") -> dict:
     """ErrorEnvelope 语义（R0-9）：scope / attempt_budget /
     recovery_action——基础设施/配置/确定性错误模型重试预算为 0；
-    只有明确 transient 且状态已变化时可重试。"""
-    from rosclaw.agentd.tooling.recovery import recovery_for
+    只有明确 transient 且状态已变化时可重试。
+
+    0901 P0-3：tool_name 进恢复提示——漂移的 task.*/artifact.*
+    名字指向真实只读工具（不再泛泛"查注册表"）。"""
+    from rosclaw.agentd.tooling.recovery import recovery_hint
 
     if code in _TRANSIENT_CODES:
         return {
             "scope": "transient",
             "attempt_budget": 1,
             "retry_after_condition": "状态已变化（context/审批/快照刷新后）",
-            "recovery_action": recovery_for(code),
+            "recovery_action": recovery_hint(code, context=tool_name),
         }
     scope = (
         "infrastructure"
@@ -251,7 +254,7 @@ def _error_envelope_details(code: str) -> dict:
         "scope": scope,
         "attempt_budget": 0,
         "retry_after_condition": "",
-        "recovery_action": recovery_for(code),
+        "recovery_action": recovery_hint(code, context=tool_name),
     }
 
 
@@ -305,7 +308,10 @@ class PiToolDispatcher:
                 summary=exc.message,
                 error_code=exc.code,
                 retryable=exc.retryable,
-                details=_error_envelope_details(exc.code),
+                details=_error_envelope_details(
+                    exc.code,
+                    tool_name=str(request.tool_name or ""),
+                ),
             )
         if result.ok:
             failures.pop(fingerprint, None)

--- a/src/rosclaw/agentd/tooling/effect_resolver.py
+++ b/src/rosclaw/agentd/tooling/effect_resolver.py
@@ -75,6 +75,10 @@ DIRECT_TOOL_EFFECTS: dict[str, EffectClassV1] = {
     "rosclaw_memory_query": EffectClassV1.READ_ONLY,
     "rosclaw_inspect": EffectClassV1.READ_ONLY,
     "rosclaw_fail_safe": EffectClassV1.SHADOW_PROPOSAL,
+    # 0901 P0-3：只读任务/交付物面（解释/查看——零副作用）。
+    "rosclaw_task_inspect": EffectClassV1.READ_ONLY,
+    "rosclaw_artifact_list": EffectClassV1.READ_ONLY,
+    "rosclaw_artifact_resolve": EffectClassV1.READ_ONLY,
     "rosclaw_request_action": EffectClassV1.PHYSICAL_EFFECT,
     "rosclaw_process_start": EffectClassV1.HOST_PROCESS,
     "rosclaw_process_status": EffectClassV1.READ_ONLY,

--- a/src/rosclaw/agentd/tooling/recovery.py
+++ b/src/rosclaw/agentd/tooling/recovery.py
@@ -51,4 +51,23 @@ def recovery_for(code: str) -> str:
     return RECOVERY_REGISTRY.get(code, "")
 
 
-__all__ = ["RECOVERY_REGISTRY", "recovery_for"]
+#: 0901 P0-3：模型按名字猜的漂移名 → 真实只读工具（实测：
+#: task.list_artifacts/artifact.open 撞 EFFECT_UNRESOLVABLE 后模型
+#: 降级 Shell/列能力/重跑任务）。
+_READ_ONLY_HINT = (
+    "查看/解释已有结果用只读工具：rosclaw_task_inspect（任务+验收+"
+    "交付物）、rosclaw_artifact_list、rosclaw_artifact_resolve——"
+    "不要重新执行"
+)
+
+
+def recovery_hint(code: str, *, context: str = "") -> str:
+    """带上下文的恢复提示：漂移的 task.*/artifact.* 名字指向真实
+    只读工具；其余回落 recovery_for（code 默认动作）。"""
+    lowered = context.lower()
+    if lowered.startswith(("task.", "artifact.")):
+        return _READ_ONLY_HINT
+    return recovery_for(code)
+
+
+__all__ = ["RECOVERY_REGISTRY", "recovery_for", "recovery_hint"]

--- a/tests/agentd/test_a0901_p03_readonly.py
+++ b/tests/agentd/test_a0901_p03_readonly.py
@@ -1,0 +1,126 @@
+"""0901 体验探讨 P0-3 红测试：只读任务/交付物能力。
+
+0901 实证：用户问"你这是啥？"——模型调 task.list_artifacts /
+artifact.open 撞 EFFECT_UNRESOLVABLE（猜名字），降级 Shell 被
+bwrap 拒，最后把任务重跑一遍制造第二套 artifact。Native Agent
+不认识确定性链刚做的事。
+
+闭环断言：
+1. pi.artifact.list（task_id 或缺省=最新任务）返回带绝对路径的
+   ArtifactRef 视图——解释/交付不用再跑仿真；
+2. pi.artifact.resolve（artifact_id）返回 path/kind/size/digest；
+3. 模型面注册只读工具：rosclaw_task_inspect / rosclaw_artifact_list
+   / rosclaw_artifact_resolve 在 MODEL_TOOL_NAMES；
+4. Resolver 漂移修复：EFFECT_UNRESOLVABLE/CAPABILITY_UNKNOWN 撞
+   task.*/artifact.* 名字时，恢复提示指向真实只读工具。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+async def _setup_with_artifact(tmp_path: Path):
+    """真实生产链跑一个任务（有 artifact 可查）。"""
+    from rosclaw.agentd.task_execution import TaskExecutionService
+    from tests.agentd.test_pi_tool_bridge import _setup
+
+    service, mission = await _setup(tmp_path)
+    kernel = service._task_kernel
+    kernel.persist_input(
+        mission_id=mission.mission_id, session_ref="s1",
+        message_id="msg_1", text="画一个五角星",
+    )
+    bound = kernel.ensure_task_for_effect(
+        mission_id=mission.mission_id, session_ref="s1",
+        backend_native_id="s1", cwd=str(tmp_path), body_id="sim/ur5e",
+        mode="SIMULATION",
+    )
+    task_id = str(bound["task_id"])
+    kernel.note_tool_use(task_id, "rosclaw_task")
+    TaskExecutionService(
+        kernel=kernel, conn=kernel._conn, home=tmp_path,
+    ).execute(
+        task_id,
+        recipe_inputs={"shape": "star5",
+                       "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+    )
+    return service, mission, task_id
+
+
+class TestArtifactBridgeReadOnly:
+    async def test_artifact_list_latest_task(self, tmp_path: Path) -> None:
+        """pi.artifact.list 缺省=最新任务——返回带绝对路径的视图。"""
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+
+        service, mission, task_id = await _setup_with_artifact(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "b.sock")
+        result = await bridge._dispatch(
+            "user:local:1000", 1, "pi.artifact.list",
+            {"token": service.control_token, "mission_id": mission.mission_id},
+        )
+        assert result.get("ok"), result
+        artifacts = result.get("artifacts") or []
+        assert artifacts, "缺 artifact 列表"
+        for a in artifacts:
+            assert a.get("path"), a
+            assert a.get("artifact_id"), a
+        await service.close()
+
+    async def test_artifact_resolve_by_id(self, tmp_path: Path) -> None:
+        """pi.artifact.resolve(artifact_id) → path/kind/size/digest。"""
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+
+        service, mission, task_id = await _setup_with_artifact(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "b.sock")
+        listed = await bridge._dispatch(
+            "user:local:1000", 1, "pi.artifact.list",
+            {"token": service.control_token, "mission_id": mission.mission_id},
+        )
+        artifact_id = str(listed["artifacts"][0]["artifact_id"])
+        resolved = await bridge._dispatch(
+            "user:local:1000", 2, "pi.artifact.resolve",
+            {"token": service.control_token,
+             "mission_id": mission.mission_id, "artifact_id": artifact_id},
+        )
+        assert resolved.get("ok"), resolved
+        view = resolved.get("artifact") or {}
+        assert view.get("path"), view
+        assert view.get("kind"), view
+        assert int(view.get("size_bytes", 0)) > 0, view
+        assert str(view.get("digest", "")).startswith("sha256:"), view
+        await service.close()
+
+
+class TestModelSurfaceReadOnlyTools:
+    def test_readonly_tools_in_model_surface(self) -> None:
+        """只读工具进模型面——解释追问不再靠猜名字。"""
+        surface = (
+            Path(__file__).resolve().parents[2]
+            / "packages/rosclaw-agent/src/tools/surface.ts"
+        ).read_text(encoding="utf-8")
+        for name in (
+            "rosclaw_task_inspect",
+            "rosclaw_artifact_list",
+            "rosclaw_artifact_resolve",
+        ):
+            assert f'"{name}"' in surface, f"{name} 不在模型面"
+
+
+class TestResolverDriftHint:
+    def test_unresolvable_task_artifact_names_hint_readonly(self) -> None:
+        """task.list_artifacts / artifact.open 这类漂移名字 →
+        恢复提示指向真实只读工具（不是泛泛"查注册表"）。"""
+        from rosclaw.agentd.tooling.recovery import recovery_hint
+
+        for name in ("task.list_artifacts", "artifact.open", "artifact.show"):
+            hint = recovery_hint("EFFECT_UNRESOLVABLE", context=name)
+            assert "rosclaw_task_inspect" in hint or "rosclaw_artifact" in hint, (
+                f"{name} 的恢复提示未指向只读工具：{hint}"
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 0901 体验审计 P0-3：last task/outcome/artifact 只读能力 + Effect Resolver 漂移修复

### 问题（0901 体验实证）
用户追问上次任务的结果/文件在哪，模型没有只读查询能力，只能猜 CLI 名（task.outcome / artifact.list 全 NOT_FOUND）——错误信封还没有可执行的恢复提示。

### 修复
- pi.artifact.list / pi.artifact.resolve 桥处理器（task_id 或会话最新任务，含 mission 级回退）。
- recovery_hint：task.*/artifact.* 漂移名 → 指向 rosclaw_task_inspect / rosclaw_artifact_list / rosclaw_artifact_resolve 的可执行提示。
- Effect Resolver 补齐 3 个只读工具（READ_ONLY），effects.generated.json 重生成（23 条）。
- TS：buildReadOnlyTaskTools（rosclaw_task_inspect / rosclaw_artifact_list / rosclaw_artifact_resolve）入 EMBODIMENT_PACK + pi-runtime 注册。

### 红→绿证据
tests/agentd/test_a0901_p03_readonly.py（4 tests）+ TS 196/0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)