### PR TITLE
feat: 0901-P0-4 解释性追问 = 只读确定性回答（硬 Gate A）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -31,6 +31,10 @@ import type { ProductStateCenter } from "../session/state-center.js";
 import { InputController } from "../native/input-controller.js";
 import { OperationWatcher } from "../native/operation-watcher.js";
 import { suppressModelTurn } from "../native/turn-disposition.js";
+import {
+	renderTerminalReply,
+	type TerminalOutcome,
+} from "../native/terminal-presenter.js";
 import { classifyModelError, ProviderErrorGate } from "../native/model-errors.js";
 import {
 	renderArtifactList,
@@ -435,6 +439,56 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			const autoTask = (persisted as { auto_task?: { task_id?: string } })
 				.auto_task;
 			if (suppressModelTurn(persisted)) {
+				// 0901 P0-4（硬 Gate A）：解释性追问 → EXPLAIN_HANDLER
+				// 只读确定性回答（从 TaskOutcome 直接呈现——零模型
+				// 回合、零新 task/trace/artifact、零仿真）。
+				const explain = (
+					persisted as {
+						explain?: {
+							task_id?: string;
+							goal?: string;
+							state?: string;
+							outcome?: Record<string, unknown>;
+							artifacts?: Array<Record<string, unknown>>;
+						};
+					}
+				).explain;
+				if (explain) {
+					const goal = String(explain.goal ?? "").slice(0, 80);
+					const refs = (explain.outcome?.artifact_refs ??
+						explain.artifacts ??
+						[]) as Array<Record<string, unknown>>;
+					const lines = refs
+						.map((r) => {
+							const kind = String(r.kind ?? r.media_type ?? "");
+							const path = String(r.path ?? "");
+							return `  · ${kind}：${path}`;
+						})
+						.filter((l) => !l.endsWith("："));
+					// 进行中的任务没有终态 outcome——诚实"还在执行"，
+					// 不把 UNKNOWN 渲染成"未达成"。
+					const inFlight = !explain.outcome;
+					const body = inFlight
+						? `刚才的任务（${String(explain.task_id ?? "").slice(0, 20)}…）：`
+							+ `${goal}——还在执行中（/activity 查看进度）`
+							+ (lines.length ? `\n已产出：\n${lines.join("\n")}` : "")
+						: `刚才的任务（${String(explain.task_id ?? "").slice(0, 20)}…）：`
+							+ `${goal}——状态 ${String(explain.state ?? "")}\n`
+							+ renderTerminalReply(
+								(explain.outcome ?? {}) as TerminalOutcome,
+							)
+							+ (lines.length ? `\n交付物：\n${lines.join("\n")}` : "");
+					pi.sendMessage(
+						{
+							customType: "rosclaw.task_explain",
+							content: body,
+							display: true,
+							details: { task_id: explain.task_id ?? "" },
+						},
+						{ triggerTurn: false },
+					);
+					return { action: "handled" as const };
+				}
 				if (autoTask?.task_id) {
 					operationWatcher.trackTask(String(autoTask.task_id));
 				}

--- a/packages/rosclaw-agent/src/native/input-controller.ts
+++ b/packages/rosclaw-agent/src/native/input-controller.ts
@@ -53,6 +53,15 @@ export class InputController {
 	): Promise<{
 		input_id?: string;
 		auto_task?: { task_id?: string; replayed?: boolean };
+		/** 0901 P0-4：EXPLAIN_HANDLER 的只读负载（outcome+artifacts）。 */
+		explain?: {
+			task_id?: string;
+			goal?: string;
+			state?: string;
+			revision?: number;
+			outcome?: Record<string, unknown> | null;
+			artifacts?: Array<Record<string, unknown>>;
+		};
 		turn_disposition?: {
 			input_id?: string;
 			owner?: string;
@@ -73,6 +82,14 @@ export class InputController {
 				ok?: boolean;
 				input?: { input_id?: string };
 				auto_task?: { task_id?: string; replayed?: boolean };
+				explain?: {
+					task_id?: string;
+					goal?: string;
+					state?: string;
+					revision?: number;
+					outcome?: Record<string, unknown> | null;
+					artifacts?: Array<Record<string, unknown>>;
+				};
 				turn_disposition?: {
 					input_id?: string;
 					owner?: string;
@@ -88,6 +105,7 @@ export class InputController {
 			return {
 				...(result.input ?? {}),
 				auto_task: result.auto_task,
+				explain: result.explain,
 				turn_disposition: result.turn_disposition,
 			};
 		} catch (err) {

--- a/src/rosclaw/agentd/explain_route.py
+++ b/src/rosclaw/agentd/explain_route.py
@@ -1,0 +1,71 @@
+"""解释性追问的只读确定性回答（0901 体验探讨 P0-4，硬 Gate A）。
+
+0901 实证：任务 FAIL+PARTIAL 后用户问"你这是啥？"——系统没有
+只读解释路径，模型重跑了整个任务（新 trace + 第二套 artifact）。
+
+解释/查看类追问（这是啥/结果呢/文件在哪/为什么失败…）且会话里
+已有任务时：由 EXPLAIN_HANDLER 认领——TurnOutcome + 交付物列表
+直接回答（零模型回合、零新 task/trace/artifact、零仿真渲染）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: 解释/查看追问标记（通用词类——问"刚才的结果"不是新指令）。
+_EXPLAIN_MARKERS = (
+    "这是啥", "这是什么", "什么意思", "刚才", "结果呢", "结果是什么",
+    "怎么样", "怎么样了", "文件在哪", "在哪呢", "在哪里", "为什么失败",
+    "怎么失败", "成功了吗", "成功了么", "给我看", "给我看看", "看看结果",
+    "什么情况", "发生什么了", "咋样了", "how did", "what happened",
+    "where is", "show me", "what is this",
+)
+
+
+def is_explain_followup(text: str) -> bool:
+    """解释/查看追问判定。"""
+    lowered = text.lower()
+    return any(m in lowered or m in text for m in _EXPLAIN_MARKERS)
+
+
+def maybe_explain_last_task(
+    service: Any, *, mission_id: str, session_ref: str,
+) -> dict[str, Any] | None:
+    """会话最近任务 + outcome + 交付物 → explain 负载（无任务/无
+    outcome 则不劫持——正常聊天走模型）。"""
+    kernel = service._task_kernel
+    latest = kernel.latest_task_for(mission_id, session_ref)
+    if latest is None:
+        # session 无绑定回落 mission 最近任务（与 pi.artifact.list 同
+        # 语义——session 轮换不丢解释面）。
+        row = kernel._conn.execute(
+            "SELECT task_id FROM tasks WHERE mission_id = ? "
+            "ORDER BY created_at DESC LIMIT 1",
+            (mission_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        latest = kernel.get_task(str(row["task_id"]))
+    if latest is None:
+        return None
+    task_id = str(latest["task_id"])
+    # outcome 幂等读取（coordinator.consider 是只读评估——已存
+    # outcome 原样返回；没有 outcome 的任务给诚实"还在进行"）。
+    outcome = None
+    try:
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+
+        outcome = TaskCoordinator(kernel).consider(task_id)
+    except Exception:  # noqa: BLE001 - outcome 不可得≠不能解释
+        outcome = None
+    return {
+        "task_id": task_id,
+        "state": str(latest.get("state", "")),
+        "goal": str(latest.get("root_goal", "") or "")[:200],
+        "revision": int(latest.get("active_revision") or 1),
+        "outcome": outcome,
+        "artifacts": kernel.artifact_refs_for(task_id),
+    }
+
+
+__all__ = ["is_explain_followup", "maybe_explain_last_task"]

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1052,6 +1052,23 @@ class PiBridgeServer:
             out: dict = {"ok": True, "input": record}
             if auto_task:
                 out["auto_task"] = auto_task
+            # 0901 P0-4（硬 Gate A）：解释性追问 → EXPLAIN_HANDLER
+            # 只读确定性回答（零模型回合、零新 task/trace/artifact）。
+            explain = None
+            if auto_task is None:
+                from rosclaw.agentd.explain_route import (
+                    is_explain_followup,
+                    maybe_explain_last_task,
+                )
+
+                if is_explain_followup(text):
+                    explain = maybe_explain_last_task(
+                        service,
+                        mission_id=str(params.get("mission_id", "")),
+                        session_ref=str(params.get("session_ref", "")),
+                    )
+            if explain:
+                out["explain"] = explain
             # P0-1（0827 审计·Input Arbiter）：权威 TurnDisposition——
             # 一条输入只有一个 Owner。TASK_ROUTER 认领后 Harness 必须
             # suppress 模型回合（否则确定性链与 Native Agent 双控制者
@@ -1061,9 +1078,17 @@ class PiBridgeServer:
                     record.get("input_id", "")
                     or params.get("message_id", "")
                 ),
-                "owner": "TASK_ROUTER" if auto_task else "PI_CONVERSATION",
-                "task_id": str(auto_task.get("task_id", "")) if auto_task else "",
-                "suppress_model_turn": bool(auto_task),
+                "owner": (
+                    "TASK_ROUTER" if auto_task
+                    else "EXPLAIN_HANDLER" if explain
+                    else "PI_CONVERSATION"
+                ),
+                "task_id": (
+                    str(auto_task.get("task_id", "")) if auto_task
+                    else str(explain.get("task_id", "")) if explain
+                    else ""
+                ),
+                "suppress_model_turn": bool(auto_task or explain),
             }
             return out
         if method == "pi.task.ensure_effect":

--- a/tests/agentd/test_a0901_p04_explain.py
+++ b/tests/agentd/test_a0901_p04_explain.py
@@ -1,0 +1,101 @@
+"""0901 体验探讨 P0-4 红测试：解释性追问 = 只读确定性回答（硬 Gate A）。
+
+0901 实证：任务 FAIL+PARTIAL 后用户问"你这是啥？"——系统没有
+只读解释路径，模型重跑了整个任务（新 trace + 第二套 artifact）。
+
+硬 Gate A（文档 §十二）：解释性追问 → 0 新 Task / 0 新 Trace /
+0 新 Artifact / 0 次仿真渲染 / 从 TaskOutcome 直接回答。
+
+闭环断言：
+1. 解释标记（这是啥/什么意思/结果呢/文件在哪/为什么失败/成功了
+   吗/给我看）→ 已有任务时 owner=EXPLAIN_HANDLER + suppress
+   模型回合 + 回答负载含 outcome+artifacts；
+2. 无最近任务时不劫持（走模型正常聊天）；
+3. 解释后账本零新增（tasks/artifacts/plans 数量不变）；
+4. 非解释的问句（"你能画五角星吗？"）不被劫持。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class TestExplainRoute:
+    def test_explain_markers(self) -> None:
+        from rosclaw.agentd.explain_route import is_explain_followup
+
+        for text in (
+            "你这是啥？", "什么意思", "结果呢", "文件在哪", "为什么失败了",
+            "成功了吗", "给我看看", "刚才那个是什么",
+        ):
+            assert is_explain_followup(text), text
+        for text in ("画一个五角星", "你能画五角星吗？", "帮我写个脚本"):
+            assert not is_explain_followup(text), text
+
+    async def test_explain_followup_deterministic_answer(
+        self, tmp_path: Path
+    ) -> None:
+        """已有终态任务 + 解释追问 → owner=EXPLAIN_HANDLER +
+        suppress + outcome 负载——零新 task/artifact。"""
+        import asyncio
+
+        from rosclaw.agentd.auto_route import reset_routed_for_tests
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        reset_routed_for_tests()
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "b.sock")
+        # 先跑完一个真实任务（画五角星——自动路由链）。
+        r1 = await bridge._dispatch(
+            "user:local:1000", 1, "pi.input.persist",
+            {"token": service.control_token, "mission_id": mission.mission_id,
+             "session_ref": "pi_1", "message_id": "m1",
+             "text": "画一个五角星"},
+        )
+        task_id = str(r1["auto_task"]["task_id"])
+        kernel = service._task_kernel
+        deadline = asyncio.get_event_loop().time() + 180
+        while asyncio.get_event_loop().time() < deadline:
+            t = kernel.get_task(task_id)
+            if t and t["state"] in ("SUCCEEDED", "FAILED"):
+                break
+            await asyncio.sleep(2)
+        counts_before = {
+            t: kernel._conn.execute(
+                f"SELECT COUNT(*) AS n FROM {t}"  # noqa: S608
+            ).fetchone()["n"]
+            for t in ("tasks", "artifacts")
+        }
+        plans_before = len(list((tmp_path / "sim" / "plans").glob("*.json")))
+        # 解释追问。
+        r2 = await bridge._dispatch(
+            "user:local:1000", 2, "pi.input.persist",
+            {"token": service.control_token, "mission_id": mission.mission_id,
+             "session_ref": "pi_1", "message_id": "m2",
+             "text": "你这是啥？"},
+        )
+        disposition = r2.get("turn_disposition") or {}
+        assert disposition.get("owner") == "EXPLAIN_HANDLER", r2
+        assert disposition.get("suppress_model_turn") is True, r2
+        explain = r2.get("explain")
+        assert explain, "缺 explain 负载"
+        assert explain.get("task_id") == task_id, explain
+        outcome = explain.get("outcome") or {}
+        assert outcome.get("verification"), outcome
+        assert explain.get("artifacts") is not None, explain
+        # 硬 Gate A：账本零新增。
+        for table, before in counts_before.items():
+            after = kernel._conn.execute(
+                f"SELECT COUNT(*) AS n FROM {table}"  # noqa: S608
+            ).fetchone()["n"]
+            assert after == before, f"{table}: {before} → {after}"
+        plans_after = len(list((tmp_path / "sim" / "plans").glob("*.json")))
+        assert plans_after == plans_before, "解释追问竟产生了新 plan"
+        await service.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1626,6 +1626,28 @@ class TestProductJourney:
             # 七审 §6 PR-SEVEN-4：轨迹级证据——verify PASS（端点/RMSE/
             # 闭合误差全过）+ 单 ExactAction 覆盖整条轨迹。
             self._assert_star_verified(home)
+            # 0901 P0-4（硬 Gate A）：PARTIAL/终态后用户问"你这是
+            # 啥？"→ EXPLAIN_HANDLER 只读确定性回答——0 新 task、
+            # 0 模型请求、0 次仿真（0901 实证：解释追问曾重跑整个
+            # 任务制造第二套 artifact）。
+            import sqlite3 as _sq3
+
+            tasks_before = _sq3.connect(
+                home / "agentd" / "missions.db"
+            ).execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+            model_turns_before_explain = len(fake.fake.requests)
+            session.send("你这是啥？\r")
+            session.expect("刚才的任务".encode(), timeout=60)
+            assert len(fake.fake.requests) == model_turns_before_explain, (
+                "解释追问竟触发模型回合"
+            )
+            tasks_after = _sq3.connect(
+                home / "agentd" / "missions.db"
+            ).execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+            assert tasks_after == tasks_before, (
+                f"解释追问竟建新任务：{tasks_before} → {tasks_after}"
+            )
+            self._journey_verdicts["explain_followup_zero_recompute"] = True
             # 6c. LIMO 交叉（六审 §6.3.10）：LIMO 动作在 UR5e body 上必须
             #     建卡前 BODY_CAPABILITY_MISMATCH，零 approval/grant/txn。
             self._assert_cross_body_rejected(session, home)


### PR DESCRIPTION
## 0901 体验审计 P0-4：解释性追问进只读模式——零新任务/零新仿真

### 问题（0901 体验实证）
用户任务完成后追问"你这是啥？"——系统起了新模型回合甚至新任务/新仿真（重跑了一遍）。解释性追问应该从 TaskOutcome 直接回答。

### 修复
- explain_route.py（新）：追问标记（这是啥/什么意思/结果呢/文件在哪/为什么失败/给我看看…）+ maybe_explain_last_task（最新任务 + mission 回退 + 只读 consider + artifact_refs——零副作用）。
- pi.input.persist：auto_task 优先，其次 explain；turn_disposition owner=EXPLAIN_HANDLER + suppress_model_turn。
- extension：suppress 路径发 rosclaw.task_explain 卡（goal + 状态 + renderTerminalReply + 产物路径）；在途任务诚实报"还在执行中"。
- input-controller：explain 字段穿透（journey 抓到的丢字段 bug）。

### 硬 Gate A（journey 实证）
星任务验收后追问"你这是啥？"→ 回答含"刚才的任务"，零新 fake-model 请求、零新任务、零新 artifact、零新仿真。tests/agentd/test_a0901_p04_explain.py（2 tests）+ product journey 3/3 + TS 196/0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)