### PR TITLE
feat: 0901-P0-5 具身终态权威——手拼低层 capability 不得发布终态

### DIFF
--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -688,6 +688,76 @@ class TaskKernel:
         # 不代替资源证明。
         provenance_failures: list[str] = []
         embodiment_used = self.task_used_embodiment(task_id)
+        # 0901 P0-5：具身任务的终态权威——手拼低层 capability（裸
+        # compute/observe/simulate 直调）的产物不得发布终态。实证：
+        # 0901 第二轮模型手拼 simulate→trace 落账，turn_end 的
+        # consider 直接把任务收成 PASS·DELIVERED（渲染/验证还在
+        # 后面跑）。
+        # 判别边界（0827 全量回归实证）：body_id 非空只是会话绑定
+        # （chat 默认绑 body——纯写文件任务也带 body_id，不得误伤）；
+        # 真正的"具身实效"是任务实际触碰了具身面：embodiment 工具
+        # 事件（task.tool_used）或 kernel 能力/仿真产物
+        # （kernel:capability:*/kernel:sim* producer）。
+        # 受信执行证据三选一：PlanGraph plan.node 事件（确定性链）、
+        # Operator 链 COMPLETED txn、或 kernel 核验血缘的产物
+        # （登记时 kernel 计算的 receipt/trace digest——受信 sim
+        # 管道跑过的密码学证明）。
+        capability_touched = self._conn.execute(
+            "SELECT COUNT(*) AS n FROM artifacts WHERE task_id = ? AND "
+            "(producer LIKE 'kernel:capability:%' OR "
+            "producer LIKE 'kernel:sim%')",
+            (task_id,),
+        ).fetchone()
+        embodied_in_effect = bool(task.get("body_id")) and (
+            embodiment_used or int(capability_touched["n"]) > 0
+        )
+        authority_failure: list[str] = []
+        if embodied_in_effect:
+            plan_events = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM task_events WHERE task_id = ? "
+                "AND event_type LIKE 'plan.node_%'",
+                (task_id,),
+            ).fetchone()
+            binding = self._conn.execute(
+                "SELECT session_ref FROM task_session_bindings "
+                "WHERE task_id = ? AND role = 'primary' LIMIT 1",
+                (task_id,),
+            ).fetchone()
+            receipts = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM action_txns "
+                "WHERE mission_id = ? AND pi_session_id = ? "
+                "AND state = 'COMPLETED'",
+                (str(task["mission_id"]),
+                 str(binding["session_ref"]) if binding else ""),
+            ).fetchone()
+            lineage_rows = self._conn.execute(
+                "SELECT metadata_json FROM artifacts WHERE task_id = ? "
+                "AND metadata_json LIKE '%\"lineage\"%'",
+                (task_id,),
+            ).fetchall()
+            # 血缘两态都算受信执行证据（登记时 kernel 打戳/核验）：
+            # render 血缘（receipt digest 实算）与 preview_2d 血缘
+            # （trace 引用 + task/revision 打戳——WP-4 产品路径）。
+            # 裸手拼产物（无 lineage 元数据）两者皆无。
+            lineage_present = any(
+                ((json.loads(str(r["metadata_json"]) or "{}")
+                  .get("lineage") or {}).get("render_receipt_digest"))
+                or (
+                    (json.loads(str(r["metadata_json"]) or "{}")
+                     .get("lineage") or {}).get("kind") == "preview_2d"
+                    and (json.loads(str(r["metadata_json"]) or "{}")
+                         .get("lineage") or {}).get("trace_id")
+                )
+                for r in lineage_rows
+            )
+            if (not int(plan_events["n"]) and not int(receipts["n"])
+                    and not lineage_present):
+                authority_failure.append(
+                    "PLAN_AUTHORITY_MISSING: 具身任务缺受信执行证据"
+                    "（PlanGraph plan.node 事件 / Operator 链 COMPLETED "
+                    "txn / kernel 核验血缘产物 三选一）——手拼低层 "
+                    "capability 不得发布终态"
+                )
         if embodiment_used:
             # P0-G：canonical alias 唯一权威换算（不再手写前缀）。
             from rosclaw.cognition.alias import canonical_resource_id
@@ -830,6 +900,7 @@ class TaskKernel:
                             "该 trace 实际内容不符——renderer 吃的不是这条 trace"
                         )
         provenance_failures += graph_failures
+        provenance_failures += authority_failure
         # R0-2（0826 体验审计 §5.R0-2）：spec 冻结的 required
         # deliverables 按 kind 核验全量产物账本——任务成功 ≠ 用户
         # 请求成功（2D 预览不满足 scene_video——kind 分野是硬边界）。

--- a/tests/agentd/test_a0901_p05_terminal_authority.py
+++ b/tests/agentd/test_a0901_p05_terminal_authority.py
@@ -1,0 +1,116 @@
+"""0901 体验探讨 P0-5 红测试：具身任务终态权威——手拼低层
+capability 不得发布终态。
+
+0901 实证（用户日志）：第二轮模型手拼低层 capability——
+simulate 产出 trace artifact 后 turn_end 的 consider→finish_task
+直接把任务收成"验收 PASS · 交付 DELIVERED"，渲染和验证还在
+后面跑。后续视频/验证 artifact 挂在了一个已终态的任务上。
+
+机制实证（本文件复现）：具身任务（body_id 非空）+ 裸 trace
+artifact + 无 PlanGraph 事件 + 无 Operator 链 txn →
+consider→finish_task 竟 COMPLETED/SUCCEEDED。
+
+闭环断言：
+1. 裸手拼产物不发布终态（task 保持 ACTIVE，无 task.terminal，
+   outcome 不 COMPLETED）；
+2. 有 PlanGraph 执行证据（plan.node 事件）→ 正常完成（自动路由
+   链回归护栏）；
+3. 无 body 的任务（hello.txt 类编码任务）不受影响（h4 语义不变）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _register_trace(kernel, task_id: str, tmp_path: Path) -> None:
+    trace_dir = tmp_path / "sim" / "traces" / "trace_hand"
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    (trace_dir / "trace.json").write_text('{"ok": true}', encoding="utf-8")
+    kernel.register_artifact(
+        task_id=task_id, path=str(trace_dir / "trace.json"),
+        media_type="application/json",
+        producer="kernel:capability:ur5e.simulate",
+    )
+
+
+class TestTerminalAuthority:
+    def test_bare_hand_chain_must_not_complete_embodied_task(
+        self, tmp_path: Path
+    ) -> None:
+        """裸手拼（无 plan.node、无 Operator txn）→ 不得终态。"""
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+        from tests.agentd.test_r01_production_chain import _kernel
+        from tests.agentd.test_r02_task_spec_deliverables import _draw_task
+
+        kernel, _conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, "让机械臂动一下")
+        kernel.note_tool_use(task_id, "rosclaw_compute")
+        _register_trace(kernel, task_id, tmp_path)
+        outcome = TaskCoordinator(kernel).consider(task_id)
+        task = kernel.get_task(task_id)
+        assert task["state"] not in ("SUCCEEDED",), (
+            f"手拼裸产物竟发布终态：{task['state']}"
+        )
+        if outcome is not None:
+            assert outcome["lifecycle"] != "COMPLETED", outcome
+        terminal = kernel._conn.execute(
+            "SELECT COUNT(*) AS n FROM task_events WHERE task_id = ? "
+            "AND event_type = 'task.terminal'",
+            (task_id,),
+        ).fetchone()
+        assert int(terminal["n"]) == 0, "裸手拼竟产生 task.terminal"
+
+    def test_plan_graph_evidence_allows_completion(
+        self, tmp_path: Path
+    ) -> None:
+        """真实生产链（plan.node 事件齐全）→ 正常终态（回归护栏）。"""
+        from rosclaw.agentd.task_execution import TaskExecutionService
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+        from tests.agentd.test_r01_production_chain import _kernel
+        from tests.agentd.test_r02_task_spec_deliverables import _draw_task
+
+        kernel, conn = _kernel(tmp_path)
+        task_id = _draw_task(kernel, tmp_path, "画一个五角星")
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        TaskExecutionService(kernel=kernel, conn=conn, home=tmp_path).execute(
+            task_id,
+            recipe_inputs={"shape": "star5",
+                           "center_m": [0.35, 0.25, 0.30], "scale_m": 0.10},
+        )
+        task = kernel.get_task(task_id)
+        assert task["state"] == "SUCCEEDED", (
+            f"生产链竟没终态（P0-5 误伤）：{task['state']}"
+        )
+
+    def test_non_body_task_unaffected(self, tmp_path: Path) -> None:
+        """无 body 的编码任务（h4 语义）不受影响——hand write+deliver
+        仍由 consider 收尾。"""
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+        from tests.agentd.test_r01_production_chain import _kernel
+
+        kernel, _conn = _kernel(tmp_path)
+        kernel.persist_input(
+            mission_id="m1", session_ref="s1",
+            message_id="msg_1", text="写一个 hello.txt 并交付",
+        )
+        bound = kernel.ensure_task_for_effect(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            cwd=str(tmp_path), body_id="",  # 无 body——编码任务
+        )
+        task_id = str(bound["task_id"])
+        hello = tmp_path / "hello.txt"
+        hello.write_text("hello\n", encoding="utf-8")
+        record = kernel.register_artifact(
+            task_id=task_id, path=str(hello),
+            media_type="text/plain", producer="model:rosclaw_deliver",
+        )
+        outcome = TaskCoordinator(kernel).consider(task_id)
+        assert outcome is not None
+        assert outcome["lifecycle"] == "COMPLETED", outcome
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agentd/test_a0901_p05_terminal_authority.py
+++ b/tests/agentd/test_a0901_p05_terminal_authority.py
@@ -68,7 +68,6 @@ class TestTerminalAuthority:
     ) -> None:
         """真实生产链（plan.node 事件齐全）→ 正常终态（回归护栏）。"""
         from rosclaw.agentd.task_execution import TaskExecutionService
-        from rosclaw.task_kernel.coordinator import TaskCoordinator
         from tests.agentd.test_r01_production_chain import _kernel
         from tests.agentd.test_r02_task_spec_deliverables import _draw_task
 
@@ -103,7 +102,7 @@ class TestTerminalAuthority:
         task_id = str(bound["task_id"])
         hello = tmp_path / "hello.txt"
         hello.write_text("hello\n", encoding="utf-8")
-        record = kernel.register_artifact(
+        kernel.register_artifact(
             task_id=task_id, path=str(hello),
             media_type="text/plain", producer="model:rosclaw_deliver",
         )


### PR DESCRIPTION
## 0901 体验审计 P0-5：禁止模型低层 capability 绕开 TaskSpec/PlanGraph 发布终态

### 问题（0901 体验实证）
第二轮模型手拼低层 capability——simulate 产出 trace artifact 后，turn_end 的 consider→finish_task 直接把任务收成"验收 PASS · 交付 DELIVERED"（渲染和验证还在后面跑）。后续视频/验证 artifact 挂在了一个已终态的任务上。

### 修复（PLAN_AUTHORITY_MISSING）
finish_task 对具身实效任务（body_id 非空 且 实际触碰具身面：tool_used 事件或 kernel:capability:*/kernel:sim* 产物）要求受信执行证据三选一：
1. PlanGraph plan.node 事件（确定性链）；
2. Operator 链 COMPLETED txn；
3. kernel 核验血缘产物（render digest 实算 / preview_2d 打戳）。

缺证 → provenance_failures 追加 PLAN_AUTHORITY_MISSING（不发布终态）。

### 判别边界（首轮全量回归 6 失败实证修正）
body_id 非空只是会话绑定（chat 默认绑 body——纯写文件任务也带 body_id，误伤 n1/wp1/wp4）；改为具身实效判定 + 血缘证据后全量 799/799。

### 红→绿证据
tests/agentd/test_a0901_p05_terminal_authority.py：裸手拼链不发布终态（无 task.terminal）/ PlanGraph 链正常完成 / 无 body 任务不受影响。全量 agentd 799 passed 0 failed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)