### PR TITLE
feat: 0901-P0-6 终态呈现产品化 + 内核消息卡——原因/文件名/绝对路径/下一步

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -21,6 +21,7 @@ import {
 import { defaultOperatorSocket, operatorCall } from "../bridge/operatord-client.js";
 import { ApprovalCardComponent } from "../ui/approval-card.js";
 import { ActionResultCardComponent, type ActionResultData } from "../ui/action-result-card.js";
+import { kernelMessageRenderers } from "../ui/kernel-message-cards.js";
 import {
 	formatKitBrokenHint,
 	formatKitRecoveredHint,
@@ -998,6 +999,13 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				notifyLeveled(ctx, `授权卡交互失败：${(err as Error).message}`, "error");
 			}
 		});
+
+		// -- 内核消息卡（0901 体验审计 P0-6）----------------------------
+		// 内部 customType（user_directive/task_terminal/task_explain）
+		// 以卡片呈现——协议标签（[rosclaw.xxx]）绝不上屏。
+		for (const [customType, card] of Object.entries(kernelMessageRenderers)) {
+			pi.registerMessageRenderer(customType, (message) => card(message));
+		}
 
 		// -- 权威 Action Result Card（五审 P0-5F）--------------------------
 		// 动作终态只由 ROSClaw runtime 渲染（结构化 outcome → 不可变卡）；

--- a/packages/rosclaw-agent/src/native/terminal-presenter.ts
+++ b/packages/rosclaw-agent/src/native/terminal-presenter.ts
@@ -36,7 +36,9 @@ export interface TerminalOutcome {
 	}>;
 }
 
-/** 交付物一行：文件名 + 绝对路径 + 打开命令（可复制执行）。 */
+/** 交付物三行：文件名（大小）/ 裸绝对路径 / 裸打开命令——
+ *  无标签前缀（0901 journey 实证：CJK 换行会把"路径："从值
+ *  中间撕开；裸行既防撕裂又便于复制）。 */
 function renderArtifactLine(ref: {
 	artifact_id?: string;
 	open_command?: string;
@@ -54,11 +56,11 @@ function renderArtifactLine(ref: {
 				? `${size} B`
 				: "";
 	const head = name
-		? `${name}${sizeText ? `（${sizeText}）` : ""}`
-		: String(ref.artifact_id ?? "artifact");
-	const pathLine = path ? `\n  路径：${path}` : "";
-	const openLine = ref.open_command ? `\n  打开：${ref.open_command}` : "";
-	return `• ${head}${pathLine}${openLine}`;
+		? `• ${name}${sizeText ? `（${sizeText}）` : ""}`
+		: `• ${String(ref.artifact_id ?? "artifact")}`;
+	const pathLine = path ? `\n  ${path}` : "";
+	const openLine = ref.open_command ? `\n  ${ref.open_command}` : "";
+	return `${head}${pathLine}${openLine}`;
 }
 
 /** 任务终态的最终用户回复（确定性——同一 outcome 永远同一文本）。 */

--- a/packages/rosclaw-agent/src/native/terminal-presenter.ts
+++ b/packages/rosclaw-agent/src/native/terminal-presenter.ts
@@ -4,8 +4,14 @@
  *  MISSING"——两个发布者互相矛盾）。
  *
  * 输出原则：
- * - PASS + DELIVERED → 完成 + 交付物打开命令；
- * - 其余 → 诚实"未完全达成" + 验收/交付状态，绝不出现完成宣称。
+ * - PASS + DELIVERED → 完成 + 交付物（文件名/绝对路径/打开命令）
+ *   + 下一步；
+ * - 其余 → 诚实"未完全达成" + 原因（验收失败逐条）+ 已产出 +
+ *   下一步，绝不出现完成宣称。
+ *
+ * 0901 P0-6（体验审计 §十二 P0-6）：一行结论不是产品——用户必须
+ * 看到 原因（为什么失败）、文件名、绝对路径、下一步（看完知道
+ * 该干嘛）。
  */
 
 export interface TerminalOutcome {
@@ -15,10 +21,44 @@ export interface TerminalOutcome {
 	/** P0-4：outputs/ 投影视图状态（DEGRADED = 投影失败但账本
 	 *  交付有效——必须如实告知，不得静默）。 */
 	workspace_projection?: string;
+	/** P0-6：验收/交付失败原因（repair_directive.failures——
+	 *  Coordinator 已持久化的权威失败清单）。 */
+	repair_directive?: {
+		failures?: string[];
+	};
 	artifact_refs?: Array<{
 		artifact_id?: string;
 		open_command?: string;
+		/** P0-6：绝对路径 + 媒体类型 + 大小（交付面三要素）。 */
+		path?: string;
+		media_type?: string;
+		size_bytes?: number;
 	}>;
+}
+
+/** 交付物一行：文件名 + 绝对路径 + 打开命令（可复制执行）。 */
+function renderArtifactLine(ref: {
+	artifact_id?: string;
+	open_command?: string;
+	path?: string;
+	size_bytes?: number;
+}): string {
+	const path = String(ref.path ?? "");
+	const name = path ? path.split("/").pop() ?? "" : "";
+	const size = Number(ref.size_bytes ?? 0);
+	const sizeText = size >= 1_048_576
+		? `${(size / 1_048_576).toFixed(1)} MB`
+		: size >= 1024
+			? `${(size / 1024).toFixed(1)} KB`
+			: size > 0
+				? `${size} B`
+				: "";
+	const head = name
+		? `${name}${sizeText ? `（${sizeText}）` : ""}`
+		: String(ref.artifact_id ?? "artifact");
+	const pathLine = path ? `\n  路径：${path}` : "";
+	const openLine = ref.open_command ? `\n  打开：${ref.open_command}` : "";
+	return `• ${head}${pathLine}${openLine}`;
 }
 
 /** 任务终态的最终用户回复（确定性——同一 outcome 永远同一文本）。 */
@@ -26,9 +66,7 @@ export function renderTerminalReply(outcome: TerminalOutcome): string {
 	const verification = String(outcome.verification ?? "UNKNOWN");
 	const delivery = String(outcome.delivery ?? "UNKNOWN");
 	const refs = outcome.artifact_refs ?? [];
-	const opens = refs
-		.map((r) => String(r.open_command ?? ""))
-		.filter(Boolean);
+	const artifactLines = refs.map(renderArtifactLine);
 	const passed = (verification === "PASS" || verification === "PASS_NEAR_LIMIT")
 		&& delivery === "DELIVERED";
 	const degraded = outcome.workspace_projection === "DEGRADED"
@@ -40,13 +78,26 @@ export function renderTerminalReply(outcome: TerminalOutcome): string {
 		const head = verification === "PASS_NEAR_LIMIT"
 			? "✅ 任务完成：验收 PASS_NEAR_LIMIT（误差接近阈值上限，勉强通过） · 交付 DELIVERED"
 			: "✅ 任务完成：验收 PASS · 交付 DELIVERED";
-		return opens.length
-			? `${head}\n交付物：${opens.join(" · ")}${degraded}`
-			: head + degraded;
+		if (!artifactLines.length) return head + degraded;
+		return (
+			`${head}\n交付物：\n${artifactLines.join("\n")}${degraded}\n`
+			+ "下一步：用上面的「打开」命令查看交付物；/activity 查看完整账本"
+		);
 	}
+	// 失败/部分达成：原因逐条（用户必须看到"为什么"）+ 已产出 +
+	// 下一步。
+	const failures = outcome.repair_directive?.failures ?? [];
+	const reasonLines = failures.length
+		? `\n原因：\n${failures.map((f) => `• ${f}`).join("\n")}`
+		: "";
+	const producedLines = artifactLines.length
+		? `\n已产出：\n${artifactLines.join("\n")}`
+		: "";
 	return (
 		`⚠️ 任务未完全达成：验收 ${verification} · 交付 ${delivery}`
-		+ "——如实说明限制，不宣称完整完成（/activity 查看账本）"
-		+ (opens.length ? `\n已产出交付物：${opens.join(" · ")}` : "")
+		+ "——如实说明限制，不宣称完整完成"
+		+ reasonLines
+		+ producedLines
+		+ "\n下一步：/activity 查看完整账本；或直接说明如何修正（在同一任务内继续，不重新跑已完成的步骤）"
 	);
 }

--- a/packages/rosclaw-agent/src/ui/kernel-message-cards.ts
+++ b/packages/rosclaw-agent/src/ui/kernel-message-cards.ts
@@ -1,0 +1,76 @@
+// HP2-COMPAT: pi-tui 组件原语（Component）——TUI 渲染原语，HP3 前保持；不新增会话装配引用。
+/** 内核消息卡（0901 体验审计 P0-6）：内部 customType 消息以卡片
+ *  呈现——[rosclaw.user_directive]/[rosclaw.task_terminal] 这类
+ *  协议标签绝不上屏（0901 实证：用户看到内部标签，不知道那是
+ *  什么）。
+ *
+ * 三类卡：
+ * - user_directive：用户指令回声（确定性链已接管——输入被
+ *   suppress 不进模型回合，但必须可见、可审计）；
+ * - task_terminal：任务终态卡（Coordinator 权威 outcome 的确定性
+ *   呈现——唯一终态发布者）；
+ * - task_explain：解释卡（只读账本回答——零新任务/零新仿真）。
+ */
+
+import type { Component } from "@earendil-works/pi-tui";
+
+/** 内核自定义消息的最小视图（pi CustomMessage 的结构子集——卡片
+ *  只用 customType/content，不与 details 的具体类型耦合）。 */
+export interface KernelMessageView {
+	customType: string;
+	content: unknown;
+}
+
+class KernelMessageCard implements Component {
+	constructor(
+		private readonly title: string,
+		private readonly content: string,
+	) {}
+
+	render(width: number): string[] {
+		const border = "─".repeat(Math.max(10, Math.min(width - 4, 76)));
+		const lines = [`┌${border}┐`, `│ ${this.title}`];
+		for (const raw of this.content.split("\n")) {
+			lines.push(raw ? `│ ${raw}` : "│");
+		}
+		lines.push(`└${border}┘`);
+		return lines;
+	}
+
+	invalidate(): void {}
+}
+
+/** content 可能是 string 或 TextContent[]（pi CustomMessage 联合
+ *  类型）——卡片只呈现文本。 */
+function contentText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (Array.isArray(content)) {
+		return content
+			.map((c) =>
+				c && typeof c === "object" && "text" in c
+					? String((c as { text?: unknown }).text ?? "")
+					: String(c),
+			)
+			.filter(Boolean)
+			.join("\n");
+	}
+	return String(content ?? "");
+}
+
+const CARD_TITLES: Record<string, string> = {
+	"rosclaw.user_directive": "📌 任务指令（确定性链接管执行——不进模型回合）",
+	"rosclaw.task_terminal": "任务终态（内核权威）",
+	"rosclaw.task_explain": "任务解释（只读账本回答——未起新任务）",
+};
+
+/** customType → 渲染卡。注册进 pi.registerMessageRenderer。 */
+export const kernelMessageRenderers: Record<
+	string,
+	(message: KernelMessageView) => Component | undefined
+> = Object.fromEntries(
+	Object.entries(CARD_TITLES).map(([customType, title]) => [
+		customType,
+		(message: KernelMessageView) =>
+			new KernelMessageCard(title, contentText(message.content)),
+	]),
+);

--- a/packages/rosclaw-agent/src/ui/kernel-message-cards.ts
+++ b/packages/rosclaw-agent/src/ui/kernel-message-cards.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Component } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 
 /** 内核自定义消息的最小视图（pi CustomMessage 的结构子集——卡片
  *  只用 customType/content，不与 details 的具体类型耦合）。 */
@@ -28,13 +29,29 @@ class KernelMessageCard implements Component {
 	) {}
 
 	render(width: number): string[] {
-		const border = "─".repeat(Math.max(10, Math.min(width - 4, 76)));
-		const lines = [`┌${border}┐`, `│ ${this.title}`];
+		// 宽度不变量（0901 journey 实证：卡片行超宽 = pi
+		// uncaughtException 直接退出进程）：每行 visibleWidth ≤
+		// width。长路径 wrap 不截断（路径是交付面信息，丢不得）。
+		const inner = Math.max(8, width - 2); // "│ " 前缀 + 余量
+		const border = "─".repeat(Math.max(8, Math.min(width - 2, 76)));
+		const lines = [
+			truncateToWidth(`┌${border}┐`, width),
+			truncateToWidth(`│ ${this.title}`, width),
+		];
 		for (const raw of this.content.split("\n")) {
-			lines.push(raw ? `│ ${raw}` : "│");
+			if (!raw) {
+				lines.push("│");
+				continue;
+			}
+			for (const piece of wrapTextWithAnsi(raw, inner)) {
+				lines.push(truncateToWidth(`│ ${piece}`, width));
+			}
 		}
-		lines.push(`└${border}┘`);
-		return lines;
+		lines.push(truncateToWidth(`└${border}┘`, width));
+		// 兜底：任何路径都不许超宽（防御 wrap 边界情况）。
+		return lines.map((l) =>
+			visibleWidth(l) > width ? truncateToWidth(l, width) : l,
+		);
 	}
 
 	invalidate(): void {}

--- a/packages/rosclaw-agent/test/a0901-p06-terminal-presenter.test.ts
+++ b/packages/rosclaw-agent/test/a0901-p06-terminal-presenter.test.ts
@@ -1,0 +1,99 @@
+/** 0901-P0-6 红测试：TerminalPresenter 产品化 + 内核消息卡渲染器。
+ *
+ * 0901 体验实证（用户原话：从用户角度真的不太好）：
+ * 1. 终态回复只有一行结论——没有原因（为什么失败）、没有文件名、
+ *    没有绝对路径、没有下一步（用户看完不知道该干嘛）；
+ * 2. 内部 customType 标签（[rosclaw.user_directive]/[rosclaw.task_terminal]）
+ *    原样漏到屏幕——内部协议细节不该出现在用户界面。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("P0-6 PASS 呈现：文件名 + 绝对路径 + 打开命令 + 下一步", async () => {
+	const { renderTerminalReply } = await import(
+		"../src/native/terminal-presenter.js"
+	);
+	const reply = renderTerminalReply({
+		verification: "PASS",
+		delivery: "DELIVERED",
+		artifact_refs: [
+			{
+				artifact_id: "art_g",
+				path: "/home/u/proj/outputs/star-scene.gif",
+				media_type: "image/gif",
+				size_bytes: 1234567,
+				open_command: "rosclaw artifact open art_g",
+			},
+		],
+	});
+	assert.match(reply, /任务完成/);
+	// 文件名（basename）。
+	assert.match(reply, /star-scene\.gif/);
+	// 绝对路径全文。
+	assert.match(reply, /\/home\/u\/proj\/outputs\/star-scene\.gif/);
+	// 打开命令仍在。
+	assert.match(reply, /rosclaw artifact open art_g/);
+	// 下一步指引。
+	assert.match(reply, /下一步/);
+});
+
+test("P0-6 FAIL 呈现：原因逐条列出（repair_directive.failures）+ 下一步", async () => {
+	const { renderTerminalReply } = await import(
+		"../src/native/terminal-presenter.js"
+	);
+	const reply = renderTerminalReply({
+		verification: "FAIL",
+		delivery: "MISSING",
+		artifact_refs: [],
+		repair_directive: {
+			failures: [
+				"DELIVERABLE_MISSING: required 交付物 scene_video 未在产物账本",
+				"TRACKING_ERROR: 最大跟踪误差 0.031m 超阈值 0.020m",
+			],
+		},
+	});
+	assert.match(reply, /未完全达成/);
+	// 原因区：用户必须能看到"为什么"。
+	assert.match(reply, /原因/);
+	assert.match(reply, /scene_video/);
+	assert.match(reply, /0\.031m/);
+	// 下一步指引。
+	assert.match(reply, /下一步/);
+});
+
+test("P0-6 内核消息卡：三个 customType 都有注册卡（不漏内部标签）", async () => {
+	const { kernelMessageRenderers } = await import(
+		"../src/ui/kernel-message-cards.js"
+	);
+	const types = Object.keys(kernelMessageRenderers);
+	assert.ok(types.includes("rosclaw.user_directive"));
+	assert.ok(types.includes("rosclaw.task_terminal"));
+	assert.ok(types.includes("rosclaw.task_explain"));
+	for (const t of types) {
+		const component = kernelMessageRenderers[t](
+			{ customType: t, content: "任务已完成：验收 PASS" },
+		);
+		assert.ok(component, `${t} 应有渲染卡`);
+		const lines = component.render(80);
+		const text = lines.join("\n");
+		// 内容呈现。
+		assert.match(text, /任务已完成/);
+		// 内部 customType 标签绝不上屏。
+		assert.doesNotMatch(text, /\[?rosclaw\.(user_directive|task_terminal|task_explain)\]?/);
+	}
+});
+
+test("P0-6 user_directive 卡标注确定性链接管", async () => {
+	const { kernelMessageRenderers } = await import(
+		"../src/ui/kernel-message-cards.js"
+	);
+	const component = kernelMessageRenderers["rosclaw.user_directive"]({
+		customType: "rosclaw.user_directive",
+		content: "画一个五角星",
+	});
+	assert.ok(component);
+	const text = component.render(80).join("\n");
+	assert.match(text, /画一个五角星/);
+	assert.match(text, /确定性链/);
+});

--- a/packages/rosclaw-agent/test/a0901-p06-terminal-presenter.test.ts
+++ b/packages/rosclaw-agent/test/a0901-p06-terminal-presenter.test.ts
@@ -84,6 +84,37 @@ test("P0-6 内核消息卡：三个 customType 都有注册卡（不漏内部标
 	}
 });
 
+test("P0-6 卡片渲染永不超宽（PTY 实证：超宽 = pi 进程崩溃退出）", async () => {
+	const { kernelMessageRenderers } = await import(
+		"../src/ui/kernel-message-cards.js"
+	);
+	const { visibleWidth } = await import("@earendil-works/pi-tui");
+	// 0901 journey 实证：长绝对路径（>80 列）让卡片行超宽 →
+	// pi uncaughtException 直接退出（Rendered line exceeds terminal
+	// width）。卡片必须 wrap 到终端宽度内。
+	const longPath =
+		"/tmp/pytest-of-nvidia/pytest-2286/test_full_journey_pty0/prefix/" +
+		"current/home/agentd/outputs/star-scene.gif";
+	for (const [t, render] of Object.entries(kernelMessageRenderers)) {
+		const component = render({
+			customType: t,
+			content: `✅ 任务完成：验收 PASS\n交付物：\n  路径：${longPath}\n  打开：rosclaw artifact open art_x`,
+		});
+		assert.ok(component);
+		for (const w of [80, 120, 40]) {
+			for (const line of component.render(w)) {
+				assert.ok(
+					visibleWidth(line) <= w,
+					`${t} 在宽度 ${w} 超宽：${visibleWidth(line)}——${line}`,
+				);
+			}
+		}
+		// wrap 后路径信息仍在（不丢字符）。
+		const text = component.render(80).join("\n");
+		assert.ok(text.includes("star-scene.gif"), `${t} 丢了文件名`);
+	}
+});
+
 test("P0-6 user_directive 卡标注确定性链接管", async () => {
 	const { kernelMessageRenderers } = await import(
 		"../src/ui/kernel-message-cards.js"

--- a/packages/rosclaw-agent/test/action-result-ui.test.ts
+++ b/packages/rosclaw-agent/test/action-result-ui.test.ts
@@ -34,6 +34,8 @@ async function collectHarness() {
 		registerEntryRenderer(customType: string, renderer: never) {
 			entryRenderers.set(customType, renderer);
 		},
+		// P0-6（0901）：内核消息卡渲染器注册（mock 空实现）。
+		registerMessageRenderer() {},
 		appendEntry(customType: string, data?: unknown) {
 			appended.push({ customType, data });
 		},

--- a/packages/rosclaw-agent/test/extension.test.ts
+++ b/packages/rosclaw-agent/test/extension.test.ts
@@ -19,6 +19,8 @@ async function collectHandlers() {
 		registerShortcut() {},
 		// P0-5F：内核结果卡/冲突条目的渲染器与落盘 API（mock 空实现）。
 		registerEntryRenderer() {},
+		// P0-6（0901）：内核消息卡渲染器注册（mock 空实现）。
+		registerMessageRenderer() {},
 		appendEntry() {},
 	};
 	const { ActiveSessionContext } = await import("../src/session/active-context.js");

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1616,7 +1616,10 @@ class TestProductJourney:
             assert "下一步".encode() in action_segment, (
                 "终态卡缺下一步指引（P0-6 产品化未生效）"
             )
-            assert "路径：".encode() in action_segment, (
+            # 绝对路径行（裸路径——无标签，防 CJK 换行撕裂）。
+            import re as _re
+
+            assert _re.search(rb"/[\w./-]*\.gif", action_segment), (
                 "终态卡缺交付物绝对路径"
             )
             assert b"rosclaw artifact open" in action_segment, (

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1609,6 +1609,28 @@ class TestProductJourney:
             )
             self._journey_verdicts["auto_route_zero_model_turns"] = True
             action_segment = session.clean[action_start:]
+            # 0901 P0-6（终态呈现产品化）：终态卡必须有 交付物文件名 +
+            # 绝对路径 + 打开命令 + 下一步——一行结论不是产品（用户
+            # 看完不知道该干嘛）。内部 customType 标签（[rosclaw.xxx]）
+            # 绝不上屏——协议细节不是用户界面。
+            assert "下一步".encode() in action_segment, (
+                "终态卡缺下一步指引（P0-6 产品化未生效）"
+            )
+            assert "路径：".encode() in action_segment, (
+                "终态卡缺交付物绝对路径"
+            )
+            assert b"rosclaw artifact open" in action_segment, (
+                "终态卡缺打开命令"
+            )
+            assert b".gif" in action_segment, "终态卡缺交付物文件名"
+            assert b"[rosclaw." not in action_segment, (
+                "内部 customType 标签漏到屏幕——渲染卡未注册"
+            )
+            # 指令回声卡：确定性链接管的输入以卡片呈现（不是裸标签）。
+            assert "确定性链接管".encode() in action_segment, (
+                "user_directive 指令回声卡未生效"
+            )
+            self._journey_verdicts["terminal_card_productized"] = True
             assert "ROSCLAW 授权请求".encode() not in action_segment, (
                 "默认安全 SIM 竟弹人工审批卡"
             )
@@ -1638,6 +1660,14 @@ class TestProductJourney:
             model_turns_before_explain = len(fake.fake.requests)
             session.send("你这是啥？\r")
             session.expect("刚才的任务".encode(), timeout=60)
+            # 0901 P0-6：解释卡以卡片呈现（标题可见），内部 customType
+            # 标签绝不上屏。
+            assert "只读账本回答".encode() in session.clean, (
+                "解释追问未以卡片呈现（task_explain 渲染卡未注册）"
+            )
+            assert b"[rosclaw." not in session.clean, (
+                "内部 customType 标签漏到屏幕——渲染卡未注册"
+            )
             assert len(fake.fake.requests) == model_turns_before_explain, (
                 "解释追问竟触发模型回合"
             )


### PR DESCRIPTION
## 0901 体验审计 P0-6：TerminalPresenter 产品化 + customType 卡片渲染

### 问题（0901 体验实证）
1. 终态回复只有一行结论——没有原因（为什么失败）、没有文件名、没有绝对路径、没有下一步（用户看完不知道该干嘛）；
2. 内部 customType 标签（[rosclaw.user_directive]/[rosclaw.task_terminal]）原样漏到屏幕。

### 修复
- TerminalPresenter：PASS 给交付物文件名+裸绝对路径+打开命令+下一步；FAIL 逐条列 repair_directive.failures 原因 + 已产出 + 下一步。
- kernel-message-cards（新）：user_directive/task_terminal/task_explain 注册卡片渲染器——协议标签绝不上屏。

### journey 实证抓到的两个真坑（红→绿）
1. 卡片行超宽（长绝对路径 122>80 列）= pi uncaughtException 直接退出进程——render 内 wrapTextWithAnsi + truncateToWidth 兜底，宽度不变量入测试；
2. CJK 换行把「路径：」从值中间撕开——交付物改裸行（文件名/路径/打开命令各占一行）。

### 证据
TS 201/0；安装产物 PTY journey A/B/C 3/3（屏幕硬断言：下一步/绝对路径/打开命令/文件名在屏 + 全屏无 [rosclaw. 标签 + 解释卡标题可见）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)