### PR TITLE
feat: 0902-R0-1 Artifact revision 作用域——旧产物不得满足新 revision（反假成功结构修复）

### DIFF
--- a/src/rosclaw/storage/migrations/037_a0902_artifact_revision.sql
+++ b/src/rosclaw/storage/migrations/037_a0902_artifact_revision.sql
@@ -1,0 +1,11 @@
+-- 0902 审计 R0-1：Artifact revision 作用域——反假成功的结构修复。
+-- 实证：用户新增"红色圆柱笔+3D 轨迹+不要 2D"（新 revision）后，旧
+-- revision 的 scene.mp4 仍在任务产物账本（task 级无 revision 分野），
+-- 验收把旧视频计为新条件已满足 → PASS/DELIVERED 假成功。
+-- artifacts 增加 revision 列；验收/交付只认当前 revision 的产物；
+-- 历史行回填 1（保守方向：旧产物不会被计入后续 revision）。
+-- 注意：本目录迁移同时被 SeekDB（episode 记忆库）套用——其自有
+-- artifacts 表无 task_id 列，索引不得引用 task_id（037 首版实证
+-- CI 失败：no such column: task_id）。任务产物表行数小，task_id+revision
+-- 过滤的表扫代价可接受；需要索引时在 agentd 专属迁移里做。
+ALTER TABLE artifacts ADD COLUMN revision INTEGER NOT NULL DEFAULT 1;

--- a/src/rosclaw/task_kernel/coordinator.py
+++ b/src/rosclaw/task_kernel/coordinator.py
@@ -96,7 +96,9 @@ class TaskCoordinator:
             term_artifacts = [
                 dict(r)
                 for r in self._conn.execute(
-                    "SELECT * FROM artifacts WHERE task_id = ?", (task_id,)
+                    "SELECT * FROM artifacts WHERE task_id = ? "
+                    "AND revision = ?",
+                    (task_id, revision),
                 ).fetchall()
             ]
             reason = str(task.get("terminal_reason") or "")
@@ -122,7 +124,8 @@ class TaskCoordinator:
         artifacts = [
             dict(r)
             for r in self._conn.execute(
-                "SELECT * FROM artifacts WHERE task_id = ?", (task_id,)
+                "SELECT * FROM artifacts WHERE task_id = ? AND revision = ?",
+                (task_id, revision),
             ).fetchall()
         ]
         # 完成信号：有产物或有冻结验收——两者皆无说明任务还在
@@ -314,7 +317,7 @@ class TaskCoordinator:
             # R0-4：用户可见交付视图（id/kind/media/size/digest/
             # open_command）——数据库里有文件 ≠ 交付成功。
             "artifact_refs": self._kernel.artifact_refs_for(
-                str(task["task_id"])
+                str(task["task_id"]), revision=revision
             ),
             "blocked_on": [],
             "created_at": created_at,

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -607,12 +607,16 @@ class TaskKernel:
             lineage["revision"] = int(task["active_revision"])
             meta["lineage"] = lineage
         meta_json = json.dumps(meta, ensure_ascii=False)
+        # 0902 R0-1：产物打 revision 戳——验收/交付只认当前 revision
+        # 的产物（0902 实证：旧 revision 的 scene 视频在新 revision
+        # 被计入 → PASS/DELIVERED 假成功）。
         self._conn.execute(
-            "INSERT INTO artifacts (artifact_id, task_id, path, media_type, "
-            "sha256, size_bytes, producer_operation_id, producer, "
-            "metadata_json, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (artifact_id, task_id, str(file), media_type, record["sha256"],
+            "INSERT INTO artifacts (artifact_id, task_id, revision, path, "
+            "media_type, sha256, size_bytes, producer_operation_id, "
+            "producer, metadata_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (artifact_id, task_id, int(task["active_revision"]),
+             str(file), media_type, record["sha256"],
              len(content), producer_operation_id or None, producer,
              meta_json, now),
         )
@@ -671,8 +675,9 @@ class TaskKernel:
             dict(r)
             for r in self._conn.execute(
                 "SELECT * FROM artifacts WHERE task_id = ? AND "
+                "revision = ? AND "
                 f"artifact_id IN ({','.join('?' * max(len(artifact_ids), 1))})",
-                (task_id, *artifact_ids),
+                (task_id, int(task["active_revision"]), *artifact_ids),
             ).fetchall()
         ] if artifact_ids else []
         from rosclaw.task_kernel.verifier import verdict_for
@@ -909,10 +914,14 @@ class TaskKernel:
         if spec_deliverables:
             from rosclaw.task_kernel.deliverables import deliverable_verdict
 
+            # 0902 R0-1：deliverable 账本只数当前 revision——旧
+            # revision 产物不得满足新条件（假成功结构修复）。
             ledger = [
                 dict(r)
                 for r in self._conn.execute(
-                    "SELECT * FROM artifacts WHERE task_id = ?", (task_id,),
+                    "SELECT * FROM artifacts WHERE task_id = ? "
+                    "AND revision = ?",
+                    (task_id, int(task["active_revision"])),
                 ).fetchall()
             ]
             dv = deliverable_verdict(spec_deliverables, ledger)
@@ -1050,19 +1059,54 @@ class TaskKernel:
             return None
         return json.loads(row["task_spec_json"])
 
-    def artifact_refs_for(self, task_id: str) -> list[dict[str, Any]]:
+    def artifacts_for_revision(
+        self, task_id: str, revision: int | None = None
+    ) -> list[dict[str, Any]]:
+        """0902 R0-1：指定 revision（默认当前活跃 revision）的产物。
+
+        验收/交付的唯一合法输入——旧 revision 产物不得满足新条件
+        （0902 假成功实证的结构修复）。显式复用走未来的
+        REUSED_UNCHANGED 标注，绝不默认计入。
+        """
+        task = self.get_task(task_id)
+        if task is None:
+            raise ValueError(f"unknown task {task_id!r}")
+        rev = int(task["active_revision"]) if revision is None else revision
+        return [
+            dict(r)
+            for r in self._conn.execute(
+                "SELECT * FROM artifacts WHERE task_id = ? AND revision = ? "
+                "ORDER BY created_at",
+                (task_id, rev),
+            ).fetchall()
+        ]
+
+    def artifact_refs_for(
+        self, task_id: str, revision: int | None = None
+    ) -> list[dict[str, Any]]:
         """R0-4（0826 体验审计 §5.R0-4）：用户可见 ArtifactRef 视图
         ——id/kind/media_type/size/digest/open_command。
 
         "数据库里有文件"不等于交付成功：交付面（ToolResult/
         TaskOutcome/CLI）只认这份带 open_command 的视图。
+
+        0902 R0-1：revision 限定——任务终态卡的"已产出"只列当前
+        revision 的产物（旧 revision 产物不得冒充新交付）。revision
+        为空 = 全量账本视图（CLI/只读查询用）。
         """
         from rosclaw.task_kernel.deliverables import artifact_delivery_kind
 
-        rows = self._conn.execute(
-            "SELECT * FROM artifacts WHERE task_id = ? ORDER BY created_at",
-            (task_id,),
-        ).fetchall()
+        if revision is None:
+            rows = self._conn.execute(
+                "SELECT * FROM artifacts WHERE task_id = ? ORDER BY created_at",
+                (task_id,),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM artifacts WHERE task_id = ? AND revision = ? "
+                "ORDER BY created_at",
+                (task_id, revision),
+            ).fetchall()
         refs: list[dict[str, Any]] = []
         for row in rows:
             artifact = dict(row)

--- a/tests/agentd/test_a0902_r01_artifact_revision.py
+++ b/tests/agentd/test_a0902_r01_artifact_revision.py
@@ -1,0 +1,147 @@
+"""0902 审计 R0-1 红测试：Artifact revision 作用域——旧产物不得满足
+新 revision（反假成功的结构修复）。
+
+0902 实证（用户日志）：用户新增"红色圆柱笔+3D 实际轨迹+不要 2D"
+（同任务新 revision）后，确定性链复用了上一 revision 的旧视频，
+receipt 仍 tool_ref=""/overlays=[]，却宣布 PASS/DELIVERED——假成功。
+
+根因：artifacts 是 task 级无 revision 分野——finish_task/consider 的
+验收账本扫描不带 revision 过滤，旧 revision 的产物满足新 revision 的
+交付条件。
+
+闭环断言：
+1. 登记时打 revision 戳（task 当前 active_revision）；
+2. 新 revision 的验收只认当前 revision 产物（旧场景视频不计入）；
+3. finish_task 显式传入的旧 revision artifact_id 不得计入验收；
+4. 迁移回填：旧行 revision=1（保守方向——不会计入后续 revision）。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _kernel(tmp_path: Path):
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return TaskKernel(conn, tmp_path)
+
+
+def _task(kernel, tmp_path: Path) -> str:
+    bound = kernel.bind_message(
+        mission_id="m1", session_ref="s1", backend_native_id="s1",
+        message_id="msg_1", text="画五角星出 3D 场景视频",
+        cwd=str(tmp_path), body_id="sim/ur5e",
+    )
+    return str(bound["task_id"])
+
+
+def _register(kernel, task_id: str, tmp_path: Path, name: str,
+              media: str = "video/mp4") -> str:
+    p = tmp_path / name
+    p.write_bytes(b"MP4" + b"x" * 2048)
+    art = kernel.register_artifact(
+        task_id=task_id, path=str(p), media_type=media,
+        producer="kernel:sim_render",
+    )
+    return str(art["artifact_id"])
+
+
+class TestArtifactRevisionScope:
+    def test_register_stamps_current_revision(self, tmp_path: Path) -> None:
+        kernel = _kernel(tmp_path)
+        task_id = _task(kernel, tmp_path)
+        art_id = _register(kernel, task_id, tmp_path, "a.mp4")
+        row = kernel._conn.execute(
+            "SELECT revision FROM artifacts WHERE artifact_id = ?",
+            (art_id,),
+        ).fetchone()
+        assert row is not None
+        assert int(row["revision"]) == 1
+
+    def test_new_revision_verification_ignores_old_artifacts(
+        self, tmp_path: Path
+    ) -> None:
+        """假成功场景：rev1 有 scene 视频；用户纠正开 rev2，只产新
+        trace——rev2 验收不得把 rev1 视频计入。"""
+        from rosclaw.task_kernel.coordinator import TaskCoordinator
+
+        kernel = _kernel(tmp_path)
+        task_id = _task(kernel, tmp_path)
+        # rev1：场景视频在账。
+        _register(kernel, task_id, tmp_path, "scene-old.mp4")
+        # 用户纠正 → rev2。
+        kernel.bind_message(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            message_id="msg_2", text="不对，加红色圆柱笔，重新来",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        task = kernel.get_task(task_id)
+        assert int(task["active_revision"]) == 2
+        # rev2 只产新 trace（没有新视频）。
+        _register(kernel, task_id, tmp_path, "trace.json",
+                  media="application/json")
+        # rev2 验收账本不得含 rev1 视频。
+        current = kernel.artifacts_for_revision(task_id, 2)
+        assert all("scene-old" not in str(a["path"]) for a in current), (
+            "旧 revision 产物竟在新 revision 账本上"
+        )
+        # consider 不得因旧视频在场而 PASS（旧视频不算数后无媒体证据
+        # 可言——不得终态成功）。
+        outcome = TaskCoordinator(kernel).consider(task_id)
+        if outcome is not None:
+            assert outcome.get("verification") not in (
+                "PASS", "PASS_NEAR_LIMIT",
+            ), f"旧产物竟满足新 revision：{outcome.get('verification')}"
+
+    def test_finish_rejects_old_revision_artifact_ids(
+        self, tmp_path: Path
+    ) -> None:
+        """finish_task 显式传入旧 revision artifact_id → 不计入验收
+        （调用方把旧产物当新交付也不行）。"""
+        kernel = _kernel(tmp_path)
+        task_id = _task(kernel, tmp_path)
+        old_art = _register(kernel, task_id, tmp_path, "scene-old.mp4")
+        kernel.bind_message(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            message_id="msg_2", text="不对，重来",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        result = kernel.finish_task(
+            task_id=task_id, summary="rev2 完成",
+            artifact_ids=[old_art],
+        )
+        assert result["status"] != "SUCCEEDED", (
+            f"旧 revision 产物竟能交付新 revision：{result}"
+        )
+
+    def test_migration_backfills_revision_1(self, tmp_path: Path) -> None:
+        """旧库（无 revision 列）迁移后历史行 revision=1（保守方向）。"""
+        from rosclaw.storage.migrations import MigrationRunner
+
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        runner = MigrationRunner()
+        # 只跑到 036（037 之前的库形态）。
+        runner.apply(conn, "sqlite")
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(artifacts)")]
+        assert "revision" in cols, "迁移后缺 revision 列"
+        kernel = _kernel(tmp_path)  # 新库直接建
+        task_id = _task(kernel, tmp_path)
+        art_id = _register(kernel, task_id, tmp_path, "a.mp4")
+        row = kernel._conn.execute(
+            "SELECT revision FROM artifacts WHERE artifact_id = ?",
+            (art_id,),
+        ).fetchone()
+        assert int(row["revision"]) == 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 0902 审计 R0-1（P0 事故实证）

用户新增"红色圆柱笔+3D 实际轨迹+不要 2D"（同任务新 revision）后，确定性链复用旧 revision 的 scene.mp4——账本是 task 级无 revision 分野，验收把旧视频计为新条件已满足 → PASS/DELIVERED 假成功。

## 修复（迁移 037 + 收口）

- artifacts.revision 列（登记打 task 当前 active_revision 戳；历史行回填 1——保守方向）；
- finish_task 的 artifact_ids 与 deliverable 账本扫描只数当前 revision；
- consider 的验收产物集只数当前 revision；
- outcome.artifact_refs 带 revision（终态卡"已产出"只列当前 revision 产物）；
- 新增 kernel.artifacts_for_revision。

## 证据

红→绿：tests/agentd/test_a0902_r01_artifact_revision.py（4 tests）。全量 agentd 814/814 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)