### PR TITLE
feat: 0902-R0-2 RequirementCompiler + 语义覆盖率门禁——recipe 只在 100% 覆盖时执行

### DIFF
--- a/src/rosclaw/agentd/auto_route.py
+++ b/src/rosclaw/agentd/auto_route.py
@@ -67,7 +67,29 @@ async def maybe_auto_route(
             }
         return None
     intent = _classify_intent(text)
-    if route_recipe({"goal": {"intent": intent}}) is None:
+    recipe_id = route_recipe({"goal": {"intent": intent}})
+    if recipe_id is None:
+        return None
+    # 0902 R0-2（§3.1 硬规则）：语义覆盖率门禁——recipe 只在材料性
+    # 要求 100% 覆盖时执行。0902 实证：关键词命中吞掉"红色圆柱笔/
+    # 3D 轨迹/不要 2D"→ 旧视频复用 → PASS/DELIVERED 假成功。任一
+    # must/forbidden 条款未被 recipe 声明覆盖 → 不自动路由（交
+    # Native Agent 编译 TaskSpec——不猜）。门禁在任务创建之前——
+    # 未覆盖不产生幽灵任务。
+    from rosclaw.task_kernel.requirements import compile_requirements
+    from rosclaw.task_kernel.task_router import RECIPE_COVERAGE
+
+    coverage = RECIPE_COVERAGE.get(recipe_id, frozenset())
+    uncovered = [r for r in compile_requirements(text)
+                 if r.verifier not in coverage]
+    if uncovered:
+        import logging
+
+        logging.getLogger("rosclaw.auto_route").info(
+            "coverage gate: recipe %s 未覆盖 %s——转 Native Agent 路径",
+            recipe_id,
+            [r.verifier for r in uncovered],
+        )
         return None
     mission = service.get_mission(mission_id)
     if mission is not None and mission.mode.value != "SIMULATION":

--- a/src/rosclaw/contracts/agent/task_spec.py
+++ b/src/rosclaw/contracts/agent/task_spec.py
@@ -85,6 +85,21 @@ DELIVERABLE_KIND_TO_ARTIFACT_KIND: dict[str, str] = {
 }
 
 
+class TaskRequirementV2(ContractModel):
+    """材料性要求条款（0902 审计 R0-2，§3.1）——每条用户要求是
+    可核验条款：level(must/forbidden) + claim（用户可读）+
+    verifier（覆盖比对键/验收键）。recipe 只在 100% 覆盖时执行。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.task_requirement.v2"
+
+    schema_version: Literal["rosclaw.task_requirement.v2"] = (
+        "rosclaw.task_requirement.v2"
+    )
+    req_id: str = Field(min_length=1)
+    level: str = Field(min_length=1)
+    claim: str = Field(min_length=1)
+    verifier: str = Field(min_length=1)
+
 class TaskDeliverableV2(ContractModel):
     """交付物声明：kind/media_type/required + 最低质量门槛。
 
@@ -160,6 +175,9 @@ class TaskSpecV2(ContractModel):
     #: 交付物声明（R0-2）：required 交付物未按 kind 出现在产物
     #: 账本 → DELIVERABLE_MISSING——任务成功 ≠ 用户请求成功。
     deliverables: list[TaskDeliverableV2] = Field(default_factory=list)
+    #: 材料性要求条款（0902 审计 R0-2）：recipe 只在 100% 覆盖时
+    #: 执行；R0-3 逐条验收。空 = 无材料性附加条件。
+    requirements: list[TaskRequirementV2] = Field(default_factory=list)
     #: 冻结验收规格关联（AcceptanceSpecV2.spec_id；未冻结为空——
     #: 诚实空，不编造）。
     acceptance_spec_id: str = ""
@@ -172,6 +190,7 @@ __all__ = [
     "TaskConstraintsV2",
     "TaskDeliverableV2",
     "TaskGoalV2",
+    "TaskRequirementV2",
     "TaskPreferencesV2",
     "TaskSpecV2",
     "TaskSubjectsV2",

--- a/src/rosclaw/task_kernel/requirements.py
+++ b/src/rosclaw/task_kernel/requirements.py
@@ -1,0 +1,114 @@
+"""RequirementCompiler（0902 审计 R0-2，§3.1）——用户目标 → 材料性
+可核验条款。
+
+0902 实证（P0 事故）：用户新增"红色圆柱笔 + 3D 实际轨迹 + 不要 2D"，
+自动路由只识别"机械臂+轨迹+画"关键词命中五角星 recipe——新材料性
+条件被吞掉，旧视频复用，宣布 PASS/DELIVERED 假成功。
+
+每条材料性要求编译为可核验条款（id/level/claim/verifier）：
+- level=must：必须有证据才算满足；
+- level=forbidden：不得出现（禁止项）；
+- verifier：覆盖/验收键——recipe 声明的覆盖集合比对键，R0-3 接
+  receipt 逐条核验。
+
+硬规则：
+- 快速配方只在语义覆盖率 100% 时执行（门禁在 task_router/
+  auto_route）；
+- 任一条款未被 recipe 声明覆盖 → 不自动路由（不猜）；
+- 词类均为通用类别（工具/颜色/平面/overlay/禁止/形状）——无任务
+  特例、无五角星硬编码。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Requirement:
+    """一条材料性要求（可核验条款）。"""
+
+    req_id: str
+    level: str  # must | forbidden
+    claim: str  # 用户可读的条款表述
+    verifier: str  # 覆盖比对键 / 验收键（R0-3 接 receipt 核验）
+
+
+def _any(text: str, markers: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(m in lowered or m in text for m in markers)
+
+
+#: 词类注册表（通用类别；新增维度 = 加一行注册，不是改逻辑）。
+_TOOL_MARKERS = ("笔", "持笔", "画笔", "马克笔", "夹爪", "吸盘",
+                 "pen", "marker", "gripper", "suction")
+_COLOR_MARKERS = ("红色", "蓝色", "绿色", "黄色", "黑色", "白色", "橙色",
+                  "紫色", "red", "blue", "green", "yellow", "black",
+                  "white")
+_OVERLAY_TRACE_MARKERS = ("显示轨迹", "看到轨迹", "轨迹可见", "叠加轨迹",
+                          "显示运动轨迹", "看到运动轨迹", "轨迹叠加",
+                          "实际轨迹", "运动轨迹可见",
+                          "show the trace", "show trajectory",
+                          "overlay trace")
+_FORBID_2D_MARKERS = ("不要 2d", "不要2d", "别给 2d", "禁止 2d",
+                      "不要二维", "别来 2d", "no 2d")
+_VERTICAL_MARKERS = ("垂直", "竖直", "立面", "vertical")
+_HORIZONTAL_MARKERS = ("水平面", "水平桌", "水平放", "horizontal")
+_SCENE_3D_MARKERS = ("3d", "三维", "场景视频", "scene video")
+_VIDEO_MARKERS = ("视频", "video", "mp4", "录像")
+_PREVIEW_MARKERS = ("gif", "动图", "2d 预览", "preview")
+_CONTACT_MARKERS = ("接触", "贴着", "贴在", "contact")
+
+#: 形状注册表：已知形状词 → shape key。recipe 覆盖集合之外的已知
+#: 形状 = "已知但未覆盖"（门禁拦截——不允许画错形状冒充）。
+_SHAPE_MARKERS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("star5", ("五角星", "星形", "star")),
+    ("circle", ("圆形", "圆圈", "画圆", "圆环", "circle")),
+    ("square", ("正方形", "方形", "square")),
+    ("triangle", ("三角形", "triangle")),
+    ("spiral", ("螺旋", "spiral")),
+)
+
+
+def compile_requirements(goal_text: str) -> list[Requirement]:
+    """目标文本 → 材料性条款列表（确定性——同一文本永远同一组
+    条款）。识别顺序即 req_id 顺序（deterministic）。"""
+    reqs: list[Requirement] = []
+
+    def _add(level: str, claim: str, verifier: str) -> None:
+        if any(r.verifier == verifier for r in reqs):
+            return
+        reqs.append(Requirement(
+            req_id=f"r{len(reqs) + 1}", level=level, claim=claim,
+            verifier=verifier,
+        ))
+
+    for shape, markers in _SHAPE_MARKERS:
+        if _any(goal_text, markers):
+            _add("must", f"绘制形状：{shape}", f"shape.{shape}")
+            break
+    if _any(goal_text, _TOOL_MARKERS):
+        _add("must", "末端挂载工具", "receipt.tool_ref")
+    if _any(goal_text, _COLOR_MARKERS):
+        _add("must", "指定颜色外观", "render.tool_color")
+    if _any(goal_text, _OVERLAY_TRACE_MARKERS):
+        _add("must", "3D 画面叠加本次实际末端运动轨迹",
+             "receipt.overlays.actual_eef_trace")
+    if _any(goal_text, _VERTICAL_MARKERS):
+        _add("must", "竖直/垂直平面作业", "plan.plane.vertical")
+    if _any(goal_text, _HORIZONTAL_MARKERS):
+        _add("must", "水平面作业", "plan.plane.horizontal")
+    if _any(goal_text, _SCENE_3D_MARKERS):
+        _add("must", "3D 场景视频交付", "deliverable.scene_3d")
+    if _any(goal_text, _VIDEO_MARKERS):
+        _add("must", "视频交付", "deliverable.video")
+    if _any(goal_text, _PREVIEW_MARKERS):
+        _add("must", "2D 预览交付", "deliverable.preview_2d")
+    if _any(goal_text, _CONTACT_MARKERS):
+        _add("must", "接触验证", "verification.contact")
+    if _any(goal_text, _FORBID_2D_MARKERS):
+        _add("forbidden", "禁止只交付 2D", "delivery.not_2d_only")
+    return reqs
+
+
+__all__ = ["Requirement", "compile_requirements"]

--- a/src/rosclaw/task_kernel/task_router.py
+++ b/src/rosclaw/task_kernel/task_router.py
@@ -28,6 +28,27 @@ RECIPE_BY_GOAL: dict[str, str] = {
     "simulate_trajectory": "recipe:sim.draw_path",
 }
 
+#: 0902 R0-2（§3.1 硬规则）：recipe 语义覆盖声明——该 recipe 能
+#: 可验证地满足哪些条款（verifier 键）。快速配方只在材料性要求
+#: 100% 覆盖时执行；任一 must/forbidden 未覆盖 → 不自动路由
+#: （交 Native Agent 编译 TaskSpec——不猜）。recipe 只能加速，
+#: 不得绕过需求编译与验收。
+RECIPE_COVERAGE: dict[str, frozenset[str]] = {
+    "recipe:sim.draw_path": frozenset({
+        # 形状：recipe 只会画注册过的形状（画错形状=冒充）。
+        "shape.star5", "shape.circle",
+        # 平面：xy 默认 + xz/yz 命名面（compile_recipe_inputs）。
+        "plan.plane.horizontal", "plan.plane.vertical",
+        # 交付：3D 场景视频 + 2D 预览 + 实际轨迹数据。
+        "deliverable.scene_3d", "deliverable.video",
+        "deliverable.preview_2d", "trace.actual",
+        # 不覆盖（——出现即转 Native Agent）：receipt.tool_ref（挂载
+        # 工具）、render.tool_color（颜色）、receipt.overlays.*（轨迹
+        # 叠加）、delivery.not_2d_only（禁止项）、verification.contact
+        # （接触）、未知形状。
+    }),
+}
+
 
 def route_recipe(spec: Mapping[str, Any], *, goal_hint: str = "") -> str | None:
     """frozen TaskSpecV2（dict 视图）→ recipe_id；无路由 → None。
@@ -86,6 +107,7 @@ def compile_recipe_inputs(goal_text: str) -> dict[str, Any]:
 __all__ = [
     "RECIPE_BY_GOAL",
     "RECIPE_BY_INTENT",
+    "RECIPE_COVERAGE",
     "compile_recipe_inputs",
     "is_task_directive",
     "route_recipe",

--- a/src/rosclaw/task_kernel/task_spec.py
+++ b/src/rosclaw/task_kernel/task_spec.py
@@ -13,6 +13,7 @@ from rosclaw.contracts.agent.task_spec import (
     TaskDeliverableV2,
     TaskGoalV2,
     TaskPreferencesV2,
+    TaskRequirementV2,
     TaskSpecV2,
     TaskSubjectsV2,
 )
@@ -114,6 +115,17 @@ def compile_task_spec(
         "manipulation.reach",
     ):
         contact_required = True
+    # 0902 R0-2：材料性要求条款随 spec 冻结（RequirementCompiler——
+    # 覆盖率门禁与逐条验收的单一事实源）。
+    from rosclaw.task_kernel.requirements import compile_requirements
+
+    requirements = [
+        TaskRequirementV2(
+            req_id=r.req_id, level=r.level, claim=r.claim,
+            verifier=r.verifier,
+        )
+        for r in compile_requirements(goal_text)
+    ]
     return TaskSpecV2(
         spec_id=new_id("tspec"),
         task_id=task_id,
@@ -136,6 +148,7 @@ def compile_task_spec(
         ),
         preferences=TaskPreferencesV2(language=language, verbosity=verbosity),
         deliverables=_compile_deliverables(goal_text),
+        requirements=requirements,
         acceptance_spec_id=acceptance_spec_id,
     )
 

--- a/tests/agentd/test_a0902_r02_requirement_coverage.py
+++ b/tests/agentd/test_a0902_r02_requirement_coverage.py
@@ -1,0 +1,157 @@
+"""0902 审计 R0-2 红测试：RequirementCompiler + 语义覆盖率门禁。
+
+0902 实证（P0 事故）：用户新增"红色圆柱笔 + 3D 实际轨迹 + 不要 2D"，
+自动路由只识别"机械臂+轨迹+画"关键词命中五角星 recipe——新材料性
+条件被吞，旧视频复用，宣布 PASS/DELIVERED 假成功。
+
+硬规则（审计 §3.1）：
+- 快速配方只有在语义覆盖率 100% 时才能执行；
+- 任一 must/forbidden 条款未被 recipe 覆盖 → 不自动路由（交
+  Native Agent 编译 TaskSpec——不猜）；
+- 未覆盖时不得创建幽灵任务（任务创建之前就拦截）。
+
+闭环断言：
+1. 编译器把工具/颜色/轨迹可见/平面/禁止/形状编译为可核验条款；
+2. 纯五角星（全覆盖）→ 自动路由不受影响（回归护栏）；
+3. 持笔/轨迹可见/不要 2D/未知形状 → 不自动路由 + 零幽灵任务；
+4. 条款随 TaskSpec 冻结（R0-3 逐条验收的输入面）。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class TestRequirementCompiler:
+    def test_plain_star_only_shape_requirement(self) -> None:
+        from rosclaw.task_kernel.requirements import compile_requirements
+
+        reqs = compile_requirements("画一个五角星")
+        verifiers = {r.verifier for r in reqs}
+        assert verifiers == {"shape.star5"}, verifiers
+
+    def test_tool_and_color_and_trace_and_forbid(self) -> None:
+        from rosclaw.task_kernel.requirements import compile_requirements
+
+        reqs = compile_requirements(
+            "末端持红色圆柱笔，在 3D 画面里显示本次实际轨迹，不要 2D"
+        )
+        verifiers = {r.verifier for r in reqs}
+        assert "receipt.tool_ref" in verifiers
+        assert "render.tool_color" in verifiers
+        assert "receipt.overlays.actual_eef_trace" in verifiers
+        forbidden = [r for r in reqs if r.level == "forbidden"]
+        assert any(r.verifier == "delivery.not_2d_only" for r in forbidden)
+
+    def test_vertical_plane_requirement(self) -> None:
+        from rosclaw.task_kernel.requirements import compile_requirements
+
+        reqs = compile_requirements("垂直桌子画五角星")
+        assert any(r.verifier == "plan.plane.vertical" for r in reqs)
+
+    def test_unknown_shape_is_known_requirement(self) -> None:
+        """画正方形：已知形状词但 recipe 不认——条款出现（未覆盖由
+        门禁拦），不允许画错形状冒充。"""
+        from rosclaw.task_kernel.requirements import compile_requirements
+
+        reqs = compile_requirements("画一个正方形")
+        assert any(r.verifier == "shape.square" for r in reqs)
+
+
+class TestCoverageGate:
+    """server 级：auto-route 门禁（PiBridgeServer._dispatch 直达）。"""
+
+    async def _persist(self, tmp_path: Path, text: str, msg: str):
+        from rosclaw.agentd.auto_route import reset_routed_for_tests
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        # 进程内路由去重表是全局的——每个用例独立（不复用
+        # message_id，否则跨用例误判"已路由"）。
+        reset_routed_for_tests()
+
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await bridge._dispatch(
+            "user:local:1000", 1, "pi.input.persist",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "session_ref": "pi_1",
+                "message_id": msg,
+                "text": text,
+            },
+        )
+        kernel = service._task_kernel
+        task_count = kernel._conn.execute(
+            "SELECT COUNT(*) AS n FROM tasks"
+        ).fetchone()["n"]
+        return result, int(task_count)
+
+    async def test_plain_star_still_auto_routes(self, tmp_path: Path) -> None:
+        """回归护栏：全覆盖输入不受影响（recipe 仍自动执行）。"""
+        result, tasks = await self._persist(
+            tmp_path, "画一个五角星，给我 GIF 和 MP4", "m1"
+        )
+        assert result.get("auto_task"), result
+        assert tasks == 1
+
+    async def test_tool_requirement_blocks_autoroute(self, tmp_path: Path) -> None:
+        """持笔 → recipe 未覆盖 → 不自动路由 + 零幽灵任务。"""
+        result, tasks = await self._persist(
+            tmp_path, "画一个五角星，机械臂末端持笔", "m1"
+        )
+        assert not result.get("auto_task"), result
+        assert tasks == 0, f"未覆盖竟建了任务（幽灵任务）: {tasks}"
+
+    async def test_trace_overlay_blocks_autoroute(self, tmp_path: Path) -> None:
+        result, tasks = await self._persist(
+            tmp_path, "画五角星视频，在 3D 画面里显示本次实际轨迹", "m1"
+        )
+        assert not result.get("auto_task"), result
+        assert tasks == 0
+
+    async def test_forbid_2d_blocks_autoroute(self, tmp_path: Path) -> None:
+        result, tasks = await self._persist(
+            tmp_path, "画五角星，不要 2D", "m1"
+        )
+        assert not result.get("auto_task"), result
+        assert tasks == 0
+
+    async def test_unknown_shape_blocks_autoroute(self, tmp_path: Path) -> None:
+        result, tasks = await self._persist(
+            tmp_path, "画一个正方形", "m1"
+        )
+        assert not result.get("auto_task"), result
+        assert tasks == 0
+
+
+class TestRequirementsFrozenInSpec:
+    def test_requirements_frozen_in_task_spec(self, tmp_path: Path) -> None:
+        """条款随 TaskSpec 冻结——R0-3 逐条验收的输入面。"""
+        import sqlite3
+
+        from rosclaw.storage.migrations import MigrationRunner
+        from rosclaw.task_kernel.service import TaskKernel
+
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        MigrationRunner().apply(conn, "sqlite")
+        kernel = TaskKernel(conn, tmp_path)
+        bound = kernel.bind_message(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            message_id="msg_1", text="画五角星，末端持红色圆柱笔",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        spec = kernel.get_task_spec(str(bound["task_id"]))
+        assert spec is not None
+        reqs = spec.get("requirements") or []
+        verifiers = {r["verifier"] for r in reqs}
+        assert "receipt.tool_ref" in verifiers
+        assert "render.tool_color" in verifiers
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/contracts/golden/rosclaw.task_spec.v2.json
+++ b/tests/contracts/golden/rosclaw.task_spec.v2.json
@@ -146,6 +146,46 @@
       "title": "TaskPreferencesV2",
       "type": "object"
     },
+    "TaskRequirementV2": {
+      "additionalProperties": true,
+      "description": "材料性要求条款（0902 审计 R0-2，§3.1）——每条用户要求是\n可核验条款：level(must/forbidden) + claim（用户可读）+\nverifier（覆盖比对键/验收键）。recipe 只在 100% 覆盖时执行。",
+      "properties": {
+        "schema_version": {
+          "const": "rosclaw.task_requirement.v2",
+          "default": "rosclaw.task_requirement.v2",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "req_id": {
+          "minLength": 1,
+          "title": "Req Id",
+          "type": "string"
+        },
+        "level": {
+          "minLength": 1,
+          "title": "Level",
+          "type": "string"
+        },
+        "claim": {
+          "minLength": 1,
+          "title": "Claim",
+          "type": "string"
+        },
+        "verifier": {
+          "minLength": 1,
+          "title": "Verifier",
+          "type": "string"
+        }
+      },
+      "required": [
+        "req_id",
+        "level",
+        "claim",
+        "verifier"
+      ],
+      "title": "TaskRequirementV2",
+      "type": "object"
+    },
     "TaskSubjectsV2": {
       "additionalProperties": true,
       "description": "作用对象：body_ref（canonical robot:<name>）、tool_ref 与\nworld_ref（R0-2：工具/场景是验收一等事实——\"持笔在桌面\"必须\n可声明、可核验，不允许最终回答自由夸大）。",
@@ -217,6 +257,13 @@
         "$ref": "#/$defs/TaskDeliverableV2"
       },
       "title": "Deliverables",
+      "type": "array"
+    },
+    "requirements": {
+      "items": {
+        "$ref": "#/$defs/TaskRequirementV2"
+      },
+      "title": "Requirements",
       "type": "array"
     },
     "acceptance_spec_id": {


### PR DESCRIPTION
## 0902 审计 R0-2（§3.1 硬规则）

0902 实证（P0 事故）："红色圆柱笔+3D 轨迹+不要 2D"被关键词吞掉命中五角星 recipe → 假成功。快速配方只在材料性要求 100% 覆盖时执行；任一 must/forbidden 未覆盖 → 不自动路由（交 Native Agent，不猜），且门禁在建任务之前（零幽灵任务）。

## 内容

- requirements.py（新）：RequirementCompiler——目标文本 → 材料性条款（工具/颜色/轨迹可见/平面/场景视频/禁止 2D/形状——通用词类注册表）；
- TaskRequirementV2 契约 + TaskSpecV2.requirements 随 revision 冻结（R0-3 逐条验收的输入面）；
- task_router.RECIPE_COVERAGE：recipe 可验证覆盖声明；
- auto_route 门禁：recipe 命中后比对覆盖，未覆盖 → None。

## 证据

红→绿：tests/agentd/test_a0902_r02_requirement_coverage.py（10 tests：编译器四组 + 门禁五组（含零幽灵任务）+ spec 冻结；plain star 回归护栏仍自动路由）。全量 agentd 套件 804/804 绿（worktree 无 PTY 构建的 journey 跳过项由 CI 完整跑）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)