### PR TITLE
feat: 0902-R0-3 逐条 Requirement 验收——PASS 必须附带 RequirementCoverage（反假成功）

### DIFF
--- a/src/rosclaw/task_kernel/requirement_check.py
+++ b/src/rosclaw/task_kernel/requirement_check.py
@@ -1,0 +1,246 @@
+"""逐条 Requirement 验收（0902 审计 R0-3，§3.1/R0-4）——PASS 必须附带
+逐条 RequirementCoverage；未覆盖/未满足条款自动阻止终态。
+
+0902 实证（P0 事故）：receipt tool_ref=""/overlays=[] 而用户要求
+"红色圆柱笔 + 3D 实际轨迹 + 不要 2D"——没有任何机制把条款和 receipt
+对上，系统宣布 PASS/DELIVERED 假成功。
+
+每条条款三态判定（诚实——不可证不冒充）：
+- SATISFIED：有证据满足；
+- VIOLATED：有证据证明未满足（receipt 在场但字段为空）；
+- UNVERIFIABLE：当前没有证据通道（颜色/接触——能力缺口诚实暴露，
+  对 must 条款同样阻止终态）。
+
+证据面（全部来自当前 revision 的账本——R0-1）：
+- receipt：产物 lineage 的 render_receipt_path（登记时 kernel 核验
+  digest——不是调用方自述）；
+- plan：trace.json 的 plan_hash → sim/plans/plan_<hash16>.json；
+- 产物 kind 集合：artifact_delivery_kind。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SATISFIED = "SATISFIED"
+VIOLATED = "VIOLATED"
+UNVERIFIABLE = "UNVERIFIABLE"
+
+#: 竖直平面命名面集合（compile_recipe_inputs 的 xz/yz 语义）。
+_VERTICAL_PLANES = frozenset({"xz", "yz"})
+
+
+def _load_receipts(artifacts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """产物血缘 → render receipt（只读已核验路径——登记时已算
+    digest）。"""
+    receipts: list[dict[str, Any]] = []
+    for artifact in artifacts:
+        try:
+            meta = json.loads(str(artifact.get("metadata_json") or "{}"))
+        except ValueError:
+            continue
+        lineage = meta.get("lineage") or {}
+        path = str(lineage.get("render_receipt_path") or "")
+        if not path:
+            continue
+        try:
+            receipts.append(json.loads(Path(path).read_text(
+                encoding="utf-8")))
+        except (OSError, ValueError):
+            continue
+    return receipts
+
+
+def _load_plan(home: Path, artifacts: list[dict[str, Any]]) -> dict[str, Any]:
+    """trace → plan_hash → plan 记录（shape/plane 的权威）。
+
+    两条路（都是 kernel 打戳的账本事实，不是调用方自述）：
+    1. 任务产物里的 trace.json（evidence 产物在账）；
+    2. 产物 lineage.trace_id → sim/traces/<id>/trace.json（受信
+       管道的渲染产物只带 trace 引用，trace 本体不直接入账——
+       wp4 形态）。
+    """
+    trace_ids: list[str] = []
+    for artifact in artifacts:
+        path = Path(str(artifact.get("path") or ""))
+        if path.name == "trace.json" and path.exists():
+            try:
+                trace = json.loads(path.read_text(encoding="utf-8"))
+            except ValueError:
+                continue
+            plan_hash = str(trace.get("plan_hash") or "")
+            if plan_hash:
+                plan_path = (
+                    Path(home) / "sim" / "plans"
+                    / f"plan_{plan_hash[:16]}.json"
+                )
+                if plan_path.exists():
+                    try:
+                        return json.loads(plan_path.read_text(
+                            encoding="utf-8"))
+                    except ValueError:
+                        return {}
+        try:
+            meta = json.loads(str(artifact.get("metadata_json") or "{}"))
+        except ValueError:
+            continue
+        lineage = meta.get("lineage") or {}
+        tid = str(lineage.get("trace_id") or "")
+        if tid:
+            trace_ids.append(tid)
+    for tid in trace_ids:
+        trace_path = Path(home) / "sim" / "traces" / tid / "trace.json"
+        if not trace_path.exists():
+            continue
+        try:
+            trace = json.loads(trace_path.read_text(encoding="utf-8"))
+        except ValueError:
+            continue
+        plan_hash = str(trace.get("plan_hash") or "")
+        if not plan_hash:
+            continue
+        plan_path = (
+            Path(home) / "sim" / "plans" / f"plan_{plan_hash[:16]}.json"
+        )
+        if plan_path.exists():
+            try:
+                return json.loads(plan_path.read_text(encoding="utf-8"))
+            except ValueError:
+                return {}
+    return {}
+
+
+def _check_one(req: dict[str, Any], *, receipts: list[dict[str, Any]],
+               plan: dict[str, Any], kinds: set[str],
+               media: set[str]) -> dict[str, Any]:
+    """单条条款判定。"""
+    verifier = str(req.get("verifier") or "")
+    claim = str(req.get("claim") or verifier)
+    level = str(req.get("level") or "must")
+    base = {"req_id": str(req.get("req_id") or ""), "claim": claim,
+            "level": level, "verifier": verifier}
+
+    def _done(status: str, evidence: str) -> dict[str, Any]:
+        return {**base, "status": status, "evidence": evidence}
+
+    if verifier.startswith("shape."):
+        want = verifier.split(".", 1)[1]
+        if not plan:
+            return _done(UNVERIFIABLE, "无 plan 记录可核对形状")
+        actual = str(plan.get("shape") or "")
+        if actual == want:
+            return _done(SATISFIED, f"plan.shape={actual}")
+        return _done(VIOLATED, f"plan.shape={actual or '∅'} ≠ {want}")
+    if verifier == "plan.plane.vertical":
+        if not plan:
+            return _done(UNVERIFIABLE, "无 plan 记录可核对平面")
+        plane = str(plan.get("plane") or "")
+        if plane in _VERTICAL_PLANES:
+            return _done(SATISFIED, f"plan.plane={plane}")
+        return _done(VIOLATED, f"plan.plane={plane or '∅'} 非竖直面")
+    if verifier == "plan.plane.horizontal":
+        if not plan:
+            return _done(UNVERIFIABLE, "无 plan 记录可核对平面")
+        plane = str(plan.get("plane") or "")
+        if plane == "xy":
+            return _done(SATISFIED, "plan.plane=xy")
+        return _done(VIOLATED, f"plan.plane={plane or '∅'} 非水平面")
+    if verifier == "receipt.tool_ref":
+        if not receipts:
+            return _done(UNVERIFIABLE, "无 render receipt 可核对工具挂载")
+        mounted = [str(r.get("tool_ref") or "") for r in receipts]
+        if any(mounted):
+            return _done(SATISFIED, f"receipt.tool_ref={mounted}")
+        return _done(VIOLATED, "receipt.tool_ref 全为空——未挂载工具")
+    if verifier == "receipt.overlays.actual_eef_trace":
+        if not receipts:
+            return _done(UNVERIFIABLE, "无 render receipt 可核对轨迹叠加")
+        for r in receipts:
+            overlays = r.get("overlays")
+            if isinstance(overlays, list) and "actual_eef_trace" in overlays:
+                return _done(SATISFIED, "overlays 含 actual_eef_trace")
+        if any("overlays" in r for r in receipts):
+            return _done(VIOLATED, "receipt.overlays 不含实际轨迹")
+        return _done(UNVERIFIABLE,
+                     "receipt 无 overlays 字段——渲染器尚不支持轨迹叠加")
+    if verifier == "render.tool_color":
+        return _done(UNVERIFIABLE, "颜色无证据通道（渲染器不回写外观属性）")
+    if verifier == "verification.contact":
+        return _done(UNVERIFIABLE, "接触无证据通道（无接触验证器）")
+    if verifier == "deliverable.scene_3d":
+        if "scene_3d" in kinds:
+            return _done(SATISFIED, "scene_3d 产物在账")
+        return _done(VIOLATED, "无 scene_3d 产物")
+    if verifier == "deliverable.video":
+        if any(m.startswith("video/") for m in media):
+            return _done(SATISFIED, "video/* 产物在账")
+        return _done(VIOLATED, "无视频产物")
+    if verifier == "deliverable.preview_2d":
+        if "preview_2d" in kinds:
+            return _done(SATISFIED, "preview_2d 产物在账")
+        return _done(VIOLATED, "无 preview_2d 产物")
+    if verifier == "delivery.not_2d_only":
+        # forbidden：主交付不得只有 2D——有 scene_3d 或 video/* 即满足
+        # 禁止项（"不违反"）。
+        has_3d_or_video = "scene_3d" in kinds or any(
+            m.startswith("video/") for m in media)
+        if has_3d_or_video:
+            return _done(SATISFIED, "存在 3D/视频交付——未违反禁止项")
+        return _done(VIOLATED, "只有 2D 产物——违反禁止项")
+    # 未知 verifier 键：不可证（不猜）。
+    return _done(UNVERIFIABLE, f"未知验收键 {verifier}——不可证")
+
+
+def check_requirements(
+    *,
+    home: Path,
+    requirements: list[dict[str, Any]],
+    artifacts: list[dict[str, Any]],
+    embodied: bool = True,
+) -> list[dict[str, Any]]:
+    """逐条验收。artifacts 必须是当前 revision 的产物集（R0-1）。
+
+    embodied=False（无本体任务——写文件类）时跳过物理证据条款
+    （shape/plane/tool/overlay/color/contact 的证据通道只在具身链
+    存在——非具身任务上它们永远 UNVERIFIABLE，是噪声不是信号）；
+    deliverable/delivery 条款（产物面）不受本体影响，照常核验。
+    """
+    if not requirements:
+        return []
+    from rosclaw.task_kernel.deliverables import artifact_delivery_kind
+
+    receipts = _load_receipts(artifacts)
+    plan = _load_plan(home, artifacts)
+    kinds = {artifact_delivery_kind(a) for a in artifacts}
+    media = {str(a.get("media_type") or "") for a in artifacts}
+    return [
+        _check_one(r, receipts=receipts, plan=plan, kinds=kinds,
+                   media=media)
+        for r in requirements
+        if embodied
+        or not str(r.get("verifier") or "").startswith(
+            ("shape.", "plan.", "receipt.", "render.", "verification.")
+        )
+    ]
+
+
+def unmet_failures(verdicts: list[dict[str, Any]]) -> list[str]:
+    """verdicts → 阻止终态的失败行（must 未满足/不可证 +
+    forbidden 被违反）。"""
+    failures: list[str] = []
+    for v in verdicts:
+        if v["status"] == SATISFIED:
+            continue
+        failures.append(
+            f"REQUIREMENT_UNMET: {v['claim']}（{v['status']}——"
+            f"{v['evidence']}）"
+        )
+    return failures
+
+
+__all__ = [
+    "SATISFIED", "UNVERIFIABLE", "VIOLATED",
+    "check_requirements", "unmet_failures",
+]

--- a/src/rosclaw/task_kernel/service.py
+++ b/src/rosclaw/task_kernel/service.py
@@ -930,6 +930,31 @@ class TaskKernel:
                     f"DELIVERABLE_MISSING: required 交付物 {kind} 未在产物"
                     "账本（按 kind 匹配——2D 预览不满足场景视频）"
                 )
+        # 0902 R0-3（审计 §3.1/R0-4）：逐条 Requirement 验收——PASS
+        # 必须附带逐条 RequirementCoverage；未满足/不可证条款阻止
+        # 终态（0902 实证：tool_ref=""/overlays=[] 竟 PASS）。
+        requirement_coverage: list[dict[str, Any]] = []
+        spec_requirements = (spec or {}).get("requirements") or []
+        if spec_requirements:
+            from rosclaw.task_kernel.requirement_check import (
+                check_requirements,
+                unmet_failures,
+            )
+
+            req_ledger = [
+                dict(r)
+                for r in self._conn.execute(
+                    "SELECT * FROM artifacts WHERE task_id = ? "
+                    "AND revision = ?",
+                    (task_id, int(task["active_revision"])),
+                ).fetchall()
+            ]
+            requirement_coverage = check_requirements(
+                home=self._home, requirements=spec_requirements,
+                artifacts=req_ledger,
+                embodied=bool(task.get("body_id")),
+            )
+            provenance_failures += unmet_failures(requirement_coverage)
         trusted_present = any(
             str(a.get("producer") or "").startswith("kernel:")
             and not str(a.get("media_type") or "").startswith("image/")
@@ -954,6 +979,10 @@ class TaskKernel:
             # P0-5：误差事实与分级随验收行持久化（checks_json 是
             # 审计面——误差/分级不回填就无从复核"接近阈值"）。
             checks_payload: dict[str, Any] = {"checks": verdict["checks"]}
+            # 0902 R0-3：PASS 附带逐条 RequirementCoverage（审计面——
+            # "每条要求都被证据满足"可复核，不是一句 PASS）。
+            if requirement_coverage:
+                checks_payload["requirement_coverage"] = requirement_coverage
             if grade:
                 checks_payload["grade"] = grade
             if tracking_max_error_m is not None:

--- a/tests/agentd/test_a0902_r03_requirement_verdicts.py
+++ b/tests/agentd/test_a0902_r03_requirement_verdicts.py
@@ -1,0 +1,207 @@
+"""0902 审计 R0-3 红测试：逐条 Requirement verdict——每个材料性要求
+一条判定；未满足/不可证 → 不得 PASS（反假成功故障注入）。
+
+0902 实证（P0 事故）：新 revision 要求"红色圆柱笔 + 3D 实际轨迹 +
+不要 2D"，receipt 仍 tool_ref=""/overlays=[]，系统宣布 PASS/DELIVERED。
+
+闭环断言（故障注入矩阵）：
+1. spec 声明持笔 + receipt tool_ref="" → REQUIREMENT_UNMET，不 PASS；
+2. 要求轨迹叠加 + receipt 无 overlays → 不 PASS；
+3. 禁止纯 2D + 只有 2D 产物 → 不 PASS；
+4. 颜色要求（无证据通道）→ UNVERIFIABLE → 不 PASS（诚实——
+   不可证不冒充）；
+5. 全满足（tool_ref 匹配 + scene_3d 在账 + 轨迹在账）→ 正常 PASS
+   （回归护栏）。
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _resource() -> dict:
+    """真实权威 manifest 资源证明（与 n0/wp4 测试同一形态）。"""
+    from rosclaw.cognition.resolver import resolve_resource
+
+    repo = Path(__file__).resolve().parents[2]
+    manifest = resolve_resource("robot", "ur5e", product_root=repo)
+    assert manifest is not None
+    return {
+        "resource_id": "robot:ur5e",
+        "manifest_digest": manifest["digests"].get("profile", ""),
+        "model_path": manifest["paths"]["mjcf"],
+        "model_digest": manifest["digests"]["mjcf"],
+        "quality": "PRODUCTION",
+        "canonical": True,
+    }
+
+
+def _kernel(tmp_path: Path):
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return TaskKernel(conn, tmp_path)
+
+
+def _write_receipt(tmp_path: Path, *, tool_ref: str = "",
+                   with_overlays: bool = False) -> Path:
+    """render receipt 故障注入点：tool_ref/overlays 由测试控制。"""
+    receipt = {
+        "schema_version": "rosclaw.render_receipt.v1",
+        "backend": "osmesa",
+        "camera": "follow",
+        "world_id": "empty",
+        "tool_ref": tool_ref,
+        "input_trace_digest": "sha256:" + "0" * 64,
+        "outputs": ["gif", "mp4"],
+    }
+    if with_overlays:
+        receipt["overlays"] = ["actual_eef_trace"]
+    path = tmp_path / "render_receipt.json"
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+    return path
+
+
+def _chain_artifacts(kernel, task_id: str, tmp_path: Path,
+                     receipt: Path) -> list[str]:
+    """当前 revision 的最小受信产物集：trace + 场景视频（带血缘）。"""
+    # plan 记录（shape/plane 验收的权威源——trace.plan_hash 链接）。
+    plan_hash = "0" * 32
+    plans = tmp_path / "sim" / "plans"
+    plans.mkdir(parents=True, exist_ok=True)
+    (plans / f"plan_{plan_hash[:16]}.json").write_text(json.dumps({
+        "shape": "star5", "plane": "xy", "hash": plan_hash,
+    }), encoding="utf-8")
+    trace = tmp_path / "trace.json"
+    trace.write_text(json.dumps({
+        "schema_version": "rosclaw.trace.v1",
+        "plan_hash": plan_hash,
+    }), encoding="utf-8")
+    t = kernel.register_artifact(
+        task_id=task_id, path=str(trace), media_type="application/json",
+        producer="kernel:capability:ur5e.simulate",
+        metadata={"resource": _resource()},
+    )
+    mp4 = tmp_path / "scene.mp4"
+    mp4.write_bytes(b"MP4" + b"x" * 4096)
+    m = kernel.register_artifact(
+        task_id=task_id, path=str(mp4), media_type="video/mp4",
+        producer="kernel:sim_render",
+        metadata={"resource": _resource(),
+                  "lineage": {"render_receipt_path": str(receipt),
+                              "kind": "scene_3d"}},
+    )
+    return [str(t["artifact_id"]), str(m["artifact_id"])]
+
+
+def _finish(kernel, task_id: str, artifact_ids: list[str]):
+    return kernel.finish_task(
+        task_id=task_id, summary="done", artifact_ids=artifact_ids,
+    )
+
+
+class TestPerRequirementVerdict:
+    def test_empty_tool_ref_blocks_pass(self, tmp_path: Path) -> None:
+        """0902 事故面：spec 声明持笔（tool:pen）+ receipt
+        tool_ref="" → 不得 PASS。"""
+        kernel = _kernel(tmp_path)
+        bound = kernel.bind_message(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            message_id="msg_1", text="画五角星，机械臂末端持笔",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        task_id = str(bound["task_id"])
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        receipt = _write_receipt(tmp_path, tool_ref="")
+        ids = _chain_artifacts(kernel, task_id, tmp_path, receipt)
+        result = _finish(kernel, task_id, ids)
+        assert result["status"] != "SUCCEEDED", result
+        assert any("REQUIREMENT_UNMET" in str(f) for f in
+                   result.get("failures", [])), result
+
+    def test_missing_overlay_blocks_pass(self, tmp_path: Path) -> None:
+        """要求 3D 画面叠加实际轨迹 + receipt 无 overlays → 不 PASS。"""
+        kernel = _kernel(tmp_path)
+        bound = kernel.bind_message(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            message_id="msg_1",
+            text="画五角星视频，在 3D 画面里显示本次实际轨迹",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        task_id = str(bound["task_id"])
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        receipt = _write_receipt(tmp_path)  # 无 overlays 字段
+        ids = _chain_artifacts(kernel, task_id, tmp_path, receipt)
+        result = _finish(kernel, task_id, ids)
+        assert result["status"] != "SUCCEEDED", result
+        assert any("REQUIREMENT_UNMET" in str(f) for f in
+                   result.get("failures", [])), result
+
+    def test_forbid_2d_only_with_only_2d_blocks(self, tmp_path: Path) -> None:
+        """"不要 2D" + 只有 2D 预览 → 禁止项违反，不 PASS。"""
+        kernel = _kernel(tmp_path)
+        bound = kernel.bind_message(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            message_id="msg_1", text="画五角星，不要 2D",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        task_id = str(bound["task_id"])
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        # 只产 2D 预览（无场景视频）。
+        gif = tmp_path / "preview.gif"
+        gif.write_bytes(b"GIF89a" + b"x" * 2048)
+        art = kernel.register_artifact(
+            task_id=task_id, path=str(gif), media_type="image/gif",
+            producer="kernel:sim_render",
+            metadata={"resource": _resource(),
+                      "lineage": {"kind": "preview_2d",
+                                  "trace_id": "t1"}},
+        )
+        result = _finish(kernel, task_id, [str(art["artifact_id"])])
+        assert result["status"] != "SUCCEEDED", result
+        assert any("REQUIREMENT_UNMET" in str(f) for f in
+                   result.get("failures", [])), result
+
+    def test_color_requirement_unverifiable_blocks(self, tmp_path: Path) -> None:
+        """颜色要求今天没有证据通道 → UNVERIFIABLE → 不 PASS
+        （不可证不冒充——能力缺口诚实暴露）。"""
+        kernel = _kernel(tmp_path)
+        bound = kernel.bind_message(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            message_id="msg_1", text="画五角星，笔要红色",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        task_id = str(bound["task_id"])
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        receipt = _write_receipt(tmp_path, tool_ref="tool:pen")
+        ids = _chain_artifacts(kernel, task_id, tmp_path, receipt)
+        result = _finish(kernel, task_id, ids)
+        assert result["status"] != "SUCCEEDED", result
+        assert any("颜色" in str(f) or "tool_color" in str(f)
+                   for f in result.get("failures", [])), result
+
+    def test_all_satisfied_passes(self, tmp_path: Path) -> None:
+        """回归护栏：全条款满足 → 正常 PASS。"""
+        kernel = _kernel(tmp_path)
+        bound = kernel.bind_message(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            message_id="msg_1", text="画五角星视频",
+            cwd=str(tmp_path), body_id="sim/ur5e",
+        )
+        task_id = str(bound["task_id"])
+        kernel.note_tool_use(task_id, "rosclaw_task")
+        receipt = _write_receipt(tmp_path)
+        ids = _chain_artifacts(kernel, task_id, tmp_path, receipt)
+        result = _finish(kernel, task_id, ids)
+        assert result["status"] == "SUCCEEDED", result.get("failures")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agentd/test_n0_no_false_success.py
+++ b/tests/agentd/test_n0_no_false_success.py
@@ -17,6 +17,7 @@ task_finish 可临时修改 acceptance、artifact cwd 分裂、用户否定后�
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
@@ -105,7 +106,16 @@ class TestNoFalseSuccess:
         # 无血缘的受信媒体声明已不被接受（LINEAGE_MISSING）。
         trace_dir = tmp_path / "sim" / "traces" / "trace_test1"
         trace_dir.mkdir(parents=True, exist_ok=True)
-        (trace_dir / "trace.json").write_text("{}", encoding="utf-8")
+        # 0902 R0-3：真实管道的 trace 必带 plan_hash（plan 记录是
+        # shape/plane 条款的核验源）——夹具对齐真实形态。
+        plan_hash = "a" * 32
+        (trace_dir / "trace.json").write_text(
+            json.dumps({"plan_hash": plan_hash}), encoding="utf-8")
+        plans = tmp_path / "sim" / "plans"
+        plans.mkdir(parents=True, exist_ok=True)
+        (plans / f"plan_{plan_hash[:16]}.json").write_text(
+            json.dumps({"shape": "star5", "plane": "xy",
+                        "hash": plan_hash}), encoding="utf-8")
         art = kernel.register_artifact(
             task_id=task_id, path=str(path), media_type="image/gif",
             producer="kernel:sim_pipeline",

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1687,6 +1687,28 @@ class TestProductJourney:
             # 6b. 对抗场景（P0-4F 场景 D）：模型谎称完成——系统必须
             #    以结构化状态为准，不采信模型自述。
             self._assert_adversarial_model_ignored(session, home)
+            # 0902 R0（反假成功 P0 事故复归）：用户对已完成任务新增
+            # 材料性要求（红笔 + 3D 实际轨迹 + 不要 2D）→ 覆盖率门禁
+            # 不得让旧 recipe 认领重跑，旧 revision 的视频不得满足新
+            # revision——绝不出现第二个"任务完成"卡；输入落到模型
+            # 路径（覆盖率不足 → 交 Native Agent，不猜）。
+            seg_before_rev = len(session.clean)
+            model_turns_before_rev = len(fake.fake.requests)
+            session.send(
+                "不对——加红色圆柱笔，在 3D 画面里显示本次实际轨迹，"
+                "不要 2D\r"
+            )
+            import time as _time
+
+            _time.sleep(8)  # 路由/模型回合窗口
+            rev_seg = session.clean[seg_before_rev:]
+            assert "任务完成：验收 PASS".encode() not in rev_seg, (
+                "0902 假成功复现：新要求竟被旧产物满足并宣布 PASS"
+            )
+            assert len(fake.fake.requests) > model_turns_before_rev, (
+                "未覆盖要求竟没落到模型路径（被旧 recipe 吞了）"
+            )
+            self._journey_verdicts["revision_no_fake_success"] = True
             # 0901 P0-1（硬 Gate B）：安装产物的 `rosclaw artifact` 一族
             # 真实可达——list 不回落顶层帮助、path 给绝对路径（0901
             # 实证：open_command 给了 `rosclaw artifact open` 但入口


### PR DESCRIPTION
## 0902 审计 R0-3（§3.1/R0-4 + R0-7 故障注入）

0902 实证（P0 事故）：receipt tool_ref=""/overlays=[] 而用户要求"红色圆柱笔+3D 实际轨迹+不要 2D"——没有机制把条款和 receipt 对上，系统宣布 PASS/DELIVERED。

## 内容

- requirement_check.py（新）：逐条三态判定 SATISFIED/VIOLATED/UNVERIFIABLE（不可证不冒充——颜色/接触今天无证据通道，诚实阻止终态而不是放行）；证据面：render receipt（血缘核验路径）+ plan 记录（trace.plan_hash / lineage.trace_id 两路）+ 当前 revision 产物 kind；
- finish_task：spec.requirements 非空 → 逐条验收进 provenance_failures；PASS 的 checks_json 附带逐条 coverage（R0-4：PASS 必须附带 RequirementCoverage）；
- 非具身任务跳过物理证据条款（shape/plane/tool/overlay/color/contact 只在具身链有证据通道——n0 实证误伤修复）；
- n0 夹具对齐真实管道形态（真实 trace 必带 plan_hash）。

## 证据

红→绿：tests/agentd/test_a0902_r03_requirement_verdicts.py（故障注入矩阵 5 条：空 tool_ref / 无 overlays / 只有 2D / 颜色不可证 / 全满足护栏）。全量 agentd 809/809 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)