### PR TITLE
feat: 0902-R1-a Approval Broker——shell 降级授权走会话内确认卡，删除全局环境变量方案

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -870,6 +870,46 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 
 		// -- Approval 卡片（NA-FIX-5，P0-5 修复）：tool 返回精确 approval_id
 		//    后才展卡——绝不取 pending 列表第一个。
+		// 0902 R1-a：shell 降级授权卡（Approval Broker——确认卡只给
+		// 允许一次/本任务允许/拒绝；批准后立即继续原操作）。在
+		// AWAITING_OPERATOR 分支之前拦截（不同 phase 名，不同决定面）。
+		pi.on("tool_execution_update", async (event, ctx) => {
+			if (event.toolName !== "bash" || !ctx.hasUI) return;
+			const details = (event.partialResult?.details ?? {}) as {
+				phase?: string;
+				request_id?: string;
+			};
+			if (details.phase !== "AWAITING_SHELL_APPROVAL" || !details.request_id) return;
+			const requestId = details.request_id;
+			ctx.ui.setWorkingMessage(`等待授权决定（${requestId}）…默认拒绝`);
+			notifyLeveled(ctx, `等待授权决定（${requestId}）…默认拒绝`, "info");
+			try {
+				const choice = await ctx.ui.select(
+					"本机无 OS 沙箱（bwrap 不可用）——当前命令需要在任务工作区内无沙箱执行（凭据/控制面对 shell 可达）",
+					["允许一次", "本任务允许（当前 revision）", "拒绝"],
+					{ timeout: 120000 },
+				);
+				const decision = choice === "允许一次"
+					? "allow_once"
+					: choice?.startsWith("本任务允许")
+						? "allow_task"
+						: "deny";
+				const decided = (await center.call("pi.shell_gate.decide", {
+					request_id: requestId,
+					decision,
+				})) as { ok: boolean; error?: string };
+				notifyLeveled(ctx,
+					decided.ok
+						? decision === "deny"
+							? "已拒绝（操作未执行）"
+							: "已批准——原操作继续（结果带 TOOL_LAYER_ONLY 标记）"
+						: `决定被拒：${decided.error ?? "unknown"}`,
+					decided.ok ? "info" : "error",
+				);
+			} catch (err) {
+				notifyLeveled(ctx, `授权卡交互失败：${(err as Error).message}`, "error");
+			}
+		});
 		pi.on("tool_execution_update", async (event, ctx) => {
 			if (
 				(event.toolName !== "rosclaw_request_action" && event.toolName !== "rosclaw_task")

--- a/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
+++ b/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
@@ -240,6 +240,46 @@ export async function createRosclawRuntime(
 							mode: active.current.mode ?? "SIMULATION",
 						});
 					},
+					// 0902 R1-a：无沙箱降级走 Approval Broker（会话内
+					// 确认卡——grant 绑定 task+revision+scope），删除
+					// 全局环境变量授权的正式路径。
+					shellGate: {
+						check: async () => {
+							const activeTask = (await center.call("pi.kernel.active", {
+								mission_id: active.current.missionId ?? "",
+								session_ref: active.current.sessionId ?? "",
+							})) as { task?: { task_id?: string; active_revision?: number } | null };
+							const task = activeTask.task;
+							if (!task?.task_id) return false;
+							const r = (await center.call("pi.shell_gate.check", {
+								task_id: task.task_id,
+								revision: task.active_revision ?? 1,
+								scope: "shell.unsandboxed",
+							})) as { granted?: boolean };
+							return r.granted === true;
+						},
+						request: async () => {
+							const activeTask = (await center.call("pi.kernel.active", {
+								mission_id: active.current.missionId ?? "",
+								session_ref: active.current.sessionId ?? "",
+							})) as { task?: { task_id?: string; active_revision?: number } | null };
+							const task = activeTask.task;
+							const r = (await center.call("pi.shell_gate.request", {
+								task_id: task?.task_id ?? "",
+								revision: task?.active_revision ?? 1,
+								mission_id: active.current.missionId ?? "",
+								session_ref: active.current.sessionId ?? "",
+								scope: "shell.unsandboxed",
+							})) as { request?: { request_id?: string } };
+							return String(r.request?.request_id ?? "");
+						},
+						status: async (requestId: string) => {
+							const r = (await center.call("pi.shell_gate.status", {
+								request_id: requestId,
+							})) as { request?: { status?: string } };
+							return String(r.request?.status ?? "UNKNOWN");
+						},
+					},
 				}),
 				// PR-H3：process 工具（长 Operation——立即返回 operation_id）。
 				...buildProcessTools({

--- a/packages/rosclaw-agent/src/tools/workspace-pack.ts
+++ b/packages/rosclaw-agent/src/tools/workspace-pack.ts
@@ -68,6 +68,52 @@ function scrubEnv(source: NodeJS.ProcessEnv): Record<string, string> {
 	return out;
 }
 
+/** 0902 R1-a：shell 降级的批准面（Approval Broker 桥接）。
+ *  check/request/status 全部经 center.call 到 agentd 账本。 */
+export interface ShellGate {
+	/** standing grant 命中（task+revision+scope 绑定，任务活跃）。 */
+	check(): Promise<boolean>;
+	/** 登记授权请求 → request_id（PENDING）。 */
+	request(): Promise<string>;
+	/** 请求状态（PENDING/APPROVED_ONCE/APPROVED_TASK/DENIED）。 */
+	status(requestId: string): Promise<string>;
+}
+
+/** 等待窗口（与 request-action 的 Operator 等待同语义：超时/中断
+ *  = 拒绝语义）。 */
+const SHELL_APPROVAL_TIMEOUT_MS = 10 * 60 * 1000;
+
+/** 无沙箱降级的会话内授权流：request → onUpdate 卡 → 轮询决定。
+ *  返回 true = 允许继续原操作（一次或本任务）。 */
+export async function awaitShellApproval(
+	gate: ShellGate,
+	onUpdate: ((partial: {
+		content: Array<{ type: "text"; text: string }>;
+		details: Record<string, unknown>;
+	}) => void) | undefined,
+	signal: AbortSignal | undefined,
+): Promise<boolean> {
+	const requestId = await gate.request();
+	onUpdate?.({
+		content: [{
+			type: "text" as const,
+			text: `等待授权决定（${requestId}）…默认拒绝`,
+		}],
+		details: { phase: "AWAITING_SHELL_APPROVAL", request_id: requestId },
+	});
+	const deadline = Date.now() + SHELL_APPROVAL_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		if (signal?.aborted) return false; // 中断 = 拒绝语义
+		const status = await gate.status(requestId);
+		if (status === "APPROVED_ONCE" || status === "APPROVED_TASK") {
+			return true;
+		}
+		if (status === "DENIED" || status === "UNKNOWN") return false;
+		await new Promise((resolve) => setTimeout(resolve, 1500));
+	}
+	return false; // 超时 = 默认拒绝
+}
+
 export interface WorkspacePackOptions {
 	/** 项目根（write/edit 的作用域；bash 的 cwd）。 */
 	root: string;
@@ -87,6 +133,9 @@ export interface WorkspacePackOptions {
 	/** 操作者显式授权的无沙箱降级（仅 SIM；bwrap 不可用的主机——
 	 *  等价 ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1）。 */
 	allowUnsandboxedShell?: () => boolean;
+	/** 0902 R1-a：无沙箱降级的 Runtime 批准面（会话内确认卡 →
+	 *  task+revision+scope 绑定的 grant）。缺失 = fail closed。 */
+	shellGate?: ShellGate;
 	/** P0-C（0824 总纲 §6.2）：effectful 工具执行前的原子
 	 *  admission（ensure_task_for_effect）——bash/write/edit
 	 *  执行前触发。 */
@@ -135,7 +184,7 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 			command: Type.String({ description: "要执行的 shell 命令" }),
 			timeout_sec: Type.Optional(Type.Number({ description: "显式超时（秒）——不填则无定时器" })),
 		}),
-		async execute(_id, params, signal) {
+		async execute(_id, params, signal, onUpdate) {
 			const command = String(params.command ?? "").trim();
 			if (!command) return denied("empty command");
 			// P0-C：首个 effectful call 的原子 admission。
@@ -170,18 +219,33 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 			const sandboxed = bwrap !== null;
 			let degradedMarker = "";
 			if (!sandboxed) {
-				const degradedAllowed = !strict
-					&& (options.allowUnsandboxedShell?.() === true
-						|| process.env.ROSCLAW_ALLOW_UNSANDBOXED_SHELL === "1");
-				if (!degradedAllowed) {
+				if (strict) {
+					return denied(
+						`${mode} 模式 shell 需要 bwrap 强隔离——本机无可用 bwrap`
+						+ "（user namespace 受限），fail closed（不裸跑）。",
+					);
+				}
+				// 0902 R1-a（审计 §5.2）：SIM 降级走会话内批准——
+				// 确认卡（允许一次/本任务允许/拒绝）→ grant 绑定
+				// task+revision+scope → 立即继续原操作。删除全局
+				// 环境变量授权的正式路径（0902 实证：用户已答"允许"
+				// 仍被要求 export ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1
+				// 并重启——不可接受）。
+				let granted = options.allowUnsandboxedShell?.() === true;
+				if (!granted && options.shellGate) {
+					granted = await options.shellGate.check();
+				}
+				if (!granted && options.shellGate) {
+					granted = await awaitShellApproval(
+						options.shellGate, onUpdate, signal,
+					);
+				}
+				if (!granted) {
 					return denied(
 						`${mode} 模式 shell 需要 bwrap 强隔离——本机无可用 bwrap`
 						+ "（user namespace 受限），fail closed（不裸跑）。"
-						+ (strict
-							? ""
-							: " SIM 下如确需无沙箱 shell，操作者须显式授权："
-								+ "ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1（结果带 "
-								+ "TOOL_LAYER_ONLY 标记）"),
+						+ " SIM 下如确需无沙箱 shell：在确认卡选「允许一次」或"
+						+ "「本任务允许」（结果带 TOOL_LAYER_ONLY 标记）",
 					);
 				}
 				degradedMarker =

--- a/packages/rosclaw-agent/test/a0902-r1a-shell-gate.test.ts
+++ b/packages/rosclaw-agent/test/a0902-r1a-shell-gate.test.ts
@@ -1,0 +1,280 @@
+/** 0902 R1-a 红测试：shell 降级授权走 Approval Broker（会话内确认
+ *  卡），删除全局环境变量授权的正式路径。
+ *
+ * 0902 实证：用户已答"允许！"，系统仍要求 export
+ * ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1 并重启——不可接受。
+ *
+ * 闭环断言：
+ * 1. 无 bwrap + 无 grant + 无注入 → fail closed（且拒文不再指向
+ *    全局环境变量）；
+ * 2. standing grant 命中 → 降级运行带 TOOL_LAYER_ONLY 标记；
+ * 3. 无 grant → 确认卡流（request→pending→允许一次）→ 立即继续
+ *    原操作；
+ * 4. 拒绝 → 不执行；
+ * 5. REAL/SHADOW 永远 fail closed（无降级路径）。
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+async function makeBash(dir: string, extras: Record<string, unknown>) {
+	const { buildWorkspacePackTools } = await import(
+		"../src/tools/workspace-pack.js"
+	);
+	const tools = buildWorkspacePackTools({
+		root: dir,
+		rosclawHome: dir,
+		mode: () => "SIMULATION",
+		bwrapPath: () => null, // 强制无 bwrap
+		...extras,
+	} as never);
+	const bash = tools.find((t) => t.name === "bash");
+	assert.ok(bash);
+	return bash;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyTool = { execute: (...a: any[]) => Promise<any> };
+
+async function run(bash: AnyTool, command: string, onUpdate?: (...a: never[]) => void) {
+	const result = await bash.execute(
+		"c1", { command }, new AbortController().signal,
+		(onUpdate ?? (async () => {})) as never, {} as never,
+	) as { content: Array<{ text: string }>; isError?: boolean };
+	return {
+		text: String(result.content[0]?.text ?? ""),
+		isError: result.isError === true,
+	};
+}
+
+test("R1-a: 无 bwrap + 无 grant → fail closed，拒文不再指向全局环境变量", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "r1a-"));
+	const bash = await makeBash(dir, {});
+	const out = await run(bash, "echo hi");
+	assert.ok(out.isError, "无 grant 裸跑了");
+	assert.doesNotMatch(out.text, /ROSCLAW_ALLOW_UNSANDBOXED_SHELL/,
+		"拒文仍指向全局环境变量——正式路径没删干净");
+	assert.match(out.text, /确认卡|允许一次/);
+});
+
+test("R1-a: standing grant 命中 → 降级运行带 TOOL_LAYER_ONLY 标记", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "r1a-"));
+	const bash = await makeBash(dir, {
+		shellGate: {
+			check: async () => true,
+			request: async () => "shg_x",
+			status: async () => "UNKNOWN",
+		},
+	});
+	const out = await run(bash, "echo hi");
+	assert.ok(!out.isError, out.text);
+	assert.match(out.text, /hi/);
+	assert.match(out.text, /TOOL_LAYER_ONLY/);
+});
+
+test("R1-a: 确认卡允许一次 → 原操作立即继续", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "r1a-"));
+	const updates: Array<Record<string, unknown>> = [];
+	const bash = await makeBash(dir, {
+		shellGate: {
+			check: async () => false,
+			request: async () => "shg_req1",
+			// 第一次轮询即已批准（模拟用户在卡上选了允许一次）。
+			status: async () => "APPROVED_ONCE",
+		},
+	});
+	const out = await run(bash, "echo hi", ((partial: unknown) => {
+		updates.push(partial as Record<string, unknown>);
+	}) as never);
+	assert.ok(!out.isError, out.text);
+	assert.match(out.text, /hi/);
+	// 卡确实弹出过（AWAITING_SHELL_APPROVAL phase 经 onUpdate 发出）。
+	assert.ok(
+		updates.some((u) =>
+			(u.details as { phase?: string })?.phase === "AWAITING_SHELL_APPROVAL"
+		),
+		"确认卡 phase 未发出",
+	);
+});
+
+test("R1-a: 拒绝 → 不执行", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "r1a-"));
+	const bash = await makeBash(dir, {
+		shellGate: {
+			check: async () => false,
+			request: async () => "shg_req2",
+			status: async () => "DENIED",
+		},
+	});
+	const out = await run(bash, "echo hi");
+	assert.ok(out.isError, "被拒仍执行了");
+	assert.doesNotMatch(out.text, /^hi$/m);
+});
+
+test("R1-a: REAL 模式无 bwrap 永远 fail closed（无降级路径）", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "r1a-"));
+	const { buildWorkspacePackTools } = await import(
+		"../src/tools/workspace-pack.js"
+	);
+	const tools = buildWorkspacePackTools({
+		root: dir,
+		rosclawHome: dir,
+		mode: () => "REAL",
+		bwrapPath: () => null,
+		shellGate: {
+			check: async () => true, // 即使有 grant——REAL 也无降级
+			request: async () => "shg_x",
+			status: async () => "APPROVED_TASK",
+		},
+	} as never);
+	const bash = tools.find((t) => t.name === "bash");
+	assert.ok(bash);
+	const out = await run(bash as never, "echo hi");
+	assert.ok(out.isError, "REAL 模式竟降级裸跑");
+});
+
+test("R1-a: 确认卡三选 → decide 正确映射（本任务允许 → allow_task）", async () => {
+	// 经扩展注册的 tool_execution_update 处理器驱动（最小 harness）。
+	const handlerList: Array<(event: unknown, ctx: unknown) => Promise<unknown>> = [];
+	const decideCalls: Array<Record<string, unknown>> = [];
+	const { createRosclawExtension } = await import("../src/extension/index.js");
+	const { ActiveSessionContext } = await import("../src/session/active-context.js");
+	const { AgentSessionCoordinator } = await import("../src/session/coordinator.js");
+	const { SessionLeaseManager } = await import("../src/session/lease-manager.js");
+	const { ProductStateCenter } = await import("../src/session/state-center.js");
+	const { LocaleManager } = await import("../src/i18n/locale.js");
+	const { resolveTaskContext } = await import("../src/native/active-task-context.js");
+
+	const active = new ActiveSessionContext({
+		sessionId: "pi_test", missionId: undefined, contextRevision: 0,
+		mode: "SIMULATION", profile: "developer", contextState: "LOADING",
+		leaseState: "NONE", actionsAllowed: false,
+	});
+	const call = async (_home: string, method: string, params?: Record<string, unknown>) => {
+		if (method === "pi.shell_gate.decide") {
+			decideCalls.push(params ?? {});
+			return { ok: true };
+		}
+		return { ok: false, error: "no bridge in test" } as Record<string, unknown>;
+	};
+	const coordinator = new AgentSessionCoordinator({
+		rosclawHome: "/tmp/rh-test", active,
+		leaseManager: new SessionLeaseManager("/tmp/rh-test", call),
+		notify: () => undefined, call,
+	});
+	const center = new ProductStateCenter({
+		rosclawHome: "/tmp/rh-test", active,
+		operatorSocket: "/tmp/rh-test/run/operatord.sock",
+		productVersion: "0.1.0", call: call as never,
+		operatorCallFn: async () => ({ ok: false }),
+	});
+	const locale = new LocaleManager("/tmp/rh-test/agent");
+	const factory = createRosclawExtension({
+		profile: "developer", version: "0.1.0", systemPrompt: "TEST",
+		active, coordinator, center, locale, rosclawHome: "/tmp/rh-test",
+		taskContext: resolveTaskContext({
+			rosclawHome: "/tmp/rh-test", cwd: "/tmp", mode: "SIMULATION",
+		}),
+	});
+	const pi = {
+		on(name: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) {
+			if (name === "tool_execution_update") handlerList.push(handler);
+		},
+		registerCommand() {}, registerShortcut() {},
+		registerEntryRenderer() {}, registerMessageRenderer() {},
+		appendEntry() {},
+	};
+	factory(pi as never);
+	assert.ok(handlerList.length >= 1, "tool_execution_update 处理器未注册");
+	const ctx = {
+		hasUI: true,
+		ui: {
+			setWorkingMessage() {},
+			notify() {},
+			select: async () => "本任务允许（当前 revision）",
+		},
+	};
+	const event = {
+		toolName: "bash",
+		partialResult: {
+			details: { phase: "AWAITING_SHELL_APPROVAL", request_id: "shg_x1" },
+		},
+	};
+	for (const h of handlerList) await h(event, ctx);
+	assert.equal(decideCalls.length, 1, "decide 未被调用");
+	assert.equal(decideCalls[0].request_id, "shg_x1");
+	assert.equal(decideCalls[0].decision, "allow_task",
+		"本任务允许 应映射 allow_task");
+});
+
+test("R1-a: 卡上选拒绝/超时未选 → deny（fail closed）", async () => {
+	const handlerList: Array<(event: unknown, ctx: unknown) => Promise<unknown>> = [];
+	const decideCalls: Array<Record<string, unknown>> = [];
+	const { createRosclawExtension } = await import("../src/extension/index.js");
+	const { ActiveSessionContext } = await import("../src/session/active-context.js");
+	const { AgentSessionCoordinator } = await import("../src/session/coordinator.js");
+	const { SessionLeaseManager } = await import("../src/session/lease-manager.js");
+	const { ProductStateCenter } = await import("../src/session/state-center.js");
+	const { LocaleManager } = await import("../src/i18n/locale.js");
+	const { resolveTaskContext } = await import("../src/native/active-task-context.js");
+	const active = new ActiveSessionContext({
+		sessionId: "pi_test", missionId: undefined, contextRevision: 0,
+		mode: "SIMULATION", profile: "developer", contextState: "LOADING",
+		leaseState: "NONE", actionsAllowed: false,
+	});
+	const call = async (_home: string, method: string, params?: Record<string, unknown>) => {
+		if (method === "pi.shell_gate.decide") {
+			decideCalls.push(params ?? {});
+			return { ok: true };
+		}
+		return { ok: false } as Record<string, unknown>;
+	};
+	const coordinator = new AgentSessionCoordinator({
+		rosclawHome: "/tmp/rh-test", active,
+		leaseManager: new SessionLeaseManager("/tmp/rh-test", call),
+		notify: () => undefined, call,
+	});
+	const center = new ProductStateCenter({
+		rosclawHome: "/tmp/rh-test", active,
+		operatorSocket: "/tmp/rh-test/run/operatord.sock",
+		productVersion: "0.1.0", call: call as never,
+		operatorCallFn: async () => ({ ok: false }),
+	});
+	const locale = new LocaleManager("/tmp/rh-test/agent");
+	const factory = createRosclawExtension({
+		profile: "developer", version: "0.1.0", systemPrompt: "TEST",
+		active, coordinator, center, locale, rosclawHome: "/tmp/rh-test",
+		taskContext: resolveTaskContext({
+			rosclawHome: "/tmp/rh-test", cwd: "/tmp", mode: "SIMULATION",
+		}),
+	});
+	const pi = {
+		on(name: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) {
+			if (name === "tool_execution_update") handlerList.push(handler);
+		},
+		registerCommand() {}, registerShortcut() {},
+		registerEntryRenderer() {}, registerMessageRenderer() {},
+		appendEntry() {},
+	};
+	factory(pi as never);
+	const ctx = {
+		hasUI: true,
+		ui: {
+			setWorkingMessage() {},
+			notify() {},
+			select: async () => undefined, // 超时/取消 = undefined
+		},
+	};
+	const event = {
+		toolName: "bash",
+		partialResult: {
+			details: { phase: "AWAITING_SHELL_APPROVAL", request_id: "shg_x2" },
+		},
+	};
+	for (const h of handlerList) await h(event, ctx);
+	assert.equal(decideCalls.length, 1);
+	assert.equal(decideCalls[0].decision, "deny", "未选择 = deny（fail closed）");
+});

--- a/src/rosclaw/agentd/pi_bridge/server.py
+++ b/src/rosclaw/agentd/pi_bridge/server.py
@@ -1260,6 +1260,51 @@ class PiBridgeServer:
                 str(params.get("session_ref", "")),
             )
             return {"ok": True, "task": task}
+        # 0902 R1-a：Approval Broker——shell 降级授权的 Runtime 批准面
+        #（删除全局环境变量授权的正式路径；0902 实证：用户已答"允许！"
+        # 仍被要求 export+重启）。grant 绑定 task+revision+scope。
+        if method == "pi.shell_gate.request":
+            from rosclaw.agentd.shell_gate import ShellGateBroker
+
+            broker = ShellGateBroker(service._task_kernel)
+            req = broker.request(
+                task_id=str(params.get("task_id", "")),
+                revision=int(params.get("revision", 0) or 0),
+                mission_id=str(params.get("mission_id", "")),
+                session_ref=str(params.get("session_ref", "")),
+                scope=str(params.get("scope", "shell.unsandboxed")),
+            )
+            return {"ok": True, "request": req}
+        if method == "pi.shell_gate.status":
+            from rosclaw.agentd.shell_gate import ShellGateBroker
+
+            broker = ShellGateBroker(service._task_kernel)
+            return {
+                "ok": True,
+                "request": broker.status(str(params.get("request_id", ""))),
+            }
+        if method == "pi.shell_gate.decide":
+            from rosclaw.agentd.shell_gate import ShellGateBroker
+
+            broker = ShellGateBroker(service._task_kernel)
+            try:
+                updated = broker.decide(
+                    str(params.get("request_id", "")),
+                    str(params.get("decision", "")),
+                )
+            except ValueError as exc:
+                return {"ok": False, "error": str(exc)}
+            return {"ok": True, "request": updated}
+        if method == "pi.shell_gate.check":
+            from rosclaw.agentd.shell_gate import ShellGateBroker
+
+            broker = ShellGateBroker(service._task_kernel)
+            granted = broker.check(
+                task_id=str(params.get("task_id", "")),
+                revision=int(params.get("revision", 0) or 0),
+                scope=str(params.get("scope", "shell.unsandboxed")),
+            )
+            return {"ok": True, "granted": granted}
         # 0901 P0-3：只读交付物面——解释/查看不再靠模型猜名字
         # （task.list_artifacts/artifact.open 漂移实证）。
         if method == "pi.artifact.list":

--- a/src/rosclaw/agentd/shell_gate.py
+++ b/src/rosclaw/agentd/shell_gate.py
@@ -1,0 +1,132 @@
+"""ShellGateBroker（0902 审计 R1-a，§5.2）——shell 降级授权的
+Runtime 批准面。
+
+0902 实证：用户说"允许！"系统仍要求 export 全局环境变量并重启。
+正确语义：确认卡（允许一次/本任务允许/拒绝）→ grant 绑定
+task+revision+scope（shell.unsandboxed）→ Runtime 立即继续原操作。
+
+不变量：
+- PENDING/未知 = fail closed；
+- 允许一次 = 该 request 行消费（不落 standing grant）；
+- 本任务允许 = standing grant（task+revision+scope 唯一）——revision
+  变化（语义变化）或任务终态后不再命中；
+- 全程进 missions.db（append-only 审计面）。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from rosclaw.contracts.common import new_id
+
+SCOPE_UNSANDBOXED_SHELL = "shell.unsandboxed"
+
+_DECISIONS = frozenset({"allow_once", "allow_task", "deny"})
+_STATUS_BY_DECISION = {
+    "allow_once": "APPROVED_ONCE",
+    "allow_task": "APPROVED_TASK",
+    "deny": "DENIED",
+}
+
+
+class ShellGateBroker:
+    """shell 降级授权的 Runtime 权威（agentd 进程内，与 kernel 同
+    连接——grant 进同一账本）。"""
+
+    def __init__(self, kernel: Any) -> None:
+        self._kernel = kernel
+        self._conn = kernel._conn
+
+    def request(self, *, task_id: str, revision: int, mission_id: str,
+                session_ref: str, scope: str) -> dict[str, Any]:
+        """登记 PENDING 授权请求（幂等——同 task+revision+scope 有
+        PENDING 时复用，不重复弹卡）。"""
+        existing = self._conn.execute(
+            "SELECT * FROM shell_gate_requests WHERE task_id = ? "
+            "AND revision = ? AND scope = ? AND status = 'PENDING' "
+            "ORDER BY created_at DESC LIMIT 1",
+            (task_id, revision, scope),
+        ).fetchone()
+        if existing is not None:
+            return dict(existing)
+        request_id = new_id("shg")
+        now = datetime.now(UTC).isoformat()
+        self._conn.execute(
+            "INSERT INTO shell_gate_requests (request_id, task_id, "
+            "revision, mission_id, session_ref, scope, status, "
+            "created_at) VALUES (?, ?, ?, ?, ?, ?, 'PENDING', ?)",
+            (request_id, task_id, revision, mission_id, session_ref,
+             scope, now),
+        )
+        return {
+            "request_id": request_id, "task_id": task_id,
+            "revision": revision, "mission_id": mission_id,
+            "session_ref": session_ref, "scope": scope,
+            "status": "PENDING", "created_at": now, "decided_at": None,
+        }
+
+    def status(self, request_id: str) -> dict[str, Any]:
+        row = self._conn.execute(
+            "SELECT * FROM shell_gate_requests WHERE request_id = ?",
+            (request_id,),
+        ).fetchone()
+        if row is None:
+            return {"request_id": request_id, "status": "UNKNOWN"}
+        return dict(row)
+
+    def decide(self, request_id: str, decision: str) -> dict[str, Any]:
+        """用户决定（允许一次/本任务允许/拒绝）——立即生效。"""
+        if decision not in _DECISIONS:
+            raise ValueError(f"unknown decision {decision!r}")
+        row = self._conn.execute(
+            "SELECT * FROM shell_gate_requests WHERE request_id = ?",
+            (request_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"unknown request {request_id!r}")
+        if row["status"] != "PENDING":
+            # 幂等：重复决定返回现状（不改变第一次决定）。
+            return dict(row)
+        now = datetime.now(UTC).isoformat()
+        status = _STATUS_BY_DECISION[decision]
+        self._conn.execute(
+            "UPDATE shell_gate_requests SET status = ?, decided_at = ? "
+            "WHERE request_id = ?",
+            (status, now, request_id),
+        )
+        if decision == "allow_task":
+            # standing grant：task+revision+scope 唯一。
+            self._conn.execute(
+                "INSERT OR IGNORE INTO shell_grants (grant_id, task_id, "
+                "revision, mission_id, scope, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (new_id("shg_grant"), str(row["task_id"]),
+                 int(row["revision"]), str(row["mission_id"]),
+                 str(row["scope"]), now),
+            )
+        updated = self.status(request_id)
+        return updated
+
+    def check(self, *, task_id: str, revision: int,
+              scope: str = SCOPE_UNSANDBOXED_SHELL) -> bool:
+        """standing grant 命中判定：revision 一致 + 任务仍活跃
+        （终态任务的 grant 不再命中）。"""
+        task = self._kernel.get_task(task_id)
+        if task is None:
+            return False
+        from rosclaw.task_kernel.service import TASK_TERMINAL
+
+        if str(task["state"]) in TASK_TERMINAL:
+            return False
+        if int(task["active_revision"]) != revision:
+            return False
+        row = self._conn.execute(
+            "SELECT 1 FROM shell_grants WHERE task_id = ? AND revision = ? "
+            "AND scope = ? LIMIT 1",
+            (task_id, revision, scope),
+        ).fetchone()
+        return row is not None
+
+
+__all__ = ["SCOPE_UNSANDBOXED_SHELL", "ShellGateBroker"]

--- a/src/rosclaw/storage/migrations/038_shell_gate.sql
+++ b/src/rosclaw/storage/migrations/038_shell_gate.sql
@@ -1,0 +1,36 @@
+-- 0902 审计 R1-a：Approval Broker（shell 降级授权）——删除全局环境
+-- 变量授权方案（ROSCLAW_ALLOW_UNSANDBOXED_SHELL）的正式路径。
+--
+-- 0902 实证：用户已在会话里明确回答"允许！"，系统仍要求其退出、
+-- export 全局环境变量、重启——全局、粗粒度、难撤销、难审计。
+--
+-- grant 绑定：task_id + revision + scope（shell.unsandboxed）+
+-- mission + session + 决定时间——本任务允许只对当前 revision 有效
+--（revision 变化 = 语义变化 = 重新询问）。一次允许 = 该 request
+-- 行本身（consume-once，不落 standing grant）。
+CREATE TABLE IF NOT EXISTS shell_gate_requests (
+    request_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    revision INTEGER NOT NULL,
+    mission_id TEXT NOT NULL,
+    session_ref TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    decided_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_shell_gate_task
+    ON shell_gate_requests(task_id, revision, scope);
+
+-- 本任务级 standing grant（本任务允许同类操作——任务终态或 revision
+-- 变化后失效由 check 侧判定：grant 行的 revision 与当前
+-- active_revision 不符即不再命中）。
+CREATE TABLE IF NOT EXISTS shell_grants (
+    grant_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    revision INTEGER NOT NULL,
+    mission_id TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(task_id, revision, scope)
+);

--- a/tests/agentd/test_a0902_r1a_shell_gate.py
+++ b/tests/agentd/test_a0902_r1a_shell_gate.py
@@ -1,0 +1,187 @@
+"""0902 审计 R1-a 红测试：Approval Broker（shell 降级授权）——
+删除全局环境变量授权方案的正式路径。
+
+0902 实证：用户已在会话里明确回答"允许！"，系统仍要求其退出、
+export ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1、重启——这不是可接受的
+产品授权。
+
+正确语义（审计 §5.2）：确认卡只给 允许一次/本任务允许/拒绝；
+批准后 Runtime 立即继续原操作；grant 绑定 task+revision+scope。
+
+闭环断言：
+1. request → PENDING；decide(允许一次) → 该请求行消费即授权
+   （standing grant 不落）；
+2. decide(本任务允许) → standing grant 落账 → check 命中；revision
+   变化后不再命中（语义变化 = 重新询问）；
+3. decide(拒绝) → check 不命中；
+4. 全局环境变量不再是正式路径（workspace-pack 的 bash 降级路径
+   不读 ROSCLAW_ALLOW_UNSANDBOXED_SHELL——TS 侧断言在
+   p06-os-isolation 测试更新）。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _kernel(tmp_path: Path):
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    return TaskKernel(conn, tmp_path)
+
+
+def _bind(kernel, tmp_path: Path) -> str:
+    bound = kernel.bind_message(
+        mission_id="m1", session_ref="s1", backend_native_id="s1",
+        message_id="msg_1", text="写一个 note.txt", cwd=str(tmp_path),
+    )
+    return str(bound["task_id"])
+
+
+class TestShellGateBroker:
+    def test_allow_once_consumes_request_no_standing_grant(
+        self, tmp_path: Path
+    ) -> None:
+        from rosclaw.agentd.shell_gate import ShellGateBroker
+
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path)
+        broker = ShellGateBroker(kernel)
+        req = broker.request(
+            task_id=task_id, revision=1, mission_id="m1", session_ref="s1",
+            scope="shell.unsandboxed",
+        )
+        assert req["status"] == "PENDING"
+        broker.decide(req["request_id"], "allow_once")
+        status = broker.status(req["request_id"])
+        assert status["status"] == "APPROVED_ONCE"
+        # 一次允许不落 standing grant——下一次同类操作要重新问。
+        assert not broker.check(task_id=task_id, revision=1)
+
+    def test_allow_task_grants_and_revision_invalidates(
+        self, tmp_path: Path
+    ) -> None:
+        from rosclaw.agentd.shell_gate import ShellGateBroker
+
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path)
+        broker = ShellGateBroker(kernel)
+        req = broker.request(
+            task_id=task_id, revision=1, mission_id="m1", session_ref="s1",
+            scope="shell.unsandboxed",
+        )
+        broker.decide(req["request_id"], "allow_task")
+        assert broker.check(task_id=task_id, revision=1)
+        # revision 变化（用户改需求）→ 不再命中（重新询问）。
+        kernel.bind_message(
+            mission_id="m1", session_ref="s1", backend_native_id="s1",
+            message_id="msg_2", text="改一下内容", cwd=str(tmp_path),
+        )
+        assert not broker.check(task_id=task_id, revision=2)
+
+    def test_deny_no_grant(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.shell_gate import ShellGateBroker
+
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path)
+        broker = ShellGateBroker(kernel)
+        req = broker.request(
+            task_id=task_id, revision=1, mission_id="m1", session_ref="s1",
+            scope="shell.unsandboxed",
+        )
+        broker.decide(req["request_id"], "deny")
+        assert not broker.check(task_id=task_id, revision=1)
+        assert broker.status(req["request_id"])["status"] == "DENIED"
+
+    def test_pending_is_fail_closed(self, tmp_path: Path) -> None:
+        """PENDING/未知请求不授权（fail closed）。"""
+        from rosclaw.agentd.shell_gate import ShellGateBroker
+
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path)
+        broker = ShellGateBroker(kernel)
+        broker.request(
+            task_id=task_id, revision=1, mission_id="m1", session_ref="s1",
+            scope="shell.unsandboxed",
+        )
+        assert not broker.check(task_id=task_id, revision=1)
+
+    def test_terminal_task_grant_expires(self, tmp_path: Path) -> None:
+        """任务终态后 standing grant 不再命中（grant 是活任务的）。"""
+        from rosclaw.agentd.shell_gate import ShellGateBroker
+
+        kernel = _kernel(tmp_path)
+        task_id = _bind(kernel, tmp_path)
+        broker = ShellGateBroker(kernel)
+        req = broker.request(
+            task_id=task_id, revision=1, mission_id="m1", session_ref="s1",
+            scope="shell.unsandboxed",
+        )
+        broker.decide(req["request_id"], "allow_task")
+        assert broker.check(task_id=task_id, revision=1)
+        kernel.transition(task_id, "SUCCEEDED", reason="done")
+        assert not broker.check(task_id=task_id, revision=1)
+
+
+class TestShellGateBridge:
+    """bridge 接线层：pi.shell_gate.* 经 PiBridgeServer._dispatch 可达。"""
+
+    async def test_bridge_request_decide_check_flow(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        kernel = service._task_kernel
+        bound = kernel.bind_message(
+            mission_id=mission.mission_id, session_ref="pi_1",
+            backend_native_id="pi_1", message_id="msg_1",
+            text="写一个 note.txt", cwd=str(tmp_path),
+        )
+        task_id = str(bound["task_id"])
+
+        async def call(method: str, params: dict) -> dict:
+            return await bridge._dispatch(
+                "user:local:1000", 1, method,
+                {"token": service.control_token, **params},
+            )
+
+        # 无 grant → check 不命中。
+        r = await call("pi.shell_gate.check", {
+            "task_id": task_id, "revision": 1, "scope": "shell.unsandboxed",
+        })
+        assert r.get("ok") and r.get("granted") is False
+        # request → PENDING。
+        r = await call("pi.shell_gate.request", {
+            "task_id": task_id, "revision": 1,
+            "mission_id": mission.mission_id, "session_ref": "pi_1",
+            "scope": "shell.unsandboxed",
+        })
+        assert r.get("ok")
+        req_id = str(r["request"]["request_id"])
+        assert r["request"]["status"] == "PENDING"
+        # decide 本任务允许 → standing grant → check 命中。
+        r = await call("pi.shell_gate.decide", {
+            "request_id": req_id, "decision": "allow_task",
+        })
+        assert r.get("ok") and r["request"]["status"] == "APPROVED_TASK"
+        r = await call("pi.shell_gate.check", {
+            "task_id": task_id, "revision": 1, "scope": "shell.unsandboxed",
+        })
+        assert r.get("granted") is True
+        # 非法决定 → 带错返回（不崩）。
+        r = await call("pi.shell_gate.decide", {
+            "request_id": req_id, "decision": "bogus",
+        })
+        assert r.get("ok") is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -803,10 +803,8 @@ def _prepare_installed_chat(
         # 六审 §8：chrome 走 i18n catalog——旅程固定 en-US（断言
         # 与 locale 无关的稳定性由 catalog parity 测试保证）。
         ROSCLAW_UI_LOCALE="en-US",
-        # P0-6：本机 user namespace 受限（Jetson 内核 uid_map 不可写）
-        # ——SIM 旅程显式授权降级 shell（结果带 TOOL_LAYER_ONLY
-        # 标记；有 bwrap 的主机此变量无影响）。
-        ROSCLAW_ALLOW_UNSANDBOXED_SHELL="1",
+        # 0902 R1-a：全局环境变量授权已从正式路径删除——无 bwrap
+        # 主机走会话内确认卡（委派腿回答），有 bwrap 主机沙箱直跑。
         PATH=f"{prefix / 'bin'}:{os.environ['PATH']}",
     )
     return home, env, rosclaw
@@ -1533,6 +1531,16 @@ class TestProductJourney:
             time.sleep(2.0)
             # 5. delegate worker。
             session.send("请委派 worker 总结这段日志\r")
+            # 0902 R1-a：无 bwrap 主机上 bash 降级走确认卡（允许一次
+            # = 第一项，Enter 选定）——不再是全局环境变量。有 bwrap 的
+            # 主机沙箱直跑（无卡）。
+            import shutil as _shutil
+
+            if _shutil.which("bwrap") is None:
+                session.expect(
+                    "本机无 OS 沙箱".encode(), timeout=120,
+                )
+                session.send("\r")  # 允许一次（第一项）
             # PR-H1：Native 直接完成（不委派）——同一 session 的工具执行。
             session.expect("已直接完成日志总结".encode(), timeout=180)
             # P0-4G（TranscriptPolicy）：SECRET_PROBE 回合后，任何后续


### PR DESCRIPTION
## 0902 审计 R1-a（§5.2）

0902 实证：用户已答"允许！"，系统仍要求 export ROSCLAW_ALLOW_UNSANDBOXED_SHELL=1 并重启。删除该全局方案的正式路径。

## 内容

- ShellGateBroker（agentd，迁移 038）：grant 绑定 task+revision+scope——允许一次=请求行消费；本任务允许=standing grant（revision 变化/任务终态即失效）；PENDING/未知/拒绝=fail closed；
- pi.shell_gate.request/status/decide/check 桥处理器；
- workspace-pack bash 降级路径改写：无 bwrap + SIM → check → 确认卡（AWAITING_SHELL_APPROVAL）→ 轮询决定 → 批准立即继续原操作（TOOL_LAYER_ONLY 标记）；REAL/SHADOW 永远 fail closed；
- 扩展卡：ctx.ui.select（允许一次/本任务允许/拒绝）→ decide——超时未选=deny；
- 旅程委派腿在无 bwrap 主机回答确认卡（本机实证——本机就是无 bwrap 主机）。

## 证据

红→绿：tests/agentd/test_a0902_r1a_shell_gate.py（broker 5 + bridge 1）+ TS 7/7 + journey A 过。

注：本地全量套件在本机 32 分钟时长下暴露一个**既有的**测试设计缺陷（test_operator.py 模块级 NOW + 10min 请求 TTL——套件慢于 ~27min 时批准请求过期），与本 PR 无关（operator 时间逻辑零交互；CI 更快不触发）。已记录待修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)