### PR TITLE
0902 R1-b: Provider 停滞分阶段看门狗——首 token 10s 提示/30s 取消，流式 idle 15s/45s 恢复

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -32,6 +32,7 @@ import type { ProductStateCenter } from "../session/state-center.js";
 import { InputController } from "../native/input-controller.js";
 import { OperationWatcher } from "../native/operation-watcher.js";
 import { suppressModelTurn } from "../native/turn-disposition.js";
+import { ProviderStallWatchdog } from "../native/provider-watchdog.js";
 import {
 	renderTerminalReply,
 	type TerminalOutcome,
@@ -131,6 +132,8 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		type LatestCtx = {
 			isIdle(): boolean;
 			hasUI: boolean;
+			/** pi ExtensionContext 自带——编程取消停滞的模型回合。 */
+			abort?: () => void;
 			ui: {
 				notify(t: string, k: "info" | "warning" | "error"): void;
 				setWidget(key: string, lines: string[] | undefined): void;
@@ -883,12 +886,20 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			const requestId = details.request_id;
 			ctx.ui.setWorkingMessage(`等待授权决定（${requestId}）…默认拒绝`);
 			notifyLeveled(ctx, `等待授权决定（${requestId}）…默认拒绝`, "info");
+			// 卡打开 = 用户在场——暂停停滞看门狗（journey 实证：确认卡
+			// 等待被 45s 流式 idle 误判取消）。
+			stallWatchdog.pauseForUser();
+			let choice: string | undefined;
 			try {
-				const choice = await ctx.ui.select(
+				choice = await ctx.ui.select(
 					"本机无 OS 沙箱（bwrap 不可用）——当前命令需要在任务工作区内无沙箱执行（凭据/控制面对 shell 可达）",
 					["允许一次", "本任务允许（当前 revision）", "拒绝"],
 					{ timeout: 120000 },
 				);
+			} finally {
+				stallWatchdog.resumeFromUser();
+			}
+			try {
 				const decision = choice === "允许一次"
 					? "allow_once"
 					: choice?.startsWith("本任务允许")
@@ -1184,6 +1195,48 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				outcome.conflictClaim = text.slice(0, 120);
 			}
 			return undefined;
+		});
+		// 0902 R1-b（审计 §7）：Provider 停滞分阶段看门狗——首 token
+		// 10s 提示/30s 取消；流式 idle 15s 状态/45s 恢复。有字节流动的
+		// 长任务不杀（流动即续期）。"Provider 是根因"不等于 ROSClaw
+		// 没责任——静默 300s 是产品缺陷。
+		const stallWatchdog = new ProviderStallWatchdog({
+			notice: (t) => latestCtx?.ui.notify(t, "warning"),
+			stallAbort: () => {
+				if (latestCtx && !latestCtx.isIdle()) latestCtx.abort?.();
+			},
+		});
+		pi.on("turn_start", async () => {
+			stallWatchdog.turnStarted();
+		});
+		pi.on("message_update", async () => {
+			stallWatchdog.contentProgress();
+		});
+		pi.on("message_end", async (event) => {
+			// 只数 assistant 消息——pi 在 turn_start 后立刻为用户 prompt
+			// 自身发 message_start/message_end（agent-loop.js runAgentLoop）。
+			// 若不按 role 过滤，stall 腿的 prompt message_end 会把看门狗
+			// 提前推进流式阶段：首 token 计时被清，"响应迟滞"提示永不
+			// 触发（journey pytest-2340/2341 实证）。
+			const role = (event as { message?: { role?: unknown } }).message?.role;
+			if (role === "assistant") stallWatchdog.contentProgress();
+		});
+		// 工具执行（含授权卡等待）是活跃证据——等卡的回合不是
+		// 停滞（journey 实证：委派腿的确认卡等待被误判停滞取消）。
+		pi.on("tool_execution_start", async () => {
+			stallWatchdog.contentProgress();
+		});
+		pi.on("tool_execution_update", async () => {
+			stallWatchdog.contentProgress();
+		});
+		pi.on("tool_execution_end", async () => {
+			stallWatchdog.contentProgress();
+		});
+		pi.on("agent_end", async () => {
+			stallWatchdog.turnEnded();
+		});
+		pi.on("turn_end", async () => {
+			stallWatchdog.turnEnded();
 		});
 		pi.on("turn_end", async () => {
 			// P0-D：Harness idle → Coordinator 自动收尾（登记/验证/

--- a/packages/rosclaw-agent/src/native/provider-watchdog.ts
+++ b/packages/rosclaw-agent/src/native/provider-watchdog.ts
@@ -1,0 +1,136 @@
+/** ProviderStallWatchdog（0902 审计 R1-b，§7）——Provider 停滞的
+ *  分阶段看门狗。
+ *
+ * 0902 实证：Provider 是根因不等于 ROSClaw 没责任——静默 300 秒
+ * 是产品缺陷（超时提示/取消/恢复属于 ROSClaw 产品责任）。
+ *
+ * 分阶段（§7）：
+ * - 首 token 迟滞：10s 提示，30s 取消（pi abort——取消传播到模型
+ *   请求）；
+ * - 流式 idle：15s 状态更新，45s 恢复；
+ * - 有字节流动的长任务不杀——每次内容流动都重置 idle 计时（不
+ *   违反"不杀 turn"红线：取消的是无声停滞，不是活跃生成）；
+ * - 回合终态即解除（无 stray 触发）。
+ */
+
+export interface ProviderStallWatchdogOptions {
+	/** 阶段提示（用户可见）。 */
+	notice: (text: string) => void;
+	/** 停滞取消（调用方接 pi ctx.abort——传播到模型请求）。 */
+	stallAbort: () => void;
+	firstTokenNoticeMs?: number;
+	firstTokenAbortMs?: number;
+	streamIdleStatusMs?: number;
+	streamIdleAbortMs?: number;
+}
+
+const DEFAULTS = {
+	firstTokenNoticeMs: 10_000,
+	firstTokenAbortMs: 30_000,
+	streamIdleStatusMs: 15_000,
+	streamIdleAbortMs: 45_000,
+};
+
+export class ProviderStallWatchdog {
+	private readonly opts: Required<ProviderStallWatchdogOptions>;
+	private firstTokenTimers: ReturnType<typeof setTimeout>[] = [];
+	private streamIdleTimers: ReturnType<typeof setTimeout>[] = [];
+	private active = false;
+	private sawContent = false;
+	private abortedOnce = false;
+	private userBusy = false;
+
+	constructor(options: ProviderStallWatchdogOptions) {
+		this.opts = { ...DEFAULTS, ...options } as Required<ProviderStallWatchdogOptions>;
+	}
+
+	/** 回合开始（turn_start）——进入"等首 token"阶段。 */
+	turnStarted(): void {
+		this._disarm();
+		this.userBusy = false;
+		this.active = true;
+		this.sawContent = false;
+		this.abortedOnce = false;
+		this._armFirstToken();
+	}
+
+	private _armFirstToken(): void {
+		if (this.userBusy) return;
+		this.firstTokenTimers.push(
+			setTimeout(() => {
+				if (!this.active || this.sawContent || this.userBusy) return;
+				this.opts.notice(
+					"模型响应迟滞（10s 无首个内容）——可能是 Provider 排队或网络慢；"
+					+ "30s 仍无响应将自动取消本次请求（可重发）",
+				);
+			}, this.opts.firstTokenNoticeMs),
+			setTimeout(() => this._stall("首 token 30s 无响应"), this.opts.firstTokenAbortMs),
+		);
+	}
+
+	/** 内容流动——首个内容结束首 token 阶段；之后每次流动都重置
+	 *  流式 idle 计时（流动即续命——长任务不杀）。 */
+	contentProgress(): void {
+		if (!this.active || this.abortedOnce || this.userBusy) return;
+		if (!this.sawContent) {
+			this.sawContent = true;
+			for (const t of this.firstTokenTimers) clearTimeout(t);
+			this.firstTokenTimers = [];
+		}
+		this._resetStreamIdle();
+	}
+
+	/** 回合终态/空闲——全部解除。 */
+	turnEnded(): void {
+		this._disarm();
+	}
+
+	/** 模态对话框打开（确认卡等用户决定中）= 用户在场——暂停计时
+	 *  （等用户回答不是 Provider 停滞；journey 实证：委派腿的确认卡
+	 *  等待被 45s idle 误判取消）。 */
+	pauseForUser(): void {
+		this.userBusy = true;
+		this._disarmTimers();
+	}
+
+	/** 对话框关闭——恢复计时（从当前状态重新武装）。 */
+	resumeFromUser(): void {
+		this.userBusy = false;
+		if (this.active && !this.abortedOnce) {
+			if (this.sawContent) this._resetStreamIdle();
+			else this._armFirstToken();
+		}
+	}
+
+
+	private _resetStreamIdle(): void {
+		for (const t of this.streamIdleTimers) clearTimeout(t);
+		this.streamIdleTimers = [
+			setTimeout(() => {
+				if (!this.active || this.abortedOnce) return;
+				this.opts.notice("模型生成中断流（15s 无新内容）——仍在等待 Provider…");
+			}, this.opts.streamIdleStatusMs),
+			setTimeout(() => this._stall("流式 idle 45s"), this.opts.streamIdleAbortMs),
+		];
+	}
+
+	private _stall(reason: string): void {
+		if (!this.active || this.abortedOnce || this.userBusy) return;
+		this.abortedOnce = true;
+		this.opts.notice(`Provider 无响应（${reason}）——已取消本次请求，可重发`);
+		this.opts.stallAbort();
+		this._disarm();
+	}
+
+	private _disarmTimers(): void {
+		for (const t of this.firstTokenTimers) clearTimeout(t);
+		for (const t of this.streamIdleTimers) clearTimeout(t);
+		this.firstTokenTimers = [];
+		this.streamIdleTimers = [];
+	}
+
+	private _disarm(): void {
+		this._disarmTimers();
+		this.active = false;
+	}
+}

--- a/packages/rosclaw-agent/test/a0902-r1b-provider-watchdog.test.ts
+++ b/packages/rosclaw-agent/test/a0902-r1b-provider-watchdog.test.ts
@@ -1,0 +1,122 @@
+/** 0902 R1-b 红测试：Provider 分阶段 watchdog（审计 §7）。
+
+0902 实证 + 0901 live 复核实证：Provider 停滞（服务端无声）→
+用户看着 Working… 静默 300 秒（pi 默认 httpIdleTimeout）——"Provider
+是根因"不等于 ROSClaw 没责任：超时提示、取消、恢复都是产品责任。
+
+分阶段（§7）：
+- 首 token 迟滞：10s 提示，30s 取消（取消传播到模型请求——
+  pi abort）；
+- 流式 idle：15s 状态更新，45s 恢复（取消）；
+- 有字节流动的长任务不杀（只在静默时触发——不违反"不杀 turn"
+  红线：取消的是无声停滞，不是活跃生成）；
+- 回合终态/空闲即解除。
+*/
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("R1-b: 首 token 10s 无内容 → 提示", async () => {
+	const { ProviderStallWatchdog } = await import(
+		"../src/native/provider-watchdog.js"
+	);
+	const notices: string[] = [];
+	let aborted = 0;
+	const wd = new ProviderStallWatchdog({
+		notice: (t) => notices.push(t),
+		stallAbort: () => { aborted++; },
+		// 测试用快速阈值。
+		firstTokenNoticeMs: 50, firstTokenAbortMs: 200,
+		streamIdleStatusMs: 100, streamIdleAbortMs: 300,
+	});
+	wd.turnStarted();
+	await new Promise((r) => setTimeout(r, 80));
+	assert.equal(notices.length, 1, "10s 无内容未提示");
+	assert.match(notices[0], /响应|迟滞|慢/);
+	assert.equal(aborted, 0, "提示期就取消了");
+	wd.turnEnded();
+});
+
+test("R1-b: 内容在 5s 到达 → 不提示不取消", async () => {
+	const { ProviderStallWatchdog } = await import(
+		"../src/native/provider-watchdog.js"
+	);
+	const notices: string[] = [];
+	let aborted = 0;
+	const wd = new ProviderStallWatchdog({
+		notice: (t) => notices.push(t),
+		stallAbort: () => { aborted++; },
+		firstTokenNoticeMs: 50, firstTokenAbortMs: 200,
+		streamIdleStatusMs: 100, streamIdleAbortMs: 300,
+	});
+	wd.turnStarted();
+	await new Promise((r) => setTimeout(r, 20));
+	wd.contentProgress(); // 5s 内首内容
+	await new Promise((r) => setTimeout(r, 20));
+	wd.contentProgress();
+	await new Promise((r) => setTimeout(r, 120));
+	// 流式 idle 状态更新不算取消——aborted 仍 0（150ms < 300ms idle 阈值）。
+	assert.equal(aborted, 0);
+	wd.turnEnded();
+});
+
+test("R1-b: 首 token 30s 无内容 → 取消一次（取消传播）", async () => {
+	const { ProviderStallWatchdog } = await import(
+		"../src/native/provider-watchdog.js"
+	);
+	let aborted = 0;
+	const wd = new ProviderStallWatchdog({
+		notice: () => {},
+		stallAbort: () => { aborted++; },
+		firstTokenNoticeMs: 30, firstTokenAbortMs: 120,
+		streamIdleStatusMs: 1000, streamIdleAbortMs: 3000,
+	});
+	wd.turnStarted();
+	await new Promise((r) => setTimeout(r, 200));
+	assert.equal(aborted, 1, "首 token 停滞未取消");
+	await new Promise((r) => setTimeout(r, 150));
+	assert.equal(aborted, 1, "取消后仍重复取消");
+	wd.turnEnded();
+});
+
+test("R1-b: 流式中途 idle 45s → 恢复（取消）；活跃流不杀", async () => {
+	const { ProviderStallWatchdog } = await import(
+		"../src/native/provider-watchdog.js"
+	);
+	let aborted = 0;
+	const wd = new ProviderStallWatchdog({
+		notice: () => {},
+		stallAbort: () => { aborted++; },
+		firstTokenNoticeMs: 30, firstTokenAbortMs: 120,
+		streamIdleStatusMs: 60, streamIdleAbortMs: 160,
+	});
+	wd.turnStarted();
+	wd.contentProgress();
+	// 活跃流动——每 40ms 一次内容，idle 阈值 160ms 不触发。
+	for (let i = 0; i < 3; i++) {
+		await new Promise((r) => setTimeout(r, 40));
+		wd.contentProgress();
+	}
+	assert.equal(aborted, 0, "活跃流被杀了（违反不杀 turn 红线）");
+	// 然后停滞 → 160ms 后取消。
+	await new Promise((r) => setTimeout(r, 220));
+	assert.equal(aborted, 1, "流式 idle 未进入恢复");
+	wd.turnEnded();
+});
+
+test("R1-b: 回合终态后定时器全解除（无 stray abort）", async () => {
+	const { ProviderStallWatchdog } = await import(
+		"../src/native/provider-watchdog.js"
+	);
+	let aborted = 0;
+	const wd = new ProviderStallWatchdog({
+		notice: () => {},
+		stallAbort: () => { aborted++; },
+		firstTokenNoticeMs: 30, firstTokenAbortMs: 80,
+		streamIdleStatusMs: 60, streamIdleAbortMs: 100,
+	});
+	wd.turnStarted();
+	wd.turnEnded();
+	await new Promise((r) => setTimeout(r, 200));
+	assert.equal(aborted, 0, "回合结束后仍触发取消");
+});

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -468,6 +468,13 @@ class _Handler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
         length = int(self.headers.get("content-length", "0"))
         body = json.loads(self.rfile.read(length) or b"{}")
+        # 0902 R1-b：provider 停滞故障注入——挂起的请求永不写回
+        # （watchdog 必须在窗口内取消，不能让回合静默死等）。
+        if getattr(self.fake, "stall", False):
+            import threading as _th
+
+            _th.Event().wait(120)
+            return
         payload = self.fake.answer(body)
         self.send_response(200)
         ctype = "text/event-stream" if body.get("stream") else "application/json"
@@ -1540,7 +1547,15 @@ class TestProductJourney:
                 session.expect(
                     "本机无 OS 沙箱".encode(), timeout=120,
                 )
-                session.send("\r")  # 允许一次（第一项）
+                # 允许一次（第一项）。Enter 竞态实证：对话框首帧
+                # 渲染与键盘接管之间存在窗口——标题仍在可见期内
+                # 每 1s 重试 Enter，直到对话框消失。
+                for _ in range(15):
+                    time.sleep(1.0)
+                    session.send("\r")
+                    time.sleep(0.5)
+                    if "本机无 OS 沙箱".encode() not in session.clean[-4000:]:
+                        break
             # PR-H1：Native 直接完成（不委派）——同一 session 的工具执行。
             session.expect("已直接完成日志总结".encode(), timeout=180)
             # P0-4G（TranscriptPolicy）：SECRET_PROBE 回合后，任何后续
@@ -1717,6 +1732,14 @@ class TestProductJourney:
                 "未覆盖要求竟没落到模型路径（被旧 recipe 吞了）"
             )
             self._journey_verdicts["revision_no_fake_success"] = True
+            # 0902 R1-b（审计 §7）：provider 停滞——分阶段看门狗提示
+            # +取消，不再静默 300s（fake server 挂起不应答的故障注入）。
+            fake.fake.stall = True
+            session.send("再聊聊这个任务\r")
+            session.expect("响应迟滞".encode(), timeout=40)  # 10s 提示
+            session.expect("已取消本次请求".encode(), timeout=60)  # 30s 取消
+            fake.fake.stall = False
+            self._journey_verdicts["provider_stall_watchdog"] = True
             # 0901 P0-1（硬 Gate B）：安装产物的 `rosclaw artifact` 一族
             # 真实可达——list 不回落顶层帮助、path 给绝对路径（0901
             # 实证：open_command 给了 `rosclaw artifact open` 但入口


### PR DESCRIPTION
## 问题（0902 审计 §7）
Provider 停滞（服务端无声排队/挂起）时，用户看着 Working… 静默 300 秒（pi 默认 httpIdleTimeout）。「Provider 是根因」不等于 ROSClaw 没责任——超时提示/取消/恢复是产品责任。

## 方案
- **ProviderStallWatchdog**（native/provider-watchdog.ts）：首 token 与流式 idle 分离计时——首 token 10s 提示 / 30s 取消（pi abort，取消传播到模型请求）；流式 idle 15s 状态 / 45s 恢复。内容流动即续期：**有字节流动的长任务不杀**（取消的是无声停滞，不违反不杀 turn 红线）。abort 只触发一次，回合终态全部解除。
- **授权卡等待 = 用户在场**：tool_execution_* 事件计活跃 + 模态对话框 pauseForUser/resumeFromUser——委派腿确认卡等待曾被 45s 流式 idle 误判取消（journey brvk9k3dl 实证）。
- **message_end 只数 assistant**：pi 在 turn_start 后立刻为用户 prompt 自身发 message_start/message_end（agent-loop runAgentLoop），不过滤会把看门狗提前推进流式阶段、首 token 提示永不触发（journey pytest-2340/2341 实证失败，修复后 pytest-2342 绿）。

## 红→绿证据
- 红：journey A stall 腿（fake server 挂起 120s 不应答）——修复前「响应迟滞」40s 超时未现（pytest-2340/2341 failure-dump + PTY transcript）。
- 绿：同一 journey 全腿通过（248s），PTY 实录含「模型响应迟滞（10s 无首个内容）」→「Provider 无响应（首 token 30s 无响应）——已取消本次请求」；委派腿确认卡「允许一次」→ bash 真实执行。
- 单元：provider-watchdog 5/5；TS 全量 213/0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)