### PR TITLE
0902 R1-c: setup/doctor 沙箱就绪——OS 隔离/图形后端一次探测+真实 smoke，会话开始一次性提示

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -9,6 +9,7 @@
 import type { ExtensionContext, ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { ActiveSessionContext } from "../session/active-context.js";
 import type { AgentSessionCoordinator } from "../session/coordinator.js";
 import {
@@ -38,6 +39,7 @@ import {
 	type TerminalOutcome,
 } from "../native/terminal-presenter.js";
 import { classifyModelError, ProviderErrorGate } from "../native/model-errors.js";
+import { _bwrapAvailable } from "../tools/workspace-pack.js";
 import {
 	renderArtifactList,
 	renderOperationLogs,
@@ -87,11 +89,34 @@ export interface RosclawExtensionOptions {
 	taskContext: import("../native/active-task-context.js").ActiveTaskContext;
 	/** PR-N5D：创建后回填的 session 引用（物化工具激活用）。 */
 	lateSession?: { session?: { setActiveToolsByName(names: string[]): void } };
+	/** 0902 R1-c（§5.3）：OS 隔离探测（测试可注入）——默认消费
+	 *  doctor 落盘的 os-isolation.json，无记录时回落 bwrap 存在性。 */
+	osIsolationProbe?: () => { isolationReady: boolean };
 }
 
 const WORKING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
+/** 0902 R1-c 默认 OS 隔离探测：doctor 落盘的 os-isolation.json 为
+ *  单源（§5.3"setup/doctor 一次探测"）；无记录时回落 bwrap 存在性。 */
+function makeDefaultOsIsolationProbe(rosclawHome: string): () => { isolationReady: boolean } {
+	return () => {
+		try {
+			const raw = readFileSync(
+				join(rosclawHome, "agent", "os-isolation.json"), "utf-8",
+			);
+			const data = JSON.parse(raw) as { isolation_ready?: unknown };
+			if (typeof data.isolation_ready === "boolean") {
+				return { isolationReady: data.isolation_ready };
+			}
+		} catch {
+			// 无记录/坏记录 → 回落存在性探测。
+		}
+		return { isolationReady: _bwrapAvailable() };
+	};
+}
+
 export function createRosclawExtension(options: RosclawExtensionOptions): ExtensionFactory {
+	const defaultOsIsolationProbe = makeDefaultOsIsolationProbe(options.rosclawHome);
 	return (pi) => {
 		// -- 品牌 + 单一状态源（六审 PR-SIX-1：Header/Footer 在同一次
 		//    refreshChrome 里用同一个 KernelSnapshotV1 重绘——不允许顶部
@@ -230,6 +255,23 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			]);
 			if (options.workspaceAutoBound && workspaceStore.current) {
 				notifyLeveled(ctx, `已自动绑定 Project：${workspaceStore.current}（/workspace show 查看）`, "info");
+			}
+			// 0902 R1-c（§5.3）：无 OS 沙箱 → 会话开始一次性提示（任务
+			// 开始前），而不是 shell 执行到一半才甩卡。探测单源 =
+			// doctor 落盘的 os-isolation.json（无记录回落 bwrap 存在性）。
+			if (ctx.hasUI) {
+				try {
+					const probe = options.osIsolationProbe ?? defaultOsIsolationProbe;
+					if (!probe().isolationReady) {
+						notifyLeveled(ctx,
+							"本机无 OS 沙箱（bwrap 不可用）——shell 类操作将在会话内"
+							+ "弹确认卡降级运行；rosclaw doctor 查看结论与修复建议",
+							"warning",
+						);
+					}
+				} catch {
+					// 探测失败不阻塞会话启动（doctor 可重跑）。
+				}
 			}
 		});
 		pi.on("session_shutdown", async () => {

--- a/packages/rosclaw-agent/test/a0902-r1c-sandbox-readiness.test.ts
+++ b/packages/rosclaw-agent/test/a0902-r1c-sandbox-readiness.test.ts
@@ -1,0 +1,123 @@
+/** 0902 R1-c 红测试（§5.3）：无 OS 沙箱时，会话开始一次性提示——
+ *  任务开始前让用户知道 shell 将走确认卡降级 + doctor 有修复结论，
+ *  而不是运行到一半才甩卡。
+ *
+ * 闭环断言：
+ * 1. 隔离不可用 → session_start 一次性 warning（含降级后果与
+ *    rosclaw doctor 修复入口）；
+ * 2. 隔离可用 → 无提示（不噪声）；
+ * 3. 默认探测消费 doctor 落盘的 os-isolation.json（探测单源，
+ *    §5.3"setup/doctor 一次探测"）；无记录时回落 bwrap 存在性探测。
+ */
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+type Handler = (event: unknown, ctx: unknown) => Promise<unknown>;
+
+async function buildExtension(
+	home: string,
+	probe?: () => { isolationReady: boolean },
+) {
+	const { createRosclawExtension } = await import("../src/extension/index.js");
+	const { ActiveSessionContext } = await import("../src/session/active-context.js");
+	const { AgentSessionCoordinator } = await import("../src/session/coordinator.js");
+	const { SessionLeaseManager } = await import("../src/session/lease-manager.js");
+	const { ProductStateCenter } = await import("../src/session/state-center.js");
+	const { LocaleManager } = await import("../src/i18n/locale.js");
+	const { resolveTaskContext } = await import("../src/native/active-task-context.js");
+
+	const handlers = new Map<string, Handler[]>();
+	const pi = {
+		on(name: string, handler: Handler) {
+			const list = handlers.get(name) ?? [];
+			list.push(handler);
+			handlers.set(name, list);
+		},
+		registerCommand() {},
+		registerShortcut() {},
+		registerEntryRenderer() {},
+		registerMessageRenderer() {},
+		appendEntry() {},
+	};
+	const active = new ActiveSessionContext({
+		sessionId: "pi_test", missionId: undefined, contextRevision: 0,
+		mode: "SIMULATION", profile: "developer", contextState: "LOADING",
+		leaseState: "NONE", actionsAllowed: false,
+	});
+	const call = async () => ({ ok: false, error: "no bridge in test" });
+	const coordinator = new AgentSessionCoordinator({
+		rosclawHome: home, active,
+		leaseManager: new SessionLeaseManager(home, call),
+		notify: () => undefined, call,
+	});
+	const center = new ProductStateCenter({
+		rosclawHome: home, active,
+		operatorSocket: join(home, "run", "operatord.sock"),
+		productVersion: "0.1.0", call: call as never,
+		operatorCallFn: async () => ({ ok: false }),
+	});
+	const locale = new LocaleManager(join(home, "agent"));
+	const factory = createRosclawExtension({
+		profile: "developer", version: "0.1.0", systemPrompt: "TEST",
+		active, coordinator, center, locale, rosclawHome: home,
+		taskContext: resolveTaskContext({ rosclawHome: home, cwd: "/tmp", mode: "SIMULATION" }),
+		...(probe ? { osIsolationProbe: probe } : {}),
+	});
+	factory(pi as never);
+	return handlers;
+}
+
+function fakeCtx(notices: string[]) {
+	return {
+		hasUI: true,
+		ui: new Proxy({
+			notify: (text: string, _kind?: string) => { notices.push(text); },
+		}, {
+			get(target, prop) {
+				if (prop in target) return (target as Record<PropertyKey, unknown>)[prop];
+				return () => undefined; // 其余 ui 方法自动 stub
+			},
+		}),
+	};
+}
+
+test("R1-c: 无 OS 沙箱 → session_start 一次性提示（降级后果 + doctor 修复入口）", async () => {
+	const home = mkdtempSync(join(tmpdir(), "r1c-"));
+	const handlers = await buildExtension(home, () => ({ isolationReady: false }));
+	const notices: string[] = [];
+	for (const h of handlers.get("session_start") ?? []) await h({}, fakeCtx(notices));
+	const hints = notices.filter((n) => n.includes("OS 沙箱"));
+	assert.equal(hints.length, 1, `应恰好提示一次，实际 ${hints.length}`);
+	assert.match(hints[0], /确认卡|降级/);
+	assert.match(hints[0], /rosclaw doctor/);
+});
+
+test("R1-c: 隔离可用 → 无提示（不噪声）", async () => {
+	const home = mkdtempSync(join(tmpdir(), "r1c-"));
+	const handlers = await buildExtension(home, () => ({ isolationReady: true }));
+	const notices: string[] = [];
+	for (const h of handlers.get("session_start") ?? []) await h({}, fakeCtx(notices));
+	assert.equal(notices.filter((n) => n.includes("OS 沙箱")).length, 0);
+});
+
+test("R1-c: 默认探测消费 doctor 落盘的 os-isolation.json（单源）", async () => {
+	const home = mkdtempSync(join(tmpdir(), "r1c-"));
+	mkdirSync(join(home, "agent"), { recursive: true });
+	writeFileSync(join(home, "agent", "os-isolation.json"), JSON.stringify({
+		checked_at: "2026-09-03T00:00:00Z",
+		bwrap: { path: null, smoke_ok: false, detail: "bwrap 未安装" },
+		isolation_ready: false,
+	}));
+	// 不注入 probe——走默认（读 doctor 落盘记录）。
+	const handlers = await buildExtension(home);
+	const notices: string[] = [];
+	for (const h of handlers.get("session_start") ?? []) await h({}, fakeCtx(notices));
+	assert.equal(
+		notices.filter((n) => n.includes("OS 沙箱")).length, 1,
+		"doctor 记录 isolation_ready=false 时必须提示",
+	);
+});

--- a/src/rosclaw/firstboot/doctor.py
+++ b/src/rosclaw/firstboot/doctor.py
@@ -98,6 +98,7 @@ class FirstbootDoctor:
         checks.extend(self._check_eurdf_zoo())
         checks.extend(self._check_provider_registry())
         checks.extend(self._check_sandbox())
+        checks.extend(self._check_os_isolation())
         checks.extend(self._check_practice())
         checks.extend(self._check_memory())
         checks.extend(self._check_docker())
@@ -479,6 +480,54 @@ class FirstbootDoctor:
         finally:
             if sandbox is not None:
                 sandbox.close()
+
+    def _check_os_isolation(self) -> list[CheckResult]:
+        """0902 R1-c（§5.3）：OS 级隔离与图形后端——启动前一次探测
+        +真实 smoke，结论落盘 home/agent/os-isolation.json（任务开始
+        前消费），而不是执行到一半甩给用户。"""
+        from rosclaw.firstboot.os_isolation import probe_and_persist
+
+        probe = probe_and_persist(self.home)
+        checks: list[CheckResult] = []
+        bwrap = probe["bwrap"]
+        if bwrap["path"] and bwrap["smoke_ok"]:
+            checks.append(CheckResult(
+                "os_isolation.bwrap", "OS isolation (bwrap)",
+                CheckStatus.PASS, False,
+                f"bwrap 可用且 smoke 通过：{bwrap['path']}",
+            ))
+        elif bwrap["path"]:
+            checks.append(CheckResult(
+                "os_isolation.bwrap", "OS isolation (bwrap)",
+                CheckStatus.WARN, False,
+                f"bwrap 已安装但 smoke 失败（user namespace 受限？）："
+                f"{bwrap['detail']}——shell 将走会话内确认卡降级",
+                "检查内核 user namespace 设置（如 kernel.unprivileged_userns_clone=1 / "
+                "apparmor userns 策略），或重装 bubblewrap",
+            ))
+        else:
+            checks.append(CheckResult(
+                "os_isolation.bwrap", "OS isolation (bwrap)",
+                CheckStatus.WARN, False,
+                "本机无 bwrap——shell 类操作将在会话内弹确认卡（降级运行）",
+                "sudo apt install bubblewrap（或提供等效 OS 沙箱）",
+            ))
+        container = probe["container"]
+        checks.append(CheckResult(
+            "os_isolation.container", "Container backend",
+            CheckStatus.PASS if container else CheckStatus.WARN, False,
+            f"容器后端可用：{container}" if container else "无 docker/podman（可选后端）",
+            None if container else "可选：安装 docker 或 podman 作为隔离后端",
+        ))
+        graphics = probe["graphics"]
+        checks.append(CheckResult(
+            "os_isolation.graphics", "Graphics backend",
+            CheckStatus.PASS if graphics else CheckStatus.WARN, False,
+            f"渲染图形后端：{graphics}" if graphics
+            else "无 OSMesa/EGL——headless 仿真渲染不可用",
+            None if graphics else "sudo apt install libosmesa6（或配置 EGL）",
+        ))
+        return checks
 
     def _check_practice(self) -> list[CheckResult]:
         try:

--- a/src/rosclaw/firstboot/os_isolation.py
+++ b/src/rosclaw/firstboot/os_isolation.py
@@ -1,0 +1,102 @@
+"""OS 级隔离与图形后端探测（0902 审计 R1-c，§5.3）。
+
+与 firstboot.doctor 的 runtime.sandbox（MuJoCo 物理沙箱）不同——
+这里探测的是 shell 执行的 OS 隔离（bwrap/容器）与渲染图形后端
+（OSMesa/EGL）。§5.3：启动前一次探测 + 真实 smoke test，无可用
+隔离时任务开始前提示一次，而不是运行到一半甩给用户。
+
+探测结果落盘 <home>/agent/os-isolation.json，chat 会话启动时消费
+（一次性提示），doctor 输出给结论+修复命令。
+"""
+
+from __future__ import annotations
+
+import ctypes.util
+import json
+import os
+import shutil
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+_BWRAP_SMOKE_TIMEOUT_S = 5.0
+
+
+def _bwrap_smoke(bwrap_path: str) -> tuple[bool, str]:
+    """真实 smoke：present 不等于 usable——云 VM 常见 user namespace
+    受限（bwrap 装了但 --unshare-all 直接失败）。"""
+    try:
+        proc = subprocess.run(
+            [bwrap_path, "--unshare-all", "--ro-bind", "/usr", "/usr",
+             "--", "true"],
+            capture_output=True, text=True, timeout=_BWRAP_SMOKE_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "smoke 超时"
+    except OSError as exc:
+        return False, str(exc)
+    if proc.returncode == 0:
+        return True, "smoke ok"
+    detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+    return False, detail[-1][:200] if detail else f"exit {proc.returncode}"
+
+
+def _graphics_backend() -> str | None:
+    """headless 渲染后端：MUJOCO_GL 显式指定 > OSMesa > EGL。
+
+    （CI 实证：装 mujoco ≠ 能渲染——libosmesa6 缺失时渲染崩。）
+    """
+    env = (os.environ.get("MUJOCO_GL") or "").strip().lower()
+    if env in ("osmesa", "egl", "glfw"):
+        return env
+    if ctypes.util.find_library("OSMesa"):
+        return "osmesa"
+    if ctypes.util.find_library("EGL"):
+        return "egl"
+    return None
+
+
+def _container_runtime() -> str | None:
+    for name in ("docker", "podman"):
+        path = shutil.which(name)
+        if path:
+            return path
+    return None
+
+
+def probe_os_isolation() -> dict:
+    """一次探测（§5.3）——bwrap 存在性+smoke、容器后端、图形后端。"""
+    bwrap_path = shutil.which("bwrap")
+    smoke_ok, smoke_detail = (
+        _bwrap_smoke(bwrap_path) if bwrap_path else (False, "bwrap 未安装")
+    )
+    graphics = _graphics_backend()
+    container = _container_runtime()
+    return {
+        "checked_at": datetime.now(UTC).isoformat(),
+        "bwrap": {
+            "path": bwrap_path,
+            "smoke_ok": smoke_ok,
+            "detail": smoke_detail,
+        },
+        "container": container,
+        "graphics": graphics,
+        # shell 强隔离可用 = bwrap 装且 smoke 过（容器 backend 是后续
+        # 可选项，当前正式路径只有 bwrap）。
+        "isolation_ready": bool(bwrap_path and smoke_ok),
+    }
+
+
+def write_readiness(home: Path, probe: dict) -> Path:
+    out = home / "agent" / "os-isolation.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        json.dumps(probe, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return out
+
+
+def probe_and_persist(home: Path) -> dict:
+    probe = probe_os_isolation()
+    write_readiness(home, probe)
+    return probe

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -570,6 +570,7 @@ def _build_and_install(tmp_path: Path) -> tuple[Path, Path]:
 from rosclaw import __version__ as PRODUCT_VERSION  # noqa: E402,N812
 from rosclaw.agentd.operator_socket import display_hash_for  # noqa: E402
 from rosclaw.contracts.operator.approval import ApprovalRequestV2  # noqa: E402
+from rosclaw.firstboot.os_isolation import probe_os_isolation  # noqa: E402
 
 
 @contextlib.contextmanager
@@ -1523,6 +1524,18 @@ class TestProductJourney:
             # Operator 初始化，不弹逐动作人工卡（ask-every-time 旅程在
             # SEVEN-7 单独覆盖 bootstrap 路径）。
             self._journey_verdicts["operator_not_required_for_safe_sim"] = True
+            # 0902 R1-c（§5.3）：无可用 OS 沙箱（缺失或 present-but-
+            # broken——userns 受限）时，会话开始即一次性提示沙箱缺失 +
+            # doctor 修复入口（任务开始前），而不是执行到一半才甩卡。
+            # 探测单源 = os_isolation.probe_os_isolation（功能 smoke，
+            # 不是 which——本机 bwrap 装了但 RTM_NEWADDR 被拒）。
+            # （模块级 import——journey 运行期间源码 checkout 隐藏。）
+            if not probe_os_isolation()["isolation_ready"]:
+                session.expect("本机无 OS 沙箱".encode(), timeout=30)
+                assert b"rosclaw doctor" in session.clean, (
+                    "沙箱提示必须带 doctor 修复入口"
+                )
+                self._journey_verdicts["sandbox_notice_at_session_start"] = True
             # 2. 普通对话。
             session.send("你好\r")
             session.expect("你好，我是 ROSClaw".encode(), timeout=90)
@@ -1539,11 +1552,11 @@ class TestProductJourney:
             # 5. delegate worker。
             session.send("请委派 worker 总结这段日志\r")
             # 0902 R1-a：无 bwrap 主机上 bash 降级走确认卡（允许一次
-            # = 第一项，Enter 选定）——不再是全局环境变量。有 bwrap 的
-            # 主机沙箱直跑（无卡）。
-            import shutil as _shutil
-
-            if _shutil.which("bwrap") is None:
+            # = 第一项，Enter 选定）——不再是全局环境变量。有可用 OS
+            # 沙箱的主机直跑（无卡）。守卫必须功能探测（bwrap 装了但
+            # userns 受限 = 不可用；which 误判曾让本机从未走过批准路径
+            # ——卡 120s 超时默认拒绝蒙混过关，批准腿零覆盖）。
+            if not probe_os_isolation()["isolation_ready"]:
                 session.expect(
                     "本机无 OS 沙箱".encode(), timeout=120,
                 )
@@ -1556,6 +1569,9 @@ class TestProductJourney:
                     time.sleep(0.5)
                     if "本机无 OS 沙箱".encode() not in session.clean[-4000:]:
                         break
+                # 批准路径必须真实走到（不是 120s 超时默认拒绝蒙混）。
+                session.expect("已批准——原操作继续".encode(), timeout=30)
+                self._journey_verdicts["shell_approval_card_approved"] = True
             # PR-H1：Native 直接完成（不委派）——同一 session 的工具执行。
             session.expect("已直接完成日志总结".encode(), timeout=180)
             # P0-4G（TranscriptPolicy）：SECRET_PROBE 回合后，任何后续

--- a/tests/test_a0902_r1c_os_isolation.py
+++ b/tests/test_a0902_r1c_os_isolation.py
@@ -1,0 +1,94 @@
+"""0902 审计 R1-c 红测试：setup/doctor 沙箱就绪（§5.3）——执行中甩给
+用户 vs 启动前一次探测。
+
+0902 实证：ubuntu VM 无 bwrap，用户跑到一半才被要求 export 全局
+环境变量并重启。§5.3：setup/doctor 一次探测 bwrap/容器/文件系统
+隔离/图形后端，自动选择可用后端并做真实 smoke test；无可用隔离时
+在任务开始前提示一次，而不是运行到一半失败。
+
+闭环断言：
+1. doctor run_full 含 os_isolation 检查组（bwrap/容器/图形后端）；
+2. bwrap 缺失 → WARN + 修复命令（不是混在一屏内部状态里无结论）；
+3. bwrap 存在但 user namespace 受限（smoke 失败）→ 检出
+   "present but broken"，不谎称可用；
+4. 探测结果落盘 home/agent/os-isolation.json（任务开始前可消费）；
+5. 无 OSMesa/EGL 图形后端 → WARN（headless 渲染需要；CI libosmesa6
+   教训——装了 mujoco 不代表能渲染）。
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+def _run_full(home: Path):
+    from rosclaw.firstboot.doctor import FirstbootDoctor
+
+    return FirstbootDoctor(home=home).run_full(json_output=True)
+
+
+class TestOsIsolationChecks:
+    def test_full_includes_os_isolation_group(self, tmp_path: Path) -> None:
+        result = _run_full(tmp_path)
+        ids = {c.id for c in result.checks}
+        assert "os_isolation.bwrap" in ids, "doctor 无 bwrap 检查"
+        assert "os_isolation.container" in ids, "doctor 无容器后端检查"
+        assert "os_isolation.graphics" in ids, "doctor 无图形后端检查"
+
+    def test_bwrap_missing_warns_with_fix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(shutil, "which", lambda _name: None)
+        result = _run_full(tmp_path)
+        bwrap = next(c for c in result.checks if c.id == "os_isolation.bwrap")
+        from rosclaw.firstboot.doctor import CheckStatus
+
+        assert bwrap.status in (CheckStatus.WARN, CheckStatus.FAIL)
+        assert bwrap.fix, "无 bwrap 必须给修复命令（§5.3/R3.6 结论+修复）"
+        assert "bwrap" in bwrap.fix or "bubblewrap" in bwrap.fix
+
+    def test_bwrap_present_but_broken_smoke_detected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """bwrap 装了但 user namespace 受限（云 VM 常见）——smoke 必须
+        检出，不得谎称隔离可用。"""
+        import rosclaw.firstboot.os_isolation as oi
+
+        monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(oi, "_bwrap_smoke", lambda _path: (False, "user namespace 受限"))
+        result = _run_full(tmp_path)
+        bwrap = next(c for c in result.checks if c.id == "os_isolation.bwrap")
+        from rosclaw.firstboot.doctor import CheckStatus
+
+        assert bwrap.status != CheckStatus.PASS, "smoke 失败不得 PASS"
+        assert "namespace" in bwrap.message or "smoke" in bwrap.message.lower()
+
+    def test_readiness_written_to_home(self, tmp_path: Path) -> None:
+        """探测落盘——chat/任务开始前可消费（§5.3 启动前处理）。"""
+        _run_full(tmp_path)
+        readiness = tmp_path / "agent" / "os-isolation.json"
+        assert readiness.exists(), "os-isolation.json 未落盘"
+        data = json.loads(readiness.read_text(encoding="utf-8"))
+        assert "bwrap" in data and "checked_at" in data
+        assert "isolation_ready" in data
+
+    def test_graphics_backend_warns_when_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import rosclaw.firstboot.os_isolation as oi
+
+        monkeypatch.setattr(oi, "_graphics_backend", lambda: None)
+        result = _run_full(tmp_path)
+        gfx = next(c for c in result.checks if c.id == "os_isolation.graphics")
+        from rosclaw.firstboot.doctor import CheckStatus
+
+        assert gfx.status == CheckStatus.WARN
+        assert gfx.fix and ("osmesa" in gfx.fix.lower() or "egl" in gfx.fix.lower())
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 问题（0902 审计 §5.3）
无 OS 沙箱的主机（云 VM 无 bwrap，或 bwrap 装了但 user namespace 受限）上，shell 类操作执行到一半才失败/甩卡。§5.3：setup/doctor 一次探测 bwrap/容器/文件系统隔离/图形后端，自动选择可用后端并做真实 smoke test；无可用隔离时在任务开始前提示一次。

## 方案
- **firstboot/os_isolation.py**：一次探测——bwrap 存在性+功能 smoke（`bwrap --unshare-all … true`：present-but-broken 可检出，本机实证 bwrap 装了但 RTM_NEWADDR 被拒）、容器后端（docker/podman）、图形后端（OSMesa/EGL——装 mujoco ≠ 能渲染，CI libosmesa6 教训）；落盘 `~/.rosclaw/agent/os-isolation.json`。
- **doctor run_full 新增 os_isolation 组**：每项结论+修复命令（§R3.6：/doctor 给结论和一键修复，不给一屏内部状态）。
- **扩展 session_start 一次性提示**：隔离不可用 → 任务开始前 warning（降级后果 + rosclaw doctor 入口）；探测单源 = doctor 落盘记录，无记录回落 bwrap 功能探测。
- **journey 委派腿守卫修谎**：which(bwrap) 只测存在——本机（present-but-broken）因此从未走过批准路径，卡 120s 超时默认拒绝蒙混过关；改功能探测后批准腿真实覆盖，新增「已批准——原操作继续」断言。

## 红→绿证据
- 红：test_a0902_r1c_os_isolation 5/5 红 → 实现后 5/5 绿；TS a0902-r1c 3/3；journey A 委派腿在原守卫下本机跳过批准路径（PTY 实录 120s 超时 deny）。
- 绿：journey A 全腿通过（127s），verdicts 新增 `sandbox_notice_at_session_start` / `shell_approval_card_approved` 均 true；TS 全量 216/0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)