### PR TITLE
0902 R2-1: RenderSpec/RenderProfile/ToolAsset 契约——通用渲染器的一等输入（§4.3）

### DIFF
--- a/src/rosclaw/contracts/agent/render_spec.py
+++ b/src/rosclaw/contracts/agent/render_spec.py
@@ -1,0 +1,146 @@
+"""RenderSpecV1 / RenderProfileV1（0902 审计 R2-1，§4.3 通用渲染器）。
+
+不再为五角星写专用画线逻辑：渲染输入是一等契约——任意已登记
+本体（body_ref + RenderProfile）、附件（attachments + mount_frame）、
+世界（world_ref）、overlay（实际/规划轨迹、waypoints、接触点、
+安全区、传感器视锥）、相机预设、输出格式，全走同一路径。
+
+诚实性不变式（§4.3/R2.5）：
+- overlay kind 与 camera preset 是冻结枚举——未知值拒绝，不静默吞；
+- source_ref 把 overlay 绑定到具体 trace/plan（渲染必须渲染"这次"
+  的证据，不允许旧产物冒充——0902 假成功教训）；
+- RenderProfile 让每个本体自带 root/qpos 映射/EEF frame/默认相机，
+  渲染器不按本体名 hardcode。
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import Field, field_validator
+
+from rosclaw.contracts.common import ContractModel
+
+#: overlay 冻结集合（§4.3 列举的六类）。
+OVERLAY_KINDS = (
+    "actual_eef_trace",
+    "planned_trace",
+    "waypoints",
+    "contact_points",
+    "safety_zone",
+    "sensor_frustum",
+)
+
+#: 相机预设冻结集合（现有 sim_render 已实现的三档）。
+CAMERA_PRESETS = ("follow", "free", "top")
+
+#: 输出格式冻结集合。
+RENDER_OUTPUTS = ("mp4", "gif")
+
+#: trace 类 overlay 的 source_ref 必须指到具体证据（trace:/plan: URI）。
+_TRACE_SOURCE_PREFIXES = ("trace:", "plan:")
+
+
+class RenderOverlayV1(ContractModel):
+    """渲染叠加层：语义 kind + 证据来源引用。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.render_overlay.v1"
+
+    schema_version: Literal["rosclaw.render_overlay.v1"] = "rosclaw.render_overlay.v1"
+    kind: str = Field(min_length=1)
+    #: trace:t1 / plan:p1 —— trace 类 overlay 必填且必须可解析形态。
+    source_ref: str = ""
+
+    @field_validator("kind")
+    @classmethod
+    def _known_kind(cls, value: str) -> str:
+        if value not in OVERLAY_KINDS:
+            raise ValueError(f"未知 overlay kind: {value}（冻结集合 {OVERLAY_KINDS}）")
+        return value
+
+    def model_post_init(self, __context: object, /) -> None:
+        if self.kind in ("actual_eef_trace", "planned_trace", "contact_points") and (
+            not self.source_ref.startswith(_TRACE_SOURCE_PREFIXES)
+        ):
+            raise ValueError(
+                f"overlay {self.kind} 的 source_ref 必须指向具体证据"
+                f"（trace:/plan: 前缀），实际: {self.source_ref!r}"
+            )
+
+
+class RenderAttachmentV1(ContractModel):
+    """附件挂载：tool_ref + 挂载坐标系（变换细节在 ToolAsset）。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.render_attachment.v1"
+
+    schema_version: Literal["rosclaw.render_attachment.v1"] = "rosclaw.render_attachment.v1"
+    tool_ref: str = Field(min_length=1)
+    mount_frame: str = Field(min_length=1)
+
+
+class RenderCameraV1(ContractModel):
+    """相机：预设 + 可选参数覆盖。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.render_camera.v1"
+
+    schema_version: Literal["rosclaw.render_camera.v1"] = "rosclaw.render_camera.v1"
+    preset: str = Field(min_length=1)
+    #: 预设之外的显式参数（lookat/distance/elevation…），键值自由但
+    #: 预设名冻结。
+    params: dict[str, float | str] = Field(default_factory=dict)
+
+    @field_validator("preset")
+    @classmethod
+    def _known_preset(cls, value: str) -> str:
+        if value not in CAMERA_PRESETS:
+            raise ValueError(f"未知相机预设: {value}（冻结集合 {CAMERA_PRESETS}）")
+        return value
+
+
+class RenderSpecV1(ContractModel):
+    """渲染任务规格（§4.3 主契约）。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.render_spec.v1"
+
+    schema_version: Literal["rosclaw.render_spec.v1"] = "rosclaw.render_spec.v1"
+    body_ref: str = Field(min_length=1)
+    world_ref: str = Field(min_length=1)
+    attachments: list[RenderAttachmentV1] = Field(default_factory=list)
+    overlays: list[RenderOverlayV1] = Field(default_factory=list)
+    cameras: list[RenderCameraV1] = Field(default_factory=list)
+    outputs: list[str] = Field(min_length=1)
+
+    @field_validator("outputs")
+    @classmethod
+    def _known_outputs(cls, value: list[str]) -> list[str]:
+        for out in value:
+            if out not in RENDER_OUTPUTS:
+                raise ValueError(f"未知输出格式: {out}（冻结集合 {RENDER_OUTPUTS}）")
+        return value
+
+
+class RenderProfileV1(ContractModel):
+    """本体渲染档案：渲染器对任意本体的一等输入（不按本体名
+    hardcode——root/qpos 映射/EEF frame/默认相机全在这里）。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.render_profile.v1"
+
+    schema_version: Literal["rosclaw.render_profile.v1"] = "rosclaw.render_profile.v1"
+    body_id: str = Field(min_length=1)
+    root_body: str = Field(min_length=1)
+    #: 关节名 → qpos 索引（渲染回放 trajectory_states 的映射）。
+    qpos_mapping: dict[str, int]
+    eef_frame: str = Field(min_length=1)
+    default_cameras: list[RenderCameraV1] = Field(default_factory=list)
+
+
+__all__ = [
+    "CAMERA_PRESETS",
+    "OVERLAY_KINDS",
+    "RENDER_OUTPUTS",
+    "RenderAttachmentV1",
+    "RenderCameraV1",
+    "RenderOverlayV1",
+    "RenderProfileV1",
+    "RenderSpecV1",
+]

--- a/src/rosclaw/contracts/agent/tool_asset.py
+++ b/src/rosclaw/contracts/agent/tool_asset.py
@@ -1,0 +1,65 @@
+"""ToolAssetV1（0902 审计 R2-1，§4.3）——工具/附件资产契约。
+
+工具（夹爪、吸盘、标记笔…）是有 manifest、多格式适配（MJCF/USD/
+URDF）和挂载变换的一等资产——不是渲染脚本里硬编码的几何体。
+
+诚实性不变式（§4.3：可视化附件不得冒充真实接触）：
+- `physical` 必填无默认——visual-only 附件必须显式声明，接触/执行
+  证据校验（R0-3 receipt.tool_ref 等 verifier）只认 physical=True
+  的附件。
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import Field, field_validator
+
+from rosclaw.contracts.common import ContractModel
+
+#: 适配格式冻结集合（当前先做 MJCF，USD/URDF 为契约预留）。
+TOOL_ADAPTER_FORMATS = ("mjcf", "usd", "urdf")
+
+
+class ToolMountV1(ContractModel):
+    """挂载变换：父坐标系 + 可选 SE(3) 偏移（米/四元数 xyzw）。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.tool_mount.v1"
+
+    schema_version: Literal["rosclaw.tool_mount.v1"] = "rosclaw.tool_mount.v1"
+    parent_frame: str = Field(min_length=1)
+    position_m: list[float] = Field(default=[0.0, 0.0, 0.0], min_length=3, max_length=3)
+    orientation_xyzw: list[float] = Field(
+        default=[0.0, 0.0, 0.0, 1.0], min_length=4, max_length=4
+    )
+
+
+class ToolAssetV1(ContractModel):
+    """工具资产 manifest。"""
+
+    SCHEMA: ClassVar[str] = "rosclaw.tool_asset.v1"
+
+    schema_version: Literal["rosclaw.tool_asset.v1"] = "rosclaw.tool_asset.v1"
+    tool_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    #: 是否物理实体（参与接触/碰撞）——必填，无默认（visual-only
+    #: 必须显式 False，杜绝可视化冒充真实接触）。
+    physical: bool
+    #: 格式 → 资产路径（至少一个；格式冻结）。
+    adapters: dict[str, str]
+    mount: ToolMountV1
+
+    @field_validator("adapters")
+    @classmethod
+    def _known_adapters(cls, value: dict[str, str]) -> dict[str, str]:
+        if not value:
+            raise ValueError("adapters 至少一个（mjcf/usd/urdf）")
+        for fmt in value:
+            if fmt not in TOOL_ADAPTER_FORMATS:
+                raise ValueError(
+                    f"未知适配格式: {fmt}（冻结集合 {TOOL_ADAPTER_FORMATS}）"
+                )
+        return value
+
+
+__all__ = ["TOOL_ADAPTER_FORMATS", "ToolAssetV1", "ToolMountV1"]

--- a/src/rosclaw/contracts/export.py
+++ b/src/rosclaw/contracts/export.py
@@ -20,6 +20,7 @@ from rosclaw.contracts.agent.decision import DecisionV1
 from rosclaw.contracts.agent.mission import MissionSessionV1
 from rosclaw.contracts.agent.model_turn import ModelTurnResultV1
 from rosclaw.contracts.agent.plan_graph import PlanGraphV1
+from rosclaw.contracts.agent.render_spec import RenderProfileV1, RenderSpecV1
 from rosclaw.contracts.agent.task_contracts import (
     ArtifactRefV1,
     EvidenceClaimV1,
@@ -31,6 +32,7 @@ from rosclaw.contracts.agent.task_contracts import (
 from rosclaw.contracts.agent.task_graph import TaskGraphPatchV1, TaskGraphV1, TaskNodeV1
 from rosclaw.contracts.agent.task_spec import TaskSpecV2
 from rosclaw.contracts.agent.tool import ToolDescriptorV2
+from rosclaw.contracts.agent.tool_asset import ToolAssetV1
 from rosclaw.contracts.agent.tool_result import ToolResultEnvelopeV2
 from rosclaw.contracts.agent.typed_ref import TypedRefV1
 from rosclaw.contracts.common import ContractModel
@@ -54,6 +56,9 @@ ALL_CONTRACTS: dict[str, type[ContractModel]] = {
         AcceptanceSpecV2,
         TaskSpecV2,
         PlanGraphV1,
+        RenderSpecV1,
+        RenderProfileV1,
+        ToolAssetV1,
         TaskNodeV1,
         TaskGraphV1,
         TaskGraphPatchV1,

--- a/tests/contracts/golden/rosclaw.render_profile.v1.json
+++ b/tests/contracts/golden/rosclaw.render_profile.v1.json
@@ -1,0 +1,88 @@
+{
+  "$defs": {
+    "RenderCameraV1": {
+      "additionalProperties": true,
+      "description": "相机：预设 + 可选参数覆盖。",
+      "properties": {
+        "schema_version": {
+          "const": "rosclaw.render_camera.v1",
+          "default": "rosclaw.render_camera.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "preset": {
+          "minLength": 1,
+          "title": "Preset",
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "title": "Params",
+          "type": "object"
+        }
+      },
+      "required": [
+        "preset"
+      ],
+      "title": "RenderCameraV1",
+      "type": "object"
+    }
+  },
+  "additionalProperties": true,
+  "description": "本体渲染档案：渲染器对任意本体的一等输入（不按本体名\nhardcode——root/qpos 映射/EEF frame/默认相机全在这里）。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.render_profile.v1",
+      "default": "rosclaw.render_profile.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "body_id": {
+      "minLength": 1,
+      "title": "Body Id",
+      "type": "string"
+    },
+    "root_body": {
+      "minLength": 1,
+      "title": "Root Body",
+      "type": "string"
+    },
+    "qpos_mapping": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "title": "Qpos Mapping",
+      "type": "object"
+    },
+    "eef_frame": {
+      "minLength": 1,
+      "title": "Eef Frame",
+      "type": "string"
+    },
+    "default_cameras": {
+      "items": {
+        "$ref": "#/$defs/RenderCameraV1"
+      },
+      "title": "Default Cameras",
+      "type": "array"
+    }
+  },
+  "required": [
+    "body_id",
+    "root_body",
+    "qpos_mapping",
+    "eef_frame"
+  ],
+  "title": "rosclaw.render_profile.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.render_profile.v1"
+}

--- a/tests/contracts/golden/rosclaw.render_spec.v1.json
+++ b/tests/contracts/golden/rosclaw.render_spec.v1.json
@@ -1,0 +1,152 @@
+{
+  "$defs": {
+    "RenderAttachmentV1": {
+      "additionalProperties": true,
+      "description": "附件挂载：tool_ref + 挂载坐标系（变换细节在 ToolAsset）。",
+      "properties": {
+        "schema_version": {
+          "const": "rosclaw.render_attachment.v1",
+          "default": "rosclaw.render_attachment.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "tool_ref": {
+          "minLength": 1,
+          "title": "Tool Ref",
+          "type": "string"
+        },
+        "mount_frame": {
+          "minLength": 1,
+          "title": "Mount Frame",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool_ref",
+        "mount_frame"
+      ],
+      "title": "RenderAttachmentV1",
+      "type": "object"
+    },
+    "RenderCameraV1": {
+      "additionalProperties": true,
+      "description": "相机：预设 + 可选参数覆盖。",
+      "properties": {
+        "schema_version": {
+          "const": "rosclaw.render_camera.v1",
+          "default": "rosclaw.render_camera.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "preset": {
+          "minLength": 1,
+          "title": "Preset",
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "title": "Params",
+          "type": "object"
+        }
+      },
+      "required": [
+        "preset"
+      ],
+      "title": "RenderCameraV1",
+      "type": "object"
+    },
+    "RenderOverlayV1": {
+      "additionalProperties": true,
+      "description": "渲染叠加层：语义 kind + 证据来源引用。",
+      "properties": {
+        "schema_version": {
+          "const": "rosclaw.render_overlay.v1",
+          "default": "rosclaw.render_overlay.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "kind": {
+          "minLength": 1,
+          "title": "Kind",
+          "type": "string"
+        },
+        "source_ref": {
+          "default": "",
+          "title": "Source Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "title": "RenderOverlayV1",
+      "type": "object"
+    }
+  },
+  "additionalProperties": true,
+  "description": "渲染任务规格（§4.3 主契约）。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.render_spec.v1",
+      "default": "rosclaw.render_spec.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "body_ref": {
+      "minLength": 1,
+      "title": "Body Ref",
+      "type": "string"
+    },
+    "world_ref": {
+      "minLength": 1,
+      "title": "World Ref",
+      "type": "string"
+    },
+    "attachments": {
+      "items": {
+        "$ref": "#/$defs/RenderAttachmentV1"
+      },
+      "title": "Attachments",
+      "type": "array"
+    },
+    "overlays": {
+      "items": {
+        "$ref": "#/$defs/RenderOverlayV1"
+      },
+      "title": "Overlays",
+      "type": "array"
+    },
+    "cameras": {
+      "items": {
+        "$ref": "#/$defs/RenderCameraV1"
+      },
+      "title": "Cameras",
+      "type": "array"
+    },
+    "outputs": {
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Outputs",
+      "type": "array"
+    }
+  },
+  "required": [
+    "body_ref",
+    "world_ref",
+    "outputs"
+  ],
+  "title": "rosclaw.render_spec.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.render_spec.v1"
+}

--- a/tests/contracts/golden/rosclaw.tool_asset.v1.json
+++ b/tests/contracts/golden/rosclaw.tool_asset.v1.json
@@ -1,0 +1,99 @@
+{
+  "$defs": {
+    "ToolMountV1": {
+      "additionalProperties": true,
+      "description": "挂载变换：父坐标系 + 可选 SE(3) 偏移（米/四元数 xyzw）。",
+      "properties": {
+        "schema_version": {
+          "const": "rosclaw.tool_mount.v1",
+          "default": "rosclaw.tool_mount.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "parent_frame": {
+          "minLength": 1,
+          "title": "Parent Frame",
+          "type": "string"
+        },
+        "position_m": {
+          "default": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 3,
+          "minItems": 3,
+          "title": "Position M",
+          "type": "array"
+        },
+        "orientation_xyzw": {
+          "default": [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+          ],
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "title": "Orientation Xyzw",
+          "type": "array"
+        }
+      },
+      "required": [
+        "parent_frame"
+      ],
+      "title": "ToolMountV1",
+      "type": "object"
+    }
+  },
+  "additionalProperties": true,
+  "description": "工具资产 manifest。",
+  "properties": {
+    "schema_version": {
+      "const": "rosclaw.tool_asset.v1",
+      "default": "rosclaw.tool_asset.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "tool_id": {
+      "minLength": 1,
+      "title": "Tool Id",
+      "type": "string"
+    },
+    "name": {
+      "minLength": 1,
+      "title": "Name",
+      "type": "string"
+    },
+    "physical": {
+      "title": "Physical",
+      "type": "boolean"
+    },
+    "adapters": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Adapters",
+      "type": "object"
+    },
+    "mount": {
+      "$ref": "#/$defs/ToolMountV1"
+    }
+  },
+  "required": [
+    "tool_id",
+    "name",
+    "physical",
+    "adapters",
+    "mount"
+  ],
+  "title": "rosclaw.tool_asset.v1",
+  "type": "object",
+  "$id": "rosclaw://schemas/rosclaw.tool_asset.v1"
+}

--- a/tests/test_a0902_r2a_render_contracts.py
+++ b/tests/test_a0902_r2a_render_contracts.py
@@ -1,0 +1,156 @@
+"""0902 审计 R2-1 红测试：RenderSpec/RenderProfile/ToolAsset 契约
+（§4.3 通用渲染器 + R2.1 契约完成）。
+
+0902 假成功根因之一：渲染是五角星专用画线逻辑，需求里的"红色圆柱
+笔/3D 场景/实际轨迹 overlay"没有契约位置——链复用旧视频冒充新
+需求。§4.3：RenderSpec 是一等契约（body_ref/world_ref/attachments/
+overlays/cameras/outputs），任何本体+附件+世界+overlay+相机组合
+都走同一渲染路径。
+
+闭环断言：
+1. 三契约注册进 ALL_CONTRACTS + golden schema 稳定；
+2. RenderSpec overlay kind 是冻结枚举（actual_eef_trace/
+   planned_trace/waypoints/contact_points/safety_zone/sensor_frustum）
+   ——未知 kind 拒绝（不静默吞）；
+3. camera preset 冻结枚举（follow/free/top）；outputs 非空且属于
+   mp4/gif；
+4. ToolAsset 必须声明 physical——visual-only 附件不得参与接触
+   声明（§4.3：可视化附件不得冒充真实接触）；
+5. RenderProfile 必须有 eef_frame 与 qpos 映射（渲染任意本体靠它，
+   不许本体名 hardcode）；
+6. RenderSpec 校验 attachments 的 mount_frame 非空、overlays 的
+   source_ref 可解析形态（trace:.../plan:...）。
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from rosclaw.contracts.export import ALL_CONTRACTS
+
+
+class TestRenderContractsRegistered:
+    def test_contracts_in_registry(self) -> None:
+        assert "rosclaw.render_spec.v1" in ALL_CONTRACTS
+        assert "rosclaw.render_profile.v1" in ALL_CONTRACTS
+        assert "rosclaw.tool_asset.v1" in ALL_CONTRACTS
+
+    def test_golden_files_exist(self) -> None:
+        from pathlib import Path
+
+        golden = Path(__file__).parent / "contracts" / "golden"
+        for stem in ("render_spec.v1", "render_profile.v1", "tool_asset.v1"):
+            assert (golden / f"rosclaw.{stem}.json").exists(), f"缺 golden: {stem}"
+
+
+class TestRenderSpec:
+    def _base(self) -> dict:
+        return {
+            "body_ref": "robot:sim/ur5e",
+            "world_ref": "world:tabletop",
+            "outputs": ["mp4"],
+        }
+
+    def test_minimal_valid(self) -> None:
+        from rosclaw.contracts.agent.render_spec import RenderSpecV1
+
+        spec = RenderSpecV1(**self._base())
+        assert spec.body_ref == "robot:sim/ur5e"
+
+    def test_overlay_kind_frozen_enum(self) -> None:
+        from rosclaw.contracts.agent.render_spec import RenderSpecV1
+
+        base = self._base()
+        base["overlays"] = [{"kind": "actual_eef_trace", "source_ref": "trace:t1"}]
+        RenderSpecV1(**base)  # 合法 kind 通过
+        base["overlays"] = [{"kind": "magic_overlay", "source_ref": "trace:t1"}]
+        with pytest.raises(PydanticValidationError):
+            RenderSpecV1(**base)
+
+    def test_overlay_source_ref_required_for_trace_kinds(self) -> None:
+        from rosclaw.contracts.agent.render_spec import RenderSpecV1
+
+        base = self._base()
+        base["overlays"] = [{"kind": "actual_eef_trace"}]
+        with pytest.raises(PydanticValidationError):
+            RenderSpecV1(**base)
+
+    def test_camera_preset_frozen_enum(self) -> None:
+        from rosclaw.contracts.agent.render_spec import RenderSpecV1
+
+        base = self._base()
+        base["cameras"] = [{"preset": "follow"}]
+        RenderSpecV1(**base)
+        base["cameras"] = [{"preset": "hollywood"}]
+        with pytest.raises(PydanticValidationError):
+            RenderSpecV1(**base)
+
+    def test_outputs_frozen_and_nonempty(self) -> None:
+        from rosclaw.contracts.agent.render_spec import RenderSpecV1
+
+        base = self._base()
+        base["outputs"] = []
+        with pytest.raises(PydanticValidationError):
+            RenderSpecV1(**base)
+        base["outputs"] = ["avi"]
+        with pytest.raises(PydanticValidationError):
+            RenderSpecV1(**base)
+
+    def test_attachment_requires_mount_frame(self) -> None:
+        from rosclaw.contracts.agent.render_spec import RenderSpecV1
+
+        base = self._base()
+        base["attachments"] = [{"tool_ref": "tool:gripper", "mount_frame": ""}]
+        with pytest.raises(PydanticValidationError):
+            RenderSpecV1(**base)
+
+
+class TestToolAsset:
+    def test_physical_flag_required_and_honest(self) -> None:
+        from rosclaw.contracts.agent.tool_asset import ToolAssetV1
+
+        # visual-only 附件合法登记，但 physical=False 必须显式。
+        asset = ToolAssetV1(
+            tool_id="tool:marker_red",
+            name="红色标记笔",
+            physical=False,
+            adapters={"mjcf": "tools/marker_red.xml"},
+            mount={"parent_frame": "ee_link"},
+        )
+        assert asset.physical is False
+        with pytest.raises(PydanticValidationError):
+            # 缺 physical 字段——默认 True 会让可视化附件冒充实体。
+            ToolAssetV1(
+                tool_id="tool:x", name="x",
+                adapters={"mjcf": "x.xml"}, mount={"parent_frame": "ee"},
+            )
+
+    def test_adapter_format_frozen(self) -> None:
+        from rosclaw.contracts.agent.tool_asset import ToolAssetV1
+
+        with pytest.raises(PydanticValidationError):
+            ToolAssetV1(
+                tool_id="tool:x", name="x", physical=True,
+                adapters={"blend": "x.blend"},  # 非法适配格式
+                mount={"parent_frame": "ee"},
+            )
+
+
+class TestRenderProfile:
+    def test_requires_eef_and_qpos_mapping(self) -> None:
+        from rosclaw.contracts.agent.render_spec import RenderProfileV1
+
+        profile = RenderProfileV1(
+            body_id="sim/ur5e",
+            root_body="base_link",
+            eef_frame="ee_link",
+            qpos_mapping={"shoulder_pan_joint": 0},
+        )
+        assert profile.eef_frame == "ee_link"
+        with pytest.raises(PydanticValidationError):
+            RenderProfileV1(body_id="sim/ur5e", root_body="base_link")  # 缺 eef/qpos
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 背景（0902 审计 §4.3 / R2.1）
渲染不能再是五角星专用画线逻辑。RenderSpec 是一等契约：任意已登记本体、附件、世界、overlay、相机组合走同一渲染路径。本 PR 是契约层（R2.1）；MuJoCo 通用 renderer adapter（R2.4）后续消费。

## 契约
- **RenderSpecV1**：body_ref/world_ref/attachments/overlays/cameras/outputs。overlay kind 六类冻结枚举（actual_eef_trace/planned_trace/waypoints/contact_points/safety_zone/sensor_frustum）、相机预设（follow/free/top）、输出（mp4/gif）——未知值拒绝，不静默吞；trace 类 overlay 的 source_ref 必须指向具体证据（trace:/plan: 前缀）——渲染必须渲染**这次**的证据（0902 假成功：链复用旧视频冒充新需求的根治锚点）。
- **RenderProfileV1**：本体自带 root/qpos 映射/EEF frame/默认相机——渲染器不按本体名 hardcode。
- **ToolAssetV1**：manifest + 适配格式冻结（mjcf/usd/urdf）+ 挂载变换；`physical` 必填无默认——visual-only 附件显式声明，不得冒充真实接触（§4.3/R2.5 物理/视觉验证分层的契约锚点）。

## 验证
- 红：tests/test_a0902_r2a_render_contracts.py 11/11 红 → 绿；
- golden 三契约经官方 exporter 导出，tests/contracts 全量 88/88；architecture 20/20；ruff 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)