### PR TITLE
0902 R3-a: rosclaw open 最短入口 + Ctrl-C 安静退出 130

### DIFF
--- a/src/rosclaw/entrypoint.py
+++ b/src/rosclaw/entrypoint.py
@@ -2,31 +2,50 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 
 def main() -> int:
     """Dispatch product workflows without importing the full legacy CLI."""
 
+    # 0902 R3-a（§6.2）：Ctrl-C 安静退出返回 130——traceback 只进
+    # debug 日志（ROSCLAW_DEBUG=1 时原样抛出便于诊断），不打终端。
+    try:
+        return _dispatch(sys.argv[1:])
+    except KeyboardInterrupt:
+        if os.environ.get("ROSCLAW_DEBUG"):
+            raise
+        print("\n已取消（Ctrl-C）", file=sys.stderr)
+        return 130
+
+
+def _dispatch(argv: list[str]) -> int:
+    """命令分派（main 的 Ctrl-C 防护外壳之下的真实路由）。"""
+    # 0902 R3-a（§6.2）：`rosclaw open <artifact-id>` 最短主入口——
+    # 重写为 artifact open（同一 handler，不允许第二条实现）。
+    if argv and argv[0] == "open":
+        argv = ["artifact", "open", *argv[1:]]
+
     # NA-FIX-8：root CLI 产品化——精简 help / commands --json / topic 指引
     # （命中即返回；未命中走既有 dispatcher，行为不变）。
     from rosclaw.root_cli import dispatch_root_cli
 
-    _help_all = sys.argv[1:] == ["help", "--all"]
-    root = dispatch_root_cli(sys.argv[1:] if not _help_all else ["commands", "--help-all"])
+    _help_all = argv == ["help", "--all"]
+    root = dispatch_root_cli(argv if not _help_all else ["commands", "--help-all"])
     if root is not None:
         return root
 
     # PR-N3：inspect self/robot/capability/asset（生态索引自检）。
     from rosclaw.cognition.inspect_cli import dispatch_inspect_argv
 
-    inspected = dispatch_inspect_argv(sys.argv[1:])
+    inspected = dispatch_inspect_argv(argv)
     if inspected is not None:
         return inspected
 
     from rosclaw.operator.cli import dispatch_operator_argv
 
-    result = dispatch_operator_argv(sys.argv[1:])
+    result = dispatch_operator_argv(argv)
     if result is not None:
         return result
 
@@ -35,7 +54,7 @@ def main() -> int:
     # legacy parser 打顶层帮助——dispatch 链缺失，不是版本漂移）。
     from rosclaw.agentd.cli import dispatch_artifact_argv
 
-    result = dispatch_artifact_argv(sys.argv[1:])
+    result = dispatch_artifact_argv(argv)
     if result is not None:
         return result
 
@@ -43,109 +62,109 @@ def main() -> int:
     # 先于 legacy parser——legacy 的 setup 只有 lerobot，契约失真。
     from rosclaw.setup_cli import dispatch_setup_argv
 
-    result = dispatch_setup_argv(sys.argv[1:])
+    result = dispatch_setup_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.daemon.cli import dispatch_daemon_argv
 
-    result = dispatch_daemon_argv(sys.argv[1:])
+    result = dispatch_daemon_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.adapters.acp.cli import dispatch_acp_argv
 
-    result = dispatch_acp_argv(sys.argv[1:])
+    result = dispatch_acp_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.operatord.cli import dispatch_operatord_argv
 
-    result = dispatch_operatord_argv(sys.argv[1:])
+    result = dispatch_operatord_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.release_verify import dispatch_release_argv
 
-    result = dispatch_release_argv(sys.argv[1:])
+    result = dispatch_release_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.knowledge.cli import dispatch_knowledge_argv
 
-    result = dispatch_knowledge_argv(sys.argv[1:])
+    result = dispatch_knowledge_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.evidence_verify import dispatch_evidence_argv
 
-    result = dispatch_evidence_argv(sys.argv[1:])
+    result = dispatch_evidence_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.robot_pack.cli import dispatch_robot_pack_argv
 
-    result = dispatch_robot_pack_argv(sys.argv[1:])
+    result = dispatch_robot_pack_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.app.cli import dispatch_app_argv
 
-    result = dispatch_app_argv(sys.argv[1:])
+    result = dispatch_app_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.collective.cli import dispatch_collective_argv
 
-    result = dispatch_collective_argv(sys.argv[1:])
+    result = dispatch_collective_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.dream.cli import dispatch_dream_argv
 
-    result = dispatch_dream_argv(sys.argv[1:])
+    result = dispatch_dream_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.continual.cli import dispatch_continual_argv
 
-    result = dispatch_continual_argv(sys.argv[1:])
+    result = dispatch_continual_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.simforge.g1_muscle_memory_cli import dispatch_muscle_memory_argv
 
-    result = dispatch_muscle_memory_argv(sys.argv[1:])
+    result = dispatch_muscle_memory_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.simforge.g1_hat_trick_cli import dispatch_hat_trick_argv
 
-    result = dispatch_hat_trick_argv(sys.argv[1:])
+    result = dispatch_hat_trick_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.simforge.phase4_cli import dispatch_phase4_argv
 
-    result = dispatch_phase4_argv(sys.argv[1:])
+    result = dispatch_phase4_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.simforge.phase3_cli import dispatch_phase3_argv
 
-    result = dispatch_phase3_argv(sys.argv[1:])
+    result = dispatch_phase3_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.product.cli import dispatch_product_argv
 
-    result = dispatch_product_argv(sys.argv[1:])
+    result = dispatch_product_argv(argv)
     if result is not None:
         return result
 
     from rosclaw.simforge.cli import dispatch_simforge_argv
 
-    result = dispatch_simforge_argv(sys.argv[1:])
+    result = dispatch_simforge_argv(argv)
     if result is not None:
         return result
 

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1774,6 +1774,23 @@ class TestProductJourney:
                 f"交付物未列出：{art_list.stdout[:300]}"
             )
             self._journey_verdicts["artifact_cli_reachable_in_install"] = True
+            # 0902 R3-a（§6.2）：`rosclaw open <id>` 最短主入口在安装
+            # 产物上真实可达（重写为 artifact open，同一 handler）。
+            import re as _re
+
+            id_match = _re.search(r"art_[0-9a-f]{24}", art_list.stdout)
+            assert id_match, f"artifact list 无 artifact id：{art_list.stdout[:300]}"
+            art_path = _subp.run(
+                [str(rosclaw), "open", id_match.group(0)], env=env,
+                capture_output=True, text=True, timeout=60,
+            )
+            # open 在无图形环境下可能打不开查看器——但 dispatch 必须
+            # 到达 artifact handler（不回落顶层帮助/未知命令）。
+            combined = art_path.stdout + art_path.stderr
+            assert "usage: rosclaw" not in combined, (
+                f"rosclaw open 回落顶层帮助：{combined[:300]}"
+            )
+            self._journey_verdicts["open_shortcut_reachable_in_install"] = True
             # 7. /compact（HOTFIX-5：真断言——compact 完成、上下文与
             #    receipt 保留、summary 可用——不是只发命令后 sleep）。
             #    先把 session 推过 keepRecentTokens 阈值（~20K tokens），

--- a/tests/test_a0902_r3a_cli_exit.py
+++ b/tests/test_a0902_r3a_cli_exit.py
@@ -1,0 +1,86 @@
+"""0902 审计 R3-a 红测试（§6.2 路径/CLI 收敛）：
+
+1. `rosclaw open <artifact-id>` 最短主入口——等价 `rosclaw artifact
+   open <id>`（TerminalPresenter 给的 open 命令必须一步到位）；
+2. Ctrl-C 安静退出返回 130——Python traceback 不打到终端（进
+   debug 日志）；普通异常路径不受影响的回归护栏。
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+class TestOpenShortcut:
+    def test_open_rewrites_to_artifact_open(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """`rosclaw open art_x` 与 `rosclaw artifact open art_x`
+        同一 handler（不允许第二条实现）。"""
+        from rosclaw import entrypoint
+
+        calls: list[list[str]] = []
+
+        def _spy(argv: list[str]) -> int:
+            calls.append(list(argv))
+            return 0
+
+        monkeypatch.setattr(
+            "rosclaw.agentd.cli.dispatch_artifact_argv", _spy
+        )
+        monkeypatch.setattr(sys, "argv", ["rosclaw", "open", "art_x"])
+        assert entrypoint.main() == 0
+        assert calls == [["artifact", "open", "art_x"]], calls
+
+    def test_open_without_id_is_usage_error(
+        self, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        from rosclaw import entrypoint
+
+        monkeypatch.setattr(sys, "argv", ["rosclaw", "open"])
+        # argparse 用法错误 = SystemExit(2) + stderr 用法提示。
+        with pytest.raises(SystemExit) as exc_info:
+            entrypoint.main()
+        assert exc_info.value.code != 0
+        assert "usage" in capsys.readouterr().err.lower()
+
+
+class TestCtrlCCleanExit:
+    def test_keyboard_interrupt_returns_130_no_traceback(
+        self, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """Ctrl-C 安静退出 130——traceback 只进 debug 日志（§6.2）。"""
+        from rosclaw import entrypoint
+
+        def _boom(_argv: list[str]) -> int:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(
+            "rosclaw.root_cli.dispatch_root_cli", _boom
+        )
+        monkeypatch.setattr(sys, "argv", ["rosclaw", "commands"])
+        rc = entrypoint.main()
+        assert rc == 130, f"Ctrl-C 应返回 130，实际 {rc}"
+        err = capsys.readouterr().err
+        assert "Traceback" not in err, f"traceback 打到了终端: {err[:300]}"
+
+    def test_other_exceptions_still_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """回归护栏：普通异常不被 130 吞掉（只拦 KeyboardInterrupt）。"""
+        from rosclaw import entrypoint
+
+        def _boom(_argv: list[str]) -> int:
+            raise RuntimeError("real bug")
+
+        monkeypatch.setattr("rosclaw.root_cli.dispatch_root_cli", _boom)
+        monkeypatch.setattr(sys, "argv", ["rosclaw", "commands"])
+        with pytest.raises(RuntimeError):
+            entrypoint.main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 背景（0902 审计 §6.2）
- CLI 收敛：`rosclaw open <artifact-id>` 是最短主入口；
- Ctrl-C 应安静退出并返回 130；Python traceback 只进 debug log（0902 实证：VM 上 Ctrl-C 打出 traceback）。

## 实现
- entrypoint 拆 `_dispatch` + 顶层 KeyboardInterrupt 防护：Ctrl-C 打印一行「已取消（Ctrl-C）」返回 130；`ROSCLAW_DEBUG=1` 时原样抛出便于诊断。普通异常不吞（回归护栏测试）。
- `rosclaw open <id>` 重写为 `artifact open <id>`——同一 handler，不允许第二条实现。

## 红→绿证据
- tests/test_a0902_r3a_cli_exit.py 4 项：open 重写到同一 handler / 无 id 用法错误 / Ctrl-C 130 无 traceback / 普通异常不吞。先红后绿。
- 安装产物 Gate：journey A Gate B 新增 `rosclaw open` 可达断言（open_shortcut_reachable_in_install），journey 全绿（175s）。
- 回归：tests/cli + artifact 交付套件 41/41。

🤖 Generated with [Claude Code](https://claude.com/claude-code)