### PR TITLE
0902 R3-b: 三层界面——终态卡默认层不再裸打内部绝对路径

### DIFF
--- a/packages/rosclaw-agent/src/native/terminal-presenter.ts
+++ b/packages/rosclaw-agent/src/native/terminal-presenter.ts
@@ -36,15 +36,17 @@ export interface TerminalOutcome {
 	}>;
 }
 
-/** 交付物三行：文件名（大小）/ 裸绝对路径 / 裸打开命令——
- *  无标签前缀（0901 journey 实证：CJK 换行会把"路径："从值
- *  中间撕开；裸行既防撕裂又便于复制）。 */
+/** 交付物行：文件名（大小）+ 短打开命令——默认层不裸打内部
+ *  绝对路径（0902 §6.1：普通用户不得看到 sim/traces 内部路径；
+ *  0901 的可达性由 open/path/export 命令承接）。verbose（诊断层
+ *  /activity）才附绝对路径。无标签前缀（0901 journey 实证：CJK
+ *  换行会把"路径："从值中间撕开）。 */
 function renderArtifactLine(ref: {
 	artifact_id?: string;
 	open_command?: string;
 	path?: string;
 	size_bytes?: number;
-}): string {
+}, verbose: boolean): string {
 	const path = String(ref.path ?? "");
 	const name = path ? path.split("/").pop() ?? "" : "";
 	const size = Number(ref.size_bytes ?? 0);
@@ -58,17 +60,21 @@ function renderArtifactLine(ref: {
 	const head = name
 		? `• ${name}${sizeText ? `（${sizeText}）` : ""}`
 		: `• ${String(ref.artifact_id ?? "artifact")}`;
-	const pathLine = path ? `\n  ${path}` : "";
+	const pathLine = verbose && path ? `\n  ${path}` : "";
 	const openLine = ref.open_command ? `\n  ${ref.open_command}` : "";
 	return `${head}${pathLine}${openLine}`;
 }
 
 /** 任务终态的最终用户回复（确定性——同一 outcome 永远同一文本）。 */
-export function renderTerminalReply(outcome: TerminalOutcome): string {
+export function renderTerminalReply(
+	outcome: TerminalOutcome,
+	options?: { verbose?: boolean },
+): string {
 	const verification = String(outcome.verification ?? "UNKNOWN");
 	const delivery = String(outcome.delivery ?? "UNKNOWN");
 	const refs = outcome.artifact_refs ?? [];
-	const artifactLines = refs.map(renderArtifactLine);
+	const verbose = options?.verbose === true;
+	const artifactLines = refs.map((ref) => renderArtifactLine(ref, verbose));
 	const passed = (verification === "PASS" || verification === "PASS_NEAR_LIMIT")
 		&& delivery === "DELIVERED";
 	const degraded = outcome.workspace_projection === "DEGRADED"

--- a/packages/rosclaw-agent/test/a0901-p06-terminal-presenter.test.ts
+++ b/packages/rosclaw-agent/test/a0901-p06-terminal-presenter.test.ts
@@ -10,7 +10,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-test("P0-6 PASS 呈现：文件名 + 绝对路径 + 打开命令 + 下一步", async () => {
+test("P0-6 PASS 呈现：文件名 + 打开命令 + 下一步（0902 R3-b：绝对路径进诊断层）", async () => {
 	const { renderTerminalReply } = await import(
 		"../src/native/terminal-presenter.js"
 	);
@@ -30,10 +30,25 @@ test("P0-6 PASS 呈现：文件名 + 绝对路径 + 打开命令 + 下一步", a
 	assert.match(reply, /任务完成/);
 	// 文件名（basename）。
 	assert.match(reply, /star-scene\.gif/);
-	// 绝对路径全文。
-	assert.match(reply, /\/home\/u\/proj\/outputs\/star-scene\.gif/);
 	// 打开命令仍在。
 	assert.match(reply, /rosclaw artifact open art_g/);
+	// 0902 R3-b：默认层不裸打绝对路径（内部路径进 verbose 诊断层）；
+	// 可达性由 open/path/export 命令承接。
+	assert.doesNotMatch(reply, /\/home\/u\/proj\/outputs\/star-scene\.gif/);
+	const verbose = renderTerminalReply({
+		verification: "PASS",
+		delivery: "DELIVERED",
+		artifact_refs: [
+			{
+				artifact_id: "art_g",
+				path: "/home/u/proj/outputs/star-scene.gif",
+				media_type: "image/gif",
+				size_bytes: 1234567,
+				open_command: "rosclaw artifact open art_g",
+			},
+		],
+	}, { verbose: true });
+	assert.match(verbose, /\/home\/u\/proj\/outputs\/star-scene\.gif/);
 	// 下一步指引。
 	assert.match(reply, /下一步/);
 });

--- a/packages/rosclaw-agent/test/a0902-r3b-terminal-layer.test.ts
+++ b/packages/rosclaw-agent/test/a0902-r3b-terminal-layer.test.ts
@@ -1,0 +1,67 @@
+/** 0902 R3-b 红测试（§6.1 三层界面）：终态卡默认层不显示内部
+ *  绝对路径——文件名 + 大小 + 短打开命令；完整路径进诊断层
+ *  （verbose）/ `rosclaw artifact path`。
+ *
+ * 0902 实证：任务卡给普通用户看 /home/ubuntu/.rosclaw/sim/traces/
+ * trace_xxx/trace.json 这种内部路径——内部复杂度成了用户负担。
+ * 0901 P0-6 的"必须看到绝对路径"由 open/path/export 命令承接
+ * （可达性不丢），默认层不再裸打路径。
+ *
+ * 闭环断言：
+ * 1. 默认：文件名 + 大小 + rosclaw open 短命令在；绝对路径不在；
+ * 2. verbose：绝对路径仍在（诊断层保留）；
+ * 3. 失败卡的"原因逐条"不受影响（0901 P0-6 红线保留）。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const REF = {
+	artifact_id: "art_g",
+	path: "/home/u/.rosclaw/sim/traces/trace_abc/trace_abc-scene.gif",
+	media_type: "image/gif",
+	size_bytes: 1234567,
+	open_command: "rosclaw open art_g",
+};
+
+test("R3-b 默认层：文件名+大小+短命令在，内部绝对路径不在", async () => {
+	const { renderTerminalReply } = await import(
+		"../src/native/terminal-presenter.js"
+	);
+	const reply = renderTerminalReply({
+		verification: "PASS",
+		delivery: "DELIVERED",
+		artifact_refs: [REF],
+	});
+	assert.match(reply, /trace_abc-scene\.gif/); // 文件名
+	assert.match(reply, /1\.2 MB/); // 大小
+	assert.match(reply, /rosclaw open art_g/); // 短打开命令
+	assert.doesNotMatch(reply, /\/home\/u\/\.rosclaw\/sim\/traces/, // 内部路径不进默认层
+		"默认层仍裸打内部绝对路径");
+});
+
+test("R3-b 诊断层（verbose）：绝对路径保留", async () => {
+	const { renderTerminalReply } = await import(
+		"../src/native/terminal-presenter.js"
+	);
+	const reply = renderTerminalReply({
+		verification: "PASS",
+		delivery: "DELIVERED",
+		artifact_refs: [REF],
+	}, { verbose: true });
+	assert.match(reply, /\/home\/u\/\.rosclaw\/sim\/traces\/trace_abc\/trace_abc-scene\.gif/);
+});
+
+test("R3-b 失败卡原因逐条不受影响（0901 P0-6 红线）", async () => {
+	const { renderTerminalReply } = await import(
+		"../src/native/terminal-presenter.js"
+	);
+	const reply = renderTerminalReply({
+		verification: "FAIL",
+		delivery: "MISSING",
+		artifact_refs: [],
+		repair_directive: { failures: ["TRACKING_ERROR: 超阈值"] },
+	});
+	assert.match(reply, /原因/);
+	assert.match(reply, /TRACKING_ERROR/);
+});

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1648,23 +1648,23 @@ class TestProductJourney:
             )
             self._journey_verdicts["auto_route_zero_model_turns"] = True
             action_segment = session.clean[action_start:]
-            # 0901 P0-6（终态呈现产品化）：终态卡必须有 交付物文件名 +
-            # 绝对路径 + 打开命令 + 下一步——一行结论不是产品（用户
-            # 看完不知道该干嘛）。内部 customType 标签（[rosclaw.xxx]）
-            # 绝不上屏——协议细节不是用户界面。
-            assert "下一步".encode() in action_segment, (
-                "终态卡缺下一步指引（P0-6 产品化未生效）"
-            )
-            # 绝对路径行（裸路径——无标签，防 CJK 换行撕裂）。
             import re as _re
 
-            assert _re.search(rb"/[\w./-]*\.gif", action_segment), (
-                "终态卡缺交付物绝对路径"
+            # 0901 P0-6 + 0902 R3-b（§6.1 三层界面）：终态卡默认层
+            # 必须有 交付物文件名 + 打开命令 + 下一步——且不得裸打
+            # 内部绝对路径（sim/traces/trace_* 是诊断层内容；可达性
+            # 由 rosclaw open/path/export 承接）。内部 customType
+            # 标签（[rosclaw.xxx]）绝不上屏。
+            assert "下一步".encode() in action_segment, (
+                "终态卡缺下一步指引（P0-6 产品化未生效）"
             )
             assert b"rosclaw artifact open" in action_segment, (
                 "终态卡缺打开命令"
             )
             assert b".gif" in action_segment, "终态卡缺交付物文件名"
+            assert not _re.search(rb"/[\w./-]*sim/traces/", action_segment), (
+                "终态卡默认层裸打内部 trace 路径（0902 §6.1 违规）"
+            )
             assert b"[rosclaw." not in action_segment, (
                 "内部 customType 标签漏到屏幕——渲染卡未注册"
             )


### PR DESCRIPTION
## 背景（0902 审计 §6.1）
普通用户不得看到 `/home/ubuntu/.rosclaw/sim/traces/...` 这类内部路径——内部复杂度不能成为用户负担。0901 P0-6 的"必须看到绝对路径"由 open/path/export 命令承接（可达性不丢），默认层不再裸打。

## 实现
- `renderTerminalReply(outcome, { verbose })`：默认层 = 文件名+大小+短打开命令；绝对路径只在 verbose（诊断层 /activity）出现。
- journey 终态卡断言随 §6.1 演进：文件名+打开命令+下一步必须在；sim/traces 内部路径必须不在（0901 旧断言与新分层冲突，0902 指令为准）。

## 红→绿证据
- tests/a0902-r3b-terminal-layer.test.ts：默认层无路径/verbose 有路径/失败卡原因红线。先红后绿。
- journey A 全绿（180s），新断言生效；TS 全量 219/0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)