### PR TITLE
0902 R2-3: 需求驱动能力组合——轨迹叠加要求真实交付，覆盖表诚实扩展

### DIFF
--- a/src/rosclaw/agentd/plan_templates.py
+++ b/src/rosclaw/agentd/plan_templates.py
@@ -150,6 +150,18 @@ def draw_path_recipe(
         d.get("kind") == "scene_video" and d.get("required")
         for d in (spec.get("deliverables") or [])
     )
+    # R2-3（0902 §4.3）：需求驱动 overlay——任务要求"显示实际轨迹"
+    # 时场景渲染必须带 actual_eef_trace overlay（RenderSpec 链），
+    # 且场景渲染因此成为必需（overlay 画在场景视频上）。
+    requirements = spec.get("requirements") or []
+    overlay_trace_required = any(
+        str(r.get("verifier") or "") == "receipt.overlays.actual_eef_trace"
+        and str(r.get("level") or "") == "must"
+        for r in requirements
+        if isinstance(r, dict)
+    )
+    if overlay_trace_required:
+        scene_required = True
 
     def h_resolve(inputs_: dict) -> dict:
         return {"ResourceRef": {"body_ref": canonical_resource_id(body_id)}}
@@ -262,11 +274,32 @@ def draw_path_recipe(
         trace = inputs_["TraceRef"]
         trace_id = trace["trace_id"]
         try:
-            result = render_scene_trace(
-                home, trace_id,
-                world_id=scene_world or "empty",
-                tool_ref=scene_tool,
-            )
+            if overlay_trace_required:
+                # R2-3：RenderSpec 驱动——overlay 证据绑定到本次
+                # trace（render_from_spec 父进程校验，旧证据冒充
+                # 会被 RENDER_EVIDENCE_MISMATCH 拒）。
+                from rosclaw.agentd.sim_render import render_from_spec
+                from rosclaw.contracts.agent.render_spec import RenderSpecV1
+
+                result = render_from_spec(
+                    home,
+                    RenderSpecV1(
+                        body_ref=f"robot:{body_id}",
+                        world_ref=f"world:{scene_world or 'empty'}",
+                        overlays=[{
+                            "kind": "actual_eef_trace",
+                            "source_ref": f"trace:{trace_id}",
+                        }],
+                        outputs=["gif", "mp4"],
+                    ),
+                    trace_id,
+                )
+            else:
+                result = render_scene_trace(
+                    home, trace_id,
+                    world_id=scene_world or "empty",
+                    tool_ref=scene_tool,
+                )
         except ValueError as exc:
             return {
                 "SceneRef": {

--- a/src/rosclaw/task_kernel/requirement_check.py
+++ b/src/rosclaw/task_kernel/requirement_check.py
@@ -158,11 +158,15 @@ def _check_one(req: dict[str, Any], *, receipts: list[dict[str, Any]],
         if not receipts:
             return _done(UNVERIFIABLE, "无 render receipt 可核对轨迹叠加")
         for r in receipts:
-            overlays = r.get("overlays")
+            # R2-2 渲染器回写 overlays_applied（真实绘制的 overlay——
+            # 宣称与画面一致）；overlays 为旧键兼容。
+            overlays = r.get("overlays_applied")
+            if not isinstance(overlays, list):
+                overlays = r.get("overlays")
             if isinstance(overlays, list) and "actual_eef_trace" in overlays:
-                return _done(SATISFIED, "overlays 含 actual_eef_trace")
-        if any("overlays" in r for r in receipts):
-            return _done(VIOLATED, "receipt.overlays 不含实际轨迹")
+                return _done(SATISFIED, "overlays_applied 含 actual_eef_trace")
+        if any(("overlays_applied" in r or "overlays" in r) for r in receipts):
+            return _done(VIOLATED, "receipt.overlays_applied 不含实际轨迹")
         return _done(UNVERIFIABLE,
                      "receipt 无 overlays 字段——渲染器尚不支持轨迹叠加")
     if verifier == "render.tool_color":
@@ -199,6 +203,7 @@ def check_requirements(
     requirements: list[dict[str, Any]],
     artifacts: list[dict[str, Any]],
     embodied: bool = True,
+    receipts: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """逐条验收。artifacts 必须是当前 revision 的产物集（R0-1）。
 
@@ -211,7 +216,7 @@ def check_requirements(
         return []
     from rosclaw.task_kernel.deliverables import artifact_delivery_kind
 
-    receipts = _load_receipts(artifacts)
+    receipts = receipts if receipts is not None else _load_receipts(artifacts)
     plan = _load_plan(home, artifacts)
     kinds = {artifact_delivery_kind(a) for a in artifacts}
     media = {str(a.get("media_type") or "") for a in artifacts}

--- a/src/rosclaw/task_kernel/task_router.py
+++ b/src/rosclaw/task_kernel/task_router.py
@@ -42,10 +42,13 @@ RECIPE_COVERAGE: dict[str, frozenset[str]] = {
         # 交付：3D 场景视频 + 2D 预览 + 实际轨迹数据。
         "deliverable.scene_3d", "deliverable.video",
         "deliverable.preview_2d", "trace.actual",
+        # R2-3（渲染器已支持，有实现才覆盖）：场景渲染按任务要求
+        # 带 actual_eef_trace overlay（RenderSpec 证据绑定到本次
+        # trace）；3D 场景视频在账即满足"不要只有 2D"禁止项。
+        "receipt.overlays.actual_eef_trace", "delivery.not_2d_only",
         # 不覆盖（——出现即转 Native Agent）：receipt.tool_ref（挂载
-        # 工具）、render.tool_color（颜色）、receipt.overlays.*（轨迹
-        # 叠加）、delivery.not_2d_only（禁止项）、verification.contact
-        # （接触）、未知形状。
+        # 工具，无资产）、render.tool_color（颜色无证据通道）、
+        # verification.contact（无接触验证器）、未知形状。
     }),
 }
 

--- a/tests/agentd/test_a0902_r02_requirement_coverage.py
+++ b/tests/agentd/test_a0902_r02_requirement_coverage.py
@@ -106,19 +106,22 @@ class TestCoverageGate:
         assert not result.get("auto_task"), result
         assert tasks == 0, f"未覆盖竟建了任务（幽灵任务）: {tasks}"
 
-    async def test_trace_overlay_blocks_autoroute(self, tmp_path: Path) -> None:
+    async def test_trace_overlay_now_auto_routes(self, tmp_path: Path) -> None:
+        """R2-3：渲染器已支持 actual_eef_trace overlay（render_from_spec
+        证据绑定）——该要求被 recipe 真实覆盖，自动路由。"""
         result, tasks = await self._persist(
             tmp_path, "画五角星视频，在 3D 画面里显示本次实际轨迹", "m1"
         )
-        assert not result.get("auto_task"), result
-        assert tasks == 0
+        assert result.get("auto_task"), result
+        assert tasks == 1
 
-    async def test_forbid_2d_blocks_autoroute(self, tmp_path: Path) -> None:
+    async def test_forbid_2d_now_auto_routes(self, tmp_path: Path) -> None:
+        """R2-3：3D 场景视频在账即满足"不要只有 2D"禁止项——自动路由。"""
         result, tasks = await self._persist(
             tmp_path, "画五角星，不要 2D", "m1"
         )
-        assert not result.get("auto_task"), result
-        assert tasks == 0
+        assert result.get("auto_task"), result
+        assert tasks == 1
 
     async def test_unknown_shape_blocks_autoroute(self, tmp_path: Path) -> None:
         result, tasks = await self._persist(

--- a/tests/agentd/test_a0902_r2c_requirement_overlays.py
+++ b/tests/agentd/test_a0902_r2c_requirement_overlays.py
@@ -1,0 +1,148 @@
+"""0902 审计 R2-3 红测试：需求驱动的能力组合——overlay 要求让
+draw_path recipe 走 RenderSpec 渲染（§4.3/R2.3），不再是"recipe
+覆盖表与实现两张皮"。
+
+0902 事故的完整闭环：用户说"在 3D 画面里显示本次实际轨迹，不要
+2D"——R0-2 门禁此前把它挡在 recipe 外（交模型），因为渲染器根本
+不支持 overlay；R2-2 渲染器支持后，recipe 必须真实交付 overlay
+（不是改表宣称覆盖）。
+
+闭环断言：
+1. 端到端：任务 spec 带 receipt.overlays.actual_eef_trace 要求 →
+   recipe 场景渲染走 render_from_spec → receipt.overlays_applied
+   含 actual_eef_trace → finish_task 逐条 verdict SATISFIED →
+   任务 SUCCEEDED（真 PASS，不是宣称）；
+2. requirement_check 读 receipt 的 overlays_applied（R2-2 的诚实
+   字段名）——旧 overlays 键兼容；
+3. 覆盖表诚实扩展：RECIPE_COVERAGE[recipe:sim.draw_path] 现在含
+   receipt.overlays.actual_eef_trace 与 delivery.not_2d_only——
+   有实现才覆盖；
+4. 门禁行为更新（R0-2 测试随能力演进）：轨迹叠加/不要 2D 现在
+   自动路由（能力真实存在）；持笔/颜色/接触仍不路由（无资产/
+   无证据通道——诚实边界不动）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+
+class TestOverlayRequirementEndToEnd:
+    async def test_overlay_requirement_delivered_and_verified(
+        self, tmp_path: Path
+    ) -> None:
+        """轨迹叠加要求 → recipe 真实交付（receipt 证据）→ 逐条
+        verdict SATISFIED → SUCCEEDED。"""
+        from rosclaw.agentd.auto_route import reset_routed_for_tests
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        reset_routed_for_tests()
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await bridge._dispatch(
+            "user:local:1000", 1, "pi.input.persist",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "session_ref": "pi_1",
+                "message_id": "msg_overlay_1",
+                # 圆形（非五角星——通用性证据）+ 轨迹叠加 + 不要 2D。
+                "text": "画一个圆形轨迹，在 3D 画面里显示本次实际轨迹，不要 2D",
+            },
+        )
+        assert result.get("ok"), result
+        auto = result.get("auto_task")
+        assert auto, f"overlay 要求已可覆盖——仍被挡在 recipe 外: {result}"
+        kernel = service._task_kernel
+        task_id = str(auto["task_id"])
+        deadline = asyncio.get_event_loop().time() + 300
+        while asyncio.get_event_loop().time() < deadline:
+            task = kernel.get_task(task_id)
+            if task and task["state"] in ("SUCCEEDED", "FAILED", "REPAIR_REQUIRED"):
+                break
+            await asyncio.sleep(2)
+        task = kernel.get_task(task_id)
+        assert task["state"] == "SUCCEEDED", (
+            f"终态 {task['state']}：{task.get('terminal_reason')}"
+        )
+        # receipt 证据：场景渲染的 overlays_applied 含实际轨迹。
+        receipts = list(
+            (tmp_path / "sim" / "traces").glob("*/render_receipt.json")
+        )
+        assert receipts, "无 render receipt"
+        applied = [
+            o for r in receipts
+            for o in (json.loads(r.read_text()).get("overlays_applied") or [])
+        ]
+        assert "actual_eef_trace" in applied, f"overlay 未真实绘制: {applied}"
+        # 逐条 verdict（验收行 checks_json 的 requirement_coverage——
+        # 在 verifications 表，不在任务行）。
+        row = kernel._conn.execute(
+            "SELECT checks_json FROM verifications WHERE task_id = ? "
+            "ORDER BY created_at DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        checks = json.loads(row["checks_json"] if row else "{}")
+        coverage = checks.get("requirement_coverage") or []
+        overlay_req = next(
+            (c for c in coverage
+             if c.get("verifier") == "receipt.overlays.actual_eef_trace"),
+            None,
+        )
+        assert overlay_req, f"验收缺 overlay 条款: {coverage}"
+        assert overlay_req["status"] == "SATISFIED", overlay_req
+        await service.close()
+
+
+class TestOverlayVerifierField:
+    def test_overlays_applied_field_read(self) -> None:
+        from rosclaw.task_kernel.requirement_check import check_requirements
+
+        receipt = {"overlays_applied": ["actual_eef_trace"]}
+        verdicts = check_requirements(
+            home=Path("/nonexistent-home"),
+            requirements=[{"req_id": "r1", "level": "must", "claim": "x",
+              "verifier": "receipt.overlays.actual_eef_trace"}],
+            artifacts=[],
+            receipts=[receipt],
+        )
+        assert verdicts[0]["status"] == "SATISFIED", verdicts
+
+    def test_overlays_absent_is_violated(self) -> None:
+        from rosclaw.task_kernel.requirement_check import check_requirements
+
+        verdicts = check_requirements(
+            home=Path("/nonexistent-home"),
+            requirements=[{"req_id": "r1", "level": "must", "claim": "x",
+              "verifier": "receipt.overlays.actual_eef_trace"}],
+            artifacts=[],
+            receipts=[{"overlays_applied": []}],
+        )
+        assert verdicts[0]["status"] == "VIOLATED", verdicts
+
+
+class TestCoverageTableHonesty:
+    def test_draw_path_covers_overlay_and_not_2d(self) -> None:
+        from rosclaw.task_kernel.task_router import RECIPE_COVERAGE
+
+        coverage = RECIPE_COVERAGE["recipe:sim.draw_path"]
+        assert "receipt.overlays.actual_eef_trace" in coverage
+        assert "delivery.not_2d_only" in coverage
+
+    def test_tool_color_contact_still_uncovered(self) -> None:
+        """无资产/无证据通道的条款仍不覆盖（诚实边界不动）。"""
+        from rosclaw.task_kernel.task_router import RECIPE_COVERAGE
+
+        coverage = RECIPE_COVERAGE["recipe:sim.draw_path"]
+        assert "receipt.tool_ref" not in coverage
+        assert "render.tool_color" not in coverage
+        assert "verification.contact" not in coverage
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 背景（0902 审计 R2.3 + 事故闭环）
0902 假成功事故的最后一块：用户说「在 3D 画面里显示本次实际轨迹，不要 2D」——R0-2 门禁把它挡在 recipe 外（交模型），因为渲染器根本不支持 overlay。R2-2（#500）渲染器支持后，recipe 必须真实交付 overlay（不是改表宣称覆盖）。

## 实现
- draw_path recipe 读任务 spec requirements：must 级 `receipt.overlays.actual_eef_trace` → 场景渲染走 `render_from_spec`（RenderSpec 证据绑定到本次 trace），场景渲染因此成为必需节点。
- 覆盖表随实现诚实扩展：`RECIPE_COVERAGE[recipe:sim.draw_path]` 新增 `receipt.overlays.actual_eef_trace` + `delivery.not_2d_only`；持笔/颜色/接触仍不覆盖（无资产/无证据通道——诚实边界不动，0902 假成功通道保持关闭）。
- requirement_check 读 receipt 的 `overlays_applied`（R2-2 诚实字段名），旧 `overlays` 键兼容。

## 红→绿证据
- tests/agentd/test_a0902_r2c_requirement_overlays.py 5/5（先红）：端到端「画一个圆形轨迹+显示实际轨迹+不要 2D」→ 自动路由 → 真实渲染（receipt overlays_applied 含 actual_eef_trace）→ 逐条 verdict SATISFIED → SUCCEEDED；verifier 字段读写；覆盖表含/不含断言。
- R0-2 门禁测试随能力演进：轨迹叠加/不要 2D 从「阻断」翻转为「自动路由」；持笔仍阻断 + 零幽灵任务。
- 回归：r02/r03/r015/r01/p1c2/wp4/p1c3 全绿；journey A 全绿（revision 假成功腿保持模型路径）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)