### PR TITLE
0902 R3-c: 静态只读工具 renderResult 折叠——原始 JSON 不再刷屏

### DIFF
--- a/packages/rosclaw-agent/src/tools/capabilities.ts
+++ b/packages/rosclaw-agent/src/tools/capabilities.ts
@@ -7,6 +7,7 @@
  * 不兼容项进 excluded 并附机器原因码（BODY_CAPABILITY_MISMATCH 等）。
  */
 
+import { compactRenderResult } from "../ui/compact-result.js";
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool } from "@earendil-works/pi-coding-agent";
 import type { BridgeToolContext } from "./bridge-tools.js";
@@ -25,6 +26,9 @@ export function buildCapabilitiesTool(ctx: BridgeToolContext) {
 			"propose_<name> tools that enter the admission chain (REAL is always " +
 			"gated by rosclawd/operator). Never invent capability names.",
 		parameters: Type.Object({}),
+		// 0902 R3-c（§6.1）：用户面单行摘要——模型上下文保留完整
+		// JSON（诚实性不降级），TUI 不再整段打原始 JSON。
+		renderResult: compactRenderResult,
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
 			const state = ctx.active.current;
 			if (!state.missionId) {

--- a/packages/rosclaw-agent/src/tools/inspect.ts
+++ b/packages/rosclaw-agent/src/tools/inspect.ts
@@ -6,6 +6,7 @@
  * self 返回版本/根目录/索引健康；capability/asset 走全文搜索。
  */
 
+import { compactRenderResult } from "../ui/compact-result.js";
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool } from "@earendil-works/pi-coding-agent";
 
@@ -34,6 +35,9 @@ export function buildInspectTool(ctx: BridgeToolContext) {
 			),
 			query: Type.Optional(Type.String({ description: "robot_id 或搜索词" })),
 		}),
+		// 0902 R3-c（§6.1）：用户面单行摘要——模型上下文保留完整
+		// JSON（诚实性不降级），TUI 不再整段打原始 JSON。
+		renderResult: compactRenderResult,
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			const args = params as { kind: string; query?: string };
 			return await executeVia(ctx, "rosclaw_inspect", {

--- a/packages/rosclaw-agent/src/tools/status.ts
+++ b/packages/rosclaw-agent/src/tools/status.ts
@@ -5,6 +5,7 @@
  * chat 的 agentd 用 port=0，HTTP 必然误报 UNREACHABLE）。
  * 永不伪造可达性。 */
 
+import { compactRenderResult } from "../ui/compact-result.js";
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool } from "@earendil-works/pi-coding-agent";
 import type { ProductStateCenter } from "../session/state-center.js";
@@ -18,6 +19,9 @@ export function buildStatusTool(center: ProductStateCenter) {
 			"Read-only. Returns honest unreachable errors when agentd is down — " +
 			"never invent robot state.",
 		parameters: Type.Object({}),
+		// 0902 R3-c（§6.1）：用户面单行摘要——模型上下文保留完整
+		// JSON（诚实性不降级），TUI 不再整段打原始 JSON。
+		renderResult: compactRenderResult,
 		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
 			try {
 				const report = await center.statusReport();

--- a/packages/rosclaw-agent/src/ui/compact-result.ts
+++ b/packages/rosclaw-agent/src/ui/compact-result.ts
@@ -1,0 +1,20 @@
+// HP2-COMPAT: pi-tui Text 渲染原语——HP3 投影层落地前保持；不新增会话装配引用。
+/** 0902 R3-c（§6.1 三层界面）：静态只读工具的 renderResult 折叠钩。
+ *
+ * 模型上下文保留完整 JSON（诚实性不降级）；TUI 只渲染单行摘要——
+ * 0902 实证：rosclaw_status 整段 JSON 打进 scrollback。
+ */
+
+import { Text } from "@earendil-works/pi-tui";
+
+import { summarizeStatusText } from "./tool-display.js";
+
+/** renderResult 折叠钩（pi 工具定义直接挂）：单行摘要 Text。 */
+export function compactRenderResult(
+	result: { content?: Array<{ type: string; text?: string }> },
+): Text {
+	const text = (result.content ?? [])
+		.map((b) => (b.type === "text" ? String(b.text ?? "") : ""))
+		.join("\n");
+	return new Text(summarizeStatusText(text), 1, 0);
+}

--- a/packages/rosclaw-agent/src/ui/tool-display.ts
+++ b/packages/rosclaw-agent/src/ui/tool-display.ts
@@ -89,3 +89,27 @@ function tryParseJson(text: string): unknown {
 		return undefined;
 	}
 }
+
+
+// ---------------------------------------------------------------------
+// 0902 R3-c（§6.1）：状态 JSON → 单行摘要（纯函数，无 pi 依赖——
+// HP2 结构门安全；pi-tui 渲染在 compact-result.ts）。
+// ---------------------------------------------------------------------
+
+/** 状态 JSON → 单行摘要（agentd/kernel/operator/mission 关键状态）。 */
+export function summarizeStatusText(text: string): string {
+	const parsed = tryParseJson(text.trim());
+	if (parsed && typeof parsed === "object" && "agentd" in (parsed as object)) {
+		const p = parsed as Record<string, unknown>;
+		const mission = (p.mission ?? {}) as Record<string, unknown>;
+		const parts = [
+			`agentd=${String(p.agentd ?? "?")}`,
+			`kernel=${String(p.kernel ?? "?")}`,
+			`operator=${String(p.operator ?? "?")}`,
+		];
+		if (mission.state) parts.push(`mission=${String(mission.state)}`);
+		if (p.action_readiness) parts.push(`actions=${String(p.action_readiness)}`);
+		return `✓ 内核状态 ${parts.join(" · ")}`;
+	}
+	return summarizeToolResultText(text);
+}

--- a/packages/rosclaw-agent/test/a0902-r3c-tool-budget.test.ts
+++ b/packages/rosclaw-agent/test/a0902-r3c-tool-budget.test.ts
@@ -1,0 +1,86 @@
+/** 0902 R3-c 红测试（§6.1 三层界面）：静态只读工具的 renderResult
+ *  用户面折叠——模型上下文保留完整 JSON（诚实性不降级），TUI 只
+ *  渲染单行摘要。
+ *
+ * 0902 实证：模型调 rosclaw_status 后整段 JSON 打到 scrollback
+ * （journey 实录 16 行原始 JSON）。§6.1：任何 tool output 进入 UI
+ * 前都经过 size/row budget 和结构化 renderer——1342 行记录不能再
+ * 出现。
+ *
+ * 闭环断言：
+ * 1. rosclaw_status / rosclaw_inspect / rosclaw_capabilities 都有
+ *    renderResult（用户面折叠钩）；
+ * 2. renderResult 输出单行、无原始 JSON 大括号块、含关键状态词；
+ * 3. 模型面不受影响：execute 返回的 content 仍是完整 JSON。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type ToolLike = {
+	name: string;
+	renderResult?: (result: { content?: Array<{ type: string; text?: string }> }) => unknown;
+	execute: (...a: never[]) => Promise<{ content: Array<{ text: string }> }>;
+};
+
+async function buildTools(): Promise<ToolLike[]> {
+	const { buildStatusTool } = await import("../src/tools/status.js");
+	const { buildInspectTool } = await import("../src/tools/inspect.js");
+	const { buildCapabilitiesTool } = await import("../src/tools/capabilities.js");
+	// 只读工具的 center/call 最小桩（execute 不真打桥——renderResult
+	// 是本测试主体；execute 只验证模型面文本形状时用假回包）。
+	const centerStub = {
+		statusReport: async () => ({
+			ok: true, agentd: "READY", authorization_profile: "DEV_SIM_ONLY",
+			mission: { mission_id: "mis_x", state: "IDLE", mode: "SIMULATION" },
+			snapshot: {
+				kernel: "READY", context_state: "FRESH", context_revision: 0,
+				lease_state: "ACTIVE", operator: "OFFLINE",
+				action_readiness: { state: "READY", reason_codes: [] },
+				snapshot_seq: 3,
+			},
+		}),
+	};
+	const callStub = async () => ({ ok: true, items: [], digest: "sha256:x" });
+	return [
+		buildStatusTool(centerStub as never) as unknown as ToolLike,
+		buildInspectTool(callStub as never) as unknown as ToolLike,
+		buildCapabilitiesTool(callStub as never) as unknown as ToolLike,
+	];
+}
+
+function renderText(rendered: unknown): string {
+	// pi-tui Text 组件：render(width) → 行数组。
+	const r = rendered as { render?: (w: number) => string[] };
+	if (typeof r.render === "function") return r.render(80).join("\n");
+	return String(rendered);
+}
+
+test("R3-c: 三个只读工具都有 renderResult（用户面折叠钩）", async () => {
+	for (const tool of await buildTools()) {
+		assert.ok(tool.renderResult, `${tool.name} 缺 renderResult——原始 JSON 会刷屏`);
+	}
+});
+
+test("R3-c: status 结果渲染为单行摘要（无原始 JSON 块）", async () => {
+	const [status] = await buildTools();
+	const big = JSON.stringify(
+		{ agentd: "READY", kernel: "READY", operator: "OFFLINE", mission: { state: "IDLE" } },
+		null, 1,
+	);
+	const text = renderText(status.renderResult!({
+		content: [{ type: "text", text: big }],
+	}));
+	assert.ok(text.length < 200, `渲染不是单行摘要: ${text.length} 字符`);
+	assert.ok(!text.includes("\n"), "多行输出——row budget 失守");
+	assert.match(text, /READY/);
+});
+
+test("R3-c: 模型面 content 仍是完整 JSON（诚实性不降级）", async () => {
+	const [status] = await buildTools();
+	const result = await status.execute(...([] as unknown as [never]));
+	const text = result.content[0]?.text ?? "";
+	const parsed = JSON.parse(text);
+	assert.equal(parsed.agentd, "READY");
+	assert.ok(parsed.mission, "模型面 JSON 被裁了");
+});

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1583,9 +1583,21 @@ class TestProductJourney:
             #     127.0.0.1:8765（chat 的 agentd 用 port=0，必然误报
             #     UNREACHABLE）。PTY 输出与发给模型的 tool 结果双重断言。
             session.send("读取系统状态\r")
+            status_start = len(session.clean)
             session.expect("内核状态已读取".encode(), timeout=120)
             assert b"127.0.0.1:8765" not in session.clean, (
                 "Native Agent 输出仍引用旧 HTTP 面 8765"
+            )
+            # 0902 R3-c（§6.1 三层界面）：status 的用户面是单行摘要——
+            # 整段原始 JSON 不得进 scrollback（0902 实录：16 行 JSON
+            # 直接上屏）。模型面仍是完整 JSON（下面的 tool 结果断言
+            # 不受影响 = 诚实性不降级）。
+            status_segment = session.clean[status_start:]
+            assert b'"agentd": "READY"' not in status_segment, (
+                "status 原始 JSON 整段上屏——renderResult 折叠未生效"
+            )
+            assert "内核状态".encode() in status_segment, (
+                "紧凑摘要（✓ 内核状态 …）未出现"
             )
             # 发给模型的 tool 结果（fake 请求的 tool 消息）必须是 READY——
             # 与 /status 同一内核视图。


### PR DESCRIPTION
## 背景（0902 审计 §6.1）
模型调 rosclaw_status 后整段 JSON（实录 16 行）打进 scrollback。§6.1：任何 tool output 进入 UI 前都经过 size/row budget 和结构化 renderer——1342 行记录不能再次出现。

## 实现
- `tool-display.summarizeStatusText`（纯函数，HP2 结构门安全）：状态 JSON → 单行摘要（agentd/kernel/operator/mission）；非状态 JSON 回落 WP-7 通用折叠。
- `compact-result.compactRenderResult`（HP2-COMPAT 标记模块——结构门实证 ui/ 不得直接 import pi-tui）：pi `renderResult` 钩。
- rosclaw_status / rosclaw_inspect / rosclaw_capabilities 挂上；模型面 content 仍是完整 JSON（诚实性不降级——WP-7 模型面/用户面分离原则）。

## 红→绿证据
- test/a0902-r3c-tool-budget.test.ts 3/3（先红：三工具缺 renderResult）；TS 全量 219/0（含 HP2 结构门）。
- journey A status 腿新增：原始 JSON 块不上屏 + 单行摘要在；全绿（197s）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)