### PR TITLE
0902 R3-d: Task Panel 按 o 打开交付物（模态内按键，不劫持输入）

### DIFF
--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -9,6 +9,7 @@
 import type { ExtensionContext, ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { readFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { ActiveSessionContext } from "../session/active-context.js";
 import type { AgentSessionCoordinator } from "../session/coordinator.js";
@@ -893,6 +894,13 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					},
 					notify: (text, kind) => notifyLeveled(ctx, text, kind),
 					onClose: () => done(true),
+					// 0902 R3-d（§6.2）：按 o 打开交付物——图形环境
+					// 探测（xdg-open 存在才注入；否则组件内诚实提示）。
+					openArtifact: spawnSync("which", ["xdg-open"]).status === 0
+						? (path: string) => {
+							spawn("xdg-open", [path], { detached: true, stdio: "ignore" }).unref();
+						}
+						: undefined,
 				});
 			}, { overlay: true });
 		};

--- a/packages/rosclaw-agent/src/workers/tasks-center.ts
+++ b/packages/rosclaw-agent/src/workers/tasks-center.ts
@@ -27,6 +27,9 @@ export interface TasksCenterDeps {
 	fetchArtifacts: (taskId: string) => Promise<Array<Record<string, unknown>>>;
 	notify: (text: string, kind: "info" | "warning" | "error") => void;
 	onClose: () => void;
+	/** 0902 R3-d（§6.2）：按 o 打开交付物（宿主注入——xdg-open
+	 *  等；无图形环境由宿主诚实告知）。 */
+	openArtifact?: (path: string) => void;
 }
 
 const POLL_MS = 2000;
@@ -57,6 +60,7 @@ export class TasksCenterComponent implements Component {
 	private tab: Tab = "Activity";
 	private showHelp = false;
 	private lines: string[] = [];
+	private artifacts: Array<Record<string, unknown>> = [];
 	private timer: ReturnType<typeof setInterval> | undefined;
 	private disposed = false;
 
@@ -96,7 +100,8 @@ export class TasksCenterComponent implements Component {
 			this.lines = renderTaskActivity(await this.deps.fetchEvents(taskId));
 			return;
 		}
-		this.lines = renderArtifactList(await this.deps.fetchArtifacts(taskId));
+		this.artifacts = await this.deps.fetchArtifacts(taskId);
+		this.lines = renderArtifactList(this.artifacts);
 	}
 
 	handleInput(data: string): void {
@@ -130,6 +135,29 @@ export class TasksCenterComponent implements Component {
 			void this.pollContent();
 			return;
 		}
+		// 0902 R3-d（§6.2）：Artifacts 页按 o 打开当前任务首个媒体
+		// 交付物（gif/mp4 优先——用户要的是视频；无媒体则第一条例
+		// 外诚实提示）。宿主注入 openArtifact（无图形环境宿主告知）。
+		if (key === "o") {
+			const media = this.artifacts.find((a) =>
+				String(a.media_type ?? "").startsWith("image/")
+				|| String(a.media_type ?? "").startsWith("video/")
+			) ?? this.artifacts[0];
+			const path = String(media?.path ?? "");
+			if (!path) {
+				this.deps.notify("该任务无交付物可打开", "info");
+				return;
+			}
+			if (!this.deps.openArtifact) {
+				this.deps.notify(
+					`本机无图形环境——rosclaw artifact path 取路径：${path.split("/").pop()}`,
+					"info",
+				);
+				return;
+			}
+			this.deps.openArtifact(path);
+			return;
+		}
 		if (key === "?") {
 			this.showHelp = !this.showHelp;
 			return;
@@ -156,7 +184,7 @@ export class TasksCenterComponent implements Component {
 			out.push("│ F2/Esc 关闭 · ↑↓ 选择 · Tab 切 Activity/Artifacts · r 刷新 · a 产物");
 			out.push("│ 任务由对话驱动：修改目标直接说，验收用 /done——面板只读");
 		} else {
-			out.push("│ ↑↓选择 Tab切页 r刷新 ?帮助 Esc关闭");
+			out.push("│ ↑↓选择 Tab切页 r刷新 o打开交付物 ?帮助 Esc关闭");
 		}
 		out.push(`└${border}┘`);
 		return out;

--- a/packages/rosclaw-agent/test/tasks-center.test.ts
+++ b/packages/rosclaw-agent/test/tasks-center.test.ts
@@ -88,3 +88,34 @@ describe("H9 Task Panel（kernel 背板）", () => {
 		panel.dispose();
 	});
 });
+
+describe("0902 R3-d：面板内按 o 打开交付物（§6.2 任务卡直接打开）", () => {
+	it("Artifacts 页按 o → 打开当前任务首个媒体交付物", async () => {
+		const opened: string[] = [];
+		const deps = makeDeps(TASKS);
+		deps.openArtifact = (path: string) => { opened.push(path); };
+		const panel = new TasksCenterComponent(deps);
+		await new Promise((r) => setTimeout(r, 30));
+		panel.handleInput("a"); // 切 Artifacts
+		await new Promise((r) => setTimeout(r, 30));
+		panel.handleInput("o");
+		await new Promise((r) => setTimeout(r, 30));
+		assert.deepEqual(opened, ["/ws/star.gif"]);
+		panel.dispose();
+	});
+
+	it("无产物任务按 o → 诚实提示，不假装打开", async () => {
+		const notes: string[] = [];
+		const deps = makeDeps(TASKS);
+		deps.fetchArtifacts = async () => [];
+		deps.openArtifact = () => { throw new Error("不应调用"); };
+		deps.notify = (t: string) => { notes.push(t); };
+		const panel = new TasksCenterComponent(deps);
+		await new Promise((r) => setTimeout(r, 30));
+		panel.handleInput("a");
+		await new Promise((r) => setTimeout(r, 30));
+		panel.handleInput("o");
+		assert.ok(notes.some((n) => n.includes("无交付物")), notes.join("|"));
+		panel.dispose();
+	});
+});


### PR DESCRIPTION
## 背景（0902 审计 §6.2）
任务卡直接显示「打开视频」——TUI 支持按 o 打开。

## 实现
- F2 Task Panel（模态 overlay，捕获按键——普通 o 字母输入不受影响的结构性保证）Artifacts 页按 o 打开当前任务首个媒体交付物（image/video 优先）。
- 无交付物 → 诚实提示「该任务无交付物可打开」；宿主未注入 opener（无图形环境，xdg-open 探测）→ 提示用 `rosclaw artifact path` 取路径。不假装打开。
- 帮助行更新。
- 运动轨迹命名核查：用户面 UI 字符串无 轨迹/trace 混用（grep 全净，残留仅代码注释）——§6.1 命名项无需改。

## 红→绿
- tasks-center.test.ts 新增 2 腿（按 o 打开正确路径 / 无产物诚实提示）；面板全量 7/7；TS 全量 224/0；journey A 绿（141s）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)