### PR TITLE
0903 体验复核：投诉不进确定性链 + 产品核心源码只读 + 空终态卡诚实化

### DIFF
--- a/packages/rosclaw-agent/src/native/terminal-presenter.ts
+++ b/packages/rosclaw-agent/src/native/terminal-presenter.ts
@@ -92,6 +92,15 @@ export function renderTerminalReply(
 			+ "下一步：用上面的「打开」命令查看交付物；/activity 查看完整账本"
 		);
 	}
+	// 0903 体验实证：UNKNOWN·UNKNOWN 空卡（投诉被当新指令建了
+	// 空 revision，consider 报 UNKNOWN/UNKNOWN 无原因）——双
+	// UNKNOWN 且零产物时诚实说"尚未产生可验收结果"，不装成终态卡。
+	if (verification === "UNKNOWN" && delivery === "UNKNOWN" && !refs.length) {
+		return (
+			"ℹ️ 任务尚未产生可验收结果（未执行或执行未完成）"
+			+ "——说明你要的修正或新目标即可，我不会拿旧结果冒充。"
+		);
+	}
 	// 失败/部分达成：原因逐条（用户必须看到"为什么"）+ 已产出 +
 	// 下一步。
 	const failures = outcome.repair_directive?.failures ?? [];

--- a/packages/rosclaw-agent/src/tools/workspace-pack.ts
+++ b/packages/rosclaw-agent/src/tools/workspace-pack.ts
@@ -18,7 +18,8 @@
 
 import { execFileSync, spawn } from "node:child_process";
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
@@ -334,6 +335,15 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 			await options.beforeEffect?.();
 			try {
 				const p = resolveInRoot(root, String(params.path));
+				// 0903（§4.4）：产品核心源码只读——普通任务不得修改
+				// 正在运行的产品（改产品走开发流程：clone+PR）。
+				if (isProductSourcePath(p)) {
+					return denied(
+						"拒绝写入：目标是正在运行的 ROSClaw 产品核心源码"
+						+ "（§4.4 普通任务不得修改产品核心）——改产品请走开发流程"
+						+ "（克隆仓库+PR），不要在本会话内改运行中的代码",
+					);
+				}
 				mkdirSync(dirname(p), { recursive: true });
 				writeFileSync(p, String(params.content), "utf-8");
 				return {
@@ -362,6 +372,12 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 			await options.beforeEffect?.();
 			try {
 				const p = resolveInRoot(root, String(params.path));
+				if (isProductSourcePath(p)) {
+					return denied(
+						"拒绝编辑：目标是正在运行的 ROSClaw 产品核心源码（§4.4）"
+						+ "——改产品请走开发流程（克隆仓库+PR）",
+					);
+				}
 				const text = readFileSync(p, "utf-8");
 				const oldText = String(params.oldText);
 				const occurrences = text.split(oldText).length - 1;
@@ -380,6 +396,28 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 	});
 
 	return [bashTool, writeTool, editTool];
+}
+
+/** 运行中产品自身源码根（0903 体验实证 + §4.4：普通任务禁止修改
+ *  正在运行的产品核心——模型在"画立方体"任务中途给规划器加形状）。
+ *  本文件位于 <产品根>/packages/rosclaw-agent/(dist/)src/tools/，
+ *  向上解析到产品根；守护 <根>/src/rosclaw 与 <根>/packages/
+ *  rosclaw-agent/src。 */
+export function productSourceRoots(): string[] {
+	const here = dirname(fileURLToPath(import.meta.url));
+	// src/tools 或 dist/src/tools → 产品根（rosclaw-agent 包的上一级
+	// 的上一级：packages/rosclaw-agent → <根>）。
+	let root = here;
+	for (let i = 0; i < 5; i++) root = dirname(root);
+	return [join(root, "src", "rosclaw"), join(root, "packages", "rosclaw-agent", "src")];
+}
+
+/** 路径是否落在运行中产品核心源码树。 */
+export function isProductSourcePath(target: string): boolean {
+	const real = resolve(target);
+	return productSourceRoots().some(
+		(r) => real === r || real.startsWith(r + sep),
+	);
 }
 
 /** bwrap 可用性（PR-H6 fail-closed 判定的真实探测）。 */

--- a/packages/rosclaw-agent/test/a0903-source-guard.test.ts
+++ b/packages/rosclaw-agent/test/a0903-source-guard.test.ts
@@ -1,0 +1,60 @@
+/** 0903 体验复核红测试（rosclaw体验0903.txt 实证 + §4.4）：
+ *  普通产品任务不得修改正在运行的产品核心源码——模型在"画立方体"
+ *  任务中途决定给规划器加 cube 形状（编辑 sim_trajectory.py 等
+ *  产品源码），把产品任务变成开发任务。
+ *
+ * 闭环断言：write/edit 目标落在运行中产品自身源码树
+ * （<产品根>/src/rosclaw 或 <产品根>/packages/rosclaw-agent/src）
+ * → 拒绝并指路；普通工作区文件不受影响。
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+async function makeTools(dir: string) {
+	const { buildWorkspacePackTools } = await import(
+		"../src/tools/workspace-pack.js"
+	);
+	return buildWorkspacePackTools({
+		root: dir, rosclawHome: dir, mode: () => "SIMULATION",
+		bwrapPath: () => "/usr/bin/bwrap", // 有沙箱——沙箱过了也不许写产品源码
+	} as never);
+}
+
+test("0903: write 到产品核心源码被拒绝（§4.4）", async () => {
+	// 真实事故形态：用户在产品 checkout 里开 chat——workspace root
+	// 就是产品根，resolveInRoot 放行，守护必须是产品源码判定。
+	const { productSourceRoots } = await import("../src/tools/workspace-pack.js");
+	const roots = productSourceRoots();
+	assert.ok(roots.length >= 1, "产品源码根解析为空");
+	const productRoot = dirname(dirname(roots[0])); // src/rosclaw → 产品根
+	const tools = await makeTools(productRoot);
+	const write = tools.find((t) => t.name === "write") as unknown as {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		execute: (...a: any[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+	};
+	const target = join(roots[0], "agentd", "sim_trajectory.py");
+	const out = await write.execute(
+		"c1", { path: target, content: "# hack" },
+		new AbortController().signal, async () => {}, {},
+	);
+	assert.ok(out.isError, "产品核心源码竟可写");
+	assert.match(out.content[0]?.text ?? "", /产品核心|开发流程/);
+});
+
+test("0903: 普通工作区文件不受影响", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "a0903-"));
+	const tools = await makeTools(dir);
+	const write = tools.find((t) => t.name === "write") as unknown as {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		execute: (...a: any[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+	};
+	const out = await write.execute(
+		"c1", { path: join(dir, "notes.txt"), content: "hello" },
+		new AbortController().signal, async () => {}, {},
+	);
+	assert.ok(!out.isError, out.content[0]?.text);
+});

--- a/src/rosclaw/cognition/index/query.py
+++ b/src/rosclaw/cognition/index/query.py
@@ -85,15 +85,41 @@ def search(index_path: Path, text: str, *, limit: int = 10) -> list[dict]:
         conn.close()
 
 
+def _robot_id_candidates(robot_id: str) -> list[str]:
+    """查询规范化（0903 体验实证：模型按 header 里的 body_id
+    "sim/ur5e" 查 robot_chain，索引 canonical_id 是 zoo 目录名
+    "ur5e"——miss 报 UNKNOWN_ROBOT）。body_id/资源 id/别名族全试。"""
+    q = str(robot_id).strip()
+    candidates = [q]
+    for sep in ("sim/", "robot:", "real/"):
+        if q.startswith(sep):
+            candidates.append(q[len(sep):])
+    if q.startswith("sim_"):
+        candidates.append(q[4:])
+    candidates.append(q.replace("-", "_"))
+    # 去重保序。
+    seen: list[str] = []
+    for c in candidates:
+        if c and c not in seen:
+            seen.append(c)
+    return seen
+
+
 def robot_chain(index_path: Path, robot_id: str, *, product_root: Path | None = None) -> dict | None:
     """一次调用返回权威资产链。索引损坏 → 重建（product_root 可由
     meta 恢复）后重试一次；仍失败 → None（调用方诚实降级）。"""
+    candidates = _robot_id_candidates(robot_id)
     for attempt in range(2):
         try:
             conn = _connect(index_path)
             try:
-                robot = _entities(conn, "kind = 'robot' AND canonical_id = ?",
-                                  (robot_id,))
+                robot = []
+                for candidate in candidates:
+                    robot = _entities(
+                        conn, "kind = 'robot' AND canonical_id = ?",
+                        (candidate,))
+                    if robot:
+                        break
                 if not robot:
                     return None
                 payload = json.loads(robot[0]["payload_json"])

--- a/src/rosclaw/task_kernel/task_router.py
+++ b/src/rosclaw/task_kernel/task_router.py
@@ -89,13 +89,22 @@ _CODE_REQUEST_MARKERS = ("写一段", "写个代码", "写代码", "代码实现
                          "python 代码", "python代码", "写个脚本",
                          "write code", "write a script")
 
+#: 情绪投诉护栏（0903 体验实证：「你画的居然是个五角星！我要的是
+#: 立方体！」含形状词，确定性链竟把投诉当新指令又画了一遍五角星
+#: 并 PASS——投诉变二次假成功）。投诉交模型（道歉+诚实解释），
+#: 不进确定性链。
+_COMPLAINT_MARKERS = ("居然", "压根", "混蛋", "什么鬼", "什么东西",
+                      "画的什么", "搞什么", "什么玩意")
+
 
 def is_task_directive(text: str) -> bool:
     """指令形式判定：疑问句/讨论/代码请求形式不自动执行。"""
     lowered = text.lower()
     if any(m in lowered or m in text for m in _QUESTION_MARKERS):
         return False
-    return not any(m in lowered or m in text for m in _CODE_REQUEST_MARKERS)
+    if any(m in lowered or m in text for m in _CODE_REQUEST_MARKERS):
+        return False
+    return not any(m in text for m in _COMPLAINT_MARKERS)
 
 
 def compile_recipe_inputs(goal_text: str) -> dict[str, Any]:

--- a/tests/agentd/test_a0903_experience.py
+++ b/tests/agentd/test_a0903_experience.py
@@ -1,0 +1,49 @@
+"""0903 体验日志复核红测试（rosclaw体验0903.txt 实证）：
+
+投诉/批评不是确定性任务指令——"你画的居然是个五角星！我要的
+是立方体！" 含可识别形状词，若不拦截会**再画一遍五角星并
+PASS**（投诉变二次假成功）。情绪/批评标记 → 交模型（道歉+诚实
+解释），不进确定性链。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestComplaintNotDirective:
+    """投诉含形状词不得触发确定性链（0903 实证：批评"你画的居然
+    是个五角星"被当成新指令又画了一遍五角星）。"""
+
+    def test_angry_complaint_not_directive(self) -> None:
+        from rosclaw.task_kernel.task_router import is_task_directive
+
+        assert not is_task_directive(
+            "你画的居然是个五角星！也没在3D仿真里展示！你压根就没思考吧！"
+            "我要的是立方体！你个混蛋！"
+        )
+        assert not is_task_directive("你画的什么鬼东西？根本不是我要的")
+        assert not is_task_directive("居然画错了，这不是我要的")
+
+    def test_legit_revision_still_directive(self) -> None:
+        """回归护栏：正常修订仍是指令（0901 的"不对——加红色圆柱笔"
+        是合法修订，不含情绪词）。"""
+        from rosclaw.task_kernel.task_router import is_task_directive
+
+        assert is_task_directive(
+            "不对——加红色圆柱笔，在 3D 画面里显示本次实际轨迹，不要 2D"
+        )
+        assert is_task_directive("画一个五角星")
+
+    def test_angry_complaint_not_auto_routed(self) -> None:
+        """端到端（编译层）：投诉文本即使进了路由前置也不得路由
+        ——零任务。"""
+        from rosclaw.task_kernel.task_router import is_task_directive
+
+        complaint = ("你画的居然是个五角星！我要的是立方体！"
+                     "你压根就没思考吧！")
+        assert not is_task_directive(complaint)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agentd/test_n3_ecosystem_index.py
+++ b/tests/agentd/test_n3_ecosystem_index.py
@@ -38,6 +38,19 @@ class TestEcosystemIndex:
         assert "fixtures" not in json.dumps(chain)
         assert "specs/ur5e" not in json.dumps(chain)
 
+    def test_robot_chain_accepts_body_id_forms(self, tmp_path: Path) -> None:
+        """0903 体验实证：模型按 header 的 body_id "sim/ur5e" 查
+        robot_chain → 未命中报 UNKNOWN_ROBOT。body_id/资源 id/别名
+        族都必须命中同一条权威链。"""
+        from rosclaw.cognition.index.builder import build_index
+        from rosclaw.cognition.index.query import robot_chain
+
+        index_path = build_index(tmp_path / "idx", REPO)
+        for form in ("ur5e", "sim/ur5e", "sim_ur5e", "robot:ur5e"):
+            chain = robot_chain(index_path, form)
+            assert chain is not None, f"{form} 未命中权威链"
+            assert chain["canonical"] is True
+
     def test_inspect_self_shape(self, tmp_path: Path) -> None:
         from rosclaw.cognition.index.builder import build_index
         from rosclaw.cognition.inspect_cli import inspect_self


### PR DESCRIPTION
## 背景（0903 体验日志 rosclaw体验0903.txt）
用户实测三问题：
1. **投诉被当新指令再画一遍五角星**：「你画的居然是个五角星！我要的是立方体！」含形状词 → 确定性链再画星并 PASS（投诉变二次假成功）。
2. **普通产品任务修改了正在运行的产品核心源码**（§4.4 明令禁止）：模型在「画立方体」任务中途给规划器加 cube 形状。
3. **UNKNOWN·UNKNOWN 空终态卡**：投诉建的空 revision 报出无原因的「任务未完全达成」。

## 修复
- is_task_directive 增情绪投诉护栏（居然/压根/混蛋/什么鬼…）——投诉交模型（道歉+诚实解释），不进确定性链；正常修订（0901「不对——加红色圆柱笔」式）不受影响（回归护栏测试）。
- workspace-pack write/edit：目标在运行中产品源码树（<产品根>/src/rosclaw、packages/rosclaw-agent/src）→ 拒绝并指路开发流程（克隆+PR）。
- 终态呈现：双 UNKNOWN + 零产物 → 诚实文案「任务尚未产生可验收结果」，不装成终态卡。

## 红→绿
- tests/agentd/test_a0903_experience.py 3 腿 + test/a0903-source-guard.test.ts 2 腿先红后绿；TS 226/0；python 回归 61/61；journey A 绿（190s）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)