### PR TITLE
0905 机制修正：删除情绪词护栏——投诉经语义覆盖自然落模型路径

### DIFF
--- a/src/rosclaw/task_kernel/requirements.py
+++ b/src/rosclaw/task_kernel/requirements.py
@@ -77,6 +77,10 @@ SHAPE_MARKERS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("square", ("正方形", "方形", "square")),
     ("triangle", ("三角形", "triangle")),
     ("spiral", ("螺旋", "spiral")),
+    # 0905：cube 注册为"已知未覆盖"——「画个立方体」与含立方体诉求
+    # 的投诉都经语义覆盖落到模型路径（模型自己处理），而不是检测
+    # 情绪词。登记≠支持执行：无欧拉笔画的受信规划+3D 验收链。
+    ("cube", ("立方体", "立方", "cube", "线框", "wireframe")),
 )
 # 兼容旧名（防止外部 import 断裂）——新代码用 SHAPE_MARKERS。
 _SHAPE_MARKERS = SHAPE_MARKERS
@@ -120,9 +124,13 @@ def compile_requirements(goal_text: str) -> list[Requirement]:
             verifier=verifier,
         ))
 
-    shape = select_shape(goal_text)
-    if shape:
-        _add("must", f"绘制形状：{shape}", f"shape.{shape}")
+    # 多形状条款：文中提到的每个形状都是独立条款（投诉"你画的居
+    # 然是个五角星！我要的是立方体！"——五角星引用被满足不算数，
+    # 立方体诉求未覆盖照样拦截）。select_shape 只决定执行输入。
+    lowered_text = goal_text.lower()
+    for shape, markers in SHAPE_MARKERS:
+        if any(m in goal_text or m in lowered_text for m in markers):
+            _add("must", f"绘制形状：{shape}", f"shape.{shape}")
     if _any(goal_text, _TOOL_MARKERS):
         _add("must", "末端挂载工具", "receipt.tool_ref")
     if _any(goal_text, _COLOR_MARKERS):

--- a/src/rosclaw/task_kernel/task_router.py
+++ b/src/rosclaw/task_kernel/task_router.py
@@ -89,22 +89,19 @@ _CODE_REQUEST_MARKERS = ("写一段", "写个代码", "写代码", "代码实现
                          "python 代码", "python代码", "写个脚本",
                          "write code", "write a script")
 
-#: 情绪投诉护栏（0903 体验实证：「你画的居然是个五角星！我要的是
-#: 立方体！」含形状词，确定性链竟把投诉当新指令又画了一遍五角星
-#: 并 PASS——投诉变二次假成功）。投诉交模型（道歉+诚实解释），
-#: 不进确定性链。
-_COMPLAINT_MARKERS = ("居然", "压根", "混蛋", "什么鬼", "什么东西",
-                      "画的什么", "搞什么", "什么玩意")
+
 
 
 def is_task_directive(text: str) -> bool:
-    """指令形式判定：疑问句/讨论/代码请求形式不自动执行。"""
+    """指令形式判定：疑问句/讨论/代码请求形式不自动执行。
+
+    0905：情绪/投诉类文本不做词表护栏——未满足的要求经由语义覆盖
+    门禁自然落到模型路径（shape.cube 已知未覆盖），模型自己处理
+    投诉（用户的明确决定，不是检测情绪的机制）。"""
     lowered = text.lower()
     if any(m in lowered or m in text for m in _QUESTION_MARKERS):
         return False
-    if any(m in lowered or m in text for m in _CODE_REQUEST_MARKERS):
-        return False
-    return not any(m in text for m in _COMPLAINT_MARKERS)
+    return not any(m in lowered or m in text for m in _CODE_REQUEST_MARKERS)
 
 
 def compile_recipe_inputs(goal_text: str) -> dict[str, Any]:

--- a/tests/agentd/test_a0903_experience.py
+++ b/tests/agentd/test_a0903_experience.py
@@ -1,9 +1,20 @@
-"""0903 体验日志复核红测试（rosclaw体验0903.txt 实证）：
+"""0905 体验复核机制修正（用户决定：不搞情绪词护栏——投诉由模型
+自己处理，机制上经语义覆盖自然落到模型路径）。
 
-投诉/批评不是确定性任务指令——"你画的居然是个五角星！我要的
-是立方体！" 含可识别形状词，若不拦截会**再画一遍五角星并
-PASS**（投诉变二次假成功）。情绪/批评标记 → 交模型（道歉+诚实
-解释），不进确定性链。
+0903 日志实证："你画的居然是个五角星！我要的是立方体！"——
+若按首个可识别形状执行 = 再画一遍五角星并 PASS（投诉变二次假
+成功）。正确机制（非情绪检测）：
+- cube 注册为"已知未覆盖"形状——立方体诉求（含投诉里的）经
+  覆盖门禁落到模型路径；
+- 多形状条款：文中提到的每个形状都是独立条款——五角星引用被
+  满足不算数，立方体未覆盖照样拦截。
+
+闭环断言：
+1. 投诉文本（含 star5+cube）→ 不自动路由 + 零幽灵任务（经覆盖
+   门禁，无任何情绪词检测）；
+2. "画个立方体" → 不自动路由（cube 已知未覆盖）；
+3. "画五角星"/"画五角星改成画圆形" → 照常自动路由（回归护栏）；
+4. requirements 多形状编译：star5+cube 两条条款都在。
 """
 
 from __future__ import annotations
@@ -11,38 +22,100 @@ from __future__ import annotations
 import pytest
 
 
-class TestComplaintNotDirective:
-    """投诉含形状词不得触发确定性链（0903 实证：批评"你画的居然
-    是个五角星"被当成新指令又画了一遍五角星）。"""
+class TestComplaintViaCoverageSemantics:
+    async def _persist(self, tmp_path, text: str, msg: str):
+        from rosclaw.agentd.auto_route import reset_routed_for_tests
+        from rosclaw.agentd.pi_bridge.server import PiBridgeServer
+        from tests.agentd.test_pi_tool_bridge import _setup
 
-    def test_angry_complaint_not_directive(self) -> None:
-        from rosclaw.task_kernel.task_router import is_task_directive
-
-        assert not is_task_directive(
-            "你画的居然是个五角星！也没在3D仿真里展示！你压根就没思考吧！"
-            "我要的是立方体！你个混蛋！"
+        reset_routed_for_tests()
+        service, mission = await _setup(tmp_path)
+        bridge = PiBridgeServer(service, tmp_path / "run" / "pi-bridge.sock")
+        result = await bridge._dispatch(
+            "user:local:1000", 1, "pi.input.persist",
+            {
+                "token": service.control_token,
+                "mission_id": mission.mission_id,
+                "session_ref": "pi_1",
+                "message_id": msg,
+                "text": text,
+            },
         )
-        assert not is_task_directive("你画的什么鬼东西？根本不是我要的")
-        assert not is_task_directive("居然画错了，这不是我要的")
+        tasks = service._task_kernel._conn.execute(
+            "SELECT COUNT(*) AS n FROM tasks"
+        ).fetchone()["n"]
+        await service.close()
+        return result, int(tasks)
 
-    def test_legit_revision_still_directive(self) -> None:
-        """回归护栏：正常修订仍是指令（0901 的"不对——加红色圆柱笔"
-        是合法修订，不含情绪词）。"""
-        from rosclaw.task_kernel.task_router import is_task_directive
-
-        assert is_task_directive(
-            "不对——加红色圆柱笔，在 3D 画面里显示本次实际轨迹，不要 2D"
+    async def test_angry_complaint_falls_to_model_via_cube(
+        self, tmp_path
+    ) -> None:
+        """投诉（star5 引用 + cube 诉求）→ 覆盖门禁落模型——不是
+        情绪词拦截。"""
+        result, tasks = await self._persist(
+            tmp_path,
+            "你画的居然是个五角星！也没在3D仿真里展示！"
+            "我要的是立方体！你个混蛋！",
+            "m1",
         )
-        assert is_task_directive("画一个五角星")
+        assert not result.get("auto_task"), result
+        assert tasks == 0, f"投诉竟建了任务: {tasks}"
 
-    def test_angry_complaint_not_auto_routed(self) -> None:
-        """端到端（编译层）：投诉文本即使进了路由前置也不得路由
-        ——零任务。"""
-        from rosclaw.task_kernel.task_router import is_task_directive
+    async def test_cube_request_falls_to_model(self, tmp_path) -> None:
+        """画立方体 → cube 已知未覆盖 → 模型路径（模型自己说明能力
+        边界或尽力而为——不画星冒充）。"""
+        result, tasks = await self._persist(
+            tmp_path, "那请用ur5机械臂画个立方体，我想看到仿真视频", "m1"
+        )
+        assert not result.get("auto_task"), result
+        assert tasks == 0
 
-        complaint = ("你画的居然是个五角星！我要的是立方体！"
-                     "你压根就没思考吧！")
-        assert not is_task_directive(complaint)
+    async def test_star_still_auto_routes(self, tmp_path) -> None:
+        result, tasks = await self._persist(tmp_path, "画一个五角星", "m1")
+        assert result.get("auto_task"), result
+        assert tasks == 1
+
+    async def test_revision_to_circle_still_auto_routes(self, tmp_path) -> None:
+        """多形状但全覆盖 → 照常执行（改成语义不受影响）。"""
+        result, tasks = await self._persist(
+            tmp_path, "画五角星改成画圆形", "m1"
+        )
+        assert result.get("auto_task"), result
+        assert tasks == 1
+
+
+class TestMultiShapeCompilation:
+    def test_all_mentioned_shapes_become_clauses(self) -> None:
+        from rosclaw.task_kernel.requirements import compile_requirements
+
+        reqs = compile_requirements("画五角星改成画圆形")
+        verifiers = {r.verifier for r in reqs}
+        assert "shape.star5" in verifiers
+        assert "shape.circle" in verifiers
+
+    def test_complaint_compiles_cube_clause(self) -> None:
+        from rosclaw.task_kernel.requirements import compile_requirements
+        from rosclaw.task_kernel.task_router import RECIPE_COVERAGE
+
+        reqs = compile_requirements(
+            "你画的居然是个五角星！我要的是立方体！"
+        )
+        verifiers = {r.verifier for r in reqs}
+        assert "shape.star5" in verifiers
+        assert "shape.cube" in verifiers
+        coverage = RECIPE_COVERAGE["recipe:sim.draw_path"]
+        assert "shape.cube" not in coverage, (
+            "cube 不得在覆盖表——登记≠支持执行"
+        )
+
+    def test_no_emotion_markers_in_router(self) -> None:
+        """机制声明：路由层不做情绪词检测（用户决定）。"""
+        import inspect
+
+        from rosclaw.task_kernel import task_router
+
+        src = inspect.getsource(task_router)
+        assert "_COMPLAINT_MARKERS" not in src
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 用户决定（0905）
不搞「情绪投诉护栏」（居然/压根/什么鬼…词表）——投诉由模型自己处理。正确机制是语义覆盖，不是情绪检测。

## 修正
- 删除 task_router 的 `_COMPLAINT_MARKERS` 及 is_task_directive 情绪分支（#510 的错误机制）。
- cube 注册为「已知未覆盖」形状——「画个立方体」与含立方体诉求的投诉经覆盖门禁落到模型路径（模型自己说明边界，不画星冒充）。
- compile_requirements 多形状条款：文中每个被提到的形状都是独立条款——投诉「你画的居然是个五角星！我要的是立方体！」中五角星引用被满足不算数，立方体未覆盖照样拦截。

## 闭环实证
- bridge 级：投诉 → 不路由 + 零幽灵任务；画立方体 → 不路由；画五角星/画五角星改成画圆形 → 照常自动执行。
- 机制声明测试：路由层无情绪词表。
- journey A 绿（161s）；holdout/r02/r2c/r015 回归 73/73。

附：feat/cube-wireframe-trace-overlay 分支已评审并删除（无 PR）——overlay 画线与已合入的 R2-2 重复且缺证据绑定；_contact_plane_of 全分支返回同一向量的死代码；stream_filter 紧凑 JSON 改动越界未验证。cube 产品能力需走正式规划/验收链设计，不合草稿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)