### PR TITLE
大道至简 R1-1：plan_cartesian 接受任意路径点——hello→五角星根治

### DIFF
--- a/src/rosclaw/agentd/sim_trajectory.py
+++ b/src/rosclaw/agentd/sim_trajectory.py
@@ -375,14 +375,27 @@ class SimTrajectoryService:
     def generate_planar_path(
         self,
         *,
-        shape: str,
-        center_m: list[float],
-        scale_m: float,
+        shape: str | None = None,
+        center_m: list[float] | None = None,
+        scale_m: float | None = None,
         plane: str = "xy",
         max_segment_m: float = 0.02,
         plane_normal_xyz: list[float] | None = None,
         plane_offset_m: float | None = None,
+        waypoints: list[dict] | None = None,
     ) -> dict[str, Any]:
+        # 大道至简 R1-1：任意路径点是通用入口——画什么由 Pi 决定，
+        # 形状枚举只是便捷参数（内部同样生成 waypoints）。
+        if waypoints is not None:
+            return self.generate_waypoint_path(
+                waypoints=waypoints, max_segment_m=max_segment_m,
+            )
+        if shape is None or center_m is None or scale_m is None:
+            raise ValueError(
+                "shape+center_m+scale_m 或 waypoints 必须给一组——"
+                "无默认形状（0905 实证：静默兜底 star5 会把 hello 画成"
+                "五角星）"
+            )
         if shape not in _SHAPES:
             raise ValueError(f"unsupported shape {shape!r} (supported: {', '.join(_SHAPES)})")
         if plane != "xy" and plane_normal_xyz is None:
@@ -489,6 +502,99 @@ class SimTrajectoryService:
                 f"半径 {scale_m}m，{len(points)} 个插值点，已闭合"
             ),
         }
+
+    def generate_waypoint_path(
+        self,
+        *,
+        waypoints: list[dict],
+        max_segment_m: float = 0.02,
+    ) -> dict[str, Any]:
+        """任意路径点规划（大道至简 R1-1——「plan_cartesian 必须接收
+        任意路径点，而不是只接受 star5/circle」）。
+
+        waypoints: [{x, y, z, contact?}]——contact=False 的目标是
+        抬笔移动段（多笔画文字/图案的笔段间隔）。每个点过安全工作
+        空间校验（规划即拒越界），按 max_segment_m 插值，canonical
+        hash + PlanStore 持久化（与形状路径同一消费面：simulate/
+        render/verify 不需要知道路径是不是形状）。
+        """
+        if not isinstance(waypoints, list) or len(waypoints) < 2:
+            raise ValueError("waypoints 至少需要 2 个点")
+        if not (0.005 <= float(max_segment_m) <= 0.1):
+            raise ValueError("max_segment_m outside range [0.005, 0.1]")
+        canonical: list[dict] = []
+        for w in waypoints:
+            try:
+                point = {
+                    "x": round(float(w["x"]), 6),
+                    "y": round(float(w["y"]), 6),
+                    "z": round(float(w["z"]), 6),
+                }
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"waypoint 必须是 {{x, y, z}} 数值点：{w!r}（{exc}）"
+                ) from exc
+            _workspace_check(point)
+            canonical.append({**point, "contact": bool(w.get("contact", True))})
+        # 线段插值；每个插值点继承其段目标的 contact 标记（抬笔段
+        # 整段 contact=False——渲染/验收层可区分绘制与移动）。
+        points: list[dict] = [dict(canonical[0])]
+        for a, b in zip(canonical, canonical[1:], strict=False):
+            seg = math.dist(
+                (a["x"], a["y"], a["z"]), (b["x"], b["y"], b["z"]),
+            )
+            steps = max(1, math.ceil(seg / float(max_segment_m)))
+            for i in range(1, steps + 1):
+                ratio = i / steps
+                points.append(
+                    {
+                        "x": round(a["x"] + (b["x"] - a["x"]) * ratio, 6),
+                        "y": round(a["y"] + (b["y"] - a["y"]) * ratio, 6),
+                        "z": round(a["z"] + (b["z"] - a["z"]) * ratio, 6),
+                        "contact": bool(b["contact"]),
+                    }
+                )
+        digest = hashlib.sha256(
+            json.dumps(points, sort_keys=True).encode()
+        ).hexdigest()
+        plan_id = f"plan_{digest[:16]}"
+        spec = _build_pose_spec(
+            [{"x": p["x"], "y": p["y"], "z": p["z"]} for p in points],
+            plane="xy",
+        )
+        self._plans_dir.mkdir(parents=True, exist_ok=True)
+        (self._plans_dir / f"{plan_id}.json").write_text(
+            json.dumps(
+                {
+                    "shape": "custom",
+                    "waypoints": canonical,
+                    "max_segment_m": max_segment_m,
+                    "points": points,
+                    "hash": digest,
+                    "spec": spec,
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        lifts = sum(1 for w in canonical if not w["contact"])
+        return {
+            "ok": True,
+            "plan_id": plan_id,
+            "hash": digest,
+            "points": points,
+            "point_count": len(points),
+            "spec": spec,
+            "summary": (
+                f"自定义路径：{len(canonical)} 个路径点"
+                + (f"（{lifts} 段抬笔移动）" if lifts else "")
+                + f"，{len(points)} 个插值点"
+            ),
+        }
+
+    def get_plan_payload(self, plan_id: str) -> dict[str, Any]:
+        """PlanStore 记录的公开读取面（审计/测试——内容寻址可反查）。"""
+        return self._load_plan(plan_id)
 
     def _load_plan(self, plan_id: str) -> dict:
         """WP-2：统一引用——kit envelope 记录（PersistentPlanStore）

--- a/src/rosclaw/agentd/tooling/native_tools.py
+++ b/src/rosclaw/agentd/tooling/native_tools.py
@@ -161,20 +161,39 @@ def register_native_tools(
                 source=NATIVE_SOURCE,
                 execution_class=ExecutionClass.COMPUTE,
                 description=(
-                    "Generate a parameterized planar Cartesian path "
-                    "(shape=star5|circle, center_m, scale_m) — sampled closed "
-                    "loop with safe-workspace validation. Returns plan_id handle."
+                    "Generate a Cartesian path: either arbitrary waypoints "
+                    "([{x,y,z,contact?}] — contact=false marks a pen-up "
+                    "transit stroke; text/figures/letters are all expressed "
+                    "as point lists by the agent) or a convenience "
+                    "shape=star5|circle with center_m/scale_m. Sampled with "
+                    "safe-workspace validation. Returns plan_id handle. "
+                    "There is NO default shape."
                 ),
                 input_schema={
                     "type": "object",
                     "properties": {
                         "shape": {"type": "string", "enum": ["star5", "circle"]},
+                        "waypoints": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "x": {"type": "number"},
+                                    "y": {"type": "number"},
+                                    "z": {"type": "number"},
+                                    "contact": {"type": "boolean"},
+                                },
+                                "required": ["x", "y", "z"],
+                            },
+                        },
                         "center_m": {"type": "array", "items": {"type": "number"}},
                         "scale_m": {"type": "number"},
                         "plane": {"type": "string", "enum": ["xy"]},
                         "max_segment_m": {"type": "number"},
                     },
-                    "required": ["shape"],
+                    # 大道至简 R1-1：shape 不再必填——waypoints 是通用
+                    # 入口；两者皆缺由执行层报错（无默认形状）。
+                    "required": [],
                     "additionalProperties": False,
                 },
 

--- a/src/rosclaw/agentd/tools.py
+++ b/src/rosclaw/agentd/tools.py
@@ -74,21 +74,36 @@ _TOOL_SCHEMAS: dict[str, StrictTool] = {
     TRAJ_PLAN_TOOL: StrictTool(
         name=TRAJ_PLAN_TOOL,
         description=(
-            "Generate a parameterized planar Cartesian path "
-            "(shape=star5|circle, center_m, scale_m) — sampled closed loop "
-            "with safe-workspace validation. Returns plan_id handle."
+            "Generate a Cartesian path: either arbitrary waypoints "
+            "([{x,y,z,contact?}] — contact=false marks a pen-up transit "
+            "stroke; anything the agent can express as points: text, "
+            "figures, letters) or a convenience shape=star5|circle with "
+            "center_m/scale_m. Sampled with safe-workspace validation. "
+            "Returns plan_id handle. There is NO default shape."
         ),
         parameters={
             "type": "object",
             "properties": {
                 "shape": {"type": "string", "enum": ["star5", "circle"]},
+                "waypoints": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "x": {"type": "number"},
+                            "y": {"type": "number"},
+                            "z": {"type": "number"},
+                            "contact": {"type": "boolean"},
+                        },
+                        "required": ["x", "y", "z"],
+                    },
+                },
                 "center_m": {"type": "array", "items": {"type": "number"}},
                 "scale_m": {"type": "number"},
                 "plane": {"type": "string", "enum": ["xy"]},
                 "max_segment_m": {"type": "number"},
             },
-            "required": ["shape", "center_m", "scale_m", "plane",
-                         "max_segment_m"],
+            "required": [],
             "additionalProperties": False,
         },
     ),
@@ -221,13 +236,30 @@ class BuiltinToolRegistry:
         )
         try:
             if name == TRAJ_PLAN_TOOL:
-                result = svc.generate_planar_path(
-                    shape=str(arguments.get("shape", "star5")),
-                    center_m=arguments.get("center_m") or [0.35, 0.25, 0.30],
-                    scale_m=float(arguments.get("scale_m", arguments.get("radius_m", 0.10))),
-                    plane=str(arguments.get("plane", "xy")),
-                    max_segment_m=float(arguments.get("max_segment_m", 0.02)),
-                )
+                waypoints = arguments.get("waypoints")
+                if waypoints is not None:
+                    # 大道至简 R1-1：任意路径点是通用入口。
+                    result = svc.generate_planar_path(
+                        waypoints=waypoints,
+                        max_segment_m=float(arguments.get("max_segment_m", 0.02)),
+                    )
+                else:
+                    # 形状便捷参数——shape 不再静默兜底 star5（0905
+                    # 实证：hello 被画成五角星的开关级根因）。
+                    shape = arguments.get("shape")
+                    if not shape:
+                        raise ValidationError(
+                            "trajectory_generate_planar_path 需要 shape "
+                            "(star5|circle) 或 waypoints 任意路径点——"
+                            "无默认形状"
+                        )
+                    result = svc.generate_planar_path(
+                        shape=str(shape),
+                        center_m=arguments.get("center_m") or [0.35, 0.25, 0.30],
+                        scale_m=float(arguments.get("scale_m", arguments.get("radius_m", 0.10))),
+                        plane=str(arguments.get("plane", "xy")),
+                        max_segment_m=float(arguments.get("max_segment_m", 0.02)),
+                    )
                 # 模型视图不带完整 points（载荷留文件——句柄+摘要）。
                 result = {k: v for k, v in result.items() if k != "points"}
                 # WP-5：SE(3) 规格本体落盘在 plan 记录里（太大不入

--- a/src/rosclaw/sim/ur5e_mcp.py
+++ b/src/rosclaw/sim/ur5e_mcp.py
@@ -170,6 +170,30 @@ def _trajectory_hash(points: list[dict]) -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 
+def _interpolate(waypoints: list[dict], max_segment_m: float) -> list[dict]:
+    """路径点列按最大线段插值。段目标带 contact=False 时整段标记
+    contact=False（抬笔移动段——多笔画文字/图案的笔段间隔）；
+    无 contact 键的路径点列保持原样（star5 记录格式不变）。"""
+    has_contact = any("contact" in w for w in waypoints)
+    points: list[dict] = [dict(waypoints[0])]
+    for a, b in zip(waypoints, waypoints[1:], strict=False):
+        seg = math.dist((a["x"], a["y"], a["z"]), (b["x"], b["y"], b["z"]))
+        steps = max(1, math.ceil(seg / max_segment_m))
+        for i in range(1, steps + 1):
+            ratio = i / steps
+            point = _canonical_point(
+                {
+                    "x": a["x"] + (b["x"] - a["x"]) * ratio,
+                    "y": a["y"] + (b["y"] - a["y"]) * ratio,
+                    "z": a["z"] + (b["z"] - a["z"]) * ratio,
+                }
+            )
+            if has_contact:
+                point["contact"] = bool(b.get("contact", True))
+            points.append(point)
+    return points
+
+
 def _workspace_check(point: dict) -> None:
     radius = math.hypot(point["x"], point["y"])
     r_lo, r_hi = _SAFE_RADIUS
@@ -185,25 +209,76 @@ def _workspace_check(point: dict) -> None:
 
 @server.tool(
     name="ur5e.plan_cartesian_path",
-    description="规划笛卡尔轨迹（COMPUTE，无副作用）：五角星等平面图形"
-    "生成顶点+插值+canonical hash；全部点经安全工作空间校验。",
+    description="规划笛卡尔轨迹（COMPUTE，无副作用）：任意路径点 "
+    "waypoints=[{x,y,z,contact?}]（contact=false 为抬笔移动段——文字/"
+    "任意图形都由 Agent 表达为点列）或便捷形状 shape=star5；全部点经"
+    "安全工作空间校验，canonical hash + 不透明 plan_id。无默认形状。",
     annotations={"readOnlyHint": True},
 )
 def plan_cartesian_path(
-    shape: str,
-    center_x: float,
-    center_y: float,
-    z: float,
-    outer_radius: float,
+    shape: str = "",
+    center_x: float = 0.0,
+    center_y: float = 0.0,
+    z: float = 0.0,
+    outer_radius: float = 0.0,
     max_segment_m: float = 0.02,
     include_payload: bool = False,
+    waypoints: list[dict] | None = None,
 ) -> str:
-    if shape != "star5":
-        raise ValueError(f"unsupported shape {shape!r} (supported: star5)")
-    if not (0.02 <= outer_radius <= 0.35):
-        raise ValueError("outer_radius out of range [0.02, 0.35]")
     if not (0.005 <= max_segment_m <= 0.1):
         raise ValueError("max_segment_m out of range [0.005, 0.1]")
+    if waypoints is not None:
+        # 大道至简 R1-1：任意路径点——画什么由 Agent 决定（hello/文字/
+        # 任意图形），ROSClaw 负责可靠插值+校验+句柄化。
+        if not isinstance(waypoints, list) or len(waypoints) < 2:
+            raise ValueError("waypoints 至少需要 2 个点")
+        canonical: list[dict] = []
+        for w in waypoints:
+            try:
+                point = _canonical_point(
+                    {"x": float(w["x"]), "y": float(w["y"]),
+                     "z": float(w["z"])}
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"waypoint 必须是 {{x, y, z}} 数值点：{w!r}（{exc}）"
+                ) from exc
+            _workspace_check(point)
+            canonical.append({**point, "contact": bool(w.get("contact", True))})
+        points = _interpolate(canonical, max_segment_m)
+        lifts = sum(1 for w in canonical if not w["contact"])
+        trajectory = {
+            "shape": "custom",
+            "waypoints": canonical,
+            "points": points,
+            "max_segment_m": max_segment_m,
+            "hash": _trajectory_hash(points),
+        }
+        summary = (
+            f"自定义路径：{len(canonical)} 个路径点"
+            + (f"（{lifts} 段抬笔移动）" if lifts else "")
+            + f"，{len(points)} 个插值点"
+        )
+        record = _plan_store().put(trajectory, summary)
+        result = {
+            "ok": True,
+            "sim_kind": SIM_KIND,
+            "plan_id": record["plan_id"],
+            "digest": record["digest"],
+            "summary": summary,
+            "point_count": len(points),
+            "workspace_ok": True,
+        }
+        if include_payload:  # dev/几何单测后门——绝不默认开
+            result["trajectory"] = trajectory
+        return json.dumps(result, ensure_ascii=False)
+    if shape != "star5":
+        raise ValueError(
+            f"unsupported shape {shape!r} (supported: star5)——或传 "
+            "waypoints 任意路径点（无默认形状）"
+        )
+    if not (0.02 <= outer_radius <= 0.35):
+        raise ValueError("outer_radius out of range [0.02, 0.35]")
     # 五角星轮廓：5 外顶点 + 5 内顶点每 36° 交替，回到起点。
     inner_radius = outer_radius * 0.381966
     waypoints: list[dict] = []
@@ -224,21 +299,7 @@ def plan_cartesian_path(
     for point in waypoints:
         _workspace_check(point)
     # 按最大线段插值。
-    points: list[dict] = [waypoints[0]]
-    for a, b in zip(waypoints, waypoints[1:], strict=False):
-        seg = math.dist((a["x"], a["y"], a["z"]), (b["x"], b["y"], b["z"]))
-        steps = max(1, math.ceil(seg / max_segment_m))
-        for i in range(1, steps + 1):
-            ratio = i / steps
-            points.append(
-                _canonical_point(
-                    {
-                        "x": a["x"] + (b["x"] - a["x"]) * ratio,
-                        "y": a["y"] + (b["y"] - a["y"]) * ratio,
-                        "z": a["z"] + (b["z"] - a["z"]) * ratio,
-                    }
-                )
-            )
+    points = _interpolate(waypoints, max_segment_m)
     trajectory = {
         "shape": shape,
         "waypoints": waypoints,

--- a/tests/agentd/test_ddzj_r11_hello_journey.py
+++ b/tests/agentd/test_ddzj_r11_hello_journey.py
@@ -1,0 +1,205 @@
+"""大道至简 R1-1 产品级实证（PTY 黑盒）：「画 hello」不再画成
+五角星——Pi 自己把字母表达成任意路径点，驱动通用物理工具链
+完成仿真+验证+渲染。
+
+0905 体验实证（rosclaw体验0905.txt）：用户要「画个hello」→ 模型
+第一次 plan_cartesian_path 直接 ValidationError（工具只认 star5/
+circle）→ 无路可走拿五角星冒充交付。本测试钉死根治后的完整
+闭环：字母 → 自定义 waypoints（多笔画+抬笔）→ 动力学 rollout →
+跟踪验证 → GIF 交付。
+
+假模型驱动（与 journey 同一 FakeModelServer 设施）：用户文本含
+「画个HI」→ 四步工具链，全部真执行。
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tests.agentd.test_product_journey import (
+    FakeModelServer,
+    PtySession,
+    _build_and_install,
+    _chunk,
+    _hidden_source_checkout,
+    _prepare_installed_chat,
+    _sse,
+    _tool_call_frames,
+)
+
+#: "HI" 两字母五笔画（h 竖/横/竖，抬笔，i 竖）——安全工作空间内。
+_HI_WAYPOINTS = [
+    {"x": 0.35, "y": 0.18, "z": 0.30},
+    {"x": 0.35, "y": 0.18, "z": 0.36},
+    {"x": 0.35, "y": 0.18, "z": 0.33},
+    {"x": 0.35, "y": 0.24, "z": 0.33},
+    {"x": 0.35, "y": 0.24, "z": 0.30},
+    {"x": 0.35, "y": 0.24, "z": 0.36},
+    {"x": 0.35, "y": 0.32, "z": 0.30, "contact": False},
+    {"x": 0.35, "y": 0.32, "z": 0.34},
+]
+
+
+def _payload_of(tool_content: str) -> dict:
+    with contextlib.suppress(Exception):
+        wrapper = json.loads(tool_content)
+        if isinstance(wrapper, dict) and "content" in wrapper:
+            wrapper = json.loads(wrapper["content"][0])
+        if isinstance(wrapper, dict):
+            value = wrapper.get("value")
+            if isinstance(value, dict):
+                return value
+            return wrapper
+    return {}
+
+
+class _HiModel:
+    """最小假模型：「画个HI」→ 自定义 waypoints 四步链。"""
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    def answer(self, body: dict) -> bytes:
+        self.requests.append(body)
+        messages = body.get("messages", [])
+        if not body.get("stream"):
+            return json.dumps(
+                {
+                    "id": "chatcmpl-fake", "object": "chat.completion",
+                    "created": 1, "model": "fake-k3",
+                    "choices": [{"index": 0, "message": {
+                        "role": "assistant", "content": "好的。"},
+                        "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 10},
+                },
+                ensure_ascii=False,
+            ).encode()
+        frames: list[bytes] = []
+        if messages and messages[-1].get("role") == "tool":
+            last = messages[-1]
+            content = str(last.get("content", ""))
+            call_id = str(last.get("tool_call_id", ""))
+            if call_id == "hi_plan":
+                plan_id = str(_payload_of(content).get("plan_id", ""))
+                assert plan_id, f"plan 缺 plan_id：{content[:200]}"
+                frames.extend(_tool_call_frames(
+                    "hi_sim", "ur5e_simulate_cartesian_trajectory",
+                    json.dumps({"plan_id": plan_id})))
+                frames.append(b"data: [DONE]\n\n")
+                return b"".join(frames)
+            if call_id == "hi_sim":
+                trace_id = str(_payload_of(content).get("trace_id", ""))
+                assert trace_id, f"simulate 缺 trace_id：{content[:200]}"
+                frames.extend(_tool_call_frames(
+                    "hi_verify", "simulation_verify_tracking",
+                    json.dumps({"trace_id": trace_id,
+                                "max_tracking_error_m": 0.05})))
+                frames.append(b"data: [DONE]\n\n")
+                return b"".join(frames)
+            if call_id == "hi_verify":
+                verdict = str(_payload_of(content).get("verdict", ""))
+                assert verdict == "PASS", f"跟踪验证未过：{content[:200]}"
+                import re
+
+                trace_id = ""
+                for m in reversed(messages):
+                    mm = re.search(r"trace_[0-9a-f]+", str(m.get("content", "")))
+                    if mm:
+                        trace_id = mm.group(0)
+                        break
+                frames.extend(_tool_call_frames(
+                    "hi_render", "simulation_render_trace",
+                    json.dumps({"trace_id": trace_id, "format": "gif"})))
+                frames.append(b"data: [DONE]\n\n")
+                return b"".join(frames)
+            # hi_render 已回 → 最终回答（基于 verify PASS + GIF 交付）。
+            frames.append(_sse(_chunk(
+                "HI 字母已绘制完成：自定义路径仿真跟踪验证 PASS，"
+                "轨迹 GIF 已交付。")))
+            frames.append(_sse(_chunk("", "stop")))
+            frames.append(b"data: [DONE]\n\n")
+            return b"".join(frames)
+        text = ""
+        for m in messages:
+            if m.get("role") == "user":
+                c = m.get("content", "")
+                if isinstance(c, list):
+                    c = " ".join(str(b.get("text", ""))
+                                 for b in c if isinstance(b, dict))
+                if not str(c).startswith("<ROSCLAW_TRUSTED_CONTEXT>"):
+                    text = str(c)
+        if "画个HI" in text:
+            frames.extend(_tool_call_frames(
+                "hi_plan", "trajectory_generate_planar_path",
+                json.dumps({"waypoints": _HI_WAYPOINTS,
+                            "max_segment_m": 0.02})))
+        else:
+            frames.append(_sse(_chunk("你好，我是 ROSClaw。")))
+            frames.append(_sse(_chunk("", "stop")))
+        frames.append(b"data: [DONE]\n\n")
+        return b"".join(frames)
+
+
+@pytest.mark.slow
+class TestPiDrawsLettersViaWaypoints:
+    def test_hello_letters_not_a_star(self, tmp_path: Path) -> None:
+        fake = FakeModelServer(log_path=tmp_path / "fake-requests.jsonl")
+        fake.fake = _HiModel()  # type: ignore[assignment]
+        fake.server.RequestHandlerClass.fake = fake.fake  # type: ignore[attr-defined]
+        prefix, _root = _build_and_install(tmp_path)
+        home, env, rosclaw = _prepare_installed_chat(tmp_path, fake, prefix)
+        try:
+            with _hidden_source_checkout():
+                session = PtySession(
+                    [str(rosclaw), "chat"], env,
+                    log_path=tmp_path / "pty-hi.log",
+                )
+                try:
+                    session.expect(b"ROSClaw Native Agent", timeout=60)
+                    session.send("你好\r")
+                    session.expect("你好，我是 ROSClaw".encode(), timeout=90)
+                    session.send(
+                        "请用机械臂画个HI字母，我要看仿真轨迹视频\r"
+                    )
+                    # Pi 驱动闭环：回答基于 verify PASS + GIF 交付。
+                    session.expect(
+                        "HI 字母已绘制完成".encode(), timeout=180,
+                    )
+                    # 0905 事故对面：五角星冒充绝不再出现。
+                    assert "五角星".encode() not in session.clean, (
+                        "画HI竟出现五角星——0905 假成功未根治"
+                    )
+                    session.send("/quit\r")
+                    session.expect(b"rosclaw continue", timeout=30)
+                    session.proc.wait(timeout=30)
+                finally:
+                    session.stop()
+        finally:
+            fake.close()
+        # 证据面：plan 记录是 custom（不是形状枚举）+ GIF 产物登记。
+        plans = list((home / "sim" / "plans").glob("*.json"))
+        assert plans, "无 plan 记录"
+        custom = [
+            p for p in plans
+            if json.loads(p.read_text()).get("shape") == "custom"
+        ]
+        assert custom, f"HI 路径竟不是 custom 形状记录: {plans}"
+        waypoints = json.loads(custom[0].read_text())["waypoints"]
+        assert any(not w.get("contact", True) for w in waypoints), (
+            "抬笔段标记丢失"
+        )
+        db = sqlite3.connect(home / "agentd" / "missions.db")
+        gifs = db.execute(
+            "SELECT COUNT(*) FROM artifacts WHERE path LIKE '%.gif'"
+        ).fetchone()[0]
+        db.close()
+        assert gifs >= 1, "GIF 未登记进产物账本"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/agentd/test_ddzj_r11_waypoints.py
+++ b/tests/agentd/test_ddzj_r11_waypoints.py
@@ -1,0 +1,163 @@
+"""大道至简 R1-1 红测试：plan_cartesian 必须接受任意路径点
+（ROSClaw_Native_Agent大道至简深度重构方案_2026-09-05 §R1）。
+
+0905 体验实证（rosclaw体验0905.txt）：用户要「画 hello」，模型第一
+次调 plan_cartesian_path 直接 ValidationError——工具只收 star5/
+circle 枚举，模型无路可走只能拿五角星冒充。「画什么由 Pi 决定；
+ROSClaw 负责把 Pi 给出的路径可靠地变成仿真、视频和验证结果」。
+
+闭环断言：
+1. 内置规划器接受任意 waypoints（多笔画/抬笔经 contact=False
+   表达）——插值、工作空间校验、canonical hash、句柄摘要；
+2. 越界点 fail-closed（规划即拒）；
+3. 内置工具 trajectory_generate_planar_path：waypoints 直通；
+   既无 shape 也无 waypoints → 报错（删除 shape 默认 star5 的
+   静默兜底——「hello→五角星」的开关级根因）；
+4. MCP 工具 ur5e.plan_cartesian_path：waypoints 直通；
+   无 shape 且无 waypoints → 报错；
+5. 自定义路径可真实仿真（simulate 接受该 plan_id 出 trace——
+   可规划还必须可执行）；
+6. 摘要诚实：自定义路径的 summary 不得出现形状名冒充。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+#: 两笔画 "HI" 形路径（h 一竖一横、i 一竖一点；contact=False 段
+#: 为抬笔移动）。全部点在安全工作空间内（半径 0.3~0.4m，z=0.3m）。
+_HI_WAYPOINTS = [
+    # h 竖
+    {"x": 0.35, "y": 0.20, "z": 0.30},
+    {"x": 0.35, "y": 0.20, "z": 0.36},
+    # 抬笔到横杠起点
+    {"x": 0.35, "y": 0.26, "z": 0.33, "contact": False},
+    # h 横
+    {"x": 0.35, "y": 0.32, "z": 0.33},
+    # 抬笔到 i
+    {"x": 0.35, "y": 0.38, "z": 0.30, "contact": False},
+    # i 竖
+    {"x": 0.35, "y": 0.38, "z": 0.34},
+]
+
+
+class TestBuiltinWaypointPlanning:
+    def test_arbitrary_waypoints_accepted(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        svc = SimTrajectoryService(tmp_path)
+        plan = svc.generate_planar_path(
+            waypoints=_HI_WAYPOINTS, max_segment_m=0.02,
+        )
+        assert plan["plan_id"]
+        assert plan["point_count"] > len(_HI_WAYPOINTS), "未插值"
+        summary = str(plan.get("summary", ""))
+        assert "五角星" not in summary and "star5" not in summary, summary
+        assert "自定义" in summary or "custom" in summary.lower(), summary
+
+    def test_out_of_workspace_point_rejected(self, tmp_path: Path) -> None:
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        svc = SimTrajectoryService(tmp_path)
+        bad = [dict(p) for p in _HI_WAYPOINTS]
+        bad[2] = {"x": 0.95, "y": 0.95, "z": 0.30}  # 半径 1.34m 越界
+        with pytest.raises(ValueError, match="workspace|outside"):
+            svc.generate_waypoint_path(waypoints=bad)
+
+    def test_contact_flags_recorded(self, tmp_path: Path) -> None:
+        """抬笔段随 plan 持久化（渲染/验收层需要区分绘制与移动）。"""
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        svc = SimTrajectoryService(tmp_path)
+        plan = svc.generate_planar_path(
+            waypoints=_HI_WAYPOINTS, max_segment_m=0.02,
+        )
+        payload = svc.get_plan_payload(str(plan["plan_id"]))
+        contacts = [bool(w.get("contact", True))
+                    for w in payload.get("waypoints", [])]
+        assert contacts.count(False) == 2, f"抬笔标记丢失: {contacts}"
+
+    def test_custom_plan_is_executable(self, tmp_path: Path) -> None:
+        """可规划必须可执行——自定义 plan_id 直接进动力学 rollout。"""
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        svc = SimTrajectoryService(tmp_path)
+        plan = svc.generate_planar_path(
+            waypoints=_HI_WAYPOINTS, max_segment_m=0.02,
+        )
+        rollout = svc.simulate_cartesian_trajectory(str(plan["plan_id"]))
+        assert rollout.get("ok") is True, rollout
+        assert rollout.get("trace_id"), rollout
+
+
+class TestBuiltinToolSurface:
+    def _registry(self):
+        from rosclaw.agentd.tools import BuiltinToolRegistry
+
+        return BuiltinToolRegistry(body_id="sim/ur5e", body_summary="UR5e")
+
+    def test_tool_accepts_waypoints(self, tmp_path: Path,
+                                    monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ROSCLAW_HOME", str(tmp_path))
+        registry = self._registry()
+        tools = registry.strict_tools(["trajectory_generate_planar_path"])
+        assert [t.name for t in tools] == ["trajectory_generate_planar_path"]
+        schema = tools[0].parameters
+        props = schema.get("properties", {})
+        assert "waypoints" in props, f"工具契约无 waypoints: {props}"
+        assert "shape" not in schema.get("required", []), (
+            "shape 不应再是必填（waypoints 是通用入口）"
+        )
+
+    def test_no_silent_star5_default(self, tmp_path: Path,
+                                     monkeypatch: pytest.MonkeyPatch) -> None:
+        """既无 shape 也无 waypoints → 报错。tools.py 曾有
+        arguments.get('shape', 'star5') 静默兜底——hello 画成五角星
+        的开关级根因，钉死防回流。"""
+        import inspect
+
+        from rosclaw.agentd import tools
+
+        src = inspect.getsource(tools)
+        assert 'get("shape", "star5")' not in src
+        assert "get('shape', 'star5')" not in src
+
+
+class TestMcpWaypointPlanning:
+    def test_mcp_tool_accepts_waypoints(self) -> None:
+        from rosclaw.sim import ur5e_mcp
+
+        result = json.loads(ur5e_mcp.plan_cartesian_path(
+            waypoints=_HI_WAYPOINTS,
+        ))
+        assert result["ok"] is True, result
+        assert result["plan_id"]
+        assert result["point_count"] > len(_HI_WAYPOINTS)
+        assert "五角星" not in result["summary"], result["summary"]
+
+    def test_mcp_tool_requires_shape_or_waypoints(self) -> None:
+        from rosclaw.sim import ur5e_mcp
+
+        with pytest.raises((ValueError, TypeError)):
+            ur5e_mcp.plan_cartesian_path(
+                shape="", center_x=0.35, center_y=0.25, z=0.30,
+                outer_radius=0.10,
+            )
+
+    def test_mcp_tool_out_of_workspace_rejected(self) -> None:
+        from rosclaw.sim import ur5e_mcp
+
+        with pytest.raises(ValueError, match="outside|radius"):
+            ur5e_mcp.plan_cartesian_path(
+                waypoints=[
+                    {"x": 0.35, "y": 0.25, "z": 0.30},
+                    {"x": 0.95, "y": 0.95, "z": 0.30},
+                ],
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 根因（0905 体验实证）

用户要「画hello」→ 模型第一次调 plan_cartesian_path 直接 ValidationError（工具只认 star5/circle 枚举）→ 无路可走拿五角星冒充交付。方案原文：「plan_cartesian 必须接收任意路径点——画什么由 Pi 决定，ROSClaw 负责把 Pi 给出的路径可靠地变成仿真、视频和验证结果」。

## 改动

- `SimTrajectoryService.generate_waypoint_path`：任意 waypoints `[{x,y,z,contact?}]`（contact=false = 抬笔移动段，多笔画文字/图案的笔段间隔）；每点安全工作空间校验（规划即拒越界）+ 插值 + canonical hash + PlanStore；`shape="custom"` 诚实标记；摘要不含形状名冒充。`generate_planar_path` 的 shape 变可选——无 waypoints 且无 shape 报错，**无默认形状**。
- `ur5e.plan_cartesian_path`（MCP）：同款 waypoints 入口；插值公共化为 `_interpolate`（contact 段标记随插值继承；star5 记录格式不变）。
- 工具契约三处同步（`_TOOL_SCHEMAS` / `native_tools` 快照广告面 / 执行分发）；**删除 tools.py 的 `shape` 静默兜底 star5**（hello→五角星的开关级根因，机制声明测试钉死防回流）。

## 验证

- 红测试 9 项先红后绿（tests/agentd/test_ddzj_r11_waypoints.py）：任意点列接受、越界即拒、抬笔标记持久化、**自定义 plan 可真实动力学 rollout**（可规划必须可执行）、无 star5 静默兜底、MCP 面无默认形状。
- PTY 产品级实证（test_ddzj_r11_hello_journey.py，66s）：Pi 用自定义 waypoints 画 HI 字母 → simulate → verify PASS → GIF 交付，全程屏幕无「五角星」——0905 事故的端到端对面。
- agentd 全量 918 passed；规划器相邻套件（n5b/n5c/n5d/n5e/n6c/nine3/p06/r04/wp2/canary/seven4/r03/p0f/r2b）97 绿。

## 边界

- recipe demo 化（rosclaw demo ur5e-star）与 Kernel 终态客观事实语义在 R0-2；任务工作区编码能力在 R1-2。

🤖 Generated with [Claude Code](https://claude.com/claude-code)