### PR TITLE
大道至简 R0-2a：五角星流程显式 demo 化（rosclaw demo run ur5e-star）

### DIFF
--- a/src/rosclaw/product/demo.py
+++ b/src/rosclaw/product/demo.py
@@ -50,7 +50,22 @@ DEMOS = {
         capability="sandbox.reach",
         mode=ExecutionMode.SIMULATION,
         description="Physics-backed MuJoCo reach with policy, collision, and task verification.",
-    )
+    ),
+    # 大道至简 R0-2a：固定五角星流程的唯一保留形态——显式 demo。
+    # 它不再拦截用户对话（聊天路径的确定性路由已删除）；Runtime
+    # 只报客观执行事实（轨迹执行+跟踪误差），不宣称用户目标完成。
+    "ur5e-star": DemoDefinition(
+        id="ur5e-star",
+        title="UR5e Star Trajectory",
+        robot="sim_ur5e",
+        capability="sim.draw_path.star5",
+        mode=ExecutionMode.SIMULATION,
+        description=(
+            "UR5e draws a five-pointed star in MuJoCo dynamics: plan → "
+            "DLS-IK rollout → tracking verification → GIF render, with "
+            "objective metrics (max/mean tracking error) and artifacts."
+        ),
+    ),
 }
 
 
@@ -78,6 +93,9 @@ def run_demo(
     if definition is None:
         choices = ", ".join(sorted(DEMOS))
         raise DemoNotFoundError(f"Unknown demo {demo_id!r}. Available demos: {choices}")
+    if demo_id == "ur5e-star":
+        return _run_star_demo(home=home, actor_id=actor_id,
+                              agent_framework=agent_framework)
     _validate_configuration(
         target=target,
         max_steps=max_steps,
@@ -106,6 +124,72 @@ def run_demo(
             actor_id=actor_id,
             agent_framework=agent_framework,
         )
+    )
+    receipt_path = store.save(receipt)
+    return receipt, receipt_path
+
+
+def _run_star_demo(
+    *,
+    home: Path | None,
+    actor_id: str,
+    agent_framework: str,
+) -> tuple[ExecutionReceipt, Path]:
+    """ur5e-star：显式五角星 demo——plan → 动力学 rollout → 跟踪验证
+    → GIF 渲染。Receipt 只携带客观执行事实（轨迹/误差/交付物），
+    不做任何用户目标语义宣称（大道至简 R0-2a）。"""
+    from rosclaw.agentd.runtime_manager import RuntimeManager
+    from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+    from rosclaw.kernel import ActionState, EvidenceDomain, EvidenceLevel
+
+    store = ProductRunStore(home)
+    # SimTrajectoryService 的 home 约定：<home>/sim/{plans,traces}——
+    # 与产品 run store 同一 ROSCLAW_HOME。
+    svc = SimTrajectoryService(
+        store.home, runtime_manager=RuntimeManager(store.home),
+    )
+    plan = svc.generate_planar_path(
+        shape="star5", center_m=[0.35, 0.25, 0.30], scale_m=0.10,
+    )
+    rollout = svc.simulate_cartesian_trajectory(str(plan["plan_id"]))
+    trace_id = str(rollout["trace_id"])
+    verify = svc.verify_tracking(trace_id, max_tracking_error_m=0.05)
+    gif = svc.render_trace(trace_id, format="gif")
+    verdict = str(verify.get("verdict", "FAIL"))
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    run_id = f"run_{timestamp}_{uuid.uuid4().hex[:8]}"
+    metrics = dict(verify.get("metrics") or {})
+    gif_path = str((gif.get("artifact") or {}).get("path") or "")
+    mp4_path = str((gif.get("mp4_artifact") or {}).get("path") or "")
+    receipt = ExecutionReceipt(
+        action_id=run_id,
+        trace_id=trace_id,
+        mode=ExecutionMode.SIMULATION,
+        body_id="sim_ur5e",
+        body_snapshot_hash="",
+        capability_id="sim.draw_path.star5",
+        final_state=(
+            ActionState.COMPLETED if verdict == "PASS" else ActionState.FAILED
+        ),
+        evidence_level=(
+            EvidenceLevel.TASK_VERIFIED
+            if verdict == "PASS"
+            else EvidenceLevel.SYNTHETIC
+        ),
+        evidence_domain=EvidenceDomain.SIMULATION,
+        simulation_result={
+            "physics_executed": bool(rollout.get("physics_executed", True)),
+            "plan_id": str(plan["plan_id"]),
+            "point_count": int(rollout.get("point_count", 0) or 0),
+            "is_safe": bool(rollout.get("is_safe", True)),
+            # 客观事实纪律：误差数值随 receipt 可被第三方独立复核。
+            "max_tracking_error_m": metrics.get("max_error_m"),
+            "mean_tracking_error_m": metrics.get("mean_error_m"),
+        },
+        verification_result=verify,
+        artifacts=[p for p in (gif_path, mp4_path) if p],
+        dispatch_result={"actor_id": actor_id,
+                         "agent_framework": agent_framework},
     )
     receipt_path = store.save(receipt)
     return receipt, receipt_path

--- a/tests/product/test_ddzj_r02_star_demo.py
+++ b/tests/product/test_ddzj_r02_star_demo.py
@@ -1,0 +1,74 @@
+"""大道至简 R0-2a 红测试：固定五角星流程显式 demo 化——
+`rosclaw demo run ur5e-star`，不拦截用户对话。
+
+方案 R0：「固定五角星流程可以留下，但只能是显式 demo——它不能
+再拦截用户对话」。Kernel/Runtime 只报客观执行事实（轨迹执行
+成功 + 最大跟踪误差），不宣称用户目标完成。
+
+闭环断言：
+1. demo 注册表含 ur5e-star（与 ur5e-reach 同一官方证据面）；
+2. run_demo("ur5e-star") 真实跑完 plan→rollout→verify→render：
+   COMPLETED + TASK_VERIFIED（PASS）+ 最大误差是客观数值 +
+   GIF 交付物在盘 + receipt 持久化；
+3. CLI 层 `demo run ur5e-star --json` 退出码 0、载荷带客观指标；
+4. 客观事实纪律：receipt 无用户目标语义字段（goal/intent/
+   satisfied）——Runtime 只说"轨迹执行成功，误差 X m"。
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+class TestStarDemoRegistry:
+    def test_ur5e_star_registered(self) -> None:
+        from rosclaw.product.demo import DEMOS, list_demos
+
+        assert "ur5e-star" in DEMOS
+        ids = [d.id for d in list_demos()]
+        assert "ur5e-star" in ids and "ur5e-reach" in ids
+
+    def test_star_demo_objective_facts_only(self, tmp_path: Path) -> None:
+        from rosclaw.product.demo import run_demo
+
+        receipt, receipt_path = run_demo("ur5e-star", home=tmp_path)
+        assert receipt.final_state.value == "COMPLETED"
+        assert receipt.verified, "跟踪验证 PASS 必须是 TASK_VERIFIED"
+        # 客观执行事实：轨迹 + 误差数值 + 交付物。
+        sim = receipt.simulation_result or {}
+        assert sim.get("physics_executed") is True, sim
+        metrics = (receipt.verification_result or {}).get("metrics") or {}
+        assert isinstance(metrics.get("max_error_m"), float), metrics
+        gifs = [a for a in receipt.artifacts if str(a).endswith(".gif")]
+        assert gifs and Path(gifs[0]).exists(), receipt.artifacts
+        assert receipt_path.exists(), "receipt 未持久化"
+        # 客观事实纪律：无用户目标语义（目标完成与否由 Pi 判断，
+        # 不是 Runtime）。
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+        for forbidden in ("goal_satisfied", "user_goal", "intent_satisfied"):
+            assert forbidden not in payload, forbidden
+
+    def test_star_demo_cli(self, tmp_path: Path) -> None:
+        import os
+
+        src = str(Path(__file__).resolve().parents[2] / "src")
+        env = {**os.environ, "PYTHONPATH": src}
+        result = subprocess.run(
+            [sys.executable, "-m", "rosclaw.entrypoint", "demo", "run",
+             "ur5e-star", "--home", str(tmp_path), "--json"],
+            capture_output=True, text=True, timeout=600, env=env,
+        )
+        assert result.returncode == 0, result.stderr[-500:]
+        payload = json.loads(result.stdout)
+        assert payload["capability_id"] == "sim.draw_path.star5"
+        vr = payload.get("verification_result") or {}
+        assert vr.get("verdict") == "PASS", vr
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 方案 R0（2026-09-05 大道至简）

「固定五角星流程可以留下，但只能是显式 demo——它不能再拦截用户对话。」聊天拦截已在 R0-1（#512）删除，本 PR 给五角星链唯一保留形态：**显式 CLI demo**。

## 改动

- `product/demo.py` 注册 `ur5e-star`：`SimTrajectoryService` 直驱 plan → DLS-IK 动力学 rollout → 跟踪验证 → GIF/MP4 渲染（不碰 kernel task / 语义 Gate）。
- Receipt 只携带**客观执行事实**：`physics_executed`/`point_count`/`max_tracking_error_m`/`mean_tracking_error_m` + 交付物路径——无用户目标语义字段。Runtime 说「轨迹执行成功，最大误差 X m」；「用户目标是否完成」由 Pi 判断。
- 与 `ur5e-reach` 同一官方证据面（ProductRunStore receipt 持久化 + `demo list` 可见）。

## 验证

- 红测试 3 项先红后绿（tests/product/test_ddzj_r02_star_demo.py）：注册表 / 客观事实纪律（receipt 无 goal_satisfied 类字段）/ CLI `demo run ur5e-star --json` exit 0 + verdict PASS。
- tests/product + tests/cli 74 绿。

## 边界

R0-2b（删除生产 recipe 链 task_execution/plan_templates + 语义 Gate 模块 task_router/requirements/requirement_check + rosclaw_task recipe 路径）是独立后续 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)