### PR TITLE
大道至简 R1-2a：任务沙箱可写可运行 + 一屏具身事实 + 具身 Skill 重写

### DIFF
--- a/packages/rosclaw-agent/skills/rosclaw-embodied/SKILL.md
+++ b/packages/rosclaw-agent/skills/rosclaw-embodied/SKILL.md
@@ -1,29 +1,51 @@
 ---
 name: rosclaw-embodied
-description: ROSClaw 具身任务纪律——权威资产、证据验收、安全分层的精简操作手册（何时用：任何涉及机器人/仿真/动作的任务）
+description: ROSClaw 具身任务纪律——通用物理原语编排、任务沙箱编码、证据验收、安全分层（何时用：任何涉及机器人/仿真/动作的任务）
 ---
 
 # ROSClaw 具身任务纪律
 
-## 权威资产
+Pi 是唯一大脑：理解用户目标、调查环境、组合通用原语、没有现成
+能力时在任务沙箱写代码、运行观察修错、判断是否完成用户目标。
 
-- 机器人模型只认 e-URDF-Zoo 权威资产（`e-urdf-zoo/<robot>/robot.mjcf.xml`）；
-  测试 fixture（tests/fixtures/）与简化模型绝不出现在交付证据里。
-- 不确定资产来源时先调查：`rosclaw robot list` / 读取 sandbox/loader
-  源码确认解析顺序，不从 / 全盘搜索同名文件。
+## 通用物理原语（SIM 自动执行，不弹批准）
+
+- `trajectory_generate_planar_path`：任意路径点 waypoints
+  `[{x,y,z,contact?}]`（contact=false=抬笔移动段）——文字/任意
+  图形都由你表达为点列；shape=star5|circle 只是便捷参数，
+  **没有默认形状**。返回 plan_id 句柄。
+- `ur5e_simulate_cartesian_trajectory(plan_id)` → trace_id
+  （真实 MuJoCo 动力学 rollout + 跟踪指标）。
+- `simulation_verify_tracking(trace_id, max_tracking_error_m)` →
+  诚实 PASS/FAIL + 误差数值。
+- `simulation_render_trace(trace_id, format=gif)` /
+  `simulation_render_scene(trace_id, camera=...)` → 交付物。
+- 观测：`ur5e.get_end_effector_pose` 等 OBSERVE 面。
+- 可信上下文每轮带 workspace_window（安全半径/z 窗口）——
+  摆 waypoints 不要越界（规划器硬校验，越界即拒）。
+
+## 任务沙箱编码
+
+- 活跃任务的 `scratch/` 区可写可运行（write/edit/bash cwd 限定在
+  session 工作区与任务 scratch 内）——写几十行 Python 把字母/
+  图形转成点列是正常能力，不需要内核替你认识任何形状。
+- scratch 是草稿——交付物登记走 outputs/（register_artifact）。
 
 ## 证据与验收
 
 - 交付物必须登记（rosclaw_artifact_register）——口头提到不算。
-- 验收条件在任务创建时冻结；task_finish 不接受新规则。
-- 机器人行为任务的完成必须有受信管道的独立验证证据；
-  手写脚本的输出不算行为证据。
-- 用户否定结果后任务重开 revision——不得沿用旧 receipt 宣称成功。
+- 仿真证据标 simulated——动力学自洽不证明真机效果。
+- 用户否定结果后修正或重开 revision——不得拿旧结果冒充。
 
 ## 安全分层
 
-- 纯计算/封闭本地仿真：自动执行。
-- 真机动作：必须走 rosclaw_execute/request_action 的 admission 链
+- SIM：物理原语工具 + 任务沙箱代码自动执行。
+- 真机动作：必须走 rosclaw_request_action 的 admission 链
   （rosclawd + permit + operator），任何其他路径都不是执行权威。
-- 仿真失败先读结构化诊断，按真实 Schema 修正参数；同一调用同一
-  参数不机械重试。
+- 改产品核心源码不是任务能力——走开发流程（克隆仓库+PR）。
+- 同一调用同一参数失败后不机械重试；先读结构化诊断。
+
+## 权威资产
+
+- 机器人模型只认 e-URDF-Zoo 权威资产；测试 fixture 绝不出现在
+  交付证据里。不确定资产来源时先调查，不从 / 全盘搜索。

--- a/packages/rosclaw-agent/src/extension/context-injection.ts
+++ b/packages/rosclaw-agent/src/extension/context-injection.ts
@@ -164,13 +164,21 @@ export function renderTrustedContext(result: ContextFetchResult): string {
 		);
 	}
 	const env = result.envelope;
-	const body = env.body as { body_id?: string; effective_body_hash?: string; summary?: string };
+	const body = env.body as {
+		body_id?: string; effective_body_hash?: string; summary?: string;
+		safe_radius_m?: number[]; safe_z_m?: number[];
+	};
 	const safety = env.safety as { mode?: string };
 	return (
 		"<ROSCLAW_TRUSTED_CONTEXT>\n" +
 		`mission: ${env.mission_id}  mode: ${safety.mode ?? ""}  revision: ${env.context_revision}\n` +
 		`body: ${body.body_id ?? ""} (hash ${String(body.effective_body_hash ?? "").slice(0, 16)})\n` +
 		`body_summary: ${body.summary ?? ""}\n` +
+		// R1-2c：安全工作空间窗口（规划器硬校验同值）——Pi 摆
+		// waypoints 不猜边界；实时位姿走 get_end_effector_pose 工具。
+		(body.safe_radius_m && body.safe_z_m
+			? `workspace_window: radius [${body.safe_radius_m[0]}, ${body.safe_radius_m[1]}]m, z [${body.safe_z_m[0]}, ${body.safe_z_m[1]}]m\n`
+			: "") +
 		`pending_approvals: ${env.pending_approvals.length}\n` +
 		(result.activeRun
 			? `task_run: ${result.activeRun.run_dir}（交付物→outputs/ 证据→evidence/ 草稿→scratch/ 日志→logs/；scratch 不得登记为交付物）\n`

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -606,6 +606,12 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 				// STALE + 禁动作（不再有"revision 碰巧没变就能动作"）。
 				options.active.markContextStale(fetched.note);
 			}
+			// R1-2a：活跃任务运行目录写入 active context——任务沙箱
+			// scratch 区成为 write/edit/bash 的额外允许根（Pi 的任务
+			// 代码写在任务目录，不写项目源码树）。
+			if (fetched.activeRun?.run_dir) {
+				options.active.patch({ taskRunDir: fetched.activeRun.run_dir });
+			}
 			// chrome 刷新由 active.subscribe → center → refreshChrome 统一
 			// 完成（applyEnvelope/markContextStale 都会触发）。
 			return {

--- a/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
+++ b/packages/rosclaw-agent/src/harness/pi/pi-runtime.ts
@@ -227,6 +227,12 @@ export async function createRosclawRuntime(
 					// 凭据/控制 token/bridge socket 不经 shell 可达）。
 					mode: () => active.current.mode,
 					rosclawHome: options.rosclawHome,
+					// R1-2a：任务沙箱 scratch 区是 write/edit/bash 的额外
+					// 允许根（活跃任务 run dir——Pi 任务代码不写项目树）。
+					extraRoots: () => {
+						const runDir = active.current.taskRunDir;
+						return runDir ? [join(runDir, "scratch")] : [];
+					},
 					// P0-C：bash/write/edit 执行前的原子 admission
 					// （首个 effectful call 建 task——动机=session
 					// 最新输入）。

--- a/packages/rosclaw-agent/src/session/active-context.ts
+++ b/packages/rosclaw-agent/src/session/active-context.ts
@@ -31,6 +31,10 @@ export interface ActiveSessionState {
 	/** 动作准入的 UI/tool 层单一判据——只有 FRESH + ACTIVE 才 true。
 	 *  admission 的内核校验仍是最终权威；本字段让 UI/工具提前诚实拒绝。 */
 	actionsAllowed: boolean;
+	/** 大道至简 R1-2a：活跃任务运行目录（pi.context active_run——
+	 *  任务沙箱 scratch 区= runDir/scratch，write/edit/bash cwd 的
+	 *  额外允许根）。无活跃任务时缺省。 */
+	taskRunDir?: string;
 }
 
 export class ActiveSessionContext {

--- a/packages/rosclaw-agent/src/tools/workspace-pack.ts
+++ b/packages/rosclaw-agent/src/tools/workspace-pack.ts
@@ -137,6 +137,10 @@ export interface WorkspacePackOptions {
 	/** 0902 R1-a：无沙箱降级的 Runtime 批准面（会话内确认卡 →
 	 *  task+revision+scope 绑定的 grant）。缺失 = fail closed。 */
 	shellGate?: ShellGate;
+	/** 大道至简 R1-2a：任务沙箱额外资根（活跃任务 run dir 的
+	 *  scratch 区——Pi 写的任务代码/脚本放这里；write/edit/bash
+	 *  的 cwd 允许落在 [root, ...extraRoots] 任一根内）。 */
+	extraRoots?: () => string[];
 	/** P0-C（0824 总纲 §6.2）：effectful 工具执行前的原子
 	 *  admission（ensure_task_for_effect）——bash/write/edit
 	 *  执行前触发。 */
@@ -168,6 +172,21 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 	const root = options.root;
 	const scrubbedEnv = scrubEnv(process.env);
 
+	/** 大道至简 R1-2a：多根路径解析——[session workspace, 任务
+	 *  scratch 区] 任一根内即合法（其余照旧拒绝）。 */
+	const resolveAllowed = (target: string): string => {
+		const roots = [root, ...(options.extraRoots?.() ?? [])];
+		let lastErr: Error | null = null;
+		for (const r of roots) {
+			try {
+				return resolveInRoot(r, target);
+			} catch (err) {
+				lastErr = err as Error;
+			}
+		}
+		throw lastErr ?? new Error(`path escapes workspace: ${target}`);
+	};
+
 	const denied = (reason: string) => ({
 		content: [{ type: "text" as const, text: `DENIED: ${reason}` }],
 		details: { error: "denied", reason } as Record<string, unknown>,
@@ -184,6 +203,9 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 		parameters: Type.Object({
 			command: Type.String({ description: "要执行的 shell 命令" }),
 			timeout_sec: Type.Optional(Type.Number({ description: "显式超时（秒）——不填则无定时器" })),
+			cwd: Type.Optional(Type.String({
+				description: "工作目录（限 session 工作区/任务 scratch 区内；缺省=session 工作区）",
+			})),
 		}),
 		async execute(_id, params, signal, onUpdate) {
 			const command = String(params.command ?? "").trim();
@@ -205,6 +227,16 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 				{ defaultTimeoutMs: options.defaultBashTimeoutMs },
 			);
 			const started = Date.now();
+			// R1-2a：cwd 参数（限允许的根内——任务 scratch 区的
+			// 脚本可直接运行；越界直接拒绝，不进执行）。
+			let effectiveCwd = root;
+			if (params.cwd !== undefined && params.cwd !== null && String(params.cwd).trim()) {
+				try {
+					effectiveCwd = resolveAllowed(String(params.cwd));
+				} catch (err) {
+					return denied((err as Error).message);
+				}
+			}
 			// P0-6（0823 审计）：全模式 shell 必须 bwrap 强隔离——
 			// SIM auto 下 Harness Shell 裸跑可绕过治理（读凭据/
 			// 控制 token、直调 bridge socket、写项目源码树）。
@@ -267,15 +299,18 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 						..._sensitiveMasks(
 							process.env.HOME ?? "", options.rosclawHome,
 						),
-						"--bind", root, root, // workspace 可写（其余宿主只读）
+						// workspace 与任务 scratch 区可写（其余宿主只读）。
+						...[root, ...(options.extraRoots?.() ?? [])].flatMap(
+							(r) => ["--bind", r, r],
+						),
 						"--unshare-net",
 						"--dev", "/dev", // 全新 devtmpfs——真设备不可见
-						"--chdir", root,
+						"--chdir", effectiveCwd,
 						"sh", "-c", command,
 					];
 				}
 				const child = spawn(spawnCmd, spawnArgs, {
-					cwd: root,
+					cwd: effectiveCwd,
 					env: scrubbedEnv,
 					signal: signal ?? undefined,
 				});
@@ -334,7 +369,7 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 			// P0-C：首个 effectful call 的原子 admission。
 			await options.beforeEffect?.();
 			try {
-				const p = resolveInRoot(root, String(params.path));
+				const p = resolveAllowed(String(params.path));
 				// 0903（§4.4）：产品核心源码只读——普通任务不得修改
 				// 正在运行的产品（改产品走开发流程：clone+PR）。
 				if (isProductSourcePath(p)) {
@@ -371,7 +406,7 @@ export function buildWorkspacePackTools(options: WorkspacePackOptions): ToolDefi
 			// P0-C：首个 effectful call 的原子 admission。
 			await options.beforeEffect?.();
 			try {
-				const p = resolveInRoot(root, String(params.path));
+				const p = resolveAllowed(String(params.path));
 				if (isProductSourcePath(p)) {
 					return denied(
 						"拒绝编辑：目标是正在运行的 ROSClaw 产品核心源码（§4.4）"

--- a/packages/rosclaw-agent/test/ddzj-r12-task-workspace.test.ts
+++ b/packages/rosclaw-agent/test/ddzj-r12-task-workspace.test.ts
@@ -1,0 +1,111 @@
+/** 大道至简 R1-2a 红测试：任务沙箱可写可运行。
+ *
+ * 方案 R1：「普通 SIM 任务允许 Pi 在 ~/.rosclaw/runs/<task>/ 自由
+ * 写代码、运行代码」——现有 run dir scratch 区（WP-8）是任务沙箱。
+ * 当前 write/edit/bash 只认 session workspaceRoot——写到任务
+ * scratch 被「path escapes workspace」拒绝。
+ *
+ * 闭环断言：
+ * 1. write/edit 接受活跃任务 scratch 区（extraRoots）；
+ * 2. 两个根之外仍拒绝（防逃逸）；
+ * 3. 产品核心源码守护在 extraRoots 下依然生效（§4.4 不削弱）；
+ * 4. bash 支持 cwd 参数（限定在允许的根内）——Pi 写的脚本可运行；
+ *    cwd 越界拒绝。
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+async function makeTools(dir: string, scratch: string) {
+	const { buildWorkspacePackTools } = await import(
+		"../src/tools/workspace-pack.js"
+	);
+	return buildWorkspacePackTools({
+		root: dir,
+		rosclawHome: dir,
+		mode: () => "SIMULATION",
+		// 本测试只关心路径限定（cwd/extraRoots），不关心沙箱——
+		// 注入无 bwrap + 操作者降级授权（真实主机的 bwrap 完好性
+		// 由 os_isolation 探测覆盖，不在此断言）。
+		bwrapPath: () => null,
+		allowUnsandboxedShell: () => true,
+		extraRoots: () => [scratch],
+	} as never);
+}
+
+test("R1-2a: write 接受任务 scratch 区（extraRoots）", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "r12-ws-"));
+	const scratch = mkdtempSync(join(tmpdir(), "r12-scratch-"));
+	const tools = await makeTools(dir, scratch);
+	const write = tools.find((t) => t.name === "write") as unknown as {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		execute: (...a: any[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+	};
+	const target = join(scratch, "letters.py");
+	const out = await write.execute(
+		"c1", { path: target, content: "print('hi')" },
+		new AbortController().signal, async () => {}, {},
+	);
+	assert.ok(!out.isError, out.content[0]?.text);
+	assert.equal(readFileSync(target, "utf-8"), "print('hi')");
+});
+
+test("R1-2a: 两个根之外仍拒绝（防逃逸）", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "r12-ws-"));
+	const scratch = mkdtempSync(join(tmpdir(), "r12-scratch-"));
+	const tools = await makeTools(dir, scratch);
+	const write = tools.find((t) => t.name === "write") as unknown as {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		execute: (...a: any[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+	};
+	const out = await write.execute(
+		"c1", { path: "/etc/r12-escape-test", content: "x" },
+		new AbortController().signal, async () => {}, {},
+	);
+	assert.ok(out.isError, "越界写入竟放行");
+});
+
+test("R1-2a: edit 在 extraRoots 下可用", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "r12-ws-"));
+	const scratch = mkdtempSync(join(tmpdir(), "r12-scratch-"));
+	const target = join(scratch, "a.txt");
+	writeFileSync(target, "hello", "utf-8");
+	const tools = await makeTools(dir, scratch);
+	const edit = tools.find((t) => t.name === "edit") as unknown as {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		execute: (...a: any[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+	};
+	const out = await edit.execute(
+		"c1", { path: target, oldText: "hello", newText: "world" },
+		new AbortController().signal, async () => {}, {},
+	);
+	assert.ok(!out.isError, out.content[0]?.text);
+	assert.equal(readFileSync(target, "utf-8"), "world");
+});
+
+test("R1-2a: bash cwd 限定允许的根——scratch 可运行脚本，越界拒绝", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "r12-ws-"));
+	const scratch = mkdtempSync(join(tmpdir(), "r12-scratch-"));
+	writeFileSync(join(scratch, "ok.sh"), "echo sandbox-ok", "utf-8");
+	const tools = await makeTools(dir, scratch);
+	const bash = tools.find((t) => t.name === "bash") as unknown as {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		execute: (...a: any[]) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+	};
+	// cwd 在 scratch：可运行 Pi 写的脚本。
+	const ok = await bash.execute(
+		"c1", { command: "sh ok.sh", cwd: scratch },
+		new AbortController().signal, async () => {}, {},
+	);
+	assert.ok(!ok.isError, ok.content[0]?.text);
+	assert.match(ok.content[0]?.text ?? "", /sandbox-ok/);
+	// cwd 越界（系统目录）→ 拒绝。
+	const bad = await bash.execute(
+		"c2", { command: "ls", cwd: "/etc" },
+		new AbortController().signal, async () => {}, {},
+	);
+	assert.ok(bad.isError, "cwd 越界竟放行");
+});

--- a/src/rosclaw/agentd/pi_bridge/context.py
+++ b/src/rosclaw/agentd/pi_bridge/context.py
@@ -27,6 +27,20 @@ def build_embodied_context(service: AgentService, mission_id: str) -> EmbodiedCo
     body = service._body_source.get_body(service._body_id)
     snapshot = service.snapshot(mission_id)
     pending = service.pending_approvals(mission_id)
+    # 大道至简 R1-2c：一屏具身事实带安全工作空间窗口（规划器
+    # 硬校验的同一数值——Pi 摆 waypoints 不必先调工具猜边界）。
+    # 静态事实（非实时位姿——实时位姿走 ur5e.get_end_effector_pose
+    # 工具，诚实不混淆）。
+    workspace_window: dict[str, object] = {}
+    if str(mission.body_binding.body_id).endswith("ur5e"):
+        from rosclaw.sim.ur5e_mcp import _SAFE_RADIUS, _SAFE_Z
+
+        workspace_window = {
+            "safe_radius_m": [_SAFE_RADIUS[0], _SAFE_RADIUS[1]],
+            "safe_z_m": [_SAFE_Z[0], _SAFE_Z[1]],
+            "note": "规划器硬校验边界——waypoints 越界即拒；"
+                    "实时末端位姿用 ur5e.get_end_effector_pose",
+        }
     envelope = EmbodiedContextEnvelopeV1(
         mission_id=mission_id,
         context_revision=snapshot.context_revision,
@@ -38,6 +52,7 @@ def build_embodied_context(service: AgentService, mission_id: str) -> EmbodiedCo
             "summary": body.summary if body else "body unavailable (fail closed)",
             "calibrated": body.calibrated if body else False,
             "issues": list(body.issues) if body else ["body source unavailable"],
+            **workspace_window,
         },
         self_state={
             "authorization_profile": service.authorization_profile(),

--- a/tests/agentd/test_ddzj_r12_context_window.py
+++ b/tests/agentd/test_ddzj_r12_context_window.py
@@ -1,0 +1,58 @@
+"""大道至简 R1-2c：一屏具身事实带安全工作空间窗口。
+
+闭环断言：sim/ur5e 任务的 trusted context envelope 含
+safe_radius_m/safe_z_m（规划器硬校验同值——Pi 摆 waypoints 不猜
+边界）；非 ur5e 本体不携带。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestWorkspaceWindow:
+    def test_ur5e_envelope_has_workspace_window(self, tmp_path) -> None:
+        import asyncio
+
+        from tests.agentd.test_pi_tool_bridge import _setup
+
+        async def run() -> dict:
+            service, mission = await _setup(tmp_path)
+            from rosclaw.agentd.pi_bridge.context import build_embodied_context
+
+            envelope = build_embodied_context(service, mission.mission_id)
+            await service.close()
+            return envelope.body
+
+        body = asyncio.run(run())
+        # _setup 的 mission 绑定 sim/ur5e——窗口必须在且与规划器
+        # 硬校验同值。
+        assert body.get("safe_radius_m") == [0.10, 0.80], body
+        assert body.get("safe_z_m") == [0.02, 1.20], body
+
+    def test_window_values_match_planner(self) -> None:
+        """窗口数值与规划器硬校验同源（不是抄来的第二份）。"""
+        from rosclaw.sim.ur5e_mcp import _SAFE_RADIUS, _SAFE_Z
+
+        assert _SAFE_RADIUS == (0.10, 0.80)
+        assert _SAFE_Z == (0.02, 1.20)
+
+
+class TestSkillRewrite:
+    def test_skill_teaches_generic_primitives(self) -> None:
+        from pathlib import Path
+
+        skill = (
+            Path(__file__).resolve().parents[2]
+            / "packages/rosclaw-agent/skills/rosclaw-embodied/SKILL.md"
+        ).read_text(encoding="utf-8")
+        assert "trajectory_generate_planar_path" in skill
+        assert "waypoints" in skill
+        # 无五角星步骤/形状特例步骤（shape 只是便捷参数的顺带
+        # 提及允许——不得有"画五角星"步骤式指引）。
+        assert "画五角星" not in skill
+        assert "五角星步骤" not in skill
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 方案 R1（2026-09-05）

「普通 SIM 任务允许 Pi 在任务目录自由写代码、运行代码」——Coding Agent 的正常能力（hello 字母转点列这类几十行脚本，不需要内核认识任何形状）。「给 Pi 注入一屏以内的 Body/Mode/EEF 信息。」「重写 rosclaw-embodied Skill。」

## 改动

- **任务沙箱可写可运行**：workspace-pack 新增 extraRoots——活跃任务 run dir 的 `scratch/` 区成为 write/edit 的额外允许根；bash 新增 `cwd` 参数（限定允许的根内，越界直接拒绝）；bwrap 沙箱下 scratch 区同样可写（--bind）。接线：pi.context 的 active_run.run_dir → ActiveSessionContext.taskRunDir → pi-runtime extraRoots。
- **一屏具身事实（R1-2c）**：trusted context envelope 带安全工作空间窗口（safe_radius_m/safe_z_m，与规划器硬校验同源同值）——Pi 摆 waypoints 不猜边界；实时位姿仍走 get_end_effector_pose 工具（静态/动态诚实不混淆）。
- **Skill 重写（R1-2d）**：rosclaw-embodied 改为通用原语编排（waypoints 规划→rollout→验证→渲染）+ 任务沙箱编码 + 证据/安全纪律；无形状步骤、无长篇规则。

## 验证

- 红测试 TS 4 项先红后绿（scratch 可写/越界拒绝/edit 可用/bash cwd 限定）；PY 3 项（envelope 窗口与规划器同值/Skill 教通用原语且无形状步骤）。
- TS 全套 230/230 + tsc；agentd+integration 1018 绿。

R1-2b（SIM 任务沙箱 bash 免批准卡，R1-a 确认卡退役）为独立后续 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)