### PR TITLE
大道至简 R2：UI 减法——只读工具折叠 + 主交付物可点击打开

### DIFF
--- a/packages/rosclaw-agent/src/native/terminal-presenter.ts
+++ b/packages/rosclaw-agent/src/native/terminal-presenter.ts
@@ -58,7 +58,9 @@ function renderArtifactLine(ref: {
 				? `${size} B`
 				: "";
 	const head = name
-		? `• ${name}${sizeText ? `（${sizeText}）` : ""}`
+		// 大道至简 R2：主交付物文件名可点击（OSC 8 file:// 链接——
+		// 终端里直接点开，不必复制路径）。
+		? `• ${path ? `\x1b]8;;file://${path}\x07${name}\x1b]8;;\x07` : name}${sizeText ? `（${sizeText}）` : ""}`
 		: `• ${String(ref.artifact_id ?? "artifact")}`;
 	const pathLine = verbose && path ? `\n  ${path}` : "";
 	const openLine = ref.open_command ? `\n  ${ref.open_command}` : "";

--- a/packages/rosclaw-agent/src/tools/task-read.ts
+++ b/packages/rosclaw-agent/src/tools/task-read.ts
@@ -16,6 +16,9 @@
 import { Type } from "@earendil-works/pi-ai";
 import { defineTool } from "@earendil-works/pi-coding-agent";
 import type { BridgeToolContext } from "./bridge-tools.js";
+// 大道至简 R2：只读任务工具挂折叠渲染钩（模型上下文留完整
+// JSON，TUI 单行摘要——0905 实证 artifact list 整段刷屏）。
+import { compactRenderResult } from "../ui/compact-result.js";
 
 function text(value: unknown): string {
 	return JSON.stringify(value, null, 1);
@@ -24,6 +27,7 @@ function text(value: unknown): string {
 export function buildReadOnlyTaskTools(ctx: BridgeToolContext) {
 	const taskInspect = defineTool({
 		name: "rosclaw_task_inspect",
+		renderResult: compactRenderResult,
 		label: "ROSClaw Task Inspect",
 		description:
 			"Read the latest task and its outcome (state, verification, " +
@@ -58,6 +62,7 @@ export function buildReadOnlyTaskTools(ctx: BridgeToolContext) {
 
 	const artifactList = defineTool({
 		name: "rosclaw_artifact_list",
+		renderResult: compactRenderResult,
 		label: "ROSClaw Artifact List",
 		description:
 			"List deliverables of the latest task (artifact id, kind, media " +
@@ -81,6 +86,7 @@ export function buildReadOnlyTaskTools(ctx: BridgeToolContext) {
 
 	const artifactResolve = defineTool({
 		name: "rosclaw_artifact_resolve",
+		renderResult: compactRenderResult,
 		label: "ROSClaw Artifact Resolve",
 		description:
 			"Resolve an artifact id to its absolute path, kind, size and " +

--- a/packages/rosclaw-agent/src/ui/tool-display.ts
+++ b/packages/rosclaw-agent/src/ui/tool-display.ts
@@ -29,6 +29,22 @@ export function summarizeToolResultText(raw: string): string {
 	const parsed = tryParseJson(text);
 	if (parsed && typeof parsed === "object") {
 		const env = parsed as Record<string, unknown>;
+		// 大道至简 R2：交付物清单 → 计数行（0905 实证：8 个
+		// artifact 的 digest/open_command/内部绝对路径整段刷屏）。
+		const artifacts = env.artifacts;
+		if (Array.isArray(artifacts)) {
+			const mediaCounts = new Map<string, number>();
+			for (const a of artifacts) {
+				const mt = String(
+					(a as Record<string, unknown>)?.media_type ?? "unknown",
+				).split("/").pop() ?? "unknown";
+				mediaCounts.set(mt, (mediaCounts.get(mt) ?? 0) + 1);
+			}
+			const breakdown = [...mediaCounts.entries()]
+				.map(([mt, n]) => `${mt} ×${n}`)
+				.join("、");
+			return `✓ ${artifacts.length} 个交付物（${breakdown}）——明细见 /activity`;
+		}
 		const status = String(env.status ?? "");
 		const cap = String(env.capability_id ?? "");
 		const value = (env.value ?? {}) as Record<string, unknown>;

--- a/packages/rosclaw-agent/test/a0901-p06-terminal-presenter.test.ts
+++ b/packages/rosclaw-agent/test/a0901-p06-terminal-presenter.test.ts
@@ -34,7 +34,10 @@ test("P0-6 PASS 呈现：文件名 + 打开命令 + 下一步（0902 R3-b：绝�
 	assert.match(reply, /rosclaw artifact open art_g/);
 	// 0902 R3-b：默认层不裸打绝对路径（内部路径进 verbose 诊断层）；
 	// 可达性由 open/path/export 命令承接。
-	assert.doesNotMatch(reply, /\/home\/u\/proj\/outputs\/star-scene\.gif/);
+	// 大道至简 R2：文件名带 OSC 8 可点击链接（escape 序列里嵌
+	// 绝对路径但终端不可见）——断言剥掉 OSC 8 后的可见文本。
+	const visible = reply.replace(/\x1b\]8;;[^\x07]*\x07/g, "");
+	assert.doesNotMatch(visible, /\/home\/u\/proj\/outputs\/star-scene\.gif/);
 	const verbose = renderTerminalReply({
 		verification: "PASS",
 		delivery: "DELIVERED",

--- a/packages/rosclaw-agent/test/a0902-r3b-terminal-layer.test.ts
+++ b/packages/rosclaw-agent/test/a0902-r3b-terminal-layer.test.ts
@@ -36,7 +36,10 @@ test("R3-b 默认层：文件名+大小+短命令在，内部绝对路径不在"
 	assert.match(reply, /trace_abc-scene\.gif/); // 文件名
 	assert.match(reply, /1\.2 MB/); // 大小
 	assert.match(reply, /rosclaw open art_g/); // 短打开命令
-	assert.doesNotMatch(reply, /\/home\/u\/\.rosclaw\/sim\/traces/, // 内部路径不进默认层
+	// 大道至简 R2：剥 OSC 8 后断言可见文本（链接 escape 里嵌
+	// 的绝对路径终端不可见——可见面仍无内部路径）。
+	const visible = reply.replace(/\x1b\]8;;[^\x07]*\x07/g, "");
+	assert.doesNotMatch(visible, /\/home\/u\/\.rosclaw\/sim\/traces/, // 内部路径不进默认层
 		"默认层仍裸打内部绝对路径");
 });
 

--- a/packages/rosclaw-agent/test/ddzj-r2-ui-subtraction.test.ts
+++ b/packages/rosclaw-agent/test/ddzj-r2-ui-subtraction.test.ts
@@ -1,0 +1,88 @@
+/** 大道至简 R2 红测试：UI 减法——默认只显示目标/进度/结果。
+ *
+ * 0905 体验实证（rosclaw体验0905.txt）：rosclaw_artifact_list 把
+ * 整段交付物 JSON（8 个 artifact 的 digest/open_command/内部绝对
+ * 路径）原样刷屏——用户看到的信息量比模型还多。
+ * 方案 R2：默认隐藏 Artifact JSON/trace ID/内部路径（只进
+ * /activity）；主交付物直接点击打开。
+ *
+ * 闭环断言：
+ * 1. 三个只读任务工具（task_inspect/artifact_list/artifact_resolve）
+ *    挂折叠渲染钩——TUI 单行摘要，模型上下文仍留完整 JSON；
+ * 2. artifact list 摘要是计数行（"8 个交付物（video ×2…）"），
+ *    不含 digest/open_command/绝对路径；
+ * 3. 终态卡交付物文件名带 OSC 8 可点击链接（file:// 绝对路径）
+ *    ——终端里直接点开；verbose 的绝对路径行不受影响。
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("R2: 只读任务工具挂折叠渲染钩", async () => {
+	const { buildReadOnlyTaskTools } = await import("../src/tools/task-read.js");
+	const tools = buildReadOnlyTaskTools({
+		active: { current: {} },
+		center: { call: async () => ({}) },
+	} as never);
+	for (const name of [
+		"rosclaw_task_inspect", "rosclaw_artifact_list", "rosclaw_artifact_resolve",
+	]) {
+		const tool = tools.find((t) => t.name === name);
+		assert.ok(tool, `缺工具 ${name}`);
+		assert.ok(
+			typeof (tool as { renderResult?: unknown }).renderResult === "function",
+			`${name} 未挂折叠渲染钩——原始 JSON 会刷屏（0905 实证）`,
+		);
+	}
+});
+
+test("R2: artifact list 摘要是计数行（无 digest/路径/open_command）", async () => {
+	const { summarizeToolResultText } = await import("../src/ui/tool-display.js");
+	const raw = JSON.stringify({
+		ok: true,
+		task_id: "task_61c6a75e",
+		artifacts: [
+			{ artifact_id: "art_1", kind: "data", media_type: "application/json",
+			  path: "/home/ubuntu/.rosclaw/sim/traces/trace_x/trace.json",
+			  size_bytes: 219467, digest: "sha256:76cc",
+			  open_command: "rosclaw artifact open art_1" },
+			{ artifact_id: "art_2", kind: "data", media_type: "video/mp4",
+			  path: "/home/ubuntu/.rosclaw/sim/traces/trace_x/trace_x.mp4",
+			  size_bytes: 79262, digest: "sha256:19cc",
+			  open_command: "rosclaw artifact open art_2" },
+			{ artifact_id: "art_3", kind: "data", media_type: "image/gif",
+			  path: "/home/ubuntu/.rosclaw/sim/traces/trace_x/trace_x.gif",
+			  size_bytes: 15407, digest: "sha256:7725",
+			  open_command: "rosclaw artifact open art_3" },
+		],
+	});
+	const line = summarizeToolResultText(raw);
+	assert.match(line, /3 个交付物|3 个产物|交付物.*3/, line);
+	assert.ok(!line.includes("sha256"), line);
+	assert.ok(!line.includes("rosclaw artifact open"), line);
+	assert.ok(!line.includes("/home/"), line);
+});
+
+test("R2: 终态卡交付物文件名可点击（OSC 8 file:// 链接）", async () => {
+	const { renderTerminalReply } = await import(
+		"../src/native/terminal-presenter.js"
+	);
+	const reply = renderTerminalReply({
+		verification: "PASS",
+		delivery: "DELIVERED",
+		lifecycle: "COMPLETED",
+		artifact_refs: [{
+			artifact_id: "art_1",
+			open_command: "rosclaw artifact open art_1",
+			path: "/home/u/.rosclaw/runs/task_1/r1/outputs/trace.gif",
+			media_type: "image/gif",
+			size_bytes: 15407,
+		}],
+	});
+	// OSC 8 超链接：\x1b]8;;file://<path>\x07<文件名>\x1b]8;;\x07。
+	assert.ok(
+		reply.includes("\x1b]8;;file:///home/u/.rosclaw/runs/task_1/r1/outputs/trace.gif\x07"),
+		`缺可点击链接：${JSON.stringify(reply)}`,
+	);
+	assert.ok(reply.includes("trace.gif"), "文件名仍可见");
+});


### PR DESCRIPTION
## 方案 R2（2026-09-05）

默认隐藏 Artifact JSON/trace ID/内部路径（只进 /activity）；主交付物直接点击打开；用户只看到目标/进度/结果。

## 改动

- **0905 实证根治**：`rosclaw_artifact_list` 把 8 个 artifact 的 digest/open_command/内部绝对路径整段刷屏——三个只读任务工具（task_inspect/artifact_list/artifact_resolve）挂 compactRenderResult 折叠钩（模型上下文留完整 JSON，诚实性不降级）；artifact list 渲染为计数行（「N 个交付物（mp4 ×2、gif ×2…）——明细见 /activity」）。
- **主交付物可点击**：终态卡交付物文件名带 OSC 8 `file://` 可点击链接（终端直接点开；escape 内嵌绝对路径终端不可见——默认层无内部路径纪律不变，断言剥 escape 后核验）。
- R3-b/P0-6 分层断言适配（剥 OSC 8 后断言可见文本）。

## 验证

红测试 3 项先红后绿；TS 233/233 + tsc；journey A 绿（177s）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)