### PR TITLE
W00：建立可复现基线（规格 2026-09-08 §4）

### DIFF
--- a/docs/implementation/baseline-versions.json
+++ b/docs/implementation/baseline-versions.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "rosclaw.w00_baseline.v1",
+  "captured_at": "2026-09-09",
+  "git": {
+    "head": "f05aafd",
+    "head_title": "大道至简 R3：A/B 真实比较门禁——负价值阻断发布（#519）",
+    "dirty_files": ["scripts/a0901_live_gate.py (untracked, preserved)"]
+  },
+  "python": {
+    "executable": ".venv/bin/python",
+    "version": "3.11.15",
+    "rosclaw_distribution": "1.0.1 (editable, from source checkout)",
+    "cli": ".venv/bin/rosclaw (entry script → rosclaw.entrypoint)",
+    "key_packages": {
+      "mujoco": "3.11.0 (dev venv) / 3.12.0 (bundle venv)",
+      "pillow": "12.3.0",
+      "numpy": "2.4.6",
+      "pydantic": "2.13.4",
+      "mcp": "1.29.0",
+      "PyYAML": "6.0.3"
+    }
+  },
+  "node": {
+    "system": "v24.19.0 (/tmp/node2219 for dev)",
+    "bundled": "v22.19.0 (arm64, inside release bundle)"
+  },
+  "pi": {
+    "pins": {"@earendil-works/pi-coding-agent": "0.83.0", "@earendil-works/pi-ai": "0.83.0", "@earendil-works/pi-tui": "0.83.0"},
+    "package_lock_sha256_16": "e2c557e386b10500",
+    "lock_resolved_entries": 241
+  },
+  "assets": {
+    "eurdf_zoo": "e-urdf-zoo/ (in-tree, force-included into wheel)",
+    "render_backend": "osmesa (probe: egl n/a, osmesa ok, xvfb n/a)",
+    "os_isolation": "NOT READY (bwrap present-but-broken: RTM_NEWADDR denied)"
+  },
+  "bundle": {
+    "path": "dist/rosclaw-1.2.0-linux-arm64.tar.gz",
+    "files_verified": 6534,
+    "vendor_wheels": 77,
+    "install_smoke": "OK (isolated /tmp/w00-pkgtest; rosclaw --version 1.2.0; doctor healthy)"
+  },
+  "secrets": {
+    "ROSCLAW_KIMI_API_KEY": "absent (real-model paths NOT_RUN)",
+    "MOONSHOT_API_KEY": "absent",
+    "KIMI_API_KEY": "absent"
+  }
+}

--- a/docs/implementation/baseline.md
+++ b/docs/implementation/baseline.md
@@ -1,0 +1,78 @@
+# W00 基线报告（ROSClaw_ClaudeCode_实施规格_2026-09-08 §4）
+
+**日期**：2026-09-09
+**基线 commit**：`f05aafd`（大道至简 R3，#519）
+**脏文件**：`scripts/a0901_live_gate.py`（untracked，0901 真实 K3 Gate 脚本——保留，不动）
+**机读清单**：`docs/implementation/baseline-versions.json`
+
+## 1. 实际运行版本（实测，非报告转述）
+
+| 项 | 值 | 来源 |
+|---|---|---|
+| Python | 3.11.15（.venv/bin/python） | 实测 |
+| rosclaw 分发 | 1.0.1（editable，源自源码 checkout） | `pip list` |
+| CLI | `.venv/bin/rosclaw` → `rosclaw.entrypoint` | 实测 |
+| MuJoCo | 3.11.0（dev venv）/ 3.12.0（bundle venv） | 实测 |
+| Pillow / NumPy / pydantic / mcp | 12.3.0 / 2.4.6 / 2.13.4 / 1.29.0 | `pip list` |
+| Node | 系统 v24.19.0（dev）；**bundle 自带 v22.19.0 arm64** | 实测 |
+| Pi pins | coding-agent / ai / tui 全 **0.83.0** | package.json |
+| package-lock | sha256[:16]=`e2c557e386b10500`，241 resolved | 实测 |
+| 渲染后端 | **osmesa**（egl n/a，xvfb n/a） | `probe_os_isolation` |
+| OS 隔离 | **未就绪**（bwrap present-but-broken：RTM_NEWADDR 被拒） | 同上 |
+| 资产 | e-urdf-zoo/（树内，wheel force-include） | 实测 |
+| 秘密 | 三个 key 均 absent——只记录"已配置/未配置"，从不打印值 | env 探测 |
+
+## 2. §2.2 逐条核对（当前代码实证）
+
+| 发现 | 状态 | 证据（当前代码） | 复现测试 |
+|---|---|---|---|
+| `_artifact_register` 无 active task + 最近 SUCCEEDED → 拒绝 | **存在（有条件）** | tool_dispatch.py：`active=None` 且 `latest=SUCCEEDED` → `TASK_ALREADY_COMPLETED`。但 dispatcher 层 `ensure_task_for_effect` 会先把任务复活成 RUNNING revision 2 遮掩——0907 的拒绝只在 handler 直达/无新动机时咬人；**复活本身就是规格 §9.2 标记的反模式（"不采用数据库直接改回 RUNNING"）** | `test_w00_baseline_repro.py` R1（xfail strict） |
+| sim_render 原子 IPC/后端探测/RenderSpec/overlay | 存在，保留 | R2-2 已建 | — |
+| 回放 `data.qpos[:model.nu]` 截断 | **存在** | sim_render.py:563——nq≠nu 模型丢状态 | R2（xfail strict） |
+| 无 spec 默认 UR5e / 相机距离固定 / 按索引采样 12fps | **存在** | sim_render.py:503 `robot_id = "ur5e"`；cam.distance=1.2/0.9/1.4 写死；fps=12 按帧数索引采样（非时间戳） | W04 处理 |
+| 同一 trace 固定结果文件名 + `candidates[:2]` | **存在** | sim_render.py:233 | R3（xfail strict） |
+| render_profiles 仅注册 sim/ur5e | **存在** | render_profiles.py:16 | W02 处理 |
+| entrypoint open alias + artifact dispatcher | 存在，保留 | 已验证 isolated install 内可用 | — |
+| Pi pins 0.83.0 + postinstall patches | 存在 | package.json + patches/apply-upstream-patches.mjs | W01 盘点 |
+| build-info 写死 pi_version/pi_commit | **存在** | build_release.sh：`"pi_version": "0.83.0"`, `"pi_commit": "588915ec…"` | W11 处理 |
+| wheel 不含 packages/rosclaw-agent（JS/Node） | **存在** | pyproject.toml force-include 只有 zoo/configs/policies/benchmarks/worker_plugins——wheel 与 tar bundle 内容不一致 | W11 处理 |
+| pytest 默认排除 integration/deployment | **存在** | pyproject.toml addopts `-m 'not integration and not deployment'` | W09/W12 处理 |
+
+## 3. 基线分发物与独立安装测试
+
+- 构建：`scripts/build_release.sh` → `dist/rosclaw-1.2.0-linux-arm64.tar.gz`（6534 文件验签通过，77 vendor wheels）。
+- 隔离安装：`/tmp/w00-pkgtest`（**不挂源码、不继承 dev PYTHONPATH、不改名 worktree**）→ `install.sh --offline --allow-untrusted-dev` exit 0，健康检查通过。
+- Smoke：`rosclaw --version` = 1.2.0；`rosclaw doctor` 健康（MuJoCo 3.12.0、zoo 在 bundle site-packages 内）。
+
+## 4. 四路复现结果
+
+| 路径 | 结果 | 说明 |
+|---|---|---|
+| unsafe rollout 错误成功表述 | **NOT_RUN** | 无 ROSCLAW_KIMI_API_KEY——真实模型回归不可执行（skip 标记，不合成冒充） |
+| 追加交付 | **复现（R1 xfail）** | handler 直达必现 TASK_ALREADY_COMPLETED；另发现 admission 复活 RUNNING 遮掩（同列为 W05 修复面） |
+| 非 UR5e 状态回放 | **复现（R2 xfail）** | `qpos[:nu]` 截断在源码实证 |
+| 无 Node/npm 启动 | **通过（无缺陷）** | PATH 无 node：bundle 自带 Node 使 chat 正常进 TUI，stdin EOF 干净退出，无 traceback |
+
+## 5. 用户可见输出 / 耗时 / 费用 / Artifact 可达性（基线）
+
+- 安装：exit 0；doctor 全绿（除预期 pytest 缺失/workspace config 提示）。
+- chat 启动：TUI 正常渲染（80 列）；启动警告文案"shell 类操作将在会话内弹确认卡降级运行"**已过时**（R1-2b 后 SIM 不再弹卡——W07 文案修正项）。
+- Artifact：isolated install 内 `rosclaw artifact list` 可达（0901 P0-1 已证，本轮未重跑真实产物）。
+- 耗时/费用：真实模型路径 NOT_RUN，无数据（不编造）。
+
+## 6. NOT_RUN 清单（明示，后续批次回填）
+
+1. 0907 unsafe rollout 真实主模型回归（§16.2-1）——待 key。
+2. 真实 A/B（W10）——待 key（R3 harness 就绪）。
+3. 十类 Agent 测试的真实模型段（W09）——待 key。
+4. 用户盲测——待 operator。
+
+## 7. 后续工作包使用该映射
+
+- W01：Pi 补丁盘点（patches/apply-upstream-patches.mjs）+ 0.83.0 基线固定。
+- W02：render_profiles 从力学模型生成 + body 契约。
+- W03：qpos/qvel/ctrl 完整状态记录与回放（解 R2 xfail）。
+- W04：后端降级全候选 + 时间驱动采样 + operation 目录（解 R3 xfail）。
+- W05：追加交付与复活反模式（解 R1 xfail——注册既有 revision，不改回 RUNNING）。
+- W07：启动警告文案修正。
+- W09/W11/W12：pytest integration 收集、wheel JS/Node 打包、build-info 动态化。

--- a/tests/agentd/test_w00_baseline_repro.py
+++ b/tests/agentd/test_w00_baseline_repro.py
@@ -1,0 +1,156 @@
+"""W00 基线复现测试（ROSClaw_ClaudeCode_实施规格_2026-09-08 §2/§4）。
+
+每条 §2.2 发现一个最小复现测试。xfail(strict=True) 标记「基线已
+复现、修复待对应工作包」——修复落地后测试翻 XPASS 即强制解标，
+不留静默漂移。真实模型路径无 key 标 NOT_RUN（不合成冒充）。
+
+基线环境：main=f05aafd，Python 3.11.15，mujoco 3.11.0（dev）/
+3.12.0（bundle venv），Pi 0.83.0，bundle Node v22.19.0。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestR1AppendDeliveryBlocked:
+    """§2.2-1：`_artifact_register` 在活跃任务缺失且最近任务
+    SUCCEEDED 时直接 TASK_ALREADY_COMPLETED 拒绝——0907 实证追加
+    产物被反复拒绝。期望行为（W05）：显式上下文与追加交付不被
+    历史成功阻断。当前基线=拒绝（本测试 xfail 记录）。"""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="W00 基线：历史 SUCCEEDED 阻断追加交付（W05 修复后解标）",
+    )
+    async def test_append_after_succeeded_allowed(self, tmp_path) -> None:
+        """0907 实证条件的精确复现：handler 直达（无 admission
+        动机遮掩）+ active=None + 最近任务 SUCCEEDED → 基线=
+        TASK_ALREADY_COMPLETED。期望（W05 §9.2）：显式上下文下
+        追加交付注册在既有 revision——不改回 RUNNING、不靠动机
+        复活任务。"""
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+        from tests.agentd.test_pi_tool_bridge import (
+            _issue_lease,
+            _request,
+            _setup,
+        )
+
+        service, mission = await _setup(tmp_path)
+        kernel = service._task_kernel
+        f = tmp_path / "a.gif"
+        f.write_bytes(b"GIF89a" + b"\x00" * 128)
+        bound = kernel.bind_message(
+            mission_id=mission.mission_id, session_ref="pi_1",
+            backend_native_id="pi_1", message_id="msg_w00_1",
+            text="画一个五角星", cwd=str(tmp_path), body_id="",
+        )
+        task_id = str(bound["task_id"])
+        artifact = kernel.register_artifact(
+            task_id=task_id, path=str(f), media_type="image/gif",
+            producer="kernel:test",
+        )
+        kernel.finish_task(
+            task_id=task_id, summary="done",
+            artifact_ids=[str(artifact["artifact_id"])],
+        )
+        assert str(kernel.get_task(task_id)["state"]) == "SUCCEEDED"
+        f2 = tmp_path / "b.txt"
+        f2.write_text("appendix", encoding="utf-8")
+        result = await PiToolDispatcher(service)._artifact_register(
+            _request(
+                "rosclaw_artifact_register", mission=mission.mission_id,
+                idem="w00_direct", lease=await _issue_lease(service, mission),
+                arguments={"path": str(f2)},
+            )
+        )
+        assert result.ok, result.summary
+        # 追加不得复活任务状态（审计历史保持 SUCCEEDED）。
+        assert str(kernel.get_task(task_id)["state"]) == "SUCCEEDED"
+        await service.close()
+
+
+class TestR2FullStateReplay:
+    """§2.2-2：sim_render 回放用 `data.qpos[:model.nu]` 截断——
+    nq≠nu 的模型（freejoint/被动关节/被动物体）丢失状态，真实
+    仿真与视频不一致（W03 修复：模型维度/关节映射驱动的完整
+    状态恢复）。"""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="W00 基线：qpos 按 nu 截断（W03 修复后解标）",
+    )
+    def test_replay_restores_full_nq_not_nu(self) -> None:
+        import inspect
+
+        from rosclaw.agentd import sim_render
+
+        src = inspect.getsource(sim_render)
+        assert "data.qpos[: int(model.nu)]" not in src, (
+            "回放仍按执行器数 nu 截断位置坐标（nq 丢失）"
+        )
+
+
+class TestR3BackendFallbackDepth:
+    """§2.2-3：后端降级只试 `candidates[:2]`——EGL 失败+OSMesa
+    不可用+Xvfb 可用时找不到真正可用的第三后端（W04 修复：
+    按可用性排序逐个真实尝试）。"""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="W00 基线：降级只试前两个后端（W04 修复后解标）",
+    )
+    def test_fallback_tries_all_candidates(self) -> None:
+        import inspect
+
+        from rosclaw.agentd import sim_render
+
+        src = inspect.getsource(sim_render)
+        assert "candidates[:2]" not in src, "后端降级仍只试前两个候选"
+
+
+class TestR4NoNodeStartup:
+    """§4.5-4：无 Node/npm 环境启动——离线包自带 Node runtime
+    （v22.19.0 arm64），PATH 无 node 时 chat 正常进入 TUI、stdin
+    EOF 干净退出。基线=通过（无 xfail）。"""
+
+    def test_chat_starts_without_system_node(self, tmp_path) -> None:
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        bundle_bin = "/tmp/w00-pkgtest/prefix/bin/rosclaw"
+        entry = (
+            [bundle_bin] if Path(bundle_bin).exists()
+            else [sys.executable, "-m", "rosclaw.entrypoint"]
+        )
+        env = {
+            "HOME": str(tmp_path),
+            "PATH": "/usr/bin:/bin",
+            "ROSCLAW_HOME": str(tmp_path / "rh"),
+        }
+        result = subprocess.run(
+            [*entry, "chat"], env=env, capture_output=True,
+            timeout=60, stdin=subprocess.DEVNULL,
+        )
+        combined = result.stdout + result.stderr
+        # 干净诊断或正常 TUI——不得是 Node 缺失的裸 traceback。
+        assert b"Traceback" not in combined, combined[-500:]
+
+
+class TestR5UnsafeRolloutReply:
+    """§2.1/§16.2-1：0907 unsafe rollout（is_safe:false + 碰撞 +
+    0.68m 误差）被同时宣布完成——真实主模型回归。"""
+
+    def test_real_model_unsafe_reply(self) -> None:
+        import os
+
+        if not os.environ.get("ROSCLAW_KIMI_API_KEY"):
+            pytest.skip(
+                "NOT_RUN: ROSCLAW_KIMI_API_KEY 未配置——真实模型回归"
+                "不可执行（不合成冒充；operator 带 key 重跑）"
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 内容

- 基线固定：HEAD=f05aafd；`docs/implementation/baseline-versions.json` 机读版本清单（实测，秘密只记配置态）；脏文件 scripts/a0901_live_gate.py 保留。
- §2.2 全部 11 条发现当前代码实证映射（存在/保留/待修+复现测试指针）。
- 基线分发物独立安装测试：不挂源码、不继承 dev PYTHONPATH、不改名 worktree——install.sh exit 0、doctor 健康。
- 四路复现：unsafe rollout=NOT_RUN（无 key，skip 明示）；追加交付/qpos 截断/后端降级深度=xfail(strict) 钉住基线（W05/W03/W04 修复后强制解标）；无 Node 启动=通过（bundle 自带 Node）。
- 新发现两处：admission 复活 RUNNING 遮掩（规格 §9.2 反模式，W05 同修）；启动警告文案过时（W07 修正）。

## 验证

复现套件 1 passed / 1 skipped(NOT_RUN) / 3 xfailed——即基线映射本身。完整测试报告见 docs/implementation/baseline.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)