### PR TITLE
W01：恢复 Pi 协议边界——patch-03/04 退役 + 签名 Skill digest 修复

### DIFF
--- a/docs/implementation/pi-patch-inventory.md
+++ b/docs/implementation/pi-patch-inventory.md
@@ -1,0 +1,45 @@
+# Pi 上游补丁盘点（W01，规格 §5.1）
+
+**基线**：`@earendil-works/pi-coding-agent@0.83.0`（package-lock sha256[:16]=`e2c557e386b10500`）
+**盘点日期**：2026-09-09
+**原则**：公开 SDK/extension hook > 已提交上游的小接口 > 临时版本绑定补丁。保留的补丁必须隔离、锚点硬失败、绑定适用版本并有退出计划。
+
+## 总表
+
+| 补丁 | 目标文件 | 原始需求 | 上游替代 | 状态 | 退出计划 |
+|---|---|---|---|---|---|
+| patch-01 resume formatter | `dist/modes/interactive/interactive-mode.js` | 退出提示必须引导 `rosclaw continue`（恢复经 kernel/binding/lease，不经外部 pi CLI）；WP-P0-1 不暴露内部 session id | 未见官方 resumeCommandFormatter hook（0.83.0） | **保留** | 上游提供 AppIdentity/resumeCommandFormatter 或等价 hook 时退休 |
+| patch-01b retire 旧 hint | 同上 | 清理旧版 patch 残留（先 return 先生效） | — | 保留（清理器） | 随 patch-01 一起退出 |
+| patch-02 builtin command policy | `dist/modes/interactive/interactive-mode.js` | `/trust /share /import /reload /update` 在 dispatch 前拦截（input hook 在 dispatch 后拦不住内建命令） | 未见官方 BuiltinCommandPolicy hook | **保留** | 上游提供命令前置 policy hook 时退休 |
+| ~~patch-03 strip reasoning on write~~ | `dist/core/session-manager.js` | （旧）TranscriptPolicy：reasoning 不持久化 | **官方机制已足**：`settingsManager.setHideThinkingBlock(true)`（P1-1，UI 不展示）；会话存储本身是受控区域 | **已退役（W01）** | 应用器自动恢复上游原文（retire 条目） |
+| ~~patch-04 never replay reasoning~~ | `dist/api/openai-completions.js`（顶层+嵌套两份） | （旧）TranscriptPolicy：绝不回放 reasoning 给 provider | **上游按官方协议管理 continuation**（thinkingSignature 按 provider 条件回放） | **已退役（W01）** | 同上 |
+
+## patch-03/04 退役依据（规格 §5.2）
+
+旧补丁的全局删除是跨 provider 的一刀切：
+
+- Kimi 的部分 thinking 配置要求**按原样保留历史 reasoning 字段**才能 continuation；
+- Claude 在工具回合中有 thinking block 协议要求；
+- 删除字段不是 0907 问题的根因（0907 是验收/证据语义问题，不是推理字段问题）。
+
+新政策（规格 §5.2 逐条落实）：
+
+1. **UI 默认不展示内部思考** → 官方 `setHideThinkingBlock(true)`（pi-runtime.ts P1-1），无需补丁。
+2. **provider continuation 所需字段** → 上游 openai-completions.js 按 provider 条件回放 thinkingSignature（官方协议），不再全局 `if(false)` 杀死。
+3. **协议状态只留在访问受控的会话存储** → `~/.rosclaw/agent/sessions/`（目录权限受控）；**不自动进入遥测**——pi.events.batch 镜像只存 hash/元数据（content 字段硬拒绝，FULL_TEXT_FORBIDDEN）。
+4. **公开导出不泄漏** → 两道：journey `_assert_reasoning_protocol`（provider 请求里 marker 只允许在官方 reasoning 字段——含 thinkingSignature 协议常量）；独立证据包（sanitized_assertions.json）的 `reasoning_forbidden_field_counts` 改为**泄漏语义**（只统计官方协议字段外的出现，verifier 全零 Gate 不变——官方字段不再误报）。
+
+## 验证
+
+| 实验 | 结果 |
+|---|---|
+| 退役-恢复机制（fresh node_modules 上 anchor→replacement 还原） | 实测：两份 openai-completions.js + session-manager.js 的 patch 文本计数归零；二次运行幂等（[already retired]） |
+| applier 硬失败语义（锚点漂移） | 保留：非 optional 锚点缺失即 exit 1 |
+| journey A（安装产物黑盒：多轮工具续接 + /compact + resume + reasoning 协议断言） | 绿（196s）——`_assert_reasoning_protocol` 替代旧 no_reasoning_replay |
+| 五轮工具续接+恢复（真实主模型 K3 thinking continuation） | **NOT_RUN**（无 ROSCLAW_KIMI_API_KEY——不合成冒充；operator 带 key 重跑） |
+| 改变身体后工具上下文刷新 | 已由 context envelope per-turn 重取 + stale 拒绝机制覆盖（既有测试） |
+
+## 应用器安全性质（本轮新增）
+
+- `retire: true` 条目：仅当已打补丁文本在场时恢复；pristine 环境 no-op；二次运行幂等。
+- 修复了空 replacement 时 `source.includes(replacement)` 恒真导致恢复被跳过的问题（第一次实现即实证）。

--- a/packages/rosclaw-agent/patches/apply-upstream-patches.mjs
+++ b/packages/rosclaw-agent/patches/apply-upstream-patches.mjs
@@ -68,23 +68,19 @@ const PATCHES = [
 			"              } }\n" +
 			"            // Handle commands",
 	},
-	// -- HOTFIX-4：TranscriptPolicy（P0-4G）-------------------------------------
-	// raw reasoning（thinking blocks / reasoning_content / redacted_thinking）
-	// 只作内存瞬态进度——写 session 前剥离；resume/replay/export 不再回放。
+	// -- 大道至简 W01（规格 §5.2）：patch-03/04 退役 ----------------------
+	// TranscriptPolicy 全局删除补丁（写前剥离 + 绝不回放）违反 thinking
+	// 模型的官方 continuation 契约（Kimi/Claude 都要求按原样保留历史
+	// reasoning）。新政策：provider continuation 由上游按官方协议管理；
+	// 会话存储是受控区域；泄漏面（UI/非协议字段/遥测）由 journey 的
+	// _assert_reasoning_protocol 钉死。以下为退役-恢复条目：已打过
+	// 补丁的 node_modules 恢复为上游原文；pristine 环境自然 no-op。
 	{
 		target: T("@earendil-works", "pi-coding-agent", "dist", "core", "session-manager.js"),
-		name: "patch-03: transcript policy — strip raw reasoning on write",
+		name: "retire patch-03 (delete strip block)",
+		retire: true,
+		optionalAnchor: true,
 		anchor:
-			"    appendMessage(message) {\n" +
-			"        const entry = {\n" +
-			"            type: \"message\",\n" +
-			"            id: generateId(this.byId),\n" +
-			"            parentId: this.leafId,\n" +
-			"            timestamp: new Date().toISOString(),\n" +
-			"            message,\n" +
-			"        };",
-		replacement:
-			"    appendMessage(message) {\n" +
 			"        // ROSCLAW-PATCH-03: TranscriptPolicy——raw reasoning 不持久化。\n" +
 			"        // thinking/reasoning 只用于内存瞬态进度；写 session 前剥离\n" +
 			"        // （thinking blocks + provider reasoning 字段变体）。\n" +
@@ -102,35 +98,21 @@ const PATCHES = [
 			"                });\n" +
 			"            }\n" +
 			"            message = clone;\n" +
-			"        }\n" +
-			"        const entry = {\n" +
-			"            type: \"message\",\n" +
-			"            id: generateId(this.byId),\n" +
-			"            parentId: this.leafId,\n" +
-			"            timestamp: new Date().toISOString(),\n" +
-			"            message,\n" +
-			"        };",
+			"        }\n",
+		replacement:
+			"",
 	},
 	{
-		// 注意：pi-ai 有顶层与嵌套（pi-coding-agent/node_modules）两份——
-		// 运行时实际加载嵌套副本，两份都必须打（见 patches/README.md）。
 		target: [
 			T("@earendil-works", "pi-ai", "dist", "api", "openai-completions.js"),
 			{ path: T("@earendil-works", "pi-coding-agent", "node_modules",
 				"@earendil-works", "pi-ai", "dist", "api", "openai-completions.js"),
 				optional: true },
 		],
-		name: "patch-04: transcript policy — never replay raw reasoning to provider",
+		name: "retire patch-04 (restore upstream thinking replay)",
+		retire: true,
+		optionalAnchor: true,
 		anchor:
-			"                    // Use the signature from the first thinking block if available (for llama.cpp server + gpt-oss)\n" +
-			"                    let signature = nonEmptyThinkingBlocks[0].thinkingSignature;\n" +
-			"                    if (model.provider === \"opencode-go\" && signature === \"reasoning\") {\n" +
-			"                        signature = \"reasoning_content\";\n" +
-			"                    }\n" +
-			"                    if (signature && signature.length > 0) {\n" +
-			"                        assistantMsg[signature] = nonEmptyThinkingBlocks.map((block) => block.thinking).join(\"\\n\");\n" +
-			"                    }",
-		replacement:
 			"                    // ROSCLAW-PATCH-04: TranscriptPolicy——raw reasoning\n" +
 			"                    // 绝不回放进 provider 请求（resume/历史消息同策）。\n" +
 			"                    // thinking blocks 只作内存瞬态进度，不再外发。\n" +
@@ -142,6 +124,15 @@ const PATCHES = [
 			"                        if (signature && signature.length > 0) {\n" +
 			"                            assistantMsg[signature] = nonEmptyThinkingBlocks.map((block) => block.thinking).join(\"\\n\");\n" +
 			"                        }\n" +
+			"                    }",
+		replacement:
+			"                    // Use the signature from the first thinking block if available (for llama.cpp server + gpt-oss)\n" +
+			"                    let signature = nonEmptyThinkingBlocks[0].thinkingSignature;\n" +
+			"                    if (model.provider === \"opencode-go\" && signature === \"reasoning\") {\n" +
+			"                        signature = \"reasoning_content\";\n" +
+			"                    }\n" +
+			"                    if (signature && signature.length > 0) {\n" +
+			"                        assistantMsg[signature] = nonEmptyThinkingBlocks.map((block) => block.thinking).join(\"\\n\");\n" +
 			"                    }",
 	},
 ];
@@ -164,6 +155,17 @@ for (const patch of PATCHES) {
 for (const [target, patches] of grouped) {
 	let source = readFileSync(target, "utf8");
 	for (const patch of patches) {
+		// retire 条目：锚点（已打的补丁文本）在场才恢复——空 replacement
+		// 或锚点即原文前缀时，"already applied" 恒真会跳过恢复（实证）。
+		if (patch.retire) {
+			if (!source.includes(patch.anchor)) {
+				console.log(`[already retired] ${patch.name}`);
+				continue;
+			}
+			source = source.replace(patch.anchor, patch.replacement);
+			console.log(`[retired] ${patch.name}`);
+			continue;
+		}
 		if (source.includes(patch.replacement)) {
 			console.log(`[already applied] ${patch.name}`);
 			continue;

--- a/packages/rosclaw-agent/skills/manifest.json
+++ b/packages/rosclaw-agent/skills/manifest.json
@@ -1,5 +1,5 @@
 {
  "skills": {
-  "rosclaw-embodied": "46137af04c351d15cb6c29678ff5a39c7b824c14afc5299f8dd19130b9ccea6a"
+  "rosclaw-embodied": "a8a18b12652870fa033ec26d341150a015875e69e45faa9a3896375b835d8b6a"
  }
 }

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1301,14 +1301,48 @@ class TestProductJourney:
                 )
         finally:
             db.close()
-        # reasoning 禁带字段计数（结构计数，不含正文）。
+        # 大道至简 W01（规格 §5.2）：reasoning 禁带字段计数的新语义
+        # ——会话存储是受控区域（可含官方 reasoning 字段）；计数器
+        # 只统计**非官方协议字段外**的出现（content/工具参数/任意
+        # 其他字段的泄漏）。verifier 的全零 Gate 不变：泄漏面零容忍，
+        # 官方字段不再误报。
+        official_reasoning_keys = (
+            "reasoning_content", "reasoning", "thinking", "redacted_thinking",
+            # thinkingSignature 的值是官方协议常量（reasoning 字段名
+            # 指定符——上游 continuation 协议的一部分，不是泄漏）。
+            "thinkingSignature",
+        )
+
+        def _leak_count(obj: object, marker: str, *, under_official: bool = False) -> int:
+            """obj 树中 marker 在非官方字段路径下的出现次数。"""
+            if isinstance(obj, dict):
+                total = 0
+                for key, value in obj.items():
+                    total += _leak_count(
+                        value, marker, under_official=(
+                            under_official or key in official_reasoning_keys
+                        ),
+                    )
+                return total
+            if isinstance(obj, list):
+                return sum(
+                    _leak_count(v, marker, under_official=under_official)
+                    for v in obj
+                )
+            if under_official:
+                return 0
+            return str(obj).count(marker)
+
         forbidden_counts: dict[str, int] = {}
         session_files = sorted((home / "agent" / "sessions").glob("*.jsonl"))
         for marker in ("reasoning_content", "redacted_thinking", REASONING_MARKER):
-            forbidden_counts[marker] = sum(
-                f.read_text(encoding="utf-8", errors="replace").count(marker)
-                for f in session_files
-            )
+            count = 0
+            for f in session_files:
+                for line in f.read_text(encoding="utf-8", errors="replace").splitlines():
+                    with contextlib.suppress(json.JSONDecodeError):
+                        entry = json.loads(line)
+                        count += _leak_count(entry, marker)
+            forbidden_counts[marker] = count
         evidence["reasoning_forbidden_field_counts"] = forbidden_counts
         evidence["compaction_entry_id"] = getattr(self, "_compaction_entry_id", None)
         evidence["verdicts"] = getattr(self, "_journey_verdicts", {})
@@ -1341,36 +1375,51 @@ class TestProductJourney:
             json.dumps(structure, indent=1), encoding="utf-8"
         )
 
-    def _assert_no_reasoning_replay(
+    def _assert_reasoning_protocol(
         self, fake: FakeModelServer, home: Path, *, from_index: int
     ) -> None:
-        """P0-4G TranscriptPolicy 验收：SECRET_PROBE 回合后，任何 provider
-        请求（live replay）、session 持久化文件、后续 resume 回放都不得
-        再出现 raw reasoning marker。
+        """大道至简 W01（规格 §5.2）：reasoning 协议状态的新政策。
 
-        from_index=2：req0=你好、req1=SECRET_PROBE 自身（marker 由 fake
-        注入在响应里，请求里没有）——从 req2 起的历史消息必须零命中。
+        patch-03/04 的全局删除退役——provider continuation 所需字段
+        按官方协议管理（Kimi/Claude thinking continuation 要求按
+        原样保留历史 reasoning）；会话存储是受控区域（可含协议
+        状态）；泄漏面只有 UI 展示/非协议字段/遥测。
+
+        断言：
+        1. provider 请求里 marker 只允许出现在官方 reasoning 字段
+           （reasoning_content 或 provider signature 变体）——绝不
+           复制进 content/工具参数/其他任意字段；
+        2. session JSONL 可含 reasoning（受控存储）——但不得以非
+           协议字段名重复出现；
+        3. 屏幕无 marker（SECRET_PROBE 腿已断言）。
+
+        from_index=2：req0=你好、req1=SECRET_PROBE 自身（marker 由
+        fake 注入在响应里，请求里没有）。
         """
-        # 1. live replay：req[from_index:] 的任何字段不得含 marker。
+        official_keys = ("reasoning_content", "reasoning", "thinking")
         for i, body in enumerate(fake.fake.requests[from_index:], start=from_index):
-            blob = json.dumps(body, ensure_ascii=False)
-            assert REASONING_MARKER not in blob, (
-                f"req{i} 的 provider 请求仍携带 raw reasoning marker"
-            )
-        # 2. session 持久化：Pi session JSONL 不得含 marker。
+            for message in body.get("messages", []):
+                for key, value in message.items():
+                    if key in official_keys:
+                        continue  # 官方协议字段——允许（continuation）
+                    if REASONING_MARKER in json.dumps(value, ensure_ascii=False):
+                        raise AssertionError(
+                            f"req{i} 的 {key} 字段泄漏 raw reasoning marker"
+                            "（只允许官方 reasoning 字段）"
+                        )
+        # session 存储是受控区域：不强制空——但不得有重复的非协议
+        # 字段变体（patch-03 时代的过滤不得变成协议状态双写）。
         sessions_dir = home / "agent" / "sessions"
         assert sessions_dir.exists(), "session 目录不存在"
         for session_file in sessions_dir.glob("*.jsonl"):
             content = session_file.read_text(encoding="utf-8", errors="replace")
-            assert REASONING_MARKER not in content, (
-                f"session 文件 {session_file.name} 持久化了 raw reasoning"
-            )
-            # 结构性断言：不得有 thinking/reasoning 字段变体。
-            for forbidden in ("reasoning_content", "redacted_thinking"):
+            # 结构性断言：官方字段外不得有第二个变体（reasoning_text
+            # 等伪造变体——那不是任何 provider 的官方协议）。
+            for forbidden in ("reasoning_text",):
                 assert forbidden not in content, (
-                    f"session 文件 {session_file.name} 含 {forbidden} 字段"
+                    f"session 文件 {session_file.name} 含非协议变体 {forbidden}"
                 )
-        self._journey_verdicts["no_reasoning_replay"] = True
+        self._journey_verdicts["reasoning_protocol_contract"] = True
 
     def _expect_compaction_entry(self, home: Path, timeout: float = 60.0) -> None:
         """等待 session JSONL 出现 compaction 条目（compact 真完成的
@@ -1659,7 +1708,7 @@ class TestProductJourney:
             # P0-4G（TranscriptPolicy）：SECRET_PROBE 回合后，任何后续
             # provider 请求都不得携带 raw reasoning marker——live replay、
             # session 持久化、resume 回放全链路零命中（四审核心反证点）。
-            self._assert_no_reasoning_replay(fake, home, from_index=2)
+            self._assert_reasoning_protocol(fake, home, from_index=2)
             # 5b. 自然语言 status（六审 §2.2.5）：模型调用的 rosclaw_status
             #     必须与 /status 同一 UDS 快照——此前它访问旧 HTTP
             #     127.0.0.1:8765（chat 的 agentd 用 port=0，必然误报

--- a/tests/agentd/test_w01_skill_manifest.py
+++ b/tests/agentd/test_w01_skill_manifest.py
@@ -1,0 +1,39 @@
+"""W01 §5.3 防回归：内置签名 Skill 的 manifest digest 必须与
+SKILL.md 内容一致——R1-2d 改 Skill 未更新签名导致 digest 不符被
+fail-closed 排除（rosclaw-embodied 从模型面消失，n2 在 main 上红）。
+
+闭环断言：verifyBundledSkills 对每个 manifest 条目给 verified
+（零 excluded）。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_bundled_skill_manifest_digests_match() -> None:
+    import subprocess
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    skills_dir = repo / "packages/rosclaw-agent" / "skills"
+    script = (
+        "import { verifyBundledSkills } from './src/extension/bundled-skills.ts';"
+        f"const r = verifyBundledSkills({str(skills_dir)!r});"
+        "console.log(JSON.stringify(r));"
+    )
+    result = subprocess.run(
+        ["npx", "tsx", "-e", script],
+        cwd=repo / "packages/rosclaw-agent",
+        capture_output=True, text=True, timeout=120,
+    )
+    assert result.returncode == 0, result.stderr[-300:]
+    payload = __import__("json").loads(result.stdout)
+    assert payload["verified"], payload
+    assert not payload["excluded"], (
+        f"Skill 被签名排除（manifest digest 与内容漂移）: {payload['excluded']}"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## 内容（规格 2026-09-08 §5）

- **补丁盘点**（docs/implementation/pi-patch-inventory.md）：4+1 补丁逐个写明需求/文件/适用版本/上游替代/退出计划。
- **patch-03/04 退役**（TranscriptPolicy 全局删除 reasoning）——违反 thinking 模型官方 continuation 契约（Kimi/Claude 都要求按原样保留历史 reasoning）。新政策：provider continuation 由上游按官方协议管理；UI 不展示用官方 `setHideThinkingBlock(true)`；会话存储是受控区域；泄漏面由 journey `_assert_reasoning_protocol` 钉死。
- **应用器 retire 机制**：已打补丁的 node_modules 恢复上游原文，pristine no-op，幂等；修复空 replacement 时 includes() 恒真导致恢复被跳过的问题（实证）。
- **修复 pre-existing main 回归**：R1-2d 改 SKILL.md 未更新 manifest.json digest → 签名不符被 fail-closed 排除，rosclaw-embodied 从模型面消失（n2 在 main 上红）——更新签名 + 防回归测试。

## 验证

- 退役-恢复实测：两份 openai-completions.js + session-manager 的 patch 文本归零，二次运行幂等。
- journey A 绿（196s：多轮工具续接 + compact + resume + 协议断言）。
- n2 绿（PYTHONPATH 实证——PTY 子进程经 editable install 解析主仓，main 合入后全绿）。
- agentd 套件 855 绿。
- 真实 K3 thinking continuation = **NOT_RUN**（无 key，不合成冒充）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)