### PR TITLE
W02：统一身体、位姿与轨迹契约

### DIFF
--- a/src/rosclaw/agentd/sim_render.py
+++ b/src/rosclaw/agentd/sim_render.py
@@ -496,15 +496,31 @@ def _render_impl(
     spec_outputs = spec_doc.get("outputs") or ["gif", "mp4"]
     spec_body_ref = str(spec_doc.get("body_ref") or "")
     # canonical MJCF（与 rollout 同一资源链）；world 来自 TaskSpec
-    # （tabletop/empty——empty 不得冒充桌面场景）。本体：spec 驱动时
-    # 走 RenderProfile 注册表（不 hardcode）；无 spec 保持 ur5e 兼容。
+    # （tabletop/empty——empty 不得冒充桌面场景）。本体身份从记录
+    # 推导（W02 §6.3：记录什么模型就用什么模型——绝不静默默认）：
+    # spec.body_ref > trace.resource.robot_id；两者皆无=旧记录
+    # 无身份，诚实拒绝（不补默认 UR5e）。
     from rosclaw.sandbox.sandbox_api import Sandbox
 
-    robot_id = "ur5e"
+    robot_id = ""
     if spec_body_ref:
         from rosclaw.agentd.render_profiles import sandbox_robot_id
 
         robot_id = sandbox_robot_id(spec_body_ref.removeprefix("robot:"))
+    else:
+        resource = trace.get("resource") or {}
+        robot_id = str(
+            resource.get("robot_id") or resource.get("resource_id") or ""
+        ).removeprefix("robot:")
+    if not robot_id:
+        raise ValueError(
+            "LEGACY_MODEL_IDENTITY_MISSING: 该 trace 无模型身份记录"
+            "（无 RenderSpec.body_ref 且 trace.resource.robot_id 缺失）"
+            "——旧记录请重跑 rollout 或显式传 body_ref；新 trace 必须"
+            "携带模型身份（不静默默认机器人）"
+        )
+    if robot_id.startswith("sim/"):
+        robot_id = robot_id.removeprefix("sim/")
     sandbox = Sandbox.create(robot_id, world_id, "mujoco")
     if not sandbox.has_physics:
         raise ValueError(f"RENDER_INPUT: canonical 模型不可用: {sandbox.load_error}")
@@ -636,6 +652,206 @@ def _render_impl(
 
 
 __all__ = ["probe_render_backend", "render_from_spec", "render_scene_trace"]
+
+
+def render_operation(
+    home: Path,
+    trace_ref: str,
+    states: list[dict],
+    *,
+    model_digest: str,
+    camera: str = "follow",
+    outputs: list[str] | None = None,
+    fps: float = 12.0,
+    duration_s: float = 0.0,
+    width: int = 640,
+    height: int = 360,
+) -> str:
+    """通用渲染 operation（W02 §6.4 + W04 先行面）——任意模型的
+    完整状态回放渲染。
+
+    新契约（相对 legacy render_scene_trace）：
+    - 完整 qpos 恢复（nq 全长——不按 nu 截断）；
+    - 时间驱动选帧（按时间戳与目标 fps——不按索引均采样）；
+    - operation 独立目录（renders/<op_id>/——同 trace 不同视角/
+      格式并发互不覆盖；结果先写临时文件再原子发布）；
+    - 模型身份经 trace 记录 → model_ref → models/ 登记解析
+      （不静默默认机器人）；
+    - 渲染在子进程执行（MUJOCO_GL 必须在 import mujoco 前设定
+      ——与 legacy 同纪律）。
+    """
+    import hashlib as _hl
+    import json as _json
+
+    if not states:
+        raise ValueError(f"RENDER_INPUT_MISSING: {trace_ref} 无 states")
+    outputs = outputs or ["gif"]
+    home = Path(home)
+    # 模型身份经 trace 记录 → model_ref → models/ 登记解析
+    # （不静默默认机器人）。
+    record_path = home / "models" / f"{trace_ref}.json"
+    model_path = ""
+    if record_path.exists():
+        op_record = _json.loads(record_path.read_text(encoding="utf-8"))
+        model_ref = str(op_record.get("model_ref", ""))
+        model_record_path = home / "models" / f"{model_ref}.json"
+        if model_record_path.exists():
+            model_path = str(
+                _json.loads(model_record_path.read_text(encoding="utf-8")).get("path") or ""
+            )
+    if not model_path or not Path(model_path).exists():
+        raise ValueError(
+            f"RENDER_MODEL_MISSING: {trace_ref} 的模型记录不可用——"
+            "渲染只接受 load_model 登记过的模型（不静默默认）"
+        )
+    import mujoco as _mj
+
+    _probe_model = _mj.MjModel.from_xml_path(model_path)
+    nq = int(_probe_model.nq)
+    for s in states:
+        if len(s.get("qpos", [])) != nq:
+            raise ValueError(
+                f"STATE_DIMENSION: qpos 长度 {len(s.get('qpos', []))} != "
+                f"nq={nq}（跨模型引用直接拒绝，不静默截断/补零）"
+            )
+    op_id = "render_" + _hl.sha256(_json.dumps({
+        "trace_ref": trace_ref, "model_digest": model_digest,
+        "camera": camera, "outputs": outputs, "fps": fps,
+    }, sort_keys=True).encode()).hexdigest()[:12]
+    op_dir = home / "renders" / op_id
+    op_dir.mkdir(parents=True, exist_ok=True)
+    backend, probe_detail = probe_render_backend()
+    if backend is None:
+        raise ValueError(
+            "RENDER_BACKEND_UNAVAILABLE: " + _json.dumps(
+                probe_detail, ensure_ascii=False,
+            )[:200]
+        )
+    spec = {
+        "operation_id": op_id,
+        "model_path": model_path,
+        "model_digest": model_digest,
+        "trace_ref": trace_ref,
+        "camera": camera,
+        "outputs": outputs,
+        "fps": float(fps),
+        "duration_s": float(duration_s),
+        "width": int(width),
+        "height": int(height),
+        "states": states,
+    }
+    spec_path = op_dir / "_render_spec.json"
+    spec_path.write_text(_json.dumps(spec, ensure_ascii=False), encoding="utf-8")
+    child_code = (
+        "import sys; sys.path.insert(0, "
+        + repr(str(Path(__file__).resolve().parents[2]))
+        + "); from rosclaw.agentd.sim_render import _render_operation_child;"
+        + f"_render_operation_child({str(home)!r}, {str(spec_path)!r})"
+    )
+    import os as _os
+    import shutil as _sh
+
+    argv = [sys.executable, "-c", child_code]
+    if backend == "xvfb":
+        env = dict(_os.environ, MUJOCO_GL="glfw")
+        argv = [_sh.which("xvfb-run") or "xvfb-run", "-a", *argv]
+    else:
+        env = dict(_os.environ, MUJOCO_GL=backend)
+    try:
+        proc = subprocess.run(
+            argv, env=env, capture_output=True, timeout=300,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError("RENDER_TIMEOUT: 渲染子进程超时（300s）") from exc
+    receipt_path = op_dir / "render_receipt.json"
+    if proc.returncode != 0 or not receipt_path.exists():
+        detail = proc.stderr.decode(errors="replace")[-400:]
+        raise ValueError(
+            f"RENDER_FAILED: 渲染子进程失败（rc={proc.returncode}）：{detail}"
+        )
+    return op_id
+
+
+def _render_operation_child(home: str, spec_path: str) -> None:
+    """渲染子进程主体（MUJOCO_GL 已在父进程 env 设定后 import）。"""
+    import json as _json
+
+    import numpy as np
+    from PIL import Image
+
+    home = Path(home)
+    spec = _json.loads(Path(spec_path).read_text(encoding="utf-8"))
+    states = spec["states"]
+    op_id = spec["operation_id"]
+    op_dir = home / "renders" / op_id
+    import mujoco
+
+    model = mujoco.MjModel.from_xml_path(spec["model_path"])
+    data = mujoco.MjData(model)
+    renderer = mujoco.Renderer(model, height=spec["height"], width=spec["width"])
+    cam = mujoco.MjvCamera()
+    xyz = [(s["qpos"][0], s["qpos"][1], s["qpos"][2]) for s in states]
+    cx = sum(p[0] for p in xyz) / len(xyz)
+    cy = sum(p[1] for p in xyz) / len(xyz)
+    cz = sum(p[2] for p in xyz) / len(xyz)
+    if spec["camera"] == "top":
+        cam.lookat[:] = [cx, cy, cz]
+        cam.distance = 1.2
+        cam.azimuth = 90.0
+        cam.elevation = -89.0
+    else:
+        cam.lookat[:] = [cx, cy, cz]
+        cam.distance = 1.2
+        cam.azimuth = 135.0
+        cam.elevation = -25.0
+    times = [float(s.get("t", 0.0)) for s in states]
+    span = times[-1] - times[0] if len(times) > 1 else 0.0
+    duration_s = float(spec["duration_s"])
+    if duration_s <= 0.0:
+        duration_s = span if span > 0 else len(states) * 0.002
+    fps = float(spec["fps"])
+    frame_count = max(2, int(round(duration_s * fps)))
+    target_times = [times[0] + (duration_s * i / (frame_count - 1))
+                    for i in range(frame_count)]
+    images = []
+    for tt in target_times:
+        idx = min(range(len(times)), key=lambda i: abs(times[i] - tt))
+        data.qpos[:] = np.array(states[idx]["qpos"], dtype=float)
+        mujoco.mj_forward(model, data)
+        renderer.update_scene(data, camera=cam)
+        images.append(Image.fromarray(renderer.render()))
+    artifacts: dict[str, Any] = {}
+    if "gif" in spec["outputs"]:
+        out = op_dir / f"{op_id}.gif"
+        tmp = op_dir / f".{op_id}.gif.tmp"
+        images[0].save(
+            tmp, format="GIF", save_all=True, append_images=images[1:],
+            duration=int(1000 / max(fps, 1.0)), loop=0,
+        )
+        tmp.replace(out)  # 原子发布
+        artifacts["gif"] = {"path": str(out), "frames": len(images),
+                            "bytes": out.stat().st_size}
+    if "mp4" in spec["outputs"]:
+        import imageio.v3 as iio
+
+        mp4 = op_dir / f"{op_id}.mp4"
+        tmp = op_dir / f".{op_id}.mp4.tmp"
+        iio.imwrite(tmp, [np.asarray(img) for img in images],
+                    fps=int(round(fps)))
+        tmp.replace(mp4)
+        artifacts["mp4"] = {"path": str(mp4), "frames": len(images),
+                            "bytes": mp4.stat().st_size}
+    (op_dir / "render_receipt.json").write_text(_json.dumps({
+        "operation_id": op_id,
+        "trace_ref": spec["trace_ref"],
+        "model_digest": spec["model_digest"],
+        "camera": spec["camera"],
+        "fps": fps,
+        "duration_s": duration_s,
+        "frame_count": len(images),
+        "artifacts": artifacts,
+        "evidence_level": "agent_generated_experiment",
+    }, ensure_ascii=False, indent=1), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/src/rosclaw/sim/api.py
+++ b/src/rosclaw/sim/api.py
@@ -1,0 +1,311 @@
+"""最小通用编程接口（W02，规格 §6.4）——Pi 写脚本组合能力的
+可导入入口。六类入口复用同一执行器/引用系统，不各自维护
+PlanStore。
+
+```text
+load_model(asset_ref | task_local_mjcf) -> model_ref + body_description
+observe(model_ref, channels, at_time) -> observation_ref
+submit_simulation(model_ref, initial_state_ref, controller_or_trajectory,
+                  duration, recording_spec) -> operation_ref
+read_trace(trace_ref, fields, interval) -> bounded_data | data_file
+render(trace_ref, render_spec) -> operation_ref
+export(artifact_ref, destination) -> exported_file
+```
+
+边界：
+- task_local_mjcf 在 task_root 内解析/复制——模型导入不直接执行
+  任意外部插件（native plugin 是另一权限类别）；
+- 控制序列仿真记录**完整状态**（qpos nq / qvel nv / ctrl nu——
+  W03 的状态契约在此先行落地）；
+- 输出标 agent-generated experiment——模型编写脚本的输出不假装
+  来自独立受信验证。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from rosclaw.sim.model_inspect import inspect_mjcf
+
+
+def load_model(
+    asset_ref: str | Path, *, task_root: Path | str,
+) -> tuple[str, dict[str, Any]]:
+    """加载模型（asset_ref 为 zoo 内名称或 task_root 内 MJCF 路径）。
+
+    返回 (model_ref, body_description)。task-local 文件复制进
+    task_root/models/（引用可跨进程解析；不执行外部插件）。
+    """
+    task_root = Path(task_root)
+    path = Path(asset_ref)
+    if not path.is_absolute():
+        # zoo 内资产名（e-urdf-zoo/<name>/robot.mjcf.xml）或任务相对路径。
+        from rosclaw.runtime.eurdf_loader import _default_zoo_path
+
+        zoo_candidate = _default_zoo_path() / str(asset_ref) / "robot.mjcf.xml"
+        task_candidate = task_root / str(asset_ref)
+        if zoo_candidate.exists():
+            path = zoo_candidate
+        elif task_candidate.exists():
+            path = task_candidate
+        else:
+            raise ValueError(
+                f"MODEL_NOT_FOUND: {asset_ref!r}（已查 zoo 与 task_root）"
+            )
+    if not path.exists():
+        raise ValueError(f"MODEL_NOT_FOUND: {path}")
+    info = inspect_mjcf(path)
+    models_dir = task_root / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+    staged = models_dir / path.name
+    if path.resolve() != staged.resolve():
+        shutil.copy2(path, staged)
+    digest_short = info.model_digest.removeprefix("sha256:")[:16]
+    model_ref = f"model_{digest_short}"
+    (models_dir / f"{model_ref}.json").write_text(json.dumps({
+        "model_ref": model_ref,
+        "path": str(staged),
+        "source_path": str(path),
+        **info.to_dict(),
+    }, ensure_ascii=False, indent=1), encoding="utf-8")
+    return model_ref, info.to_dict()
+
+
+def _load_model_record(model_ref: str, task_root: Path) -> dict[str, Any]:
+    record_path = task_root / "models" / f"{model_ref}.json"
+    if not record_path.exists():
+        raise ValueError(f"REF_NOT_FOUND: model {model_ref!r} 不在 task_root")
+    return json.loads(record_path.read_text(encoding="utf-8"))
+
+
+def observe(
+    model_ref: str,
+    channels: list[str],
+    *,
+    at_time: float | None = None,
+    task_root: Path | str,
+    initial_state_ref: str | None = None,
+) -> str:
+    """只读观测（返回 observation_ref——内容随记录持久化）。
+
+    channels：joint_positions / joint_velocities / eef_pose:<site>。
+    at_time=None = 初始状态（或 initial_state_ref 指定状态）。
+    """
+    import mujoco
+    import numpy as np
+
+    task_root = Path(task_root)
+    record = _load_model_record(model_ref, task_root)
+    model = mujoco.MjModel.from_xml_path(record["path"])
+    data = mujoco.MjData(model)
+    if initial_state_ref:
+        state = _load_state_record(initial_state_ref, task_root)
+        data.qpos[:] = np.array(state["qpos"], dtype=float)
+        data.qvel[:] = np.array(state.get("qvel", [0.0] * model.nv), dtype=float)
+    mujoco.mj_forward(model, data)
+
+    out: dict[str, Any] = {"model_ref": model_ref, "time": float(data.time)}
+    if "joint_positions" in channels:
+        out["joint_positions"] = [round(float(v), 8) for v in data.qpos]
+    if "joint_velocities" in channels:
+        out["joint_velocities"] = [round(float(v), 8) for v in data.qvel]
+    for ch in channels:
+        if ch.startswith("eef_pose:"):
+            site_name = ch.split(":", 1)[1]
+            site_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, site_name)
+            if site_id < 0:
+                raise ValueError(f"SITE_NOT_FOUND: {site_name!r}")
+            # site_xquat 在部分 mujoco 版本不存在——由 site_xmat
+            # 旋转矩阵转显式命名的 xyzw 四元数（§6.2 命名契约）。
+            from rosclaw.agentd.sim_trajectory import _mat_to_quat_xyzw
+
+            mat = [
+                [float(data.site_xmat[site_id][i]) for i in range(0, 3)],
+                [float(data.site_xmat[site_id][i]) for i in range(3, 6)],
+                [float(data.site_xmat[site_id][i]) for i in range(6, 9)],
+            ]
+            out[ch] = {
+                "position": [round(float(v), 8) for v in data.site_xpos[site_id]],
+                "quaternion_xyzw": _mat_to_quat_xyzw(mat),
+            }
+    obs_id = "obs_" + hashlib.sha256(
+        json.dumps(out, sort_keys=True).encode()
+    ).hexdigest()[:16]
+    (task_root / "models" / f"{obs_id}.json").write_text(
+        json.dumps(out, ensure_ascii=False, indent=1), encoding="utf-8",
+    )
+    return obs_id
+
+
+def _load_state_record(state_ref: str, task_root: Path) -> dict[str, Any]:
+    path = task_root / "models" / f"{state_ref}.json"
+    if not path.exists():
+        raise ValueError(f"REF_NOT_FOUND: state {state_ref!r}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def submit_simulation(
+    model_ref: str,
+    initial_state_ref: str | None,
+    controller_or_trajectory: dict[str, Any],
+    duration: float,
+    recording_spec: dict[str, Any] | None = None,
+    *,
+    task_root: Path | str,
+) -> str:
+    """控制序列仿真——记录完整状态（qpos/qvel/ctrl，W03 契约）。
+
+    controller_or_trajectory：{"ctrl_series": [[...], ...]}（每步
+    nu 维）或 {"hold": true}（零控制保持）。模型编写的控制器
+    不得写权威 metrics——输出标 agent-generated experiment。
+    返回 operation_ref（trace 记录可经 read_trace/render 消费）。
+    """
+    import mujoco
+    import numpy as np
+
+    task_root = Path(task_root)
+    record = _load_model_record(model_ref, task_root)
+    model = mujoco.MjModel.from_xml_path(record["path"])
+    data = mujoco.MjData(model)
+    if initial_state_ref:
+        state = _load_state_record(initial_state_ref, task_root)
+        data.qpos[:] = np.array(state["qpos"], dtype=float)
+        if state.get("qvel"):
+            data.qvel[:] = np.array(state["qvel"], dtype=float)
+
+    ctrl_series = controller_or_trajectory.get("ctrl_series")
+    if ctrl_series is None and not controller_or_trajectory.get("hold"):
+        raise ValueError(
+            "CONTROLLER_INVALID: 需要 ctrl_series 或 hold（动态控制器"
+            "进程是受限能力，见规格 §6.4）"
+        )
+    if ctrl_series:
+        for step_ctrl in ctrl_series:
+            if len(step_ctrl) != int(model.nu):
+                raise ValueError(
+                    f"CTRL_DIMENSION: 控制向量长度 {len(step_ctrl)} != "
+                    f"nu={int(model.nu)}"
+                )
+    steps = max(1, int(round(float(duration) / float(model.opt.timestep))))
+    states: list[dict[str, Any]] = []
+    started = time.monotonic()
+    for step in range(steps):
+        if ctrl_series:
+            data.ctrl[:] = np.array(
+                ctrl_series[min(step, len(ctrl_series) - 1)], dtype=float,
+            )
+        mujoco.mj_step(model, data)
+        states.append({
+            "t": round(float(data.time), 6),
+            "qpos": [round(float(v), 8) for v in data.qpos],
+            "qvel": [round(float(v), 8) for v in data.qvel],
+            "ctrl": [round(float(v), 8) for v in data.ctrl],
+        })
+    digest = hashlib.sha256(
+        json.dumps(states, sort_keys=True).encode()
+    ).hexdigest()[:16]
+    op_id = f"op_{digest}"
+    payload = {
+        "operation_id": op_id,
+        "kind": "agent_generated_experiment",
+        "model_ref": model_ref,
+        "model_digest": record["model_digest"],
+        "duration_s": float(duration),
+        "timestep_s": float(model.opt.timestep),
+        "steps": steps,
+        "wall_ms": round((time.monotonic() - started) * 1000, 1),
+        "states_digest": "sha256:" + hashlib.sha256(
+            json.dumps(states, sort_keys=True).encode()
+        ).hexdigest(),
+        "states": states,
+    }
+    (task_root / "models" / f"{op_id}.json").write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8",
+    )
+    return op_id
+
+
+def read_trace(
+    trace_ref: str,
+    fields: list[str] | None = None,
+    interval: float | None = None,
+    *,
+    task_root: Path | str,
+    max_points: int = 480,
+) -> dict[str, Any]:
+    """读取仿真记录（有界——默认 decimate 到 max_points）。"""
+    task_root = Path(task_root)
+    payload = _load_state_record(trace_ref, task_root)
+    states = payload.get("states") or []
+    if interval:
+        states = [s for s in states if s["t"] % max(float(interval), 1e-9)
+                  < float(payload.get("timestep_s", 0.002))]
+    if len(states) > max_points:
+        step = len(states) / max_points
+        states = [states[round(i * step)] for i in range(max_points)]
+    if fields:
+        states = [
+            {k: v for k, v in s.items() if k == "t" or k in fields}
+            for s in states
+        ]
+    return {
+        "operation_id": payload.get("operation_id", trace_ref),
+        "model_ref": payload.get("model_ref", ""),
+        "model_digest": payload.get("model_digest", ""),
+        "kind": payload.get("kind", ""),
+        "states": states,
+    }
+
+
+def render(
+    trace_ref: str,
+    render_spec: dict[str, Any],
+    *,
+    task_root: Path | str,
+) -> str:
+    """渲染仿真记录（operation 目录独立——同 trace 不同视角/格式
+    互不覆盖）。返回 render operation_ref。"""
+    task_root = Path(task_root)
+    payload = _load_state_record(trace_ref, task_root)
+    states = payload.get("states") or []
+    if not states:
+        raise ValueError(f"RENDER_INPUT_MISSING: {trace_ref} 无 states")
+    from rosclaw.agentd.sim_render import render_operation
+
+    return render_operation(
+        task_root, trace_ref, states,
+        model_digest=str(payload.get("model_digest", "")),
+        camera=str(render_spec.get("camera", "follow")),
+        outputs=list(render_spec.get("outputs") or ["gif"]),
+        fps=float(render_spec.get("fps", 12.0)),
+        duration_s=float(payload.get("duration_s", 0.0)),
+    )
+
+
+def export(
+    artifact_ref: str, destination: Path | str, *, task_root: Path | str,
+) -> Path:
+    """导出产物到指定路径（目标存在不静默覆盖）。"""
+    task_root = Path(task_root)
+    destination = Path(destination)
+    source = task_root / "renders" / artifact_ref
+    if not source.exists():
+        source = task_root / "models" / f"{artifact_ref}.json"
+    if not source.exists():
+        raise ValueError(f"ARTIFACT_NOT_FOUND: {artifact_ref!r}")
+    if destination.exists():
+        raise ValueError(f"EXPORT_TARGET_EXISTS: {destination}（不静默覆盖）")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    return destination
+
+
+__all__ = [
+    "load_model", "observe", "submit_simulation",
+    "read_trace", "render", "export",
+]

--- a/src/rosclaw/sim/model_inspect.py
+++ b/src/rosclaw/sim/model_inspect.py
@@ -1,0 +1,117 @@
+"""可推导的身体档案（W02，规格 §6.1）——从加载的 MJCF 推出，
+不从注册表或机器人名称猜。
+
+力学模型（MJCF/URDF）是维度与关节顺序的唯一权威：内容摘要、
+nq/nv/nu、joint 名称与类型、qpos/dof 地址、执行器→关节映射、
+控制类型与限制、传感器、camera/site。RenderProfile 只放展示
+偏好（默认视角/颜色/EEF 偏好），不复制这份力学真相。
+
+没有夹爪不能从机器人名称猜有夹爪——`gripper` 只反映模型里
+实际存在的执行器驱动夹持机构（本轮：存在名为 gripper 的
+actuated joint 才为 True，否则恒 False）。
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ModelInspection:
+    """从 MJCF 推出的身体档案（只读——不是 RenderProfile）。"""
+
+    model_digest: str
+    nq: int
+    nv: int
+    nu: int
+    joints: list[dict[str, Any]] = field(default_factory=list)
+    actuators: list[dict[str, Any]] = field(default_factory=list)
+    sensors: list[dict[str, Any]] = field(default_factory=list)
+    cameras: list[str] = field(default_factory=list)
+    sites: list[str] = field(default_factory=list)
+    gripper: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_digest": self.model_digest,
+            "nq": self.nq, "nv": self.nv, "nu": self.nu,
+            "joints": self.joints,
+            "actuators": self.actuators,
+            "sensors": self.sensors,
+            "cameras": self.cameras,
+            "sites": self.sites,
+            "gripper": self.gripper,
+        }
+
+
+_JOINT_TYPES = {0: "free", 1: "ball", 2: "slide", 3: "hinge"}
+
+
+def inspect_mjcf(path: Path | str) -> ModelInspection:
+    """加载 MJCF 并推出身体档案。加载失败给结构化错误。"""
+    import mujoco
+
+    path = Path(path)
+    if not path.exists():
+        raise ValueError(f"MODEL_NOT_FOUND: {path}")
+    try:
+        model = mujoco.MjModel.from_xml_path(str(path))
+    except Exception as exc:
+        raise ValueError(f"MODEL_LOAD_ERROR: {path}: {exc}") from exc
+    digest = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+    joints: list[dict[str, Any]] = []
+    for i in range(model.njnt):
+        joints.append({
+            "name": mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, i) or f"joint_{i}",
+            "type": _JOINT_TYPES.get(int(model.jnt_type[i]), str(int(model.jnt_type[i]))),
+            "qpos_addr": int(model.jnt_qposadr[i]),
+            "dof_addr": int(model.jnt_dofadr[i]),
+        })
+
+    actuators: list[dict[str, Any]] = []
+    for i in range(model.nu):
+        joint_id = int(model.actuator_trnid[i][0])
+        joint_name = (
+            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+            if joint_id >= 0 else ""
+        )
+        actuators.append({
+            "name": mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, i) or f"actuator_{i}",
+            "joint": joint_name or f"joint_{joint_id}",
+            "ctrlrange": [float(model.actuator_ctrlrange[i][0]),
+                          float(model.actuator_ctrlrange[i][1])],
+        })
+
+    sensors: list[dict[str, Any]] = []
+    for i in range(model.nsensor):
+        sensors.append({
+            "name": mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_SENSOR, i) or f"sensor_{i}",
+            "type": str(mujoco.mjtSensor(model.sensor_type[i]).name).removeprefix("mjSENS_").lower(),
+        })
+
+    cameras = [
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_CAMERA, i) or f"camera_{i}"
+        for i in range(model.ncam)
+    ]
+    sites = [
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_SITE, i) or f"site_{i}"
+        for i in range(model.nsite)
+    ]
+
+    # 夹爪：只反映实际存在的执行器驱动夹持机构——不从名字猜。
+    actuator_joints = {a["joint"] for a in actuators}
+    gripper = any("gripper" in j for j in actuator_joints)
+
+    return ModelInspection(
+        model_digest=digest,
+        nq=int(model.nq), nv=int(model.nv), nu=int(model.nu),
+        joints=joints, actuators=actuators, sensors=sensors,
+        cameras=cameras, sites=sites, gripper=gripper,
+    )
+
+
+__all__ = ["ModelInspection", "inspect_mjcf"]

--- a/tests/agentd/test_w02_contracts.py
+++ b/tests/agentd/test_w02_contracts.py
@@ -1,0 +1,226 @@
+"""W02 红测试（规格 2026-09-08 §6）：
+
+6.1 可推导的身体档案——从加载的 MJCF 推出（不是从注册表/名字猜）：
+- freejoint（nq=7, nv=6）、ball joint（nq=4, nv=3）、被动铰链、
+  执行器少于关节数的 fixture 均能 inspect；
+- joint 名称/类型/qpos 地址/dof 地址、执行器→关节映射、
+  控制类型与限制、传感器、camera/site 全齐；
+- 没有夹爪不从机器人名称猜有夹爪。
+
+6.3/§2.2：渲染回放不得默认 UR5e——trace/plan 记录什么模型就
+用什么模型；记录缺失=legacy/unverified 标记，不静默默认。
+
+6.4：最小 Python API（load_model/observe/submit_simulation/
+read_trace/render/export）实际可导入可组合——task_local_mjcf
+可加载（任务根内解析，不执行外部插件）。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+FIXTURE_MJCF = """<mujoco model="w02_fixture">
+  <worldbody>
+    <body name="free_obj" pos="0 0 0.1">
+      <freejoint name="obj_free"/>
+      <geom type="box" size="0.02 0.02 0.02" mass="0.5"/>
+    </body>
+    <body name="arm" pos="0.3 0 0.3">
+      <joint name="shoulder" type="hinge" axis="0 0 1"/>
+      <geom type="capsule" size="0.01 0.1"/>
+      <body name="forearm" pos="0 0 0.1">
+        <joint name="elbow" type="ball"/>
+        <geom type="capsule" size="0.008 0.08"/>
+        <site name="tip" pos="0 0 0.08"/>
+      </body>
+    </body>
+    <camera name="overhead" pos="0.3 0 1.2" euler="0 0 0"/>
+  </worldbody>
+  <actuator>
+    <motor name="shoulder_motor" joint="shoulder" ctrlrange="-1 1"/>
+  </actuator>
+  <sensor>
+    <jointpos joint="shoulder"/>
+  </sensor>
+</mujoco>
+"""
+
+
+class TestModelInspection:
+    def test_fixture_dimensions_and_mapping(self, tmp_path) -> None:
+        """nq≠nv≠nu 的 fixture：freejoint(7/6) + hinge(1/1) + ball(4/3)
+        → nq=12, nv=10；执行器 1 个（少于关节数）。"""
+        from rosclaw.sim.model_inspect import inspect_mjcf
+
+        path = tmp_path / "fixture.xml"
+        path.write_text(FIXTURE_MJCF, encoding="utf-8")
+        info = inspect_mjcf(path)
+        assert info.nq == 12, info
+        assert info.nv == 10, info
+        assert info.nu == 1, info
+        assert info.model_digest.startswith("sha256:")
+        joint_names = [j["name"] for j in info.joints]
+        assert "obj_free" in joint_names and "shoulder" in joint_names
+        assert "elbow" in joint_names
+        types = {j["name"]: j["type"] for j in info.joints}
+        assert types["obj_free"] == "free"
+        assert types["elbow"] == "ball"
+        # 执行器→关节映射：shoulder_motor → shoulder（elbow 是被动
+        # 关节——不得把 ball joint 说成 actuator）。
+        assert info.actuators == [
+            {"name": "shoulder_motor", "joint": "shoulder",
+             "ctrlrange": [-1.0, 1.0]}
+        ]
+        passive = {j["name"] for j in info.joints} - {
+            a["joint"] for a in info.actuators
+        }
+        assert "elbow" in passive
+        # camera/site/传感器
+        assert "overhead" in info.cameras
+        assert "tip" in info.sites
+        assert any(s.get("type") == "jointpos" for s in info.sensors)
+
+    def test_no_gripper_invention(self, tmp_path) -> None:
+        """无夹爪模型 → 不得出现夹爪声明（不从名字猜）。"""
+        from rosclaw.sim.model_inspect import inspect_mjcf
+
+        path = tmp_path / "fixture.xml"
+        path.write_text(FIXTURE_MJCF, encoding="utf-8")
+        info = inspect_mjcf(path)
+        assert info.gripper is False
+
+
+class TestNoDefaultRobot:
+    def test_missing_model_identity_is_legacy_not_ur5e(self) -> None:
+        """无 spec 且无模型身份记录 → legacy/unverified 标记或诚实
+        拒绝——绝不静默默认 UR5e。"""
+        import inspect
+
+        from rosclaw.agentd import sim_render
+
+        src = inspect.getsource(sim_render)
+        # 默认机器人必须是"从记录推导"——裸字面量默认不再存在。
+        assert 'robot_id = "ur5e"' not in src, (
+            "回放仍存在裸 UR5e 默认（记录什么模型才用什么模型）"
+        )
+
+
+class TestPythonApi:
+    def test_api_importable_and_composable(self, tmp_path) -> None:
+        """六类入口存在且可组合：load_model → submit_simulation →
+        read_trace → render → export。"""
+        from rosclaw.sim import api
+
+        for name in (
+            "load_model", "observe", "submit_simulation",
+            "read_trace", "render", "export",
+        ):
+            assert callable(getattr(api, name, None)), f"缺 api.{name}"
+
+    def test_load_task_local_mjcf(self, tmp_path) -> None:
+        """任务根内 MJCF 可加载并返回 model_ref + body_description
+        （nq/nv/nu/站点）。"""
+        from rosclaw.sim import api
+
+        mjcf = tmp_path / "task_model.xml"
+        mjcf.write_text(FIXTURE_MJCF, encoding="utf-8")
+        ref, desc = api.load_model(mjcf, task_root=tmp_path)
+        assert ref
+        assert desc["nq"] == 12 and desc["nu"] == 1
+        assert "tip" in desc["sites"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+class TestQuaternionContract:
+    def test_pose_spec_uses_named_xyzw(self, tmp_path) -> None:
+        """§6.2：位姿契约的对外四元数必须命名明确
+        （orientation_xyzw / quaternion_xyzw）——禁止匿名四元素
+        数组在边界自由流通。"""
+        import json
+
+        from rosclaw.agentd.sim_trajectory import SimTrajectoryService
+
+        svc = SimTrajectoryService(tmp_path)
+        plan = svc.generate_planar_path(
+            shape="star5", center_m=[0.35, 0.25, 0.30], scale_m=0.05,
+        )
+        payload = svc.get_plan_payload(str(plan["plan_id"]))
+        spec = payload.get("spec") or {}
+        text = json.dumps(spec)
+        # 显式命名的 xyzw 字段在场；不允许裸 "orientation": [w,x,y,z]
+        # 无后缀字段（匿名四元素数组）。
+        assert "orientation_xyzw" in text or "quaternion_xyzw" in text, text[:300]
+        import re as _re
+
+        assert not _re.search(r'"orientation"\s*:\s*\[', text), (
+            "出现匿名 orientation 数组（必须 *_xyzw 命名）"
+        )
+
+
+class TestApiEndToEnd:
+    def test_load_simulate_render_export(self, tmp_path) -> None:
+        """六入口组合闭环：load_model → submit_simulation（完整
+        状态）→ read_trace → render（子进程正确后端+时间驱动）
+        → export（真实可解码 GIF）。"""
+        from rosclaw.sim import api
+
+        mjcf = tmp_path / "task_model.xml"
+        mjcf.write_text(FIXTURE_MJCF, encoding="utf-8")
+        ref, desc = api.load_model(mjcf, task_root=tmp_path)
+        op = api.submit_simulation(
+            ref, None, {"ctrl_series": [[0.3]] * 50}, 0.1,
+            task_root=tmp_path,
+        )
+        trace = api.read_trace(op, task_root=tmp_path)
+        assert len(trace["states"]) == 50
+        assert len(trace["states"][0]["qpos"]) == 12  # 完整 nq
+        assert len(trace["states"][0]["ctrl"]) == 1  # 完整 nu
+        rop = api.render(
+            op, {"camera": "top", "outputs": ["gif"], "fps": 8.0},
+            task_root=tmp_path,
+        )
+        out = api.export(
+            rop + "/" + rop + ".gif", tmp_path / "out.gif",
+            task_root=tmp_path,
+        )
+        assert out.exists() and out.stat().st_size > 500
+        # GIF 可解码（PIL 打开 + 帧数>1）。
+        from PIL import Image
+
+        with Image.open(out) as img:
+            assert getattr(img, "n_frames", 1) >= 2
+        # 渲染 receipt 标 agent-generated（不冒充受信验证）。
+        import json
+
+        receipt = json.loads(
+            (tmp_path / "renders" / rop / "render_receipt.json").read_text()
+        )
+        assert receipt["evidence_level"] == "agent_generated_experiment"
+
+    def test_cross_model_reference_rejected(self, tmp_path) -> None:
+        """§6.3：跨模型引用（qpos 维度不符）直接拒绝——不静默
+        截断或补零。"""
+        from rosclaw.sim import api
+
+        mjcf = tmp_path / "task_model.xml"
+        mjcf.write_text(FIXTURE_MJCF, encoding="utf-8")
+        ref, _ = api.load_model(mjcf, task_root=tmp_path)
+        op = api.submit_simulation(
+            ref, None, {"ctrl_series": [[0.3]] * 5}, 0.01,
+            task_root=tmp_path,
+        )
+        # 篡改 states 维度 → 渲染必须拒绝（STATE_DIMENSION）。
+        import json as _json
+
+        record = tmp_path / "models" / f"{op}.json"
+        payload = _json.loads(record.read_text())
+        payload["states"][0]["qpos"] = [0.0, 0.0, 0.0]  # 3 != nq=12
+        record.write_text(_json.dumps(payload))
+        states = payload["states"]
+        import pytest as _pt
+
+        with _pt.raises(ValueError, match="STATE_DIMENSION"):
+            api.render(op, {"outputs": ["gif"]}, task_root=tmp_path)

--- a/tests/agentd/test_w02_contracts.py
+++ b/tests/agentd/test_w02_contracts.py
@@ -219,7 +219,6 @@ class TestApiEndToEnd:
         payload = _json.loads(record.read_text())
         payload["states"][0]["qpos"] = [0.0, 0.0, 0.0]  # 3 != nq=12
         record.write_text(_json.dumps(payload))
-        states = payload["states"]
         import pytest as _pt
 
         with _pt.raises(ValueError, match="STATE_DIMENSION"):


### PR DESCRIPTION
## 内容（规格 2026-09-08 §6）

- **6.1 可推导身体档案**：`rosclaw/sim/model_inspect.py`——从加载的 MJCF 推出 digest/nq/nv/nu/joint（名称/类型/qpos+dof 地址）/执行器→关节映射+控制限制/传感器/camera/site；不从名字猜夹爪（freejoint/ball/被动铰链/少执行器 fixture 实测）。
- **6.3 消除默认机器人**：sim_render 回放本体从记录推导（spec body_ref > trace.resource.resource_id），缺失=LEGACY_MODEL_IDENTITY_MISSING 诚实拒绝；新 render_operation 对跨模型引用 STATE_DIMENSION 直接拒绝（不静默截断/补零）。
- **6.4 最小 Python API**：`rosclaw/sim/api.py` 六入口（load_model/observe/submit_simulation/read_trace/render/export）；task-local MJCF 可加载；控制序列仿真记录完整状态（qpos nq + qvel nv + ctrl nu——W03 契约先行落地）；输出标 agent_generated_experiment。
- **render_operation**（W04 先行面）：完整 qpos 恢复 + 时间驱动选帧 + operation 独立目录 + 渲染子进程 + 原子发布。
- **6.2 四元数命名契约测试**（禁止匿名 orientation 数组）。

## 验证

红测试 8 项；agentd+integration 1006 绿；渲染回归 36 绿；e2e 组合闭环实测（load→simulate→render→export 可解码 GIF）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)