### PR TITLE
W03: full-state recording and honest replay (spec §7)

### DIFF
--- a/docs/implementation/w03-state-replay.md
+++ b/docs/implementation/w03-state-replay.md
@@ -1,0 +1,67 @@
+# W03 真实状态记录与完整回放（规格 §7）
+
+**分支**：a-w03-state-replay（基于 a-w02-contracts，§17 依赖：W03←W02/W00）
+**日期**：2026-09-09
+
+## 改动
+
+### §7.1 记录侧：完整状态 + 显式维度声明
+
+`src/rosclaw/sandbox/backends/mujoco_cpu.py`：
+
+- `record_sample` 记录**完整** `qpos`（nq）/`qvel`（nv）/`ctrl`（nu）——
+  替换旧的 `data.qpos[:nu]` / `data.qvel[:nu]` 截断。
+- `trajectory_states.json` 升级 `rosclaw.trajectory_states.v2`：
+  显式携带 `dims: {nq, nv, nu}` 与 `model_digest`——维度成为
+  声明契约，不再由消费者猜。
+- 观测指标改用完整状态数组；跟踪误差保持「实际 vs 同时刻指令」
+  语义（受控子集 `qpos[:nu] - command`，§7.3 定义锚点）。
+- receipt 的 `final_qpos` 保持 nu 维契约不变（与 trajectory
+  目标同维度比较）。
+- 回放校验接受 v1（旧记录）与 v2。
+
+### §7.2 回放侧：同模型完整恢复，旧记录诚实标注
+
+`src/rosclaw/agentd/sim_render.py` 新增 `restore_frame_state()`：
+
+- 文件声明 dims 与模型不符 → `MODEL_DIMS_MISMATCH`（跨模型引用拒绝）；
+- qpos 长度 == nq → 完整恢复（视频回放 = 状态恢复 + 相机 +
+  `mj_forward` 仅前向，不重仿真）；
+- qpos 长度 == nu < nq（旧截断记录）→ `LEGACY_PARTIAL_STATE`
+  诚实拒绝——**绝不补零冒充完整状态**；
+- 其他长度 → `STATE_DIMENSION`。
+
+`_render_impl` 帧循环改走该函数；render receipt 新增
+`state_contract`（`declared_dims_v2` / `legacy_undeclared_dims`）
+标注兼容回放。`sim_trajectory.py` 的实际 eef FK 回放复用同一
+恢复函数（记录侧 v2 后旧截断赋值在 nq≠nu 模型上必然错位）。
+
+### §7.2 续仿真检查点
+
+`src/rosclaw/sim/api.py` 新增 `_restore_initial_state()`：
+`observe` / `submit_simulation` 的 initial_state_ref 恢复统一
+校验——状态记录声明 `model_digest` 且不符 → `CROSS_MODEL_REF`；
+qpos/qvel 维度不符 → `STATE_DIMENSION`（不截断、不补零）。
+
+### W00 解标
+
+`TestR2FullStateReplay::test_replay_restores_full_nq_not_nu`
+xfail(strict) 解除——源码锚点 + W03 行为测试双保险。
+
+## 验证（红→绿）
+
+| 测试 | 结果 |
+|---|---|
+| test_w03_state_replay.py（10：dims/模型摘要声明、完整 qpos/qvel/ctrl、源码无截断守卫、恢复接受完整 nq、错误长度拒绝不补零、声明 dims 跨模型拒绝、LEGACY_PARTIAL_STATE、FK 回放锚点、续仿真维度/跨模型拒绝） | 红（首跑 1 failed 确认）→ 绿 10/10 |
+| W00 R2 解标 + 全量 baseline | 绿（2 xfail 剩 R1/R3 = W05/W04 目标；R5 NOT_RUN skip） |
+| tests/sandbox + tests/agentd 全量（除 PTY journey） | 783 passed, 1 flaky（test_discover_limo_fixture 单独重跑通过，与本轮无关——MCP fixture 发现时序） |
+| ruff check src tests | 全过 |
+
+## 边界说明
+
+- 当前 `_model_layout_error` 仍拒绝 nq≠nv≠nu 的 rollout 模型
+  （joint-position 后端的指令语义是 nu 维航点）——这是**诚实拒绝**
+  而非数据丢失；本轮把记录/回放契约改成显式全维度，后续放开
+  布局时不会再静默丢状态。
+- 真实模型（K3）具身回放验收：**NOT_RUN**（无 ROSCLAW_KIMI_API_KEY
+  ——不合成冒充；operator 带 key 重跑）。

--- a/src/rosclaw/agentd/sim_render.py
+++ b/src/rosclaw/agentd/sim_render.py
@@ -464,6 +464,46 @@ def _apply_overlay_geoms(renderer: Any, overlays: list[tuple[str, Any]]) -> list
     return drawn
 
 
+def restore_frame_state(
+    model: Any,
+    data: Any,
+    qpos: list[float],
+    declared_dims: dict[str, Any] | None,
+) -> str:
+    """W03 §7.2：视频回放的状态恢复——同模型完整 qpos 恢复 +
+    仅前向（调用方随后 mj_forward，不重仿真）。
+
+    维度纪律（绝不补零冒充完整状态）：
+    - 文件声明 dims 与模型不符 → MODEL_DIMS_MISMATCH（跨模型引用拒绝）；
+    - qpos 长度 == nq → 完整恢复；
+    - qpos 长度 == nu < nq（旧版按执行器数截断的记录）→
+      LEGACY_PARTIAL_STATE 诚实拒绝；
+    - 其他长度 → STATE_DIMENSION。
+    """
+    import numpy as np
+
+    nq = int(model.nq)
+    nu = int(model.nu)
+    if declared_dims is not None:
+        declared_nq = int(declared_dims.get("nq", nq))
+        if declared_nq != nq:
+            raise ValueError(
+                f"MODEL_DIMS_MISMATCH: 状态文件声明 nq={declared_nq}，"
+                f"当前模型 nq={nq}（跨模型引用拒绝回放）"
+            )
+    if len(qpos) == nq:
+        data.qpos[:] = np.asarray(qpos, dtype=float)
+        return "restored"
+    if len(qpos) == nu and nq != nu:
+        raise ValueError(
+            f"LEGACY_PARTIAL_STATE: 旧记录仅含 nu={nu} 维位置，当前模型 "
+            f"nq={nq}——拒绝补零冒充完整状态（需重新 rollout 取得完整记录）"
+        )
+    raise ValueError(
+        f"STATE_DIMENSION: qpos 长度 {len(qpos)} != nq={nq}"
+    )
+
+
 def _render_impl(
     home: Path,
     trace_id: str,
@@ -483,7 +523,11 @@ def _render_impl(
     trace_path = trace_dir / "trace.json"
     states_path = trace_dir / "trajectory_states.json"
     trace = json.loads(trace_path.read_text(encoding="utf-8"))
-    states = json.loads(states_path.read_text(encoding="utf-8"))["states"]
+    states_payload = json.loads(states_path.read_text(encoding="utf-8"))
+    states = states_payload["states"]
+    # W03 §7.1：v2 文件显式声明 nq/nv/nu；缺声明 = 旧记录
+    # （receipt 标 legacy_undeclared_dims 兼容回放）。
+    declared_dims = states_payload.get("dims")
     states_digest = "sha256:" + hashlib.sha256(
         states_path.read_bytes()
     ).hexdigest()
@@ -525,7 +569,6 @@ def _render_impl(
     if not sandbox.has_physics:
         raise ValueError(f"RENDER_INPUT: canonical 模型不可用: {sandbox.load_error}")
     import mujoco
-    import numpy as np
 
     model = sandbox.physics_model
     data = sandbox.physics_data
@@ -576,7 +619,9 @@ def _render_impl(
         images = []
         for idx in frames_idx:
             q = positions[idx]
-            data.qpos[: int(model.nu)] = np.array(q[: int(model.nu)])
+            # W03 §7.2：同模型完整状态恢复（维度不符诚实拒绝，
+            # 不按 nu 截断、不补零）。
+            restore_frame_state(model, data, q, declared_dims)
             mujoco.mj_forward(model, data)
             renderer.update_scene(data, camera=cam)
             if overlay_geoms:
@@ -628,6 +673,12 @@ def _render_impl(
             trace_path.read_bytes()
         ).hexdigest(),
         "states_digest": states_digest,
+        # W03 §7.2：状态契约标注——v2 声明维度 / 旧记录兼容回放
+        # （旧记录完整长度恰好等于 nq 时恢复有效；截断记录已在
+        # restore_frame_state 诚实拒绝）。
+        "state_contract": (
+            "declared_dims_v2" if declared_dims else "legacy_undeclared_dims"
+        ),
         "outputs": sorted(artifacts),
         "resource": trace.get("resource") or {},
     }

--- a/src/rosclaw/agentd/sim_trajectory.py
+++ b/src/rosclaw/agentd/sim_trajectory.py
@@ -779,10 +779,16 @@ class SimTrajectoryService:
             import mujoco
 
             states_path = out_dir / "trajectory_states.json"
-            states = json.loads(states_path.read_text(encoding="utf-8"))["states"]
+            states_payload = json.loads(states_path.read_text(encoding="utf-8"))
+            states = states_payload["states"]
+            # W03 §7.2：FK 回放与视频回放同一恢复契约（完整状态
+            # + 维度诚实拒绝，不按 nu 截断）。
+            from rosclaw.agentd.sim_render import restore_frame_state
+
+            declared_dims = states_payload.get("dims")
             actual: list[dict] = []
             for sample in states:
-                data.qpos[: int(model.nu)] = np.array(sample["qpos"])
+                restore_frame_state(model, data, sample["qpos"], declared_dims)
                 mujoco.mj_forward(model, data)
                 pos = data.site_xpos[site_id]
                 r_mat = np.array(data.site_xmat[site_id]).reshape(3, 3).tolist()

--- a/src/rosclaw/sandbox/backends/mujoco_cpu.py
+++ b/src/rosclaw/sandbox/backends/mujoco_cpu.py
@@ -206,9 +206,11 @@ class MujocoCpuBackend:
             data.ctrl[: int(model.nu)] = perturbed
         mujoco.mj_forward(model, data)
         nu = int(model.nu)
-        previous_command = data.qpos[:nu].copy()
+        # W03 §7.1：内部跟踪/记录一律先取完整状态，指令比较再取
+        # 受控子集——nq≠nu 的模型不再被静默截断。
+        previous_command = data.qpos.copy()[:nu]
         initial_qpos = previous_command.copy()
-        previous_velocity = data.qvel[:nu].copy()
+        previous_velocity = data.qvel.copy()
         max_velocity = 0.0
         max_acceleration = 0.0
         max_tracking_error = 0.0
@@ -228,8 +230,8 @@ class MujocoCpuBackend:
             nonlocal max_velocity, max_acceleration, max_tracking_error
             nonlocal peak_contact_force, minimum_contact_distance, unstable_steps
             nonlocal deadline_missed, nan_detected, previous_velocity
-            qpos = data.qpos[:nu].copy()
-            qvel = data.qvel[:nu].copy()
+            qpos = data.qpos.copy()
+            qvel = data.qvel.copy()
             nan_detected = nan_detected or bool(
                 not np.isfinite(qpos).all() or not np.isfinite(qvel).all()
             )
@@ -239,7 +241,8 @@ class MujocoCpuBackend:
             previous_velocity = qvel
             max_tracking_error = max(
                 max_tracking_error,
-                float(np.max(np.abs(qpos - command), initial=0.0)),
+                # 跟踪误差 = 实际 vs 同时刻指令（受控子集，§7.3）。
+                float(np.max(np.abs(qpos[:nu] - command), initial=0.0)),
             )
             if step_wall_sec > control_dt:
                 deadline_missed += 1
@@ -276,8 +279,10 @@ class MujocoCpuBackend:
                 {
                     "step": step_count,
                     "time": float(data.time),
-                    "qpos": data.qpos[:nu].copy().tolist(),
-                    "qvel": data.qvel[:nu].copy().tolist(),
+                    # §7.1：完整状态——qpos(nq)/qvel(nv)/ctrl(nu)。
+                    "qpos": data.qpos.copy().tolist(),
+                    "qvel": data.qvel.copy().tolist(),
+                    "ctrl": data.ctrl.copy().tolist(),
                     "command": command.tolist(),
                     "contacts": int(data.ncon),
                 }
@@ -337,7 +342,7 @@ class MujocoCpuBackend:
 
         record_sample(previous_command)
 
-        final_qpos = data.qpos[:nu].copy()
+        final_qpos = data.qpos.copy()[:nu]
         final_tracking_error = float(np.max(np.abs(final_qpos - previous_command), initial=0.0))
         velocity_violation = max_velocity > request.max_joint_velocity_radps + 1e-9
         tracking_violation = final_tracking_error > request.max_final_tracking_error_rad
@@ -403,7 +408,10 @@ class MujocoCpuBackend:
                 "initial_state_hash": canonical_hash(initial_qpos.tolist()),
             },
         )
-        self._persist_artifacts(receipt, samples, request.artifact_dir)
+        self._persist_artifacts(
+            receipt, samples, request.artifact_dir,
+            model=model, model_digest=model_hash,
+        )
         return receipt
 
     @staticmethod
@@ -506,6 +514,9 @@ class MujocoCpuBackend:
         receipt: TrajectorySimulationReceipt,
         samples: list[dict[str, Any]],
         artifact_dir: Path | None,
+        *,
+        model: Any = None,
+        model_digest: str = "",
     ) -> None:
         if artifact_dir is None:
             return
@@ -513,10 +524,21 @@ class MujocoCpuBackend:
         request_path = root / "trajectory_request.json"
         states_path = root / "trajectory_states.json"
         request_hash = _atomic_json(request_path, receipt.request)
-        states_hash = _atomic_json(
-            states_path,
-            {"schema_version": "rosclaw.trajectory_states.v1", "states": samples},
-        )
+        # W03 §7.1：v2 显式声明维度与模型摘要——回放/续仿真据此
+        # 校验同模型完整状态恢复，不再靠消费者猜维度。
+        states_payload: dict[str, Any] = {
+            "schema_version": "rosclaw.trajectory_states.v2",
+            "states": samples,
+        }
+        if model is not None:
+            states_payload["dims"] = {
+                "nq": int(model.nq),
+                "nv": int(model.nv),
+                "nu": int(model.nu),
+            }
+        if model_digest:
+            states_payload["model_digest"] = model_digest
+        states_hash = _atomic_json(states_path, states_payload)
         receipt.artifacts.extend([request_path.as_uri(), states_path.as_uri()])
         receipt.artifact_hashes.update(
             {request_path.name: request_hash, states_path.name: states_hash}
@@ -681,7 +703,8 @@ class MujocoCpuBackend:
         persisted_states = load_artifact_json(states_artifact, "states_artifact")
         if persisted_states is not None and not (
             isinstance(persisted_states, dict)
-            and persisted_states.get("schema_version") == "rosclaw.trajectory_states.v1"
+            and persisted_states.get("schema_version")
+            in {"rosclaw.trajectory_states.v1", "rosclaw.trajectory_states.v2"}
             and isinstance(persisted_states.get("states"), list)
             and persisted_states["states"]
         ):

--- a/src/rosclaw/sim/api.py
+++ b/src/rosclaw/sim/api.py
@@ -97,7 +97,6 @@ def observe(
     at_time=None = 初始状态（或 initial_state_ref 指定状态）。
     """
     import mujoco
-    import numpy as np
 
     task_root = Path(task_root)
     record = _load_model_record(model_ref, task_root)
@@ -105,8 +104,9 @@ def observe(
     data = mujoco.MjData(model)
     if initial_state_ref:
         state = _load_state_record(initial_state_ref, task_root)
-        data.qpos[:] = np.array(state["qpos"], dtype=float)
-        data.qvel[:] = np.array(state.get("qvel", [0.0] * model.nv), dtype=float)
+        _restore_initial_state(
+            model, data, state, model_digest=str(record["model_digest"]),
+        )
     mujoco.mj_forward(model, data)
 
     out: dict[str, Any] = {"model_ref": model_ref, "time": float(data.time)}
@@ -149,6 +149,45 @@ def _load_state_record(state_ref: str, task_root: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _restore_initial_state(
+    model: Any,
+    data: Any,
+    state: dict[str, Any],
+    *,
+    model_digest: str = "",
+) -> None:
+    """W03 §7.2 续仿真检查点：完整状态恢复 + 模型一致性校验。
+
+    - 状态记录声明 model_digest 且与目标模型不符 → CROSS_MODEL_REF；
+    - qpos/qvel 维度不符 → STATE_DIMENSION（绝不截断或补零）。
+    """
+    import numpy as np
+
+    declared_digest = str(state.get("model_digest", ""))
+    if declared_digest and model_digest and declared_digest != model_digest:
+        raise ValueError(
+            f"CROSS_MODEL_REF: 状态记录模型 {declared_digest[:24]}… "
+            f"!= 目标模型 {model_digest[:24]}…"
+        )
+    qpos = state.get("qpos")
+    if not isinstance(qpos, list) or len(qpos) != int(model.nq):
+        raise ValueError(
+            f"STATE_DIMENSION: 状态 qpos 长度 "
+            f"{len(qpos) if isinstance(qpos, list) else '缺失'} != "
+            f"nq={int(model.nq)}（不截断、不补零）"
+        )
+    data.qpos[:] = np.array(qpos, dtype=float)
+    qvel = state.get("qvel")
+    if qvel is not None:
+        if not isinstance(qvel, list) or len(qvel) != int(model.nv):
+            raise ValueError(
+                f"STATE_DIMENSION: 状态 qvel 长度 "
+                f"{len(qvel) if isinstance(qvel, list) else '非数组'} != "
+                f"nv={int(model.nv)}"
+            )
+        data.qvel[:] = np.array(qvel, dtype=float)
+
+
 def submit_simulation(
     model_ref: str,
     initial_state_ref: str | None,
@@ -174,9 +213,9 @@ def submit_simulation(
     data = mujoco.MjData(model)
     if initial_state_ref:
         state = _load_state_record(initial_state_ref, task_root)
-        data.qpos[:] = np.array(state["qpos"], dtype=float)
-        if state.get("qvel"):
-            data.qvel[:] = np.array(state["qvel"], dtype=float)
+        _restore_initial_state(
+            model, data, state, model_digest=str(record["model_digest"]),
+        )
 
     ctrl_series = controller_or_trajectory.get("ctrl_series")
     if ctrl_series is None and not controller_or_trajectory.get("hold"):

--- a/tests/agentd/test_w00_baseline_repro.py
+++ b/tests/agentd/test_w00_baseline_repro.py
@@ -73,13 +73,9 @@ class TestR1AppendDeliveryBlocked:
 class TestR2FullStateReplay:
     """§2.2-2：sim_render 回放用 `data.qpos[:model.nu]` 截断——
     nq≠nu 的模型（freejoint/被动关节/被动物体）丢失状态，真实
-    仿真与视频不一致（W03 修复：模型维度/关节映射驱动的完整
-    状态恢复）。"""
+    仿真与视频不一致（W03 已修复：restore_frame_state 完整状态
+    恢复 + 维度诚实拒绝；行为测试见 test_w03_state_replay.py）。"""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="W00 基线：qpos 按 nu 截断（W03 修复后解标）",
-    )
     def test_replay_restores_full_nq_not_nu(self) -> None:
         import inspect
 

--- a/tests/agentd/test_w03_state_replay.py
+++ b/tests/agentd/test_w03_state_replay.py
@@ -1,0 +1,245 @@
+"""W03 红测试（规格 2026-09-08 §7）：真实状态记录与完整回放。
+
+§7.1 新记录必须保存完整 qpos（长度 nq）、qvel（长度 nv）、ctrl
+（长度 nu），并显式声明维度与模型摘要——nq≠nv≠nu 的模型
+（freejoint/被动关节）不得再被静默截断。
+
+§7.2 视频回放 = 同模型状态恢复 + 相机 + 仅前向（不重仿真）；
+旧部分关节 trace = 有标注的兼容回放或受信回放拒绝——绝不
+补零冒充完整证据。
+
+§7.2 续仿真检查点 = 状态维度/模型摘要校验，跨模型引用拒绝。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rosclaw.sandbox.backends import MujocoCpuBackend, RolloutRequest, ScenarioSpec
+from rosclaw.sandbox.backends.fingerprints import file_hash
+from rosclaw.sandbox.sandbox_api import Sandbox
+
+HOME = [-1.5708, -1.5708, 1.5708, -1.5708, -1.5708, 0.0]
+
+FREEJOINT_MJCF = """<mujoco model="w03_fixture">
+  <worldbody>
+    <body name="cube" pos="0 0 0.1">
+      <freejoint name="cube_free"/>
+      <geom type="box" size="0.02 0.02 0.02" mass="0.5"/>
+    </body>
+    <body name="arm" pos="0.3 0 0.3">
+      <joint name="shoulder" type="hinge" axis="0 0 1"/>
+      <geom type="capsule" size="0.01 0.1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="shoulder_motor" joint="shoulder" ctrlrange="-1 1"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _rollout(tmp_path):
+    sandbox = Sandbox.create("ur5e", "empty", "mujoco")
+    assert sandbox.has_physics, sandbox.load_error
+    scenario = ScenarioSpec(
+        scenario_id="w03-state-contract",
+        robot_id="ur5e",
+        world_id="empty",
+        body_snapshot_hash="sha256:test-body-snapshot",
+        model_hash=file_hash(sandbox.model_path),
+        seed=7,
+    )
+    request = RolloutRequest(
+        scenario=scenario,
+        trajectory=[HOME],
+        artifact_dir=tmp_path,
+    )
+    backend = MujocoCpuBackend(sandbox)
+    try:
+        receipt = backend.rollout(request)
+    finally:
+        sandbox.close()
+    assert receipt.physics_executed is True
+    return tmp_path / "trajectory_states.json"
+
+
+def _model_dims():
+    import mujoco
+
+    sandbox = Sandbox.create("ur5e", "empty", "mujoco")
+    assert sandbox.has_physics, sandbox.load_error
+    model = sandbox.physics_model
+    dims = (int(model.nq), int(model.nv), int(model.nu))
+    sandbox.close()
+    assert mujoco is not None
+    return dims
+
+
+class TestFullStateRecording:
+    def test_states_file_declares_dims_and_model(self, tmp_path) -> None:
+        """§7.1：trajectory_states.json 必须显式声明 nq/nv/nu 与
+        模型摘要——维度不再是消费者猜出来的隐式契约。"""
+        states_path = _rollout(tmp_path)
+        payload = json.loads(states_path.read_text(encoding="utf-8"))
+        nq, nv, nu = _model_dims()
+        dims = payload.get("dims") or {}
+        assert dims.get("nq") == nq, f"缺 dims.nq: {payload.keys()}"
+        assert dims.get("nv") == nv
+        assert dims.get("nu") == nu
+        assert str(payload.get("model_digest", "")).startswith("sha256:"), (
+            "缺模型摘要（回放无法校验同模型恢复）"
+        )
+
+    def test_samples_record_full_qpos_qvel_ctrl(self, tmp_path) -> None:
+        """§7.1：每个采样保存完整 qpos(nq)/qvel(nv)/ctrl(nu)。"""
+        states_path = _rollout(tmp_path)
+        payload = json.loads(states_path.read_text(encoding="utf-8"))
+        nq, nv, nu = _model_dims()
+        samples = payload["states"]
+        assert samples
+        for sample in samples[:5] + samples[-2:]:
+            assert len(sample["qpos"]) == nq, (
+                f"qpos 长度 {len(sample['qpos'])} != nq={nq}（截断丢失状态）"
+            )
+            assert len(sample["qvel"]) == nv, (
+                f"qvel 长度 {len(sample['qvel'])} != nv={nv}"
+            )
+            assert len(sample.get("ctrl", [])) == nu, (
+                "缺完整 ctrl 记录（长度 nu）"
+            )
+
+    def test_recording_source_has_no_nu_truncation(self) -> None:
+        """回归守卫：记录路径不得再出现按 nu 截断的 qpos/qvel。"""
+        import inspect
+
+        from rosclaw.sandbox.backends import mujoco_cpu
+
+        src = inspect.getsource(mujoco_cpu)
+        assert "data.qpos[:nu].copy()" not in src
+        assert "data.qvel[:nu].copy()" not in src
+
+
+class TestReplayStateRestore:
+    """sim_render 回放侧：同模型完整恢复 + 维度校验 + 旧 trace 标注。"""
+
+    def _model(self):
+        sandbox = Sandbox.create("ur5e", "empty", "mujoco")
+        assert sandbox.has_physics, sandbox.load_error
+        return sandbox
+
+    def test_restore_accepts_full_nq(self) -> None:
+        from rosclaw.agentd.sim_render import restore_frame_state
+
+        sandbox = self._model()
+        try:
+            model, data = sandbox.physics_model, sandbox.physics_data
+            nq = int(model.nq)
+            qpos = [0.1 * (i + 1) for i in range(nq)]
+            outcome = restore_frame_state(model, data, qpos, declared_dims=None)
+            assert outcome == "restored"
+            assert abs(float(data.qpos[nq - 1]) - qpos[-1]) < 1e-9
+        finally:
+            sandbox.close()
+
+    def test_restore_rejects_wrong_length_no_zero_pad(self) -> None:
+        """维度不符 = 受信回放拒绝——绝不补零冒充完整状态。"""
+        from rosclaw.agentd.sim_render import restore_frame_state
+
+        sandbox = self._model()
+        try:
+            model, data = sandbox.physics_model, sandbox.physics_data
+            with pytest.raises(ValueError, match="STATE_DIMENSION"):
+                restore_frame_state(
+                    model, data, [0.0, 0.0], declared_dims=None,
+                )
+        finally:
+            sandbox.close()
+
+    def test_restore_rejects_declared_dims_mismatch(self) -> None:
+        """文件声明 dims 与模型不符（跨模型引用）→ 拒绝。"""
+        from rosclaw.agentd.sim_render import restore_frame_state
+
+        sandbox = self._model()
+        try:
+            model, data = sandbox.physics_model, sandbox.physics_data
+            nq = int(model.nq)
+            with pytest.raises(ValueError, match="MODEL_DIMS_MISMATCH"):
+                restore_frame_state(
+                    model,
+                    data,
+                    [0.0] * nq,
+                    declared_dims={"nq": nq + 7, "nv": 6, "nu": 6},
+                )
+        finally:
+            sandbox.close()
+
+    def test_legacy_truncated_sample_marked_not_zero_padded(self) -> None:
+        """旧 trace（qpos 按 nu 截断、无 dims 声明）在 nq>nu 模型上
+        = LEGACY_PARTIAL_STATE 诚实拒绝——不是补零继续。"""
+        import mujoco
+
+        from rosclaw.agentd.sim_render import restore_frame_state
+
+        model = mujoco.MjModel.from_xml_string(FREEJOINT_MJCF)
+        data = mujoco.MjData(model)
+        assert int(model.nq) == 8 and int(model.nu) == 1
+        # 旧记录只存了 nu=1 维——nq=8 的模型上不得补零冒充。
+        with pytest.raises(ValueError, match="LEGACY_PARTIAL_STATE"):
+            restore_frame_state(model, data, [0.5], declared_dims=None)
+        # 完整 nq=8 则正常恢复（兼容回放）。
+        outcome = restore_frame_state(
+            model, data, [0.0] * 8, declared_dims=None,
+        )
+        assert outcome == "restored"
+
+    def test_replay_source_has_no_truncation(self) -> None:
+        """W00 R2 的行为锚点：回放恢复不再按 nu 截断。"""
+        import inspect
+
+        from rosclaw.agentd import sim_render
+
+        src = inspect.getsource(sim_render)
+        assert "data.qpos[: int(model.nu)]" not in src
+
+
+class TestContinueSimulationCheckpoint:
+    """§7.2：续仿真检查点——状态维度与模型一致性校验。"""
+
+    def test_initial_state_wrong_dims_rejected(self, tmp_path) -> None:
+        from rosclaw.sim import api
+
+        mjcf = tmp_path / "m.xml"
+        mjcf.write_text(FREEJOINT_MJCF, encoding="utf-8")
+        ref, desc = api.load_model(mjcf, task_root=tmp_path)
+        assert desc["nq"] == 8
+        bad_state = tmp_path / "models" / "state_bad.json"
+        bad_state.write_text(json.dumps({"qpos": [0.0, 0.0]}))
+        with pytest.raises(ValueError, match="STATE_DIMENSION"):
+            api.submit_simulation(
+                ref, "state_bad", {"hold": True}, 0.01, task_root=tmp_path,
+            )
+
+    def test_cross_model_state_rejected(self, tmp_path) -> None:
+        """状态记录声明的模型摘要与目标模型不符 → 拒绝续仿真。"""
+        from rosclaw.sim import api
+
+        mjcf = tmp_path / "m.xml"
+        mjcf.write_text(FREEJOINT_MJCF, encoding="utf-8")
+        ref, desc = api.load_model(mjcf, task_root=tmp_path)
+        foreign = tmp_path / "models" / "state_foreign.json"
+        foreign.write_text(json.dumps({
+            "model_digest": "sha256:" + "0" * 64,
+            "qpos": [0.0] * desc["nq"],
+        }))
+        with pytest.raises(ValueError, match="CROSS_MODEL_REF"):
+            api.submit_simulation(
+                ref, "state_foreign", {"hold": True}, 0.01,
+                task_root=tmp_path,
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
规格 2026-09-08 §7（W03，依赖 W02/W00——stacked on #522，合并后自动 retarget main）。

- 记录侧：完整 qpos(nq)/qvel(nv)/ctrl(nu)；trajectory_states v2 显式声明 dims + model_digest
- 回放侧：restore_frame_state 同模型完整恢复；MODEL_DIMS_MISMATCH / LEGACY_PARTIAL_STATE / STATE_DIMENSION 诚实拒绝，绝不补零；receipt state_contract 标注
- FK 回放（sim_trajectory）与续仿真检查点（sim.api）复用同一契约；CROSS_MODEL_REF 拒绝
- W00 R2 xfail 解标

验证：W03 10/10 绿（红→绿）；sandbox+agentd 全量 783 passed（1 flaky 与本轮无关，单独重跑通过）；ruff 全过。
真实模型具身回放验收 NOT_RUN（无 key，不合成冒充）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)