### PR TITLE
W05: post-terminal append delivery without task revival (spec §9.2)

### DIFF
--- a/docs/implementation/w05-delivery-lifecycle.md
+++ b/docs/implementation/w05-delivery-lifecycle.md
@@ -1,0 +1,53 @@
+# W05 交付生命周期：追加交付（规格 §9.2）
+
+**分支**：a-w05-delivery-lifecycle（基于 main=ab0ae5a，§17 依赖：W05←W00）
+**日期**：2026-09-09
+
+## 问题（W00 R1 / 0907 实证）
+
+`_artifact_register` 只认「最近 active task」：任务 SUCCEEDED
+后模型补交付物（补图/补分析/改视角产物）被
+`TASK_ALREADY_COMPLETED` 反复拒绝；而 dispatcher 前置的
+`ensure_task_for_effect` 在有未附着新输入时会把迟到请求绑定成
+新 revision（RUNNING 复活反模式）。
+
+## 改动（`src/rosclaw/agentd/pi_bridge/tool_dispatch.py`）
+
+1. **追加交付**：无 active task 时查最近任务——终态
+   （SUCCEEDED/FAILED/BLOCKED/CANCELLED）即追加：登记在既有
+   任务的当前 revision，**不改回 RUNNING、不 bump revision、
+   审计历史保持终态**。追加产物 metadata 标
+   `appended_post_terminal` + `task_state_at_registration`
+   （不冒充验收期交付）；结果 summary 带可行动引导
+   （「任务保持 SUCCEEDED……用户有新目标时会开始新任务」）。
+2. **迟到请求不自动激活新 revision**：`rosclaw_deliver` /
+   `rosclaw_artifact_register` 移除 dispatcher 前置
+   `ensure_task_for_effect`；admission 收缩进
+   `_artifact_register` 且**仅在无任务史时**触发（P0-C 交付
+   优先金丝雀保留）。有任务史时未附着的新输入不被迟到工具
+   请求绑定——新 revision 由该输入自己的回合创建。
+3. **模型不能挂任意任务**：请求合约无 `task_id` 字段（既有
+   保证，回归测试锚定）——任务解析只在服务端按
+   mission+session。
+
+## 验证（红→绿）
+
+| 测试 | 结果 |
+|---|---|
+| test_w05_delivery_lifecycle.py（5：wire 路径追加/追加标记可审计/迟到请求不激活新 revision/交付优先 admission 保留/合约无 task_id） | 红（4 failed：拒绝+复活确认）→ 绿 5/5 |
+| W00 R1 解标 | 绿（剩 R2/R3 xfail = W03/W04 目标——W03 已在其分支解 R2） |
+| test_canary_residuals 语义更新（引导进追加 summary，不再拒绝） | 绿 |
+| test_pi_tool_bridge 验证链 | 绿 |
+| tests/agentd + tests/sandbox 全量（除 PTY journey） | 见 PR（后台跑） |
+| ruff check src tests | 全过 |
+
+## §9 其余条款现状（本轮未改，记录备查）
+
+- §9.1 客观事实进结果对象：大道至简 R0-2 已落（kernel 只报客观
+  执行事实；UI 不按 exit 0 显示成功）——既有。
+- §9.3 幂等/取消/重启：execute() idempotency 重放 + Operation
+  状态机（前期审计）——既有；REAL UNKNOWN 不重试——REAL 门禁
+  仍关闭。
+- §9.4 Artifact 来源独立：内容寻址幂等 upsert + producer 区分
+  （kernel:/model:）+ evidence 区 kernel-only——既有（P0-E/N4.1）。
+- 真实模型追加交付验收：**NOT_RUN**（无 key，不合成冒充）。

--- a/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
+++ b/src/rosclaw/agentd/pi_bridge/tool_dispatch.py
@@ -603,15 +603,14 @@ class PiToolDispatcher:
         # 幂等交付入口（普通文件工具创建的交付物）；capability 产物
         # 自动登记不走模型。
         if name == "rosclaw_deliver":
-            # P0-C：deliver 也是 effectful——首个 effectful call 就是
-            # 交付时先原子 admission（否则裸 NO_ACTIVE_TASK——
-            # 金丝雀实证模型先 deliver 后干活的路径）。
-            self._ensure_task_for_effect(request)
+            # P0-C：deliver 也是 effectful——无任务史时首个
+            # effectful call 原子 admission（在 _artifact_register
+            # 内按需触发）；W05 §9.2：有任务史时不预绑定——终态
+            # 追加不得借 admission 绑定未附着输入激活新 revision。
             result = await self._artifact_register(request)
             self._coordinator_consider(request, result)
             return result
         if name == "rosclaw_artifact_register":
-            self._ensure_task_for_effect(request)
             result = await self._artifact_register(request)
             self._coordinator_consider(request, result)
             return result
@@ -716,22 +715,34 @@ class PiToolDispatcher:
     async def _artifact_register(
         self, request: PiToolRequestV1
     ) -> PiToolResultV1:
-        """PR-H4：交付物登记（实读文件算 hash——口头提到不算）。"""
+        """PR-H4：交付物登记（实读文件算 hash——口头提到不算）。
+
+        W05 §9.2 追加交付：终态（SUCCEEDED/FAILED/BLOCKED/
+        CANCELLED）后的登记是**追加**——注册在既有任务的当前
+        revision，不改回 RUNNING、不 bump revision、不绑定未
+        附着的新输入（迟到请求不得自动激活新 revision）。无任务
+        史时保留 P0-C 交付优先 admission。"""
         kernel = self._service._task_kernel
         task = kernel.active_task_for(request.mission_id, request.pi_session_id)
+        appended_post_terminal = False
         if task is None:
-            # 终态后语义（0824 金丝雀实证）：Coordinator 已验收完成的任务
-            # 不需要再交付——给可行动的引导，不是裸错误。
+            from rosclaw.task_kernel.service import TASK_TERMINAL
+
             latest = kernel.latest_task_for(
                 request.mission_id, request.pi_session_id
             )
-            if latest is not None and str(latest.get("state")) == "SUCCEEDED":
-                raise ToolBridgeError(
-                    "TASK_ALREADY_COMPLETED",
-                    "任务已验收完成（SUCCEEDED）——无需再交付；"
-                    "用户有新目标时会开始新任务，请直接回答即可",
+            if latest is not None and str(latest.get("state")) in TASK_TERMINAL:
+                task = latest
+                appended_post_terminal = True
+            elif latest is None:
+                # 交付优先（P0-C 金丝雀）：无任务史——首个 effectful
+                # call 原子 admission 建任务。
+                self._ensure_task_for_effect(request)
+                task = kernel.active_task_for(
+                    request.mission_id, request.pi_session_id
                 )
-            raise ToolBridgeError("NO_ACTIVE_TASK", "无活跃任务")
+            if task is None:
+                raise ToolBridgeError("NO_ACTIVE_TASK", "无活跃任务")
         path = str(request.arguments.get("path", ""))
         if not path:
             raise ToolBridgeError("INVALID_ARGUMENTS", "path required")
@@ -760,9 +771,28 @@ class PiToolDispatcher:
                 task_id=task["task_id"], path=resolved,
                 media_type=str(request.arguments.get("media_type", "application/octet-stream")),
                 producer="model:rosclaw_artifact_register",
+                metadata=(
+                    {
+                        "appended_post_terminal": True,
+                        "task_state_at_registration": str(task["state"]),
+                    }
+                    if appended_post_terminal else None
+                ),
             )
         except ValueError as exc:
             raise ToolBridgeError("ARTIFACT_MISSING", str(exc)) from exc
+        if appended_post_terminal:
+            return PiToolResultV1(
+                request_id=request.request_id,
+                ok=True, status="REGISTERED",
+                summary=(
+                    f"追加交付已登记：{_Path(artifact['path']).name}"
+                    f"（{artifact['size_bytes']}B）"
+                    f"artifact_id={artifact['artifact_id']}——任务保持 "
+                    f"{task['state']}（审计历史不变，未复活任务）；"
+                    "用户有新目标时会开始新任务"
+                ),
+            )
         return PiToolResultV1(
             request_id=request.request_id,
             ok=True, status="REGISTERED",

--- a/tests/agentd/test_canary_residuals.py
+++ b/tests/agentd/test_canary_residuals.py
@@ -2,16 +2,13 @@
 
 1. 渲染能力描述诚实标明产出物（MP4 可发现——模型选了无 MP4 的
    2D 预览渲染的根因）；
-2. 终态后交付调用给可行动引导（TASK_ALREADY_COMPLETED——不是
-   裸 NO_ACTIVE_TASK）。
+2. 终态后交付调用的语义（W05 §9.2 起）：追加交付登记在既有
+   revision 并带可行动引导——不再 TASK_ALREADY_COMPLETED 拒绝。
 """
 
 from __future__ import annotations
 
-import sqlite3
 from pathlib import Path
-
-import pytest
 
 
 def _descriptor(tool_id: str):
@@ -41,38 +38,33 @@ class TestRenderDiscoverability:
 
 
 class TestCompletedTaskGuidance:
-    def test_deliver_after_succeeded_gives_guidance(self, tmp_path: Path) -> None:
-        from rosclaw.storage.migrations import MigrationRunner
-        from rosclaw.task_kernel.service import TaskKernel
-
-        conn = sqlite3.connect(":memory:", check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        MigrationRunner().apply(conn, "sqlite")
-        kernel = TaskKernel(conn, tmp_path)
-        kernel.persist_input(
-            mission_id="mis_1", session_ref="s1",
-            message_id="msg_1", text="生成交付物",
+    async def test_deliver_after_succeeded_appends_with_guidance(
+        self, tmp_path: Path
+    ) -> None:
+        """W05 §9.2：终态后登记 = 追加交付（带引导），不是裸错误
+        也不是 TASK_ALREADY_COMPLETED 拒绝。"""
+        from tests.agentd.test_pi_tool_bridge import (
+            _issue_lease,
+            _request,
+            _setup,
         )
-        bound = kernel.ensure_task_for_effect(
-            mission_id="mis_1", session_ref="s1",
-            backend_native_id="s1", cwd=str(tmp_path),
-        )
-        task_id = str(bound["task_id"])
-        from rosclaw.task_kernel.coordinator import TaskCoordinator
+        from tests.agentd.test_w05_delivery_lifecycle import _succeeded_task
 
-        f = tmp_path / "a.txt"
-        f.write_text("x", encoding="utf-8")
-        kernel.register_artifact(task_id=task_id, path=str(f),
-                                 media_type="text/plain")
-        TaskCoordinator(kernel).consider(task_id)
-        assert kernel.get_task(task_id)["state"] == "SUCCEEDED"
-        # 终态后再登记 → 友好引导（TASK_ALREADY_COMPLETED），不是
-        # 裸 NO_ACTIVE_TASK。
-        from rosclaw.agentd.pi_bridge.tool_dispatch import ToolBridgeError
+        service, mission = await _setup(tmp_path)
+        await _succeeded_task(service, mission, tmp_path)
+        f2 = tmp_path / "b.txt"
+        f2.write_text("appendix", encoding="utf-8")
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
 
-        with pytest.raises(ToolBridgeError) as exc:
-            raise ToolBridgeError(
-                "TASK_ALREADY_COMPLETED",
-                "任务已验收完成（SUCCEEDED）——无需再交付",
+        result = await PiToolDispatcher(service).execute(
+            _request(
+                "rosclaw_artifact_register", mission=mission.mission_id,
+                idem="canary_append",
+                lease=await _issue_lease(service, mission),
+                arguments={"path": str(f2)},
             )
-        assert exc.value.code == "TASK_ALREADY_COMPLETED"
+        )
+        assert result.ok, result.summary
+        assert "追加交付" in result.summary
+        assert "用户有新目标时会开始新任务" in result.summary
+        await service.close()

--- a/tests/agentd/test_w00_baseline_repro.py
+++ b/tests/agentd/test_w00_baseline_repro.py
@@ -16,13 +16,9 @@ import pytest
 class TestR1AppendDeliveryBlocked:
     """§2.2-1：`_artifact_register` 在活跃任务缺失且最近任务
     SUCCEEDED 时直接 TASK_ALREADY_COMPLETED 拒绝——0907 实证追加
-    产物被反复拒绝。期望行为（W05）：显式上下文与追加交付不被
-    历史成功阻断。当前基线=拒绝（本测试 xfail 记录）。"""
+    产物被反复拒绝（W05 已修复：显式上下文下追加注册在既有
+    revision，不复活任务；行为测试见 test_w05_delivery_lifecycle.py）。"""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="W00 基线：历史 SUCCEEDED 阻断追加交付（W05 修复后解标）",
-    )
     async def test_append_after_succeeded_allowed(self, tmp_path) -> None:
         """0907 实证条件的精确复现：handler 直达（无 admission
         动机遮掩）+ active=None + 最近任务 SUCCEEDED → 基线=

--- a/tests/agentd/test_w05_delivery_lifecycle.py
+++ b/tests/agentd/test_w05_delivery_lifecycle.py
@@ -1,0 +1,173 @@
+"""W05 红测试（规格 2026-09-08 §9.2）：追加交付生命周期。
+
+- 首个交付完成（SUCCEEDED）后能补图/补产物——追加注册在既有
+  revision，不改回 RUNNING、不靠动机输入复活任务；
+- 迟到工具请求不能因为"允许修改"而自动激活新 revision
+  （未附着的新输入不被迟到请求绑定）；
+- 交付优先路径保留（无任务史时 deliver 即 admission）；
+- 模型不能通过填写 task_id 挂到任意任务（请求合约无 task_id
+  字段——服务端按 mission+session 解析）。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.agentd.test_pi_tool_bridge import _issue_lease, _request, _setup
+
+
+async def _succeeded_task(service, mission, tmp_path, text="画一个五角星"):
+    kernel = service._task_kernel
+    f = tmp_path / "a.gif"
+    f.write_bytes(b"GIF89a" + b"\x00" * 128)
+    bound = kernel.bind_message(
+        mission_id=mission.mission_id, session_ref="pi_1",
+        backend_native_id="pi_1", message_id="msg_w05_1",
+        text=text, cwd=str(tmp_path), body_id="",
+    )
+    task_id = str(bound["task_id"])
+    artifact = kernel.register_artifact(
+        task_id=task_id, path=str(f), media_type="image/gif",
+        producer="kernel:test",
+    )
+    kernel.finish_task(
+        task_id=task_id, summary="done",
+        artifact_ids=[str(artifact["artifact_id"])],
+    )
+    assert str(kernel.get_task(task_id)["state"]) == "SUCCEEDED"
+    return task_id, bound
+
+
+class TestAppendAfterTerminal:
+    async def test_append_after_succeeded_wire_path(self, tmp_path) -> None:
+        """0907 实证场景走完整 wire 路径：SUCCEEDED 后追加交付
+        成功登记，任务审计历史保持终态。"""
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+
+        service, mission = await _setup(tmp_path)
+        kernel = service._task_kernel
+        task_id, bound = await _succeeded_task(service, mission, tmp_path)
+        revision_before = int(bound["revision"])
+        f2 = tmp_path / "appendix.txt"
+        f2.write_text("补充分析", encoding="utf-8")
+        result = await PiToolDispatcher(service).execute(
+            _request(
+                "rosclaw_artifact_register", mission=mission.mission_id,
+                idem="w05_append_1",
+                lease=await _issue_lease(service, mission),
+                arguments={"path": str(f2)},
+            )
+        )
+        assert result.ok, result.summary
+        task = kernel.get_task(task_id)
+        assert str(task["state"]) == "SUCCEEDED", (
+            "追加交付不得复活任务状态（审计历史保持终态）"
+        )
+        assert int(task["active_revision"]) == revision_before, (
+            "追加交付不得 bump revision"
+        )
+        await service.close()
+
+    async def test_append_marked_post_terminal(self, tmp_path) -> None:
+        """追加产物元数据可审计：标记 appended_post_terminal 与
+        登记时任务状态——不冒充验收期交付。"""
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+
+        service, mission = await _setup(tmp_path)
+        kernel = service._task_kernel
+        task_id, _ = await _succeeded_task(service, mission, tmp_path)
+        f2 = tmp_path / "b.txt"
+        f2.write_text("appendix", encoding="utf-8")
+        result = await PiToolDispatcher(service).execute(
+            _request(
+                "rosclaw_artifact_register", mission=mission.mission_id,
+                idem="w05_append_2",
+                lease=await _issue_lease(service, mission),
+                arguments={"path": str(f2)},
+            )
+        )
+        assert result.ok, result.summary
+        rows = kernel._conn.execute(
+            "SELECT metadata_json FROM artifacts WHERE task_id = ? "
+            "ORDER BY rowid DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert rows is not None
+        import json
+
+        meta = json.loads(rows["metadata_json"] or "{}")
+        assert meta.get("appended_post_terminal") is True, meta
+        assert meta.get("task_state_at_registration") == "SUCCEEDED"
+        await service.close()
+
+    async def test_late_request_does_not_auto_activate_revision(
+        self, tmp_path
+    ) -> None:
+        """迟到请求不得自动激活新 revision：SUCCEEDED 后到达的
+        新用户输入（未附着）保持未附着——新 revision 由该输入
+        自己的回合创建，不由迟到的工具请求绑定。"""
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+
+        service, mission = await _setup(tmp_path)
+        kernel = service._task_kernel
+        task_id, _ = await _succeeded_task(service, mission, tmp_path)
+        # 新用户输入已持久化但尚未附着（下一回合才绑定）。
+        kernel.persist_input(
+            mission_id=mission.mission_id, session_ref="pi_1",
+            message_id="msg_w05_new", text="再补一张俯视图",
+        )
+        f2 = tmp_path / "late.txt"
+        f2.write_text("late appendix", encoding="utf-8")
+        result = await PiToolDispatcher(service).execute(
+            _request(
+                "rosclaw_artifact_register", mission=mission.mission_id,
+                idem="w05_late",
+                lease=await _issue_lease(service, mission),
+                arguments={"path": str(f2)},
+            )
+        )
+        assert result.ok, result.summary
+        row = kernel._conn.execute(
+            "SELECT task_id FROM user_inputs WHERE message_id = ?",
+            ("msg_w05_new",),
+        ).fetchone()
+        assert row is not None and row["task_id"] is None, (
+            "迟到工具请求把未附着新输入绑定成了新 revision"
+        )
+        assert str(kernel.get_task(task_id)["state"]) == "SUCCEEDED"
+        await service.close()
+
+    async def test_deliver_first_still_admits(self, tmp_path) -> None:
+        """P0-C 金丝雀保留：无任务史 + 未附着输入时 deliver 即
+        admission（首个 effectful call 建任务）——不被 W05 改没。"""
+        from rosclaw.agentd.pi_bridge.tool_dispatch import PiToolDispatcher
+
+        service, mission = await _setup(tmp_path)
+        kernel = service._task_kernel
+        f = tmp_path / "first.txt"
+        f.write_text("first delivery", encoding="utf-8")
+        result = await PiToolDispatcher(service).execute(
+            _request(
+                "rosclaw_artifact_register", mission=mission.mission_id,
+                idem="w05_first",
+                lease=await _issue_lease(service, mission),
+                arguments={"path": str(f)},
+            )
+        )
+        assert result.ok, result.summary
+        # mock gateway 下 coordinator 会随即验收终态——断言任务已
+        # 创建（admission 生效），不要求仍活跃。
+        task = kernel.latest_task_for(mission.mission_id, "pi_1")
+        assert task is not None, "交付优先 admission 未建任务"
+        await service.close()
+
+    async def test_request_contract_has_no_task_id(self) -> None:
+        """§9.2：模型不能通过填写 task_id 挂到任意任务——请求
+        合约不接受 task_id 字段（任务解析只在服务端）。"""
+        from rosclaw.contracts.pi.tool_request import PiToolRequestV1
+
+        assert "task_id" not in PiToolRequestV1.model_fields
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
规格 2026-09-08 §9.2（W05，依赖 W00）。

- 终态后交付 = 追加：登记在既有任务当前 revision，不改回 RUNNING、不 bump revision、审计历史保持终态；metadata 标 appended_post_terminal
- 迟到工具请求不再借 admission 绑定未附着输入激活新 revision（deliver-first admission 在无任务史时保留）
- W00 R1 xfail 解标；canary 引导语义进追加 summary

验证：W05 5/5 绿（红→绿）；agentd+sandbox 全量 888 passed；ruff 全过。
真实模型追加交付验收 NOT_RUN（无 key，不合成冒充）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)