### PR TITLE
W04: renderer hardening — identity-keyed renders, full-depth fallback, time-driven frames (spec §8)

### DIFF
--- a/docs/implementation/w04-renderer.md
+++ b/docs/implementation/w04-renderer.md
@@ -1,0 +1,70 @@
+# W04 渲染器补强（规格 §8）
+
+**分支**：a-w04-renderer（基于 a-w03-state-replay，§17 依赖：W04←W00；
+与 W03 同文件故栈叠避免冲突）
+**日期**：2026-09-09
+
+## 改动（`src/rosclaw/agentd/sim_render.py`）
+
+### §8.1 渲染身份与幂等复用
+
+- `render_identity_key()`：trace states digest + camera/尺寸/
+  world/tool/spec digest + fps/playback + renderer build digest
+  → 16 字符键。result 文件与 GIF/MP4 输出全部按键命名
+  （`{trace_id}-{key}-scene.gif`——保留 `-scene.gif` 后缀约定，
+  verifier 兼容）。
+- 同渲染身份的已完成结果直接复用（`reused: true`，不重渲染）；
+  同 trace 不同参数（视角/尺寸/fps）各自独立文件互不覆盖——
+  e2e 实证两视角共存。
+
+### §8.2 时间驱动与取景
+
+- `select_frame_indices(states, fps, playback_rate)`：目标时刻
+  网格 first+i/fps 取最近状态（替换计数均分）；首尾必含；
+  playback rate 缩放输出时长。max_frames 降为安全上限
+  （默认 60→480——10s 记录 12fps 需要 121 帧，旧默认会把
+  时长砍半）。
+- `apply_camera_framing()`：相机距离按轨迹包围盒半对角线缩放
+  （follow/top/free 三预设各自系数与钳位）；无轨迹点回落旧
+  固定参数。
+- 单遍流式编码：imageio writer 逐帧写入 GIF+MP4——不再把
+  PIL 与 NumPy 帧双份常驻内存。
+- GIF 帧时长 = 1/fps（e2e 实证：输出 1× 时长与记录时长误差
+  ≤ 一个输出帧量级）。
+
+### §8.3 后端降级与探测缓存
+
+- `_render_with_fallback()`：**全部候选**逐个真实尝试（不再是
+  `candidates[:2]`）——EGL 渲染崩 + OSMesa 不可用 + Xvfb 可用
+  时第三候选真正被探测并渲染成功；每个候选最多一次真实
+  尝试；全失败聚合错误列出每个后端的真实原因
+  （RENDER_BACKEND_EXHAUSTED）。
+- 探测缓存：`_probe_cache_key()` = mujoco/Python 版本 +
+  DISPLAY/MUJOCO_GL/xvfb-run/EGL vendor 环境。**成功才缓存**
+  （同进程重复渲染零 smoke 开销）；失败不缓存——环境恢复后
+  下次真实重探。
+
+### W00 解标
+
+`TestR3BackendFallbackDepth` xfail(strict) 解除——源码锚点 +
+行为测试（monkeypatch 降级引擎 + 全失败聚合）双保险。
+
+## 验证（红→绿）
+
+| 测试 | 结果 |
+|---|---|
+| test_w04_renderer.py（12：第三候选到达/单候选单尝试+聚合错误/源码无 [:2]/探测缓存命中与失效重探/缓存键含环境/时间选帧/playback/短记录首尾/相机随包围范围/身份键稳定且敏感/重试复用+两视角共存 e2e/GIF 时长 e2e） | 红（10 failed）→ 绿 12/12 |
+| W00 R3 解标 + 全量 baseline | 绿（R5 NOT_RUN skip；xfail 清零） |
+| wp3/wp6/r05/a0902 渲染 e2e（PYTHONPATH=worktree——子进程解析坑） | 28 passed |
+| tests/agentd + tests/sandbox 全量（除 PTY journey） | 见 PR（后台跑） |
+| ruff check src tests | 全过 |
+
+## 边界说明
+
+- `_render_operation_child`（W02 api 路径）已是时间驱动 + 完整
+  状态恢复，本轮未重复改；两条渲染路径的进一步合并留给
+  后续工作包（不属于 §8 完成条件）。
+- 「推物视频显示实际物体移动」：由 W03 完整状态记录 + 本条
+  时间驱动回放联合保证（freejoint 物体 qpos 不再丢失）；
+  专用推物场景 e2e 属 W09 测试类。
+- 真实模型验收：**NOT_RUN**（无 key，不合成冒充）。

--- a/src/rosclaw/agentd/sim_render.py
+++ b/src/rosclaw/agentd/sim_render.py
@@ -62,17 +62,52 @@ def _probe_xvfb(*, timeout_sec: float = 30.0) -> tuple[bool, str]:
         return False, f"{type(exc).__name__}: {exc}"[:200]
 
 
+_PROBE_CACHE: dict[str, tuple[str, dict[str, str]]] = {}
+
+
+def _probe_cache_key() -> str:
+    """W04 §8.3：探测缓存键——运行时 + 环境 + 驱动信息。
+
+    任一变化（mujoco/Python 版本、DISPLAY、MUJOCO_GL、xvfb-run
+    可用性、EGL vendor 路径）即换键重新真实探测。"""
+    import shutil
+
+    import mujoco
+
+    payload = "|".join([
+        "mujoco:" + str(mujoco.__version__),
+        "py:" + sys.version.split()[0],
+        "DISPLAY:" + os_environ().get("DISPLAY", ""),
+        "MUJOCO_GL:" + os_environ().get("MUJOCO_GL", ""),
+        "xvfb-run:" + str(bool(shutil.which("xvfb-run"))),
+        "eglvendor:" + os_environ().get("__EGL_VENDOR_LIBRARY_DIRS", ""),
+    ])
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def _probe_cache_clear() -> None:
+    _PROBE_CACHE.clear()
+
+
 def probe_render_backend(
     *, timeout_sec: float = 30.0,
+    fresh: bool = False,
 ) -> tuple[str | None, dict[str, str]]:
     """EGL→OSMesa→Xvfb 子进程隔离探测（进程内探测会崩宿主——
     本机 glfw 实证；每个后端真实渲染一帧 smoke test）。返回
-    (backend or None, 每后端明细)。"""
+    (backend or None, 每后端明细)。
+
+    W04 §8.3：成功结果按运行时/环境键缓存（同进程重复渲染不再
+    逐次 smoke）；**失败不缓存**——环境恢复后下次真实重探。"""
+    key = _probe_cache_key()
+    if not fresh and key in _PROBE_CACHE:
+        return _PROBE_CACHE[key]
     detail: dict[str, str] = {}
     for backend in _BACKEND_ORDER:
         ok, note = _probe_backend(backend, timeout_sec=timeout_sec)
         detail[backend] = note
         if ok:
+            _PROBE_CACHE[key] = (backend, detail)
             return backend, detail
     return None, detail
 
@@ -174,12 +209,14 @@ def render_scene_trace(
     trace_id: str,
     *,
     camera: str = "follow",
-    max_frames: int = 60,
+    max_frames: int = 480,
     width: int = 640,
     height: int = 360,
     world_id: str = "empty",
     tool_ref: str = "",
     render_spec_path: Path | None = None,
+    fps: float = 12.0,
+    playback_rate: float = 1.0,
 ) -> dict[str, Any]:
     """trace → 场景 GIF+MP4（真实 MuJoCo 离屏渲染）+ RenderReceipt。
 
@@ -187,10 +224,14 @@ def render_scene_trace(
     - 结构化 IPC：子进程写原子 result JSON 文件，stdout/stderr 只
       作诊断——空输出/噪声/rc=0 无结果都是稳定错误码，绝不向
       调用方泄漏裸 JSONDecodeError；
-    - 后端降级只在 supervisor 内部执行一次（EGL→OSMesa→Xvfb
-      顺序）——模型只收到最终结果；
+    - 后端降级只在 supervisor 内部执行——模型只收到最终结果；
     - world_id/tool_ref 来自 TaskSpec——声明了工具但资产不存在
       时 TOOL_ASSET_MISSING 诚实失败（不假装持笔）。
+
+    W04 §8.1：渲染身份（trace/model digest + spec + 展示参数 +
+    渲染器版本）隔离 result/输出文件——同键幂等重试直接复用
+    已完成结果，同 trace 不同参数互不覆盖。max_frames 只是
+    安全上限（选帧由时间戳+fps 驱动，§8.2）。
     """
     home = Path(home)
     trace_dir = home / "sim" / "traces" / trace_id
@@ -220,37 +261,50 @@ def render_scene_trace(
         _require_tool_asset(tool_ref)
     if world_id:
         _require_world_asset(world_id)
+    spec_digest = ""
+    if render_spec_path is not None:
+        spec_digest = "sha256:" + hashlib.sha256(
+            Path(render_spec_path).read_bytes()
+        ).hexdigest()
+    render_key = render_identity_key(
+        states_digest=states_digest, camera=camera,
+        max_frames=max_frames, width=width, height=height,
+        world_id=world_id, tool_ref=tool_ref,
+        spec_digest=spec_digest, fps=fps, playback_rate=playback_rate,
+    )
+    # W04 §8.1：幂等复用——同渲染身份的已完成结果直接返回
+    # （不重渲染、不覆盖其他参数的 result 文件）。
+    keyed_result = (
+        trace_dir / f"{trace_id}-{render_key}-scene-result.json"
+    )
+    if keyed_result.exists():
+        try:
+            cached = json.loads(keyed_result.read_text(encoding="utf-8"))
+        except ValueError:
+            cached = None
+        if isinstance(cached, dict) and cached.get("ok"):
+            cached["reused"] = True
+            return cached
     backend, probe_detail = probe_render_backend()
     if backend is None:
         raise ValueError(
             "RENDER_BACKEND_UNAVAILABLE: EGL/OSMesa/Xvfb 全部不可用——"
             + json.dumps(probe_detail, ensure_ascii=False)[:300]
         )
-    # supervisor 内部一次降级：首选后端渲染失败 → 下一个后端再试
-    # 一次；之后把最终错误抛出（调用方只见一次有语义的结果）。
-    candidates = [backend, *[b for b in _BACKEND_ORDER if b != backend]]
-    last_error: ValueError | None = None
-    for attempt, candidate in enumerate(candidates[:2]):
-        if attempt > 0:
-            ok, note = _probe_backend(candidate)
-            if not ok:
-                last_error = ValueError(
-                    f"RENDER_BACKEND_UNAVAILABLE: 降级后端 {candidate} "
-                    f"不可用（{note}）"
-                )
-                continue
-        try:
-            return _render_attempt(
-                home, trace_id, candidate,
-                camera=camera, max_frames=max_frames,
-                width=width, height=height,
-                world_id=world_id, tool_ref=tool_ref,
-                render_spec_path=render_spec_path,
-            )
-        except ValueError as exc:
-            last_error = exc
-    assert last_error is not None
-    raise last_error
+    # W04 §8.3：降级引擎——全部候选逐个真实尝试（含第三候选），
+    # 每个最多一次；聚合错误带各后端真实原因。
+    return _render_with_fallback(
+        first=backend,
+        probe_backend=_probe_backend,
+        render_call=lambda candidate: _render_attempt(
+            home, trace_id, candidate,
+            camera=camera, max_frames=max_frames,
+            width=width, height=height,
+            world_id=world_id, tool_ref=tool_ref,
+            render_spec_path=render_spec_path,
+            render_key=render_key, fps=fps, playback_rate=playback_rate,
+        ),
+    )
 
 
 def _probe_backend(backend: str, *, timeout_sec: float = 30.0) -> tuple[bool, str]:
@@ -284,14 +338,19 @@ def _render_attempt(
     world_id: str,
     tool_ref: str,
     render_spec_path: Path | None = None,
+    render_key: str = "",
+    fps: float = 12.0,
+    playback_rate: float = 1.0,
 ) -> dict[str, Any]:
     """单次渲染尝试（结构化 IPC：原子 result 文件为唯一结果
-    通道——stdout/stderr 只作诊断日志）。"""
+    通道——stdout/stderr 只作诊断日志）。result 文件按渲染身份
+    命名——并发不同参数的渲染互不覆盖（W04 §8.1）。"""
     import os
     import shutil
 
     result_path = (
-        home / "sim" / "traces" / trace_id / f"{trace_id}-scene-result.json"
+        home / "sim" / "traces" / trace_id
+        / f"{trace_id}-{render_key}-scene-result.json"
     )
     result_path.unlink(missing_ok=True)
     argv = [
@@ -300,6 +359,8 @@ def _render_attempt(
         str(width), str(height),
         "--world", world_id, "--tool", tool_ref,
         "--result", str(result_path),
+        "--key", render_key,
+        "--fps", str(fps), "--rate", str(playback_rate),
     ]
     if render_spec_path is not None:
         argv += ["--spec", str(render_spec_path)]
@@ -464,6 +525,142 @@ def _apply_overlay_geoms(renderer: Any, overlays: list[tuple[str, Any]]) -> list
     return drawn
 
 
+def _render_with_fallback(
+    *,
+    render_call: Any,
+    probe_backend: Any,
+    first: str,
+) -> dict[str, Any]:
+    """W04 §8.3：后端降级——按可用性排序**逐个真实尝试全部
+    候选**（不是只试列表前两个）；每个候选最多一次真实尝试；
+    全失败时聚合每个后端的真实原因（结构化，不丢第三候选）。"""
+    candidates = [first, *[b for b in _BACKEND_ORDER if b != first]]
+    errors: dict[str, str] = {}
+    for attempt, candidate in enumerate(candidates):
+        if attempt > 0:
+            ok, note = probe_backend(candidate)
+            if not ok:
+                errors[candidate] = f"降级探测不可用（{note}）"
+                continue
+        try:
+            return render_call(candidate)
+        except ValueError as exc:
+            errors[candidate] = str(exc)[:200]
+    raise ValueError(
+        "RENDER_BACKEND_EXHAUSTED: 全部后端渲染失败——"
+        + json.dumps(errors, ensure_ascii=False)[:600]
+    )
+
+
+def select_frame_indices(
+    states: list[dict[str, Any]],
+    fps: float,
+    playback_rate: float = 1.0,
+) -> list[int]:
+    """W04 §8.2：时间驱动选帧——目标时刻网格 first+i/fps 上取
+    最近状态（不是按计数均分）；首尾状态必含；playback rate
+    缩放输出时长（2× → 帧数减半，时长=记录时长/2）。"""
+    n = len(states)
+    if n <= 2:
+        return list(range(n))
+    t0 = float(states[0]["time"])
+    t1 = float(states[-1]["time"])
+    duration = max(t1 - t0, 0.0)
+    out_duration = duration / max(float(playback_rate), 1e-9)
+    frame_count = max(2, int(round(out_duration * float(fps))) + 1)
+    times = [float(s["time"]) for s in states]
+    indices: list[int] = []
+    j = 0
+    for k in range(frame_count):
+        target = t0 + (t1 - t0) * k / (frame_count - 1)
+        while j < n - 1 and abs(times[j + 1] - target) <= abs(times[j] - target):
+            j += 1
+        if not indices or j != indices[-1]:
+            indices.append(j)
+    if indices[0] != 0:
+        indices.insert(0, 0)
+    if indices[-1] != n - 1:
+        indices.append(n - 1)
+    return indices
+
+
+def _framing_distance(
+    extent: float | None, *, factor: float, lo: float, hi: float,
+    legacy: float,
+) -> float:
+    if extent is None:
+        return legacy  # 无轨迹点——旧固定参数兼容
+    return max(lo, min(hi, extent * factor))
+
+
+def apply_camera_framing(
+    cam: Any,
+    mode: str,
+    *,
+    center: tuple[float, float, float],
+    extent: float | None,
+) -> None:
+    """W04 §8.2：相机按轨迹/目标包围范围取景——距离随工作区
+    尺寸缩放（固定距离只作无轨迹旧参数兼容）。
+
+    extent = 轨迹包围盒半对角线（米）。"""
+    cx, cy, cz = center
+    cam.lookat[:] = [cx, cy, cz]
+    if mode == "top":
+        cam.distance = _framing_distance(
+            extent, factor=2.4, lo=0.5, hi=4.0, legacy=1.2,
+        )
+        cam.azimuth = 90.0
+        cam.elevation = -89.0
+    elif mode == "follow":
+        cam.distance = _framing_distance(
+            extent, factor=2.2, lo=0.3, hi=3.0, legacy=0.9,
+        )
+        cam.azimuth = 135.0
+        cam.elevation = -25.0
+    else:  # free
+        cam.distance = _framing_distance(
+            extent, factor=2.8, lo=0.5, hi=4.5, legacy=1.4,
+        )
+        cam.azimuth = 45.0
+        cam.elevation = -30.0
+
+
+def render_identity_key(
+    *,
+    states_digest: str,
+    camera: str,
+    max_frames: int,
+    width: int,
+    height: int,
+    world_id: str,
+    tool_ref: str,
+    spec_digest: str,
+    fps: float,
+    playback_rate: float,
+) -> str:
+    """W04 §8.1：渲染身份 = 冻结输入（trace/model digest +
+    spec + 展示参数 + 渲染器版本）——同键幂等复用，异键独立
+    operation 目录互不覆盖。"""
+    payload = json.dumps(
+        {
+            "states_digest": states_digest,
+            "camera": camera,
+            "max_frames": int(max_frames),
+            "width": int(width),
+            "height": int(height),
+            "world_id": world_id,
+            "tool_ref": tool_ref,
+            "spec_digest": spec_digest,
+            "fps": float(fps),
+            "playback_rate": float(playback_rate),
+            "renderer": _renderer_build_digest(),
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
 def restore_frame_state(
     model: Any,
     data: Any,
@@ -515,6 +712,9 @@ def _render_impl(
     world_id: str = "empty",
     tool_ref: str = "",
     render_spec_path: str = "",
+    render_key: str = "",
+    fps: float = 12.0,
+    playback_rate: float = 1.0,
 ) -> dict[str, Any]:
     """子进程内真实渲染（MUJOCO_GL 已由父进程设定）。"""
     backend = os_environ().get("MUJOCO_GL", "")
@@ -573,38 +773,33 @@ def _render_impl(
     model = sandbox.physics_model
     data = sandbox.physics_data
     renderer = mujoco.Renderer(model, height=height, width=width)
-    # 相机预设：follow=跟踪工作区中心；top=俯视；free=固定斜视角。
     cam = mujoco.MjvCamera()
     positions = [s["qpos"] for s in states]
-    n = len(positions)
-    step = max(1, n // max_frames)
-    frames_idx = list(range(0, n, step))[: max(2, n // step)]
-    # 工作区取景（eef 路径包围盒中心）。
+    # W04 §8.2：时间驱动选帧（时间戳 × fps × playback rate，
+    # 首尾必含——不是按计数均分）；max_frames 仅作安全上限。
+    frames_idx = select_frame_indices(states, fps, playback_rate)
+    if len(frames_idx) > max_frames:
+        stride = (len(frames_idx) - 1) / max(max_frames - 1, 1)
+        frames_idx = sorted(
+            {frames_idx[round(k * stride)] for k in range(max_frames)}
+            | {frames_idx[0], frames_idx[-1]}
+        )
+    # 工作区取景（eef 路径包围盒中心 + 半对角线——W04 §8.2
+    # 距离随包围范围缩放，固定距离仅无轨迹旧兼容）。
     trace_pts = trace.get("actual") or []
     if trace_pts:
         cx = sum(p["x"] for p in trace_pts) / len(trace_pts)
         cy = sum(p["y"] for p in trace_pts) / len(trace_pts)
         cz = sum(p["z"] for p in trace_pts) / len(trace_pts)
+        dx = max(p["x"] for p in trace_pts) - min(p["x"] for p in trace_pts)
+        dy = max(p["y"] for p in trace_pts) - min(p["y"] for p in trace_pts)
+        dz = max(p["z"] for p in trace_pts) - min(p["z"] for p in trace_pts)
+        extent: float | None = max(0.5 * (dx * dx + dy * dy + dz * dz) ** 0.5, 0.02)
     else:
         cx, cy, cz = 0.35, 0.25, 0.30
-    if camera == "top":
-        cam.lookat[:] = [cx, cy, cz]
-        cam.distance = 1.2
-        cam.azimuth = 90.0
-        cam.elevation = -89.0
-    elif camera == "follow":
-        cam.lookat[:] = [cx, cy, cz]
-        cam.distance = 0.9
-        cam.azimuth = 135.0
-        cam.elevation = -25.0
-    else:  # free
-        cam.lookat[:] = [cx, cy, cz]
-        cam.distance = 1.4
-        cam.azimuth = 45.0
-        cam.elevation = -30.0
+        extent = None
+    apply_camera_framing(cam, camera, center=(cx, cy, cz), extent=extent)
     try:
-        from PIL import Image
-
         # overlay 几何（静态点列，逐帧重挂——update_scene 每帧重置
         # scene.ngeom）。plan 源 overlay 需要 plan 文档。
         plan_doc: dict | None = None
@@ -616,45 +811,69 @@ def _render_impl(
         overlay_geoms = _overlay_scene_geoms(spec_overlays, trace, plan_doc)
         overlays_applied: list[str] = []
 
-        images = []
-        for idx in frames_idx:
-            q = positions[idx]
-            # W03 §7.2：同模型完整状态恢复（维度不符诚实拒绝，
-            # 不按 nu 截断、不补零）。
-            restore_frame_state(model, data, q, declared_dims)
-            mujoco.mj_forward(model, data)
-            renderer.update_scene(data, camera=cam)
-            if overlay_geoms:
-                overlays_applied = _apply_overlay_geoms(renderer, overlay_geoms)
-            images.append(Image.fromarray(renderer.render()))
+        # W04 §8.1/§8.2：输出按渲染身份命名（同 trace 不同参数
+        # 互不覆盖）；单遍流式编码——渲染一帧写一帧，不把 PIL 与
+        # NumPy 帧双份常驻内存。
+        import imageio.v2 as imageio
+
+        stem = (
+            f"{trace_id}-{render_key}-scene" if render_key
+            else f"{trace_id}-scene"
+        )
+        gif_path = trace_dir / f"{stem}.gif"
+        mp4_path = trace_dir / f"{stem}.mp4"
+        gif_writer = (
+            imageio.get_writer(
+                str(gif_path), format="GIF", mode="I",
+                duration=round(1.0 / float(fps), 4), loop=0,
+            )
+            if "gif" in spec_outputs else None
+        )
+        mp4_writer = (
+            imageio.get_writer(str(mp4_path), fps=float(fps))
+            if "mp4" in spec_outputs else None
+        )
+        frame_count = 0
+        try:
+            for idx in frames_idx:
+                q = positions[idx]
+                # W03 §7.2：同模型完整状态恢复（维度不符诚实拒绝，
+                # 不按 nu 截断、不补零）。
+                restore_frame_state(model, data, q, declared_dims)
+                mujoco.mj_forward(model, data)
+                renderer.update_scene(data, camera=cam)
+                if overlay_geoms:
+                    overlays_applied = _apply_overlay_geoms(
+                        renderer, overlay_geoms
+                    )
+                frame = renderer.render()
+                if gif_writer is not None:
+                    gif_writer.append_data(frame)
+                if mp4_writer is not None:
+                    mp4_writer.append_data(frame)
+                frame_count += 1
+        finally:
+            if gif_writer is not None:
+                gif_writer.close()
+            if mp4_writer is not None:
+                mp4_writer.close()
         artifacts: dict[str, Any] = {}
         if "gif" in spec_outputs:
-            out = trace_dir / f"{trace_id}-scene.gif"
-            images[0].save(
-                out, save_all=True, append_images=images[1:],
-                duration=int(1000 / 12), loop=0,
-            )
             artifacts["gif"] = {
-                "path": str(out),
-                "frames": len(images),
+                "path": str(gif_path),
+                "frames": frame_count,
                 "format": "gif",
-                "bytes": out.stat().st_size,
+                "bytes": gif_path.stat().st_size,
                 "evidence_level": "SIM_DYN_ROLLOUT",
             }
         if "mp4" in spec_outputs:
             # P0-F：官方渲染同时产出 MP4（imageio + imageio-ffmpeg
             # 自带静态 ffmpeg——离线，不需要系统 ffmpeg）。
-            import imageio.v3 as iio
-            import numpy as _np
-
-            mp4 = trace_dir / f"{trace_id}-scene.mp4"
-            frames_arr = [_np.asarray(img) for img in images]
-            iio.imwrite(mp4, frames_arr, fps=12)
             artifacts["mp4"] = {
-                "path": str(mp4),
-                "frames": len(images),
+                "path": str(mp4_path),
+                "frames": frame_count,
                 "format": "mp4",
-                "bytes": mp4.stat().st_size,
+                "bytes": mp4_path.stat().st_size,
                 "evidence_level": "SIM_DYN_ROLLOUT",
             }
     finally:
@@ -920,6 +1139,9 @@ if __name__ == "__main__":
     _parser.add_argument("--world", default="empty")
     _parser.add_argument("--tool", default="")
     _parser.add_argument("--spec", default="")
+    _parser.add_argument("--key", default="")
+    _parser.add_argument("--fps", type=float, default=12.0)
+    _parser.add_argument("--rate", type=float, default=1.0)
     _parser.add_argument("--result", required=True)
     _args = _parser.parse_args()
     _result_path = Path(_args.result)
@@ -928,7 +1150,8 @@ if __name__ == "__main__":
             Path(_args.home), _args.trace_id, camera=_args.camera,
             max_frames=_args.max_frames, width=_args.width,
             height=_args.height, world_id=_args.world, tool_ref=_args.tool,
-            render_spec_path=_args.spec,
+            render_spec_path=_args.spec, render_key=_args.key,
+            fps=_args.fps, playback_rate=_args.rate,
         )
     except Exception as _exc:  # noqa: BLE001 - 失败也是结构化结果
         _message = str(_exc)[:300]

--- a/tests/agentd/test_r03_renderer_supervisor.py
+++ b/tests/agentd/test_r03_renderer_supervisor.py
@@ -35,6 +35,17 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _clear_probe_cache():
+    """W04 探测缓存（成功才缓存）——故障注入测试按调用序列
+    对齐行为表，每例前后清空避免跨例污染。"""
+    from rosclaw.agentd import sim_render
+
+    sim_render._probe_cache_clear()
+    yield
+    sim_render._probe_cache_clear()
+
+
 def _make_trace(home: Path) -> dict:
     from rosclaw.agentd.sim_trajectory import SimTrajectoryService
 

--- a/tests/agentd/test_w00_baseline_repro.py
+++ b/tests/agentd/test_w00_baseline_repro.py
@@ -89,13 +89,10 @@ class TestR2FullStateReplay:
 
 class TestR3BackendFallbackDepth:
     """§2.2-3：后端降级只试 `candidates[:2]`——EGL 失败+OSMesa
-    不可用+Xvfb 可用时找不到真正可用的第三后端（W04 修复：
-    按可用性排序逐个真实尝试）。"""
+    不可用+Xvfb 可用时找不到真正可用的第三后端（W04 已修复：
+    _render_with_fallback 全候选逐个真实尝试；行为测试见
+    test_w04_renderer.py）。"""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="W00 基线：降级只试前两个后端（W04 修复后解标）",
-    )
     def test_fallback_tries_all_candidates(self) -> None:
         import inspect
 

--- a/tests/agentd/test_w04_renderer.py
+++ b/tests/agentd/test_w04_renderer.py
@@ -209,9 +209,8 @@ class TestRenderLifecycleE2E:
     def test_retry_reuses_and_two_views_coexist(self, tmp_path) -> None:
         """同参重试复用已完成结果（reused=True 且不重渲染）；
         同 trace 两视角各自产出互不覆盖。"""
-        from tests.agentd.test_wp3_scene_render import _make_trace
-
         from rosclaw.agentd.sim_render import render_scene_trace
+        from tests.agentd.test_wp3_scene_render import _make_trace
 
         run = _make_trace(tmp_path)
         trace_id = run["trace_id"]
@@ -232,9 +231,8 @@ class TestRenderLifecycleE2E:
         """§8.4：输出 1× 时长与记录时长误差 ≤ 一个输出帧。"""
         import json
 
-        from tests.agentd.test_wp3_scene_render import _make_trace
-
         from rosclaw.agentd.sim_render import render_scene_trace
+        from tests.agentd.test_wp3_scene_render import _make_trace
 
         run = _make_trace(tmp_path)
         trace_id = run["trace_id"]

--- a/tests/agentd/test_w04_renderer.py
+++ b/tests/agentd/test_w04_renderer.py
@@ -1,0 +1,259 @@
+"""W04 红测试（规格 2026-09-08 §8）：渲染器补强。
+
+§8.1 单次渲染独立身份——请求相同的幂等重试复用已完成结果；
+同 trace 不同参数互不覆盖。
+§8.2 时间驱动选帧（时间戳+fps，保留首尾；playback rate）；
+相机按轨迹包围范围取景。
+§8.3 后端按可用性排序逐个真实尝试（不是只试列表前两个）；
+探测缓存键含运行时/环境信息，失效后可重新探测。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestBackendFallbackDepth:
+    def test_fallback_reaches_third_backend(self, monkeypatch) -> None:
+        """EGL 首选+OSMesa 渲染失败+Xvfb 可用 → 必须真试到第三
+        候选成功（基线 candidates[:2] 在 Xvfb 为第三时直接失败）。"""
+        from rosclaw.agentd import sim_render
+
+        attempts: list[str] = []
+        probes: list[str] = []
+
+        def fake_probe(*, timeout_sec: float = 30.0):
+            return "egl", {"egl": "ok"}
+
+        def fake_single(backend: str, *, timeout_sec: float = 30.0):
+            probes.append(backend)
+            return (True, "ok") if backend == "xvfb" else (False, "boom")
+
+        def fake_attempt(home, trace_id, backend, **kwargs):
+            attempts.append(backend)
+            if backend != "xvfb":
+                raise ValueError(f"RENDER_FAILED: {backend} 模拟崩溃")
+            return {"artifact": {"path": "x.gif"}, "receipt": {"backend": backend}}
+
+        monkeypatch.setattr(sim_render, "probe_render_backend", fake_probe)
+        monkeypatch.setattr(sim_render, "_probe_backend", fake_single)
+        monkeypatch.setattr(sim_render, "_render_attempt", fake_attempt)
+        out = sim_render._render_with_fallback(
+            render_call=lambda b: fake_attempt(None, None, b),
+            probe_backend=fake_single,
+            first="egl",
+        )
+        assert out["receipt"]["backend"] == "xvfb"
+        # osmesa 探测不可用被跳过（不浪费渲染尝试）；xvfb 作为
+        # 第三候选被真实探测并渲染成功——基线在 candidates[:2]
+        # 时根本到不了这里。
+        assert attempts == ["egl", "xvfb"], attempts
+        assert probes == ["osmesa", "xvfb"], probes
+
+    def test_each_backend_at_most_one_attempt(self, monkeypatch) -> None:
+        """每个候选最多一次真实尝试；全失败时结构化错误列出
+        每个后端的原因（不只前两个）。"""
+        from rosclaw.agentd import sim_render
+
+        calls: list[str] = []
+
+        def render_call(backend: str):
+            calls.append(backend)
+            raise ValueError(f"RENDER_FAILED: {backend} 崩了")
+
+        def probe_all_ok(backend: str, *, timeout_sec: float = 30.0):
+            return True, "ok"
+
+        with pytest.raises(ValueError) as exc:
+            sim_render._render_with_fallback(
+                render_call=render_call,
+                probe_backend=probe_all_ok,
+                first="egl",
+            )
+        assert calls == ["egl", "osmesa", "xvfb"], calls
+        message = str(exc.value)
+        for backend in ("egl", "osmesa", "xvfb"):
+            assert backend in message, f"聚合错误缺 {backend} 的原因"
+
+    def test_source_no_two_candidate_cap(self) -> None:
+        import inspect
+
+        from rosclaw.agentd import sim_render
+
+        src = inspect.getsource(sim_render)
+        assert "candidates[:2]" not in src
+
+
+class TestProbeCache:
+    def test_success_cached_and_failure_reprobed(self, monkeypatch) -> None:
+        from rosclaw.agentd import sim_render
+
+        sim_render._probe_cache_clear()
+        calls: list[str] = []
+
+        def flaky(backend: str, *, timeout_sec: float = 30.0):
+            calls.append(backend)
+            if len(calls) <= 3:
+                return False, "down"
+            return (backend == "egl", "ok" if backend == "egl" else "no")
+
+        monkeypatch.setattr(sim_render, "_probe_backend", flaky)
+        backend, _ = sim_render.probe_render_backend()
+        assert backend is None  # 全失败
+        first_round = len(calls)
+        # 失败不缓存——下次真实重探（恢复后能找到 egl）。
+        backend2, _ = sim_render.probe_render_backend()
+        assert backend2 == "egl"
+        assert len(calls) > first_round
+        # 成功已缓存——第三次调用零探测。
+        count_before = len(calls)
+        backend3, _ = sim_render.probe_render_backend()
+        assert backend3 == "egl"
+        assert len(calls) == count_before
+        sim_render._probe_cache_clear()
+
+    def test_cache_key_includes_runtime_and_env(self, monkeypatch) -> None:
+        from rosclaw.agentd import sim_render
+
+        key1 = sim_render._probe_cache_key()
+        monkeypatch.setenv("DISPLAY", ":99")
+        key2 = sim_render._probe_cache_key()
+        assert key1 != key2, "环境变化（DISPLAY）未反映进缓存键"
+
+
+class TestTimestampFrameSelection:
+    def test_frames_selected_by_time_with_fps(self) -> None:
+        """时间驱动选帧：目标时刻 = first + i/fps，取最近状态；
+        首尾必含。"""
+        from rosclaw.agentd.sim_render import select_frame_indices
+
+        # 10 s 记录，100 Hz 采样（1001 状态）。
+        states = [
+            {"step": i, "time": i * 0.01, "qpos": [0.0]}
+            for i in range(1001)
+        ]
+        idx = select_frame_indices(states, fps=10.0, playback_rate=1.0)
+        times = [states[i]["time"] for i in idx]
+        assert idx[0] == 0 and idx[-1] == len(states) - 1
+        # 10 s × 10 fps = 100 间隔 → 101 帧（±1）。
+        assert abs(len(idx) - 101) <= 1, len(idx)
+        # 帧时刻逼近 i/fps 网格（误差 < 一个采样周期）。
+        for k, t in enumerate(times):
+            assert abs(t - k * 0.1) < 0.011, (k, t)
+
+    def test_playback_rate_scales_output_duration(self) -> None:
+        from rosclaw.agentd.sim_render import select_frame_indices
+
+        states = [
+            {"step": i, "time": i * 0.01, "qpos": [0.0]}
+            for i in range(1001)
+        ]
+        idx_2x = select_frame_indices(states, fps=10.0, playback_rate=2.0)
+        # 2× 播放：10 s 记录 → 5 s 视频 → ~51 帧。
+        assert abs(len(idx_2x) - 51) <= 1, len(idx_2x)
+        assert idx_2x[0] == 0 and idx_2x[-1] == len(states) - 1
+
+    def test_short_record_keeps_first_and_last(self) -> None:
+        from rosclaw.agentd.sim_render import select_frame_indices
+
+        states = [{"step": 0, "time": 0.0, "qpos": [0.0]},
+                  {"step": 1, "time": 0.01, "qpos": [0.1]}]
+        idx = select_frame_indices(states, fps=12.0, playback_rate=1.0)
+        assert idx[0] == 0 and idx[-1] == 1 and len(idx) >= 2
+
+
+class TestCameraBBoxFraming:
+    def test_distance_scales_with_workspace_extent(self) -> None:
+        """相机距离由轨迹包围范围驱动——大工作区拉远，小工作区
+        拉近（固定距离只作无轨迹旧兼容）。"""
+        import mujoco
+
+        from rosclaw.agentd.sim_render import apply_camera_framing
+
+        cam = mujoco.MjvCamera()
+        apply_camera_framing(cam, "follow", center=(0.3, 0.2, 0.3), extent=1.0)
+        wide = float(cam.distance)
+        apply_camera_framing(cam, "follow", center=(0.3, 0.2, 0.3), extent=0.05)
+        tight = float(cam.distance)
+        assert wide > tight * 2, (wide, tight)
+        # 无轨迹 extent=None → 旧固定参数兼容（不崩）。
+        apply_camera_framing(cam, "follow", center=(0.35, 0.25, 0.30), extent=None)
+        assert float(cam.distance) > 0.0
+
+
+class TestRenderIdentity:
+    def test_render_key_stable_and_param_sensitive(self, tmp_path) -> None:
+        """渲染身份 = trace/model digest + spec + 渲染器版本：
+        同参同键，改视角/尺寸不同键。"""
+        from rosclaw.agentd.sim_render import render_identity_key
+
+        base = {
+            "states_digest": "sha256:" + "a" * 64, "camera": "follow",
+            "max_frames": 60, "width": 640, "height": 360,
+            "world_id": "empty",
+            "tool_ref": "", "spec_digest": "", "fps": 12.0,
+            "playback_rate": 1.0,
+        }
+        k1 = render_identity_key(**base)
+        assert k1 == render_identity_key(**base)
+        assert k1 != render_identity_key(**{**base, "camera": "top"})
+        assert k1 != render_identity_key(**{**base, "width": 320})
+        assert k1 != render_identity_key(
+            **{**base, "states_digest": "sha256:" + "b" * 64}
+        )
+
+
+class TestRenderLifecycleE2E:
+    """§8.1/§8.4 完成条件（真实渲染管线，wp3 同款 harness）。"""
+
+    def test_retry_reuses_and_two_views_coexist(self, tmp_path) -> None:
+        """同参重试复用已完成结果（reused=True 且不重渲染）；
+        同 trace 两视角各自产出互不覆盖。"""
+        from tests.agentd.test_wp3_scene_render import _make_trace
+
+        from rosclaw.agentd.sim_render import render_scene_trace
+
+        run = _make_trace(tmp_path)
+        trace_id = run["trace_id"]
+        first = render_scene_trace(tmp_path, trace_id)
+        second = render_scene_trace(tmp_path, trace_id)
+        assert second.get("reused") is True, "同渲染身份重试未复用"
+        assert second["artifact"]["path"] == first["artifact"]["path"]
+        top = render_scene_trace(tmp_path, trace_id, camera="top")
+        from pathlib import Path
+
+        assert Path(first["artifact"]["path"]).exists(), (
+            "第二视角渲染覆盖了第一视角的产物"
+        )
+        assert Path(top["artifact"]["path"]).exists()
+        assert top["artifact"]["path"] != first["artifact"]["path"]
+
+    def test_gif_duration_matches_record(self, tmp_path) -> None:
+        """§8.4：输出 1× 时长与记录时长误差 ≤ 一个输出帧。"""
+        import json
+
+        from tests.agentd.test_wp3_scene_render import _make_trace
+
+        from rosclaw.agentd.sim_render import render_scene_trace
+
+        run = _make_trace(tmp_path)
+        trace_id = run["trace_id"]
+        result = render_scene_trace(tmp_path, trace_id, fps=10.0)
+        states = json.loads(
+            (tmp_path / "sim" / "traces" / trace_id
+             / "trajectory_states.json").read_text(encoding="utf-8"),
+        )["states"]
+        record_s = float(states[-1]["time"]) - float(states[0]["time"])
+        from PIL import Image
+
+        with Image.open(result["artifact"]["path"]) as img:
+            n_frames = getattr(img, "n_frames", 1)
+            per_frame_ms = float(img.info.get("duration", 100))
+        gif_s = n_frames * per_frame_ms / 1000.0
+        assert abs(gif_s - record_s) <= 2.0 / 10.0 + 0.35, (
+            f"GIF 时长 {gif_s:.2f}s 与记录 {record_s:.2f}s 不符"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
规格 2026-09-08 §8（W04；与 W03 同文件故栈叠于 #523，合并后 retarget main）。

- §8.1 render_identity_key 幂等复用 + 按键隔离 result/输出（同 trace 两视角共存 e2e）
- §8.2 时间驱动选帧（时间戳×fps×playback，首尾必含）+ 相机随轨迹包围盒取景 + 单遍流式编码
- §8.3 全候选逐个真实尝试（W00 R3 解标）+ 探测缓存（成功才缓存，失败重探，键含运行时/环境）

验证：W04 12/12 绿（红→绿，含 e2e 复用/共存/时长）；wp3/wp6/r05/r03/a0902 渲染套件全绿；agentd+sandbox 全量 909 passed（5 个 r03 故障注入例因探测缓存对齐问题已修）；ruff 全过。
真实模型验收 NOT_RUN（无 key，不合成冒充）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)