### PR TITLE
W06: honest isolation notice + negative probes (spec §10)

### DIFF
--- a/docs/implementation/w06-isolation.md
+++ b/docs/implementation/w06-isolation.md
@@ -1,0 +1,51 @@
+# W06 一次批准与真实隔离（规格 §10）
+
+**分支**：a-w06-isolation（基于 main=8221d27，§17 依赖：W06←W01）
+**日期**：2026-09-09
+
+## 现状盘点（保留已有可用实现）
+
+- workspace-pack shell 执行：bwrap 真实 exec 探测（`--ro-bind / /
+  true`——非存在性检查）；不可用时 REAL/SHADOW **fail closed**，
+  SIM 降级带 `[TOOL_LAYER_ONLY]` 诚实标记（R1-2b）——**正确，保留**。
+- 本机实测：bwrap 两种 smoke 均失败（uid map Permission denied /
+  RTM_NEWADDR）→ 执行路径自动走降级标记，无谎言。
+- REAL 缺 Operator 无法执行：consent channel / action admission
+  行为链已有测试覆盖（test_consent_channel 等）——保留不重复。
+- evidence 受信区 kernel-only（P0-E）——进程内 provenance 的
+  实际边界，本轮补行为锚点。
+
+## 发现的谎言（已修）
+
+会话开始的隔离提示文案宣称「shell 类操作将在会话内**弹确认卡
+降级运行**」——该确认卡已被大道至简 R1-2b 退役（SIM 任务沙箱
+bash 自动执行），提示在承诺一个不存在的机制（§10.2「不暗中
+降级」反面：也不得宣称不存在的批准）。且提示挂在
+session_start 上，resume/switch 会重复展示（§10.2「无沙箱
+警告仅……显示一次」）。
+
+**修改（packages/rosclaw-agent/src/extension/index.ts）**：
+
+1. 文案如实：「任务代码直接在宿主执行：可访问工作区外文件与
+   网络，产物证据为进程内 provenance（非安全隔离、非防篡改）；
+   rosclaw doctor 查看结论与修复建议」。
+2. `isolationNoticeShown` 一次性标志——resume/switch 不重复。
+
+## 验证（红→绿）
+
+| 测试 | 结果 |
+|---|---|
+| test_w06_isolation.py（4：ready⇒真实 smoke 不变式/落盘一致/evidence 区模型拒绝+kernel 通过/REAL·SHADOW 永不 POLICY_AUTO） | 绿 4/4（本机 bwrap broken 实测不就绪） |
+| a0902-r1c TS（提示一次含两次 session_start/文案无「确认卡」/隔离可用无提示/doctor 落盘单源） | 绿 3/3 |
+| TS 全量（232 例） | 229 pass / 0 fail / 3 skipped（6 个初始失败=stale 资产构建顺序，重构建后全绿，与本轮无关） |
+| ruff check src tests | 全过 |
+
+## 边界说明
+
+- §10.1「真实 OS 隔离」：本机 bwrap broken——无法形成真实
+  权限隔离，声明已降级为进程内 provenance（提示文案 +
+  evidence kernel-only 边界 + TOOL_LAYER_ONLY 执行标记）。
+  bwrap 可用的宿主上 workspace-pack 自动走强隔离（既有）。
+- 同范围不重复批准/取消批准不影响聊天：Approval Broker
+  （0902-R1）与 consent 链既有覆盖。
+- 真实模型验收：**NOT_RUN**（无 key，不合成冒充）。

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -151,6 +151,8 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 		// WP-P0-3：恢复对账报告（恢复了什么/重新验证了什么/哪些权限
 		// 失效）——一次性展示，不重复。
 		let resumeReportShown = !options.resumed;
+		// W06 §10.2：无沙箱警告仅显示一次（resume/switch 不重复）。
+		let isolationNoticeShown = false;
 		let refreshChrome: () => void = () => undefined;
 		let probeTimer: ReturnType<typeof setInterval> | null = null;
 		// 十审 W2：Worker 完成推送——custom message 注入（不冒充用户
@@ -260,13 +262,18 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 			// 0902 R1-c（§5.3）：无 OS 沙箱 → 会话开始一次性提示（任务
 			// 开始前），而不是 shell 执行到一半才甩卡。探测单源 =
 			// doctor 落盘的 os-isolation.json（无记录回落 bwrap 存在性）。
+			// W06 §10.2：仅显示一次（resume/switch 不重复）；文案如实
+			// ——R1-2b 后 SIM shell 自动执行（TOOL_LAYER_ONLY 标记），
+			// 不存在"弹确认卡降级"，不得再如此宣称。
 			if (ctx.hasUI) {
 				try {
 					const probe = options.osIsolationProbe ?? defaultOsIsolationProbe;
-					if (!probe().isolationReady) {
+					if (!isolationNoticeShown && !probe().isolationReady) {
+						isolationNoticeShown = true;
 						notifyLeveled(ctx,
-							"本机无 OS 沙箱（bwrap 不可用）——shell 类操作将在会话内"
-							+ "弹确认卡降级运行；rosclaw doctor 查看结论与修复建议",
+							"本机无 OS 隔离（bwrap 不可用）——任务代码直接在宿主执行："
+							+ "可访问工作区外文件与网络，产物证据为进程内 provenance"
+							+ "（非安全隔离、非防篡改）；rosclaw doctor 查看结论与修复建议",
 							"warning",
 						);
 					}

--- a/packages/rosclaw-agent/src/extension/index.ts
+++ b/packages/rosclaw-agent/src/extension/index.ts
@@ -270,10 +270,11 @@ export function createRosclawExtension(options: RosclawExtensionOptions): Extens
 					const probe = options.osIsolationProbe ?? defaultOsIsolationProbe;
 					if (!isolationNoticeShown && !probe().isolationReady) {
 						isolationNoticeShown = true;
+						// 通知区会裁剪长文本——doctor 修复入口必须前置
+						// （journey 实证：长文后半段根本不显示）。
 						notifyLeveled(ctx,
-							"本机无 OS 隔离（bwrap 不可用）——任务代码直接在宿主执行："
-							+ "可访问工作区外文件与网络，产物证据为进程内 provenance"
-							+ "（非安全隔离、非防篡改）；rosclaw doctor 查看结论与修复建议",
+							"本机无 OS 隔离——宿主直接执行（证据=进程内 provenance，"
+							+ "非防篡改）；rosclaw doctor 查看结论与修复建议",
 							"warning",
 						);
 					}

--- a/packages/rosclaw-agent/test/a0902-r1c-sandbox-readiness.test.ts
+++ b/packages/rosclaw-agent/test/a0902-r1c-sandbox-readiness.test.ts
@@ -90,9 +90,15 @@ test("R1-c: 无 OS 沙箱 → session_start 一次性提示（降级后果 + doc
 	const handlers = await buildExtension(home, () => ({ isolationReady: false }));
 	const notices: string[] = [];
 	for (const h of handlers.get("session_start") ?? []) await h({}, fakeCtx(notices));
-	const hints = notices.filter((n) => n.includes("OS 沙箱"));
+	// W06 §10.2：resume/switch 再次 session_start 不重复提示。
+	for (const h of handlers.get("session_start") ?? []) await h({}, fakeCtx(notices));
+	const hints = notices.filter((n) => n.includes("OS 隔离"));
 	assert.equal(hints.length, 1, `应恰好提示一次，实际 ${hints.length}`);
-	assert.match(hints[0], /确认卡|降级/);
+	// 文案如实：宿主直接执行 + 进程内 provenance——R1-2b 后
+	// SIM shell 自动执行，不存在"弹确认卡降级"，不得如此宣称。
+	assert.match(hints[0], /宿主执行/);
+	assert.match(hints[0], /provenance/);
+	assert.doesNotMatch(hints[0], /确认卡/);
 	assert.match(hints[0], /rosclaw doctor/);
 });
 
@@ -101,7 +107,7 @@ test("R1-c: 隔离可用 → 无提示（不噪声）", async () => {
 	const handlers = await buildExtension(home, () => ({ isolationReady: true }));
 	const notices: string[] = [];
 	for (const h of handlers.get("session_start") ?? []) await h({}, fakeCtx(notices));
-	assert.equal(notices.filter((n) => n.includes("OS 沙箱")).length, 0);
+	assert.equal(notices.filter((n) => n.includes("OS 隔离")).length, 0);
 });
 
 test("R1-c: 默认探测消费 doctor 落盘的 os-isolation.json（单源）", async () => {
@@ -117,7 +123,7 @@ test("R1-c: 默认探测消费 doctor 落盘的 os-isolation.json（单源）", 
 	const notices: string[] = [];
 	for (const h of handlers.get("session_start") ?? []) await h({}, fakeCtx(notices));
 	assert.equal(
-		notices.filter((n) => n.includes("OS 沙箱")).length, 1,
+		notices.filter((n) => n.includes("OS 隔离")).length, 1,
 		"doctor 记录 isolation_ready=false 时必须提示",
 	);
 });

--- a/packages/rosclaw-agent/test/a0902-r1c-sandbox-readiness.test.ts
+++ b/packages/rosclaw-agent/test/a0902-r1c-sandbox-readiness.test.ts
@@ -96,7 +96,7 @@ test("R1-c: 无 OS 沙箱 → session_start 一次性提示（降级后果 + doc
 	assert.equal(hints.length, 1, `应恰好提示一次，实际 ${hints.length}`);
 	// 文案如实：宿主直接执行 + 进程内 provenance——R1-2b 后
 	// SIM shell 自动执行，不存在"弹确认卡降级"，不得如此宣称。
-	assert.match(hints[0], /宿主执行/);
+	assert.match(hints[0], /宿主直接执行/);
 	assert.match(hints[0], /provenance/);
 	assert.doesNotMatch(hints[0], /确认卡/);
 	assert.match(hints[0], /rosclaw doctor/);

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1683,7 +1683,7 @@ class TestProductJourney:
                 # 长提示按终端宽度换行——"rosclaw doctor" 可能被
                 # 折行拆开；压缩空白后比对（0901 CJK 撕裂同款防线）。
                 squashed = b"".join(session.clean.split())
-                assert "rosclawdoctor".encode() in squashed, (
+                assert b"rosclawdoctor" in squashed, (
                     "沙箱提示必须带 doctor 修复入口"
                 )
                 self._journey_verdicts["sandbox_notice_at_session_start"] = True

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1680,7 +1680,10 @@ class TestProductJourney:
                 # W06 §10.2：文案如实（宿主执行 + 进程内
                 # provenance），一次性显示。
                 session.expect("本机无 OS 隔离".encode(), timeout=30)
-                assert b"rosclaw doctor" in session.clean, (
+                # 长提示按终端宽度换行——"rosclaw doctor" 可能被
+                # 折行拆开；压缩空白后比对（0901 CJK 撕裂同款防线）。
+                squashed = b"".join(session.clean.split())
+                assert "rosclawdoctor".encode() in squashed, (
                     "沙箱提示必须带 doctor 修复入口"
                 )
                 self._journey_verdicts["sandbox_notice_at_session_start"] = True

--- a/tests/agentd/test_product_journey.py
+++ b/tests/agentd/test_product_journey.py
@@ -1677,7 +1677,9 @@ class TestProductJourney:
             # 不是 which——本机 bwrap 装了但 RTM_NEWADDR 被拒）。
             # （模块级 import——journey 运行期间源码 checkout 隐藏。）
             if not probe_os_isolation()["isolation_ready"]:
-                session.expect("本机无 OS 沙箱".encode(), timeout=30)
+                # W06 §10.2：文案如实（宿主执行 + 进程内
+                # provenance），一次性显示。
+                session.expect("本机无 OS 隔离".encode(), timeout=30)
                 assert b"rosclaw doctor" in session.clean, (
                     "沙箱提示必须带 doctor 修复入口"
                 )

--- a/tests/agentd/test_w06_isolation.py
+++ b/tests/agentd/test_w06_isolation.py
@@ -1,0 +1,116 @@
+"""W06 红测试（规格 2026-09-08 §10）：一次批准与真实隔离。
+
+§10.1 负向探针：
+- present ≠ usable——bwrap 可执行文件存在但 smoke 失败（云 VM
+  user namespace 受限）时不得宣布隔离就绪；
+- 无法形成真实权限隔离时声明降级为进程内 provenance——
+  evidence 受信区 kernel-only 是该声明级别的实际执行边界。
+
+§10.2 REAL 永不走 POLICY_AUTO（fake REAL 缺 Operator 无法
+执行——行为链由 consent/admission 测试覆盖，此处锚定判定
+函数不跨域）。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+
+class TestProbeHonesty:
+    def test_ready_implies_real_smoke(self, tmp_path) -> None:
+        """不变式：isolation_ready=True 必须有真实 smoke 通过
+        （bwrap smoke_ok 或容器后端可用）——存在性不宣布隔离。"""
+        from rosclaw.firstboot.os_isolation import probe_and_persist
+
+        probe = probe_and_persist(tmp_path)
+        bwrap_ok = bool((probe.get("bwrap") or {}).get("smoke_ok"))
+        container_ok = bool(probe.get("container"))
+        if probe["isolation_ready"]:
+            assert bwrap_ok or container_ok, (
+                f"无真实 smoke 通过却宣布隔离就绪: {probe}"
+            )
+        else:
+            # 不就绪时必须有可诊断的诚实原因（不是空记录）。
+            assert probe.get("bwrap") is not None
+            detail = str((probe.get("bwrap") or {}).get("detail", ""))
+            assert detail or container_ok is False
+
+    def test_persisted_record_matches_probe(self, tmp_path) -> None:
+        """落盘记录与探测一致（消费方读到什么就是什么）。"""
+        import json
+
+        from rosclaw.firstboot.os_isolation import probe_and_persist
+
+        probe = probe_and_persist(tmp_path)
+        record = json.loads(
+            (tmp_path / "agent" / "os-isolation.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert record["isolation_ready"] == probe["isolation_ready"]
+
+
+class TestProvenanceBoundary:
+    def test_evidence_zone_rejects_model_producer(self, tmp_path) -> None:
+        """进程内 provenance 的实际边界：evidence 受信区只接受
+        kernel 管道登记——模型不能自写受信证据（OS 隔离不可用
+        时的诚实声明级别）。"""
+        import pytest
+
+        from rosclaw.storage.migrations import MigrationRunner
+        from rosclaw.task_kernel.service import TaskKernel
+
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        MigrationRunner().apply(conn, "sqlite")
+        kernel = TaskKernel(conn, tmp_path)
+        kernel.persist_input(
+            mission_id="mis_1", session_ref="s1",
+            message_id="msg_1", text="验证 evidence 边界",
+        )
+        bound = kernel.ensure_task_for_effect(
+            mission_id="mis_1", session_ref="s1",
+            backend_native_id="s1", cwd=str(tmp_path),
+        )
+        task_id = str(bound["task_id"])
+        revision = int(bound["revision"])
+        evidence_dir = (
+            tmp_path / "runs" / task_id / f"r{revision}" / "evidence"
+        )
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        fake = evidence_dir / "verify_self.json"
+        fake.write_text('{"verdict": "PASS"}', encoding="utf-8")
+        with pytest.raises(ValueError, match="EVIDENCE_KERNEL_ONLY"):
+            kernel.register_artifact(
+                task_id=task_id, path=str(fake),
+                media_type="application/json",
+                producer="model:rosclaw_artifact_register",
+            )
+        # kernel 管道可登记（边界是生产者身份，不是目录位置）。
+        record = kernel.register_artifact(
+            task_id=task_id, path=str(fake),
+            media_type="application/json",
+            producer="kernel:verifier",
+        )
+        assert record["artifact_id"]
+
+
+class TestRealNeverPolicyAuto:
+    def test_real_shadow_never_auto(self) -> None:
+        """POLICY_AUTO 判定对 REAL/SHADOW 永远 False（政策授权
+        不跨域——缺 Operator 时 REAL 无自动路径）。"""
+        from rosclaw.agentd.pi_bridge.action_admission import (
+            ActionAdmissionService,
+        )
+
+        admission = ActionAdmissionService.__new__(ActionAdmissionService)
+        for mode in ("REAL", "SHADOW"):
+            mission = SimpleNamespace(mode=SimpleNamespace(value=mode))
+            assert admission._policy_auto_applies(mission, None) is False
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
规格 2026-09-08 §10（W06，依赖 W01）。

- 修复谎言：启动隔离提示承诺了已被 R1-2b 退役的 shell 确认卡；改为如实说明宿主执行 + 进程内 provenance + doctor 入口；一次性显示（resume/switch 不重复）
- 负向探针：ready⇒真实 smoke 不变式（本机 bwrap 两种 smoke 均失败实测）、落盘一致、evidence kernel-only 边界、REAL/SHADOW 永不 POLICY_AUTO
- 既有正确实现保留：workspace-pack bwrap 真实 exec 探测 + REAL/SHADOW fail closed + TOOL_LAYER_ONLY 降级标记

验证：python 探针 4/4；r1c TS 3/3；TS 全量 229 pass/0 fail；ruff 全过。
真实模型验收 NOT_RUN（无 key，不合成冒充）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)