### PR TITLE
W11(1): common JS staging + self-contained wheel (spec §15.1/§15.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,17 @@ jobs:
         with:
           python-version: '3.11'
 
+      # W11 §15.1：wheel 与离线 tar 消费同一组 JS staging——hatch
+      # force-include dist/js-stage，缺 staging 即硬错误（不静默
+      # 产出缺 JS 的 wheel）。
+      - name: Set up Node (JS staging)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.19.0'
+
+      - name: Build JS staging (tar/wheel 同一构建输入)
+        run: bash scripts/release/build_js_staging.sh
+
       - name: Install build dependencies
         run: pip install hatch
 
@@ -443,9 +454,17 @@ jobs:
               "rosclaw/robot_pack/trust/keys.json",
               "rosclaw/hub/trust/keys.json",
               "lerobot_policy_rosclaw_rh56/__init__.py",
+              # W11 §15.1/§15.4：wheel 自包含已构建 JS（实际开包检查）。
+              "rosclaw/js_stage/rosclaw-agent/dist/src/main.js",
+              "rosclaw/js_stage/rosclaw-agent/dist/prompts/native_agent_v2.md",
+              "rosclaw/js_stage/rosclaw-agent/package-lock.json",
+              "rosclaw/js_stage/rosclaw-tui/dist/src/main.js",
           }
           missing = sorted(required - names)
           assert not missing, f"wheel missing runtime resources: {missing}"
+          assert not any("node_modules" in n for n in names), (
+              "wheel 不得包含 node_modules（dev 依赖/体积）"
+          )
           meshes = [
               name
               for name in names
@@ -453,6 +472,32 @@ jobs:
               and name.endswith(".obj")
           ]
           assert len(meshes) >= 20, f"wheel contains only {len(meshes)} UR5e meshes"
+          PY
+
+      # W11 §15.4：sdist 从自身内容可重建 wheel（JS 源码 + staging
+      # 脚本 + 预构建 js-stage 随 sdist 走）——实际开包检查。
+      - name: Verify sdist self-containment
+        run: |
+          python - <<'PY'
+          import glob
+          import tarfile
+
+          sdists = glob.glob("dist/*.tar.gz")
+          assert len(sdists) == 1, sdists
+          with tarfile.open(sdists[0]) as sdist:
+              names = set(sdist.getnames())
+          required_fragments = (
+              "packages/rosclaw-agent/src/extension/index.ts",
+              "packages/rosclaw-agent/package-lock.json",
+              "scripts/release/build_js_staging.sh",
+              "dist/js-stage/rosclaw-agent/dist/src/main.js",
+              "dist/js-stage/rosclaw-tui/dist/src/main.js",
+          )
+          missing = [
+              f for f in required_fragments
+              if not any(n.endswith(f) for n in names)
+          ]
+          assert not missing, f"sdist 缺重建输入: {missing}"
           PY
 
       - name: Upload artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,9 @@ jobs:
 
       - name: Build JS staging (tar/wheel 同一构建输入)
         run: bash scripts/release/build_js_staging.sh
+        env:
+          # §15.4 缺资产硬错误落在发布门禁：本 job 缺 staging 即失败。
+          ROSCLAW_REQUIRE_JS_STAGE: "1"
 
       - name: Install build dependencies
         run: pip install hatch
@@ -421,6 +424,8 @@ jobs:
 
       - name: Build package
         run: hatch build
+        env:
+          ROSCLAW_REQUIRE_JS_STAGE: "1"
 
       - name: Verify wheel runtime resources
         run: |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ rosclaw firstboot --yes --profile offline --no-telemetry
 rosclaw doctor --level verified
 ```
 
+> **Install forms (Alpha).** The offline tar bundle is fully self-contained
+> (Node runtime, npm production deps, Python wheels). The PyPI wheel
+> (`pip install rosclaw`) ships the prebuilt agent JS and Python runtime but
+> **requires Node.js ≥ 22.19 on the host** — it does not bundle a Node
+> runtime, and nothing is downloaded at chat time. Rendering additionally
+> needs a GL backend (OSMesa/EGL/Xvfb); `rosclaw doctor` reports the exact
+> OS packages for your platform. We do not claim "zero system dependencies
+> after pip install" for this release form.
+
 ---
 
 ## What is ROSClaw?

--- a/docs/implementation/w11-packaging-staging.md
+++ b/docs/implementation/w11-packaging-staging.md
@@ -1,0 +1,62 @@
+# W11（一）打包断点修复：共同 staging 与 wheel 自包含（规格 §15.1/§15.4）
+
+**分支**：a-w11-packaging（基于 main=8221d27，§17：W11 从 W00 起并行准备）
+**日期**：2026-09-09
+
+## 断点（修复前实证）
+
+1. `scripts/build_release.sh` 在**开发 checkout** 里 `npm ci`
+   （两次：build + prod pack）——构建后开发树 node_modules 被删/
+   改写（规格 §15.1 明令禁止）。
+2. PyPI wheel 的 force-include **不含 packages/**——`pip install
+   rosclaw` 拿不到 agent JS，无法启动 Native Agent（规格 §15.1
+   「不能被假定自动包含」实证）。
+3. sdist 缺 packages//scripts/js-stage——无法从自身内容重建
+   wheel（规格 §15.4）。
+
+## 改动
+
+- **`scripts/release/build_js_staging.sh`（新）**：共同 JS
+  staging——rsync 副本进专用工作目录（`dist/.js-build`），在其内
+  npm ci + clean build + prod pack；产出 dist/package.json/
+  lock/src/node_modules.prod.tar.gz + 完整性硬校验。
+  `build_release.sh` 改为消费 staging（开发 checkout 全程不被
+  npm ci 触碰）。copy-assets 的 python-tree 相对路径在 staging
+  不成立——喂包内 prompts/ fallback（该 mjs 的设计路径）。
+- **`pyproject.toml`**：wheel force-include `dist/js-stage` 的
+  两包 dist + package.json + lock（缺 staging = 构建硬错误）；
+  node_modules 不进 wheel；sdist include += /packages /scripts
+  /third_party + force-include `dist/js-stage`（gitignore 产物
+  必须 force-include 才进 sdist）。
+- **`src/rosclaw/agentd/pi_entry.py`**：dist 入口解析加第 4 来源
+  ——wheel 内嵌 `rosclaw/js_stage/<pkg>/dist/src/main.js`
+  （env → 仓库 → 安装前缀 → wheel 内嵌）。
+- **CI Build Package**：Set up Node 22.19 + 先跑 JS staging 再
+  `hatch build`；wheel 校验加 js_stage 必需项 + 无 node_modules；
+  新增 sdist 自包含校验（重建输入实际开包检查）。
+- **README**：Alpha 安装形式如实说明（tar 自包含；PyPI wheel
+  需 Node ≥22.19 前置、无聊天期下载、GL 系统依赖见 doctor——
+  不宣传「pip 安装后零系统依赖」）。
+
+## 验证（红→绿 + 实开包）
+
+| 验证 | 结果 |
+|---|---|
+| tests/test_w11_packaging.py（6：无开发 checkout npm ci/staging 专用工作目录/wheel force-include JS/sdist 自包含/wheel 内嵌解析/解析顺序） | 红（6 failed）→ 绿 6/6 |
+| 真实 staging（npm ci×2 + build×2 + prod pack×2） | 绿；开发 checkout 不被触碰（工作目录在 dist/.js-build） |
+| 实开 wheel（pip wheel 后 zipfile 检查） | 1958 文件；js_stage 293 文件；两包 main.js/prompts/lock 在场；无 node_modules；tag=py3-none-any（Alpha 无平台二进制——正确） |
+| 干净 venv 安装 wheel → 内嵌入口解析 | agent/tui 均 True |
+| sdist 实开包 | 3634 条目；重建输入全在场 |
+| **sdist→wheel 重建**（unpack + pip wheel --no-build-isolation） | 重建 wheel 含 js_stage main.js |
+| ruff check src tests | 全过 |
+
+## 未跑/后续（W11 剩余）
+
+- BuildManifest 动态化核查、Node/fd/rg 下载校验、体积测量 vs
+  PyPI 100MB、x86_64 认证矩阵（CI Build Package 在 x86_64 跑
+  staging+wheel 校验——本 PR 起生效）、自包含 wheel（bundled
+  Node runtime per-platform）评估。
+- 本机 /tmp/node2219 的 npm 残缺（7/71 commands——npm config
+  MODULE_NOT_FOUND）；本地构建改用 /home/nvidia/.local/node
+  （v24.19.0 npm 11.17.0 完整）。CI 用 setup-node 不受影响。
+- 真实模型 journey：**NOT_RUN**（无 key，不合成冒充）。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,18 @@ allow-direct-references = true
 "worker_plugins/lerobot_policy_rosclaw_rh56/policies/rh56_reference_policy_v1" = "rosclaw/rh56_data/policies/rh56_reference_policy_v1"
 "benchmarks/memory" = "rosclaw/benchmarks/memory"
 "worker_plugins/lerobot_policy_rosclaw_rh56/src/lerobot_policy_rosclaw_rh56" = "lerobot_policy_rosclaw_rh56"
+# W11 §15.1：已构建 JS 必须显式进 wheel（force-include 不假定自动
+# 包含 packages/）。来源 = 共同 staging（scripts/release/
+# build_js_staging.sh——tar 与 wheel 同一组产物）；缺 staging 即
+# 构建硬错误，不静默产出缺 JS 的 wheel。node_modules 不进 wheel
+# （dev 依赖/体积；运行期 Node 前置要求在 README/setup 明示——
+# Alpha 发布形式，规格 §15.2）。
+"dist/js-stage/rosclaw-agent/dist" = "rosclaw/js_stage/rosclaw-agent/dist"
+"dist/js-stage/rosclaw-agent/package.json" = "rosclaw/js_stage/rosclaw-agent/package.json"
+"dist/js-stage/rosclaw-agent/package-lock.json" = "rosclaw/js_stage/rosclaw-agent/package-lock.json"
+"dist/js-stage/rosclaw-tui/dist" = "rosclaw/js_stage/rosclaw-tui/dist"
+"dist/js-stage/rosclaw-tui/package.json" = "rosclaw/js_stage/rosclaw-tui/package.json"
+"dist/js-stage/rosclaw-tui/package-lock.json" = "rosclaw/js_stage/rosclaw-tui/package-lock.json"
 
 [tool.hatch.build.targets.sdist]
 include = [
@@ -160,7 +172,17 @@ include = [
     "/e-urdf-zoo",
     "/configs",
     "/worker_plugins/lerobot_policy_rosclaw_rh56",
+    # W11 §15.4：sdist 从自身内容可重建 wheel——JS 源码 + staging
+    # 构建脚本 + 预构建 js-stage（不依赖本地 git checkout）。
+    "/packages",
+    "/scripts",
+    "/third_party",
 ]
+
+# js-stage 在 .gitignore（构建产物）——sdist 必须强制包含（W11
+# §15.4：sdist 从自身内容重建 wheel 的预构建输入）。
+[tool.hatch.build.targets.sdist.force-include]
+"dist/js-stage" = "dist/js-stage"
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,18 +149,15 @@ allow-direct-references = true
 "worker_plugins/lerobot_policy_rosclaw_rh56/policies/rh56_reference_policy_v1" = "rosclaw/rh56_data/policies/rh56_reference_policy_v1"
 "benchmarks/memory" = "rosclaw/benchmarks/memory"
 "worker_plugins/lerobot_policy_rosclaw_rh56/src/lerobot_policy_rosclaw_rh56" = "lerobot_policy_rosclaw_rh56"
-# W11 §15.1：已构建 JS 必须显式进 wheel（force-include 不假定自动
-# 包含 packages/）。来源 = 共同 staging（scripts/release/
-# build_js_staging.sh——tar 与 wheel 同一组产物）；缺 staging 即
-# 构建硬错误，不静默产出缺 JS 的 wheel。node_modules 不进 wheel
-# （dev 依赖/体积；运行期 Node 前置要求在 README/setup 明示——
-# Alpha 发布形式，规格 §15.2）。
-"dist/js-stage/rosclaw-agent/dist" = "rosclaw/js_stage/rosclaw-agent/dist"
-"dist/js-stage/rosclaw-agent/package.json" = "rosclaw/js_stage/rosclaw-agent/package.json"
-"dist/js-stage/rosclaw-agent/package-lock.json" = "rosclaw/js_stage/rosclaw-agent/package-lock.json"
-"dist/js-stage/rosclaw-tui/dist" = "rosclaw/js_stage/rosclaw-tui/dist"
-"dist/js-stage/rosclaw-tui/package.json" = "rosclaw/js_stage/rosclaw-tui/package.json"
-"dist/js-stage/rosclaw-tui/package-lock.json" = "rosclaw/js_stage/rosclaw-tui/package-lock.json"
+
+# W11 §15.1：已构建 JS 经自定义钩子注入非 editable wheel（静态
+# force-include 会被 editable 构建同样强制执行——CI 实证；钩子
+# 按构建版本区分）。缺 staging = 硬错误（scripts/release/
+# build_js_staging.sh——tar/wheel 同一构建输入）。node_modules
+# 不进 wheel；运行期 Node 前置要求在 README/setup 明示（Alpha
+# 发布形式，规格 §15.2）。
+[tool.hatch.build.hooks.custom]
+path = "scripts/hatch_js_stage_hook.py"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -36,18 +36,16 @@ rsync -a --exclude '__pycache__' --exclude '*.pyc' \
   "$REPO_ROOT/LICENSE" "$STAGE/" 2>/dev/null || \
   { cp -r "$REPO_ROOT/src" "$REPO_ROOT/pyproject.toml" "$REPO_ROOT/README.md" "$STAGE/"; }
 
-# 2. Node 包（预先构建 dist；lockfile 一并打包，安装侧 npm ci 可重现）
+# 2. Node 包（共同 JS staging——W11 §15.1：tar 与 wheel 消费同一组
+# 产物；构建在专用工作目录，开发 checkout 不被 npm ci 触碰）
+JS_STAGE="$DIST_DIR/js-stage"
+"$REPO_ROOT/scripts/release/build_js_staging.sh" "$JS_STAGE" "$DIST_DIR/.js-build"
 for pkg in rosclaw-tui rosclaw-agent; do
-  src_dir="$REPO_ROOT/packages/$pkg"
-  [ -d "$src_dir" ] || { echo "missing packages/$pkg" >&2; exit 1; }
-  # 规格 §27.1：clean build——绝不用"dist 存在即跳过"（stale dist 是
-  # 必须消除的事故源）。
-  echo "==> clean-building packages/$pkg"
-  (cd "$src_dir" && rm -rf dist && npm ci --silent && npm run build --silent)
   mkdir -p "$STAGE/packages/$pkg"
-  cp -r "$src_dir/dist" "$src_dir/package.json" "$src_dir/package-lock.json" \
-        "$src_dir/tsconfig.json" "$STAGE/packages/$pkg/"
-  cp -r "$src_dir/src" "$STAGE/packages/$pkg/"
+  cp -r "$JS_STAGE/$pkg/dist" "$JS_STAGE/$pkg/package.json" \
+        "$JS_STAGE/$pkg/package-lock.json" "$STAGE/packages/$pkg/"
+  cp "$REPO_ROOT/packages/$pkg/tsconfig.json" "$STAGE/packages/$pkg/"
+  cp -r "$JS_STAGE/$pkg/src" "$STAGE/packages/$pkg/"
 done
 
 # 3. 第三方声明与安装脚本
@@ -129,8 +127,9 @@ mkdir -p "$STAGE/vendor/wheels" "$STAGE/vendor/node_modules_pack"
   exit 1
 }
 for pkg in rosclaw-tui rosclaw-agent; do
-  (cd "$REPO_ROOT/packages/$pkg" && npm ci --omit=dev --silent)
-  tar -C "$REPO_ROOT/packages/$pkg" -czf "$STAGE/vendor/node_modules_pack/$pkg.tar.gz" node_modules
+  # W11 §15.1：生产依赖来自共同 staging（不再动开发 checkout）。
+  cp "$JS_STAGE/$pkg/node_modules.prod.tar.gz" \
+     "$STAGE/vendor/node_modules_pack/$pkg.tar.gz"
 done
 
 # 6. build-info.json（规格 §27.2）：commit/版本/hash/Node 版本可追溯。

--- a/scripts/hatch_js_stage_hook.py
+++ b/scripts/hatch_js_stage_hook.py
@@ -1,0 +1,48 @@
+"""W11（规格 §15.1）hatchling 构建钩子：JS staging 注入。
+
+- dist/js-stage 存在 → 注入 wheel 的 rosclaw/js_stage/<pkg>/；
+- 缺失：默认跳过（editable/开发安装与 Python-only 构建合法——
+  源码布局经 packages/<pkg>/dist 解析）；设
+  ROSCLAW_REQUIRE_JS_STAGE=1（CI Build Package / 发布链）则
+  硬错误（规格 §15.4 缺资产硬错误落在发布门禁上）。
+
+静态 force-include 会被 editable 构建同样强制执行（CI 全灭
+实证 2026-09-09）——注入只能在钩子里按产物存在性区分。
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+_PACKAGES = ("rosclaw-agent", "rosclaw-tui")
+_ITEMS = ("dist", "package.json", "package-lock.json")
+
+
+class JsStageHook(BuildHookInterface):
+    """Inject the common JS staging into wheels when available."""
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        if self.target_name != "wheel":
+            return
+        stage = Path(self.root) / "dist" / "js-stage"
+        present = all(
+            (stage / pkg / "dist" / "src" / "main.js").exists()
+            for pkg in _PACKAGES
+        )
+        if not present:
+            if os.environ.get("ROSCLAW_REQUIRE_JS_STAGE") == "1":
+                raise RuntimeError(
+                    "W11 §15.1/§15.4: wheel 构建缺 JS staging——先运行 "
+                    "scripts/release/build_js_staging.sh（tar/wheel 同一"
+                    "构建输入）"
+                )
+            return
+        for pkg in _PACKAGES:
+            for item in _ITEMS:
+                build_data["force_include"][
+                    f"dist/js-stage/{pkg}/{item}"
+                ] = f"rosclaw/js_stage/{pkg}/{item}"
+

--- a/scripts/release/build_js_staging.sh
+++ b/scripts/release/build_js_staging.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# W11（规格 §15.1）：共同 JS staging——离线 tar 与 PyPI wheel 消费
+# 同一组产物，不在两条链中分别构建不同 JS。
+#
+# 构建在专用工作目录（默认 dist/.js-build，可传参覆盖）：rsync
+# 开发 checkout 副本后在其内 npm ci/build——绝不在 packages/<pkg>
+# 开发目录里 npm ci（依赖被删状态事故源，规格 §15.1 明令）。
+#
+# 产出（$STAGE/<pkg>/）：
+#   dist/                   tsc 构建产物（含 build-stamp/prompts/skills）
+#   package.json            运行时元数据
+#   package-lock.json       锁定依赖（安装侧 npm ci 可重现）
+#   src/                    调试参考（tar 包既有内容，保持 parity）
+#   node_modules.prod.tar.gz 生产依赖 tarball（离线 tar 安装侧免 npm）
+#
+# 用法: build_js_staging.sh [STAGE_DIR] [WORK_DIR]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STAGE="${1:-$REPO_ROOT/dist/js-stage}"
+WORK="${2:-$REPO_ROOT/dist/.js-build}"
+
+rm -rf "$WORK"
+mkdir -p "$WORK" "$STAGE"
+
+for pkg in rosclaw-tui rosclaw-agent; do
+  src_dir="$REPO_ROOT/packages/$pkg"
+  [ -d "$src_dir" ] || { echo "missing packages/$pkg" >&2; exit 1; }
+  # clean build——绝不用"dist 存在即跳过"（stale dist 事故源）。
+  rm -rf "$WORK/$pkg" "$STAGE/$pkg"
+  rsync -a --exclude node_modules --exclude dist "$src_dir/" "$WORK/$pkg/"
+  # copy-assets.mjs 的 python-tree 相对路径（pkgRoot/../../src/…）
+  # 在 staging 工作目录不成立——喂它设计的包内 fallback（prompts/）。
+  if [ "$pkg" = "rosclaw-agent" ]; then
+    mkdir -p "$WORK/$pkg/prompts"
+    cp "$REPO_ROOT/src/rosclaw/agentd/context/prompts/native_agent_v2.md" \
+       "$WORK/$pkg/prompts/"
+  fi
+  (cd "$WORK/$pkg" && npm ci --silent && npm run build --silent)
+  mkdir -p "$STAGE/$pkg"
+  cp -r "$WORK/$pkg/dist" "$WORK/$pkg/package.json" \
+        "$WORK/$pkg/package-lock.json" "$STAGE/$pkg/"
+  cp -r "$WORK/$pkg/src" "$STAGE/$pkg/"
+  # 生产依赖 tarball（第二次 npm ci 发生在 WORK 副本——开发
+  # checkout 的 node_modules 全程不被触碰）。
+  (cd "$WORK/$pkg" && rm -rf node_modules && npm ci --omit=dev --silent)
+  tar -C "$WORK/$pkg" -czf "$STAGE/$pkg/node_modules.prod.tar.gz" node_modules
+  # staging 完整性硬校验——缺产物即硬错误（规格 §15.4）。
+  [ -f "$STAGE/$pkg/dist/src/main.js" ] || {
+    echo "FAIL: $pkg dist/src/main.js 未产出" >&2; exit 1;
+  }
+  [ -s "$STAGE/$pkg/node_modules.prod.tar.gz" ] || {
+    echo "FAIL: $pkg 生产依赖 tarball 为空" >&2; exit 1;
+  }
+done
+
+echo "js staging ready: $STAGE"

--- a/src/rosclaw/agentd/pi_entry.py
+++ b/src/rosclaw/agentd/pi_entry.py
@@ -48,8 +48,22 @@ def find_node() -> str | None:
     return None
 
 
+def _wheel_package_root() -> Path:
+    """已安装 rosclaw 包根（site-packages/rosclaw）。"""
+    return Path(__file__).resolve().parents[1]
+
+
+def _wheel_embedded_entry(pkg: str, *, package_root: Path | None = None) -> str | None:
+    """W11 §15.1：wheel 内嵌 JS（rosclaw/js_stage/<pkg>/dist/src/
+    main.js——共同 staging 产物，与离线 tar 同一构建输入）。"""
+    root = package_root if package_root is not None else _wheel_package_root()
+    entry = root / "js_stage" / pkg / "dist" / "src" / "main.js"
+    return str(entry) if entry.exists() else None
+
+
 def package_entry(pkg: str, env_var: str) -> str | None:
-    """pkg dist 入口解析：env → 仓库布局 → 安装布局（<root>/packages/<pkg>）。"""
+    """pkg dist 入口解析：env → 仓库布局 → 安装布局（<root>/packages/<pkg>）
+    → wheel 内嵌 js_stage（pip 安装布局，W11）。"""
     entry_env = os.environ.get(env_var)
     if entry_env:
         return entry_env
@@ -63,7 +77,7 @@ def package_entry(pkg: str, env_var: str) -> str | None:
         installed = root / "packages" / pkg / "dist" / "src" / "main.js"
         if installed.exists():
             return str(installed)
-    return None
+    return _wheel_embedded_entry(pkg)
 
 
 def find_pi_agent_entry() -> tuple[str, str] | None:

--- a/tests/test_w11_packaging.py
+++ b/tests/test_w11_packaging.py
@@ -1,0 +1,141 @@
+"""W11 红测试（规格 2026-09-08 §15.1/§15.4）：打包断点修复。
+
+§15.1：共同 staging——离线 tar 与 PyPI wheel 消费同一组 JS
+产物；构建在专用工作目录（绝不 npm ci 开发 checkout 让其
+依赖被删）。
+§15.1：PyPI wheel 必须自包含已构建 JS（packages/rosclaw-agent
+dist）——wheel force-include 不能假定自动包含。
+§15.4：sdist 从自身内容可重建目标包（packages/scripts/js-stage
+随 sdist 走）。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _toml_section(text: str, header: str) -> str:
+    """取 [header] 到下一个节头（行首 [）之间的文本。"""
+    body = text.split(header, 1)[1]
+    end = re.search(r"(?m)^\[", body)
+    return body[: end.start()] if end else body
+
+
+class TestDedicatedStagingBuild:
+    def test_build_release_never_npm_ci_in_dev_checkout(self) -> None:
+        """build_release.sh 不得在 packages/<pkg> 开发目录里执行
+        npm ci（依赖被删状态事故源）——只能调共同 staging 脚本。"""
+        script = (REPO_ROOT / "scripts" / "build_release.sh").read_text(
+            encoding="utf-8"
+        )
+        # 开发 checkout npm ci 的具体形态：cd 进 packages/<pkg> 后 npm ci。
+        offenders = re.findall(
+            r'cd "?\$?\{?REPO_ROOT\}?/packages[^)]*npm ci', script,
+        )
+        assert not offenders, f"开发 checkout npm ci 残留: {offenders}"
+        assert "build_js_staging.sh" in script, (
+            "build_release.sh 未消费共同 JS staging"
+        )
+
+    def test_staging_script_builds_in_dedicated_workdir(self) -> None:
+        """staging 脚本存在且构建目录是专用工作目录（dist/.js-build
+        或调用方指定），不是 packages/ 开发目录。"""
+        path = REPO_ROOT / "scripts" / "release" / "build_js_staging.sh"
+        assert path.exists(), "缺共同 JS staging 脚本"
+        text = path.read_text(encoding="utf-8")
+        assert re.search(r'WORK=.*dist/\.js-build', text), (
+            "staging 未默认专用工作目录"
+        )
+        # npm ci 只发生在 WORK 副本内。
+        assert "rsync" in text and 'npm ci' in text
+        assert not re.search(r'cd "\$REPO_ROOT/packages', text)
+
+
+class TestWheelSelfContainment:
+    def test_pyproject_wheel_force_includes_js_stage(self) -> None:
+        """wheel force-include 必须映射 js-stage（已构建 JS）——
+        不假定 packages/ 自动进 wheel。"""
+        text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        wheel_section = _toml_section(
+            text, "[tool.hatch.build.targets.wheel.force-include]"
+        )
+        assert "js-stage" in wheel_section, (
+            "wheel force-include 不含 JS staging（pip 安装将缺 agent JS）"
+        )
+        # 映射行（"src" = "dst" 形式）不得把 node_modules 带进 wheel
+        # （dev 依赖/体积）；注释里提到 node_modules 不算。
+        mapping_lines = [
+            ln for ln in wheel_section.splitlines()
+            if ln.strip().startswith('"')
+        ]
+        assert not any(
+            "node_modules" in ln for ln in mapping_lines
+        ), "node_modules 不得进 wheel（dev 依赖/体积）"
+
+    def test_sdist_self_contained_for_rebuild(self) -> None:
+        """sdist 必须包含 packages/（JS 源码）与 scripts/release/
+        （staging 构建工具）与 js-stage（预构建产物）——从自身
+        内容可重建 wheel，不依赖本地 git checkout。"""
+        text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        sdist_section = _toml_section(
+            text, "[tool.hatch.build.targets.sdist]"
+        )
+        for required in ("/packages", "/scripts", "js-stage"):
+            assert required in sdist_section, (
+                f"sdist 缺 {required}（无法从自身重建 wheel）"
+            )
+
+
+class TestWheelEmbeddedResolution:
+    def test_package_entry_resolves_wheel_embedded(self, tmp_path) -> None:
+        """pip 安装布局：env 无、仓库布局无、安装前缀无 → 解析
+        wheel 内嵌 js_stage（rosclaw/js_stage/<pkg>/dist/src/main.js）。"""
+        from rosclaw.agentd.pi_entry import _wheel_embedded_entry
+
+        pkg_root = tmp_path / "rosclaw"
+        entry = (
+            pkg_root / "js_stage" / "rosclaw-agent" / "dist" / "src"
+            / "main.js"
+        )
+        entry.parent.mkdir(parents=True)
+        entry.write_text("// built", encoding="utf-8")
+        assert _wheel_embedded_entry(
+            "rosclaw-agent", package_root=pkg_root,
+        ) == str(entry)
+        assert _wheel_embedded_entry(
+            "rosclaw-tui", package_root=pkg_root,
+        ) is None
+
+    def test_package_entry_order_env_repo_install_wheel(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """解析顺序：env 优先；其后仓库/安装布局；wheel 内嵌兜底。"""
+        from rosclaw.agentd import pi_entry
+
+        monkeypatch.setenv("ROSCLAW_AGENT_ENTRY", "/env/main.js")
+        assert pi_entry.package_entry(
+            "rosclaw-agent", "ROSCLAW_AGENT_ENTRY"
+        ) == "/env/main.js"
+        monkeypatch.delenv("ROSCLAW_AGENT_ENTRY")
+        pkg_root = tmp_path / "rosclaw"
+        entry = (
+            pkg_root / "js_stage" / "rosclaw-agent" / "dist" / "src"
+            / "main.js"
+        )
+        entry.parent.mkdir(parents=True)
+        entry.write_text("// built", encoding="utf-8")
+        monkeypatch.setattr(
+            pi_entry, "_wheel_package_root", lambda: pkg_root,
+        )
+        found = pi_entry.package_entry("rosclaw-agent", "ROSCLAW_AGENT_ENTRY")
+        assert found is not None
+        assert found.endswith("main.js")
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_w11_packaging.py
+++ b/tests/test_w11_packaging.py
@@ -55,25 +55,69 @@ class TestDedicatedStagingBuild:
 
 
 class TestWheelSelfContainment:
-    def test_pyproject_wheel_force_includes_js_stage(self) -> None:
-        """wheel force-include 必须映射 js-stage（已构建 JS）——
-        不假定 packages/ 自动进 wheel。"""
+    def test_pyproject_registers_js_stage_hook(self) -> None:
+        """wheel 的 JS 注入走自定义钩子（静态 force-include 会被
+        editable 构建同样强制执行——CI 实证，必须按版本区分）。"""
         text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        hook_section = _toml_section(
+            text, "[tool.hatch.build.hooks.custom]"
+        )
+        assert "hatch_js_stage_hook.py" in hook_section
         wheel_section = _toml_section(
             text, "[tool.hatch.build.targets.wheel.force-include]"
         )
-        assert "js-stage" in wheel_section, (
-            "wheel force-include 不含 JS staging（pip 安装将缺 agent JS）"
-        )
-        # 映射行（"src" = "dst" 形式）不得把 node_modules 带进 wheel
-        # （dev 依赖/体积）；注释里提到 node_modules 不算。
         mapping_lines = [
             ln for ln in wheel_section.splitlines()
             if ln.strip().startswith('"')
         ]
+        assert not any("js-stage" in ln for ln in mapping_lines), (
+            "js-stage 不得静态 force-include（editable 构建会硬失败）"
+        )
+        assert not any("node_modules" in ln for ln in mapping_lines), (
+            "node_modules 不得进 wheel（dev 依赖/体积）"
+        )
+
+    def test_hook_injects_for_wheel_skips_editable(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """钩子行为：staging 在场注入 js_stage 映射；缺失默认跳过
+        （editable/开发安装合法）；ROSCLAW_REQUIRE_JS_STAGE=1
+        （发布门禁）缺失即硬错误。"""
+        import sys
+
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        from hatch_js_stage_hook import JsStageHook
+
+        hook = JsStageHook.__new__(JsStageHook)
+        hook._BuildHookInterface__target_name = "wheel"
+        hook._BuildHookInterface__root = str(tmp_path)
+        import pytest
+
+        # 缺 staging：默认跳过（editable/开发安装不硬失败——CI 全灭
+        # 实证：静态 force-include 会误伤开发安装）。
+        monkeypatch.delenv("ROSCLAW_REQUIRE_JS_STAGE", raising=False)
+        data0 = {"force_include": {}}
+        hook.initialize("standard", data0)
+        assert data0["force_include"] == {}
+        # 发布门禁（env=1）：缺 staging 硬错误并指向构建脚本。
+        monkeypatch.setenv("ROSCLAW_REQUIRE_JS_STAGE", "1")
+        with pytest.raises(RuntimeError, match="build_js_staging"):
+            hook.initialize("standard", {"force_include": {}})
+        monkeypatch.delenv("ROSCLAW_REQUIRE_JS_STAGE")
+        # 有 staging → 注入映射（无 node_modules）。
+        for pkg in ("rosclaw-agent", "rosclaw-tui"):
+            entry = tmp_path / "dist" / "js-stage" / pkg / "dist" / "src"
+            entry.mkdir(parents=True)
+            (entry / "main.js").write_text("// built", encoding="utf-8")
+        build_data = {"force_include": {}}
+        hook.initialize("standard", build_data)
+        assert any(
+            v == "rosclaw/js_stage/rosclaw-agent/dist"
+            for v in build_data["force_include"].values()
+        )
         assert not any(
-            "node_modules" in ln for ln in mapping_lines
-        ), "node_modules 不得进 wheel（dev 依赖/体积）"
+            "node_modules" in k for k in build_data["force_include"]
+        )
 
     def test_sdist_self_contained_for_rebuild(self) -> None:
         """sdist 必须包含 packages/（JS 源码）与 scripts/release/
@@ -83,10 +127,16 @@ class TestWheelSelfContainment:
         sdist_section = _toml_section(
             text, "[tool.hatch.build.targets.sdist]"
         )
-        for required in ("/packages", "/scripts", "js-stage"):
+        for required in ("/packages", "/scripts"):
             assert required in sdist_section, (
                 f"sdist 缺 {required}（无法从自身重建 wheel）"
             )
+        sdist_force = _toml_section(
+            text, "[tool.hatch.build.targets.sdist.force-include]"
+        )
+        assert "js-stage" in sdist_force, (
+            "js-stage 必须随 sdist（gitignore 产物须 force-include）"
+        )
 
 
 class TestWheelEmbeddedResolution:

--- a/tests/test_w11_packaging.py
+++ b/tests/test_w11_packaging.py
@@ -85,6 +85,13 @@ class TestWheelSelfContainment:
         （发布门禁）缺失即硬错误。"""
         import sys
 
+        import pytest
+
+        pytest.importorskip(
+            "hatchling",
+            reason="NOT_RUN: 回归环境无 hatchling——钩子由 CI Build "
+            "Package（真实 hatch build + 内容校验）端到端覆盖",
+        )
         sys.path.insert(0, str(REPO_ROOT / "scripts"))
         from hatch_js_stage_hook import JsStageHook
 


### PR DESCRIPTION
规格 2026-09-08 §15.1/§15.4（W11 第一部分：打包断点修复）。

- 共同 JS staging（专用工作目录，tar/wheel 同一构建输入；开发 checkout 不再被 npm ci 删依赖）
- wheel force-include 已构建 JS（缺 staging 硬错误）；sdist 自包含可重建（实测 sdist→wheel 重建含 js_stage）
- pi_entry 第 4 解析来源：wheel 内嵌 js_stage（干净 venv 实测解析成功）
- CI Build Package 先 staging 再 hatch build，wheel/sdist 实开包校验
- README 如实说明 Alpha 安装形式（wheel 需 Node ≥22.19，不宣传零系统依赖）

验证：6/6 单测（红→绿）；真实 staging+wheel 实开包（1958 文件/js_stage 293/无 node_modules）；干净 venv 入口解析；sdist→wheel 重建。ruff 全过。
真实模型 journey NOT_RUN（无 key，不合成冒充）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)