### PR TITLE
W07: artifact CLI contract tests + export no silent overwrite (spec §11)

### DIFF
--- a/docs/implementation/w07-ui-delivery.md
+++ b/docs/implementation/w07-ui-delivery.md
@@ -1,0 +1,45 @@
+# W07 用户界面、路径和远程交付（规格 §11）
+
+**分支**：a-w07-ui-delivery（基于 main=06a8918b，§17 依赖：W07←W04–W06 已合入）
+**日期**：2026-09-09
+
+## 现状盘点（保留已有可用实现）
+
+- `rosclaw artifact list/show/path/open/export` + `rosclaw open`
+  重写（同一 handler，无第二实现）——0901 P0-1 / 0902 R3-a 已建；
+  安装产物可达性已有 journey 硬 Gate（list/open 不回落顶层帮助）。
+- 无显示环境 open → 绝对路径 + 导出提示（OSC 8 不假装把远程
+  文件带到本机）；桌面 xdg-open 只说「已交给系统默认程序」
+  （不声称用户已看过）。
+- §11.1 界面减法（只显示目标/进度/结果）已由大道至简 R2 落地。
+
+## 发现的缺口（已修）
+
+- `cmd_artifact_export` 目标已存在时**静默覆盖**（与 §6.4
+  api.export 的 EXPORT_TARGET_EXISTS 纪律矛盾——导出是证据链
+  动作）：改为拒绝并提示（rc=4）。
+
+## 新增测试（tests/agentd/test_w07_ui_delivery.py，6 例）
+
+真实 handler + 真实账本（MissionStore DB + TaskKernel 登记）经
+`entrypoint._dispatch` 全链：
+- help 列五个子命令；
+- 合法 ID 无显示环境 → 绝对路径 + 导出提示，不声称已打开；
+- 未知 ID rc=2；登记后文件被删 rc=3（诚实报缺失）；
+- 导出内容一致 + 目标存在拒绝静默覆盖（红→绿：基线静默覆盖）；
+- `rosclaw open <id>` 重写可达（同一 handler）。
+
+## 验证
+
+| 测试 | 结果 |
+|---|---|
+| test_w07_ui_delivery.py | 红 1（静默覆盖）→ 绿 6/6 |
+| tests/cli + root_cli + a0902_r3a + a0901_p02 + a0902_review | 53 全过 |
+| ruff check src tests | 全过 |
+
+## 边界说明
+
+- 多会话歧义/`latest` 作用域：legacy `explain` 的 run_reference
+  是旧 CLI 面；产品面 artifact 命令以 artifact_id 为准（无
+  latest 猜测语义需要修）。
+- 真实模型 journey：**NOT_RUN**（无 key，不合成冒充）。

--- a/src/rosclaw/agentd/cli.py
+++ b/src/rosclaw/agentd/cli.py
@@ -261,6 +261,11 @@ def cmd_artifact_export(args: argparse.Namespace) -> int:
     dest = Path(str(args.dest))
     if dest.is_dir():
         dest = dest / src.name
+    # W07 §11.2/§6.4：目标已存在不静默覆盖（与 api.export 的
+    # EXPORT_TARGET_EXISTS 同一纪律——导出是证据链动作）。
+    if dest.exists():
+        print(f"导出目标已存在：{dest}（不静默覆盖——换个路径或先删除）")
+        return 4
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dest)
     print(f"已导出：{dest}（{view['size_bytes']}B，{view['digest'][:19]}…）")

--- a/tests/agentd/test_w07_ui_delivery.py
+++ b/tests/agentd/test_w07_ui_delivery.py
@@ -1,0 +1,130 @@
+"""W07 红测试（规格 2026-09-08 §11.2/§11.3）：交付面 CLI 真实行为。
+
+§11.2：help、合法 ID、未知 ID、文件缺失、导出——真实 handler
+行为（不平行实现第二个 dispatcher）。
+§11.3：无显示环境给可复制路径 + 导出提示（OSC 8 file URL 不是
+依赖）；导出不静默覆盖既有文件。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _home_with_artifact(tmp_path: Path) -> tuple[Path, str, Path]:
+    """真实账本：MissionStore DB + TaskKernel 登记的交付物。"""
+    from rosclaw.storage.migrations import MigrationRunner
+    from rosclaw.task_kernel.service import TaskKernel
+
+    home = tmp_path / "home"
+    db = home / "agentd" / "missions.db"
+    db.parent.mkdir(parents=True)
+    conn = sqlite3.connect(str(db), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    MigrationRunner().apply(conn, "sqlite")
+    kernel = TaskKernel(conn, home)
+    kernel.persist_input(
+        mission_id="mis_1", session_ref="s1",
+        message_id="msg_1", text="生成交付物",
+    )
+    bound = kernel.ensure_task_for_effect(
+        mission_id="mis_1", session_ref="s1",
+        backend_native_id="s1", cwd=str(tmp_path),
+    )
+    payload = tmp_path / "report.txt"
+    payload.write_text("交付内容", encoding="utf-8")
+    art = kernel.register_artifact(
+        task_id=str(bound["task_id"]), path=str(payload),
+        media_type="text/plain", producer="kernel:test",
+    )
+    conn.commit()
+    conn.close()
+    return home, str(art["artifact_id"]), payload
+
+
+def _run(argv: list[str], home: Path, monkeypatch, capsys):
+    """经 entrypoint._dispatch 真实路由（不绕过 dispatch 链）。"""
+    monkeypatch.setenv("ROSCLAW_HOME", str(home))
+    from rosclaw.entrypoint import _dispatch
+
+    rc = _dispatch(argv)
+    out = capsys.readouterr()
+    return rc, out.out + out.err
+
+
+class TestArtifactCliContract:
+    def test_help_lists_subcommands(self, tmp_path, monkeypatch, capsys) -> None:
+        home, _art, _p = _home_with_artifact(tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            _run(["artifact", "--help"], home, monkeypatch, capsys)
+        assert exc.value.code == 0
+        text = capsys.readouterr().out
+        for sub in ("list", "show", "path", "open", "export"):
+            assert sub in text
+
+    def test_list_and_open_valid_id_no_display(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        """合法 ID + 无显示环境 → 给绝对路径 + 导出提示（不假装
+        打开了查看器，OSC 8 file URL 不是依赖）。"""
+        home, art_id, payload = _home_with_artifact(tmp_path)
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        rc, out = _run(["artifact", "list"], home, monkeypatch, capsys)
+        assert rc == 0 and art_id in out
+        rc, out = _run(["artifact", "open", art_id], home, monkeypatch, capsys)
+        assert rc == 0
+        assert str(payload) in out
+        assert "artifact export" in out
+        assert "已用系统默认程序打开" not in out, "无显示环境不得声称已打开"
+
+    def test_unknown_id_rc2(self, tmp_path, monkeypatch, capsys) -> None:
+        home, _art, _p = _home_with_artifact(tmp_path)
+        rc, out = _run(
+            ["artifact", "open", "art_nonexistent"], home, monkeypatch, capsys,
+        )
+        assert rc == 2 and "未知交付物" in out
+
+    def test_missing_file_rc3(self, tmp_path, monkeypatch, capsys) -> None:
+        home, art_id, payload = _home_with_artifact(tmp_path)
+        payload.unlink()  # 登记后文件被删——诚实报缺失
+        rc, out = _run(["artifact", "open", art_id], home, monkeypatch, capsys)
+        assert rc == 3 and "缺失" in out
+
+    def test_export_and_no_silent_overwrite(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        """导出到指定路径；目标已存在时拒绝静默覆盖（§11.2/§6.4
+        同一纪律——api.export 已是 EXPORT_TARGET_EXISTS）。"""
+        home, art_id, payload = _home_with_artifact(tmp_path)
+        dest = tmp_path / "out" / "copy.txt"
+        rc, out = _run(
+            ["artifact", "export", art_id, str(dest)],
+            home, monkeypatch, capsys,
+        )
+        assert rc == 0 and dest.read_text(encoding="utf-8") == "交付内容"
+        rc, out = _run(
+            ["artifact", "export", art_id, str(dest)],
+            home, monkeypatch, capsys,
+        )
+        assert rc != 0 and "已存在" in out, (
+            "export 静默覆盖了既有文件"
+        )
+
+    def test_open_shortcut_rewrites_to_artifact_open(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        """`rosclaw open <id>` 重写为 artifact open（同一 handler，
+        无第二实现）——无显示环境同样给路径。"""
+        home, art_id, payload = _home_with_artifact(tmp_path)
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        rc, out = _run(["open", art_id], home, monkeypatch, capsys)
+        assert rc == 0 and str(payload) in out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
规格 2026-09-08 §11（W07，依赖 W04–W06 已合入）。

- 6 例真实 handler 测试经 entrypoint dispatch：help/合法 ID/未知 ID/文件缺失/导出/open 重写
- 修复：cmd_artifact_export 静默覆盖既有文件 → 拒绝（rc=4）
- 既有保留：无显示环境给路径+导出提示（OSC 8 不假装）；桌面只说已交给系统程序

验证：6/6（静默覆盖红→绿）；CLI 相关套件 53 全过；ruff 全过。真实模型 journey NOT_RUN。

🤖 Generated with [Claude Code](https://claude.com/claude-code)