### PR TITLE
W08: Pi 0.83.0 → 0.85.1 validated upgrade + reproducible candidate flow (spec §12)

### DIFF
--- a/docs/implementation/w08-pi-upgrade-0.85.1.md
+++ b/docs/implementation/w08-pi-upgrade-0.85.1.md
@@ -1,0 +1,53 @@
+# W08 Pi 0.83.0 → 0.85.1 升级（规格 §12）
+
+**分支**：a-w08-pi-upgrade（基于 main=06a8918b）
+**日期**：2026-09-09
+
+## 升级流程（§12.1 落地）
+
+`scripts/release/pi_upgrade_candidate.sh <version>`：专用工作目录
+内 bump pins（deps+overrides 两段对齐）→ `npm install
+--ignore-scripts` 重生成 lock（与补丁应用分开，失败可归因）→
+补丁重放（锚点漂移硬失败）→ 构建 → TS 套件 → JSON 报告
+（lock 摘要前后/逐步状态/回退命令）。真实模型 A/B 标 NOT_RUN
+（属 W10，不合成冒充）。
+
+## 0.85.1 候选实测（一轮完整执行）
+
+| 步骤 | 结果 |
+|---|---|
+| pin bump + lock 重生成 | ✅ lock sha256 e2c557e3→deeaa3cc |
+| 补丁重放（0.85.1 dist） | ✅ patch-01/02 锚点全命中，retire 幂等 |
+| 构建 | ❌→✅ 初始失败：`TUI` 在 0.85.1 变 type-only（拆分为接口 `TUI` + `TuiMainScreen`/`TuiAltScreen` 实现类） |
+| 兼容适配 | `new TUI(terminal)` → `new TuiMainScreen(terminal)`（implements TUI，成员经 TuiBase 不变）：`packages/rosclaw-tui/src/app.ts`、`packages/rosclaw-agent/src/harness/pi/pi-picker.ts` |
+| rosclaw-agent TS 套件 | ✅ 229 pass / 0 fail / 3 skip |
+| rosclaw-tui TS 套件 | ✅ 27/27 |
+| release bundle 构建（test_pna10_release，含 build-info） | ✅ 通过（含 wheel + Node bundle + SBOM 全链） |
+| wheel journey（安装产物 PTY） | CI 门禁跑（本 PR 触发） |
+| 真实模型 A/B | **NOT_RUN**（无 key——不合成冒充；W10 门禁） |
+
+## 单源化改动（§12.1-6 manifest 诚实）
+
+- `pi-upstream.lock.json` → 0.85.1 + tag commit d981de12 + 新
+  lock 摘要（升级记录单源）。
+- `build_release.sh` build-info 的 `pi_version`/`pi_commit` 从
+  锁定记录读——不再写死 0.83.0（W00 基线标注的 W11 项顺手关闭）。
+- pin 断言测试改为从单源读（test_pi_dependency_boundary /
+  package-entry.test.ts / test_pna10_release）。
+- 新增 `tests/test_w08_pi_upgrade.py`：pin 单源一致 + lock 摘要
+  防漂移 + 不写死守卫 + 补丁钉版重放（无 node_modules 跳过）。
+
+## 回退
+
+`git checkout` 本 PR 涉及的 package.json/package-lock.json/
+pi-upstream.lock.json/app.ts/pi-picker.ts 即回到 0.83.0（补丁
+在 0.83.0 上同样可重放——W01 起既有性质）；会话/Artifact 不受
+pin 影响（存储层无 Pi 版本耦合）。
+
+## 边界
+
+- §12.2 契约清单大部分由既有 journey/TS 套件覆盖（resume/
+  compact/幂等/abort 等在 CI 门禁）；真实模型 continuation
+  字段行为属 W10。
+- 定时 CI 自动开 candidate PR（§12.1-1）属工具化增强，本轮
+  交付可复现脚本 + 一轮实测；schedule 触发器留给后续。

--- a/packages/rosclaw-agent/package-lock.json
+++ b/packages/rosclaw-agent/package-lock.json
@@ -7,11 +7,12 @@
 		"": {
 			"name": "rosclaw-agent",
 			"version": "0.1.0",
+			"hasInstallScript": true,
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "0.83.0",
-				"@earendil-works/pi-ai": "0.83.0",
-				"@earendil-works/pi-coding-agent": "0.83.0",
-				"@earendil-works/pi-tui": "0.83.0"
+				"@earendil-works/pi-agent-core": "0.85.1",
+				"@earendil-works/pi-ai": "0.85.1",
+				"@earendil-works/pi-coding-agent": "0.85.1",
+				"@earendil-works/pi-tui": "0.85.1"
 			},
 			"bin": {
 				"rosclaw-agent": "dist/src/main.js"
@@ -25,12 +26,13 @@
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
-			"version": "0.91.1",
-			"resolved": "https://registry.npmmirror.com/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"version": "0.123.0",
+			"resolved": "https://registry.npmmirror.com/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+			"integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
 			"license": "MIT",
 			"dependencies": {
-				"json-schema-to-ts": "^3.1.1"
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
 			},
 			"bin": {
 				"anthropic-ai-sdk": "bin/cli"
@@ -119,17 +121,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.977.6",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/core/-/core-3.977.6.tgz",
-			"integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+			"version": "3.977.9",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/core/-/core-3.977.9.tgz",
+			"integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.2",
-				"@aws-sdk/xml-builder": "^3.972.37",
+				"@aws-sdk/types": "^3.974.5",
+				"@aws-sdk/xml-builder": "^3.972.40",
 				"@aws/lambda-invoke-store": "^0.3.0",
-				"@smithy/core": "^3.31.1",
+				"@smithy/core": "^3.33.3",
 				"@smithy/signature-v4": "^5.6.12",
-				"@smithy/types": "^4.16.1",
+				"@smithy/types": "^4.17.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -138,15 +140,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.67",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
-			"integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+			"version": "3.972.70",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+			"integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -154,17 +156,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.69",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
-			"integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+			"version": "3.972.72",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+			"integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/fetch-http-handler": "^5.6.13",
-				"@smithy/node-http-handler": "^4.9.13",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/fetch-http-handler": "^5.7.2",
+				"@smithy/node-http-handler": "^4.11.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -172,13 +174,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-			"version": "4.9.13",
-			"resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
-			"integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+			"version": "4.12.1",
+			"resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+			"integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.18.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -186,23 +188,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.973.12",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
-			"integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+			"version": "3.973.15",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+			"integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/credential-provider-env": "^3.972.67",
-				"@aws-sdk/credential-provider-http": "^3.972.69",
-				"@aws-sdk/credential-provider-login": "^3.972.74",
-				"@aws-sdk/credential-provider-process": "^3.972.67",
-				"@aws-sdk/credential-provider-sso": "^3.973.11",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.73",
-				"@aws-sdk/nested-clients": "^3.997.41",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/credential-provider-env": "^3.972.70",
+				"@aws-sdk/credential-provider-http": "^3.972.72",
+				"@aws-sdk/credential-provider-login": "^3.972.77",
+				"@aws-sdk/credential-provider-process": "^3.972.70",
+				"@aws-sdk/credential-provider-sso": "^3.973.14",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.76",
+				"@aws-sdk/nested-clients": "^3.997.44",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
 				"@smithy/credential-provider-imds": "^4.4.16",
-				"@smithy/types": "^4.16.1",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -210,16 +212,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.74",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
-			"integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+			"version": "3.972.77",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+			"integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/nested-clients": "^3.997.41",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/nested-clients": "^3.997.44",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -227,21 +229,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.78",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
-			"integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+			"version": "3.972.82",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+			"integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.67",
-				"@aws-sdk/credential-provider-http": "^3.972.69",
-				"@aws-sdk/credential-provider-ini": "^3.973.12",
-				"@aws-sdk/credential-provider-process": "^3.972.67",
-				"@aws-sdk/credential-provider-sso": "^3.973.11",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.73",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
+				"@aws-sdk/credential-provider-env": "^3.972.70",
+				"@aws-sdk/credential-provider-http": "^3.972.72",
+				"@aws-sdk/credential-provider-ini": "^3.973.15",
+				"@aws-sdk/credential-provider-process": "^3.972.70",
+				"@aws-sdk/credential-provider-sso": "^3.973.14",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.76",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
 				"@smithy/credential-provider-imds": "^4.4.16",
-				"@smithy/types": "^4.16.1",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -249,15 +251,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.67",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
-			"integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+			"version": "3.972.70",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+			"integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -265,17 +267,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.973.11",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
-			"integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+			"version": "3.973.14",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+			"integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/nested-clients": "^3.997.41",
-				"@aws-sdk/token-providers": "3.1103.0",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/nested-clients": "^3.997.44",
+				"@aws-sdk/token-providers": "3.1116.0",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -283,16 +285,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1103.0",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
-			"integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+			"version": "3.1116.0",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+			"integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/nested-clients": "^3.997.41",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/nested-clients": "^3.997.44",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -300,16 +302,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.73",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
-			"integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+			"version": "3.972.76",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+			"integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/nested-clients": "^3.997.41",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/nested-clients": "^3.997.44",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -317,14 +319,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.31",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
-			"integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
+			"version": "3.972.34",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+			"integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -332,14 +334,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.26",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
-			"integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
+			"version": "3.972.29",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+			"integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -347,17 +349,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.49",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.49.tgz",
-			"integrity": "sha512-wGYJvu1/stdWuzGcNyh44u8aY7ArU8XFrMesBlzIYn70HWVCRBNEngQexDuPIMu0NEgsKGKmTc0uvnS/bF7KWw==",
+			"version": "3.972.52",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+			"integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/fetch-http-handler": "^5.6.13",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/fetch-http-handler": "^5.7.2",
 				"@smithy/signature-v4": "^5.6.12",
-				"@smithy/types": "^4.16.1",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -365,18 +367,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.41",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
-			"integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+			"version": "3.997.44",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+			"integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.977.6",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.43",
-				"@aws-sdk/types": "^3.974.2",
-				"@smithy/core": "^3.31.1",
-				"@smithy/fetch-http-handler": "^5.6.13",
-				"@smithy/node-http-handler": "^4.9.13",
-				"@smithy/types": "^4.16.1",
+				"@aws-sdk/core": "^3.977.9",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.46",
+				"@aws-sdk/types": "^3.974.5",
+				"@smithy/core": "^3.33.3",
+				"@smithy/fetch-http-handler": "^5.7.2",
+				"@smithy/node-http-handler": "^4.11.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -384,13 +386,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-			"version": "4.9.13",
-			"resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
-			"integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+			"version": "4.12.1",
+			"resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+			"integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.18.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -398,14 +400,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.43",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
-			"integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+			"version": "3.996.46",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+			"integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.2",
+				"@aws-sdk/types": "^3.974.5",
 				"@smithy/signature-v4": "^5.6.12",
-				"@smithy/types": "^4.16.1",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -430,12 +432,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.974.2",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/types/-/types-3.974.2.tgz",
-			"integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+			"version": "3.974.5",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/types/-/types-3.974.5.tgz",
+			"integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.16.1",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -443,9 +445,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.965.8",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
-			"integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+			"version": "3.965.10",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+			"integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -455,12 +457,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmmirror.com/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
-			"integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+			"version": "3.972.40",
+			"resolved": "https://registry.npmmirror.com/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+			"integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.16.1",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -485,13 +487,27 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.83.0",
-			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
-			"integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==",
+		"node_modules/@earendil-works/chord": {
+			"version": "0.85.1",
+			"resolved": "https://registry.npmmirror.com/@earendil-works/chord/-/chord-0.85.1.tgz",
+			"integrity": "sha512-VDlkEC3dhCzQ5fcyH1OhG19dq+6jCn+rqc/iXFivwDYGR5anwo2RCiXij9PpHhqNR5GuhhE+Er69Zi1Sn4eY6w==",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.83.0",
+				"esbuild": "0.28.1"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.85.1",
+			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
+			"integrity": "sha512-hIXIP3eAWueAYiAl8aMvWCvvZ8Q5gT3Dip5bE5uJyIGh4+YlWRjtMLI4BaeoXoSs93zndjue61u1B/vhefLnuA==",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/chord": "^0.85.1",
+				"@earendil-works/pi-ai": "^0.85.1",
+				"@earendil-works/pi-telemetry": "^0.85.1",
 				"diff": "8.0.4",
 				"ignore": "7.0.5",
 				"typebox": "1.3.7",
@@ -502,20 +518,19 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.83.0",
-			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
-			"integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
+			"version": "0.85.1",
+			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+			"integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/sdk": "0.91.1",
+				"@anthropic-ai/sdk": "0.123.0",
 				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@earendil-works/pi-telemetry": "^0.85.1",
 				"@google/genai": "1.52.0",
-				"@mistralai/mistralai": "2.2.6",
-				"@opentelemetry/api": "1.9.0",
 				"@smithy/node-http-handler": "4.7.3",
 				"http-proxy-agent": "7.0.2",
 				"https-proxy-agent": "7.0.6",
-				"openai": "6.26.0",
+				"openai": "6.40.0",
 				"partial-json": "0.1.7",
 				"typebox": "1.3.7"
 			},
@@ -527,20 +542,21 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.83.0",
-			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.83.0.tgz",
-			"integrity": "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==",
+			"version": "0.85.1",
+			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.85.1.tgz",
+			"integrity": "sha512-FGRN+OHbWaefBPGaTggAdLjrIHW+s2PzLyglz/5dfLzb9of7uuXMXYC0fJIeZTw+shS32o2cuQ9jF7YSDuL/oQ==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.83.0",
-				"@earendil-works/pi-ai": "^0.83.0",
-				"@earendil-works/pi-tui": "^0.83.0",
+				"@earendil-works/chord": "^0.85.1",
+				"@earendil-works/pi-agent-core": "^0.85.1",
+				"@earendil-works/pi-ai": "^0.85.1",
+				"@earendil-works/pi-tui": "^0.85.1",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
 				"diff": "8.0.4",
-				"glob": "13.0.6",
+				"grok-mermaid": "0.2.2",
 				"highlight.js": "10.7.3",
 				"hosted-git-info": "9.0.3",
 				"ignore": "7.0.5",
@@ -549,11 +565,11 @@
 				"proper-lockfile": "4.1.2",
 				"semver": "7.8.0",
 				"typebox": "1.3.7",
-				"undici": "8.5.0",
+				"undici": "8.9.0",
 				"yaml": "2.9.0"
 			},
 			"bin": {
-				"pi": "dist/cli.js"
+				"pi": "dist/bundle/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
@@ -563,12 +579,13 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
-			"version": "0.91.1",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"version": "0.123.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+			"integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
 			"license": "MIT",
 			"dependencies": {
-				"json-schema-to-ts": "^3.1.1"
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
 			},
 			"bin": {
 				"anthropic-ai-sdk": "bin/cli"
@@ -997,12 +1014,25 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.83.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/chord": {
+			"version": "0.85.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.1.tgz",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.83.0",
+				"esbuild": "0.28.1"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.85.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/chord": "^0.85.1",
+				"@earendil-works/pi-ai": "^0.85.1",
+				"@earendil-works/pi-telemetry": "^0.85.1",
 				"diff": "8.0.4",
 				"ignore": "7.0.5",
 				"typebox": "1.3.7",
@@ -1013,19 +1043,18 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-			"version": "0.83.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
+			"version": "0.85.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
 			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/sdk": "0.91.1",
+				"@anthropic-ai/sdk": "0.123.0",
 				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@earendil-works/pi-telemetry": "^0.85.1",
 				"@google/genai": "1.52.0",
-				"@mistralai/mistralai": "2.2.6",
-				"@opentelemetry/api": "1.9.0",
 				"@smithy/node-http-handler": "4.7.3",
 				"http-proxy-agent": "7.0.2",
 				"https-proxy-agent": "7.0.6",
-				"openai": "6.26.0",
+				"openai": "6.40.0",
 				"partial-json": "0.1.7",
 				"typebox": "1.3.7"
 			},
@@ -1036,9 +1065,17 @@
 				"node": ">=22.19.0"
 			}
 		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+			"version": "0.85.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-			"version": "0.83.0",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
+			"version": "0.85.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.85.1.tgz",
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",
@@ -1046,6 +1083,422 @@
 			},
 			"engines": {
 				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
@@ -1251,26 +1704,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.40.0",
-				"ws": "^8.18.0",
-				"zod": "^3.25.0 || ^4.0.0",
-				"zod-to-json-schema": "^3.25.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.9.0"
-			},
-			"peerDependenciesMeta": {
-				"@opentelemetry/api": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1282,24 +1715,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.41.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
@@ -1484,6 +1899,12 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"license": "MIT"
+		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
 			"version": "22.19.19",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
@@ -1547,15 +1968,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
@@ -1634,11 +2055,58 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
+		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"license": "Unlicense"
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
 			"version": "1.2.0",
@@ -1752,23 +2220,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
-			"version": "13.0.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"minimatch": "^10.2.2",
-				"minipass": "^7.1.3",
-				"path-scurry": "^2.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
 			"version": "10.6.2",
 			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
@@ -1800,6 +2251,15 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+			"integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
 			"version": "10.7.3",
@@ -1957,15 +2417,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2011,13 +2462,10 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+			"integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
 			"license": "Apache-2.0",
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
@@ -2078,22 +2526,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"lru-cache": "^11.0.0",
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
@@ -2207,6 +2639,16 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"license": "ISC"
 		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/standardwebhooks": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+			"integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
+		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
@@ -2238,9 +2680,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+			"integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22.19.0"
@@ -2327,28 +2769,19 @@
 				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+		"node_modules/@earendil-works/pi-telemetry": {
+			"version": "0.85.1",
+			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+			"integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
 			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-			"version": "3.25.2",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.25.28 || ^4"
+			"engines": {
+				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.83.0",
-			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
-			"integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==",
+			"version": "0.85.1",
+			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-tui/-/pi-tui-0.85.1.tgz",
+			"integrity": "sha512-OIzw9efInmO4WOBnD4TxcTdBjmzvYJpzslkgoUro946nEGoYWg5rwv1p4fDt3/JvMx9QybryUCUwlm7j8Dreig==",
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",
@@ -2356,6 +2789,422 @@
 			},
 			"engines": {
 				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@google/genai": {
@@ -2380,44 +3229,6 @@
 				"@modelcontextprotocol/sdk": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@mistralai/mistralai": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmmirror.com/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.40.0",
-				"ws": "^8.18.0",
-				"zod": "^3.25.0 || ^4.0.0",
-				"zod-to-json-schema": "^3.25.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.9.0"
-			},
-			"peerDependenciesMeta": {
-				"@opentelemetry/api": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@opentelemetry/api": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmmirror.com/@opentelemetry/api/-/api-1.9.0.tgz",
-			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmmirror.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -2478,12 +3289,12 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.31.1",
-			"resolved": "https://registry.npmmirror.com/@smithy/core/-/core-3.31.1.tgz",
-			"integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+			"version": "3.33.3",
+			"resolved": "https://registry.npmmirror.com/@smithy/core/-/core-3.33.3.tgz",
+			"integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.16.1",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2491,13 +3302,13 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.4.16",
-			"resolved": "https://registry.npmmirror.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
-			"integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmmirror.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+			"integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.33.2",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2505,13 +3316,13 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.6.13",
-			"resolved": "https://registry.npmmirror.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
-			"integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmmirror.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+			"integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.18.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2545,13 +3356,13 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.6.12",
-			"resolved": "https://registry.npmmirror.com/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
-			"integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmmirror.com/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+			"integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.31.1",
-				"@smithy/types": "^4.16.1",
+				"@smithy/core": "^3.33.3",
+				"@smithy/types": "^4.17.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2559,9 +3370,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.16.1",
-			"resolved": "https://registry.npmmirror.com/@smithy/types/-/types-4.16.1.tgz",
-			"integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmmirror.com/@smithy/types/-/types-4.18.0.tgz",
+			"integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2595,6 +3406,12 @@
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmmirror.com/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "22.20.1",
@@ -2705,11 +3522,58 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
+		},
 		"node_modules/extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmmirror.com/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"license": "MIT"
+		},
+		"node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmmirror.com/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"license": "Unlicense"
 		},
 		"node_modules/fetch-blob": {
 			"version": "3.2.0",
@@ -2747,9 +3611,9 @@
 			}
 		},
 		"node_modules/gaxios": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmmirror.com/gaxios/-/gaxios-7.3.0.tgz",
-			"integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmmirror.com/gaxios/-/gaxios-7.3.1.tgz",
+			"integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"extend": "^3.0.2",
@@ -2953,13 +3817,10 @@
 			}
 		},
 		"node_modules/openai": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmmirror.com/openai/-/openai-6.26.0.tgz",
-			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmmirror.com/openai/-/openai-6.40.0.tgz",
+			"integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
 			"license": "Apache-2.0",
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
@@ -2993,9 +3854,9 @@
 			"license": "MIT"
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.5",
-			"resolved": "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.6.5.tgz",
-			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"version": "7.6.6",
+			"resolved": "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.6.6.tgz",
+			"integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -3043,6 +3904,16 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/standardwebhooks": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmmirror.com/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+			"integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
 		},
 		"node_modules/ts-algebra": {
 			"version": "2.0.0",
@@ -3092,9 +3963,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.21.2",
-			"resolved": "https://registry.npmmirror.com/ws/-/ws-8.21.2.tgz",
-			"integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+			"version": "8.21.3",
+			"resolved": "https://registry.npmmirror.com/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -3125,24 +3996,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
-		"node_modules/zod": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmmirror.com/zod/-/zod-4.4.3.tgz",
-			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.25.2",
-			"resolved": "https://registry.npmmirror.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/packages/rosclaw-agent/package.json
+++ b/packages/rosclaw-agent/package.json
@@ -19,16 +19,16 @@
 		"node": ">=22.19.0"
 	},
 	"dependencies": {
-		"@earendil-works/pi-coding-agent": "0.83.0",
-		"@earendil-works/pi-agent-core": "0.83.0",
-		"@earendil-works/pi-ai": "0.83.0",
-		"@earendil-works/pi-tui": "0.83.0"
+		"@earendil-works/pi-coding-agent": "0.85.1",
+		"@earendil-works/pi-agent-core": "0.85.1",
+		"@earendil-works/pi-ai": "0.85.1",
+		"@earendil-works/pi-tui": "0.85.1"
 	},
 	"overrides": {
-		"@earendil-works/pi-coding-agent": "0.83.0",
-		"@earendil-works/pi-agent-core": "0.83.0",
-		"@earendil-works/pi-ai": "0.83.0",
-		"@earendil-works/pi-tui": "0.83.0"
+		"@earendil-works/pi-coding-agent": "0.85.1",
+		"@earendil-works/pi-agent-core": "0.85.1",
+		"@earendil-works/pi-ai": "0.85.1",
+		"@earendil-works/pi-tui": "0.85.1"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.0",

--- a/packages/rosclaw-agent/pi-upstream.lock.json
+++ b/packages/rosclaw-agent/pi-upstream.lock.json
@@ -1,7 +1,7 @@
 {
-  "package_version": "0.83.0",
-  "source_commit": "588915ec71714688cee8b7153339e8bdebb3e82e",
+  "package_version": "0.85.1",
+  "source_commit": "d981de1229ef899957bbe968bc8dcda02a21f477",
   "license": "MIT",
-  "package_lock_sha256": "e2c557e386b10500ba8a823d1c5971054163046f2ff0c4532dbb8e6a377d6108",
+  "package_lock_sha256": "deeaa3cc24a5e392c12b51d56b6e1d454495c755f5ef52360173f5524ed14dc9",
   "characterization_suite_version": "1"
 }

--- a/packages/rosclaw-agent/src/harness/pi/pi-picker.ts
+++ b/packages/rosclaw-agent/src/harness/pi/pi-picker.ts
@@ -1,13 +1,13 @@
 /** ROSClaw 会话选择器（总纲 WP-P0-1 §5.1/§13）。
  *
- * 组合 Pi 0.83.0 公开 API（SessionSelectorComponent + pi-tui），不复制
+ * 组合 Pi 公开 API（W08：0.85.1 起 TUI 接口化，主屏用 TuiMainScreen）（SessionSelectorComponent + pi-tui），不复制
  * picker/search/tree 内核。交互结构参考上游
  * packages/coding-agent/src/cli/session-picker.ts（MIT，固定
  * v0.83.0；上游 selectSession 不是公开 export，本文件是总纲允许的
  * 极薄组装层——差异测试：test/session-discovery.test.ts）。
  */
 
-import { ProcessTerminal, TUI } from "@earendil-works/pi-tui";
+import { ProcessTerminal, TuiMainScreen } from "@earendil-works/pi-tui";
 import { SessionSelectorComponent } from "@earendil-works/pi-coding-agent";
 import type { SessionInfo } from "@earendil-works/pi-coding-agent";
 
@@ -22,7 +22,7 @@ export async function browseSessions(
 	allSessionsLoader: SessionsLoader,
 ): Promise<string | null> {
 	const terminal = new ProcessTerminal();
-	const ui = new TUI(terminal);
+	const ui = new TuiMainScreen(terminal);
 	return new Promise((resolve) => {
 		let resolved = false;
 		const finish = (path: string | null) => {

--- a/packages/rosclaw-agent/test/package-entry.test.ts
+++ b/packages/rosclaw-agent/test/package-entry.test.ts
@@ -12,12 +12,15 @@ test("package bin entry exists and dist is built", () => {
 });
 
 test("pi dependencies are exactly pinned (no ^ ranges)", () => {
+	// W08：pi 单源版本——deps/overrides 全部钉同一版本（0.83.0→0.85.1
+	// 升级走 pi_upgrade_candidate.sh + 契约层验证后改这里）。
+	const PI_PIN = "0.85.1";
 	for (const [name, version] of Object.entries(pkg.dependencies)) {
 		assert.ok(!version.startsWith("^") && !version.startsWith("~"), `${name} must be exact-pinned`);
-		assert.equal(version, "0.83.0", `${name} must be 0.83.0`);
+		assert.equal(version, PI_PIN, `${name} must be ${PI_PIN}`);
 	}
 	for (const version of Object.values(pkg.overrides)) {
-		assert.equal(version, "0.83.0");
+		assert.equal(version, PI_PIN);
 	}
 });
 

--- a/packages/rosclaw-tui/package-lock.json
+++ b/packages/rosclaw-tui/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "rosclaw-tui",
 			"version": "0.1.0",
 			"dependencies": {
-				"@earendil-works/pi-tui": "0.83.0",
+				"@earendil-works/pi-tui": "0.85.1",
 				"chalk": "^5.3.0"
 			},
 			"bin": {
@@ -23,9 +23,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.83.0",
-			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
-			"integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==",
+			"version": "0.85.1",
+			"resolved": "https://registry.npmmirror.com/@earendil-works/pi-tui/-/pi-tui-0.85.1.tgz",
+			"integrity": "sha512-OIzw9efInmO4WOBnD4TxcTdBjmzvYJpzslkgoUro946nEGoYWg5rwv1p4fDt3/JvMx9QybryUCUwlm7j8Dreig==",
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",

--- a/packages/rosclaw-tui/package.json
+++ b/packages/rosclaw-tui/package.json
@@ -16,7 +16,7 @@
 		"start": "node dist/src/main.js"
 	},
 	"dependencies": {
-		"@earendil-works/pi-tui": "0.83.0",
+		"@earendil-works/pi-tui": "0.85.1",
 		"chalk": "^5.3.0"
 	},
 	"devDependencies": {

--- a/packages/rosclaw-tui/src/app.ts
+++ b/packages/rosclaw-tui/src/app.ts
@@ -11,8 +11,9 @@ import {
 	ProcessTerminal,
 	SelectList,
 	Text,
-	TUI,
+	TuiMainScreen,
 	matchesKey,
+	type TUI,
 } from "@earendil-works/pi-tui";
 import { parseArgs as parseSchemaArgs } from "./commands/args-parser.js";
 import { MaskedInput } from "./components/masked-input.js";
@@ -94,7 +95,7 @@ export class RosclawTuiApp {
 		}
 
 		const terminal = new ProcessTerminal();
-		this.tui = new TUI(terminal);
+		this.tui = new TuiMainScreen(terminal);
 		this.statusText = new Text(this.statusString());
 		this.editor = new Editor(this.tui, editorTheme);
 		this.editor.onSubmit = (text) => {

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -133,7 +133,7 @@ for pkg in rosclaw-tui rosclaw-agent; do
 done
 
 # 6. build-info.json（规格 §27.2）：commit/版本/hash/Node 版本可追溯。
-python3 - "$STAGE" "$VERSION" <<'PY'
+python3 - "$STAGE" "$VERSION" "$REPO_ROOT" <<'PY'
 import hashlib, json, subprocess, sys
 from pathlib import Path
 
@@ -154,11 +154,21 @@ except Exception:
 node_version = subprocess.check_output(["node", "--version"], text=True).strip()     if subprocess.call(["bash", "-c", "command -v node >/dev/null"]) == 0 else ""
 info = {
     "rosclaw_commit": commit,
-    "pi_version": "0.83.0",
-    "pi_commit": "588915ec71714688cee8b7153339e8bdebb3e82e",
+    # W08 §12.1-6：pi 版本/commit 从锁定记录读（不写死）——
+    # pi-upstream.lock.json 是单源，升级走 candidate 流程更新它。
+    "pi_version": "",
+    "pi_commit": "",
     "node_version": node_version,
     "packages": {},
 }
+_repo_root = Path(sys.argv[3])
+_upstream_lock = _repo_root / "packages" / "rosclaw-agent" / "pi-upstream.lock.json"
+if not _upstream_lock.exists():
+    _upstream_lock = stage / "packages" / "rosclaw-agent" / "pi-upstream.lock.json"
+if _upstream_lock.exists():
+    _lock = json.loads(_upstream_lock.read_text())
+    info["pi_version"] = str(_lock.get("package_version", ""))
+    info["pi_commit"] = str(_lock.get("source_commit", ""))
 for pkg in ("rosclaw-tui", "rosclaw-agent"):
     pkg_dir = stage / "packages" / pkg
     lock = pkg_dir / "package-lock.json"

--- a/scripts/release/pi_upgrade_candidate.sh
+++ b/scripts/release/pi_upgrade_candidate.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# W08（规格 §12.1）：Pi 候选升级——一轮可复现的 candidate 尝试。
+#
+# 不在聊天启动时更新；不改生产 pin——在专用工作目录做完整实验：
+#   bump pins（deps+overrides）→ npm install 重生成 lock → 应用
+#   补丁（锚点漂移=硬失败，进入报告）→ 构建 + TS 套件 → 报告。
+#
+# 报告写实测结果（补丁应用/构建/测试哪些过、哪些不过），不以
+# fixture 代替真实模型结论（真实模型 A/B 属 W10，标 NOT_RUN）。
+#
+# 用法: pi_upgrade_candidate.sh <target_version> [REPORT_JSON]
+# 回退: git checkout -- packages/*/package.json packages/*/package-lock.json
+set -euo pipefail
+
+TARGET="${1:?用法: pi_upgrade_candidate.sh <target_version> [REPORT_JSON]}"
+REPORT="${2:-}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$REPO_ROOT/dist/.pi-upgrade-$TARGET"
+STAGE="/tmp"
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+PI_PKGS='@earendil-works/pi-coding-agent @earendil-works/pi-agent-core @earendil-works/pi-ai @earendil-works/pi-tui'
+
+echo "==> candidate: pi $TARGET（工作目录 $WORK）"
+for pkg in rosclaw-tui rosclaw-agent; do
+  rsync -a --exclude node_modules --exclude dist \
+    "$REPO_ROOT/packages/$pkg/" "$WORK/$pkg/"
+done
+
+# bump 所有 pin（dependencies + overrides 两段同版本对齐——
+# 不凭版本号相同推定同一模块实例，§12.1-2）。
+for pkg in rosclaw-tui rosclaw-agent; do
+  python3 - "$WORK/$pkg/package.json" "$TARGET" <<'PY'
+import json, sys
+path, target = sys.argv[1], sys.argv[2]
+data = json.load(open(path))
+bumped = []
+for section in ("dependencies", "devDependencies", "overrides"):
+    for name in list((data.get(section) or {})):
+        if name.startswith("@earendil-works/pi-"):
+            old = data[section][name]
+            if old != target:
+                data[section][name] = target
+                bumped.append(f"{section}:{name} {old}->{target}")
+if bumped:
+    json.dump(data, open(path, "w"), indent="\t", ensure_ascii=False)
+    open(path, "a").write("\n")
+print("\n".join(bumped) if bumped else "(no pi pins)")
+PY
+done
+
+OLD_LOCK=$(sha256sum "$REPO_ROOT/packages/rosclaw-agent/package-lock.json" | cut -d' ' -f1)
+
+status_lock=ok
+status_patch=skipped
+status_build=skipped
+status_tests=skipped
+patch_log=""
+for pkg in rosclaw-tui rosclaw-agent; do
+  # --ignore-scripts：补丁应用与 lock 生成分开（postinstall 会
+  # 自动跑补丁——分开才能分辨 lock 失败 vs 补丁锚点漂移）。
+  echo "==> npm install --ignore-scripts（重生成 lock）packages/$pkg"
+  if ! (cd "$WORK/$pkg" && npm install --ignore-scripts --silent); then
+    status_lock="failed:$pkg"
+    break
+  fi
+done
+
+if [ "$status_lock" = "ok" ]; then
+  echo "==> 应用上游补丁（锚点漂移=硬失败）"
+  if patch_log=$(cd "$WORK/rosclaw-agent" && node patches/apply-upstream-patches.mjs 2>&1); then
+    status_patch=ok
+  else
+    status_patch="failed"
+  fi
+  echo "$patch_log"
+fi
+
+if [ "$status_patch" = "ok" ]; then
+  echo "==> 构建"
+  for pkg in rosclaw-tui rosclaw-agent; do
+    mkdir -p "$WORK/$pkg/prompts"
+    cp "$REPO_ROOT/src/rosclaw/agentd/context/prompts/native_agent_v2.md" \
+       "$WORK/$pkg/prompts/" 2>/dev/null || true
+    if ! (cd "$WORK/$pkg" && npm run build --silent); then
+      status_build="failed:$pkg"
+      break
+    fi
+  done
+  [ "$status_build" = skipped ] || true
+  if [ "$status_build" = "skipped" ]; then status_build=ok; fi
+fi
+
+if [ "$status_build" = "ok" ]; then
+  echo "==> TS 套件"
+  if (cd "$WORK/rosclaw-agent" && node --test dist/test/*.test.js 2>&1 | tail -6); then
+    status_tests=ok
+  else
+    status_tests="failed"
+  fi
+fi
+
+NEW_LOCK=$(sha256sum "$WORK/rosclaw-agent/package-lock.json" | cut -d' ' -f1)
+
+python3 - "$REPORT" <<PY
+import json, sys
+report = {
+    "candidate": "pi $TARGET",
+    "from_version": "0.83.0",
+    "lock_digest_before": "sha256:$OLD_LOCK",
+    "lock_digest_after": "sha256:$NEW_LOCK",
+    "lock_changed": "$OLD_LOCK" != "$NEW_LOCK",
+    "steps": {
+        "pin_bump_and_lock": "$status_lock",
+        "patch_apply": "$status_patch",
+        "build": "$status_build",
+        "ts_suite": "$status_tests",
+    },
+    "patch_log": """$(echo "$patch_log" | head -20 | sed 's/"/\\"/g')""",
+    "real_model_ab": "NOT_RUN（真实模型验收属 W10——不合成冒充）",
+    "rollback": "git checkout -- packages/*/package.json packages/*/package-lock.json",
+}
+text = json.dumps(report, ensure_ascii=False, indent=1)
+print(text)
+if "$REPORT":
+    open("$REPORT", "w").write(text + "\n")
+PY
+
+# 诚实终态：任一步失败即非零退出（候选被证据拒绝是有效结论）。
+[ "$status_tests" = "ok" ] || exit 1
+echo "==> 候选 $TARGET 通过契约层（lock/补丁/构建/TS 套件）"

--- a/tests/agentd/test_pna10_release.py
+++ b/tests/agentd/test_pna10_release.py
@@ -40,7 +40,13 @@ class TestReleaseGate:
     def test_build_info_and_bundled_node(self, tmp_path: Path) -> None:
         root = _build(tmp_path)
         info = json.loads((root / "build-info.json").read_text())
-        assert info["pi_version"] == "0.83.0"
+        # W08：pi_version 从锁定记录读（不写死）——与
+        # pi-upstream.lock.json 一致即真。
+        upstream = json.loads(
+            (REPO / "packages" / "rosclaw-agent" / "pi-upstream.lock.json")
+            .read_text()
+        )
+        assert info["pi_version"] == upstream["package_version"]
         assert info["rosclaw_commit"]
         for pkg in ("rosclaw-tui", "rosclaw-agent"):
             assert info["packages"][pkg]["dist_sha256"], pkg

--- a/tests/architecture/test_pi_dependency_boundary.py
+++ b/tests/architecture/test_pi_dependency_boundary.py
@@ -34,16 +34,36 @@ HARNESS_ONLY_PACKAGES = (
 )
 HARNESS_PACKAGE_DIR = "rosclaw-agent"
 
+def _pinned_versions() -> dict[str, str]:
+    """W08：pin 单源 = rosclaw-agent package.json（deps 段）。"""
+    import json
+    from pathlib import Path
+
+    pkg = json.loads(
+        (Path(__file__).resolve().parents[2] / "packages"
+         / "rosclaw-agent" / "package.json").read_text()
+    )
+    return {
+        name: ver for name, ver in (pkg.get("dependencies") or {}).items()
+        if name.startswith("@earendil-works/")
+    }
+
+
 ALLOWED_PI_PACKAGES = {
-    "@earendil-works/pi-tui": "0.83.0",
-    "@earendil-works/pi-ai": "0.83.0",
+    name: ver for name, ver in _pinned_versions().items()
+    if name in ("@earendil-works/pi-tui", "@earendil-works/pi-ai")
 }
 
 ALLOWED_HARNESS_PACKAGES = {
-    "@earendil-works/pi-coding-agent": "0.83.0",
-    "@earendil-works/pi-agent-core": "0.83.0",
-    "@earendil-works/pi-ai": "0.83.0",
-    "@earendil-works/pi-tui": "0.83.0",
+    name: ver
+    for name, ver in _pinned_versions().items()
+    if name
+    in (
+        "@earendil-works/pi-coding-agent",
+        "@earendil-works/pi-agent-core",
+        "@earendil-works/pi-ai",
+        "@earendil-works/pi-tui",
+    )
 }
 
 BANNED_PYTHON_IMPORTS = re.compile(r"pi_agent_core|pi_coding_agent|hermes_agent|opencode_agent")

--- a/tests/test_w08_pi_upgrade.py
+++ b/tests/test_w08_pi_upgrade.py
@@ -1,0 +1,83 @@
+"""W08 红测试（规格 2026-09-08 §12）：Pi 升级候选纪律。
+
+- pin 单源一致：package.json deps/overrides 与
+  pi-upstream.lock.json 的 package_version 一致（升级只走
+  candidate 流程同时改两边）；
+- build-info 不写死 pi 版本（从锁定记录读——§12.1-6 manifest
+  记录有效运行版本）；
+- 补丁在钉版上可重放（node_modules 缺失时 NOT_RUN 跳过——
+  不合成冒充）。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENT = REPO_ROOT / "packages" / "rosclaw-agent"
+
+
+class TestPinSingleSource:
+    def test_package_json_matches_upstream_lock(self) -> None:
+        pkg = json.loads((AGENT / "package.json").read_text())
+        upstream = json.loads((AGENT / "pi-upstream.lock.json").read_text())
+        pin = upstream["package_version"]
+        for section in ("dependencies", "overrides"):
+            for name, ver in (pkg.get(section) or {}).items():
+                if name.startswith("@earendil-works/pi-"):
+                    assert ver == pin, (
+                        f"{section}.{name}={ver} 与 pi-upstream.lock "
+                        f"{pin} 不一致——升级必须走 candidate 流程"
+                    )
+
+    def test_lockfile_digest_matches_record(self) -> None:
+        """pi-upstream.lock.json 的 package_lock_sha256 = 实际
+        package-lock.json 摘要（漂移即发现）。"""
+        import hashlib
+
+        upstream = json.loads((AGENT / "pi-upstream.lock.json").read_text())
+        actual = hashlib.sha256(
+            (AGENT / "package-lock.json").read_bytes()
+        ).hexdigest()
+        assert upstream["package_lock_sha256"] == actual, (
+            "lock 漂移——重跑 pi_upgrade_candidate.sh 重生成记录"
+        )
+
+
+class TestBuildInfoDynamic:
+    def test_build_release_no_hardcoded_pi_version(self) -> None:
+        text = (REPO_ROOT / "scripts" / "build_release.sh").read_text(
+            encoding="utf-8"
+        )
+        assert not re.search(r'"pi_version":\s*"0\.', text), (
+            "build-info 写死 pi 版本——必须从 pi-upstream.lock.json 读"
+        )
+        assert "pi-upstream.lock.json" in text
+
+
+class TestPatchReplayOnPin:
+    def test_patches_apply_on_current_pin(self) -> None:
+        """补丁在钉版上幂等可重放（node_modules 不在场 = NOT_RUN
+        跳过，不合成冒充）。"""
+        import shutil
+        import subprocess
+
+        node = shutil.which("node")
+        nm = AGENT / "node_modules"
+        if not node or not (nm / "@earendil-works").exists():
+            import pytest
+
+            pytest.skip("NOT_RUN: node/node_modules 不在场")
+        result = subprocess.run(
+            [node, "patches/apply-upstream-patches.mjs"],
+            cwd=AGENT, capture_output=True, text=True, timeout=120,
+        )
+        assert result.returncode == 0, result.stderr[-300:]
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
规格 2026-09-08 §12（W08）。

**升级内容**：pins 0.83.0→0.85.1（deps+overrides 对齐）+ locks 重生成；0.85.1 API diff：`TUI` 变 type-only → `TuiMainScreen` 适配（app.ts/pi-picker.ts）；pi-upstream.lock.json 成单源（build-info 动态读，不写死）。

**流程**：scripts/release/pi_upgrade_candidate.sh = bump→lock→补丁重放→构建→TS 套件→JSON 报告+回退命令，专用工作目录。

**实测证据**：补丁在 0.85.1 全命中；agent TS 229/0；tui TS 27/27；release bundle 全链构建过（pna10）。真实模型 A/B NOT_RUN（无 key，不合成冒充）。

回退：git checkout 本 PR 的 pins/locks/适配文件即回 0.83.0（补丁双向可重放）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)