### PR TITLE
build: exclude dist/test from JS staging

### DIFF
--- a/scripts/release/build_js_staging.sh
+++ b/scripts/release/build_js_staging.sh
@@ -40,6 +40,9 @@ for pkg in rosclaw-tui rosclaw-agent; do
   mkdir -p "$STAGE/$pkg"
   cp -r "$WORK/$pkg/dist" "$WORK/$pkg/package.json" \
         "$WORK/$pkg/package-lock.json" "$STAGE/$pkg/"
+  # 测试文件不是运行内容——不进 staging（wheel/tar 是发布物；
+  # 体积 + 测试夹具字符串会误触秘密扫描）。
+  rm -rf "$STAGE/$pkg/dist/test"
   cp -r "$WORK/$pkg/src" "$STAGE/$pkg/"
   # 生产依赖 tarball（第二次 npm ci 发生在 WORK 副本——开发
   # checkout 的 node_modules 全程不被触碰）。


### PR DESCRIPTION
测试文件不进发布 staging（wheel/tar 是运行物；测试夹具字符串 sk-test-* 会误触秘密扫描，且白占体积）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)