### PR TITLE
test(infra): xdist 并行正式引入——collection 确定性与并行安全修复

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libosmesa6 xvfb
 
       - name: Run full non-deployment suite
-        run: pytest -q -m 'not slow and not integration and not deployment'
+        # 0911 验证：套件已并行安全（collection 确定性 sorted 参数化 +
+        # AF_UNIX 短路径修复；本地 -n 8 全量实证 7245 通过零并行噪声）。
+        # loadfile 保持文件内顺序（文件内顺序依赖不受影响）。
+        run: pytest -q -n auto --dist loadfile -m 'not slow and not integration and not deployment'
 
   product-acceptance:
     name: Product Acceptance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,12 @@ def move_joints(self, positions: list[float], duration: float = 2.0) -> bool:
 - **Coverage**: Aim for high coverage on business logic; skip framework/type-system tests
 - **Mocking**: Mock external dependencies (hardware, network), not internal modules
 - **Integration tests**: Place in `tests/` with `test_*.py` naming
+- **Parallel local runs**: the suite is xdist-safe — `pytest tests/ -n auto --dist loadfile`
+  cuts a full local run from hours to minutes. Keep collection order
+  deterministic: never parametrize over `list(<set>)` (set iteration order
+  follows the per-process hash seed); use `sorted(...)` instead. PTY journey
+  tests (`tests/agentd/test_product_journey.py`) must still run exclusively
+  (they hide the source checkout), never under `-n`.
 
 ## Questions?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,10 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
+    # 0911 验证：全量套件并行（-n auto --dist loadfile）——本地
+    # 串行 ~2.5h → 并行 ~6min；collection 确定性由 sorted 参数化
+    # 保证（不依赖 PYTHONHASHSEED）。
+    "pytest-xdist>=3.5.0",
     "ruff>=0.1.0",
     "mypy>=1.5.0",
     "jsonschema>=4.0.0",

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import socket
 import stat
+import tempfile
 import threading
 import time
 from datetime import UTC, datetime, timedelta
@@ -650,8 +651,11 @@ def test_client_rejects_daemon_uid_outside_operator_expectation(
     assert error.value.code == "UNEXPECTED_DAEMON_UID"
 
 
-def test_client_rejects_socket_inside_writable_directory(tmp_path: Path) -> None:
-    runtime_dir = tmp_path / "attacker-controlled"
+def test_client_rejects_socket_inside_writable_directory() -> None:
+    # xdist 实证（0911 验证）：xdist 的 tmp 路径带 popen-gwN 段，拼接
+    # socket 名后超过 AF_UNIX sun_path 107 字节上限——socket 目录用
+    # 短前缀 mkdtemp（安全语义不变：目录 0o777 可写即攻击面）。
+    runtime_dir = Path(tempfile.mkdtemp(prefix="rsock-")) / "attacker-controlled"
     runtime_dir.mkdir()
     runtime_dir.chmod(0o777)
     socket_path = runtime_dir / "rosclawd.sock"

--- a/tests/sense/test_mock_collector.py
+++ b/tests/sense/test_mock_collector.py
@@ -11,7 +11,10 @@ class TestMockCollector:
         assert "hot_knee" in SCENARIOS
         assert "kick_not_ready" in SCENARIOS
 
-    @pytest.mark.parametrize("scenario", list(SCENARIOS))
+    # xdist 实证（0911 验证）：SCENARIOS 是 frozenset——list() 的迭代序
+    # 依赖字符串 hash（每进程随机），各 worker collection 顺序不一致
+    # 会被 xdist 判为"收集分叉"。sorted() 让 collection 与进程种子无关。
+    @pytest.mark.parametrize("scenario", sorted(SCENARIOS))
     def test_collect_returns_state(self, scenario):
         collector = MockCollector(robot_id="g1", scenario=scenario)
         state = collector.collect()


### PR DESCRIPTION
0911 深度验证发现套件从未并行验证过，首次 xdist 即暴露两处真实缺陷：

- `test_mock_collector` 以 `list(frozenset)` 参数化——迭代序依赖每进程 hash 种子，xdist worker 收集顺序分叉（Different tests were collected）。改 `sorted()`，三种子收集逐字节一致。
- daemon socket 测试在 xdist `popen-gwN` 长路径下 AF_UNIX sun_path 超 107 字节——socket 目录改短前缀 mkdtemp（安全语义不变）。

同时：pytest-xdist 进 dev extra；CI full-regression 切换 `-n auto --dist loadfile`（60min 预算历史两次触顶 cancel）；CONTRIBUTING 记录并行纪律（sorted 参数化、PTY journey 仍独占串行）。

红→绿：红=collection 分叉 + AF_UNIX path too long；绿=本地 `-n 8` 全量 **7245 通过零并行噪声**（无 PYTHONHASHSEED 环境 hack）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)