### PR TITLE
test(h4): 修复 h4 腐烂——改断 R0-2b 内核静默契约并挂入 CI

### DIFF
--- a/.github/workflows/native-agent-gate.yml
+++ b/.github/workflows/native-agent-gate.yml
@@ -76,10 +76,14 @@ jobs:
         run: |
           cd packages/rosclaw-agent
           timeout 600 npm ci --fetch-retries=5 --fetch-retry-mintimeout=15000 --fetch-retry-maxtimeout=60000 || timeout 600 npm ci
+          # 0911 验证：h4 类 PTY 测试的 skip 门是 dist 存在——npm ci 不
+          # 产出 dist（此前 h4 在任何 CI job 都 skip，腐烂三周无人能见）。
+          # 显式 build 让它们在本 job 真跑，堵住本地-only 覆盖空洞。
+          npm run build
       - name: Run product journey
         id: run
         run: |
-          .venv/bin/python -m pytest tests/agentd/test_product_journey.py tests/agentd/test_hf5_4_action_result_ui.py -q --tb=short \
+          .venv/bin/python -m pytest tests/agentd/test_product_journey.py tests/agentd/test_hf5_4_action_result_ui.py tests/agentd/test_h4_verifier_live.py -q --tb=short \
             --junitxml=/tmp/junit-journey.xml
       # 六审 §9.2.4：publishable 证据先 curate 成单份（pytest-0/
       # pytest-current/test_*0/test_*current 的 glob 会把同一 PTY 日志

--- a/tests/agentd/test_h4_verifier_live.py
+++ b/tests/agentd/test_h4_verifier_live.py
@@ -1,10 +1,17 @@
-"""PR-H4 产品 Gate（总纲 v2 §12）：验收闭环 + TurnGuard。
+"""PR-H4 产品 Gate（总纲 v2 §12）：验收闭环 + 内核静默终态。
 
-PTY `rosclaw chat` + 假模型编排 + 真实内核：
-1. 模型 write 后直接回答（不收尾）→ TurnGuard 注入一次结构化提醒；
-2. 模型被提醒后 artifact_register + task_finish → verifier 真跑 →
-   SUCCEEDED + verifications 行 + accepted_at；
-3. 零 WorkOrder/零 execution；task 终态与 TUI 一致。
+PTY `rosclaw chat` + 假模型编排 + 真实内核。当前契约（大道至简
+R0-2b，#515 之后的真实行为）：
+1. 模型 write → deliver → 自己向用户汇报（叙述权在模型——Kernel
+   不在 turn_end 自动宣布"任务完成：验收"，R0-2b 已删除该播报）；
+2. Kernel Coordinator 在 turn_end **静默**自动收尾：tasks=SUCCEEDED、
+   verifications=PASS、accepted_at 落账、task_outcomes 六维齐全——
+   全程零模型调用（收尾不唤醒 Agent）；
+3. 零 WorkOrder/零 execution；TUI 不出现 Kernel 验收播报。
+
+0911 验证实证：本测试曾等待 R0-2b 已删除的 TUI 播报而腐烂
+（#440 后未更新；CI 无 dist 即 skip，零覆盖）。现改断新契约：
+DB 终态（轮询等待）+ 内核静默（PTY 无播报）+ 零模型调用收尾。
 """
 
 from __future__ import annotations
@@ -12,6 +19,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -45,12 +53,6 @@ class _VerifierFake:
     def answer(self, body: dict) -> bytes:
         self.requests.append(body)
         messages = body.get("messages", [])
-
-        def _text(m: dict) -> str:
-            content = m.get("content", "")
-            if isinstance(content, list):
-                return " ".join(str(b.get("text", "")) for b in content if isinstance(b, dict))
-            return str(content)
 
         if not body.get("stream"):
             return json.dumps({
@@ -97,6 +99,23 @@ class _VerifierFakeServer(_FakeServer):
         _threading.Thread(target=self.server.serve_forever, daemon=True).start()
 
 
+def _await_task_terminal(db_path: Path, timeout: float = 180.0) -> tuple[list, list]:
+    """轮询内核账本直到任务终态（Coordinator 自动收尾是异步的——
+    不等 TUI 播报，DB 是唯一权威）。"""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        db = sqlite3.connect(db_path)
+        tasks = db.execute(
+            "SELECT task_id, state, accepted_at FROM tasks"
+        ).fetchall()
+        verifications = db.execute("SELECT status FROM verifications").fetchall()
+        db.close()
+        if tasks and tasks[0][1] == "SUCCEEDED" and tasks[0][2]:
+            return tasks, verifications
+        time.sleep(2)
+    return tasks, verifications
+
+
 class TestVerifierClosedLoop:
     def test_coordinator_auto_finish(self, tmp_path: Path) -> None:
         fake = _VerifierFakeServer()
@@ -110,17 +129,15 @@ class TestVerifierClosedLoop:
         try:
             session.expect(b"ROSClaw Native Agent", timeout=120)
             session.send("写一个 hello.txt 并交付\r")
-            # 模型回答已交付 → turn_end Coordinator 自动验收 →
-            # 任务完成通知（零模型调用收尾）。
+            # 模型叙述权：模型自己汇报已交付（R0-2b——Kernel 不替
+            # 模型宣布验收）。
             session.expect("hello.txt 已写入并交付".encode(), timeout=240)
-            session.expect("任务完成：验收".encode(), timeout=120)
+            requests_at_final_answer = len(fake.fake.requests)
+            # 内核静默自动收尾：轮询 DB 直到 SUCCEEDED + accepted_at。
+            tasks, verifications = _await_task_terminal(
+                home / "agentd" / "missions.db"
+            )
             db = sqlite3.connect(home / "agentd" / "missions.db")
-            tasks = db.execute(
-                "SELECT task_id, state, accepted_at FROM tasks"
-            ).fetchall()
-            verifications = db.execute(
-                "SELECT status FROM verifications"
-            ).fetchall()
             artifacts = db.execute("SELECT path, sha256 FROM artifacts").fetchall()
             orders = db.execute("SELECT COUNT(*) FROM work_orders").fetchone()[0]
             # TaskOutcomeV2 落库且六维齐全。
@@ -128,25 +145,36 @@ class TestVerifierClosedLoop:
                 "SELECT outcome_json FROM task_outcomes"
             ).fetchall()
             db.close()
-            assert len(tasks) == 1 and tasks[0][1] == "SUCCEEDED", tasks
+            assert len(tasks) == 1 and tasks[0][1] == "SUCCEEDED", (
+                f"Coordinator 未在 180s 内自动收尾: {tasks}"
+            )
+            assert tasks[0][2], "accepted_at 必须落账"
+            # 零模型调用收尾：最终回答到账本终态之间不得有新请求。
+            assert len(fake.fake.requests) == requests_at_final_answer, (
+                f"收尾过程唤醒了模型（{requests_at_final_answer} → "
+                f"{len(fake.fake.requests)} 请求）——终态后零模型回合被违反"
+            )
             # P0-D：模型全程未调用 task_finish（收尾仪式已删除）。
-            import json as _json
-
-            tool_frames = _json.dumps(
+            tool_frames = json.dumps(
                 [m for req in fake.fake.requests for m in req.get("messages", [])]
             )
             assert "rosclaw_task_finish" not in tool_frames, (
                 "模型仍在手动 task_finish——收尾仪式未删除"
             )
             assert outcome_rows, "task_outcomes 未落库"
-            outcome = _json.loads(outcome_rows[0][0])
+            outcome = json.loads(outcome_rows[0][0])
             assert outcome["lifecycle"] == "COMPLETED"
             assert outcome["verification"] == "PASS"
             assert outcome["delivery"] == "DELIVERED"
-            assert tasks[0][2], "accepted_at 必须落账"
             assert verifications and verifications[0][0] == "PASS", verifications
             assert artifacts, "artifact 未登记"
             assert orders == 0
+            # R0-2b 内核静默契约：PTY 全程不得出现 Kernel 验收播报
+            #（用户看到的是模型自己的叙述，不是 Kernel 的终态宣布）。
+            pty_log = (tmp_path / "pty-h4.log").read_bytes()
+            assert "任务完成：验收".encode() not in pty_log, (
+                "Kernel 仍在自动宣布验收——R0-2b 静默契约被违反"
+            )
             session.expect_with_resend(b"rosclaw continue", "/quit\r", timeout=60)
             session.proc.wait(timeout=30)
         finally:


### PR DESCRIPTION
0911 深度验证实证：`test_h4_verifier_live` 等待"任务完成：验收"TUI 播报——该播报被大道至简 R0-2b（#515）**有意删除**（Kernel 不替模型宣布验收）。测试 #440（0824）后未更新，且任何 CI job 都无 dist 即 skip——**腐烂三周不可见**。失败现场 DB 实际 SUCCEEDED+verification PASS+交付齐全：内核链路全对，测试期待的是退役行为。

新契约断言（与现行产品行为一致）：
- 模型叙述在场（叙述权在模型）；
- 轮询 DB 等 Coordinator 静默自动收尾：SUCCEEDED+accepted_at+verifications PASS+task_outcomes 六维+零 WorkOrder；
- **零模型调用收尾**（最终回答后请求数不变）；
- **内核静默**：PTY 全程无"任务完成：验收"播报。

CI 覆盖：journey job 显式 `npm run build`（npm ci 不产 dist）并把本测试加入运行列表——堵住 `find_pi_agent_entry` 门控测试的本地-only 覆盖空洞。

红→绿：红=PTY 超时等退役播报（122s 实证）；绿=本地真 PTY 全流程通过（DB 终态/零调用/静默三项核验齐全）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)