### PR TITLE
test(ci): 墙钟 SLO/基准测试隔离 perf_serial 串行段——根治 xdist 负载误红

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,12 @@ jobs:
         # 0911 验证：套件已并行安全（collection 确定性 sorted 参数化 +
         # AF_UNIX 短路径修复；本地 -n 8 全量实证 7245 通过零并行噪声）。
         # loadfile 保持文件内顺序（文件内顺序依赖不受影响）。
-        run: pytest -q -n auto --dist loadfile -m 'not slow and not integration and not deployment'
+        # perf_serial（墙钟 SLO/基准）在并行负载下测量失真（main
+        # bdcb115 实证 849ms>600ms 误红）——并行段排除、串行段补跑。
+        run: pytest -q -n auto --dist loadfile -m 'not slow and not integration and not deployment and not perf_serial'
+
+      - name: Run perf_serial suite (serial — wall-clock measurements must be unloaded)
+        run: pytest -q -p no:xdist -m 'perf_serial and not slow and not integration and not deployment'
 
   product-acceptance:
     name: Product Acceptance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,11 @@ def move_joints(self, positions: list[float], duration: float = 2.0) -> bool:
   follows the per-process hash seed); use `sorted(...)` instead. PTY journey
   tests (`tests/agentd/test_product_journey.py`) must still run exclusively
   (they hide the source checkout), never under `-n`.
+- **Wall-clock SLO/benchmark tests**: mark them `perf_serial` — timing
+  assertions are meaningless under parallel worker load (CI evidence: a
+  10k-session catalog SLO measured 849ms under xdist vs ~350ms serial).
+  CI runs them in a dedicated serial step; locally use
+  `pytest -m perf_serial -p no:xdist`.
 
 ## Questions?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,4 +251,7 @@ markers = [
     "rh56_hw: marks tests requiring the physical RH56 hand (ROSCLAW_RH56_HW=1)",
     "rh56_shadow: marks tests running the RH56 real-body shadow gate",
     "rh56_execute: marks tests executing on the physical RH56 (also requires ROSCLAW_RH56_EXECUTE_ACK=YES)",
+    # xdist 实证（main=bdcb115 CI 红）：墙钟 SLO/基准断言在并行负载下
+    # 测量失真——并行段排除、同 job 串行段补跑（测量必须无负载）。
+    "perf_serial: wall-clock SLO/benchmark assertions; excluded from xdist parallel runs and executed in a dedicated serial step",
 ]

--- a/tests/agentd/test_wp02_session_catalog.py
+++ b/tests/agentd/test_wp02_session_catalog.py
@@ -14,6 +14,8 @@ import json
 import time
 from pathlib import Path
 
+import pytest
+
 from tests.agentd.test_pi_tool_bridge import _setup
 
 
@@ -91,6 +93,10 @@ class TestCatalogBackfill:
         await service.close()
 
 
+# 墙钟 SLO（10k 会话 list/search）：xdist 并行负载下测量失真——
+# main CI 实证 849ms>600ms 误红（串行同代码 347ms 量级）。
+# perf_serial：并行段排除、串行段补跑（测量必须无负载才有效）。
+@pytest.mark.perf_serial
 class TestCatalogPerformance:
     async def test_10k_sessions_list_search_slo(self, tmp_path: Path) -> None:
         """10,000 会话：list p95 < 300ms、搜索 < 150ms（总纲 §WP-P0-2）。"""

--- a/tests/storage/test_seekdb_native.py
+++ b/tests/storage/test_seekdb_native.py
@@ -171,6 +171,9 @@ def test_repository_dual_write_via_projection(tmp_path, store: SeekDBEmbeddedSto
 
 
 @pytest.mark.slow
+# 墙钟对比基准（native hnsw vs sqlite 扫描）：并行负载下两次测量
+# 受竞争影响不可比——perf_serial 串行段运行。
+@pytest.mark.perf_serial
 def test_native_benchmark_vs_sqlite_scan(tmp_path, store: SeekDBEmbeddedStore) -> None:
     """Native HNSW vector search must beat SQLite full-table scan at 10k records."""
     from rosclaw.memory.seekdb_client import SQLiteKnowledgeStore

--- a/tests/test_performance_benchmarks.py
+++ b/tests/test_performance_benchmarks.py
@@ -19,6 +19,10 @@ from rosclaw.provider.builtins.critic import MockCriticProvider
 from rosclaw.provider.core.manifest import ProviderManifest
 from rosclaw.provider.core.request import ProviderRequest
 
+# 全文件墙钟基准：xdist 并行负载下测量失真（main CI 实证——目录
+# SLO 测试 849ms>600ms 误红）。perf_serial：并行段排除、串行段补跑。
+pytestmark = pytest.mark.perf_serial
+
 
 def _make_critic_manifest():
     return ProviderManifest(


### PR DESCRIPTION
main=bdcb115 CI Full Regression 实证红：`test_10k_sessions_list_search_slo` 测得 list **849ms** 超 600ms 上限——同代码串行仅 ~350ms 量级；xdist 4 worker 负载下墙钟测量失真（SLO 测试度量的是无负载性能，并行段里它度量的是调度竞争）。

处置（不降验收标准，只让测量回到有效环境）：
- 新 marker `perf_serial`：TestCatalogPerformance（10k 会话 SLO）+ test_performance_benchmarks 全文件 + seekdb native vs sqlite 对比基准；
- CI full-regression：并行段排除 perf_serial，新增串行补跑段（`-p no:xdist`，11 例 ~4s）；CONTRIBUTING 同步。

红→绿：红=main CI 849ms>600ms（并行负载测量）；绿=本地串行段 11 例全过 + 并行段收集排除正确。

🤖 Generated with [Claude Code](https://claude.com/claude-code)